### PR TITLE
Reimplement macOS process retrieval to fix process state value

### DIFF
--- a/src/data_provider/include/defer.hpp
+++ b/src/data_provider/include/defer.hpp
@@ -1,0 +1,21 @@
+#ifndef _DEFER_HPP
+#define _DEFER_HPP
+
+template <typename F>
+struct privDefer {
+	F f;
+	privDefer(F f) : f(f) {}
+	~privDefer() { f(); }
+};
+
+template <typename F>
+privDefer<F> defer_func(F f) {
+	return privDefer<F>(f);
+}
+
+#define DEFER_1(x, y) x##y
+#define DEFER_2(x, y) DEFER_1(x, y)
+#define DEFER_3(x)    DEFER_2(x, __COUNTER__)
+#define defer(code)   auto DEFER_3(_defer_) = defer_func([&](){code;})
+
+#endif // _DEFER_HPP

--- a/src/data_provider/include/defer.hpp
+++ b/src/data_provider/include/defer.hpp
@@ -1,5 +1,6 @@
 #ifndef _DEFER_HPP
 #define _DEFER_HPP
+/*
  * Wazuh SysInfo
  * Copyright (C) 2022, Wazuh Inc.
  * February 15, 2022.
@@ -8,6 +9,7 @@
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
+ */
 
 template <typename F>
 struct privDefer {

--- a/src/data_provider/include/defer.hpp
+++ b/src/data_provider/include/defer.hpp
@@ -1,5 +1,13 @@
 #ifndef _DEFER_HPP
 #define _DEFER_HPP
+ * Wazuh SysInfo
+ * Copyright (C) 2022, Wazuh Inc.
+ * February 15, 2022.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
 
 template <typename F>
 struct privDefer {

--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -519,8 +519,7 @@ void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> callback) co
 
     processor_set_name_array_t psets;
     mach_msg_type_number_t  pcnt;
-    kern_return_t kr = 0;
-    kr = host_processor_sets(port, &psets, &pcnt);
+    kern_return_t kr { host_processor_sets(port, &psets, &pcnt) };
 
     if (KERN_SUCCESS != kr)
     {
@@ -529,7 +528,7 @@ void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> callback) co
 
     defer(mach_vm_deallocate(mach_task_self(), (mach_vm_address_t)(uintptr_t)psets, pcnt * sizeof(*psets)));
 
-    for (mach_msg_type_number_t i = 0; i < pcnt; i++)
+    for (mach_msg_type_number_t i = 0; i < pcnt; ++i)
     {
         processor_set_t pset;
         kr = host_processor_set_priv(port, psets[i], &pset);
@@ -554,7 +553,7 @@ void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> callback) co
 
         defer(mach_vm_deallocate(mach_task_self(), reinterpret_cast<mach_vm_address_t>(tasks), taskCount * sizeof(*tasks)));
 
-        for (mach_msg_type_number_t j = 0; j < taskCount; j++)
+        for (mach_msg_type_number_t j = 0; j < taskCount; ++j)
         {
             const auto& task { tasks[j] };
             defer(mach_port_deallocate(mach_task_self(), task));
@@ -595,7 +594,7 @@ void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> callback) co
                 // Go through all threads, translating the thread state to a unified process state and take the minimum state value.
                 State state = State::Zombie;
 
-                for (mach_msg_type_number_t k = 0; k < threadCount; k++)
+                for (mach_msg_type_number_t k = 0; k < threadCount; ++k)
                 {
                     thread_basic_info_data_t info;
                     mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;

--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -194,6 +194,9 @@ struct DarwinProcessInfo
         result["nice"]       = nice;
         result["vm_size"]    = virtualMemorySizeKiB;
         result["start_time"] = startTime;
+        result["euser"]  = "";
+        result["ruser"]  = "";
+        result["rgroup"]  = "";
 
         getpwuid_r(euid, &userInfo, buff.data(), buff.size(), &userInfoPtr);
 

--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -183,11 +183,8 @@ struct DarwinProcessInfo
         }
 
         std::vector<char> buff(maxBufferSize, '\0');
-        passwd userInfo;
-        group groupInfo;
-        // infoPtr will point to "info" if calls to getpwuid_r are successful.
+        passwd userInfo = {};
         passwd* userInfoPtr { nullptr };
-        group* groupInfoPtr { nullptr };
 
         result["pid"]        = std::to_string(pid);
         result["name"]       = std::move(name);
@@ -198,7 +195,6 @@ struct DarwinProcessInfo
         result["vm_size"]    = virtualMemorySizeKiB;
         result["start_time"] = startTime;
 
-        memset(&userInfo, 0, sizeof userInfo);
         getpwuid_r(euid, &userInfo, buff.data(), buff.size(), &userInfoPtr);
 
         if (userInfoPtr)
@@ -220,7 +216,8 @@ struct DarwinProcessInfo
             }
         }
 
-        memset(&groupInfo, 0, sizeof groupInfo);
+        group groupInfo = {};
+        group* groupInfoPtr { nullptr };
         getgrgid_r(rgid, &groupInfo, buff.data(), buff.size(), &groupInfoPtr);
 
         if (groupInfoPtr)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #11855 |


## Description
This PR solves a problem where most of the processes reported by sysinfo would be shown as "running" even when they are not. We have been using a field that is gives the "running" state a different meaning.  Looking at `sys/proc.h` we can see that the "run" state actually means the process is _runnable_:

```
/* Status values. */
#define SIDL    1               /* Process being created by fork. */
#define SRUN    2               /* Currently runnable. */
#define SSLEEP  3               /* Sleeping on an address. */
#define SSTOP   4               /* Process debugging or suspension. */
#define SZOMB   5               /* Awaiting collection by parent. */
```

In order to fix this issue, what the PR does reimplement the way we retrieve the processes, doing something similar to what Apple's `top` and `htop` do, which is to go through all the threads of a process, convert thread states to a unified process state and take its minimum.

Note that the new API we are now using needs the calling process to be run by root. This shouldn't be a problem considering the agent already runs as root. The top commands works around this limitation by using the suid bit, the same way `sudo` does.

The numerical values assigned to the states is such that it makes sense to use its order to interpret the minimum state of all threads as the process state.

As a side note, this PR makes use of a [defer mechanism](https://www.gingerbill.org/article/2015/08/19/defer-in-cpp) for C++ that is similar to what one would use in the Go language. We do this to avoid having to handle multiple return paths when throwing exceptions without having to write a smart deleter for each type. 
