### PR TITLE
Enable Solaris network inventory by default

### DIFF
--- a/etc/templates/config/sunos/wodle-syscollector.template
+++ b/etc/templates/config/sunos/wodle-syscollector.template
@@ -5,7 +5,7 @@
     <scan_on_start>yes</scan_on_start>
     <hardware>no</hardware>
     <os>yes</os>
-    <network>no</network>
+    <network>yes</network>
     <packages>no</packages>
     <ports all="no">no</ports>
     <processes>no</processes>


### PR DESCRIPTION
|Related issue|
|---|
|#11224|

## Description

Hi team!

This PR aims to enable network collection for Solaris agent by default, a feature enabled by #11450.

## Tests

- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Retrocompatibility with older Wazuh versions

Regards,
Nico