### PR TITLE
Remove xfail marks and update syscollector and experimental API tests healthchecks

### DIFF
--- a/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
@@ -8,16 +8,10 @@ from healthcheck_utils import get_agent_health_base, check
 if __name__ == "__main__":
     # Check that the syscollector differences are sent. This is part of the DBs synchronization process, and it happens
     # after the scan (modules with debug = 2 is needed).
+    sync_sent_logs = ('DEBUG: Sync sent: {"component":'f'"{component}"' for component in
+                      ('syscollector_processes', 'syscollector_osinfo', 'syscollector_ports', 'syscollector_hwinfo',
+                       'syscollector_packages', 'syscollector_network_iface', 'syscollector_network_protocol',
+                       'syscollector_network_address'))
 
-    # Uncomment this snippet when https://github.com/wazuh/wazuh/issues/11829 is solved
-    # sync_sent_logs = ('DEBUG: Sync sent: {"component":'f'"{component}"' for component in
-    #                   ('syscollector_processes', 'syscollector_osinfo', 'syscollector_ports', 'syscollector_hwinfo',
-    #                    'syscollector_packages', 'syscollector_network_iface', 'syscollector_network_protocol',
-    #                    'syscollector_network_address'))
-    #
-    # exit(any(check(os.system(f"grep -q '{log}' /var/ossec/logs/ossec.log")) for log in sync_sent_logs)
-    #      or get_agent_health_base())
-
-    # Remove this snippet when https://github.com/wazuh/wazuh/issues/11829 is solved
-    exit(check(os.system("grep -q 'wazuh-modulesd:syscollector.*INFO: Evaluation finished.' /var/ossec/logs/ossec.log"))
+    exit(any(check(os.system(f"grep -q '{log}' /var/ossec/logs/ossec.log")) for log in sync_sent_logs)
          or get_agent_health_base())

--- a/api/test/integration/env/configurations/syscollector/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/syscollector/agent/healthcheck/healthcheck.py
@@ -8,16 +8,10 @@ from healthcheck_utils import get_agent_health_base, check
 if __name__ == "__main__":
     # Check that the syscollector differences are sent. This is part of the DBs synchronization process, and it happens
     # after the scan (modules with debug = 2 is needed).
+    sync_sent_logs = ('DEBUG: Sync sent: {"component":'f'"{component}"' for component in
+                      ('syscollector_processes', 'syscollector_osinfo', 'syscollector_ports', 'syscollector_hwinfo',
+                       'syscollector_packages', 'syscollector_network_iface', 'syscollector_network_protocol',
+                       'syscollector_network_address'))
 
-    # Uncomment this snippet when https://github.com/wazuh/wazuh/issues/11829 is solved
-    # sync_sent_logs = ('DEBUG: Sync sent: {"component":'f'"{component}"' for component in
-    #                   ('syscollector_processes', 'syscollector_osinfo', 'syscollector_ports', 'syscollector_hwinfo',
-    #                    'syscollector_packages', 'syscollector_network_iface', 'syscollector_network_protocol',
-    #                    'syscollector_network_address'))
-    #
-    # exit(any(check(os.system(f"grep -q '{log}' /var/ossec/logs/ossec.log")) for log in sync_sent_logs)
-    #      or get_agent_health_base())
-
-    # Remove this snippet when https://github.com/wazuh/wazuh/issues/11829 is solved
-    exit(check(os.system("grep -q 'wazuh-modulesd:syscollector.*INFO: Evaluation finished.' /var/ossec/logs/ossec.log"))
+    exit(any(check(os.system(f"grep -q '{log}' /var/ossec/logs/ossec.log")) for log in sync_sent_logs)
          or get_agent_health_base())

--- a/api/test/integration/test_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_experimental_endpoints.tavern.yaml
@@ -208,10 +208,6 @@ stages:
 ---
 test_name: GET /experimental/syscollector/netaddr
 
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
-
 stages:
 
   - name: Request
@@ -276,10 +272,6 @@ stages:
 
 ---
 test_name: GET /experimental/syscollector/netiface
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -357,10 +349,6 @@ stages:
 ---
 test_name: GET /experimental/syscollector/netproto
 
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
-
 stages:
 
   - name: Request
@@ -424,10 +412,6 @@ stages:
 
 ---
 test_name: GET /experimental/syscollector/os
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -502,10 +486,6 @@ stages:
 ---
 test_name: GET /experimental/syscollector/packages
 
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
-
 stages:
 
   - name: Request
@@ -546,10 +526,6 @@ stages:
 
 ---
 test_name: GET /experimental/syscollector/ports
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -638,10 +614,6 @@ stages:
 
 ---
 test_name: GET /experimental/syscollector/processes
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 

--- a/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
@@ -188,10 +188,6 @@ stages:
 ---
 test_name: GET /experimental/syscollector/hardware
 
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
-
 stages:
 
   - name: Request all agents (Partially allowed, user agnostic)
@@ -245,10 +241,6 @@ stages:
 ---
 test_name: GET /experimental/syscollector/netaddr
 
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
-
 stages:
 
   - name: Request all agents (Partially allowed, user agnostic)
@@ -293,10 +285,6 @@ stages:
 
 ---
 test_name: GET /experimental/syscollector/netiface
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -343,10 +331,6 @@ stages:
 ---
 test_name: GET /experimental/syscollector/netproto
 
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
-
 stages:
 
   - name: Request all agents (Partially allowed, user agnostic)
@@ -391,10 +375,6 @@ stages:
 
 ---
 test_name: GET /experimental/syscollector/os
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -441,10 +421,6 @@ stages:
 ---
 test_name: GET /experimental/syscollector/packages
 
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
-
 stages:
 
   - name:  Request all agents (Partially allowed, user agnostic)
@@ -478,10 +454,6 @@ stages:
 
 ---
 test_name: GET /experimental/syscollector/ports
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -535,10 +507,6 @@ stages:
 
 ---
 test_name: GET /experimental/syscollector/processes
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 

--- a/api/test/integration/test_rbac_black_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_syscollector_endpoints.tavern.yaml
@@ -1,10 +1,6 @@
 ---
 test_name: GET OS SYSCOLLECTOR RBAC
 
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
-
 stages:
 
   - name: Get os from an agent (Allow)
@@ -54,10 +50,6 @@ stages:
 ---
 test_name: GET HARDWARE SYSCOLLECTOR RBAC
 
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
-
 stages:
 
   - name: Get hardware from an agent (Allow)
@@ -101,10 +93,6 @@ stages:
 ---
 test_name: GET NETADDR SYSCOLLECTOR RBAC
 
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
-
 stages:
 
   - name: Get netaddr from an agent (Allow)
@@ -141,10 +129,6 @@ stages:
 
 ---
 test_name: GET NETIFACE SYSCOLLECTOR RBAC
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -194,10 +178,6 @@ stages:
 ---
 test_name: GET NETPROTO SYSCOLLECTOR RBAC
 
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
-
 stages:
 
   - name: Get netiface from an agent (Allow)
@@ -233,10 +213,6 @@ stages:
 
 ---
 test_name: GET PACKAGES SYSCOLLECTOR RBAC
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -284,10 +260,6 @@ stages:
 ---
 test_name: GET PORTS SYSCOLLECTOR RBAC
 
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
-
 stages:
 
   - name: Get netiface from an agent (Allow)
@@ -333,10 +305,6 @@ stages:
 
 ---
 test_name: GET PROCESSES SYSCOLLECTOR RBAC
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 

--- a/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
@@ -188,10 +188,6 @@ stages:
 ---
 test_name: GET /experimental/syscollector/hardware
 
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
-
 stages:
 
   - name: Request all agents (Partially allowed, user agnostic)
@@ -243,10 +239,6 @@ stages:
 
 ---
 test_name: GET /experimental/syscollector/netaddr
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -300,10 +292,6 @@ stages:
 ---
 test_name: GET /experimental/syscollector/netiface
 
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
-
 stages:
 
   - name: Request all agents (Partially allowed, user agnostic)
@@ -355,10 +343,6 @@ stages:
 
 ---
 test_name: GET /experimental/syscollector/netproto
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -412,10 +396,6 @@ stages:
 ---
 test_name: GET /experimental/syscollector/os
 
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
-
 stages:
 
   - name: Request all agents (Partially allowed, user agnostic)
@@ -468,10 +448,6 @@ stages:
 ---
 test_name: GET /experimental/syscollector/packages
 
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
-
 stages:
 
   - name:  Request all agents (Partially allowed, user agnostic)
@@ -509,10 +485,6 @@ stages:
 
 ---
 test_name: GET /experimental/syscollector/ports
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -566,10 +538,6 @@ stages:
 
 ---
 test_name: GET /experimental/syscollector/processes
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 

--- a/api/test/integration/test_rbac_white_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_syscollector_endpoints.tavern.yaml
@@ -1,10 +1,6 @@
 ---
 test_name: GET OS SYSCOLLECTOR RBAC
 
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
-
 stages:
 
   - name: Get os from an agent (Allow)
@@ -57,10 +53,6 @@ stages:
 ---
 test_name: GET HARDWARE SYSCOLLECTOR RBAC
 
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
-
 stages:
 
   - name: Get hardware from an agent (Allow)
@@ -104,10 +96,6 @@ stages:
 ---
 test_name: GET NETADDR SYSCOLLECTOR RBAC
 
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
-
 stages:
 
   - name: Get netaddr from an agent (Allow)
@@ -144,10 +132,6 @@ stages:
 
 ---
 test_name: GET NETIFACE SYSCOLLECTOR RBAC
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -197,10 +181,6 @@ stages:
 ---
 test_name: GET NETPROTO SYSCOLLECTOR RBAC
 
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
-
 stages:
 
   - name: Get netiface from an agent (Allow)
@@ -236,10 +216,6 @@ stages:
 
 ---
 test_name: GET PACKAGES SYSCOLLECTOR RBAC
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -287,10 +263,6 @@ stages:
 ---
 test_name: GET PORTS SYSCOLLECTOR RBAC
 
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
-
 stages:
 
   - name: Get netiface from an agent (Allow)
@@ -336,10 +308,6 @@ stages:
 
 ---
 test_name: GET PROCESSES SYSCOLLECTOR RBAC
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 

--- a/api/test/integration/test_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_syscollector_endpoints.tavern.yaml
@@ -1,10 +1,6 @@
 ---
 test_name: GET /syscollector/{agent_id}/os
 
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
-
 stages:
 
   - name: Get the OS of an agent
@@ -60,8 +56,6 @@ stages:
 test_name: GET /syscollector/{agent_id}/os?{select}
 
 marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
   - parametrize:
       key: field
       vals:
@@ -97,10 +91,6 @@ stages:
 
 ---
 test_name: GET /syscollector/{agent_id}/hardware
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -150,8 +140,6 @@ stages:
 test_name: GET /syscollector/{agent_id}/hardware?{select}
 
 marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
   - parametrize:
       key: field
       vals:
@@ -182,10 +170,6 @@ stages:
 
 ---
 test_name: GET /syscollector/{agent_id}/packages
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -543,8 +527,6 @@ stages:
 test_name: GET /syscollector/{agent_id}/packages?{select}
 
 marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
   - parametrize:
       key: field
       vals:
@@ -578,10 +560,6 @@ stages:
 
 ---
 test_name: GET /syscollector/{agent_id}/processes
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -1012,8 +990,6 @@ stages:
 test_name: GET /syscollector/{agent_id}/processes?{sort,select}
 
 marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
   - parametrize:
       key: field
       vals:
@@ -1079,10 +1055,6 @@ stages:
 
 ---
 test_name: GET /syscollector/{agent_id}/ports
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -1290,8 +1262,6 @@ stages:
 test_name: GET /syscollector/{agent_id}/port?{sort,select}
 
 marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
   - parametrize:
       key: field
       vals:
@@ -1343,10 +1313,6 @@ stages:
 
 ---
 test_name: GET /syscollector/{agent_id}/netaddr
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -1689,8 +1655,6 @@ stages:
 test_name: GET /syscollector/{agent_id}/netaddr?{sort,select}
 
 marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
   - parametrize:
       key: field
       vals:
@@ -1738,10 +1702,6 @@ stages:
 
 ---
 test_name: GET /syscollector/{agent_id}/netproto
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -2024,8 +1984,6 @@ stages:
 test_name: GET /syscollector/{agent_id}/netproto?{sort,select}
 
 marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
   - parametrize:
       key: field
       vals:
@@ -2072,10 +2030,6 @@ stages:
 
 ---
 test_name: GET /syscollector/{agent_id}/netiface
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -2686,8 +2640,6 @@ stages:
 test_name: GET /syscollector/{agent_id}/netiface?{sort,select}
 
 marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
   - parametrize:
       key: field
       vals:
@@ -2744,10 +2696,6 @@ stages:
 ---
 test_name: GET /syscollector/{agent_id}/os
 
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
-
 stages:
 
   - name: Get the OS of an agent
@@ -2797,8 +2745,6 @@ stages:
 test_name: GET /syscollector/{agent_id}/os?{select}
 
 marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
   - parametrize:
       key: field
       vals:
@@ -2836,10 +2782,6 @@ stages:
 
 ---
 test_name: GET /syscollector/{agent_id}/hardware
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -2885,8 +2827,6 @@ stages:
 test_name: GET /syscollector/{agent_id}/hardware?{select}
 
 marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
   - parametrize:
       key: field
       vals:
@@ -2917,10 +2857,6 @@ stages:
 
 ---
 test_name: GET /syscollector/{agent_id}/netaddr
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -3221,8 +3157,6 @@ stages:
 test_name: GET /syscollector/{agent_id}/netaddr?{sort,select}
 
 marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
   - parametrize:
       key: field
       vals:
@@ -3256,10 +3190,6 @@ stages:
 
 ---
 test_name: GET /syscollector/{agent_id}/netproto
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -3557,8 +3487,6 @@ stages:
 test_name: GET /syscollector/{agent_id}/netproto?{sort,select}
 
 marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
   - parametrize:
       key: field
       vals:
@@ -3604,10 +3532,6 @@ stages:
 
 ---
 test_name: GET /syscollector/{agent_id}/netiface
-
-marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
 
 stages:
 
@@ -4203,8 +4127,6 @@ stages:
 test_name: GET /syscollector/{agent_id}/netiface?{sort,select}
 
 marks:
-  - xfail  # Syscollector databases synchronization randomly fails - https://github.com/wazuh/wazuh/issues/11829.
-           # Remove xfail mark and change healthcheck when #11829 is solved.
   - parametrize:
       key: field
       vals:


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/12114 |



## Description

This PR closes #12114.

In this pull request, the xfail marks in experimental and syscollector API endpoints integration tests have been removed as the issue making them fail has been solved. The new agent healthchecks used in these tests have been uncommented and the old ones have been deleted.