### PR TITLE
Make GCP module compatible with Python3.6 (#12238)

### DIFF
--- a/wodles/gcloud/buckets/bucket.py
+++ b/wodles/gcloud/buckets/bucket.py
@@ -132,7 +132,7 @@ class WazuhGCloudBucket(WazuhGCloudIntegration):
         except (TypeError, IndexError):
             return list()
 
-    def _update_last_processed_files(self, processed_files: list[storage.blob]):
+    def _update_last_processed_files(self, processed_files: list):
         """Remove the records for the previous execution and store the new values from the current one.
 
         Parameters
@@ -151,12 +151,13 @@ class WazuhGCloudBucket(WazuhGCloudIntegration):
                 pass
 
             for blob in processed_files:
+                creation_time = datetime.strftime(blob.time_created, self.datetime_format)
                 self.db_connector.execute(self.sql_insert_processed_file.format(table_name=self.db_table_name,
                                                                                 project_id=self.project_id,
                                                                                 bucket_name=self.bucket_name,
                                                                                 prefix=self.prefix,
                                                                                 blob_name=blob.name,
-                                                                                creation_time=blob.time_created))
+                                                                                creation_time=creation_time))
     processed_files = list()
 
     def _get_last_creation_time(self):


### PR DESCRIPTION
|Related issue|
|---|
|Closes #12238|

# Description
In this PR we modify the Google Cloud integration module to support Python `3.6` to `3.9`. We only had to remove a type hint that used generics -which is a `Python 3.9` feature- and modify the way the dates are stored in the database to consider that in `Python 3.6` the `datetime.strptime` method couldn't parse dates which had collons as delimiter in the time zone information.

## Tests performed
All the tests passed, so the module is working as expected in `Python 3.6`.

### Unit tests
The tests passed without problems:
```
(wazuh-unit) ➜  wodles git:(fix/12238-make-gcp-compatible-with-python-3-6) ✗ pytest gcloud --disable-warnings
==================================== test session starts ====================================
platform linux -- Python 3.10.2, pytest-6.2.5, py-1.11.0, pluggy-0.13.1
rootdir: /home/gonzz/git/wazuh/wodles
plugins: asyncio-0.15.1
collected 6 items                                                                           

gcloud/tests/test_access_logs.py .                                                    [ 16%]
gcloud/tests/test_bucket.py .                                                         [ 33%]
gcloud/tests/test_integration.py ...                                                  [ 83%]
gcloud/tests/test_subscriber.py .                                                     [100%]

=============================== 6 passed, 1 warning in 0.21s ================================
```

### Pub/Sub

#### One thread and one hundred messages
```
[root@5c24deae2639 gcloud]# python3 /var/ossec/wodles/gcloud/gcloud -p wazuh-dev-258815 -s wazuh-audit-logs -c /var/ossec/wodles/gcloud/credentials.json -l 2 -T pubsub
gcloud_wodle - INFO - Received and acknowledged 100 messages
```

#### Ten threads and five hundred messages
```
[root@5c24deae2639 gcloud]# python3 /var/ossec/wodles/gcloud/gcloud -p wazuh-dev-258815 -s wazuh-audit-logs -c /var/ossec/wodles/gcloud/credentials.json -l 2 -T pubsub -t 10 -m 500
gcloud_wodle - INFO - Received and acknowledged 500 messages
```

### Storage

#### Specifying a `only_logs_after` date
```
[root@e22993148f2e gcloud]# python3 /var/ossec/wodles/gcloud/gcloud -b framework-test-bucket -l 2 -c /var/ossec/wodles/gcloud/credentials.json -T access_logs -o 2021-dec-20
gcloud_wodle - INFO - Processing test_1_new.txt
gcloud_wodle - INFO - The creation time of test_22.txt is older than 2021-12-20 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - Processing test_2_new.txt
gcloud_wodle - INFO - The creation time of test_3.txt is older than 2021-12-20 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - Processing test_3_new.txt
gcloud_wodle - INFO - The creation time of test_4.txt is older than 2021-12-20 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_5.txt is older than 2021-12-20 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - Updating previously processed files.
gcloud_wodle - INFO - Received 3 messages
[root@e22993148f2e gcloud]# python3 /var/ossec/wodles/gcloud/gcloud -b framework-test-bucket -l 2 -c /var/ossec/wodles/gcloud/credentials.json -T access_logs -o 2021-dec-20
gcloud_wodle - INFO - Skipping previously processed file: test_1_new.txt
gcloud_wodle - INFO - The creation time of test_22.txt is older than 2021-12-20 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - Skipping previously processed file: test_2_new.txt
gcloud_wodle - INFO - The creation time of test_3.txt is older than 2021-12-20 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - Skipping previously processed file: test_3_new.txt
gcloud_wodle - INFO - The creation time of test_4.txt is older than 2021-12-20 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_5.txt is older than 2021-12-20 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - Received 0 messages
```


#### Without specifying a `only_logs_after` and having no files for the execution date
```
[root@e22993148f2e gcloud]# python3 /var/ossec/wodles/gcloud/gcloud -b framework-test-bucket -l 2 -c /var/ossec/wodles/gcloud/credentials.json -T access_logs  
gcloud_wodle - INFO - The creation time of test_1_new.txt is older than 2022-02-15 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_22.txt is older than 2022-02-15 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_2_new.txt is older than 2022-02-15 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_3.txt is older than 2022-02-15 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_3_new.txt is older than 2022-02-15 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_4.txt is older than 2022-02-15 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_5.txt is older than 2022-02-15 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - Received 0 messages
```

#### Without specifying a `only_logs_after` having new files for the execution date
```
[root@e22993148f2e gcloud]# python3 /var/ossec/wodles/gcloud/gcloud -b framework-test-bucket -l 2 -c /var/ossec/wodles/gcloud/credentials.json -T access_logs
gcloud_wodle - INFO - The creation time of test_1_new.txt is older than 2022-02-15 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_22.txt is older than 2022-02-15 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_2_new.txt is older than 2022-02-15 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_3.txt is older than 2022-02-15 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_3_new.txt is older than 2022-02-15 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_4.txt is older than 2022-02-15 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_5.txt is older than 2022-02-15 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - Processing test_6.txt
gcloud_wodle - INFO - Updating previously processed files.
gcloud_wodle - INFO - Received 1 message
[root@e22993148f2e gcloud]# python3 /var/ossec/wodles/gcloud/gcloud -b framework-test-bucket -l 2 -c /var/ossec/wodles/gcloud/credentials.json -T access_logs
gcloud_wodle - INFO - The creation time of test_1_new.txt is older than 2022-02-15 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_22.txt is older than 2022-02-15 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_2_new.txt is older than 2022-02-15 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_3.txt is older than 2022-02-15 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_3_new.txt is older than 2022-02-15 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_4.txt is older than 2022-02-15 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_5.txt is older than 2022-02-15 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - Skipping previously processed file: test_6.txt
gcloud_wodle - INFO - Received 0 messages
```

#### Specifying a prefix
```
[root@e22993148f2e gcloud]# python3 /var/ossec/wodles/gcloud/gcloud -b framework-test-bucket -l 2 -c /var/ossec/wodles/gcloud/credentials.json -T access_logs -o 2021-jan-01 -P test_prefix
gcloud_wodle - INFO - Processing test_prefix/test_1.txt
gcloud_wodle - INFO - Updating previously processed files.
gcloud_wodle - INFO - Received 1 message
[root@e22993148f2e gcloud]# python3 /var/ossec/wodles/gcloud/gcloud -b framework-test-bucket -l 2 -c /var/ossec/wodles/gcloud/credentials.json -T access_logs -o 2021-jan-01 -P test_prefix
gcloud_wodle - INFO - Skipping previously processed file: test_prefix/test_1.txt
gcloud_wodle - INFO - Received 0 messages
```

#### Having an empty bucket
```
[root@e22993148f2e gcloud]# python3 /var/ossec/wodles/gcloud/gcloud -b framework-test-bucket -l 2 -c /var/ossec/wodles/gcloud/credentials.json -T access_logs -o 2021-jan-01 -P test_empty
gcloud_wodle - INFO - Received 0 messages
```

#### Using log level 1
```
[root@e22993148f2e gcloud]# python3 /var/ossec/wodles/gcloud/gcloud -b framework-test-bucket -l 1 -c /var/ossec/wodles/gcloud/credentials.json -T access_logs -o 2021-jan-01
gcloud_wodle - INFO - Processing test_1_new.txt
gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 1", "source": "gcp_bucket"}}'"
gcloud_wodle - INFO - Processing test_22.txt
gcloud_wodle - INFO - Processing test_2_new.txt
gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 2", "source": "gcp_bucket"}}'"
gcloud_wodle - INFO - Processing test_3.txt
gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 3", "source": "gcp_bucket"}}'"
gcloud_wodle - INFO - Processing test_3_new.txt
gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 3", "source": "gcp_bucket"}}'"
gcloud_wodle - INFO - Processing test_4.txt
gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 4", "source": "gcp_bucket"}}'"
gcloud_wodle - INFO - Processing test_5.txt
gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 5", "source": "gcp_bucket"}}'"
gcloud_wodle - INFO - Processing test_6.txt
gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 6", "source": "gcp_bucket"}}'"
gcloud_wodle - INFO - Updating previously processed files.
gcloud_wodle - INFO - Received 7 messages
```
