### PR TITLE
Adding a warning message in case the amount of groups exceeds the socket size

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -4694,8 +4694,9 @@ void test_wdb_global_select_group_belong_exec_fail(void **state)
     will_return_always(__wrap_sqlite3_bind_int, SQLITE_OK);
     /* wdb_exec_stmt_sized */
     wrap_wdb_exec_stmt_sized_failed_call(STMT_SINGLE_COLUMN);
+    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Failed to get agent groups.");
+    expect_string(__wrap__mdebug1, formatted_msg, "Failed to get agent groups: ERROR MESSAGE.");
 
     j_result = wdb_global_select_group_belong(data->wdb, 1);
     assert_null(j_result);
@@ -4713,8 +4714,7 @@ void test_wdb_global_select_group_belong_socket_size_error(void **state)
     will_return_always(__wrap_sqlite3_bind_int, SQLITE_OK);
     /* wdb_exec_stmt_sized */
     wrap_wdb_exec_stmt_sized_socket_full_call(NULL, STMT_SINGLE_COLUMN);
-
-    expect_string(__wrap__mdebug2, formatted_msg, "The agent's groups exceed the socket maximum response size.");
+    expect_string(__wrap__mwarn, formatted_msg, "The agent's groups exceed the socket maximum response size.");
 
     j_result = wdb_global_select_group_belong(data->wdb, 1);
     assert_null(j_result);

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -4086,9 +4086,27 @@ void test_wdb_global_select_groups_exec_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
 
-    will_return(__wrap_wdb_exec_stmt, NULL);
+    /* wdb_exec_stmt_sized */
+    wrap_wdb_exec_stmt_sized_failed_call(STMT_MULTI_COLUMN);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__mdebug1, formatted_msg, "wdb_exec_stmt(): ERROR MESSAGE");
+    expect_string(__wrap__mdebug1, formatted_msg, "Failed to get groups: ERROR MESSAGE.");
+
+    result = wdb_global_select_groups(data->wdb);
+
+    assert_null(result);
+}
+
+void test_wdb_global_select_groups_socket_full(void **state)
+{
+    cJSON *result = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+
+    /* wdb_exec_stmt_sized */
+    wrap_wdb_exec_stmt_sized_socket_full_call(NULL, STMT_MULTI_COLUMN);
+    expect_string(__wrap__mwarn, formatted_msg, "The groups exceed the socket maximum response size.");
 
     result = wdb_global_select_groups(data->wdb);
 
@@ -4102,7 +4120,9 @@ void test_wdb_global_select_groups_success(void **state)
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
-    will_return(__wrap_wdb_exec_stmt, (cJSON*) 1);
+
+    /* wdb_exec_stmt_sized */
+    wrap_wdb_exec_stmt_sized_success_call((cJSON*) 1, STMT_MULTI_COLUMN);
 
     result = wdb_global_select_groups(data->wdb);
 
@@ -8195,6 +8215,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_global_select_groups_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_groups_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_groups_exec_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_select_groups_socket_full, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_groups_success, test_setup, test_teardown),
         /* Tests wdb_global_select_agent_keepalive */
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_keepalive_transaction_fail,

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -861,9 +861,6 @@ int wdb_global_delete_group(wdb_t *wdb, char* group_name) {
 }
 
 cJSON* wdb_global_select_groups(wdb_t *wdb) {
-    sqlite3_stmt *stmt = NULL;
-    cJSON * result = NULL;
-
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
         mdebug1("Cannot begin transaction");
         return NULL;
@@ -874,12 +871,15 @@ cJSON* wdb_global_select_groups(wdb_t *wdb) {
         return NULL;
     }
 
-    stmt = wdb->stmt[WDB_STMT_GLOBAL_SELECT_GROUPS];
+    sqlite3_stmt *stmt = wdb->stmt[WDB_STMT_GLOBAL_SELECT_GROUPS];
 
-    result = wdb_exec_stmt(stmt);
+    int sql_status = SQLITE_ERROR;
+    cJSON* result = wdb_exec_stmt_sized(stmt, WDB_MAX_RESPONSE_SIZE, &sql_status, STMT_MULTI_COLUMN);
 
-    if (!result) {
-        mdebug1("wdb_exec_stmt(): %s", sqlite3_errmsg(wdb->db));
+    if (SQLITE_ROW == sql_status) {
+        mwarn("The groups exceed the socket maximum response size.");
+    } else if (SQLITE_DONE != sql_status) {
+        mdebug1("Failed to get groups: %s.", sqlite3_errmsg(wdb->db));
     }
 
     return result;

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -748,9 +748,9 @@ cJSON* wdb_global_select_group_belong(wdb_t *wdb, int id_agent) {
     cJSON *result = wdb_exec_stmt_sized(stmt, WDB_MAX_RESPONSE_SIZE, &sql_status, STMT_SINGLE_COLUMN);
 
     if (SQLITE_ROW == sql_status) {
-        mdebug2("The agent's groups exceed the socket maximum response size.");
+        mwarn("The agent's groups exceed the socket maximum response size.");
     } else if (SQLITE_DONE != sql_status) {
-        mdebug1("Failed to get agent groups.");
+        mdebug1("Failed to get agent groups: %s.", sqlite3_errmsg(wdb->db));
     }
 
     return result;


### PR DESCRIPTION
|Related issue|
|---|
|#12312|

## Description

This PR updates the `wdb_global_select_groups()` method to properly inform the case when the whole **group** table of `global.db` doesn't fit through the 65kb socket.

Also, if  `wdb_global_select_groups()`  or `wdb_global_select_group_belong()` fail during an SQLite statement execution, the corresponding message is printed.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
