### PR TITLE
Fix agent groups assignment and unassignment.

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -17,6 +17,9 @@
 #include "../wrappers/posix/time_wrappers.h"
 #include "wazuhdb_op.h"
 
+#define GROUPS_SIZE 10
+#define AGENTS_SIZE 10
+
 extern void __real_cJSON_Delete(cJSON *item);
 extern int test_mode;
 
@@ -6897,7 +6900,6 @@ void test_wdb_global_calculate_agent_group_csv_success(void **state) {
 /* wdb_global_assign_agent_group */
 
 void test_wdb_global_assign_agent_group_success(void **state) {
-    #define GROUPS_SIZE 10
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
     int group_id = 1;
@@ -6953,7 +6955,6 @@ void test_wdb_global_assign_agent_group_success(void **state) {
 }
 
 void test_wdb_global_assign_agent_group_invalid_group_name(void **state) {
-    #define GROUPS_SIZE 10
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
     int initial_priority = 0;
@@ -6983,7 +6984,6 @@ void test_wdb_global_assign_agent_group_invalid_group_name(void **state) {
 }
 
 void test_wdb_global_assign_agent_group_insert_belong_error(void **state) {
-    #define GROUPS_SIZE 10
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
     int initial_priority = 0;
@@ -7029,7 +7029,6 @@ void test_wdb_global_assign_agent_group_insert_belong_error(void **state) {
 }
 
 void test_wdb_global_assign_agent_group_find_error(void **state) {
-    #define GROUPS_SIZE 10
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
     int initial_priority = 0;
@@ -7065,7 +7064,6 @@ void test_wdb_global_assign_agent_group_find_error(void **state) {
 }
 
 void test_wdb_global_assign_agent_group_insert_error(void **state) {
-    #define GROUPS_SIZE 10
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
     int group_id = 1;
@@ -7117,7 +7115,6 @@ void test_wdb_global_assign_agent_group_insert_error(void **state) {
 }
 
 void test_wdb_global_assign_agent_group_invalid_json(void **state) {
-    #define GROUPS_SIZE 10
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
     int initial_priority = 0;
@@ -7154,7 +7151,6 @@ void create_wdb_global_get_agent_max_group_priority_success_call(int agent_id, c
 /* wdb_global_unassign_agent_group */
 
 void test_wdb_global_unassign_agent_group_success(void **state) {
-    #define GROUPS_SIZE 10
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
     int group_id = 1;
@@ -7240,7 +7236,6 @@ void create_wdb_global_assign_agent_group_success_call(int agent_id, int group_i
 }
 
 void test_wdb_global_unassign_agent_group_success_assign_default_group(void **state) {
-    #define GROUPS_SIZE 10
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
     int group_id = 1;
@@ -7292,7 +7287,6 @@ void test_wdb_global_unassign_agent_group_success_assign_default_group(void **st
 }
 
 void test_wdb_global_unassign_agent_group_delete_tuple_error(void **state) {
-    #define GROUPS_SIZE 10
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
     cJSON* find_group_resp = cJSON_Parse("[{\"id\":1}]");
@@ -7330,7 +7324,6 @@ void test_wdb_global_unassign_agent_group_delete_tuple_error(void **state) {
 }
 
 void test_wdb_global_unassign_agent_group_find_error(void **state) {
-    #define GROUPS_SIZE 10
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
     cJSON* find_group_resp = cJSON_Parse("[{\"id\":1}]");
@@ -7357,7 +7350,6 @@ void test_wdb_global_unassign_agent_group_find_error(void **state) {
 }
 
 void test_wdb_global_unassign_agent_group_invalid_json(void **state) {
-    #define GROUPS_SIZE 10
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
     cJSON* find_group_resp = cJSON_Parse("[{\"id\":1}]");
@@ -7538,7 +7530,6 @@ void create_wdb_global_set_agent_group_context_success_call(int agent_id, char* 
 }
 
 void test_wdb_global_set_agent_groups_override_success(void **state) {
-    #define AGENTS_SIZE 10
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
     int group_id = 1;
@@ -7579,7 +7570,6 @@ void test_wdb_global_set_agent_groups_override_success(void **state) {
 }
 
 void test_wdb_global_set_agent_groups_override_delete_error(void **state) {
-    #define AGENTS_SIZE 10
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
     int group_id = 1;
@@ -7622,7 +7612,6 @@ void test_wdb_global_set_agent_groups_override_delete_error(void **state) {
 }
 
 void test_wdb_global_set_agent_groups_add_modes_assign_error(void **state) {
-    #define AGENTS_SIZE 10
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
     char group_name[] = "GROUP";
@@ -7666,7 +7655,6 @@ void test_wdb_global_set_agent_groups_add_modes_assign_error(void **state) {
 }
 
 void test_wdb_global_set_agent_groups_append_success(void **state) {
-    #define AGENTS_SIZE 10
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
     int group_id = 1;
@@ -7709,7 +7697,6 @@ void test_wdb_global_set_agent_groups_append_success(void **state) {
 }
 
 void test_wdb_global_set_agent_groups_empty_only_success(void **state) {
-    #define AGENTS_SIZE 10
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
     int group_id = 1;
@@ -7752,7 +7739,6 @@ void test_wdb_global_set_agent_groups_empty_only_success(void **state) {
 }
 
 void test_wdb_global_set_agent_groups_empty_only_not_empty_error(void **state) {
-    #define AGENTS_SIZE 10
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
     char group_name[] = "GROUP";
@@ -7783,7 +7769,6 @@ void test_wdb_global_set_agent_groups_empty_only_not_empty_error(void **state) {
 }
 
 void test_wdb_global_set_agent_groups_remove_success(void **state) {
-    #define AGENTS_SIZE 10
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
     int group_id = 1;
@@ -7826,7 +7811,6 @@ void test_wdb_global_set_agent_groups_remove_success(void **state) {
 }
 
 void test_wdb_global_set_agent_groups_remove_unassign_error(void **state) {
-    #define AGENTS_SIZE 10
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
     //int group_id = 1;
@@ -7868,7 +7852,6 @@ void test_wdb_global_set_agent_groups_remove_unassign_error(void **state) {
 }
 
 void test_wdb_global_set_agent_groups_invalid_json(void **state) {
-    #define AGENTS_SIZE 10
     test_struct_t *data  = (test_struct_t *)*state;
     char sync_status[] = "synced";
     wdb_groups_set_mode_t mode = WDB_GROUP_REMOVE;
@@ -7890,7 +7873,6 @@ void test_wdb_global_set_agent_groups_invalid_json(void **state) {
 }
 
 void test_wdb_global_set_agent_groups_calculate_csv_error(void **state) {
-    #define AGENTS_SIZE 10
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
     int group_id = 1;
@@ -7932,7 +7914,6 @@ void test_wdb_global_set_agent_groups_calculate_csv_error(void **state) {
 }
 
 void test_wdb_global_set_agent_groups_set_group_ctx_error(void **state) {
-    #define AGENTS_SIZE 10
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
     int group_id = 1;

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1226,11 +1226,9 @@ wdbc_result wdb_global_assign_agent_group(wdb_t *wdb, int id, cJSON* j_groups, i
                     result = WDBC_ERROR;
                 }
             }
-
             cJSON* j_find_response = wdb_global_find_group(wdb, group_name);
             if (j_find_response) {
                 cJSON* j_group_id = cJSON_GetObjectItem(j_find_response->child, "id");
-                cJSON_Delete(j_find_response);
                 if (cJSON_IsNumber(j_group_id)) {
                     if (OS_INVALID == wdb_global_insert_agent_belong(wdb, j_group_id->valueint, id, priority)) {
                         mdebug1("Unable to insert group '%s' for agent '%d'", group_name, id);
@@ -1241,6 +1239,7 @@ wdbc_result wdb_global_assign_agent_group(wdb_t *wdb, int id, cJSON* j_groups, i
                 } else {
                     mwarn("The group '%s' does not exist", group_name);
                 }
+                cJSON_Delete(j_find_response);
             } else {
                 mdebug1("Unable to find the id of the group '%s'", group_name);
                 result = WDBC_ERROR;
@@ -1262,7 +1261,6 @@ wdbc_result wdb_global_unassign_agent_group(wdb_t *wdb, int id, cJSON* j_groups)
             cJSON* j_find_response = wdb_global_find_group(wdb, group_name);
             if (j_find_response) {
                 cJSON* j_group_id = cJSON_GetObjectItem(j_find_response->child, "id");
-                cJSON_Delete(j_find_response);
                 if (cJSON_IsNumber(j_group_id)) {
                     if (OS_SUCCESS == wdb_global_delete_tuple_belong(wdb, j_group_id->valueint, id)) {
                         if (OS_INVALID == wdb_global_get_agent_max_group_priority(wdb, id)) {
@@ -1272,6 +1270,7 @@ wdbc_result wdb_global_unassign_agent_group(wdb_t *wdb, int id, cJSON* j_groups)
                                 mdebug1("Agent '%03d' reassigned to 'default' group", id);
                             } else {
                                 merror("There was an error assigning the agent '%03d' to default group", id);
+                                result = WDBC_ERROR;
                             }
                             cJSON_Delete(j_default_group);
                         }
@@ -1282,6 +1281,7 @@ wdbc_result wdb_global_unassign_agent_group(wdb_t *wdb, int id, cJSON* j_groups)
                 } else {
                     mwarn("The group '%s' does not exist", group_name);
                 }
+                cJSON_Delete(j_find_response);
             } else {
                 mdebug1("Unable to find the id of the group '%s'", group_name);
                 result = WDBC_ERROR;

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1273,6 +1273,8 @@ wdbc_result wdb_global_unassign_agent_group(wdb_t *wdb, int id, cJSON* j_groups)
                         mdebug1("Unable to delete group '%s' for agent '%d'", group_name, id);
                         result = WDBC_ERROR;
                     }
+                } else {
+                    mwarn("The group '%s' does not exist", group_name);
                 }
             } else {
                 mdebug1("Unable to find the id of the group '%s'", group_name);

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1256,22 +1256,23 @@ wdbc_result wdb_global_unassign_agent_group(wdb_t *wdb, int id, cJSON* j_groups)
             cJSON* j_find_response = wdb_global_find_group(wdb, group_name);
             if (j_find_response) {
                 cJSON* j_group_id = cJSON_GetObjectItem(j_find_response->child, "id");
-                int group_id = j_group_id->valueint;
                 cJSON_Delete(j_find_response);
-                if (OS_SUCCESS == wdb_global_delete_tuple_belong(wdb, group_id, id)) {
-                    if (OS_INVALID == wdb_global_get_agent_max_group_priority(wdb, id)) {
-                        cJSON* j_default_group = cJSON_CreateArray();
-                        cJSON_AddItemToArray(j_default_group, cJSON_CreateString("default"));
-                        if (WDBC_OK == wdb_global_assign_agent_group(wdb, id, j_default_group, 0)) {
-                            mdebug1("Agent '%03d' reassigned to 'default' group", id);
-                        } else {
-                            merror("There was an error assigning the agent '%03d' to default group", id);
+                if (cJSON_IsNumber(j_group_id)) {
+                    if (OS_SUCCESS == wdb_global_delete_tuple_belong(wdb, j_group_id->valueint, id)) {
+                        if (OS_INVALID == wdb_global_get_agent_max_group_priority(wdb, id)) {
+                            cJSON* j_default_group = cJSON_CreateArray();
+                            cJSON_AddItemToArray(j_default_group, cJSON_CreateString("default"));
+                            if (WDBC_OK == wdb_global_assign_agent_group(wdb, id, j_default_group, 0)) {
+                                mdebug1("Agent '%03d' reassigned to 'default' group", id);
+                            } else {
+                                merror("There was an error assigning the agent '%03d' to default group", id);
+                            }
+                            cJSON_Delete(j_default_group);
                         }
-                        cJSON_Delete(j_default_group);
+                    } else {
+                        mdebug1("Unable to delete group '%s' for agent '%d'", group_name, id);
+                        result = WDBC_ERROR;
                     }
-                } else {
-                    mdebug1("Unable to delete group '%s' for agent '%d'", group_name, id);
-                    result = WDBC_ERROR;
                 }
             } else {
                 mdebug1("Unable to find the id of the group '%s'", group_name);


### PR DESCRIPTION
|Related issue|
|---|
|#12168|

## Description

This PR implements the following changes:
- Assigns a default group if the agent ends without any other group.
- Fix segfault during group unassignment if we pass a non-existent group name.
- Check during group assignment that the name doesn't contain "comma", otherwise ignores it.
- Fix segfault during group assignment as a consequence of the previous change. Before it was trying to get an id of the group without checking if the group exists.

## Scan-build report

![11](https://user-images.githubusercontent.com/13010397/153622153-68f5cecb-7047-46b5-8f33-07c2c0a59e2e.png)

## Valgrind report 

![20](https://user-images.githubusercontent.com/13010397/153622330-c348746f-5975-41d7-b9ac-b905f787c477.png)

## Logs

![21](https://user-images.githubusercontent.com/13010397/153625126-d1d8e201-f7ba-46e0-9f0b-dd7f447519ec.png)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)