### PR TITLE
UT for new multigroup functions - First iteration

### DIFF
--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -34,7 +34,8 @@ list(APPEND remoted_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,w_
                             -Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_Add -Wl,--wrap,OSHash_Add_ex \
                             -Wl,--wrap,checkBinaryFile -Wl,--wrap,OSHash_Set -Wl,--wrap,_minfo \
                             -Wl,--wrap,opendir -Wl,--wrap,cldir_ex -Wl,--wrap,wreaddir -Wl,--wrap=_mwarn \
-                            -Wl,--wrap,closedir")
+                            -Wl,--wrap,closedir -Wl,--wrap,OSHash_Clean -Wl,--wrap,rmdir_ex \
+                            -Wl,--wrap,OS_SHA256_String")
 
 list(APPEND remoted_names "test_secure")
 list(APPEND remoted_flags "-Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose -Wl,--wrap,remove \

--- a/src/unit_tests/remoted/test_manager.c
+++ b/src/unit_tests/remoted/test_manager.c
@@ -1188,6 +1188,57 @@ void test_group_changed_invalid_group(void **state)
     assert_true(group_changed("test_default,test_test_default,invalid_group"));
 }
 
+void test_process_deleted_groups_delete(void **state)
+{
+    groups[0]->exists = false;
+    groups[0]->has_changed = false;
+    groups[1]->exists = true;
+    groups[1]->has_changed = false;
+
+    process_deleted_groups();
+
+    assert_non_null(groups[0]);
+    assert_string_equal(groups[0]->name, "test_test_default");
+    assert_non_null(groups[0]->f_sum);
+    assert_non_null(groups[0]->f_sum[0]);
+    assert_string_equal(groups[0]->f_sum[0]->name, "test_test_file");
+    assert_string_equal(groups[0]->f_sum[0]->sum, "12345ABCDEF67890");
+    assert_null(groups[0]->f_sum[1]);
+    assert_false(groups[0]->has_changed);
+    assert_false(groups[0]->exists);
+    assert_null(groups[1]);
+}
+
+void test_process_deleted_groups_no_changes(void **state)
+{
+    groups[0]->exists = true;
+    groups[0]->has_changed = false;
+    groups[1]->exists = true;
+    groups[1]->has_changed = false;
+
+    process_deleted_groups();
+
+    assert_non_null(groups[0]);
+    assert_string_equal(groups[0]->name, "test_default");
+    assert_non_null(groups[0]->f_sum);
+    assert_non_null(groups[0]->f_sum[0]);
+    assert_string_equal(groups[0]->f_sum[0]->name, "test_file");
+    assert_string_equal(groups[0]->f_sum[0]->sum, "ABCDEF1234567890");
+    assert_null(groups[0]->f_sum[1]);
+    assert_false(groups[0]->has_changed);
+    assert_false(groups[0]->exists);
+    assert_non_null(groups[1]);
+    assert_string_equal(groups[1]->name, "test_test_default");
+    assert_non_null(groups[1]->f_sum);
+    assert_non_null(groups[1]->f_sum[0]);
+    assert_string_equal(groups[1]->f_sum[0]->name, "test_test_file");
+    assert_string_equal(groups[1]->f_sum[0]->sum, "12345ABCDEF67890");
+    assert_null(groups[1]->f_sum[1]);
+    assert_false(groups[1]->has_changed);
+    assert_false(groups[1]->exists);
+    assert_null(groups[2]);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -1239,6 +1290,9 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_group_changed_has_changed, test_find_group_setup, test_c_group_teardown),
         cmocka_unit_test_setup_teardown(test_group_changed_not_exists, test_find_group_setup, test_c_group_teardown),
         cmocka_unit_test_setup_teardown(test_group_changed_invalid_group, test_find_group_setup, test_c_group_teardown),
+        // Test process_deleted_groups
+        cmocka_unit_test_setup_teardown(test_process_deleted_groups_delete, test_find_group_setup, test_c_group_teardown),
+        cmocka_unit_test_setup_teardown(test_process_deleted_groups_no_changes, test_find_group_setup, test_c_group_teardown),
     };
     return cmocka_run_group_tests(tests, test_setup_group, test_teardown_group);
 }

--- a/src/unit_tests/wrappers/wazuh/os_crypto/sha256_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/os_crypto/sha256_op_wrappers.c
@@ -1,0 +1,22 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "sha256_op_wrappers.h"
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+int __wrap_OS_SHA256_String(const char *str, os_sha256 output) {
+    check_expected(str);
+
+    snprintf(output, 65, "%s", mock_type(char *));
+
+    return 0;
+}

--- a/src/unit_tests/wrappers/wazuh/os_crypto/sha256_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/os_crypto/sha256_op_wrappers.h
@@ -1,0 +1,22 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+
+#ifndef SHA256_OP_WRAPPERS_H
+#define SHA256_OP_WRAPPERS_H
+
+#include "headers/shared.h"
+#include <string.h>
+#include <sys/types.h>
+
+typedef char os_sha256[65];
+
+int __wrap_OS_SHA256_String(const char *str, os_sha256 output);
+
+#endif


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/12109|

## Description

Tests added for the following functions:

-  process_deleted_groups()
-  process_deleted_multi_groups()
- find_group()
- find_multi_group()
- find_group_from_file()
- find_multi_group_from_file()
- fsum_changed()
- group_changed()