### PR TITLE
Solve warnings compilation wazuh server

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,7 @@ uname_M := $(shell sh -c 'uname -m 2>/dev/null || echo not')
 HAS_CHECKMODULE = $(shell command -v checkmodule > /dev/null && echo YES)
 HAS_SEMODULE_PACKAGE = $(shell command -v semodule_package > /dev/null && echo YES)
 CHECK_ARCHLINUX := $(shell sh -c 'grep "Arch Linux" /etc/os-release > /dev/null && echo YES || echo not')
-CHECK_CENTOS5 := $(shell sh -c 'grep "CentOS release 5." /etc/redhat-release > /dev/null && echo YES || echo not')
+CHECK_CENTOS5 := $(shell sh -c 'grep "CentOS release 5." /etc/redhat-release 2>&1 > /dev/null && echo YES || echo not')
 
 ARCH_FLAGS =
 

--- a/src/active-response/firewalld-drop.c
+++ b/src/active-response/firewalld-drop.c
@@ -99,7 +99,7 @@ int main (int argc, char **argv) {
         if (access(fw_cmd_tmp, F_OK) < 0) {
             char fw_cmd_path[COMMANDSIZE_4096];
             memset(fw_cmd_path, '\0', COMMANDSIZE_4096);
-            snprintf(fw_cmd_path, COMMANDSIZE_4096 - 1, "/usr%s", fw_cmd_tmp);
+            snprintf(fw_cmd_path, sizeof(fw_cmd_path), "/usr%s", fw_cmd_tmp);
             if (access(fw_cmd_path, F_OK) < 0) {
                 memset(log_msg, '\0', OS_MAXSTR);
                 snprintf(log_msg, OS_MAXSTR -1, "The firewall-cmd file '%s' is not accessible: %s (%d)", fw_cmd_path, strerror(errno), errno);
@@ -107,8 +107,7 @@ int main (int argc, char **argv) {
                 cJSON_Delete(input_json);
                 return OS_INVALID;
             }
-            strncpy(fw_cmd, fw_cmd_path, COMMANDSIZE_4096);
-            fw_cmd[COMMANDSIZE_4096 - 1] = '\0';
+            strncpy(fw_cmd, fw_cmd_path, sizeof(fw_cmd));
         } else {
             strncpy(fw_cmd, fw_cmd_tmp, COMMANDSIZE_4096 - 1);
         }

--- a/src/active-response/firewalld-drop.c
+++ b/src/active-response/firewalld-drop.c
@@ -107,7 +107,8 @@ int main (int argc, char **argv) {
                 cJSON_Delete(input_json);
                 return OS_INVALID;
             }
-            strncpy(fw_cmd, fw_cmd_path, COMMANDSIZE_4096 - 1);
+            strncpy(fw_cmd, fw_cmd_path, COMMANDSIZE_4096);
+            fw_cmd[COMMANDSIZE_4096 - 1] = '\0';
         } else {
             strncpy(fw_cmd, fw_cmd_tmp, COMMANDSIZE_4096 - 1);
         }

--- a/src/active-response/firewalld-drop.c
+++ b/src/active-response/firewalld-drop.c
@@ -82,23 +82,19 @@ int main (int argc, char **argv) {
     }
 
     if (!strcmp("Linux", uname_buffer.sysname)) {
-        char arg1[COMMANDSIZE_4096];
-        char fw_cmd[COMMANDSIZE_4096];
+        char arg1[COMMANDSIZE_4096] = {0};
+        char fw_cmd[COMMANDSIZE_4096] = {0};
         char fw_cmd_tmp[COMMANDSIZE_4096 - 5] = DEFAULT_FW_CMD;
 
-        memset(arg1, '\0', COMMANDSIZE_4096);
         if (action == ADD_COMMAND) {
             strcpy(arg1, "--add-rich-rule");
         } else {
             strcpy(arg1, "--remove-rich-rule");
         }
 
-        memset(fw_cmd, '\0', COMMANDSIZE_4096);
-
         // Checking if firewall-cmd is present
         if (access(fw_cmd_tmp, F_OK) < 0) {
-            char fw_cmd_path[COMMANDSIZE_4096];
-            memset(fw_cmd_path, '\0', COMMANDSIZE_4096);
+            char fw_cmd_path[COMMANDSIZE_4096] = {0};
             snprintf(fw_cmd_path, sizeof(fw_cmd_path), "/usr%s", fw_cmd_tmp);
             if (access(fw_cmd_path, F_OK) < 0) {
                 memset(log_msg, '\0', OS_MAXSTR);
@@ -107,7 +103,7 @@ int main (int argc, char **argv) {
                 cJSON_Delete(input_json);
                 return OS_INVALID;
             }
-            strncpy(fw_cmd, fw_cmd_path, sizeof(fw_cmd));
+            snprintf(fw_cmd, sizeof(fw_cmd), "%s", fw_cmd_path);
         } else {
             strncpy(fw_cmd, fw_cmd_tmp, COMMANDSIZE_4096 - 1);
         }

--- a/src/active-response/firewalls/default-firewall-drop.c
+++ b/src/active-response/firewalls/default-firewall-drop.c
@@ -91,7 +91,7 @@ int main (int argc, char **argv) {
         if (access(iptables_tmp, F_OK) < 0) {
             char iptables_path[COMMANDSIZE_4096];
             memset(iptables_path, '\0', COMMANDSIZE_4096);
-            snprintf(iptables_path, COMMANDSIZE_4096 - 1, "/usr%s", iptables_tmp);
+            snprintf(iptables_path, sizeof(iptables_path), "/usr%s", iptables_tmp);
             if (access(iptables_path, F_OK) < 0) {
                 memset(log_msg, '\0', OS_MAXSTR);
                 snprintf(log_msg, OS_MAXSTR -1, "The iptables file '%s' is not accessible: %s (%d)", iptables_path, strerror(errno), errno);
@@ -99,8 +99,7 @@ int main (int argc, char **argv) {
                 cJSON_Delete(input_json);
                 return OS_SUCCESS;
             }
-            strncpy(iptables, iptables_path, COMMANDSIZE_4096);
-            iptables[COMMANDSIZE_4096 - 1] = '\0';
+            strncpy(iptables, iptables_path, sizeof(iptables));
         } else {
             strncpy(iptables, iptables_tmp, COMMANDSIZE_4096 - 1);
         }

--- a/src/active-response/firewalls/default-firewall-drop.c
+++ b/src/active-response/firewalls/default-firewall-drop.c
@@ -99,7 +99,8 @@ int main (int argc, char **argv) {
                 cJSON_Delete(input_json);
                 return OS_SUCCESS;
             }
-            strncpy(iptables, iptables_path, COMMANDSIZE_4096 - 1);
+            strncpy(iptables, iptables_path, COMMANDSIZE_4096);
+            iptables[COMMANDSIZE_4096 - 1] = '\0';
         } else {
             strncpy(iptables, iptables_tmp, COMMANDSIZE_4096 - 1);
         }

--- a/src/active-response/firewalls/default-firewall-drop.c
+++ b/src/active-response/firewalls/default-firewall-drop.c
@@ -89,8 +89,7 @@ int main (int argc, char **argv) {
 
         // Checking if iptables is present
         if (access(iptables_tmp, F_OK) < 0) {
-            char iptables_path[COMMANDSIZE_4096];
-            memset(iptables_path, '\0', COMMANDSIZE_4096);
+            char iptables_path[COMMANDSIZE_4096] = {0};
             snprintf(iptables_path, sizeof(iptables_path), "/usr%s", iptables_tmp);
             if (access(iptables_path, F_OK) < 0) {
                 memset(log_msg, '\0', OS_MAXSTR);
@@ -99,13 +98,12 @@ int main (int argc, char **argv) {
                 cJSON_Delete(input_json);
                 return OS_SUCCESS;
             }
-            strncpy(iptables, iptables_path, sizeof(iptables));
+            snprintf(iptables, sizeof(iptables), "%s", iptables_path);
         } else {
             strncpy(iptables, iptables_tmp, COMMANDSIZE_4096 - 1);
         }
 
-        char arg[3];
-        memset(arg, '\0', 3);
+        char arg[3] = {0};
         if (action == ADD_COMMAND) {
             strcpy(arg, "-I");
         } else {

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -42,11 +42,11 @@ int OS_AddNewAgent(keystore *keys, const char *id, const char *name, const char 
     os_md5 md2;
     char str1[STR_SIZE + 1];
     char str2[STR_SIZE + 1];
-    char _id[9] = { '\0' };
+    char _id[12] = { '\0' };
     char buffer[KEYSIZE] = { '\0' };
 
     if (!id) {
-        snprintf(_id, 9, "%03d", ++keys->id_counter);
+        snprintf(_id, 12, "%03d", ++keys->id_counter);
         id = _id;
     }
     else {

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -46,7 +46,7 @@ int OS_AddNewAgent(keystore *keys, const char *id, const char *name, const char 
     char buffer[KEYSIZE] = { '\0' };
 
     if (!id) {
-        snprintf(_id, 12, "%03d", ++keys->id_counter);
+        snprintf(_id,sizeof(_id), "%03d", ++keys->id_counter);
         id = _id;
     }
     else {

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -906,7 +906,7 @@ void OS_ReadMSG_analysisd(int m_queue)
         os_calloc(1, sizeof(Eventinfo), lf);
         os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
         lf->year = prev_year;
-        snprintf(lf->mon, 4, "%s", prev_month);
+        memcpy(lf->mon, prev_month, sizeof(prev_month));
         lf->day = today;
 
         if (OS_GetLogLocation(today, prev_year, prev_month) < 0) {
@@ -2204,7 +2204,7 @@ void * w_log_rotate_thread(__attribute__((unused)) void * args){
                 }
 
                 today = day;
-                snprintf(prev_month, 4, "%s", mon);
+                memcpy(prev_month, mon, sizeof(mon));
                 prev_year = year;
             }
         }

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -906,7 +906,8 @@ void OS_ReadMSG_analysisd(int m_queue)
         os_calloc(1, sizeof(Eventinfo), lf);
         os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
         lf->year = prev_year;
-        strncpy(lf->mon, prev_month, 3);
+        strncpy(lf->mon, prev_month, 4);
+        lf->mon[3] = '\0';
         lf->day = today;
 
         if (OS_GetLogLocation(today, prev_year, prev_month) < 0) {
@@ -2204,7 +2205,8 @@ void * w_log_rotate_thread(__attribute__((unused)) void * args){
                 }
 
                 today = day;
-                strncpy(prev_month, mon, 3);
+                strncpy(prev_month, mon, 4);
+                prev_month[3] = '\0';
                 prev_year = year;
             }
         }

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -906,8 +906,7 @@ void OS_ReadMSG_analysisd(int m_queue)
         os_calloc(1, sizeof(Eventinfo), lf);
         os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
         lf->year = prev_year;
-        strncpy(lf->mon, prev_month, 4);
-        lf->mon[3] = '\0';
+        snprintf(lf->mon, 4, "%s", prev_month);
         lf->day = today;
 
         if (OS_GetLogLocation(today, prev_year, prev_month) < 0) {
@@ -2205,8 +2204,7 @@ void * w_log_rotate_thread(__attribute__((unused)) void * args){
                 }
 
                 today = day;
-                strncpy(prev_month, mon, 4);
-                prev_month[3] = '\0';
+                snprintf(prev_month, 4, "%s", mon);
                 prev_year = year;
             }
         }

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -906,7 +906,7 @@ void OS_ReadMSG_analysisd(int m_queue)
         os_calloc(1, sizeof(Eventinfo), lf);
         os_calloc(Config.decoder_order_size, sizeof(DynamicField), lf->fields);
         lf->year = prev_year;
-        memcpy(lf->mon, prev_month, sizeof(prev_month));
+        memset(lf->mon, 0, sizeof(lf->mon));
         lf->day = today;
 
         if (OS_GetLogLocation(today, prev_year, prev_month) < 0) {

--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -877,7 +877,8 @@ char *_loadmemory(char *at, char *str, OSList* log_msg)
         size_t strsize = 0;
         if ((strsize = strlen(str)) < OS_SIZE_1024) {
             os_calloc(strsize + 1, sizeof(char), at);
-            strncpy(at, str, strsize);
+            memcpy(at, str, strsize);
+            at[strsize] = '\0';
             return (at);
         } else {
             smerror(log_msg, SIZE_ERROR, str);
@@ -898,7 +899,7 @@ char *_loadmemory(char *at, char *str, OSList* log_msg)
             merror(MEM_ERROR, errno, strerror(errno));
             return (NULL);
         }
-        strncat(at, str, strsize);
+        strncat(at, str, strsize + 1);
         at[finalsize - 1] = '\0';
 
         return (at);

--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -878,7 +878,6 @@ char *_loadmemory(char *at, char *str, OSList* log_msg)
         if ((strsize = strlen(str)) < OS_SIZE_1024) {
             os_calloc(strsize + 1, sizeof(char), at);
             memcpy(at, str, strsize);
-            at[strsize] = '\0';
             return (at);
         } else {
             smerror(log_msg, SIZE_ERROR, str);
@@ -899,8 +898,7 @@ char *_loadmemory(char *at, char *str, OSList* log_msg)
             merror(MEM_ERROR, errno, strerror(errno));
             return (NULL);
         }
-        strncat(at, str, strsize + 1);
-        at[finalsize - 1] = '\0';
+        strcat(at, str);
 
         return (at);
     }

--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -893,7 +893,7 @@ char *_loadmemory(char *at, char *str, OSList* log_msg)
             smerror(log_msg, SIZE_ERROR, str);
             return (NULL);
         }
-        at = (char *) realloc(at, (finalsize + 1) * sizeof(char));
+        at = (char *) realloc(at, finalsize * sizeof(char));
         if (at == NULL) {
             merror(MEM_ERROR, errno, strerror(errno));
             return (NULL);

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -906,7 +906,7 @@ char* ParseRuleComment(Eventinfo *lf) {
         if (n + (z = strlen(str)) >= OS_COMMENT_MAX)
             return strdup(lf->generated_rule->comment);
 
-        strncpy(&final[n], str, z);
+        strncat(final, str, OS_COMMENT_MAX - n);
         n += z;
 
         if (!(end = strchr(var, ')'))) {
@@ -972,7 +972,7 @@ char* ParseRuleComment(Eventinfo *lf) {
             if (n + (z = strlen(field)) >= OS_COMMENT_MAX)
                 return strdup(lf->generated_rule->comment);
 
-            strncpy(&final[n], field, z);
+            strncat(final, field, OS_COMMENT_MAX - n);
             n += z;
         }
     }
@@ -980,7 +980,7 @@ char* ParseRuleComment(Eventinfo *lf) {
     if (n + (z = strlen(str)) >= OS_COMMENT_MAX)
         return strdup(lf->generated_rule->comment);
 
-    strncpy(&final[n], str, z);
+    strncat(final, str, OS_COMMENT_MAX - n);
     final[n + z] = '\0';
     return strdup(final);
 }

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -2033,8 +2033,7 @@ STATIC char *loadmemory(char *at, const char *str, OSList* log_msg)
             return (NULL);
         }
 
-        strncat(at, str, strsize + 1);
-        at[finalsize - 1] = '\0';
+        strcat(at, str);
 
         return (at);
     }

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -2009,7 +2009,7 @@ STATIC char *loadmemory(char *at, const char *str, OSList* log_msg)
                 merror(MEM_ERROR, errno, strerror(errno));
                 return (NULL);
             }
-            strncpy(at, str, strsize);
+            memcpy(at, str, strsize);
             return (at);
         } else {
             smerror(log_msg, SIZE_ERROR, str);
@@ -2033,7 +2033,7 @@ STATIC char *loadmemory(char *at, const char *str, OSList* log_msg)
             return (NULL);
         }
 
-        strncat(at, str, strsize);
+        strncat(at, str, strsize + 1);
         at[finalsize - 1] = '\0';
 
         return (at);

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1258,7 +1258,7 @@ int read_data_unit(const char *content) {
     if (content[len_value_str - 1] == 'B' || content[len_value_str - 1] == 'b') {
         if (isalpha(content[len_value_str - 2])){
             os_calloc(len_value_str, sizeof(char), value_str);
-            strncpy(value_str, content, len_value_str - 2);
+            memcpy(value_str, content, len_value_str - 2);
 
             if (OS_StrIsNum(value_str)) {
                 read_value = atoi(value_str);

--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -46,7 +46,7 @@ static int wm_vuldet_provider_os_list(xml_node **node, vu_os_feed **feeds, char 
 static void wm_vuldet_set_port_to_url(char **url, int port);
 static int wm_vuldet_add_allow_os(update_node *update, char *os_tags);
 static int wm_vuldet_read_provider_content(xml_node **node, char *name, char multi_provider, provider_options *options);
-static char wm_vuldet_provider_type(char *pr_name);
+static int wm_vuldet_provider_type(char *pr_name);
 static void wm_vuldet_remove_os_feed(vu_os_feed *feed, char full_r);
 static void wm_vuldet_remove_os_feed_list(vu_os_feed *feeds);
 static void wm_vuldet_init_provider_options(provider_options *options);
@@ -516,7 +516,7 @@ int wm_vuldet_read_provider(const OS_XML *xml, xml_node *node, update_node **upd
     char *pr_name = NULL;
     vu_os_feed *os_list = NULL;
     int result;
-    char multi_provider;
+    int multi_provider;
     provider_options p_options = { .multi_path = 0 };
     int retval = OS_INVALID;
 
@@ -990,7 +990,7 @@ int wm_vuldet_read_provider_content(xml_node **node, char *name, char multi_prov
     return 0;
 }
 
-char wm_vuldet_provider_type(char *pr_name) {
+int wm_vuldet_provider_type(char *pr_name) {
     if (strcasestr(pr_name, vu_feed_tag[FEED_CANONICAL]) ||
         strcasestr(pr_name, vu_feed_tag[FEED_DEBIAN]) ||
         strcasestr(pr_name, vu_feed_tag[FEED_ALAS]) ||

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -179,6 +179,7 @@
 #define EXEC_INV_JSON   "(1315): Invalid JSON message: '%s'"
 #define EXEC_INV_CMD    "(1316): Invalid AR command: '%s'"
 #define EXEC_CMD_FAIL   "(1317): Could not launch command %s (%d)"
+#define EXEC_BAD_NAME   "(1318): Command name truncated %s"
 
 #define AR_NOAGENT_ERROR                "(1320): Agent '%s' not found."
 #define EXEC_QUEUE_CONNECTION_ERROR     "(1321): Error communicating with queue '%s'."

--- a/src/monitord/rotate_log.c
+++ b/src/monitord/rotate_log.c
@@ -292,7 +292,7 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
             if (mktime(&tm) <= threshold) {
                 size = snprintf(path, sizeof(path), "%s/%s", base_dir, dirent->d_name);
 
-                if (size + 1 <= (int)sizeof(path)) {
+                if (size < (int)sizeof(path)) {
                     mdebug2("Removing old log '%s'", path);
                     unlink(path);
                 }

--- a/src/monitord/rotate_log.c
+++ b/src/monitord/rotate_log.c
@@ -208,9 +208,9 @@ void remove_old_logs(const char *base_dir, int keep_log_days) {
         }
 
         if (sscanf(dirent->d_name, "%d", &year) > 0) {
-            int size = snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
+            int size = snprintf(path, sizeof(path), "%s/%s", base_dir, dirent->d_name);
 
-            if (size < PATH_MAX) {
+            if (size < (int)sizeof(path)) {
                 remove_old_logs_y(path, year, threshold);
             }
         }
@@ -244,9 +244,9 @@ void remove_old_logs_y(const char * base_dir, int year, time_t threshold) {
             }
         }
 
-        int size = snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
+        int size = snprintf(path, sizeof(path), "%s/%s", base_dir, dirent->d_name);
 
-        if (size < PATH_MAX) {
+        if (size < (int)sizeof(path)) {
             if (month < 12) {
                 remove_old_logs_m(path, year, month, threshold);
             } else {
@@ -290,9 +290,9 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
             tm.tm_mday = day;
 
             if (mktime(&tm) <= threshold) {
-                size = snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
+                size = snprintf(path, sizeof(path), "%s/%s", base_dir, dirent->d_name);
 
-                if (size + 1 <= PATH_MAX) {
+                if (size + 1 <= (int)sizeof(path)) {
                     mdebug2("Removing old log '%s'", path);
                     unlink(path);
                 }
@@ -303,9 +303,9 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
             tm.tm_mday = day;
 
             if (mktime(&tm) <= threshold) {
-                size = snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
+                size = snprintf(path, sizeof(path), "%s/%s", base_dir, dirent->d_name);
 
-                if (size < PATH_MAX) {
+                if (size < (int)sizeof(path)) {
                     mdebug2("Removing old log '%s'", path);
                     unlink(path);
                 }
@@ -316,9 +316,9 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
             tm.tm_mday = day;
 
             if (mktime(&tm) <= threshold) {
-                size = snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
+                size = snprintf(path, sizeof(path), "%s/%s", base_dir, dirent->d_name);
 
-                if (size < PATH_MAX) {
+                if (size < (int)sizeof(path)) {
                     mdebug2("Removing old log '%s'", path);
                     unlink(path);
                 }
@@ -329,9 +329,9 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
             tm.tm_mday = day;
 
             if (mktime(&tm) <= threshold) {
-                size = snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
+                size = snprintf(path, sizeof(path), "%s/%s", base_dir, dirent->d_name);
 
-                if (size < PATH_MAX) {
+                if (size < (int)sizeof(path)) {
                     mdebug2("Removing old log '%s'", path);
                     unlink(path);
                 }

--- a/src/monitord/rotate_log.c
+++ b/src/monitord/rotate_log.c
@@ -210,7 +210,7 @@ void remove_old_logs(const char *base_dir, int keep_log_days) {
         if (sscanf(dirent->d_name, "%d", &year) > 0) {
             int size = snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
 
-            if (size + 1 <= PATH_MAX) {
+            if (size < PATH_MAX) {
                 remove_old_logs_y(path, year, threshold);
             }
         }
@@ -246,7 +246,7 @@ void remove_old_logs_y(const char * base_dir, int year, time_t threshold) {
 
         int size = snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
 
-        if (size + 1 <= PATH_MAX) {
+        if (size < PATH_MAX) {
             if (month < 12) {
                 remove_old_logs_m(path, year, month, threshold);
             } else {
@@ -305,7 +305,7 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
             if (mktime(&tm) <= threshold) {
                 size = snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
 
-                if (size + 1 <= PATH_MAX) {
+                if (size < PATH_MAX) {
                     mdebug2("Removing old log '%s'", path);
                     unlink(path);
                 }
@@ -318,7 +318,7 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
             if (mktime(&tm) <= threshold) {
                 size = snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
 
-                if (size + 1 <= PATH_MAX) {
+                if (size < PATH_MAX) {
                     mdebug2("Removing old log '%s'", path);
                     unlink(path);
                 }
@@ -331,7 +331,7 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
             if (mktime(&tm) <= threshold) {
                 size = snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
 
-                if (size + 1 <= PATH_MAX) {
+                if (size < PATH_MAX) {
                     mdebug2("Removing old log '%s'", path);
                     unlink(path);
                 }

--- a/src/monitord/rotate_log.c
+++ b/src/monitord/rotate_log.c
@@ -208,8 +208,11 @@ void remove_old_logs(const char *base_dir, int keep_log_days) {
         }
 
         if (sscanf(dirent->d_name, "%d", &year) > 0) {
-            snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
-            remove_old_logs_y(path, year, threshold);
+            int size = snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
+
+            if (size + 1 <= PATH_MAX) {
+                remove_old_logs_y(path, year, threshold);
+            }
         }
     }
 
@@ -241,12 +244,14 @@ void remove_old_logs_y(const char * base_dir, int year, time_t threshold) {
             }
         }
 
-        snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
+        int size = snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
 
-        if (month < 12) {
-            remove_old_logs_m(path, year, month, threshold);
-        } else {
-            mwarn("Unexpected folder '%s'", path);
+        if (size + 1 <= PATH_MAX) {
+            if (month < 12) {
+                remove_old_logs_m(path, year, month, threshold);
+            } else {
+                mwarn("Unexpected folder '%s'", path);
+            }
         }
     }
 
@@ -261,7 +266,7 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
     time_t now = time(NULL);
     struct tm tm = { .tm_sec = 0 };
     int counter;
-
+    int size = 0;
     localtime_r(&now, &tm);
 
     tm.tm_year = year - 1900;
@@ -285,9 +290,12 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
             tm.tm_mday = day;
 
             if (mktime(&tm) <= threshold) {
-                snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
-                mdebug2("Removing old log '%s'", path);
-                unlink(path);
+                size = snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
+
+                if (size + 1 <= PATH_MAX) {
+                    mdebug2("Removing old log '%s'", path);
+                    unlink(path);
+                }
             }
         }
 
@@ -295,9 +303,12 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
             tm.tm_mday = day;
 
             if (mktime(&tm) <= threshold) {
-                snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
-                mdebug2("Removing old log '%s'", path);
-                unlink(path);
+                size = snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
+
+                if (size + 1 <= PATH_MAX) {
+                    mdebug2("Removing old log '%s'", path);
+                    unlink(path);
+                }
             }
         }
 
@@ -305,9 +316,12 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
             tm.tm_mday = day;
 
             if (mktime(&tm) <= threshold) {
-                snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
-                mdebug2("Removing old log '%s'", path);
-                unlink(path);
+                size = snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
+
+                if (size + 1 <= PATH_MAX) {
+                    mdebug2("Removing old log '%s'", path);
+                    unlink(path);
+                }
             }
         }
 
@@ -315,9 +329,12 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
             tm.tm_mday = day;
 
             if (mktime(&tm) <= threshold) {
-                snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
-                mdebug2("Removing old log '%s'", path);
-                unlink(path);
+                size = snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
+
+                if (size + 1 <= PATH_MAX) {
+                    mdebug2("Removing old log '%s'", path);
+                    unlink(path);
+                }
             }
         }
 

--- a/src/monitord/rotate_log.c
+++ b/src/monitord/rotate_log.c
@@ -266,7 +266,6 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
     time_t now = time(NULL);
     struct tm tm = { .tm_sec = 0 };
     int counter;
-    int size = 0;
     localtime_r(&now, &tm);
 
     tm.tm_year = year - 1900;
@@ -290,7 +289,7 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
             tm.tm_mday = day;
 
             if (mktime(&tm) <= threshold) {
-                size = snprintf(path, sizeof(path), "%s/%s", base_dir, dirent->d_name);
+                const int size = snprintf(path, sizeof(path), "%s/%s", base_dir, dirent->d_name);
 
                 if (size >= 0 && (size_t)size < sizeof(path)) {
                     mdebug2("Removing old log '%s'", path);
@@ -303,7 +302,7 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
             tm.tm_mday = day;
 
             if (mktime(&tm) <= threshold) {
-                size = snprintf(path, sizeof(path), "%s/%s", base_dir, dirent->d_name);
+                const int size = snprintf(path, sizeof(path), "%s/%s", base_dir, dirent->d_name);
 
                 if (size >= 0 && (size_t)size < sizeof(path)) {
                     mdebug2("Removing old log '%s'", path);
@@ -316,7 +315,7 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
             tm.tm_mday = day;
 
             if (mktime(&tm) <= threshold) {
-                size = snprintf(path, sizeof(path), "%s/%s", base_dir, dirent->d_name);
+                const int size = snprintf(path, sizeof(path), "%s/%s", base_dir, dirent->d_name);
 
                 if (size >= 0 && (size_t)size < sizeof(path)) {
                     mdebug2("Removing old log '%s'", path);
@@ -329,7 +328,7 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
             tm.tm_mday = day;
 
             if (mktime(&tm) <= threshold) {
-                size = snprintf(path, sizeof(path), "%s/%s", base_dir, dirent->d_name);
+                const int size = snprintf(path, sizeof(path), "%s/%s", base_dir, dirent->d_name);
 
                 if (size >= 0 && (size_t)size < sizeof(path)) {
                     mdebug2("Removing old log '%s'", path);

--- a/src/monitord/rotate_log.c
+++ b/src/monitord/rotate_log.c
@@ -208,9 +208,9 @@ void remove_old_logs(const char *base_dir, int keep_log_days) {
         }
 
         if (sscanf(dirent->d_name, "%d", &year) > 0) {
-            int size = snprintf(path, sizeof(path), "%s/%s", base_dir, dirent->d_name);
+            const int size = snprintf(path, sizeof(path), "%s/%s", base_dir, dirent->d_name);
 
-            if (size < (int)sizeof(path)) {
+            if (size >= 0 && (size_t)size < sizeof(path)) {
                 remove_old_logs_y(path, year, threshold);
             }
         }
@@ -244,9 +244,9 @@ void remove_old_logs_y(const char * base_dir, int year, time_t threshold) {
             }
         }
 
-        int size = snprintf(path, sizeof(path), "%s/%s", base_dir, dirent->d_name);
+        const int size = snprintf(path, sizeof(path), "%s/%s", base_dir, dirent->d_name);
 
-        if (size < (int)sizeof(path)) {
+        if (size >= 0 && (size_t)size < sizeof(path)) {
             if (month < 12) {
                 remove_old_logs_m(path, year, month, threshold);
             } else {
@@ -292,7 +292,7 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
             if (mktime(&tm) <= threshold) {
                 size = snprintf(path, sizeof(path), "%s/%s", base_dir, dirent->d_name);
 
-                if (size < (int)sizeof(path)) {
+                if (size >= 0 && (size_t)size < sizeof(path)) {
                     mdebug2("Removing old log '%s'", path);
                     unlink(path);
                 }
@@ -305,7 +305,7 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
             if (mktime(&tm) <= threshold) {
                 size = snprintf(path, sizeof(path), "%s/%s", base_dir, dirent->d_name);
 
-                if (size < (int)sizeof(path)) {
+                if (size >= 0 && (size_t)size < sizeof(path)) {
                     mdebug2("Removing old log '%s'", path);
                     unlink(path);
                 }
@@ -318,7 +318,7 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
             if (mktime(&tm) <= threshold) {
                 size = snprintf(path, sizeof(path), "%s/%s", base_dir, dirent->d_name);
 
-                if (size < (int)sizeof(path)) {
+                if (size >= 0 && (size_t)size < sizeof(path)) {
                     mdebug2("Removing old log '%s'", path);
                     unlink(path);
                 }
@@ -331,7 +331,7 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
             if (mktime(&tm) <= threshold) {
                 size = snprintf(path, sizeof(path), "%s/%s", base_dir, dirent->d_name);
 
-                if (size < (int)sizeof(path)) {
+                if (size >= 0 && (size_t)size < sizeof(path)) {
                     mdebug2("Removing old log '%s'", path);
                     unlink(path);
                 }

--- a/src/os_crypto/blowfish/bf_op.c
+++ b/src/os_crypto/blowfish/bf_op.c
@@ -25,7 +25,7 @@ typedef unsigned char uchar;
 int OS_BF_Str(const char *input, char *output, const char *charkey,
               long size, short int action)
 {
-    BF_KEY key = { };
+    BF_KEY key = {.P = {0}};
     static unsigned char cbc_iv [8] = {0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10};
     unsigned char iv[8];
 

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -249,9 +249,9 @@ void OS_ReadKeys(keystore *keys, key_mode_t key_mode, int save_removed)
 
             *tmp_str = '\0';
             tmp_str++;
-            int bytes_written = snprintf(id, sizeof(id), "%s", valid_str);
+            const int bytes_written = snprintf(id, sizeof(id), "%s", valid_str);
 
-            if (bytes_written + 1 > (int)sizeof(id)) {
+            if (bytes_written >= 0 && (size_t)bytes_written >= (int)sizeof(id)) {
                 merror(INVALID_KEY, id);
             }
 

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -249,8 +249,11 @@ void OS_ReadKeys(keystore *keys, key_mode_t key_mode, int save_removed)
 
             *tmp_str = '\0';
             tmp_str++;
-            strncpy(id, valid_str, KEYSIZE);
-            id[KEYSIZE] = '\0';
+            int bytes_written = snprintf(id, sizeof(id), "%s", valid_str);
+
+            if (bytes_written + 1 > (int)sizeof(id)) {
+                merror(INVALID_KEY, id);
+            }
 
             /* Update counter */
 

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -251,11 +251,11 @@ void OS_ReadKeys(keystore *keys, key_mode_t key_mode, int save_removed)
             tmp_str++;
             const int bytes_written = snprintf(id, sizeof(id), "%s", valid_str);
 
-            if ((size_t)bytes_written >= sizeof(id)) {
-                merror(INVALID_KEY, id);
+            if (bytes_written < 0) {
+                merror(INVALID_KEY " Error %d (%s).", id, errno, strerror(errno));
             }
-            else if (bytes_written < 0) {
-                merror("Error %d (%s).", errno, strerror(errno));
+            else if ((size_t)bytes_written >= sizeof(id)) {
+                merror(INVALID_KEY, id);
             }
 
             /* Update counter */

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -251,8 +251,11 @@ void OS_ReadKeys(keystore *keys, key_mode_t key_mode, int save_removed)
             tmp_str++;
             const int bytes_written = snprintf(id, sizeof(id), "%s", valid_str);
 
-            if (bytes_written >= 0 && (size_t)bytes_written >= (int)sizeof(id)) {
+            if ((size_t)bytes_written >= sizeof(id)) {
                 merror(INVALID_KEY, id);
+            }
+            else if (bytes_written < 0) {
+                merror("Error %d (%s).", errno, strerror(errno));
             }
 
             /* Update counter */

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -249,7 +249,8 @@ void OS_ReadKeys(keystore *keys, key_mode_t key_mode, int save_removed)
 
             *tmp_str = '\0';
             tmp_str++;
-            strncpy(id, valid_str, KEYSIZE - 1);
+            strncpy(id, valid_str, KEYSIZE);
+            id[KEYSIZE] = '\0';
 
             /* Update counter */
 

--- a/src/os_execd/exec.c
+++ b/src/os_execd/exec.c
@@ -69,7 +69,13 @@ int ReadExecConfig()
         tmp_str += 3;
 
         /* Set the name */
-        strncpy(exec_names[exec_size], str_pt, OS_FLSIZE);
+        if (strlen(str_pt) <= OS_FLSIZE) {
+            strncpy(exec_names[exec_size], str_pt, OS_FLSIZE);
+        }
+        else {
+            memcpy(exec_names[exec_size], str_pt, OS_FLSIZE);
+        }
+
         exec_names[exec_size][OS_FLSIZE] = '\0';
 
         str_pt = tmp_str;

--- a/src/os_execd/exec.c
+++ b/src/os_execd/exec.c
@@ -69,14 +69,11 @@ int ReadExecConfig()
         tmp_str += 3;
 
         /* Set the name */
-        if (strlen(str_pt) <= OS_FLSIZE) {
-            strncpy(exec_names[exec_size], str_pt, OS_FLSIZE);
-        }
-        else {
-            memcpy(exec_names[exec_size], str_pt, OS_FLSIZE);
-        }
+        int bytes_written = snprintf(exec_names[exec_size], sizeof(exec_names[exec_size]), "%s", str_pt);
 
-        exec_names[exec_size][OS_FLSIZE] = '\0';
+        if ((size_t)bytes_written + 1 > sizeof(exec_names[exec_size])) {
+            merror(EXEC_BAD_NAME, exec_names[exec_size]);
+        }
 
         str_pt = tmp_str;
 

--- a/src/os_execd/exec.c
+++ b/src/os_execd/exec.c
@@ -71,8 +71,11 @@ int ReadExecConfig()
         /* Set the name */
         const int bytes_written = snprintf(exec_names[exec_size], sizeof(exec_names[exec_size]), "%s", str_pt);
 
-        if (bytes_written >= 0 && (size_t)bytes_written >= sizeof(exec_names[exec_size])) {
+        if ((size_t)bytes_written >= sizeof(exec_names[exec_size])) {
             merror(EXEC_BAD_NAME, exec_names[exec_size]);
+        }
+        else if (bytes_written < 0) {
+            merror("Error %d (%s).", errno, strerror(errno));
         }
 
         str_pt = tmp_str;

--- a/src/os_execd/exec.c
+++ b/src/os_execd/exec.c
@@ -71,11 +71,11 @@ int ReadExecConfig()
         /* Set the name */
         const int bytes_written = snprintf(exec_names[exec_size], sizeof(exec_names[exec_size]), "%s", str_pt);
 
-        if ((size_t)bytes_written >= sizeof(exec_names[exec_size])) {
-            merror(EXEC_BAD_NAME, exec_names[exec_size]);
+        if (bytes_written < 0) {
+            merror(EXEC_BAD_NAME " Error %d (%s).", exec_names[exec_size], errno, strerror(errno));
         }
-        else if (bytes_written < 0) {
-            merror("Error %d (%s).", errno, strerror(errno));
+        else if ((size_t)bytes_written >= sizeof(exec_names[exec_size])) {
+            merror(EXEC_BAD_NAME, exec_names[exec_size]);
         }
 
         str_pt = tmp_str;

--- a/src/os_execd/exec.c
+++ b/src/os_execd/exec.c
@@ -69,9 +69,9 @@ int ReadExecConfig()
         tmp_str += 3;
 
         /* Set the name */
-        int bytes_written = snprintf(exec_names[exec_size], sizeof(exec_names[exec_size]), "%s", str_pt);
+        const int bytes_written = snprintf(exec_names[exec_size], sizeof(exec_names[exec_size]), "%s", str_pt);
 
-        if ((size_t)bytes_written + 1 > sizeof(exec_names[exec_size])) {
+        if (bytes_written >= 0 && (size_t)bytes_written >= sizeof(exec_names[exec_size])) {
             merror(EXEC_BAD_NAME, exec_names[exec_size]);
         }
 

--- a/src/os_execd/exec.c
+++ b/src/os_execd/exec.c
@@ -73,8 +73,7 @@ int ReadExecConfig()
 
         if (bytes_written < 0) {
             merror(EXEC_BAD_NAME " Error %d (%s).", exec_names[exec_size], errno, strerror(errno));
-        }
-        else if ((size_t)bytes_written >= sizeof(exec_names[exec_size])) {
+        } else if ((size_t)bytes_written >= sizeof(exec_names[exec_size])) {
             merror(EXEC_BAD_NAME, exec_names[exec_size]);
         }
 

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -331,7 +331,7 @@ MailMsg *OS_RecvMailQ(file_queue *fileq, struct tm *p, MailConfig *Mail, MailMsg
                  al_data->comment);
 
 
-        strncpy(msg_sms_tmp->body, logs, 128);
+        strncpy(msg_sms_tmp->body, logs, BODY_SIZE - 1);
         msg_sms_tmp->body[127] = '\0';
         *msg_sms = msg_sms_tmp;
     }
@@ -694,7 +694,7 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
                  alert_desc);
 
 
-        strncpy(msg_sms_tmp->body, logs, 128);
+        strncpy(msg_sms_tmp->body, logs, BODY_SIZE - 1);
         msg_sms_tmp->body[127] = '\0';
         *msg_sms = msg_sms_tmp;
     }
@@ -732,7 +732,8 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
 
     /* Like tab, tab_child is used to derterminate the number of times a line must be tabbed. */
     os_malloc(256*sizeof(char), tab_child);
-    strncpy(tab_child, tab, 256*sizeof(char));
+    strncpy(tab_child, tab, 256*sizeof(char)-1);
+    tab_child[256*sizeof(char)-1] = '\0';
 
 
     /* If final node, it print */
@@ -744,12 +745,16 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
         log_size = strlen(key) + strlen(tab) + strlen(item->string) + strlen(delimitator) + strlen(endline);
 
         if (body_size > log_size) {
-            strncat(printed, tab, strlen(tab));
-            strncat(printed, item->string, strlen(item->string));
-            strncat(printed, delimitator, strlen(delimitator));
+            strncat(printed, tab, body_size);
+            body_size -= strlen(tab);
+            strncat(printed, item->string, body_size);
+            body_size -= strlen(item->string);
+            strncat(printed, delimitator,body_size);
+            body_size -= strlen(delimitator);
             strncat(printed, key, body_size);
-            strncat(printed, endline, strlen(endline));
-            body_size -= log_size;
+            body_size -= strlen(key);
+            strncat(printed, endline, body_size);
+            body_size -= strlen(endline);
         }
 
         free(key);
@@ -762,10 +767,12 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
 
         if(body_size > log_size){
             item->string[0] = toupper(item->string[0]);
-            strncat(printed, tab, strlen(tab));
-            strncat(printed, item->string, strlen(item->string));
-            strncat(printed, delimitator, strlen(delimitator));
-            body_size -= log_size;
+            strncat(printed, tab, body_size);
+            body_size -= strlen(tab);
+            strncat(printed, item->string, body_size);
+            body_size -= strlen(item->string);
+            strncat(printed, delimitator, body_size);
+            body_size -= strlen(delimitator);
         }
 
         while(json_array = cJSON_GetArrayItem(item, i), json_array){
@@ -774,8 +781,9 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
 
             if(body_size > log_size){
                 strncat(printed, json_array->valuestring, body_size);
-                strncat(printed, space, strlen(space));
-                body_size -= log_size;
+                body_size -= strlen(json_array->valuestring);
+                strncat(printed, space,body_size);
+                body_size -= strlen(space);
             }
 
             free(key);
@@ -783,8 +791,8 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
         }
 
         if(body_size > strlen(endline)){
-            strncat(printed, endline, strlen(endline));
-            body_size -= log_size;
+            strncat(printed, endline, body_size);
+            body_size -= strlen(endline);
         }
 
     }
@@ -797,10 +805,12 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
 
                 if (body_size > log_size) {
                     item->string[0] = toupper(item->string[0]);
-                    strncat(printed, tab, strlen(tab));
-                    strncat(printed, item->string, strlen(item->string));
-                    strncat(printed, endline, strlen(endline));
-                    body_size -= log_size;
+                    strncat(printed, tab, body_size);
+                    body_size -= strlen(tab);
+                    strncat(printed, item->string, body_size);
+                    body_size -= strlen(item->string);
+                    strncat(printed, endline, body_size);
+                    body_size -= strlen(endline);
                 }
             }
             /*Cannot be tabulated more than 6 times in the message */

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -330,9 +330,7 @@ MailMsg *OS_RecvMailQ(file_queue *fileq, struct tm *p, MailConfig *Mail, MailMsg
                  al_data->rule,
                  al_data->comment);
 
-
-        strncpy(msg_sms_tmp->body, logs, BODY_SIZE - 1);
-        msg_sms_tmp->body[127] = '\0';
+        snprintf(msg_sms_tmp->body, BODY_SIZE, "%.128s", logs);
         *msg_sms = msg_sms_tmp;
     }
 

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -742,7 +742,7 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
 
         if (body_size > log_size) {
             snprintf(printed + strlen(printed), body_size, "%s%s%s%s%s", tab, item->string, delimitator, key, endline);
-            body_size -= strlen(tab) + strlen(item->string) + strlen(delimitator) + strlen(key) + strlen(endline);
+            body_size -= log_size;
         }
 
         free(key);
@@ -756,7 +756,7 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
         if(body_size > log_size){
             item->string[0] = toupper(item->string[0]);
             snprintf(printed + strlen(printed), body_size, "%s%s%s", tab, item->string, delimitator);
-            body_size -= strlen(tab) + strlen(item->string) + strlen(delimitator);
+            body_size -= log_size;
         }
 
         while(json_array = cJSON_GetArrayItem(item, i), json_array){
@@ -764,8 +764,8 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
             log_size = strlen(key) + strlen(space);
 
             if(body_size > log_size){
-                snprintf(printed + strlen(printed), body_size, "%s%s", json_array->valuestring, space);
-                body_size -= strlen(json_array->valuestring) + strlen(space);
+                snprintf(printed + strlen(printed), body_size, "%s%s", key, space);
+                body_size -= log_size;
             }
 
             free(key);
@@ -788,7 +788,7 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
                 if (body_size > log_size) {
                     item->string[0] = toupper(item->string[0]);
                     snprintf(printed + strlen(printed), body_size, "%s%s%s", tab, item->string, endline);
-                    body_size -= strlen(tab) + strlen(item->string) + strlen(endline);
+                    body_size -= log_size;
                 }
             }
             /*Cannot be tabulated more than 6 times in the message */

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -330,7 +330,7 @@ MailMsg *OS_RecvMailQ(file_queue *fileq, struct tm *p, MailConfig *Mail, MailMsg
                  al_data->rule,
                  al_data->comment);
 
-        snprintf(msg_sms_tmp->body, BODY_SIZE, "%.128s", logs);
+        snprintf(msg_sms_tmp->body, BODY_SIZE, "%.127s", logs);
         *msg_sms = msg_sms_tmp;
     }
 
@@ -691,9 +691,7 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
                  rule_id,
                  alert_desc);
 
-
-        strncpy(msg_sms_tmp->body, logs, BODY_SIZE - 1);
-        msg_sms_tmp->body[127] = '\0';
+        snprintf(msg_sms_tmp->body, BODY_SIZE, "%.127s", logs);
         *msg_sms = msg_sms_tmp;
     }
 
@@ -743,16 +741,8 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
         log_size = strlen(key) + strlen(tab) + strlen(item->string) + strlen(delimitator) + strlen(endline);
 
         if (body_size > log_size) {
-            strncat(printed, tab, body_size);
-            body_size -= strlen(tab);
-            strncat(printed, item->string, body_size);
-            body_size -= strlen(item->string);
-            strncat(printed, delimitator,body_size);
-            body_size -= strlen(delimitator);
-            strncat(printed, key, body_size);
-            body_size -= strlen(key);
-            strncat(printed, endline, body_size);
-            body_size -= strlen(endline);
+            snprintf(printed + strlen(printed), body_size, "%s%s%s%s%s", tab, item->string, delimitator, key, endline);
+            body_size -= strlen(tab) + strlen(item->string) + strlen(delimitator) + strlen(key) + strlen(endline);
         }
 
         free(key);
@@ -765,12 +755,8 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
 
         if(body_size > log_size){
             item->string[0] = toupper(item->string[0]);
-            strncat(printed, tab, body_size);
-            body_size -= strlen(tab);
-            strncat(printed, item->string, body_size);
-            body_size -= strlen(item->string);
-            strncat(printed, delimitator, body_size);
-            body_size -= strlen(delimitator);
+            snprintf(printed + strlen(printed), body_size, "%s%s%s", tab, item->string, delimitator);
+            body_size -= strlen(tab) + strlen(item->string) + strlen(delimitator);
         }
 
         while(json_array = cJSON_GetArrayItem(item, i), json_array){
@@ -778,10 +764,8 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
             log_size = strlen(key) + strlen(space);
 
             if(body_size > log_size){
-                strncat(printed, json_array->valuestring, body_size);
-                body_size -= strlen(json_array->valuestring);
-                strncat(printed, space,body_size);
-                body_size -= strlen(space);
+                snprintf(printed + strlen(printed), body_size, "%s%s", json_array->valuestring, space);
+                body_size -= strlen(json_array->valuestring) + strlen(space);
             }
 
             free(key);
@@ -803,12 +787,8 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
 
                 if (body_size > log_size) {
                     item->string[0] = toupper(item->string[0]);
-                    strncat(printed, tab, body_size);
-                    body_size -= strlen(tab);
-                    strncat(printed, item->string, body_size);
-                    body_size -= strlen(item->string);
-                    strncat(printed, endline, body_size);
-                    body_size -= strlen(endline);
+                    snprintf(printed + strlen(printed), body_size, "%s%s%s", tab, item->string, endline);
+                    body_size -= strlen(tab) + strlen(item->string) + strlen(endline);
                 }
             }
             /*Cannot be tabulated more than 6 times in the message */

--- a/src/os_xml/os_xml.c
+++ b/src/os_xml/os_xml.c
@@ -502,12 +502,13 @@ fail:
 
 static int _writecontent(const char *str, size_t size, unsigned int parent, OS_XML *_lxml)
 {
-    _lxml->ct[parent] = (char *)calloc(size, sizeof(char));
+    _lxml->ct[parent] = (char *)calloc(size + 1, sizeof(char));
     if ( _lxml->ct[parent] == NULL) {
         snprintf(_lxml->err, XML_ERR_LENGTH, "XMLERR: Memory error.");
         return (-1);
     }
-    strncpy(_lxml->ct[parent], str, size - 1);
+    strncpy(_lxml->ct[parent], str, size);
+    _lxml->ct[parent][size] = '\0';
 
     return (0);
 }

--- a/src/os_xml/os_xml.c
+++ b/src/os_xml/os_xml.c
@@ -507,9 +507,8 @@ static int _writecontent(const char *str, size_t size, unsigned int parent, OS_X
         snprintf(_lxml->err, XML_ERR_LENGTH, "XMLERR: Memory error.");
         return (-1);
     }
-    strncpy(_lxml->ct[parent], str, size);
-    _lxml->ct[parent][size] = '\0';
 
+    snprintf(_lxml->ct[parent], size + 1, "%s", str);
     return (0);
 }
 

--- a/src/os_xml/os_xml.c
+++ b/src/os_xml/os_xml.c
@@ -22,7 +22,7 @@
 
 /* Prototypes */
 static int _oscomment(OS_XML *_lxml) __attribute__((nonnull));
-static int _writecontent(const char *str, size_t size, unsigned int parent, OS_XML *_lxml) __attribute__((nonnull));
+static int _writecontent(const char *str, __attribute__((unused)) size_t size, unsigned int parent, OS_XML *_lxml) __attribute__((nonnull));
 static int _writememory(const char *str, XML_TYPE type, size_t size,
                         unsigned int parent, OS_XML *_lxml) __attribute__((nonnull));
 static int _xml_fgetc(FILE *fp, OS_XML *_lxml) __attribute__((nonnull));
@@ -500,9 +500,9 @@ fail:
     return (-1);
 }
 
-static int _writecontent(const char *str, size_t size, unsigned int parent, OS_XML *_lxml)
+static int _writecontent(const char *str, __attribute__((unused)) size_t size, unsigned int parent, OS_XML *_lxml)
 {
-    _lxml->ct[parent] = strndup(str, size);
+    _lxml->ct[parent] = strdup(str);
 
     if ( _lxml->ct[parent] == NULL) {
         snprintf(_lxml->err, XML_ERR_LENGTH, "XMLERR: Memory error.");

--- a/src/os_xml/os_xml.c
+++ b/src/os_xml/os_xml.c
@@ -502,13 +502,13 @@ fail:
 
 static int _writecontent(const char *str, size_t size, unsigned int parent, OS_XML *_lxml)
 {
-    _lxml->ct[parent] = (char *)calloc(size + 1, sizeof(char));
+    _lxml->ct[parent] = strndup(str, size);
+
     if ( _lxml->ct[parent] == NULL) {
         snprintf(_lxml->err, XML_ERR_LENGTH, "XMLERR: Memory error.");
         return (-1);
     }
 
-    snprintf(_lxml->ct[parent], size + 1, "%s", str);
     return (0);
 }
 

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -514,8 +514,10 @@ STATIC void c_group(const char *group, char ** files, file_sum ***_f_sum, char *
         if (OS_MD5_File(merged, md5sum, OS_TEXT) != 0) {
             f_sum[0]->sum[0] = '\0';
             merror("Accessing file '%s'", merged);
-        } else {
-            strncpy(f_sum[0]->sum, md5sum, 32);
+        }
+        else{
+            strncpy(f_sum[0]->sum, md5sum, 33);
+            f_sum[0]->sum[32] = '\0';
             os_strdup(SHAREDCFG_FILENAME, f_sum[0]->name);
         }
 
@@ -532,7 +534,8 @@ STATIC void c_group(const char *group, char ** files, file_sum ***_f_sum, char *
             os_realloc(f_sum, (f_size + 2) * sizeof(file_sum *), f_sum);
             *_f_sum = f_sum;
             os_calloc(1, sizeof(file_sum), f_sum[f_size]);
-            strncpy(f_sum[f_size]->sum, md5sum, 32);
+            strncpy(f_sum[f_size]->sum, md5sum, 33);
+            f_sum[f_size]->sum[32] = '\0';
             os_strdup(DEFAULTAR_FILE, f_sum[f_size]->name);
             f_sum[f_size + 1] = NULL;
 
@@ -607,7 +610,8 @@ STATIC void c_group(const char *group, char ** files, file_sum ***_f_sum, char *
                 os_realloc(f_sum, (f_size + 2) * sizeof(file_sum *), f_sum);
                 *_f_sum = f_sum;
                 os_calloc(1, sizeof(file_sum), f_sum[f_size]);
-                strncpy(f_sum[f_size]->sum, md5sum, 32);
+                strncpy(f_sum[f_size]->sum, md5sum, 33);
+                f_sum[f_size]->sum[32] = '\0';
                 os_strdup(files[i], f_sum[f_size]->name);
 
                 if (create_merged) {
@@ -632,7 +636,8 @@ STATIC void c_group(const char *group, char ** files, file_sum ***_f_sum, char *
             f_sum[0]->sum[0] = '\0';
         }
 
-        strncpy(f_sum[0]->sum, md5sum, 32);
+        strncpy(f_sum[0]->sum, md5sum, 33);
+        f_sum[0]->sum[32] = '\0';
         os_strdup(SHAREDCFG_FILENAME, f_sum[0]->name);
     }
 }
@@ -1115,7 +1120,8 @@ STATIC group_t* find_group_from_file(const char * file, const char * md5, char g
         if (f_sum) {
             for (j = 0; f_sum[j]; j++) {
                 if (!(strcmp(f_sum[j]->name, file) || strcmp(f_sum[j]->sum, md5))) {
-                    strncpy(group, groups[i]->name, OS_SIZE_65536);
+                    strncpy(group, groups[i]->name, OS_SIZE_65536 - 1);
+                    group[OS_SIZE_65536 - 1] = '\0';
                     return groups[i];
                 }
             }
@@ -1134,7 +1140,7 @@ STATIC group_t* find_multi_group_from_file(const char * file, const char * md5, 
         if (f_sum) {
             for (j = 0; f_sum[j]; j++) {
                 if (!(strcmp(f_sum[j]->name, file) || strcmp(f_sum[j]->sum, md5))) {
-                    strncpy(multigroup, multi_groups[i]->name, OS_SIZE_65536);
+                    snprintf(multigroup, OS_SIZE_65536, "%s", multi_groups[i]->name);
                     return multi_groups[i];
                 }
             }

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -1118,8 +1118,7 @@ STATIC group_t* find_group_from_file(const char * file, const char * md5, char g
         if (f_sum) {
             for (j = 0; f_sum[j]; j++) {
                 if (!(strcmp(f_sum[j]->name, file) || strcmp(f_sum[j]->sum, md5))) {
-                    strncpy(group, groups[i]->name, OS_SIZE_65536 - 1);
-                    group[OS_SIZE_65536 - 1] = '\0';
+                    snprintf(group, OS_SIZE_65536, "%s", groups[i]->name);
                     return groups[i];
                 }
             }

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -514,10 +514,8 @@ STATIC void c_group(const char *group, char ** files, file_sum ***_f_sum, char *
         if (OS_MD5_File(merged, md5sum, OS_TEXT) != 0) {
             f_sum[0]->sum[0] = '\0';
             merror("Accessing file '%s'", merged);
-        }
-        else{
-            strncpy(f_sum[0]->sum, md5sum, sizeof(f_sum[0]->sum));
-            f_sum[0]->sum[sizeof(f_sum[0]->sum) - 1] = '\0';
+        } else{
+            snprintf(f_sum[0]->sum, sizeof(f_sum[0]->sum), "%s", md5sum);
             os_strdup(SHAREDCFG_FILENAME, f_sum[0]->name);
         }
 
@@ -534,8 +532,7 @@ STATIC void c_group(const char *group, char ** files, file_sum ***_f_sum, char *
             os_realloc(f_sum, (f_size + 2) * sizeof(file_sum *), f_sum);
             *_f_sum = f_sum;
             os_calloc(1, sizeof(file_sum), f_sum[f_size]);
-            strncpy(f_sum[f_size]->sum, md5sum, sizeof(f_sum[f_size]->sum));
-            f_sum[f_size]->sum[sizeof(f_sum[f_size]->sum) - 1] = '\0';
+            snprintf(f_sum[f_size]->sum, sizeof(f_sum[f_size]->sum), "%s", md5sum);
             os_strdup(DEFAULTAR_FILE, f_sum[f_size]->name);
             f_sum[f_size + 1] = NULL;
 
@@ -610,8 +607,7 @@ STATIC void c_group(const char *group, char ** files, file_sum ***_f_sum, char *
                 os_realloc(f_sum, (f_size + 2) * sizeof(file_sum *), f_sum);
                 *_f_sum = f_sum;
                 os_calloc(1, sizeof(file_sum), f_sum[f_size]);
-                strncpy(f_sum[f_size]->sum, md5sum, sizeof(f_sum[f_size]->sum));
-                f_sum[f_size]->sum[sizeof(f_sum[f_size]->sum) - 1] = '\0';
+                snprintf(f_sum[f_size]->sum, sizeof(f_sum[f_size]->sum), "%s", md5sum);
                 os_strdup(files[i], f_sum[f_size]->name);
 
                 if (create_merged) {
@@ -636,8 +632,7 @@ STATIC void c_group(const char *group, char ** files, file_sum ***_f_sum, char *
             f_sum[0]->sum[0] = '\0';
         }
 
-        strncpy(f_sum[0]->sum, md5sum,sizeof(f_sum[0]->sum));
-        f_sum[0]->sum[sizeof(f_sum[0]->sum) - 1] = '\0';
+        snprintf(f_sum[0]->sum, sizeof(f_sum[0]->sum), "%s", md5sum);
         os_strdup(SHAREDCFG_FILENAME, f_sum[0]->name);
     }
 }
@@ -1325,11 +1320,8 @@ static int send_file_toagent(const char *agent_id, const char *group, const char
             snprintf(file, OS_SIZE_1024, "%s/%s/%s", sharedcfg_dir, multi_group_hash_pt, name);
         } else {
             OS_SHA256_String(group, multi_group_hash);
-            char _hash[9] = {0};
-            strncpy(_hash, multi_group_hash, sizeof(_hash));
-            _hash[sizeof(_hash) - 1] = '\0';
-            OSHash_Add_ex(m_hash, group, strdup(_hash));
-            snprintf(file, OS_SIZE_1024, "%s/%s/%s", sharedcfg_dir, _hash, name);
+            OSHash_Add_ex(m_hash, group, strndup(multi_group_hash, 8));
+            snprintf(file, OS_SIZE_1024, "%s/%.8s/%s", sharedcfg_dir, multi_group_hash, name);
         }
     } else {
         snprintf(file, OS_SIZE_1024, "%s/%s/%s", sharedcfg_dir, group, name);

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -1038,7 +1038,6 @@ STATIC void process_deleted_groups() {
 
 STATIC void process_deleted_multi_groups() {
     char multi_path[PATH_MAX] = {0};
-    char _hash[9] = {0};
     os_sha256 multi_group_hash;
     bool update = 0;
     unsigned int i;
@@ -1071,8 +1070,7 @@ STATIC void process_deleted_multi_groups() {
                 multi_groups_size++;
             } else {
                 OS_SHA256_String(old_multi_groups[i]->name, multi_group_hash);
-                strncpy(_hash, multi_group_hash, 8);
-                snprintf(multi_path, PATH_MAX,"%s/%s", MULTIGROUPS_DIR, _hash);
+                snprintf(multi_path, PATH_MAX,"%s/%.8s", MULTIGROUPS_DIR, multi_group_hash);
                 rmdir_ex(multi_path);
                 free_file_sum(old_multi_groups[i]->f_sum);
                 os_free(old_multi_groups[i]->name);
@@ -1329,7 +1327,8 @@ static int send_file_toagent(const char *agent_id, const char *group, const char
         } else {
             OS_SHA256_String(group, multi_group_hash);
             char _hash[9] = {0};
-            strncpy(_hash, multi_group_hash, 8);
+            strncpy(_hash, multi_group_hash, sizeof(_hash));
+            _hash[sizeof(_hash) - 1] = '\0';
             OSHash_Add_ex(m_hash, group, strdup(_hash));
             snprintf(file, OS_SIZE_1024, "%s/%s/%s", sharedcfg_dir, _hash, name);
         }

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -516,8 +516,8 @@ STATIC void c_group(const char *group, char ** files, file_sum ***_f_sum, char *
             merror("Accessing file '%s'", merged);
         }
         else{
-            strncpy(f_sum[0]->sum, md5sum, 33);
-            f_sum[0]->sum[32] = '\0';
+            strncpy(f_sum[0]->sum, md5sum, sizeof(f_sum[0]->sum));
+            f_sum[0]->sum[sizeof(f_sum[0]->sum) - 1] = '\0';
             os_strdup(SHAREDCFG_FILENAME, f_sum[0]->name);
         }
 
@@ -534,8 +534,8 @@ STATIC void c_group(const char *group, char ** files, file_sum ***_f_sum, char *
             os_realloc(f_sum, (f_size + 2) * sizeof(file_sum *), f_sum);
             *_f_sum = f_sum;
             os_calloc(1, sizeof(file_sum), f_sum[f_size]);
-            strncpy(f_sum[f_size]->sum, md5sum, 33);
-            f_sum[f_size]->sum[32] = '\0';
+            strncpy(f_sum[f_size]->sum, md5sum, sizeof(f_sum[f_size]->sum));
+            f_sum[f_size]->sum[sizeof(f_sum[f_size]->sum) - 1] = '\0';
             os_strdup(DEFAULTAR_FILE, f_sum[f_size]->name);
             f_sum[f_size + 1] = NULL;
 
@@ -610,8 +610,8 @@ STATIC void c_group(const char *group, char ** files, file_sum ***_f_sum, char *
                 os_realloc(f_sum, (f_size + 2) * sizeof(file_sum *), f_sum);
                 *_f_sum = f_sum;
                 os_calloc(1, sizeof(file_sum), f_sum[f_size]);
-                strncpy(f_sum[f_size]->sum, md5sum, 33);
-                f_sum[f_size]->sum[32] = '\0';
+                strncpy(f_sum[f_size]->sum, md5sum, sizeof(f_sum[f_size]->sum));
+                f_sum[f_size]->sum[sizeof(f_sum[f_size]->sum) - 1] = '\0';
                 os_strdup(files[i], f_sum[f_size]->name);
 
                 if (create_merged) {
@@ -636,8 +636,8 @@ STATIC void c_group(const char *group, char ** files, file_sum ***_f_sum, char *
             f_sum[0]->sum[0] = '\0';
         }
 
-        strncpy(f_sum[0]->sum, md5sum, 33);
-        f_sum[0]->sum[32] = '\0';
+        strncpy(f_sum[0]->sum, md5sum,sizeof(f_sum[0]->sum));
+        f_sum[0]->sum[sizeof(f_sum[0]->sum) - 1] = '\0';
         os_strdup(SHAREDCFG_FILENAME, f_sum[0]->name);
     }
 }

--- a/src/remoted/netbuffer.c
+++ b/src/remoted/netbuffer.c
@@ -184,10 +184,11 @@ int nb_queue(netbuffer_t * buffer, int socket, char * crypt_msg, ssize_t msg_siz
     int retval = -1;
     int header_size = sizeof(uint32_t);
     char data[msg_size + header_size];
+    const uint32_t bytes = wnet_order(msg_size);
 
     memcpy((data + header_size), crypt_msg, msg_size);
     // Add header at begining, first 4 bytes, it is message msg_size
-    *(uint32_t *)(data) = wnet_order(msg_size);
+    memcpy(data, &bytes, header_size);
 
     w_mutex_lock(&mutex);
 

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -478,9 +478,9 @@ STATIC void HandleSecureMessage(char *buffer, int recv_b, struct sockaddr_storag
             int id = OS_IsAllowedID(&keys, buffer + 1);
 
             if (id < 0) {
-                strncpy(agname, "unknown", sizeof(agname));
+                strncpy(agname, "unknown", sizeof(agname) - 1);
             } else {
-                strncpy(agname, keys.keyentries[id]->name, sizeof(agname));
+                strncpy(agname, keys.keyentries[id]->name, sizeof(agname) - 1);
             }
 
             key_unlock();

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -478,14 +478,12 @@ STATIC void HandleSecureMessage(char *buffer, int recv_b, struct sockaddr_storag
             int id = OS_IsAllowedID(&keys, buffer + 1);
 
             if (id < 0) {
-                strncpy(agname, "unknown", sizeof(agname) - 1);
+                snprintf(agname, sizeof(agname), "unknown");
             } else {
-                strncpy(agname, keys.keyentries[id]->name, sizeof(agname) - 1);
+                snprintf(agname, sizeof(agname), "%s", keys.keyentries[id]->name);
             }
 
             key_unlock();
-
-            agname[sizeof(agname) - 1] = '\0';
 
             mwarn(ENC_IP_ERROR, buffer + 1, srcip, agname);
 

--- a/src/rootcheck/check_rc_if.c
+++ b/src/rootcheck/check_rc_if.c
@@ -57,10 +57,9 @@ void check_rc_if()
 {
     int _fd, _errors = 0, _total = 0;
     struct ifreq tmp_str[16];
-
+    const int max_if = sizeof(tmp_str)/sizeof(struct ifreq);
+    int index = 0;
     struct ifconf _if;
-    struct ifreq *_ir;
-    struct ifreq *_ifend;
     struct ifreq _ifr;
 
     _fd = socket(AF_INET, SOCK_DGRAM, 0);
@@ -79,12 +78,9 @@ void check_rc_if()
         return;
     }
 
-    _ifend = (struct ifreq *) (void *) ((char *)tmp_str + _if.ifc_len);
-    _ir = tmp_str;
-
     /* Loop over all interfaces */
-    for (; _ir < _ifend; _ir++) {
-        strncpy(_ifr.ifr_name, _ir->ifr_name, sizeof(_ifr.ifr_name));
+    for (index = 0; index < max_if; index++) {
+        memcpy(_ifr.ifr_name, tmp_str[index].ifr_name, sizeof(_ifr.ifr_name));
 
         /* Get information from each interface */
         if (ioctl(_fd, SIOCGIFFLAGS, (char *)&_ifr) == -1) {
@@ -108,6 +104,7 @@ void check_rc_if()
             _errors++;
         }
     }
+
     close(_fd);
 
     if (_errors == 0) {

--- a/src/rootcheck/common.c
+++ b/src/rootcheck/common.c
@@ -451,7 +451,7 @@ int is_file(char *file_name)
     DIR     *dp = NULL;
 
     if (!file_name) {
-        mterror(ARGV0, "RK: Invalid file name: %s!", file_name);
+        mterror(ARGV0, "RK: Invalid file name: NULL!");
         return ret;
     }
 

--- a/src/rootcheck/common.c
+++ b/src/rootcheck/common.c
@@ -451,7 +451,7 @@ int is_file(char *file_name)
     DIR     *dp = NULL;
 
     if (!file_name) {
-        mterror(ARGV0, "RK: Invalid file name: NULL!");
+        mtdebug2(ARGV0, "RK: Invalid file name: NULL!");
         return ret;
     }
 

--- a/src/shared/custom_output_search_replace.c
+++ b/src/shared/custom_output_search_replace.c
@@ -48,7 +48,7 @@ char *searchAndReplace(const char *orig, const char *search, const char *value)
         total_bytes_allocated += value_len;
         os_realloc(tmp, total_bytes_allocated, tmp);
 
-        strncpy(tmp + tmp_offset, value, value_len);
+        strncpy(tmp + tmp_offset, value, total_bytes_allocated - tmp_offset);
         tmp_offset += value_len;
 
         /* Search for further occurrences */

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -39,7 +39,7 @@ static int w_enrollment_process_response(SSL *ssl);
 /* Auxiliary */
 static void w_enrollment_verify_ca_certificate(const SSL *ssl, const char *ca_cert, const char *hostname);
 static void w_enrollment_concat_group(char *buff, const char* centralized_group);
-static int w_enrollment_concat_src_ip(char *buff, const size_t size_buff, const char* sender_ip, const int use_src_ip);
+static int w_enrollment_concat_src_ip(char *buff, const size_t remain_size, const char* sender_ip, const int use_src_ip);
 static void w_enrollment_concat_key(char *buff, keyentry* key);
 static int w_enrollment_process_agent_key(char *buffer);
 static int w_enrollment_store_key_entry(const char* keys);
@@ -531,11 +531,12 @@ static void w_enrollment_concat_group(char *buff, const char* centralized_group)
  *
  * @param buff buffer where the IP section will be concatenated
  * @param sender_ip Sender IP, if null it will be filled with "src"
+ * @param remain_size Remain size of buffer. It is buffer_size - strlen(buffer)
  * @return return code
  * @retval 0 on success
  * @retval -1 if ip is invalid
  */
-static int w_enrollment_concat_src_ip(char *buff, const size_t size_buff, const char* sender_ip, const int use_src_ip) {
+static int w_enrollment_concat_src_ip(char *buff, const size_t remain_size, const char* sender_ip, const int use_src_ip) {
     assert(buff != NULL); // buff should not be NULL.
 
     if(sender_ip && !use_src_ip) { // Force an IP
@@ -543,7 +544,7 @@ static int w_enrollment_concat_src_ip(char *buff, const size_t size_buff, const 
         if (OS_IsValidIP(sender_ip, NULL)) {
             char opt_buf[256] = {0};
             snprintf(opt_buf,254," IP:'%s'",sender_ip);
-            strncat(buff,opt_buf, size_buff - 1);
+            strncat(buff,opt_buf, remain_size - 1);
         } else {
             merror("Invalid IP address provided for sender IP.");
             return -1;

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -39,7 +39,7 @@ static int w_enrollment_process_response(SSL *ssl);
 /* Auxiliary */
 static void w_enrollment_verify_ca_certificate(const SSL *ssl, const char *ca_cert, const char *hostname);
 static void w_enrollment_concat_group(char *buff, const char* centralized_group);
-static int w_enrollment_concat_src_ip(char *buff, const char* sender_ip, const int use_src_ip);
+static int w_enrollment_concat_src_ip(char *buff, const size_t size_buff, const char* sender_ip, const int use_src_ip);
 static void w_enrollment_concat_key(char *buff, keyentry* key);
 static int w_enrollment_process_agent_key(char *buffer);
 static int w_enrollment_store_key_entry(const char* keys);
@@ -281,7 +281,7 @@ static int w_enrollment_send_message(w_enrollment_ctx *cfg) {
         w_enrollment_concat_group(buf, cfg->target_cfg->centralized_group);
     }
 
-    if (w_enrollment_concat_src_ip(buf, cfg->target_cfg->sender_ip, cfg->target_cfg->use_src_ip)) {
+    if (w_enrollment_concat_src_ip(buf, OS_SIZE_65536 + OS_SIZE_4096 - strlen(buf), cfg->target_cfg->sender_ip, cfg->target_cfg->use_src_ip)) {
         os_free(buf);
         if(lhostname != cfg->target_cfg->agent_name)
             os_free(lhostname);
@@ -535,7 +535,7 @@ static void w_enrollment_concat_group(char *buff, const char* centralized_group)
  * @retval 0 on success
  * @retval -1 if ip is invalid
  */
-static int w_enrollment_concat_src_ip(char *buff, const char* sender_ip, const int use_src_ip) {
+static int w_enrollment_concat_src_ip(char *buff, const size_t size_buff, const char* sender_ip, const int use_src_ip) {
     assert(buff != NULL); // buff should not be NULL.
 
     if(sender_ip && !use_src_ip) { // Force an IP
@@ -543,7 +543,7 @@ static int w_enrollment_concat_src_ip(char *buff, const char* sender_ip, const i
         if (OS_IsValidIP(sender_ip, NULL)) {
             char opt_buf[256] = {0};
             snprintf(opt_buf,254," IP:'%s'",sender_ip);
-            strncat(buff,opt_buf,254);
+            strncat(buff,opt_buf, size_buff);
         } else {
             merror("Invalid IP address provided for sender IP.");
             return -1;

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -543,7 +543,7 @@ static int w_enrollment_concat_src_ip(char *buff, const size_t size_buff, const 
         if (OS_IsValidIP(sender_ip, NULL)) {
             char opt_buf[256] = {0};
             snprintf(opt_buf,254," IP:'%s'",sender_ip);
-            strncat(buff,opt_buf, size_buff);
+            strncat(buff,opt_buf, size_buff - 1);
         } else {
             merror("Invalid IP address provided for sender IP.");
             return -1;

--- a/src/shared/mem_op.c
+++ b/src/shared/mem_op.c
@@ -109,9 +109,7 @@ char *os_LoadString(char *at, const char *str)
         }
         at = newat;
 
-        strncat(at, str, strsize + 1);
-        at[finalsize - 1] = '\0';
-
+        strcat(at, str);
         return (at);
     }
 

--- a/src/shared/mem_op.c
+++ b/src/shared/mem_op.c
@@ -109,7 +109,7 @@ char *os_LoadString(char *at, const char *str)
         }
         at = newat;
 
-        strncat(at, str, strsize);
+        strncat(at, str, strsize + 1);
         at[finalsize - 1] = '\0';
 
         return (at);

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -428,8 +428,7 @@ static int _do_print_syscheck(FILE *fp, __attribute__((unused)) int all_files, i
                 if (!(csv_output || json_output)) {
                     printf("\nChanges for %s:\n", read_day);
                 }
-                strncpy(saved_read_day, read_day, 24);
-                saved_read_day[24] = '\0';
+                snprintf(saved_read_day, sizeof(saved_read_day), "%s", read_day);
             }
             strftime(read_day, 23, "%Y %h %d %T", &tm_result);
 

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -428,7 +428,8 @@ static int _do_print_syscheck(FILE *fp, __attribute__((unused)) int all_files, i
                 if (!(csv_output || json_output)) {
                     printf("\nChanges for %s:\n", read_day);
                 }
-                strncpy(saved_read_day, read_day, 23);
+                strncpy(saved_read_day, read_day, 24);
+                saved_read_day[24] = '\0';
             }
             strftime(read_day, 23, "%Y %h %d %T", &tm_result);
 

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -498,10 +498,12 @@ void wstr_split(char *str, char *delim, char *replace_delim, int occurrences, ch
 
             for (count = 0, new_term_it = (*splitted_str)[splitted_count]; count < occurrences; count++) {
                 if (count) {
-                    strncpy(new_term_it, new_delim, new_delim_size);
+                    strncpy(new_term_it, new_delim, term_size);
+                    term_size -= new_delim_size;
                     new_term_it += new_delim_size;
                 }
-                strncpy(new_term_it, acc_strs[count], strlen(acc_strs[count]));
+                strncpy(new_term_it, acc_strs[count], term_size);
+                term_size -= strlen(acc_strs[count]);
                 new_term_it += strlen(acc_strs[count]);
                 os_free(acc_strs[count]);
             }

--- a/src/shared/validate_op.c
+++ b/src/shared/validate_op.c
@@ -29,7 +29,7 @@
 
 static char *_read_file(const char *high_name, const char *low_name, const char *defines_file) __attribute__((nonnull(3)));
 static void _init_masks(void);
-static const char *__gethour(const char *str, char *ossec_hour, const int size_ossec_hour) __attribute__((nonnull));
+static const char *__gethour(const char *str, char *ossec_hour, const size_t ossec_hour_len) __attribute__((nonnull));
 
 /**
  * @brief Convert the netmask from an integer value, valid from 0 to 128.
@@ -681,9 +681,8 @@ int OS_IsonTime(const char *time_str, const char *ossec_time)
  */
 #define RM_WHITE(x)while(*x == ' ')x++;
 
-static const char *__gethour(const char *str, char *ossec_hour, const int size_ossec_hour)
+static const char *__gethour(const char *str, char *ossec_hour, const size_t ossec_hour_len)
 {
-    int bytes_written = 0;
     int _size = 0;
     int chour = 0;
     int cmin = 0;
@@ -734,9 +733,9 @@ static const char *__gethour(const char *str, char *ossec_hour, const int size_o
         str++;
         if ((*str == 'm') || (*str == 'M')) {
             if (chour == 12) chour = 0;
-            bytes_written = snprintf(ossec_hour, size_ossec_hour, "%02d:%02d", chour, cmin);
+            const int bytes_written = snprintf(ossec_hour, ossec_hour_len, "%02d:%02d", chour, cmin);
 
-            if (bytes_written + 1 > size_ossec_hour) {
+            if (bytes_written >= 0 && (size_t)bytes_written >= ossec_hour_len) {
                 return (NULL);
             }
 
@@ -755,9 +754,9 @@ static const char *__gethour(const char *str, char *ossec_hour, const int size_o
                 return (NULL);
             }
 
-            bytes_written = snprintf(ossec_hour, size_ossec_hour, "%02d:%02d", chour, cmin);
+            const int bytes_written = snprintf(ossec_hour, ossec_hour_len, "%02d:%02d", chour, cmin);
 
-            if (bytes_written + 1 > size_ossec_hour) {
+            if (bytes_written >= 0 && (size_t)bytes_written >= ossec_hour_len) {
                 return (NULL);
             }
 
@@ -766,9 +765,9 @@ static const char *__gethour(const char *str, char *ossec_hour, const int size_o
         }
 
     } else {
-        bytes_written = snprintf(ossec_hour, size_ossec_hour, "%02d:%02d", chour, cmin);
+        const int bytes_written = snprintf(ossec_hour, ossec_hour_len, "%02d:%02d", chour, cmin);
 
-        if (bytes_written + 1 > size_ossec_hour) {
+        if (bytes_written >= 0 && (size_t)bytes_written >= ossec_hour_len) {
             return (NULL);
         }
 
@@ -809,7 +808,7 @@ char *OS_IsValidTime(const char *time_str)
     }
 
     /* Get first hour */
-    time_str = __gethour(time_str, first_hour, 7);
+    time_str = __gethour(time_str, first_hour, sizeof(first_hour));
 
     if (!time_str) {
         return (NULL);
@@ -828,7 +827,7 @@ char *OS_IsValidTime(const char *time_str)
     RM_WHITE(time_str);
 
     /* Get second hour */
-    time_str = __gethour(time_str, second_hour, 7);
+    time_str = __gethour(time_str, second_hour, sizeof(second_hour));
     if (!time_str) {
         return (NULL);
     }

--- a/src/shared/validate_op.c
+++ b/src/shared/validate_op.c
@@ -767,7 +767,7 @@ static const char *__gethour(const char *str, char *ossec_hour, const size_t oss
     } else {
         const int bytes_written = snprintf(ossec_hour, ossec_hour_len, "%02d:%02d", chour, cmin);
 
-        if (bytes_written >= 0 && (size_t)bytes_written >= ossec_hour_len) {
+        if (bytes_written < 0 || (size_t)bytes_written >= ossec_hour_len) {
             return (NULL);
         }
 

--- a/src/shared/validate_op.c
+++ b/src/shared/validate_op.c
@@ -735,7 +735,7 @@ static const char *__gethour(const char *str, char *ossec_hour, const size_t oss
             if (chour == 12) chour = 0;
             const int bytes_written = snprintf(ossec_hour, ossec_hour_len, "%02d:%02d", chour, cmin);
 
-            if (bytes_written >= 0 && (size_t)bytes_written >= ossec_hour_len) {
+            if (bytes_written < 0 || (size_t)bytes_written >= ossec_hour_len) {
                 return (NULL);
             }
 
@@ -756,7 +756,7 @@ static const char *__gethour(const char *str, char *ossec_hour, const size_t oss
 
             const int bytes_written = snprintf(ossec_hour, ossec_hour_len, "%02d:%02d", chour, cmin);
 
-            if (bytes_written >= 0 && (size_t)bytes_written >= ossec_hour_len) {
+            if (bytes_written < 0 || (size_t)bytes_written >= ossec_hour_len) {
                 return (NULL);
             }
 

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -362,7 +362,7 @@ void test_w_enrollment_concat_src_ip_small_buff(void **state) {
     expect_value(__wrap_OS_IsValidIP, final_ip, NULL);
     will_return(__wrap_OS_IsValidIP, 1);
 
-    ret = w_enrollment_concat_src_ip(buf, 29 - strlen(buf), sender_ip, 0);
+    ret = w_enrollment_concat_src_ip(buf, 30 - strlen(buf), sender_ip, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(buf, " IP:'192.168.1.1'");
 
@@ -370,7 +370,7 @@ void test_w_enrollment_concat_src_ip_small_buff(void **state) {
     expect_value(__wrap_OS_IsValidIP, final_ip, NULL);
     will_return(__wrap_OS_IsValidIP, 1);
 
-    ret = w_enrollment_concat_src_ip(buf, 29 - strlen(buf), sender_ip, 0);
+    ret = w_enrollment_concat_src_ip(buf, 30 - strlen(buf), sender_ip, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(buf, " IP:'192.168.1.1' IP:'192.168");
 }

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -23,7 +23,7 @@
 #define NEW_IP1         "192.0.0.0"
 #define RAW_KEY         "6dd186d1740f6c80d4d380ebe72c8061db175881e07e809eb44404c836a7ef96"
 
-extern int w_enrollment_concat_src_ip(char *buff, const char* sender_ip, const int use_src_ip);
+extern int w_enrollment_concat_src_ip(char *buff, const size_t size_buff, const char* sender_ip, const int use_src_ip);
 extern void w_enrollment_concat_group(char *buff, const char* centralized_group);
 extern void w_enrollment_concat_key(char *buff, keyentry* key_entry);
 extern void w_enrollment_verify_ca_certificate(const SSL *ssl, const char *ca_cert, const char *hostname);
@@ -130,6 +130,14 @@ int test_setup_concats(void **state) {
     char *buf;
     os_calloc(OS_SIZE_65536 + OS_SIZE_4096 + 1, sizeof(char), buf);
     buf[OS_SIZE_65536 + OS_SIZE_4096] = '\0';
+    *state = buf;
+    return 0;
+}
+
+int test_setup_concats_small_buff(void **state) {
+    char *buf;
+    os_calloc(30, sizeof(char), buf);
+    buf[29] = '\0';
     *state = buf;
     return 0;
 }
@@ -311,7 +319,7 @@ void test_w_enrollment_concat_src_ip_invalid_ip(void **state) {
     will_return(__wrap_OS_IsValidIP, 0);
 
     expect_string(__wrap__merror, formatted_msg, "Invalid IP address provided for sender IP.");
-    int ret = w_enrollment_concat_src_ip(buf, sender_ip, 0);
+    int ret = w_enrollment_concat_src_ip(buf, OS_SIZE_65536 + OS_SIZE_4096 - strlen(buf), sender_ip, 0);
     assert_int_equal(ret, -1);
 }
 
@@ -322,7 +330,7 @@ void test_w_enrollment_concat_src_ip_valid_ip(void **state) {
     expect_value(__wrap_OS_IsValidIP, final_ip, NULL);
     will_return(__wrap_OS_IsValidIP, 1);
 
-    int ret = w_enrollment_concat_src_ip(buf, sender_ip, 0);
+    int ret = w_enrollment_concat_src_ip(buf, OS_SIZE_65536 + OS_SIZE_4096 - strlen(buf), sender_ip, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(buf, " IP:'192.168.1.1'");
 }
@@ -331,7 +339,7 @@ void test_w_enrollment_concat_src_ip_empty_ip(void **state) {
     char *buf = *state;
     const char* sender_ip = NULL;
 
-    int ret = w_enrollment_concat_src_ip(buf, sender_ip, 1);
+    int ret = w_enrollment_concat_src_ip(buf, OS_SIZE_65536 + OS_SIZE_4096 - strlen(buf), sender_ip, 1);
     assert_int_equal(ret, 0);
     assert_string_equal(buf, " IP:'src'");
 }
@@ -341,21 +349,43 @@ void test_w_enrollment_concat_src_ip_incomaptible_opt(void **state) {
     const char* sender_ip ="192.168.1.1";
 
     expect_string(__wrap__merror, formatted_msg, "Incompatible sender_ip options: Forcing IP while using use_source_ip flag.");
-    int ret = w_enrollment_concat_src_ip(buf, sender_ip, 1);
+    int ret = w_enrollment_concat_src_ip(buf, OS_SIZE_65536 + OS_SIZE_4096 - strlen(buf), sender_ip, 1);
     assert_int_equal(ret, -1);
+}
+
+void test_w_enrollment_concat_src_ip_small_buff(void **state) {
+    int ret = 0;
+    char *buf = *state;
+    const char* sender_ip = "192.168.1.1";
+
+    expect_string(__wrap_OS_IsValidIP, ip_address, sender_ip);
+    expect_value(__wrap_OS_IsValidIP, final_ip, NULL);
+    will_return(__wrap_OS_IsValidIP, 1);
+
+    ret = w_enrollment_concat_src_ip(buf, 29 - strlen(buf), sender_ip, 0);
+    assert_int_equal(ret, 0);
+    assert_string_equal(buf, " IP:'192.168.1.1'");
+
+    expect_string(__wrap_OS_IsValidIP, ip_address, sender_ip);
+    expect_value(__wrap_OS_IsValidIP, final_ip, NULL);
+    will_return(__wrap_OS_IsValidIP, 1);
+
+    ret = w_enrollment_concat_src_ip(buf, 29 - strlen(buf), sender_ip, 0);
+    assert_int_equal(ret, 0);
+    assert_string_equal(buf, " IP:'192.168.1.1' IP:'192.168");
 }
 
 void test_w_enrollment_concat_src_ip_default(void **state) {
     char *buf = *state;
     const char* sender_ip = NULL;
 
-    int ret = w_enrollment_concat_src_ip(buf, sender_ip, 0);
+    int ret = w_enrollment_concat_src_ip(buf, OS_SIZE_65536 + OS_SIZE_4096 - strlen(buf), sender_ip, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(buf, "");
 }
 
 void test_w_enrollment_concat_src_ip_empty_buff(void **state) {
-    expect_assert_failure(w_enrollment_concat_src_ip(NULL, NULL, 0));
+    expect_assert_failure(w_enrollment_concat_src_ip(NULL, 0, NULL, 0));
 }
 
 /**********************************************/
@@ -1185,6 +1215,7 @@ int main() {
         cmocka_unit_test_setup_teardown(test_w_enrollment_concat_src_ip_valid_ip, test_setup_concats, test_teardown_concats),
         cmocka_unit_test_setup_teardown(test_w_enrollment_concat_src_ip_empty_ip, test_setup_concats, test_teardown_concats),
         cmocka_unit_test_setup_teardown(test_w_enrollment_concat_src_ip_incomaptible_opt, test_setup_concats, test_teardown_concats),
+        cmocka_unit_test_setup_teardown(test_w_enrollment_concat_src_ip_small_buff, test_setup_concats_small_buff, test_teardown_concats),
         cmocka_unit_test(test_w_enrollment_concat_src_ip_empty_buff),
         // w_enrollment_concat_group
         cmocka_unit_test(test_w_enrollment_concat_group_empty_buff),

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -23,7 +23,7 @@
 #define NEW_IP1         "192.0.0.0"
 #define RAW_KEY         "6dd186d1740f6c80d4d380ebe72c8061db175881e07e809eb44404c836a7ef96"
 
-extern int w_enrollment_concat_src_ip(char *buff, const size_t size_buff, const char* sender_ip, const int use_src_ip);
+extern int w_enrollment_concat_src_ip(char *buff, const size_t remain_size, const char* sender_ip, const int use_src_ip);
 extern void w_enrollment_concat_group(char *buff, const char* centralized_group);
 extern void w_enrollment_concat_key(char *buff, keyentry* key_entry);
 extern void w_enrollment_verify_ca_certificate(const SSL *ssl, const char *ca_cert, const char *hostname);

--- a/src/util/agent_control.c
+++ b/src/util/agent_control.c
@@ -648,7 +648,7 @@ int main(int argc, char **argv)
             } else if (agent_id) {
                 printf("\n** Unable to run active response on all agents.\n");
             } else {
-                printf("\n** Unable to run active response on agent: %s\n", agent_id);
+                printf("\n** Unable to run active response on agent: NULL\n");
             }
 
             exit(1);

--- a/src/util/agent_control.c
+++ b/src/util/agent_control.c
@@ -646,9 +646,9 @@ int main(int argc, char **argv)
                 printf("%s",cJSON_PrintUnformatted(root));
                 cJSON_Delete(root);
             } else if (agent_id) {
-                printf("\n** Unable to run active response on all agents.\n");
+                printf("\n** Unable to run active response on agent: %s\n", agent_id);
             } else {
-                printf("\n** Unable to run active response on agent: NULL\n");
+                printf("\n** Unable to run active response on all agents.\n");
             }
 
             exit(1);

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -1275,7 +1275,7 @@ int wdb_parse_syscheck(wdb_t * wdb, wdb_component_t component, char * input, cha
             size_t unsc_size = strlen(unsc_checksum);
             size_t mark_size = strlen(mark);
             os_realloc(unsc_checksum, unsc_size + mark_size + 1, unsc_checksum);
-            strncpy(unsc_checksum + unsc_size, mark, mark_size);
+            strncpy(unsc_checksum + unsc_size, mark, mark_size + 1);
             unsc_checksum[unsc_size + mark_size] = '\0';
         }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -3486,6 +3486,7 @@ references *wm_vuldet_extract_advisories(cJSON *advisories) {
 
 void wm_vuldet_adapt_title(char *title, char *cve) {
     // Remove unnecessary line jumps and spaces
+    const size_t size_title = strlen(title);
     size_t size;
     int offset;
     char *title_ofs;
@@ -3503,7 +3504,8 @@ void wm_vuldet_adapt_title(char *title, char *cve) {
         offset += strlen(cve) + 1;
     }
     os_strdup(title + offset, title_ofs);
-    strncpy(title, title_ofs, strlen(title_ofs) + 1);
+    strncpy(title, title_ofs, size_title);
+    title[size_title] = '\0';
     free(title_ofs);
 }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -3486,7 +3486,7 @@ references *wm_vuldet_extract_advisories(cJSON *advisories) {
 
 void wm_vuldet_adapt_title(char *title, char *cve) {
     // Remove unnecessary line jumps and spaces
-    const size_t size_title = strlen(title);
+    const size_t title_size = strlen(title);
     size_t size;
     int offset;
     char *title_ofs;
@@ -3504,8 +3504,7 @@ void wm_vuldet_adapt_title(char *title, char *cve) {
         offset += strlen(cve) + 1;
     }
     os_strdup(title + offset, title_ofs);
-    strncpy(title, title_ofs, size_title);
-    title[size_title] = '\0';
+    snprintf(title, title_size, "%s", title_ofs);
     free(title_ofs);
 }
 

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -331,13 +331,11 @@ int wm_exec(char *command, char **output, int *exitcode, int secs, const char * 
             } else if (strlen(env_path) >= OS_SIZE_6144) {
                 merror("at wm_exec(): PATH environment variable too large.");
             } else {
-                int size = snprintf(NULL, 0, "%s:%s", add_path, env_path);
+                int bytes_written = snprintf(new_path, OS_SIZE_6144, "%s:%s", add_path, env_path);
 
-                if (size + 1 > OS_SIZE_6144) {
-                    os_realloc(new_path, size + 1, new_path);
+                if (bytes_written + 1 > OS_SIZE_6144) {
+                    merror("at wm_exec(): New environment variable too large.");
                 }
-
-                snprintf(new_path, size + 1, "%s:%s", add_path, env_path);
             }
 
             if (setenv("PATH", new_path, 1) < 0) {

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -331,7 +331,13 @@ int wm_exec(char *command, char **output, int *exitcode, int secs, const char * 
             } else if (strlen(env_path) >= OS_SIZE_6144) {
                 merror("at wm_exec(): PATH environment variable too large.");
             } else {
-                snprintf(new_path, OS_SIZE_6144 - 1, "%s:%s", add_path, env_path);
+                int size = snprintf(NULL, 0, "%s:%s", add_path, env_path);
+
+                if (size + 1 > OS_SIZE_6144) {
+                    os_realloc(new_path, size + 1, new_path);
+                }
+
+                snprintf(new_path, size + 1, "%s:%s", add_path, env_path);
             }
 
             if (setenv("PATH", new_path, 1) < 0) {

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -333,8 +333,11 @@ int wm_exec(char *command, char **output, int *exitcode, int secs, const char * 
             } else {
                 const int bytes_written = snprintf(new_path, OS_SIZE_6144, "%s:%s", add_path, env_path);
 
-                if (bytes_written < 0 || bytes_written >= OS_SIZE_6144) {
+                if (bytes_written >= OS_SIZE_6144) {
                     merror("at wm_exec(): New environment variable too large.");
+                }
+                else if (bytes_written < 0) {
+                    merror("at wm_exec(): New environment variable error: %d (%s).", errno, strerror(errno));
                 }
             }
 

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -333,7 +333,7 @@ int wm_exec(char *command, char **output, int *exitcode, int secs, const char * 
             } else {
                 const int bytes_written = snprintf(new_path, OS_SIZE_6144, "%s:%s", add_path, env_path);
 
-                if (bytes_written >= 0 && bytes_written >= OS_SIZE_6144) {
+                if (bytes_written < 0 || bytes_written >= OS_SIZE_6144) {
                     merror("at wm_exec(): New environment variable too large.");
                 }
             }

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -331,9 +331,9 @@ int wm_exec(char *command, char **output, int *exitcode, int secs, const char * 
             } else if (strlen(env_path) >= OS_SIZE_6144) {
                 merror("at wm_exec(): PATH environment variable too large.");
             } else {
-                int bytes_written = snprintf(new_path, OS_SIZE_6144, "%s:%s", add_path, env_path);
+                const int bytes_written = snprintf(new_path, OS_SIZE_6144, "%s:%s", add_path, env_path);
 
-                if (bytes_written + 1 > OS_SIZE_6144) {
+                if (bytes_written >= 0 && bytes_written >= OS_SIZE_6144) {
                     merror("at wm_exec(): New environment variable too large.");
                 }
             }

--- a/src/wazuh_modules/wm_github.c
+++ b/src/wazuh_modules/wm_github.c
@@ -304,8 +304,7 @@ STATIC void wm_github_execute_scan(wm_github *github_config, int initial_scan) {
                             if ((next_page == NULL) || (strlen(next_page) >= OS_SIZE_8192)) {
                                 scan_finished = 1;
                             } else {
-                                memset(url, '\0', OS_SIZE_8192);
-                                strncpy(url, next_page, OS_SIZE_8192 - 1);
+                                snprintf(url, OS_SIZE_8192, "%s", next_page);
                                 os_free(next_page);
                             }
                         } else {

--- a/src/wazuh_modules/wm_github.c
+++ b/src/wazuh_modules/wm_github.c
@@ -305,7 +305,7 @@ STATIC void wm_github_execute_scan(wm_github *github_config, int initial_scan) {
                                 scan_finished = 1;
                             } else {
                                 memset(url, '\0', OS_SIZE_8192);
-                                strncpy(url, next_page, strlen(next_page));
+                                strncpy(url, next_page, OS_SIZE_8192 - 1);
                                 os_free(next_page);
                             }
                         } else {

--- a/src/wazuh_modules/wm_github.c
+++ b/src/wazuh_modules/wm_github.c
@@ -304,7 +304,7 @@ STATIC void wm_github_execute_scan(wm_github *github_config, int initial_scan) {
                             if ((next_page == NULL) || (strlen(next_page) >= OS_SIZE_8192)) {
                                 scan_finished = 1;
                             } else {
-                                snprintf(url, OS_SIZE_8192, "%s", next_page);
+                                snprintf(url, sizeof(url), "%s", next_page);
                                 os_free(next_page);
                             }
                         } else {

--- a/src/wazuh_modules/wm_keyrequest.c
+++ b/src/wazuh_modules/wm_keyrequest.c
@@ -381,7 +381,7 @@ int wm_key_request_dispatch(char * buffer, const wm_krequest_t * data) {
             return -1;
         }
 
-        authd_force_options_t authd_force_options = {0};
+        authd_force_options_t authd_force_options = {.enabled = 0};
         if(data->force_insert) {
             authd_force_options.enabled = true;
         }

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -428,8 +428,7 @@ STATIC void wm_office365_execute_scan(wm_office365* office365_config, int initia
                             if ((next_page == NULL) || (strlen(next_page) >= OS_SIZE_8192)) {
                                 scan_finished = 1;
                             } else {
-                                memset(url, '\0', OS_SIZE_8192);
-                                strncpy(url, next_page, OS_SIZE_8192 - 1);
+                                snprintf(url, OS_SIZE_8192, "%s", next_page);
                                 os_free(next_page);
                             }
                         }

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -429,7 +429,7 @@ STATIC void wm_office365_execute_scan(wm_office365* office365_config, int initia
                                 scan_finished = 1;
                             } else {
                                 memset(url, '\0', OS_SIZE_8192);
-                                strncpy(url, next_page, strlen(next_page));
+                                strncpy(url, next_page, OS_SIZE_8192 - 1);
                                 os_free(next_page);
                             }
                         }

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -428,7 +428,7 @@ STATIC void wm_office365_execute_scan(wm_office365* office365_config, int initia
                             if ((next_page == NULL) || (strlen(next_page) >= OS_SIZE_8192)) {
                                 scan_finished = 1;
                             } else {
-                                snprintf(url, OS_SIZE_8192, "%s", next_page);
+                                snprintf(url, sizeof(url), "%s", next_page);
                                 os_free(next_page);
                             }
                         }


### PR DESCRIPTION
|Related issue|
|---|
|#12098|

## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh server project. During the development, I solved the compile warnings only for the server. Warnings for the agent will be resolved in other issues (#12099 and #12100). The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Output</summary>

```
~/wazuh/src$ make -j2 TARGET=server
grep: /etc/redhat-release: No such file or directory
checkmodule -M -m -o selinux/wazuh.mod selinux/wazuh.te
semodule_package -o selinux/wazuh.pp -m selinux/wazuh.mod
make build_sysinfo build_shared_modules build_syscollector
make[1]: Entering directory '/home/hanes/wazuh/src'
grep: /etc/redhat-release: No such file or directory
    CC libwazuhext.so
/usr/bin/ld: missing --end-group; added as last command line option
cd data_provider/ && mkdir -p build && cd build && cmake     .. && make
cd shared_modules/dbsync/ && mkdir -p build && cd build && cmake    .. && make
-- The C compiler identification is GNU 9.3.0
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/data_provider/build
make[2]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
make[3]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
Scanning dependencies of target sysinfo
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/shared_modules/dbsync/build
make[2]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[3]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
[ 10%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync.cpp.o
[  7%] Building CXX object CMakeFiles/sysinfo.dir/src/network/networkInterfaceLinux.cpp.o
[ 15%] Building CXX object CMakeFiles/sysinfo.dir/src/osinfo/sysOsParsers.cpp.o
[ 20%] Building CXX object CMakeFiles/dbsync.dir/src/dbsyncPipelineFactory.cpp.o
[ 30%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync_implementation.cpp.o
[ 23%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserDeb.cpp.o
[ 40%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_dbengine.cpp.o
[ 30%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserExtra.cpp.o
[ 38%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserRpm.cpp.o
[ 46%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserRpmLegacy.cpp.o
[ 50%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_wrapper.cpp.o
[ 60%] Linking CXX shared library lib/libdbsync.so
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 60%] Built target dbsync
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync_example
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 70%] Building CXX object example/CMakeFiles/dbsync_example.dir/main.cpp.o
[ 80%] Linking CXX executable ../bin/dbsync_example
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 80%] Built target dbsync_example
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 90%] Building CXX object testtool/CMakeFiles/dbsync_test_tool.dir/main.cpp.o
[ 53%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/rpmPackageManager.cpp.o
[ 61%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfoLinux.cpp.o
[ 69%] Building CXX object CMakeFiles/sysinfo.dir/src/utilsWrapperLinux.cpp.o
[100%] Linking CXX executable ../bin/dbsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[100%] Built target dbsync_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
cd shared_modules/rsync/ && mkdir -p build && cd build && cmake     .. && make
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
[ 76%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfo.cpp.o
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/shared_modules/rsync/build
make[2]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[3]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
Scanning dependencies of target rsync
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[ 12%] Building CXX object CMakeFiles/rsync.dir/src/rsync.cpp.o
[ 84%] Linking CXX shared library lib/libsysinfo.so
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
[ 84%] Built target sysinfo
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
Scanning dependencies of target sysinfo_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
[ 92%] Building CXX object testtool/CMakeFiles/sysinfo_test_tool.dir/main.cpp.o
[ 25%] Building CXX object CMakeFiles/rsync.dir/src/rsyncImplementation.cpp.o
[100%] Linking CXX executable ../bin/sysinfo_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
[100%] Built target sysinfo_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
[ 37%] Linking CXX shared library lib/librsync.so
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[ 37%] Built target rsync
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
Scanning dependencies of target rsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[ 50%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/main.cpp.o
[ 62%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/agentEmulator.cpp.o
[ 75%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/oneTimeSync.cpp.o
[ 87%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/managerEmulator.cpp.o
[100%] Linking CXX executable ../bin/rsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[100%] Built target rsync_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
cd wazuh_modules/syscollector/ && mkdir -p build && cd build && cmake     .. && make
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/wazuh_modules/syscollector/build
make[2]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[3]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
Scanning dependencies of target syscollector
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[ 16%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorImp.cpp.o
[ 33%] Building CXX object CMakeFiles/syscollector.dir/src/syscollector.cpp.o
[ 50%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorNormalizer.cpp.o
[ 66%] Linking CXX shared library lib/libsyscollector.so
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[ 66%] Built target syscollector
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
Scanning dependencies of target syscollector_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[ 83%] Building CXX object testtool/CMakeFiles/syscollector_test_tool.dir/main.cpp.o
[100%] Linking CXX executable ../bin/syscollector_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[100%] Built target syscollector_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[1]: Leaving directory '/home/hanes/wazuh/src'
make wazuh-maild - wazuh-csyslogd - wazuh-agentlessd - wazuh-execd - wazuh-logcollector - wazuh-remoted wazuh-agentd manage_agents utils active-responses wazuh-syscheckd wazuh-monitord wazuh-reportd wazuh-authd wazuh-analysisd wazuh-logtest-legacy wazuh-dbd - wazuh-integratord wazuh-modulesd wazuh-db
make[1]: Entering directory '/home/hanes/wazuh/src'
grep: /etc/redhat-release: No such file or directory
    CC os_maild/maild.o
    CC os_maild/sendmail.o
    CC os_maild/sendcustomemail.o
    CC os_maild/os_maild_client.o
    CC os_maild/config.o
    CC os_maild/mail_list.o
    CC os_maild/mailcom.o
    CC config/wmodules-aws.o
    CC config/localfile-config.o
    CC config/rootcheck-config.o
    CC config/remote-config.o
    CC config/active-response.o
    CC config/wmodules-osquery-monitor.o
    CC config/integrator-config.o
    CC config/wmodules-agent-upgrade.o
    CC config/socket-config.o
    CC config/reports-config.o
    CC config/alerts-config.o
    CC config/agentlessd-config.o
    CC config/wmodules_syscollector.o
    CC config/wmodules-oscap.o
    CC config/config.o
    CC config/wmodules-github.o
    CC config/wmodules-docker.o
    CC config/syscheck-config.o
    CC config/global-config.o
    CC config/client-config.o
    CC config/labels-config.o
    CC config/email-alerts-config.o
    CC config/wmodules-sca.o
    CC config/wmodules-fluent.o
    CC config/wmodules-office365.o
    CC config/cluster-config.o
    CC config/rules-config.o
    CC config/dbd-config.o
    CC config/wmodules-key-request.o
    CC config/wmodules-vuln-detector.o
    CC config/wmodules-azure.o
    CC config/authd-config.o
    CC config/wmodules-task-manager.o
    CC config/buffer-config.o
    CC config/wmodules-command.o
    CC config/csyslogd-config.o
    CC config/wmodules-ciscat.o
    CC config/wmodules-gcp.o
    CC config/logtest-config.o
    CC config/wmodules-config.o
    CC wazuh_modules/wm_control.o
    CC wazuh_modules/wmcom.o
    CC wazuh_modules/wm_oscap.o
    CC wazuh_modules/wm_gcp.o
    CC wazuh_modules/wmodules.o
    CC wazuh_modules/wm_azure.o
    CC wazuh_modules/wm_office365.o
    CC wazuh_modules/wm_exec.o
    CC wazuh_modules/wm_osquery_monitor.o
    CC wazuh_modules/wm_task_general.o
    CC wazuh_modules/wm_aws.o
    CC wazuh_modules/wm_syscollector.o
    CC wazuh_modules/wm_keyrequest.o
    CC wazuh_modules/wm_github.o
    CC wazuh_modules/wm_database.o
    CC wazuh_modules/wm_download.o
    CC wazuh_modules/wm_docker.o
    CC wazuh_modules/wm_sca.o
    CC wazuh_modules/wm_fluent.o
    CC wazuh_modules/wm_command.o
    CC wazuh_modules/wm_ciscat.o
    CC wazuh_modules/agent_upgrade/wm_agent_upgrade.o
    CC wazuh_modules/vulnerability_detector/wm_vuln_detector.o
    CC wazuh_modules/vulnerability_detector/wm_vuln_detector_evr.o
    CC wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.o
    CC wazuh_modules/task_manager/wm_task_manager.o
    CC wazuh_modules/task_manager/wm_task_manager_parsing.o
    CC wazuh_modules/task_manager/wm_task_manager_commands.o
    CC wazuh_modules/task_manager/wm_task_manager_tasks.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_manager.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_upgrades.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_parsing.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_commands.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks_callbacks.o
    CC wazuh_db/wdb_metadata.o
    CC wazuh_db/wdb_agents.o
    CC wazuh_db/wdb_integrity.o
    CC wazuh_db/wdb_global.o
    CC wazuh_db/wdb_syscollector.o
    CC wazuh_db/wdb_upgrade.o
    CC wazuh_db/wdb_task.o
    CC wazuh_db/wdb_scan_info.o
    CC wazuh_db/wdb.o
    CC wazuh_db/wdb_parser.o
    CC wazuh_db/wdb_fim.o
    CC wazuh_db/wdb_sca.o
    CC wazuh_db/wdb_rootcheck.o
    CC wazuh_db/wdb_ciscat.o
    CC wazuh_db/helpers/wdb_global_helpers.o
    CC wazuh_db/helpers/wdb_agents_helpers.o
    CC wazuh_db/schema_global_upgrade_v2.o
    CC wazuh_db/schema_upgrade_v3.o
    CC wazuh_db/schema_upgrade_v1.o
    CC wazuh_db/schema_upgrade_v8.o
    CC wazuh_db/schema_agents.o
    CC wazuh_db/schema_upgrade_v6.o
    CC wazuh_db/schema_global_upgrade_v1.o
    CC wazuh_db/schema_task_manager.o
    CC wazuh_db/schema_upgrade_v4.o
    CC wazuh_db/schema_global.o
    CC wazuh_db/schema_upgrade_v2.o
    CC wazuh_db/schema_upgrade_v5.o
    CC wazuh_db/schema_global_upgrade_v3.o
    CC wazuh_db/schema_vuln_detector.o
    CC wazuh_db/schema_upgrade_v7.o
    CC os_crypto/blowfish/bf_op.o
    CC os_crypto/md5/md5_op.o
    CC os_crypto/sha1/sha1_op.o
    CC os_crypto/shared/keys.o
    CC os_crypto/shared/msgs.o
    CC os_crypto/md5_sha1/md5_sha1_op.o
    CC os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.o
    CC os_crypto/sha256/sha256_op.o
    CC os_crypto/sha512/sha512_op.o
    CC os_crypto/aes/aes_op.o
    CC os_crypto/hmac/hmac.o
    CC os_crypto/signature/signature.o
    CC shared/json-queue.o
    CC shared/read-alert.o
    CC shared/rootcheck_op.o
    CC shared/notify_op.o
    CC shared/regex_op.o
    CC shared/store_op.o
    CC shared/bzip2_op.o
    CC shared/exec_op.o
    CC shared/mem_op.o
    CC shared/request_op.o
    CC shared/log_builder.o
    CC shared/time_op.o
    CC shared/file_op.o
    CC shared/pthreads_op.o
    CC shared/integrity_op.o
    CC shared/queue_linked_op.o
    CC shared/os_utils.o
    CC shared/rbtree_op.o
    CC shared/fs_op.o
    CC shared/cluster_utils.o
    CC shared/read-agents.o
    CC shared/audit_op.o
    CC shared/syscheck_op.o
    CC shared/yaml2json.o
    CC shared/buffer_op.o
    CC shared/report_op.o
    CC shared/sig_op.o
    CC shared/sym_load.o
    CC shared/wait_op.o
    CC shared/help.o
    CC shared/labels_op.o
    CC shared/auth_client.o
    CC shared/list_op.o
    CC shared/privsep_op.o
    CC shared/hash_op.o
    CC shared/b64.o
    CC shared/file-queue.o
    CC shared/math_op.o
    CC shared/atomic.o
    CC shared/rules_op.o
    CC shared/string_op.o
    CC shared/url.o
    CC shared/version_op.o
    CC shared/enrollment_op.o
    CC shared/vector_op.o
    CC shared/mq_op.o
    CC shared/sysinfo_utils.o
    CC shared/custom_output_search_replace.o
    CC shared/validate_op.o
    CC shared/json_op.o
    CC shared/schedule_scan.o
    CC shared/expression.o
    CC shared/debug_op.o
    CC shared/remoted_op.o
    CC shared/bqueue_op.o
    CC shared/queue_op.o
    CC shared/utf8_op.o
    CC shared/randombytes.o
    CC shared/agent_op.o
    CC shared/wazuhdb_op.o
    CC os_net/os_net.o
    CC os_regex/os_regex_match.o
    CC os_regex/os_regex.o
    CC os_regex/os_regex_str.o
    CC os_regex/os_match.o
    CC os_regex/os_regex_compile.o
    CC os_regex/os_regex_startswith.o
    CC os_regex/os_regex_free_pattern.o
    CC os_regex/os_match_compile.o
    CC os_regex/os_regex_strbreak.o
    CC os_regex/os_match_free_pattern.o
    CC os_regex/os_regex_maps.o
    CC os_regex/os_regex_execute.o
    CC os_regex/os_match_execute.o
    CC os_xml/os_xml_variables.o
    CC os_xml/os_xml.o
    CC os_xml/os_xml_access.o
    CC os_xml/os_xml_node_access.o
    CC os_xml/os_xml_writer.o
    CC os_zlib/os_zlib.o
    CC os_auth/ssl.o
    CC os_auth/check_cert.o
    CC addagent/validate.o
    CC analysisd/logmsg.o
    CC os_csyslogd/config.o
    CC os_csyslogd/csyscom.o
    CC os_csyslogd/main.o
    CC os_csyslogd/csyslogd.o
    CC os_csyslogd/alert.o
    CC agentlessd/lessdcom.o
    CC agentlessd/main.o
    CC agentlessd/agentlessd.o
    CC os_execd/exec.o
    CC os_execd/config.o
    CC os_execd/wcom.o
    CC os_execd/execd.o
    CC os_execd/win_execd.o
    CC active-response/active_responses.o
    CC logcollector/read_ossecalert.o
    CC logcollector/state.o
    CC logcollector/config.o
    CC logcollector/logcollector.o
    CC logcollector/read_djb_multilog.o
    CC logcollector/read_postgresql_log.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from logcollector/read_postgresql_log.c:13:
In function ‘strncpy’,
    inlined from ‘read_postgresql_log’ at logcollector/read_postgresql_log.c:114:17:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin___strncpy_chk’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘read_postgresql_log’ at logcollector/read_postgresql_log.c:106:17:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin___strncpy_chk’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_ucs2_le.o
    CC logcollector/read_mssql_log.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from logcollector/read_mssql_log.c:13:
In function ‘strncpy’,
    inlined from ‘read_mssql_log’ at logcollector/read_mssql_log.c:117:17:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin___strncpy_chk’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘read_mssql_log’ at logcollector/read_mssql_log.c:108:17:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin___strncpy_chk’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_win_el.o
    CC logcollector/lccom.o
    CC logcollector/read_macos.o
    CC logcollector/read_json.o
    CC logcollector/read_win_event_channel.o
    CC logcollector/read_syslog.o
    CC logcollector/main.o
    CC logcollector/read_audit.o
    CC logcollector/read_multiline_regex.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from logcollector/read_audit.c:10:
In function ‘strncpy’,
    inlined from ‘audit_send_msg’ at logcollector/read_audit.c:31:13:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_audit.c: In function ‘audit_send_msg’:
logcollector/read_audit.c:25:13: note: length computed here
   25 |         z = strlen(cache[i]);
      |             ^~~~~~~~~~~~~~~~
    CC logcollector/read_nmapg.o
    CC logcollector/read_command.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from logcollector/read_nmapg.c:11:
In function ‘strncat’,
    inlined from ‘read_nmapg’ at logcollector/read_nmapg.c:246:13:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:136:10: warning: ‘__builtin___strncat_chk’ output may be truncated copying between 27 and 65533 bytes from a string of length 65536 [-Wstringop-truncation]
  136 |   return __builtin___strncat_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_mysql_log.o
    CC logcollector/read_ucs2_be.o
    CC logcollector/read_multiline.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from logcollector/read_multiline.c:11:
In function ‘strncpy’,
    inlined from ‘read_multiline’ at logcollector/read_multiline.c:96:9:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output may be truncated copying between 0 and 65534 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/macos_log.o
    CC logcollector/read_fullcommand.o
    CC logcollector/read_snortfull.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from logcollector/read_snortfull.c:11:
In function ‘strncpy’,
    inlined from ‘read_snortfull’ at logcollector/read_snortfull.c:54:17:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output may be truncated copying 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC remoted/manager.o
    CC remoted/state.o
    CC remoted/sendmsg.o
    CC remoted/request.o
    CC remoted/cfga-forward.o
    CC remoted/queue.o
    CC remoted/ar-forward.o
    CC remoted/netcounter.o
    CC remoted/config.o
    CC remoted/secure.o
    CC remoted/remoted.o
    CC remoted/main.o
    CC remoted/syslog.o
    CC remoted/shared_download.o
    CC remoted/syslogtcp.o
    CC remoted/netbuffer.o
    CC client-agent/state.o
    CC client-agent/sendmsg.o
    CC client-agent/request.o
    CC client-agent/agentd.o
    CC client-agent/config.o
    CC client-agent/event-forward.o
    CC client-agent/rotate_log.o
    CC client-agent/receiver-win.o
    CC client-agent/main.o
    CC client-agent/restart_agent.o
    CC client-agent/receiver.o
    CC client-agent/buffer.o
    CC client-agent/start_agent.o
    CC client-agent/agcom.o
    CC client-agent/notify.o
    CC monitord/rotate_log.o
    CC monitord/compress_log.o
    CC addagent/read_from_user.o
    CC addagent/main.o
    CC addagent/manage_keys.o
    CC addagent/manage_agents.o
    CC util/clear_stats.o
    CC util/agent_control.o
    CC util/verify-agent-conf.o
    CC util/wazuh-regex.o
    CC util/parallel-regex.o
    CC active-response/firewalls/default-firewall-drop.o
    CC shared/file_op_proc.o
    CC shared/debug_op_proc.o
    CC active-response/firewalls/pf.o
    CC active-response/firewalls/npf.o
    CC active-response/firewalls/ipfw.o
    CC active-response/firewalld-drop.o
    CC active-response/disable-account.o
    CC active-response/host-deny.o
    CC active-response/ip-customblock.o
    CC active-response/restart-wazuh.o
    CC active-response/route-null.o
    CC active-response/kaspersky.o
    CC active-response/wazuh-slack.o
    CC syscheckd/db/schema_fim_db.o
    CC syscheckd/run_realtime.o
    CC syscheckd/config.o
    CC syscheckd/create_db.o
    CC syscheckd/run_check.o
    CC syscheckd/syscheck.o
    CC syscheckd/fim_diff_changes.o
    CC syscheckd/fim_sync.o
    CC syscheckd/syscom.o
    CC syscheckd/main.o
    CC syscheckd/db/fim_db.o
    CC syscheckd/db/fim_db_files.o
    CC syscheckd/db/fim_db_registries.o
    CC syscheckd/whodata/audit_healthcheck.o
    CC syscheckd/whodata/audit_rule_handling.o
    CC syscheckd/whodata/syscheck_audit.o
    CC syscheckd/whodata/audit_parse.o
    CC syscheckd/whodata/win_whodata.o
    CC syscheckd/registry/registry.o
    CC syscheckd/registry/events.o
    CC rootcheck/common_rcl.o
    CC rootcheck/config.o
    CC rootcheck/check_rc_files.o
    CC rootcheck/check_rc_ports.o
rootcheck/check_rc_files.c: In function ‘check_rc_files’:
rootcheck/check_rc_files.c:171:52: warning: ‘%s’ directive output may be truncated writing up to 1024 bytes into a region of size 1023 [-Wformat-truncation=]
  171 |             snprintf(file_path, OS_SIZE_1024, "%s%c%s", basedir, PATH_SEP, file);
      |                                                    ^~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from rootcheck/check_rc_files.c:11:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output 2 or more bytes (assuming 1026) into a destination of size 1024
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rootcheck/check_rc_files.c:169:50: warning: ‘__builtin_snprintf’ output may be truncated before the last format character [-Wformat-truncation=]
  169 |             snprintf(file_path, OS_SIZE_1024, "%s", file);
      |                                                  ^
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from rootcheck/check_rc_files.c:11:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin_snprintf’ output between 1 and 1025 bytes into a destination of size 1024
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rootcheck/check_rc_files.c:191:44: warning: ‘%s’ directive output may be truncated writing up to 1024 bytes into a region of size between 979 and 2003 [-Wformat-truncation=]
  191 |             snprintf(op_msg, OS_SIZE_2048, "Rootkit '%s' detected "
      |                                            ^~~~~~~~~~~~~~~~~~~~~~~~
  192 |                      "by the presence of file '%s'.", name, file_path);
      |                                                             ~~~~~~~~~
rootcheck/check_rc_files.c:192:48: note: format string is defined here
  192 |                      "by the presence of file '%s'.", name, file_path);
      |                                                ^~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from rootcheck/check_rc_files.c:11:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 48 and 2096 bytes into a destination of size 2048
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC rootcheck/win-process.o
    CC rootcheck/unix-process.o
    CC rootcheck/common.o
rootcheck/unix-process.c: In function ‘os_get_process_list’:
rootcheck/unix-process.c:28:40: warning: ‘ -p ’ directive output may be truncated writing 4 bytes into a region of size between 0 and 1024 [-Wformat-truncation=]
   28 |     snprintf(command, OS_SIZE_1024, "%s -p %d 2> /dev/null", ps, mpid);
      |                                        ^~~~
rootcheck/unix-process.c:28:37: note: directive argument in the range [1, 32768]
   28 |     snprintf(command, OS_SIZE_1024, "%s -p %d 2> /dev/null", ps, mpid);
      |                                     ^~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from rootcheck/unix-process.c:11:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 19 and 1047 bytes into a destination of size 1024
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC rootcheck/rootcheck.o
    CC rootcheck/check_rc_if.o
    CC rootcheck/check_open_ports.o
    CC rootcheck/os_string.o
    CC rootcheck/win-common.o
    CC rootcheck/check_rc_readproc.o
    CC rootcheck/check_rc_dev.o
    CC rootcheck/check_rc_sys.o
rootcheck/check_rc_dev.c: In function ‘read_dev_dir’:
rootcheck/check_rc_dev.c:41:47: warning: ‘%s’ directive output may be truncated writing up to 4097 bytes into a region of size 1018 [-Wformat-truncation=]
   41 |         snprintf(op_msg, OS_SIZE_1024, "File '%s' present on /dev."
      |                                               ^~
......
  140 |         read_dev_file(f_name);
      |                       ~~~~~~                   
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from rootcheck/check_rc_dev.c:12:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 47 and 4144 bytes into a destination of size 1024
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC rootcheck/run_rk_check.o
rootcheck/check_rc_sys.c: In function ‘read_sys_dir’:
rootcheck/check_rc_sys.c:93:52: warning: ‘%s’ directive output may be truncated writing up to 4097 bytes into a region of size 998 [-Wformat-truncation=]
   93 |                     snprintf(op_msg, OS_SIZE_1024, "Anomaly detected in file "
      |                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~
......
  284 |         read_sys_file(f_name, do_read);
      |                       ~~~~~~                        
rootcheck/check_rc_sys.c:94:32: note: format string is defined here
   94 |                              "'%s'. File size doesn't match what we found. "
      |                                ^~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from rootcheck/check_rc_sys.c:11:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 99 and 4196 bytes into a destination of size 1024
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rootcheck/check_rc_sys.c:122:51: warning: ‘%s’ directive output may be truncated writing up to 4097 bytes into a region of size 1018 [-Wformat-truncation=]
  122 |             snprintf(op_msg, OS_SIZE_1024, "File '%s' is owned by root "
      |                                                   ^~
......
  284 |         read_sys_file(f_name, do_read);
      |                       ~~~~~~                       
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from rootcheck/check_rc_sys.c:11:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 64 and 4161 bytes into a destination of size 1024
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rootcheck/check_rc_sys.c:40:67: warning: ‘%s’ directive output may be truncated writing up to 4097 bytes into a region of size 998 [-Wformat-truncation=]
   40 |         snprintf(op_msg, OS_SIZE_1024, "Anomaly detected in file '%s'. "
      |                                                                   ^~
......
  284 |         read_sys_file(f_name, do_read);
      |                       ~~~~~~                                       
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from rootcheck/check_rc_sys.c:11:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 106 and 4203 bytes into a destination of size 1024
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC rootcheck/check_rc_policy.o
    CC rootcheck/check_rc_pids.o
    CC rootcheck/check_rc_trojans.o
    CC monitord/sign_log.o
    CC monitord/manage_files.o
    CC monitord/moncom.o
    CC monitord/monitord.o
    CC monitord/main.o
    CC monitord/generate_reports.o
    CC monitord/monitor_actions.o
    CC reportd/report.o
    CC os_auth/main-server.o
    CC os_auth/local-server.o
    CC os_auth/config.o
    CC os_auth/authcom.o
    CC os_auth/auth.o
./analysisd/compiled_rules/register_rule.sh build
*Build completed.
    CC analysisd/output/jsonout.o
    CC analysisd/output/prelude.o
    CC analysisd/output/zeromq.o
    CC analysisd/format/json_extended.o
    CC analysisd/format/to_json.o
    CC analysisd/alerts/exec.o
    CC analysisd/alerts/log.o
    CC analysisd/alerts/getloglocation.o
    CC analysisd/cdb/cdb_hash.o
    CC analysisd/cdb/uint32_pack.o
    CC analysisd/cdb/uint32_unpack.o
    CC analysisd/cdb/cdb_make.o
    CC analysisd/cdb/cdb.o
    CC analysisd/decoders/plugin_decoders-live.o
    CC analysisd/decoders/decoder-live.o
    CC analysisd/decoders/hostinfo-live.o
    CC analysisd/decoders/decode-xml-live.o
    CC analysisd/decoders/winevtchannel-live.o
    CC analysisd/decoders/syscheck-live.o
    CC analysisd/decoders/syscollector-live.o
    CC analysisd/decoders/security_configuration_assessment-live.o
    CC analysisd/decoders/dbsync-live.o
    CC analysisd/decoders/geoip-live.o
    CC analysisd/decoders/rootcheck-live.o
    CC analysisd/decoders/ciscat-live.o
    CC analysisd/decoders/decoders_list-live.o
    CC analysisd/decoders/plugins/pf_decoder-live.o
    CC analysisd/decoders/plugins/json_decoder-live.o
    CC analysisd/decoders/plugins/sonicwall_decoder-live.o
    CC analysisd/decoders/plugins/symantecws_decoder-live.o
    CC analysisd/decoders/plugins/ossecalert_decoder-live.o
    CC analysisd/compiled_rules/generic_samples-live.o
    CC analysisd/rules_list-test.o
    CC analysisd/asyscom-test.o
    CC analysisd/state-test.o
    CC analysisd/stats-test.o
    CC analysisd/mitre-test.o
    CC analysisd/lists-test.o
    CC analysisd/active-response-test.o
    CC analysisd/fts-test.o
    CC analysisd/lists_list-test.o
    CC analysisd/config-test.o
    CC analysisd/labels-test.o
    CC analysisd/cleanevent-test.o
    CC analysisd/eventinfo-test.o
    CC analysisd/eventinfo_list-test.o
    CC analysisd/ar_json-test.o
    CC analysisd/lists_make-test.o
    CC analysisd/config_json-test.o
    CC analysisd/rules-test.o
    CC analysisd/logtest-test.o
    CC analysisd/accumulator-test.o
    CC analysisd/dodiff-test.o
    CC analysisd/testrule-test.o
    CC analysisd/analysisd-test.o
    CC analysisd/decoders/plugin_decoders-test.o
    CC analysisd/decoders/decoder-test.o
    CC analysisd/decoders/hostinfo-test.o
    CC analysisd/decoders/decode-xml-test.o
    CC analysisd/decoders/winevtchannel-test.o
    CC analysisd/decoders/syscheck-test.o
    CC analysisd/decoders/syscollector-test.o
    CC analysisd/decoders/security_configuration_assessment-test.o
    CC analysisd/decoders/dbsync-test.o
    CC analysisd/decoders/geoip-test.o
    CC analysisd/decoders/rootcheck-test.o
    CC analysisd/decoders/ciscat-test.o
    CC analysisd/decoders/decoders_list-test.o
    CC analysisd/decoders/plugins/pf_decoder-test.o
    CC analysisd/decoders/plugins/json_decoder-test.o
    CC analysisd/decoders/plugins/sonicwall_decoder-test.o
    CC analysisd/decoders/plugins/symantecws_decoder-test.o
    CC analysisd/decoders/plugins/ossecalert_decoder-test.o
    CC analysisd/compiled_rules/generic_samples-test.o
    CC os_dbd/config.o
    CC os_dbd/db_op.o
    CC os_dbd/rules.o
    CC os_dbd/main.o
    CC os_dbd/server.o
    CC os_dbd/alert.o
    CC os_dbd/dbd.o
    CC os_integrator/integrator.o
    CC os_integrator/intgcom.o
    CC os_integrator/config.o
    CC os_integrator/main.o
    CC wazuh_modules/main.o
    CC wazuh_db/main.o
    LINK libwazuh.a
ar: `u' modifier ignored since `D' is the default (see `U')
    RANLIB libwazuh.a
    CC libwazuhshared.so
/usr/bin/ld: missing --end-group; added as last command line option
    LINK rootcheck.a
ar: `u' modifier ignored since `D' is the default (see `U')
    RANLIB rootcheck.a
    CC wazuh-monitord
    CC wazuh-reportd
    CC wazuh-authd
    CC analysisd/rules_list-live.o
    CC analysisd/asyscom-live.o
    CC analysisd/state-live.o
    CC analysisd/stats-live.o
    CC analysisd/mitre-live.o
    CC analysisd/lists-live.o
    CC analysisd/active-response-live.o
    CC analysisd/fts-live.o
    CC analysisd/lists_list-live.o
    CC analysisd/config-live.o
    CC analysisd/labels-live.o
    CC analysisd/cleanevent-live.o
    CC analysisd/eventinfo-live.o
    CC analysisd/eventinfo_list-live.o
    CC analysisd/ar_json-live.o
    CC analysisd/lists_make-live.o
    CC analysisd/config_json-live.o
    CC analysisd/rules-live.o
    CC analysisd/logtest-live.o
    CC analysisd/accumulator-live.o
    CC analysisd/dodiff-live.o
    CC analysisd/analysisd-live.o
    LINK alerts.a
ar: `u' modifier ignored since `D' is the default (see `U')
    LINK cdb.a
ar: `u' modifier ignored since `D' is the default (see `U')
    RANLIB cdb.a
    LINK decoders-live.a
ar: `u' modifier ignored since `D' is the default (see `U')
    LINK decoders-test.a
ar: `u' modifier ignored since `D' is the default (see `U')
    CC wazuh-dbd
    CC wazuh-integratord
    CC wazuh-modulesd
    CC wazuh-db
    CC wazuh-maild
    CC wazuh-csyslogd
    CC wazuh-agentlessd
    CC wazuh-execd
    CC wazuh-logcollector
    CC wazuh-remoted
    CC wazuh-agentd
    CC manage_agents
    CC clear_stats
    CC agent_control
    CC verify-agent-conf
    CC wazuh-regex
    CC parallel-regex
    CC default-firewall-drop
    CC pf
    CC npf
    CC ipfw
    CC firewalld-drop
    CC disable-account
    CC host-deny
    CC ip-customblock
    CC restart-wazuh
    CC route-null
    CC kaspersky
    CC wazuh-slack
    CC wazuh-syscheckd
    CC wazuh-analysisd
    CC wazuh-logtest-legacy
make[1]: Leaving directory '/home/hanes/wazuh/src'
make settings
make[1]: Entering directory '/home/hanes/wazuh/src'
grep: /etc/redhat-release: No such file or directory

General settings:
    TARGET:             server
    V:                  
    DEBUG:              
    DEBUGAD             
    INSTALLDIR:         
    DATABASE:           
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/16
    EXTERNAL_SRC_ONLY:  
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_ZEROMQ:         no
    USE_GEOIP:          no
    USE_PRELUDE:        no
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        yes
    USE_AUDIT:          yes
    DISABLE_SYSC:       no
    DISABLE_CISCAT:     no
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DENABLE_SYSC -DENABLE_CISCAT -DENABLE_AUDIT
Compiler:
    CFLAGS            -pthread -Iexternal/libdb/build_unix/ -Iexternal/pacman/lib/libalpm/ -Iexternal/libarchive/libarchive -Wl,--start-group -Iexternal/audit-userspace/lib -DNDEBUG -O2 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DENABLE_SYSC -DENABLE_CISCAT -DENABLE_AUDIT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Ishared_modules/common -Ishared_modules/dbsync/include -Ishared_modules/rsync/include -Iwazuh_modules/syscollector/include  -Idata_provider/include  -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include 
    LDFLAGS           '-Wl,-rpath,/../lib' -pthread -lrt -ldl -O2 -Lshared_modules/dbsync/build/lib -Lshared_modules/rsync/build/lib  -Lwazuh_modules/syscollector/build/lib -Ldata_provider/build/lib
    LIBS              -lrt -ldl -lm 
    CC                cc
    MAKE              make
make[1]: Leaving directory '/home/hanes/wazuh/src'

Done building server

```

</details>

## Compilation using wazuh-packages (GCC 9.4)

<details>
<summary>Output</summary>

```
grep: /etc/redhat-release: No such file or directory
make[2]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src'
checkmodule -M -m -o selinux/wazuh.mod selinux/wazuh.te
checkmodule:  loading policy configuration from selinux/wazuh.te
checkmodule:  policy configuration loaded
checkmodule:  writing binary representation (version 14) to selinux/wazuh.mod
semodule_package -o selinux/wazuh.pp -m selinux/wazuh.mod
make build_sysinfo build_shared_modules build_syscollector
grep: /etc/redhat-release: No such file or directory
make[3]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src'
    CC libwazuhext.so
cd data_provider/ && mkdir -p build && cd build && cmake     .. && make
cd shared_modules/dbsync/ && mkdir -p build && cd build && cmake    .. && make
-- The C compiler identification is GNU 4.7.2
-- The C compiler identification is GNU 4.7.2
-- The CXX compiler identification is GNU 9.4.0
-- The CXX compiler identification is GNU 9.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Configuring done
-- Generating done
-- Build files have been written to: /build_wazuh/manager/wazuh-manager-4.4.0/src/data_provider/build
-- Generating done
-- Build files have been written to: /build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/dbsync/build
make[4]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/data_provider/build'
make[4]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/dbsync/build'
make[5]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/data_provider/build'
make[6]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/data_provider/build'
make[5]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/dbsync/build'
make[6]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync
make[6]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/dbsync/build'
make[6]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/dbsync/build'
[ 10%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync.cpp.o
Scanning dependencies of target sysinfo
make[6]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/data_provider/build'
make[6]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/data_provider/build'
[  7%] Building CXX object CMakeFiles/sysinfo.dir/src/network/networkInterfaceLinux.cpp.o
[ 15%] Building CXX object CMakeFiles/sysinfo.dir/src/osinfo/sysOsParsers.cpp.o
[ 20%] Building CXX object CMakeFiles/dbsync.dir/src/dbsyncPipelineFactory.cpp.o
[ 30%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync_implementation.cpp.o
[ 23%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserDeb.cpp.o
[ 40%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_dbengine.cpp.o
[ 30%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserExtra.cpp.o
[ 38%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserRpm.cpp.o
[ 46%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserRpmLegacy.cpp.o
[ 50%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_wrapper.cpp.o
[ 60%] Linking CXX shared library lib/libdbsync.so
make[6]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/dbsync/build'
[ 60%] Built target dbsync
make[6]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync_example
make[6]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/dbsync/build'
make[6]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/dbsync/build'
[ 70%] Building CXX object example/CMakeFiles/dbsync_example.dir/main.cpp.o
[ 80%] Linking CXX executable ../bin/dbsync_example
make[6]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/dbsync/build'
[ 80%] Built target dbsync_example
make[6]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync_test_tool
make[6]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/dbsync/build'
make[6]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/dbsync/build'
[ 90%] Building CXX object testtool/CMakeFiles/dbsync_test_tool.dir/main.cpp.o
[ 53%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/rpmPackageManager.cpp.o
[ 61%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfoLinux.cpp.o
[100%] Linking CXX executable ../bin/dbsync_test_tool
make[6]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/dbsync/build'
[100%] Built target dbsync_test_tool
make[5]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/dbsync/build'
make[4]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/dbsync/build'
cd shared_modules/rsync/ && mkdir -p build && cd build && cmake     .. && make
-- The C compiler identification is GNU 4.7.2
-- The CXX compiler identification is GNU 9.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/rsync/build
make[4]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/rsync/build'
make[5]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/rsync/build'
make[6]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/rsync/build'
Scanning dependencies of target rsync
make[6]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/rsync/build'
make[6]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/rsync/build'
[ 12%] Building CXX object CMakeFiles/rsync.dir/src/rsync.cpp.o
[ 69%] Building CXX object CMakeFiles/sysinfo.dir/src/utilsWrapperLinux.cpp.o
[ 76%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfo.cpp.o
[ 84%] Linking CXX shared library lib/libsysinfo.so
make[6]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/data_provider/build'
[ 84%] Built target sysinfo
make[6]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/data_provider/build'
Scanning dependencies of target sysinfo_test_tool
make[6]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/data_provider/build'
make[6]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/data_provider/build'
[ 92%] Building CXX object testtool/CMakeFiles/sysinfo_test_tool.dir/main.cpp.o
[ 25%] Building CXX object CMakeFiles/rsync.dir/src/rsyncImplementation.cpp.o
[100%] Linking CXX executable ../bin/sysinfo_test_tool
make[6]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/data_provider/build'
[100%] Built target sysinfo_test_tool
make[5]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/data_provider/build'
make[4]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/data_provider/build'
[ 37%] Linking CXX shared library lib/librsync.so
make[6]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/rsync/build'
[ 37%] Built target rsync
make[6]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/rsync/build'
Scanning dependencies of target rsync_test_tool
make[6]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/rsync/build'
make[6]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/rsync/build'
[ 50%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/main.cpp.o
[ 62%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/agentEmulator.cpp.o
[ 75%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/oneTimeSync.cpp.o
[ 87%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/managerEmulator.cpp.o
[100%] Linking CXX executable ../bin/rsync_test_tool
make[6]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/rsync/build'
[100%] Built target rsync_test_tool
make[5]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/rsync/build'
make[4]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/shared_modules/rsync/build'
cd wazuh_modules/syscollector/ && mkdir -p build && cd build && cmake     .. && make
-- The C compiler identification is GNU 4.7.2
-- The CXX compiler identification is GNU 9.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /build_wazuh/manager/wazuh-manager-4.4.0/src/wazuh_modules/syscollector/build
make[4]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/wazuh_modules/syscollector/build'
make[5]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/wazuh_modules/syscollector/build'
make[6]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/wazuh_modules/syscollector/build'
Scanning dependencies of target syscollector
make[6]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/wazuh_modules/syscollector/build'
make[6]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/wazuh_modules/syscollector/build'
[ 33%] Building CXX object CMakeFiles/syscollector.dir/src/syscollector.cpp.o
[ 33%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorImp.cpp.o
[ 50%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorNormalizer.cpp.o
[ 66%] Linking CXX shared library lib/libsyscollector.so
make[6]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/wazuh_modules/syscollector/build'
[ 66%] Built target syscollector
make[6]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/wazuh_modules/syscollector/build'
Scanning dependencies of target syscollector_test_tool
make[6]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/wazuh_modules/syscollector/build'
make[6]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/wazuh_modules/syscollector/build'
[ 83%] Building CXX object testtool/CMakeFiles/syscollector_test_tool.dir/main.cpp.o
[100%] Linking CXX executable ../bin/syscollector_test_tool
make[6]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/wazuh_modules/syscollector/build'
[100%] Built target syscollector_test_tool
make[5]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/wazuh_modules/syscollector/build'
make[4]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src/wazuh_modules/syscollector/build'
make[3]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src'
make wazuh-maild - wazuh-csyslogd - wazuh-agentlessd - wazuh-execd - wazuh-logcollector - wazuh-remoted wazuh-agentd manage_agents utils active-responses wazuh-syscheckd wazuh-monitord wazuh-reportd wazuh-authd wazuh-analysisd wazuh-logtest-legacy wazuh-dbd - wazuh-integratord wazuh-modulesd wazuh-db
grep: /etc/redhat-release: No such file or directory
make[3]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src'
    CC os_maild/config.o
    CC os_maild/mail_list.o
    CC os_maild/mailcom.o
    CC os_maild/maild.o
    CC os_maild/os_maild_client.o
    CC os_maild/sendcustomemail.o
    CC os_maild/sendmail.o
    CC config/active-response.o
    CC config/agentlessd-config.o
    CC config/alerts-config.o
    CC config/authd-config.o
    CC config/buffer-config.o
    CC config/client-config.o
    CC config/cluster-config.o
    CC config/config.o
    CC config/csyslogd-config.o
    CC config/dbd-config.o
    CC config/email-alerts-config.o
    CC config/global-config.o
    CC config/integrator-config.o
    CC config/labels-config.o
    CC config/localfile-config.o
    CC config/logtest-config.o
    CC config/remote-config.o
    CC config/reports-config.o
    CC config/rootcheck-config.o
    CC config/rules-config.o
    CC config/socket-config.o
    CC config/syscheck-config.o
    CC config/wmodules-agent-upgrade.o
    CC config/wmodules-aws.o
    CC config/wmodules-azure.o
    CC config/wmodules-ciscat.o
    CC config/wmodules-command.o
    CC config/wmodules-config.o
    CC config/wmodules-docker.o
    CC config/wmodules-fluent.o
    CC config/wmodules-gcp.o
    CC config/wmodules-github.o
    CC config/wmodules-key-request.o
    CC config/wmodules-office365.o
    CC config/wmodules-oscap.o
    CC config/wmodules-osquery-monitor.o
    CC config/wmodules-sca.o
    CC config/wmodules-task-manager.o
    CC config/wmodules-vuln-detector.o
    CC config/wmodules_syscollector.o
    CC wazuh_modules/wm_aws.o
    CC wazuh_modules/wm_azure.o
    CC wazuh_modules/wm_ciscat.o
    CC wazuh_modules/wm_command.o
    CC wazuh_modules/wm_control.o
    CC wazuh_modules/wm_database.o
    CC wazuh_modules/wm_docker.o
    CC wazuh_modules/wm_download.o
    CC wazuh_modules/wm_exec.o
    CC wazuh_modules/wm_fluent.o
    CC wazuh_modules/wm_gcp.o
    CC wazuh_modules/wm_github.o
    CC wazuh_modules/wm_keyrequest.o
    CC wazuh_modules/wm_office365.o
    CC wazuh_modules/wm_oscap.o
    CC wazuh_modules/wm_osquery_monitor.o
    CC wazuh_modules/wm_sca.o
    CC wazuh_modules/wm_syscollector.o
    CC wazuh_modules/wm_task_general.o
    CC wazuh_modules/wmcom.o
    CC wazuh_modules/wmodules.o
    CC wazuh_modules/agent_upgrade/wm_agent_upgrade.o
    CC wazuh_modules/vulnerability_detector/wm_vuln_detector.o
    CC wazuh_modules/vulnerability_detector/wm_vuln_detector_evr.o
    CC wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.o
    CC wazuh_modules/task_manager/wm_task_manager.o
    CC wazuh_modules/task_manager/wm_task_manager_commands.o
    CC wazuh_modules/task_manager/wm_task_manager_parsing.o
    CC wazuh_modules/task_manager/wm_task_manager_tasks.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_commands.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_manager.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_parsing.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks_callbacks.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_upgrades.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.o
    CC wazuh_db/wdb.o
    CC wazuh_db/wdb_agents.o
    CC wazuh_db/wdb_ciscat.o
    CC wazuh_db/wdb_fim.o
    CC wazuh_db/wdb_global.o
    CC wazuh_db/wdb_integrity.o
    CC wazuh_db/wdb_metadata.o
    CC wazuh_db/wdb_parser.o
    CC wazuh_db/wdb_rootcheck.o
    CC wazuh_db/wdb_sca.o
    CC wazuh_db/wdb_scan_info.o
    CC wazuh_db/wdb_syscollector.o
    CC wazuh_db/wdb_task.o
    CC wazuh_db/wdb_upgrade.o
    CC wazuh_db/helpers/wdb_agents_helpers.o
    CC wazuh_db/helpers/wdb_global_helpers.o
    CC wazuh_db/schema_agents.o
    CC wazuh_db/schema_global.o
    CC wazuh_db/schema_global_upgrade_v1.o
    CC wazuh_db/schema_global_upgrade_v2.o
    CC wazuh_db/schema_global_upgrade_v3.o
    CC wazuh_db/schema_task_manager.o
    CC wazuh_db/schema_upgrade_v1.o
    CC wazuh_db/schema_upgrade_v2.o
    CC wazuh_db/schema_upgrade_v3.o
    CC wazuh_db/schema_upgrade_v4.o
    CC wazuh_db/schema_upgrade_v5.o
    CC wazuh_db/schema_upgrade_v6.o
    CC wazuh_db/schema_upgrade_v7.o
    CC wazuh_db/schema_upgrade_v8.o
    CC wazuh_db/schema_vuln_detector.o
    CC os_crypto/blowfish/bf_op.o
    CC os_crypto/md5/md5_op.o
    CC os_crypto/sha1/sha1_op.o
    CC os_crypto/shared/keys.o
    CC os_crypto/shared/msgs.o
    CC os_crypto/md5_sha1/md5_sha1_op.o
    CC os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.o
    CC os_crypto/sha256/sha256_op.o
    CC os_crypto/sha512/sha512_op.o
    CC os_crypto/aes/aes_op.o
    CC os_crypto/hmac/hmac.o
    CC os_crypto/signature/signature.o
    CC shared/agent_op.o
    CC shared/atomic.o
    CC shared/audit_op.o
    CC shared/auth_client.o
    CC shared/b64.o
    CC shared/bqueue_op.o
    CC shared/buffer_op.o
    CC shared/bzip2_op.o
    CC shared/cluster_utils.o
    CC shared/custom_output_search_replace.o
    CC shared/debug_op.o
    CC shared/enrollment_op.o
    CC shared/exec_op.o
    CC shared/expression.o
    CC shared/file-queue.o
    CC shared/file_op.o
    CC shared/fs_op.o
    CC shared/hash_op.o
    CC shared/help.o
    CC shared/integrity_op.o
    CC shared/json-queue.o
    CC shared/json_op.o
    CC shared/labels_op.o
    CC shared/list_op.o
    CC shared/log_builder.o
    CC shared/math_op.o
    CC shared/mem_op.o
    CC shared/mq_op.o
    CC shared/notify_op.o
    CC shared/os_utils.o
    CC shared/privsep_op.o
    CC shared/pthreads_op.o
    CC shared/queue_linked_op.o
    CC shared/queue_op.o
    CC shared/randombytes.o
    CC shared/rbtree_op.o
    CC shared/read-agents.o
    CC shared/read-alert.o
    CC shared/regex_op.o
    CC shared/remoted_op.o
    CC shared/report_op.o
    CC shared/request_op.o
    CC shared/rootcheck_op.o
    CC shared/rules_op.o
    CC shared/schedule_scan.o
    CC shared/sig_op.o
    CC shared/store_op.o
    CC shared/string_op.o
    CC shared/sym_load.o
    CC shared/syscheck_op.o
    CC shared/sysinfo_utils.o
    CC shared/time_op.o
    CC shared/url.o
    CC shared/utf8_op.o
    CC shared/validate_op.o
    CC shared/vector_op.o
    CC shared/version_op.o
    CC shared/wait_op.o
    CC shared/wazuhdb_op.o
    CC shared/yaml2json.o
    CC os_net/os_net.o
    CC os_regex/os_match.o
    CC os_regex/os_match_compile.o
    CC os_regex/os_match_execute.o
    CC os_regex/os_match_free_pattern.o
    CC os_regex/os_regex.o
    CC os_regex/os_regex_compile.o
    CC os_regex/os_regex_execute.o
    CC os_regex/os_regex_free_pattern.o
    CC os_regex/os_regex_maps.o
    CC os_regex/os_regex_match.o
    CC os_regex/os_regex_startswith.o
    CC os_regex/os_regex_str.o
    CC os_xml/os_xml.o
    CC os_regex/os_regex_strbreak.o
    CC os_xml/os_xml_access.o
    CC os_xml/os_xml_node_access.o
    CC os_xml/os_xml_variables.o
    CC os_xml/os_xml_writer.o
    CC os_zlib/os_zlib.o
    CC os_auth/ssl.o
    CC os_auth/check_cert.o
    CC addagent/validate.o
    CC analysisd/logmsg.o
    CC os_csyslogd/alert.o
    CC os_csyslogd/config.o
    CC os_csyslogd/csyscom.o
    CC os_csyslogd/csyslogd.o
    CC os_csyslogd/main.o
    CC agentlessd/agentlessd.o
    CC agentlessd/lessdcom.o
    CC agentlessd/main.o
    CC os_execd/config.o
    CC os_execd/exec.o
    CC os_execd/execd.o
    CC os_execd/wcom.o
    CC os_execd/win_execd.o
    CC active-response/active_responses.o
    CC logcollector/config.o
    CC logcollector/lccom.o
    CC logcollector/logcollector.o
    CC logcollector/macos_log.o
    CC logcollector/main.o
    CC logcollector/read_audit.o
    CC logcollector/read_command.o
    CC logcollector/read_djb_multilog.o
    CC logcollector/read_fullcommand.o
    CC logcollector/read_json.o
    CC logcollector/read_macos.o
    CC logcollector/read_mssql_log.o
    CC logcollector/read_multiline.o
    CC logcollector/read_multiline_regex.o
    CC logcollector/read_mysql_log.o
    CC logcollector/read_nmapg.o
    CC logcollector/read_ossecalert.o
    CC logcollector/read_postgresql_log.o
    CC logcollector/read_snortfull.o
    CC logcollector/read_syslog.o
    CC logcollector/read_ucs2_be.o
    CC logcollector/read_ucs2_le.o
    CC logcollector/read_win_el.o
    CC logcollector/read_win_event_channel.o
    CC logcollector/state.o
    CC remoted/ar-forward.o
    CC remoted/cfga-forward.o
    CC remoted/config.o
    CC remoted/main.o
    CC remoted/manager.o
    CC remoted/netbuffer.o
    CC remoted/netcounter.o
    CC remoted/queue.o
    CC remoted/remoted.o
    CC remoted/request.o
    CC remoted/secure.o
    CC remoted/sendmsg.o
    CC remoted/shared_download.o
    CC remoted/state.o
    CC remoted/syslog.o
    CC remoted/syslogtcp.o
    CC client-agent/agcom.o
    CC client-agent/agentd.o
    CC client-agent/buffer.o
    CC client-agent/config.o
    CC client-agent/event-forward.o
    CC client-agent/main.o
    CC client-agent/notify.o
    CC client-agent/receiver-win.o
    CC client-agent/receiver.o
    CC client-agent/request.o
    CC client-agent/restart_agent.o
    CC client-agent/rotate_log.o
    CC client-agent/sendmsg.o
    CC client-agent/start_agent.o
    CC client-agent/state.o
    CC monitord/rotate_log.o
    CC monitord/compress_log.o
    CC addagent/main.o
    CC addagent/manage_agents.o
    CC addagent/manage_keys.o
    CC addagent/read_from_user.o
    CC util/clear_stats.o
    CC util/agent_control.o
    CC util/verify-agent-conf.o
    CC util/wazuh-regex.o
    CC util/parallel-regex.o
    CC active-response/firewalls/default-firewall-drop.o
    CC shared/file_op_proc.o
    CC shared/debug_op_proc.o
    CC active-response/firewalls/pf.o
    CC active-response/firewalls/npf.o
    CC active-response/firewalls/ipfw.o
    CC active-response/firewalld-drop.o
    CC active-response/disable-account.o
    CC active-response/host-deny.o
    CC active-response/ip-customblock.o
    CC active-response/restart-wazuh.o
    CC active-response/route-null.o
    CC active-response/kaspersky.o
    CC active-response/wazuh-slack.o
    CC syscheckd/db/schema_fim_db.o
    CC syscheckd/config.o
    CC syscheckd/create_db.o
    CC syscheckd/fim_diff_changes.o
    CC syscheckd/fim_sync.o
    CC syscheckd/main.o
    CC syscheckd/run_check.o
    CC syscheckd/run_realtime.o
    CC syscheckd/syscheck.o
    CC syscheckd/syscom.o
    CC syscheckd/db/fim_db.o
    CC syscheckd/db/fim_db_files.o
    CC syscheckd/db/fim_db_registries.o
    CC syscheckd/whodata/audit_healthcheck.o
    CC syscheckd/whodata/audit_parse.o
    CC syscheckd/whodata/audit_rule_handling.o
    CC syscheckd/whodata/syscheck_audit.o
    CC syscheckd/whodata/win_whodata.o
    CC syscheckd/registry/events.o
    CC syscheckd/registry/registry.o
    CC rootcheck/check_open_ports.o
    CC rootcheck/check_rc_dev.o
    CC rootcheck/check_rc_files.o
    CC rootcheck/check_rc_if.o
    CC rootcheck/check_rc_pids.o
    CC rootcheck/check_rc_policy.o
    CC rootcheck/check_rc_ports.o
    CC rootcheck/check_rc_readproc.o
    CC rootcheck/check_rc_sys.o
    CC rootcheck/check_rc_trojans.o
    CC rootcheck/common.o
    CC rootcheck/common_rcl.o
    CC rootcheck/config.o
    CC rootcheck/os_string.o
    CC rootcheck/rootcheck.o
    CC rootcheck/run_rk_check.o
    CC rootcheck/unix-process.o
    CC rootcheck/win-common.o
    CC rootcheck/win-process.o
    CC monitord/generate_reports.o
    CC monitord/main.o
    CC monitord/manage_files.o
    CC monitord/moncom.o
    CC monitord/monitor_actions.o
    CC monitord/monitord.o
    CC monitord/sign_log.o
    CC reportd/report.o
    CC os_auth/main-server.o
    CC os_auth/local-server.o
    CC os_auth/config.o
    CC os_auth/authcom.o
    CC os_auth/auth.o
./analysisd/compiled_rules/register_rule.sh build
*Build completed.
    CC analysisd/output/jsonout.o
    CC analysisd/output/prelude.o
    CC analysisd/output/zeromq.o
    CC analysisd/format/json_extended.o
    CC analysisd/format/to_json.o
    CC analysisd/alerts/exec.o
    CC analysisd/alerts/getloglocation.o
    CC analysisd/alerts/log.o
    CC analysisd/cdb/cdb.o
    CC analysisd/cdb/cdb_hash.o
    CC analysisd/cdb/cdb_make.o
    CC analysisd/cdb/uint32_pack.o
    CC analysisd/cdb/uint32_unpack.o
    CC analysisd/decoders/ciscat-live.o
    CC analysisd/decoders/dbsync-live.o
    CC analysisd/decoders/decode-xml-live.o
    CC analysisd/decoders/decoder-live.o
    CC analysisd/decoders/decoders_list-live.o
    CC analysisd/decoders/geoip-live.o
    CC analysisd/decoders/hostinfo-live.o
    CC analysisd/decoders/plugin_decoders-live.o
    CC analysisd/decoders/rootcheck-live.o
    CC analysisd/decoders/security_configuration_assessment-live.o
    CC analysisd/decoders/syscheck-live.o
    CC analysisd/decoders/syscollector-live.o
    CC analysisd/decoders/winevtchannel-live.o
    CC analysisd/decoders/plugins/json_decoder-live.o
    CC analysisd/decoders/plugins/ossecalert_decoder-live.o
    CC analysisd/decoders/plugins/pf_decoder-live.o
    CC analysisd/decoders/plugins/sonicwall_decoder-live.o
    CC analysisd/decoders/plugins/symantecws_decoder-live.o
    CC analysisd/compiled_rules/generic_samples-live.o
    CC analysisd/accumulator-test.o
    CC analysisd/active-response-test.o
    CC analysisd/ar_json-test.o
    CC analysisd/asyscom-test.o
    CC analysisd/cleanevent-test.o
    CC analysisd/config-test.o
    CC analysisd/config_json-test.o
    CC analysisd/dodiff-test.o
    CC analysisd/eventinfo-test.o
    CC analysisd/eventinfo_list-test.o
    CC analysisd/fts-test.o
    CC analysisd/labels-test.o
    CC analysisd/lists-test.o
    CC analysisd/lists_list-test.o
    CC analysisd/lists_make-test.o
    CC analysisd/logtest-test.o
    CC analysisd/mitre-test.o
    CC analysisd/rules-test.o
    CC analysisd/rules_list-test.o
    CC analysisd/state-test.o
    CC analysisd/stats-test.o
    CC analysisd/testrule-test.o
    CC analysisd/analysisd-test.o
    CC analysisd/decoders/ciscat-test.o
    CC analysisd/decoders/dbsync-test.o
    CC analysisd/decoders/decode-xml-test.o
    CC analysisd/decoders/decoder-test.o
    CC analysisd/decoders/decoders_list-test.o
    CC analysisd/decoders/geoip-test.o
    CC analysisd/decoders/hostinfo-test.o
    CC analysisd/decoders/plugin_decoders-test.o
    CC analysisd/decoders/rootcheck-test.o
    CC analysisd/decoders/security_configuration_assessment-test.o
    CC analysisd/decoders/syscheck-test.o
    CC analysisd/decoders/syscollector-test.o
    CC analysisd/decoders/winevtchannel-test.o
    CC analysisd/decoders/plugins/json_decoder-test.o
    CC analysisd/decoders/plugins/ossecalert_decoder-test.o
    CC analysisd/decoders/plugins/pf_decoder-test.o
    CC analysisd/decoders/plugins/sonicwall_decoder-test.o
    CC analysisd/decoders/plugins/symantecws_decoder-test.o
    CC analysisd/compiled_rules/generic_samples-test.o
    CC os_dbd/alert.o
    CC os_dbd/config.o
    CC os_dbd/db_op.o
    CC os_dbd/dbd.o
    CC os_dbd/main.o
    CC os_dbd/rules.o
    CC os_dbd/server.o
    CC os_integrator/config.o
    CC os_integrator/integrator.o
    CC os_integrator/intgcom.o
    CC os_integrator/main.o
    CC wazuh_modules/main.o
    CC wazuh_db/main.o
    LINK libwazuh.a
    RANLIB libwazuh.a
    CC libwazuhshared.so
    LINK rootcheck.a
    RANLIB rootcheck.a
    CC wazuh-monitord
    CC wazuh-reportd
    CC wazuh-authd
    CC analysisd/accumulator-live.o
    CC analysisd/active-response-live.o
    CC analysisd/ar_json-live.o
    CC analysisd/asyscom-live.o
    CC analysisd/cleanevent-live.o
    CC analysisd/config-live.o
    CC analysisd/config_json-live.o
    CC analysisd/dodiff-live.o
    CC analysisd/eventinfo-live.o
    CC analysisd/eventinfo_list-live.o
    CC analysisd/fts-live.o
    CC analysisd/labels-live.o
    CC analysisd/lists-live.o
    CC analysisd/lists_list-live.o
    CC analysisd/lists_make-live.o
    CC analysisd/logtest-live.o
    CC analysisd/mitre-live.o
    CC analysisd/rules-live.o
    CC analysisd/rules_list-live.o
    CC analysisd/state-live.o
    CC analysisd/stats-live.o
    CC analysisd/analysisd-live.o
    LINK alerts.a
    LINK cdb.a
    RANLIB cdb.a
    LINK decoders-live.a
    LINK decoders-test.a
    CC wazuh-dbd
    CC wazuh-integratord
    CC wazuh-modulesd
    CC wazuh-db
    CC wazuh-maild
    CC wazuh-csyslogd
    CC wazuh-agentlessd
    CC wazuh-execd
    CC wazuh-logcollector
    CC wazuh-remoted
    CC wazuh-agentd
    CC manage_agents
    CC clear_stats
    CC agent_control
    CC verify-agent-conf
    CC wazuh-regex
    CC parallel-regex
    CC default-firewall-drop
    CC pf
    CC ipfw
    CC npf
    CC firewalld-drop
    CC disable-account
    CC host-deny
    CC ip-customblock
    CC restart-wazuh
    CC route-null
    CC kaspersky
    CC wazuh-slack
    CC wazuh-syscheckd
    CC wazuh-analysisd
    CC wazuh-logtest-legacy
make[3]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src'
make settings
grep: /etc/redhat-release: No such file or directory
make[3]: Entering directory `/build_wazuh/manager/wazuh-manager-4.4.0/src'

General settings:
    TARGET:             server
    V:                  
    DEBUG:              no
    DEBUGAD             
    INSTALLDIR:         
    DATABASE:           
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/16
    EXTERNAL_SRC_ONLY:  
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_ZEROMQ:         no
    USE_GEOIP:          no
    USE_PRELUDE:        no
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        yes
    USE_AUDIT:          yes
    DISABLE_SYSC:       no
    DISABLE_CISCAT:     no
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DENABLE_SYSC -DENABLE_CISCAT -DENABLE_AUDIT
Compiler:
    CFLAGS            -pthread -Iexternal/libdb/build_unix/ -Iexternal/pacman/lib/libalpm/ -Iexternal/libarchive/libarchive -Wl,--start-group -Iexternal/audit-userspace/lib -DNDEBUG -O2 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DENABLE_SYSC -DENABLE_CISCAT -DENABLE_AUDIT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Ishared_modules/common -Ishared_modules/dbsync/include -Ishared_modules/rsync/include -Iwazuh_modules/syscollector/include  -Idata_provider/include  -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include 
    LDFLAGS           '-Wl,-rpath,/../lib' -pthread -lrt -ldl -O2 -Lshared_modules/dbsync/build/lib -Lshared_modules/rsync/build/lib  -Lwazuh_modules/syscollector/build/lib -Ldata_provider/build/lib
    LIBS              -lrt -ldl -lm 
    CC                cc
    MAKE              make
make[3]: Leaving directory `/build_wazuh/manager/wazuh-manager-4.4.0/src'

Done building server

```

</details>

## Compilation using GCC 10.2.1

<details>
<summary>Output</summary>

```
~/wazuh/wazuh/src (12098-solve-several-warnings-compilation-wazuh-server) $ make -j4 TARGET=server
grep: /etc/redhat-release: No such file or directory
make build_sysinfo build_shared_modules build_syscollector
make[1]: Entering directory '/home/hanes/wazuh/wazuh/src'
grep: /etc/redhat-release: No such file or directory
    CC libwazuhext.so
/usr/bin/ld: missing --end-group; added as last command line option
cd data_provider/ && mkdir -p build && cd build && cmake     .. && make
cd shared_modules/dbsync/ && mkdir -p build && cd build && cmake    .. && make
-- The C compiler identification is GNU 10.2.1
-- The C compiler identification is GNU 10.2.1
-- The CXX compiler identification is GNU 10.2.1
-- The CXX compiler identification is GNU 10.2.1
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc - works
-- Check for working C compiler: /usr/bin/cc - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ - works
-- Check for working CXX compiler: /usr/bin/c++ - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Configuring done
-- Generating done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/wazuh/src/data_provider/build
-- Build files have been written to: /home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build
make[2]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[2]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[3]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[3]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target sysinfo
Scanning dependencies of target dbsync
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 10%] Building CXX object CMakeFiles/dbsync.dir/src/dbsyncPipelineFactory.cpp.o
[ 20%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync.cpp.o
[ 30%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync_implementation.cpp.o
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
[  7%] Building CXX object CMakeFiles/sysinfo.dir/src/network/networkInterfaceLinux.cpp.o
[ 40%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_dbengine.cpp.o
[ 15%] Building CXX object CMakeFiles/sysinfo.dir/src/osinfo/sysOsParsers.cpp.o
[ 50%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_wrapper.cpp.o
[ 23%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserDeb.cpp.o
[ 30%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserExtra.cpp.o
[ 38%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserRpm.cpp.o
[ 46%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserRpmLegacy.cpp.o
[ 53%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/rpmPackageManager.cpp.o
[ 60%] Linking CXX shared library lib/libdbsync.so
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 60%] Built target dbsync
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync_example
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 70%] Building CXX object example/CMakeFiles/dbsync_example.dir/main.cpp.o
[ 61%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfoLinux.cpp.o
[ 80%] Linking CXX executable ../bin/dbsync_example
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 80%] Built target dbsync_example
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 90%] Building CXX object testtool/CMakeFiles/dbsync_test_tool.dir/main.cpp.o
[ 69%] Building CXX object CMakeFiles/sysinfo.dir/src/utilsWrapperLinux.cpp.o
[ 76%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfo.cpp.o
[ 84%] Linking CXX shared library lib/libsysinfo.so
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
[ 84%] Built target sysinfo
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
Scanning dependencies of target sysinfo_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
[ 92%] Building CXX object testtool/CMakeFiles/sysinfo_test_tool.dir/main.cpp.o
[100%] Linking CXX executable ../bin/dbsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[100%] Built target dbsync_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[2]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
cd shared_modules/rsync/ && mkdir -p build && cd build && cmake     .. && make
-- The C compiler identification is GNU 10.2.1
-- The CXX compiler identification is GNU 10.2.1
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/wazuh/src/shared_modules/rsync/build
make[2]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[3]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
Scanning dependencies of target rsync
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
[ 25%] Building CXX object CMakeFiles/rsync.dir/src/rsync.cpp.o
[ 25%] Building CXX object CMakeFiles/rsync.dir/src/rsyncImplementation.cpp.o
[100%] Linking CXX executable ../bin/sysinfo_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
[100%] Built target sysinfo_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[2]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
[ 37%] Linking CXX shared library lib/librsync.so
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
[ 37%] Built target rsync
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
Scanning dependencies of target rsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
[ 50%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/main.cpp.o
[ 62%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/agentEmulator.cpp.o
[ 75%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/oneTimeSync.cpp.o
[ 87%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/managerEmulator.cpp.o
[100%] Linking CXX executable ../bin/rsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
[100%] Built target rsync_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[2]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
cd wazuh_modules/syscollector/ && mkdir -p build && cd build && cmake     .. && make
-- The C compiler identification is GNU 10.2.1
-- The CXX compiler identification is GNU 10.2.1
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build
make[2]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[3]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
Scanning dependencies of target syscollector
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
[ 33%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorImp.cpp.o
[ 33%] Building CXX object CMakeFiles/syscollector.dir/src/syscollector.cpp.o
[ 50%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorNormalizer.cpp.o
[ 66%] Linking CXX shared library lib/libsyscollector.so
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
[ 66%] Built target syscollector
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
Scanning dependencies of target syscollector_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
[ 83%] Building CXX object testtool/CMakeFiles/syscollector_test_tool.dir/main.cpp.o
[100%] Linking CXX executable ../bin/syscollector_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
[100%] Built target syscollector_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[2]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[1]: Leaving directory '/home/hanes/wazuh/wazuh/src'
make wazuh-maild - wazuh-csyslogd - wazuh-agentlessd - wazuh-execd - wazuh-logcollector - wazuh-remoted wazuh-agentd manage_agents utils active-responses wazuh-syscheckd wazuh-monitord wazuh-reportd wazuh-authd wazuh-analysisd wazuh-logtest-legacy wazuh-dbd - wazuh-integratord wazuh-modulesd wazuh-db
make[1]: Entering directory '/home/hanes/wazuh/wazuh/src'
grep: /etc/redhat-release: No such file or directory
    CC os_maild/config.o
    CC os_maild/mailcom.o
    CC os_maild/maild.o
    CC os_maild/mail_list.o
    CC os_maild/os_maild_client.o
    CC os_maild/sendcustomemail.o
    CC os_maild/sendmail.o
    CC config/active-response.o
    CC config/agentlessd-config.o
    CC config/alerts-config.o
    CC config/authd-config.o
    CC config/buffer-config.o
    CC config/client-config.o
    CC config/cluster-config.o
    CC config/config.o
    CC config/csyslogd-config.o
    CC config/dbd-config.o
    CC config/email-alerts-config.o
    CC config/global-config.o
    CC config/integrator-config.o
    CC config/labels-config.o
    CC config/localfile-config.o
    CC config/logtest-config.o
    CC config/remote-config.o
    CC config/reports-config.o
    CC config/rootcheck-config.o
    CC config/rules-config.o
    CC config/socket-config.o
    CC config/syscheck-config.o
    CC config/wmodules-agent-upgrade.o
    CC config/wmodules-aws.o
    CC config/wmodules-azure.o
    CC config/wmodules-ciscat.o
    CC config/wmodules-command.o
    CC config/wmodules-config.o
    CC config/wmodules-docker.o
    CC config/wmodules-fluent.o
    CC config/wmodules-gcp.o
    CC config/wmodules-github.o
    CC config/wmodules-key-request.o
    CC config/wmodules-office365.o
    CC config/wmodules-oscap.o
    CC config/wmodules-osquery-monitor.o
    CC config/wmodules-sca.o
    CC config/wmodules_syscollector.o
    CC config/wmodules-task-manager.o
    CC config/wmodules-vuln-detector.o
    CC wazuh_modules/wm_aws.o
    CC wazuh_modules/wm_azure.o
    CC wazuh_modules/wm_ciscat.o
    CC wazuh_modules/wmcom.o
    CC wazuh_modules/wm_command.o
    CC wazuh_modules/wm_control.o
    CC wazuh_modules/wm_database.o
    CC wazuh_modules/wm_docker.o
    CC wazuh_modules/wm_download.o
    CC wazuh_modules/wm_exec.o
    CC wazuh_modules/wm_fluent.o
    CC wazuh_modules/wm_gcp.o
    CC wazuh_modules/wm_github.o
    CC wazuh_modules/wm_keyrequest.o
    CC wazuh_modules/wmodules.o
    CC wazuh_modules/wm_office365.o
    CC wazuh_modules/wm_oscap.o
    CC wazuh_modules/wm_osquery_monitor.o
    CC wazuh_modules/wm_sca.o
    CC wazuh_modules/wm_syscollector.o
    CC wazuh_modules/wm_task_general.o
    CC wazuh_modules/agent_upgrade/wm_agent_upgrade.o
    CC wazuh_modules/vulnerability_detector/wm_vuln_detector.o
    CC wazuh_modules/vulnerability_detector/wm_vuln_detector_evr.o
    CC wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.o
    CC wazuh_modules/task_manager/wm_task_manager.o
    CC wazuh_modules/task_manager/wm_task_manager_commands.o
    CC wazuh_modules/task_manager/wm_task_manager_parsing.o
    CC wazuh_modules/task_manager/wm_task_manager_tasks.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_commands.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_manager.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_parsing.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks_callbacks.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_upgrades.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.o
    CC wazuh_db/wdb_agents.o
    CC wazuh_db/wdb.o
    CC wazuh_db/wdb_ciscat.o
    CC wazuh_db/wdb_fim.o
    CC wazuh_db/wdb_global.o
    CC wazuh_db/wdb_integrity.o
    CC wazuh_db/wdb_metadata.o
    CC wazuh_db/wdb_parser.o
    CC wazuh_db/wdb_rootcheck.o
    CC wazuh_db/wdb_sca.o
    CC wazuh_db/wdb_scan_info.o
    CC wazuh_db/wdb_syscollector.o
    CC wazuh_db/wdb_task.o
    CC wazuh_db/wdb_upgrade.o
    CC wazuh_db/helpers/wdb_agents_helpers.o
    CC wazuh_db/helpers/wdb_global_helpers.o
    CC wazuh_db/schema_agents.o
    CC wazuh_db/schema_global.o
    CC wazuh_db/schema_global_upgrade_v1.o
    CC wazuh_db/schema_global_upgrade_v2.o
    CC wazuh_db/schema_global_upgrade_v3.o
    CC wazuh_db/schema_task_manager.o
    CC wazuh_db/schema_upgrade_v1.o
    CC wazuh_db/schema_upgrade_v2.o
    CC wazuh_db/schema_upgrade_v3.o
    CC wazuh_db/schema_upgrade_v4.o
    CC wazuh_db/schema_upgrade_v5.o
    CC wazuh_db/schema_upgrade_v6.o
    CC wazuh_db/schema_upgrade_v7.o
    CC wazuh_db/schema_upgrade_v8.o
    CC wazuh_db/schema_vuln_detector.o
    CC os_crypto/blowfish/bf_op.o
    CC os_crypto/md5/md5_op.o
    CC os_crypto/sha1/sha1_op.o
    CC os_crypto/shared/keys.o
    CC os_crypto/shared/msgs.o
    CC os_crypto/md5_sha1/md5_sha1_op.o
    CC os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.o
    CC os_crypto/sha256/sha256_op.o
    CC os_crypto/sha512/sha512_op.o
    CC os_crypto/aes/aes_op.o
    CC os_crypto/hmac/hmac.o
    CC os_crypto/signature/signature.o
    CC shared/agent_op.o
    CC shared/atomic.o
    CC shared/audit_op.o
    CC shared/auth_client.o
    CC shared/b64.o
    CC shared/bqueue_op.o
    CC shared/buffer_op.o
    CC shared/bzip2_op.o
    CC shared/cluster_utils.o
    CC shared/custom_output_search_replace.o
    CC shared/debug_op.o
    CC shared/enrollment_op.o
    CC shared/exec_op.o
    CC shared/expression.o
    CC shared/file_op.o
    CC shared/file-queue.o
    CC shared/fs_op.o
    CC shared/hash_op.o
    CC shared/help.o
    CC shared/integrity_op.o
    CC shared/json_op.o
    CC shared/json-queue.o
    CC shared/labels_op.o
    CC shared/list_op.o
    CC shared/log_builder.o
    CC shared/math_op.o
    CC shared/mem_op.o
    CC shared/mq_op.o
    CC shared/notify_op.o
    CC shared/os_utils.o
    CC shared/privsep_op.o
    CC shared/pthreads_op.o
    CC shared/queue_linked_op.o
    CC shared/queue_op.o
    CC shared/randombytes.o
    CC shared/rbtree_op.o
    CC shared/read-agents.o
    CC shared/read-alert.o
    CC shared/regex_op.o
    CC shared/remoted_op.o
    CC shared/report_op.o
    CC shared/request_op.o
    CC shared/rootcheck_op.o
    CC shared/rules_op.o
    CC shared/schedule_scan.o
    CC shared/sig_op.o
    CC shared/store_op.o
    CC shared/string_op.o
    CC shared/sym_load.o
    CC shared/syscheck_op.o
    CC shared/sysinfo_utils.o
    CC shared/time_op.o
    CC shared/url.o
    CC shared/utf8_op.o
    CC shared/validate_op.o
    CC shared/vector_op.o
    CC shared/version_op.o
    CC shared/wait_op.o
    CC shared/wazuhdb_op.o
    CC shared/yaml2json.o
    CC os_net/os_net.o
    CC os_regex/os_match.o
    CC os_regex/os_match_compile.o
    CC os_regex/os_match_execute.o
    CC os_regex/os_match_free_pattern.o
    CC os_regex/os_regex.o
    CC os_regex/os_regex_compile.o
    CC os_regex/os_regex_execute.o
    CC os_regex/os_regex_free_pattern.o
    CC os_regex/os_regex_maps.o
    CC os_regex/os_regex_match.o
    CC os_regex/os_regex_startswith.o
    CC os_regex/os_regex_strbreak.o
    CC os_regex/os_regex_str.o
    CC os_xml/os_xml_access.o
    CC os_xml/os_xml.o
    CC os_xml/os_xml_node_access.o
    CC os_xml/os_xml_variables.o
    CC os_xml/os_xml_writer.o
    CC os_zlib/os_zlib.o
    CC os_auth/ssl.o
    CC os_auth/check_cert.o
    CC addagent/validate.o
    CC analysisd/logmsg.o
    CC os_csyslogd/alert.o
    CC os_csyslogd/config.o
    CC os_csyslogd/csyscom.o
    CC os_csyslogd/csyslogd.o
    CC os_csyslogd/main.o
    CC agentlessd/agentlessd.o
    CC agentlessd/lessdcom.o
    CC agentlessd/main.o
    CC os_execd/config.o
    CC os_execd/exec.o
    CC os_execd/execd.o
    CC os_execd/wcom.o
    CC os_execd/win_execd.o
    CC active-response/active_responses.o
    CC logcollector/config.o
    CC logcollector/lccom.o
    CC logcollector/logcollector.o
    CC logcollector/macos_log.o
    CC logcollector/main.o
    CC logcollector/read_audit.o
    CC logcollector/read_command.o
    CC logcollector/read_djb_multilog.o
    CC logcollector/read_fullcommand.o
    CC logcollector/read_json.o
logcollector/read_djb_multilog.c: In function ‘read_djbmultilog’:
logcollector/read_djb_multilog.c:158:76: warning: ‘%s’ directive output may be truncated writing up to 65510 bytes into a region of size between 65008 and 65520 [-Wformat-truncation=]
  158 |                 snprintf(buffer, OS_MAXSTR, "%s %02d %02d:%02d:%02d %s %s: %s",
      |                                                                            ^~
logcollector/read_djb_multilog.c:158:17: note: ‘snprintf’ output 17 or more bytes (assuming 66039) into a destination of size 65536
  158 |                 snprintf(buffer, OS_MAXSTR, "%s %02d %02d:%02d:%02d %s %s: %s",
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  159 |                          djb_month[tm_result.tm_mon],
      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  160 |                          tm_result.tm_mday,
      |                          ~~~~~~~~~~~~~~~~~~
  161 |                          tm_result.tm_hour,
      |                          ~~~~~~~~~~~~~~~~~~
  162 |                          tm_result.tm_min,
      |                          ~~~~~~~~~~~~~~~~~
  163 |                          tm_result.tm_sec,
      |                          ~~~~~~~~~~~~~~~~~
  164 |                          djb_host,
      |                          ~~~~~~~~~
  165 |                          lf->djb_program_name,
      |                          ~~~~~~~~~~~~~~~~~~~~~
  166 |                          p);
      |                          ~~
    CC logcollector/read_macos.o
    CC logcollector/read_mssql_log.o
    CC logcollector/read_multiline.o
logcollector/read_mssql_log.c: In function ‘read_mssql_log’:
logcollector/read_mssql_log.c:117:17: warning: ‘strncpy’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  117 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_mssql_log.c:108:17: warning: ‘strncpy’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  108 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_multiline_regex.o
    CC logcollector/read_mysql_log.o
logcollector/read_multiline.c: In function ‘read_multiline’:
logcollector/read_multiline.c:96:9: warning: ‘strncpy’ output may be truncated copying between 0 and 65534 bytes from a string of length 65536 [-Wstringop-truncation]
   96 |         strncpy(buffer + buffer_size, str, OS_MAXSTR - buffer_size - 2);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_nmapg.o
logcollector/read_mysql_log.c: In function ‘read_mysql_log’:
logcollector/read_mysql_log.c:105:56: warning: ‘%s’ directive output may be truncated writing up to 65521 bytes into a region of size between 65489 and 65524 [-Wformat-truncation=]
  105 |             snprintf(buffer, OS_MAXSTR, "MySQL log: %s %s",
      |                                                        ^~
logcollector/read_mysql_log.c:105:13: note: ‘snprintf’ output between 13 and 65569 bytes into a destination of size 65536
  105 |             snprintf(buffer, OS_MAXSTR, "MySQL log: %s %s",
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  106 |                      __mysql_last_time, p);
      |                      ~~~~~~~~~~~~~~~~~~~~~
logcollector/read_mysql_log.c:158:55: warning: ‘%s’ directive output may be truncated writing up to 65504 bytes into a region of size between 65489 and 65524 [-Wformat-truncation=]
  158 |            snprintf(buffer, OS_MAXSTR, "MySQL log: %s %s",
      |                                                       ^~
logcollector/read_mysql_log.c:158:12: note: ‘snprintf’ output between 13 and 65552 bytes into a destination of size 65536
  158 |            snprintf(buffer, OS_MAXSTR, "MySQL log: %s %s",
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  159 |                     __mysql_last_time, p);
      |                     ~~~~~~~~~~~~~~~~~~~~~
logcollector/read_mysql_log.c:206:54: warning: ‘%s’ directive output may be truncated writing up to 65509 bytes into a region of size between 65489 and 65524 [-Wformat-truncation=]
  206 |           snprintf(buffer, OS_MAXSTR, "MySQL log: %s %s",
      |                                                      ^~
logcollector/read_mysql_log.c:206:11: note: ‘snprintf’ output between 13 and 65557 bytes into a destination of size 65536
  206 |           snprintf(buffer, OS_MAXSTR, "MySQL log: %s %s",
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  207 |                    __mysql_last_time, p);
      |                    ~~~~~~~~~~~~~~~~~~~~~
logcollector/read_nmapg.c: In function ‘read_nmapg’:
logcollector/read_nmapg.c:222:49: warning: ‘, open ports:’ directive output may be truncated writing 13 bytes into a region of size between 0 and 65530 [-Wformat-truncation=]
  222 |         snprintf(final_msg, OS_MAXSTR, "Host: %s, open ports:",
      |                                                 ^~~~~~~~~~~~~
logcollector/read_nmapg.c:222:9: note: ‘snprintf’ output between 20 and 65550 bytes into a destination of size 65536
  222 |         snprintf(final_msg, OS_MAXSTR, "Host: %s, open ports:",
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  223 |                  ip);
      |                  ~~~
logcollector/read_nmapg.c:246:13: warning: ‘strncat’ output may be truncated copying between 27 and 65533 bytes from a string of length 65536 [-Wstringop-truncation]
  246 |             strncat(final_msg, buffer, final_msg_s);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_ossecalert.o
    CC logcollector/read_postgresql_log.o
    CC logcollector/read_snortfull.o
    CC logcollector/read_syslog.o
    CC logcollector/read_ucs2_be.o
    CC logcollector/read_ucs2_le.o
    CC logcollector/read_win_el.o
logcollector/read_postgresql_log.c: In function ‘read_postgresql_log’:
logcollector/read_postgresql_log.c:114:17: warning: ‘strncpy’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  114 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_postgresql_log.c:106:17: warning: ‘strncpy’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_snortfull.c: In function ‘read_snortfull’:
logcollector/read_snortfull.c:54:17: warning: ‘strncpy’ output may be truncated copying 65536 bytes from a string of length 65536 [-Wstringop-truncation]
   54 |                 strncpy(f_msg, str, OS_MAXSTR);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_win_event_channel.o
    CC logcollector/state.o
    CC remoted/ar-forward.o
    CC remoted/cfga-forward.o
    CC remoted/config.o
    CC remoted/main.o
    CC remoted/manager.o
    CC remoted/netbuffer.o
    CC remoted/netcounter.o
    CC remoted/queue.o
    CC remoted/remoted.o
    CC remoted/request.o
    CC remoted/secure.o
    CC remoted/sendmsg.o
    CC remoted/shared_download.o
    CC remoted/state.o
    CC remoted/syslog.o
    CC remoted/syslogtcp.o
    CC client-agent/agcom.o
    CC client-agent/agentd.o
    CC client-agent/buffer.o
    CC client-agent/config.o
    CC client-agent/event-forward.o
    CC client-agent/main.o
    CC client-agent/notify.o
    CC client-agent/receiver.o
    CC client-agent/receiver-win.o
    CC client-agent/request.o
    CC client-agent/restart_agent.o
    CC client-agent/rotate_log.o
    CC client-agent/sendmsg.o
    CC client-agent/start_agent.o
    CC client-agent/state.o
    CC monitord/rotate_log.o
    CC monitord/compress_log.o
    CC addagent/main.o
    CC addagent/manage_agents.o
    CC addagent/manage_keys.o
    CC addagent/read_from_user.o
    CC util/clear_stats.o
    CC util/agent_control.o
    CC util/verify-agent-conf.o
    CC util/wazuh-regex.o
    CC util/parallel-regex.o
    CC active-response/firewalls/default-firewall-drop.o
    CC shared/file_op_proc.o
    CC shared/debug_op_proc.o
    CC active-response/firewalls/pf.o
    CC active-response/firewalls/npf.o
    CC active-response/firewalls/ipfw.o
    CC active-response/firewalld-drop.o
    CC active-response/disable-account.o
    CC active-response/host-deny.o
    CC active-response/ip-customblock.o
    CC active-response/restart-wazuh.o
    CC active-response/route-null.o
    CC active-response/kaspersky.o
    CC active-response/wazuh-slack.o
    CC syscheckd/db/schema_fim_db.o
    CC syscheckd/config.o
    CC syscheckd/create_db.o
    CC syscheckd/fim_diff_changes.o
    CC syscheckd/fim_sync.o
    CC syscheckd/main.o
    CC syscheckd/run_check.o
    CC syscheckd/run_realtime.o
    CC syscheckd/syscheck.o
    CC syscheckd/syscom.o
    CC syscheckd/db/fim_db.o
    CC syscheckd/db/fim_db_files.o
    CC syscheckd/db/fim_db_registries.o
    CC syscheckd/whodata/audit_healthcheck.o
    CC syscheckd/whodata/audit_parse.o
    CC syscheckd/whodata/audit_rule_handling.o
    CC syscheckd/whodata/syscheck_audit.o
    CC syscheckd/whodata/win_whodata.o
    CC syscheckd/registry/events.o
    CC syscheckd/registry/registry.o
    CC rootcheck/check_open_ports.o
    CC rootcheck/check_rc_dev.o
    CC rootcheck/check_rc_files.o
rootcheck/check_rc_files.c: In function ‘check_rc_files’:
rootcheck/check_rc_files.c:171:52: warning: ‘%s’ directive output may be truncated writing up to 1024 bytes into a region of size 1023 [-Wformat-truncation=]
  171 |             snprintf(file_path, OS_SIZE_1024, "%s%c%s", basedir, PATH_SEP, file);
      |                                                    ^~
rootcheck/check_rc_files.c:171:13: note: ‘snprintf’ output 2 or more bytes (assuming 1026) into a destination of size 1024
  171 |             snprintf(file_path, OS_SIZE_1024, "%s%c%s", basedir, PATH_SEP, file);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rootcheck/check_rc_files.c:169:50: warning: ‘snprintf’ output may be truncated before the last format character [-Wformat-truncation=]
  169 |             snprintf(file_path, OS_SIZE_1024, "%s", file);
      |                                                  ^
rootcheck/check_rc_files.c:169:13: note: ‘snprintf’ output between 1 and 1025 bytes into a destination of size 1024
  169 |             snprintf(file_path, OS_SIZE_1024, "%s", file);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC rootcheck/check_rc_if.o
    CC rootcheck/check_rc_pids.o
    CC rootcheck/check_rc_policy.o
    CC rootcheck/check_rc_ports.o
    CC rootcheck/check_rc_readproc.o
    CC rootcheck/check_rc_sys.o
    CC rootcheck/check_rc_trojans.o
    CC rootcheck/common.o
    CC rootcheck/common_rcl.o
    CC rootcheck/config.o
rootcheck/check_rc_sys.c: In function ‘read_sys_dir.isra’:
rootcheck/check_rc_sys.c:93:52: warning: ‘%s’ directive output may be truncated writing up to 4097 bytes into a region of size 998 [-Wformat-truncation=]
   93 |                     snprintf(op_msg, OS_SIZE_1024, "Anomaly detected in file "
      |                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~
......
  284 |         read_sys_file(f_name, do_read);
      |                       ~~~~~~                        
rootcheck/check_rc_sys.c:94:32: note: format string is defined here
   94 |                              "'%s'. File size doesn't match what we found. "
      |                                ^~
rootcheck/check_rc_sys.c:93:21: note: ‘snprintf’ output between 99 and 4196 bytes into a destination of size 1024
   93 |                     snprintf(op_msg, OS_SIZE_1024, "Anomaly detected in file "
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   94 |                              "'%s'. File size doesn't match what we found. "
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   95 |                              "Possible kernel level rootkit.",
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   96 |                              file_name);
      |                              ~~~~~~~~~~
rootcheck/check_rc_sys.c:122:51: warning: ‘%s’ directive output may be truncated writing up to 4097 bytes into a region of size 1018 [-Wformat-truncation=]
  122 |             snprintf(op_msg, OS_SIZE_1024, "File '%s' is owned by root "
      |                                                   ^~
......
  284 |         read_sys_file(f_name, do_read);
      |                       ~~~~~~                       
rootcheck/check_rc_sys.c:122:13: note: ‘snprintf’ output between 64 and 4161 bytes into a destination of size 1024
  122 |             snprintf(op_msg, OS_SIZE_1024, "File '%s' is owned by root "
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  123 |                      "and has written permissions to anyone.", file_name);
      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rootcheck/check_rc_sys.c:40:67: warning: ‘%s’ directive output may be truncated writing up to 4097 bytes into a region of size 998 [-Wformat-truncation=]
   40 |         snprintf(op_msg, OS_SIZE_1024, "Anomaly detected in file '%s'. "
      |                                                                   ^~
......
  284 |         read_sys_file(f_name, do_read);
      |                       ~~~~~~                                       
rootcheck/check_rc_sys.c:40:9: note: ‘snprintf’ output between 106 and 4203 bytes into a destination of size 1024
   40 |         snprintf(op_msg, OS_SIZE_1024, "Anomaly detected in file '%s'. "
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   41 |                  "Hidden from stats, but showing up on readdir. "
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   42 |                  "Possible kernel level rootkit.",
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   43 |                  file_name);
      |                  ~~~~~~~~~~
    CC rootcheck/os_string.o
    CC rootcheck/rootcheck.o
    CC rootcheck/run_rk_check.o
    CC rootcheck/unix-process.o
    CC rootcheck/win-common.o
    CC rootcheck/win-process.o
    CC monitord/generate_reports.o
rootcheck/unix-process.c: In function ‘os_get_process_list’:
rootcheck/unix-process.c:28:40: warning: ‘ -p ’ directive output may be truncated writing 4 bytes into a region of size between 0 and 1024 [-Wformat-truncation=]
   28 |     snprintf(command, OS_SIZE_1024, "%s -p %d 2> /dev/null", ps, mpid);
      |                                        ^~~~
rootcheck/unix-process.c:28:37: note: directive argument in the range [1, 32768]
   28 |     snprintf(command, OS_SIZE_1024, "%s -p %d 2> /dev/null", ps, mpid);
      |                                     ^~~~~~~~~~~~~~~~~~~~~~~
rootcheck/unix-process.c:28:5: note: ‘snprintf’ output between 19 and 1047 bytes into a destination of size 1024
   28 |     snprintf(command, OS_SIZE_1024, "%s -p %d 2> /dev/null", ps, mpid);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC monitord/main.o
    CC monitord/manage_files.o
    CC monitord/moncom.o
    CC monitord/monitor_actions.o
    CC monitord/monitord.o
    CC monitord/sign_log.o
    CC reportd/report.o
    CC os_auth/main-server.o
    CC os_auth/local-server.o
    CC os_auth/config.o
    CC os_auth/authcom.o
    CC os_auth/auth.o
./analysisd/compiled_rules/register_rule.sh build
*Build completed.
    CC analysisd/output/jsonout.o
    CC analysisd/output/prelude.o
    CC analysisd/output/zeromq.o
    CC analysisd/format/json_extended.o
    CC analysisd/format/to_json.o
    CC analysisd/alerts/exec.o
    CC analysisd/alerts/getloglocation.o
    CC analysisd/alerts/log.o
    CC analysisd/cdb/cdb.o
    CC analysisd/cdb/cdb_hash.o
    CC analysisd/cdb/cdb_make.o
    CC analysisd/cdb/uint32_pack.o
    CC analysisd/cdb/uint32_unpack.o
    CC analysisd/decoders/ciscat-live.o
    CC analysisd/decoders/dbsync-live.o
    CC analysisd/decoders/decoder-live.o
    CC analysisd/decoders/decoders_list-live.o
    CC analysisd/decoders/decode-xml-live.o
    CC analysisd/decoders/geoip-live.o
    CC analysisd/decoders/hostinfo-live.o
    CC analysisd/decoders/plugin_decoders-live.o
    CC analysisd/decoders/rootcheck-live.o
    CC analysisd/decoders/security_configuration_assessment-live.o
    CC analysisd/decoders/syscheck-live.o
    CC analysisd/decoders/syscollector-live.o
    CC analysisd/decoders/winevtchannel-live.o
    CC analysisd/decoders/plugins/json_decoder-live.o
    CC analysisd/decoders/plugins/ossecalert_decoder-live.o
    CC analysisd/decoders/plugins/pf_decoder-live.o
    CC analysisd/decoders/plugins/sonicwall_decoder-live.o
    CC analysisd/decoders/plugins/symantecws_decoder-live.o
    CC analysisd/compiled_rules/generic_samples-live.o
    CC analysisd/accumulator-test.o
    CC analysisd/active-response-test.o
    CC analysisd/ar_json-test.o
    CC analysisd/asyscom-test.o
    CC analysisd/cleanevent-test.o
    CC analysisd/config-test.o
    CC analysisd/config_json-test.o
    CC analysisd/dodiff-test.o
    CC analysisd/eventinfo-test.o
    CC analysisd/eventinfo_list-test.o
    CC analysisd/fts-test.o
    CC analysisd/labels-test.o
    CC analysisd/lists-test.o
    CC analysisd/lists_list-test.o
    CC analysisd/lists_make-test.o
    CC analysisd/logtest-test.o
    CC analysisd/mitre-test.o
    CC analysisd/rules-test.o
    CC analysisd/rules_list-test.o
    CC analysisd/state-test.o
    CC analysisd/stats-test.o
    CC analysisd/testrule-test.o
    CC analysisd/analysisd-test.o
    CC analysisd/decoders/ciscat-test.o
    CC analysisd/decoders/dbsync-test.o
    CC analysisd/decoders/decoder-test.o
    CC analysisd/decoders/decoders_list-test.o
    CC analysisd/decoders/decode-xml-test.o
    CC analysisd/decoders/geoip-test.o
    CC analysisd/decoders/hostinfo-test.o
    CC analysisd/decoders/plugin_decoders-test.o
    CC analysisd/decoders/rootcheck-test.o
    CC analysisd/decoders/security_configuration_assessment-test.o
    CC analysisd/decoders/syscheck-test.o
    CC analysisd/decoders/syscollector-test.o
    CC analysisd/decoders/winevtchannel-test.o
    CC analysisd/decoders/plugins/json_decoder-test.o
    CC analysisd/decoders/plugins/ossecalert_decoder-test.o
    CC analysisd/decoders/plugins/pf_decoder-test.o
    CC analysisd/decoders/plugins/sonicwall_decoder-test.o
    CC analysisd/decoders/plugins/symantecws_decoder-test.o
    CC analysisd/compiled_rules/generic_samples-test.o
    CC os_dbd/alert.o
    CC os_dbd/config.o
    CC os_dbd/dbd.o
    CC os_dbd/db_op.o
    CC os_dbd/main.o
    CC os_dbd/rules.o
    CC os_dbd/server.o
    CC os_integrator/config.o
    CC os_integrator/integrator.o
    CC os_integrator/intgcom.o
    CC os_integrator/main.o
    CC wazuh_modules/main.o
    CC wazuh_db/main.o
    LINK libwazuh.a
ar: `u' modifier ignored since `D' is the default (see `U')
    CC libwazuhshared.so
/usr/bin/ld: missing --end-group; added as last command line option
    LINK rootcheck.a
ar: `u' modifier ignored since `D' is the default (see `U')
    RANLIB rootcheck.a
    CC analysisd/accumulator-live.o
    RANLIB libwazuh.a
    CC analysisd/active-response-live.o
    CC analysisd/ar_json-live.o
    CC analysisd/asyscom-live.o
    CC analysisd/cleanevent-live.o
    CC analysisd/config-live.o
    CC analysisd/config_json-live.o
    CC analysisd/dodiff-live.o
    CC analysisd/eventinfo-live.o
    CC analysisd/eventinfo_list-live.o
    CC analysisd/fts-live.o
    CC analysisd/labels-live.o
    CC analysisd/lists-live.o
    CC analysisd/lists_list-live.o
    CC analysisd/lists_make-live.o
    CC analysisd/logtest-live.o
    CC analysisd/mitre-live.o
    CC analysisd/rules-live.o
    CC analysisd/rules_list-live.o
    CC analysisd/state-live.o
    CC analysisd/stats-live.o
    CC analysisd/analysisd-live.o
    LINK alerts.a
ar: `u' modifier ignored since `D' is the default (see `U')
    LINK cdb.a
ar: `u' modifier ignored since `D' is the default (see `U')
    RANLIB cdb.a
    LINK decoders-live.a
ar: `u' modifier ignored since `D' is the default (see `U')
    LINK decoders-test.a
ar: `u' modifier ignored since `D' is the default (see `U')
    CC wazuh-dbd
    CC wazuh-integratord
    CC wazuh-modulesd
    CC wazuh-db
    CC wazuh-maild
    CC wazuh-csyslogd
    CC wazuh-agentlessd
    CC wazuh-execd
    CC wazuh-logcollector
    CC wazuh-remoted
    CC wazuh-agentd
    CC manage_agents
    CC clear_stats
    CC agent_control
    CC verify-agent-conf
    CC wazuh-regex
    CC parallel-regex
    CC default-firewall-drop
    CC pf
    CC npf
    CC ipfw
    CC firewalld-drop
    CC disable-account
    CC host-deny
    CC ip-customblock
    CC restart-wazuh
    CC route-null
    CC kaspersky
    CC wazuh-slack
    CC wazuh-syscheckd
    CC wazuh-monitord
    CC wazuh-reportd
    CC wazuh-authd
    CC wazuh-logtest-legacy
    CC wazuh-analysisd
make[1]: Leaving directory '/home/hanes/wazuh/wazuh/src'
make settings
make[1]: Entering directory '/home/hanes/wazuh/wazuh/src'
grep: /etc/redhat-release: No such file or directory

General settings:
    TARGET:             server
    V:                  
    DEBUG:              
    DEBUGAD             
    INSTALLDIR:         
    DATABASE:           
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/16
    EXTERNAL_SRC_ONLY:  
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_ZEROMQ:         no
    USE_GEOIP:          no
    USE_PRELUDE:        no
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          yes
    DISABLE_SYSC:       no
    DISABLE_CISCAT:     no
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DENABLE_SYSC -DENABLE_CISCAT -DENABLE_AUDIT
Compiler:
    CFLAGS            -pthread -Iexternal/libdb/build_unix/ -Iexternal/pacman/lib/libalpm/ -Iexternal/libarchive/libarchive -Wl,--start-group -Iexternal/audit-userspace/lib -DNDEBUG -O2 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DENABLE_SYSC -DENABLE_CISCAT -DENABLE_AUDIT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Ishared_modules/common -Ishared_modules/dbsync/include -Ishared_modules/rsync/include -Iwazuh_modules/syscollector/include  -Idata_provider/include  -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include 
    LDFLAGS           '-Wl,-rpath,/../lib' -pthread -lrt -ldl -O2 -Lshared_modules/dbsync/build/lib -Lshared_modules/rsync/build/lib  -Lwazuh_modules/syscollector/build/lib -Ldata_provider/build/lib
    LIBS              -lrt -ldl -lm 
    CC                cc
    MAKE              make
make[1]: Leaving directory '/home/hanes/wazuh/wazuh/src'

Done building server

```
</details>

Regards
Hanes

## Tests


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors