### PR TITLE
Add agent-groups receiving task on worker nodes

### DIFF
--- a/framework/wazuh/core/cluster/client.py
+++ b/framework/wazuh/core/cluster/client.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from typing import Tuple, Dict, List
 
 import uvloop
+
 from wazuh.core.cluster import common
 from wazuh.core.cluster.utils import context_tag
 
@@ -96,13 +97,13 @@ class AbstractClientManager:
         while True:
             try:
                 transport, protocol = await self.loop.create_connection(
-                                    protocol_factory=lambda: self.handler_class(loop=self.loop, on_con_lost=on_con_lost,
-                                                                                name=self.name, logger=self.logger,
-                                                                                fernet_key=self.configuration['key'],
-                                                                                cluster_items=self.cluster_items,
-                                                                                manager=self, **self.extra_args),
-                                    host=self.configuration['nodes'][0], port=self.configuration['port'],
-                                    ssl=ssl_context)
+                    protocol_factory=lambda: self.handler_class(loop=self.loop, on_con_lost=on_con_lost,
+                                                                name=self.name, logger=self.logger,
+                                                                fernet_key=self.configuration['key'],
+                                                                cluster_items=self.cluster_items,
+                                                                manager=self, **self.extra_args),
+                    host=self.configuration['nodes'][0], port=self.configuration['port'],
+                    ssl=ssl_context)
                 self.client = protocol
             except ConnectionRefusedError:
                 self.logger.error("Could not connect to master. Trying again in 10 seconds.")
@@ -136,8 +137,6 @@ class AbstractClient(common.Handler):
 
         Parameters
         ----------
-        loop : uvloop.EventLoopPolicy
-            Asyncio loop.
         on_con_lost : asyncio.Future object
             Low-level callback to notify when the connection has ended.
         name : str
@@ -155,11 +154,11 @@ class AbstractClient(common.Handler):
         """
         super().__init__(fernet_key=fernet_key, logger=logger, tag=f"{tag} {name}", cluster_items=cluster_items)
         self.loop = loop
+        self.server = manager
         self.name = name
         self.on_con_lost = on_con_lost
         self.connected = False
         self.client_data = self.name.encode()
-        self.manager = manager
 
     def connection_result(self, future_result):
         """Callback function called when the master sends a response to the hello command sent by the worker.

--- a/framework/wazuh/core/cluster/cluster.json
+++ b/framework/wazuh/core/cluster/cluster.json
@@ -83,7 +83,7 @@
         "worker": {
             "sync_integrity": 9,
             "sync_agent_info": 10,
-            "sync_agent_groups": 10,
+            "sync_agent_groups": 30,
             "timeout_agent_groups": 40,
             "keep_alive": 60,
             "connection_retry": 10,

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -600,20 +600,24 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         logger = ''
         command = ''
         error_command = ''
+        timeout = 0
         sync_dict = {}
         if info_type == 'agent-info':
             logger = self.task_loggers['Agent-info sync']
             command = b'syn_m_a_e'
             error_command = b'syn_m_a_err'
             sync_dict = self.sync_agent_info_status
+            timeout = self.cluster_items['intervals']['master']['timeout_agent_info']
         elif info_type == 'agent-groups':
             logger = self.task_loggers['Agent-groups sync']
             command = b'syn_m_g_e'
             error_command = b'syn_m_g_err'
             sync_dict = self.sync_agent_groups_status
+            timeout = self.cluster_items['intervals']['master']['timeout_agent_groups']
 
-        return await super().sync_wazuh_db_information(task_id=task_id, info_type=info_type, error_command=error_command,
-                                                       logger=logger, command=command, sync_dict=sync_dict)
+        return await super().sync_wazuh_db_information(
+            task_id=task_id, info_type=info_type, error_command=error_command,
+            logger=logger, command=command, sync_dict=sync_dict, timeout=timeout)
 
     async def send_agent_groups_information(self):
         """Function in charge of sending the group information to the worker node.

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -324,7 +324,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             client = client.decode()
             if client in self.server.clients:
                 result = (await self.server.clients[client].send_request(b'dapi',
-                                                                          request_id.encode() + b' ' + request)).decode()
+                                                                         request_id.encode() + b' ' + request)).decode()
             else:
                 raise exception.WazuhClusterError(3022, extra_message=client)
         # Add request to local API requests queue.

--- a/framework/wazuh/core/cluster/server.py
+++ b/framework/wazuh/core/cluster/server.py
@@ -29,6 +29,8 @@ class AbstractServerHandler(c_common.Handler):
         ----------
         server : AbstractServer object
             Abstract server object that created this handler.
+        loop : asyncio.AbstractEventLoop
+            Asyncio loop.
         fernet_key : str
             Key used to encrypt and decrypt messages.
         cluster_items : dict

--- a/framework/wazuh/core/cluster/server.py
+++ b/framework/wazuh/core/cluster/server.py
@@ -29,8 +29,6 @@ class AbstractServerHandler(c_common.Handler):
         ----------
         server : AbstractServer object
             Abstract server object that created this handler.
-        loop : asyncio.AbstractEventLoop
-            Asyncio loop.
         fernet_key : str
             Key used to encrypt and decrypt messages.
         cluster_items : dict

--- a/framework/wazuh/core/cluster/tests/test_client.py
+++ b/framework/wazuh/core/cluster/tests/test_client.py
@@ -189,7 +189,7 @@ async def test_acm_start(add_tasks_mock, starmap_mock):
 def test_ac_init():
     """Check the correct initialization of the AbstractClient object."""
 
-    assert abstract_client.manager is None
+    assert abstract_client.server is None
     assert abstract_client.client_data == b"name"
     assert abstract_client.connected is False
     assert isinstance(abstract_client.on_con_lost, FutureMock)

--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -17,6 +17,7 @@ from unittest.mock import patch, MagicMock, mock_open, call
 
 import cryptography
 import pytest
+from freezegun import freeze_time
 from uvloop import EventLoopPolicy, new_event_loop
 
 from wazuh import Wazuh
@@ -32,14 +33,17 @@ with patch('wazuh.common.wazuh_uid'):
 
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser
         import wazuh.core.cluster.common as cluster_common
+        import wazuh.core.common as core_common
         import wazuh.core.results as wresults
+        from wazuh.core.wdb import WazuhDBConnection
 
 # Globals
 
 cluster_items = {"etc/": {"permissions": "0o640", "source": "master", "files": ["client.keys"],
                           "description": "client keys file database"},
                  "intervals": {"worker": {"sync_integrity": 9, "sync_agent_info": 10, "sync_agent_groups": 10,
-                                          "keep_alive": 60, "connection_retry": 10, "max_failed_keepalive_attempts": 2},
+                                          "keep_alive": 60, "connection_retry": 10, "max_failed_keepalive_attempts": 2,
+                                          "timeout_agent_groups": 40},
                                "master": {"recalculate_integrity": 8, "check_worker_lastkeepalive": 60,
                                           "max_allowed_time_without_keepalive": 120},
                                "communication": {"timeout_cluster_request": 20, "timeout_dapi_request": 200,
@@ -501,6 +505,138 @@ async def test_handler_send_request_ko():
 
     with pytest.raises(exception.WazuhClusterError, match=r'.* 3018 .*'):
         await handler.send_request(b'some bytes', b'some data')
+
+
+@pytest.mark.asyncio
+@patch('wazuh.core.cluster.common.Handler.send_request')
+async def test_handler_get_chunks_in_task_id(send_request_mock):
+    """Test if all chunks are collected from task_id."""
+
+    class TaskMock:
+        def __init__(self):
+            self.payload = b'{"Objective": "fix_behavior"}'
+
+    handler = cluster_common.Handler(fernet_key, cluster_items)
+    handler.in_str[b'17'] = TaskMock()
+    assert await handler.get_chunks_in_task_id(task_id=b'17', error_command=b'') == {"Objective": "fix_behavior"}
+
+    # Test KeyError
+    with pytest.raises(exception.WazuhClusterError, match='.* 3035 .*'):
+        await handler.get_chunks_in_task_id(task_id=b'18', error_command=b'test_error')
+
+    send_request_mock.assert_called_with(
+        command=b'test_error', data=b'error while trying to access string under task_id b\'18\'.')
+
+    # Test ValueError
+    send_request_mock.reset_mock()
+    handler.in_str[b'17'].payload = b'{"Objective": \'fix_behavior"}'
+    with pytest.raises(exception.WazuhClusterError, match='.* 3036 .*'):
+        await handler.get_chunks_in_task_id(task_id=b'17', error_command=b'test_error')
+
+    send_request_mock.assert_called_with(
+        command=b'test_error', data=b'error while trying to load JSON: Expecting value: line 1 column 15 (char 14)')
+
+
+@pytest.mark.asyncio
+@patch('wazuh.core.cluster.common.Handler.send_request')
+async def test_handler_update_chunks_wdb(send_request_mock):
+    """Test that the received chunks are sent correctly to wdb."""
+
+    class LoggerMock:
+        """Auxiliary class."""
+
+        def __init__(self):
+            self._debug = []
+            self._debug2 = []
+            self._error = []
+
+        def debug(self, data):
+            """Auxiliary method."""
+            self._debug.append(data)
+
+        def debug2(self, data):
+            """Auxiliary method."""
+            self._debug2.append(data)
+
+        def error(self, data):
+            """Auxiliary method."""
+            self._error.append(data)
+
+    class ServerMock:
+        def __init__(self, task_pool):
+            self.task_pool = task_pool
+
+    logger = LoggerMock()
+    handler = cluster_common.Handler(fernet_key, cluster_items)
+    handler.server = ServerMock(None)
+
+    with patch('wazuh.core.cluster.cluster.run_in_pool',
+               return_value={'total_updated': 0, 'errors_per_folder': {'key': 'value'}, 'generic_errors': ['ERR'],
+                             'updated_chunks': 2, 'time_spent': 6,
+                             'error_messages': {'chunks': [[0, 0], [1, 1]], 'others': ['other1', 'other2']}}):
+        with patch.object(LoggerMock, "debug") as logger_debug_mock:
+            with patch.object(LoggerMock, "debug2") as logger_debug2_mock:
+                with patch.object(LoggerMock, "error") as logger_error_mock:
+                    assert await handler.update_chunks_wdb(
+                        data={'chunks': [0, 1, 2, 3, 4]}, info_type='info',
+                        logger=logger, error_command=b'ERROR') == {'error_messages': [0, 1],
+                                                                   'errors_per_folder': {'key': 'value'},
+                                                                   'generic_errors': ['ERR'], 'time_spent': 6,
+                                                                   'total_updated': 0, 'updated_chunks': 2}
+                    logger_debug_mock.assert_has_calls([call('2/5 chunks updated in wazuh-db in 6.000000s.')])
+                    logger_debug2_mock.assert_has_calls([call('Chunk 1/5: 0'), call('Chunk 2/5: 1')])
+                    logger_error_mock.assert_has_calls([call('other1'), call('other2'),
+                                                        call('Wazuh-db response for chunk 1/5 was not "ok": 0'),
+                                                        call('Wazuh-db response for chunk 2/5 was not "ok": 1')])
+
+    # Test Exception
+    send_request_mock.reset_mock()
+    with pytest.raises(exception.WazuhClusterError,
+                       match=r'.*Error 3037 - Error while processing Agent-info chunks: .*'):
+        await handler.update_chunks_wdb(data={'chunks': [0, 1, 2, 3, 4]}, info_type='info',
+                                        logger=logger, error_command=b'ERROR')
+    send_request_mock.assert_has_calls(
+        [call(command=b'ERROR',
+              data=b'error processing info chunks in process pool: '
+                   b'Error 2005 - Could not connect to wdb socket: [Errno 2] No such file or directory')])
+
+
+@pytest.mark.asyncio
+@patch('wazuh.core.cluster.common.Handler.send_request', return_value=b"some data")
+async def test_handler_send_result_to_manager(send_request_mock):
+    """Check that the results are sent correctly."""
+
+    handler = cluster_common.Handler(fernet_key, cluster_items)
+    assert await handler.send_result_to_manager(command=b'testing', result={'dict': '0'}) == b"some data"
+    send_request_mock.assert_has_calls([call(command=b'testing', data=b'{"dict": "0"}')])
+
+
+@pytest.mark.asyncio
+@freeze_time("2022-02-15")
+@patch('wazuh.core.cluster.common.Handler.send_result_to_manager', return_value=b"ok")
+@patch('wazuh.core.cluster.common.Handler.update_chunks_wdb', return_value={'updated_chunks': 1})
+@patch('wazuh.core.cluster.common.Handler.get_chunks_in_task_id', return_value={'test': 'chunks_in_task_id'})
+async def test_handler_sync_wazuh_db_information(get_chunks_in_task_id_mock, update_chunks_wdb_mock,
+                                                 send_result_to_manager_mock):
+    """Check that data is sent to wazuh-db."""
+
+    class LoggerMock:
+        """Auxiliary class."""
+
+        def __init__(self):
+            self._info = []
+
+        def info(self, data):
+            """Auxiliary method."""
+            self._info.append(data)
+
+    logger = LoggerMock()
+    sync_dict = {'date_start_master': 0, 'date_end_master': 0, 'n_synced_chunks': 0}
+    handler = cluster_common.Handler(fernet_key, cluster_items)
+    with patch.object(LoggerMock, "info") as logger_info_mock:
+        assert await handler.sync_wazuh_db_information(task_id=b'1', info_type='info', logger=logger, command=b'command',
+                                                       error_command=b'error_command', sync_dict=sync_dict) == b'ok'
+        logger_info_mock.assert_has_calls([call('Finished in 0.000s. Updated 1 chunks.')])
 
 
 @pytest.mark.asyncio
@@ -1058,6 +1194,341 @@ def test_wazuh_common_get_node():
     with patch('wazuh.core.cluster.common.Handler.get_manager', return_value=mock_manager) as manager_mock:
         mock_class.get_node()
         manager_mock.assert_called_once()
+
+
+# Test SyncTask class methods
+
+def test_sync_task_init():
+    """Test '__init__' method from the SyncTask class."""
+    sync_task = cluster_common.SyncTask(b"cmd", logging.getLogger("wazuh"),
+                                        cluster_common.Handler(fernet_key, cluster_items))
+
+    assert sync_task.cmd == b"cmd"
+    assert sync_task.logger == logging.getLogger("wazuh")
+    assert isinstance(sync_task.server, cluster_common.Handler)
+
+
+@pytest.mark.asyncio
+@patch('wazuh.core.cluster.common.Handler.send_request', return_value=Exception())
+async def test_sync_task_request_permission(send_request_mock):
+    """Check if a True value is returned once a permission to start synchronization is granted or a False when it
+    is not."""
+
+    sync_task = cluster_common.SyncTask(b"cmd", logging.getLogger("wazuh"),
+                                        cluster_common.Handler(fernet_key, cluster_items))
+
+    # Test first condition
+    with patch.object(logging.getLogger("wazuh"), "error") as logger_mock:
+        assert await sync_task.request_permission() is False
+        send_request_mock.assert_called_with(command=b"cmd" + b"_p", data=b"")
+        logger_mock.assert_called_once_with(f"Error asking for permission: {Exception()}")
+
+    with patch.object(logging.getLogger("wazuh"), "debug") as logger_mock:
+        # Test second condition
+        send_request_mock.return_value = b"True"
+        assert await sync_task.request_permission() is True
+        send_request_mock.assert_called_with(command=b"cmd" + b"_p", data=b"")
+        logger_mock.assert_called_once_with("Permission to synchronize granted.")
+
+        # Test third condition
+        send_request_mock.return_value = b"False"
+        assert await sync_task.request_permission() is False
+        send_request_mock.assert_called_with(command=b"cmd" + b"_p", data=b"")
+        logger_mock.assert_called_with("Master didn't grant permission to start a new synchronization: b'False'")
+
+
+# Test SyncFiles class methods
+
+@pytest.mark.asyncio
+@patch("json.dumps", return_value='')
+@patch("os.path.relpath", return_value="path")
+@patch("os.unlink", return_value="unlinked path")
+@patch("wazuh.core.cluster.cluster.compress_files", return_value="files/path/")
+async def test_sync_files_sync_ok(compress_files_mock, unlink_mock, relpath_mock, json_dumps_mock):
+    """Check if the methods to synchronize with master are defined."""
+    files_to_sync = {"path1": "metadata1"}
+    files_metadata = {"path2": "metadata2"}
+
+    class ServerMock:
+        """Class used to mock the self.worker value and enter the conditions inside the try."""
+
+        def __init__(self):
+            self.name = "Testing"
+            self.count = 1
+
+        async def send_request(self, command, data):
+            """Decide with will be the right output depending on the scenario."""
+            if command == b"cmd" and data == b"" and self.count == 1:
+                return b"Error"
+            elif command == b"cmd" and data == b"" and self.count == 2:
+                return b"OK"
+            elif command == b"cmd_e" and b"OK path" and self.count == 2:
+                return Exception()
+            elif command == b"cmd" and data == b"" and self.count == 3:
+                return b"OK"
+            elif command == b"cmd_e" and b"OK path" and self.count == 3:
+                return b"Error"
+            elif command == b"cmd" and data == b"" and self.count == 4:
+                return b"OK"
+            elif command == b"cmd_e" and b"OK path" and self.count == 4:
+                return b"OK"
+
+        async def send_file(self, filename):
+            """Auxiliary method."""
+            pass
+
+    worker_mock = ServerMock()
+    sync_files = cluster_common.SyncFiles(b"cmd", logging.getLogger("wazuh"), worker_mock)
+
+    # Test second condition
+    with patch.object(logging.getLogger("wazuh"), "error") as logger_mock:
+        await sync_files.sync(files_to_sync, files_metadata)
+        json_dumps_mock.assert_called_once_with(
+            exception.WazuhClusterError(code=3016, extra_message=str(b"Error")),
+            cls=cluster_common.WazuhJSONEncoder)
+        logger_mock.assert_called_once_with("Error")
+
+    worker_mock.count = 2
+    with patch.object(ServerMock, "send_file") as send_file_mock:
+        # Test if present in try and second exception
+        with patch.object(logging.getLogger("wazuh"), "debug") as logger_debug_mock:
+            with patch.object(logging.getLogger("wazuh"), "error") as logger_error_mock:
+                await sync_files.sync(files_to_sync, files_metadata)
+                send_file_mock.assert_called_once_with(filename='files/path/')
+                logger_debug_mock.assert_has_calls([call(
+                    f"Compressing {'files and ' if files_to_sync else ''}'files_metadata.json' of {len(files_metadata)}"
+                    f" files."), call("Sending zip file to master."), call("Zip file sent to master.")])
+                logger_error_mock.assert_called_once_with("Error sending zip file: ")
+                compress_files_mock.assert_called_once_with(name="Testing", list_path=files_to_sync,
+                                                            cluster_control_json=files_metadata)
+                unlink_mock.assert_called_once_with("files/path/")
+                relpath_mock.assert_called_once_with('files/path/', core_common.wazuh_path)
+                assert json_dumps_mock.call_count == 2
+
+                # Reset all mocks
+                all_mocks = [send_file_mock, logger_debug_mock, logger_error_mock, compress_files_mock, unlink_mock,
+                             relpath_mock, json_dumps_mock]
+                for mock in all_mocks:
+                    mock.reset_mock()
+
+                # Test elif present in try and first exception
+                worker_mock.count = 3
+                await sync_files.sync(files_to_sync, files_metadata)
+                send_file_mock.assert_called_once_with(filename='files/path/')
+                logger_debug_mock.assert_has_calls([call(
+                    f"Compressing {'files and ' if files_to_sync else ''}'files_metadata.json' of {len(files_metadata)}"
+                    f" files."), call("Sending zip file to master."), call("Zip file sent to master.")])
+                logger_error_mock.assert_called_once_with(
+                    f"Error sending zip file: {exception.WazuhException(3016, 'Error')}")
+                compress_files_mock.assert_called_once_with(name="Testing", list_path=files_to_sync,
+                                                            cluster_control_json=files_metadata)
+                unlink_mock.assert_called_once_with("files/path/")
+                relpath_mock.assert_called_once_with('files/path/', core_common.wazuh_path)
+                json_dumps_mock.assert_called_once()
+
+                # Reset all mocks
+                all_mocks = [send_file_mock, logger_debug_mock, logger_error_mock, compress_files_mock, unlink_mock,
+                             relpath_mock, json_dumps_mock]
+                for mock in all_mocks:
+                    mock.reset_mock()
+
+            # Test return
+            worker_mock.count = 4
+            assert await sync_files.sync(files_to_sync, files_metadata) is True
+            send_file_mock.assert_called_once_with(filename='files/path/')
+            logger_debug_mock.assert_has_calls([call(
+                f"Compressing {'files and ' if files_to_sync else ''}'files_metadata.json' of {len(files_metadata)}"
+                f" files."), call("Sending zip file to master."), call("Zip file sent to master.")])
+            compress_files_mock.assert_called_once_with(name="Testing", list_path=files_to_sync,
+                                                        cluster_control_json=files_metadata)
+            unlink_mock.assert_called_once_with("files/path/")
+            relpath_mock.assert_called_once_with('files/path/', core_common.wazuh_path)
+
+
+@pytest.mark.asyncio
+@patch("wazuh.core.cluster.common.Handler.send_request", return_value=Exception())
+async def test_sync_files_sync_ko(send_request_mock):
+    """Test if the right exceptions are being risen when necessary."""
+    files_to_sync = {"path1": "metadata1"}
+    files_metadata = {"path2": "metadata2"}
+
+    sync_files = cluster_common.SyncFiles(b"cmd", logging.getLogger("wazuh"),
+                                          cluster_common.Handler(fernet_key, cluster_items))
+
+    # Test first condition
+    with pytest.raises(Exception):
+        await sync_files.sync(files_to_sync, files_metadata)
+
+    send_request_mock.assert_called_once()
+
+
+# Test SyncWazuhdb class
+
+def test_sync_wazuh_db_init():
+    """Test the '__init__' method from the SyncWazuhdb class."""
+
+    sync_wazuh_db = cluster_common.SyncWazuhdb(
+        manager=cluster_common.Handler(fernet_key, cluster_items), logger=logging.getLogger("wazuh"), cmd=b"cmd",
+        data_retriever=None, get_data_command="get_command", set_data_command="set_command", pivot_key=None)
+
+    assert sync_wazuh_db.get_data_command == "get_command"
+    assert sync_wazuh_db.set_data_command == "set_command"
+    assert sync_wazuh_db.data_retriever is None
+
+
+@pytest.mark.asyncio
+@patch("wazuh.core.wdb.socket.socket")
+async def test_sync_wazuh_db_retrieve_information(socket_mock):
+    """Check the proper functionality of the function in charge of
+    obtaining the information from the database of the manager nodes."""
+    counter = 0
+    def data_generator(command):
+        nonlocal counter
+        counter += 1
+        if counter < 3:
+            return 'due', {'id': counter}
+        else:
+            return 'ok', {'id': counter}
+
+    wdb_conn = WazuhDBConnection()
+    logger = logging.getLogger("wazuh")
+    handler = cluster_common.Handler(fernet_key, cluster_items)
+    sync_object = cluster_common.SyncWazuhdb(manager=handler, logger=logger, cmd=b'syn_a_w_m',
+                                             data_retriever=wdb_conn.run_wdb_command,
+                                             get_data_command='global sync-agent-info-get ',
+                                             set_data_command='global sync-agent-info-set')
+
+    with patch.object(sync_object, 'data_retriever', side_effect=data_generator):
+        assert await sync_object.retrieve_information() == [{'id': 1}, {'id': 2}, {'id': 3}]
+
+    sync_object = cluster_common.SyncWazuhdb(manager=handler, logger=logger, cmd=b'syn_a_w_m',
+                                             data_retriever=wdb_conn.run_wdb_command,
+                                             get_data_command='global sync-agent-info-get ', get_payload={'last_id': 0},
+                                             set_data_command='global sync-agent-info-set', pivot_key='last_id')
+
+    with patch.object(sync_object, 'data_retriever', return_value=('ok', '[{"data": [{"id": 45}]}]')):
+        assert await sync_object.retrieve_information() == ['[{"data": [{"id": 45}]}]']
+        assert sync_object.get_payload == {'last_id': 45}
+
+    # data_retriever returns a JSON that does not follow the pivoting scheme
+    with patch.object(sync_object, 'data_retriever', return_value=('ok', '[{"data": {"id": 45}}]')):
+        assert await sync_object.retrieve_information() == ['[{"data": {"id": 45}}]']
+        assert sync_object.get_payload == {'last_id': 0}
+
+    # data_retriever returns a JSON that does not follow the pivoting scheme
+    with patch.object(sync_object, 'data_retriever', side_effect=exception.WazuhException(1000)):
+        with patch.object(sync_object.logger, 'error') as logger_error_mock:
+            assert await sync_object.retrieve_information() == []
+            logger_error_mock.assert_called_with('Error obtaining data from wazuh-db: Error 1000 - Wazuh Internal Error')
+
+
+@pytest.mark.asyncio
+@freeze_time('1970-01-01')
+@patch("json.dumps", return_value="")
+@patch('wazuh.core.cluster.common.perf_counter', return_value=0)
+async def test_sync_wazuh_db_sync_ok(perf_counter_mock, json_dumps_mock):
+    """Check if the information is being properly sent to the master/worker node."""
+
+    sync_wazuh_db = cluster_common.SyncWazuhdb(
+        manager=cluster_common.Handler(fernet_key, cluster_items), logger=logging.getLogger("wazuh"), cmd=b"cmd",
+        data_retriever=None, get_data_command="get_command", set_data_command="set_command", pivot_key=None)
+
+    # Test try and if
+    with patch.object(sync_wazuh_db.logger, "debug") as logger_debug_mock:
+        with patch("wazuh.core.cluster.common.Handler.send_string", return_value=b"OK") as send_string_mock:
+            with patch("wazuh.core.cluster.common.Handler.send_request",
+                       side_effect=None) as send_request_mock:
+                assert await sync_wazuh_db.sync(start_time=10, chunks=['a', 'b']) is True
+                send_request_mock.assert_called_once_with(command=b"cmd", data=b"OK")
+                json_dumps_mock.assert_called_with({'set_data_command': 'set_command',
+                                                    'payload': {}, 'chunks': ['a', 'b']})
+                logger_debug_mock.assert_has_calls([call(f"All chunks sent.")])
+
+            send_string_mock.assert_called_with(b"")
+
+    # Test else
+    with patch.object(sync_wazuh_db.logger, "info") as logger_info_mock:
+        assert await sync_wazuh_db.sync(start_time=10, chunks=[]) is True
+        logger_info_mock.assert_called_once_with(f"Finished in -10.000s (0 chunks sent).")
+
+    # Test except
+    with patch("wazuh.core.cluster.common.Handler.send_string", return_value=b'Error 1'):
+        sync_wazuh_db.server = cluster_common.Handler(fernet_key, cluster_items)
+        with pytest.raises(exception.WazuhClusterError, match=r".* 3016 .*"):
+            await sync_wazuh_db.sync(start_time=10, chunks=['a'])
+
+
+@patch("json.loads", return_value={"updated_chunks": 10, "error_messages": None})
+@patch('wazuh.core.cluster.common.perf_counter', return_value=0)
+def test_end_sending_agent_information(perf_counter_mock, json_loads_mock):
+    """Check the correct output message when a command "syn_m_a_e", "syn_m_g_e" or "syn_w_g_e" takes place."""
+
+    logger = logging.getLogger('testing')
+    with patch.object(logger, "info") as logger_info_mock:
+        assert cluster_common.end_sending_agent_information(logger, 0,"response") == (b'ok', b'Thanks')
+        json_loads_mock.assert_called_once_with("response")
+        logger_info_mock.assert_called_once_with("Finished in 0.000s (10 chunks updated).")
+
+    with patch.object(logger, "error") as logger_error_mock:
+        json_loads_mock.return_value = {"updated_chunks": 10, "error_messages": "error"}
+        assert cluster_common.end_sending_agent_information(logger, 0, "response") == (b'ok', b'Thanks')
+        logger_error_mock.assert_called_once_with(
+            "Finished in 0.000s (10 chunks updated). There were 5 chunks with errors: error")
+
+
+def test_error_receiving_agent_information():
+    """Check the correct output message when a command
+    "syn_m_a_err", "syn_m_g_err", "syn_w_g_err" or "syn_w_g_err" takes place."""
+
+    logger = logging.getLogger('testing')
+    with patch.object(logger, "error") as logger_error_mock:
+        assert cluster_common.error_receiving_agent_information(logger, "response", "info") == (b'ok', b'Thanks')
+        logger_error_mock.assert_called_once_with("There was an error while processing info on the master: response")
+
+
+@patch("wazuh.core.cluster.common.WazuhDBConnection")
+def test_send_data_to_wdb_ko(WazuhDBConnection_mock):
+    """Check if the data chunks are being properly forward to the Wazuh-db socket."""
+
+    class MockWazuhDBConnection:
+        """Auxiliary class."""
+
+        def __init__(self):
+            self.exceptions = 0
+
+        def send(self, data, raw):
+            """Auxiliary method."""
+            if self.exceptions == 0:
+                raise TimeoutError
+            elif self.exceptions == 1:
+                return ''
+            else:
+                raise Exception
+
+        def close(self):
+            """Auxiliary method."""
+            pass
+
+    WazuhDBConnection_mock.return_value = MockWazuhDBConnection()
+
+    result = cluster_common.send_data_to_wdb(data={'chunks': ['[{"data": ""}]'], 'payload': {}, 'set_data_command': ''},
+                                             timeout=15, info_type='agent-groups')
+    assert result['error_messages']['others'] == ['Timeout while processing agent-groups chunks.']
+
+    WazuhDBConnection_mock.return_value.exceptions += 1
+    result = cluster_common.send_data_to_wdb(data={'chunks': ['1chunk', '2chunk'], 'set_data_command': ''},
+                                             timeout=15)
+    assert result['updated_chunks'] == 2
+
+    WazuhDBConnection_mock.return_value.exceptions += 1
+    result = cluster_common.send_data_to_wdb(data={'chunks': ['1chunk', '2chunk'], 'set_data_command': ''},
+                                             timeout=15)
+    assert result['error_messages']['chunks'] == [(0, ''), (1, '')]
+
+    with patch('wazuh.core.cluster.master.utils.Timeout', side_effect=Exception):
+        result = cluster_common.send_data_to_wdb(data={'chunks': ['1chunk', '2chunk'], 'set_data_command': ''},
+                                                 timeout=15)
+        assert result['error_messages']['others'] == ['Error while processing agent-info chunks: ']
 
 
 @patch.object(logging, "error")

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -36,7 +36,7 @@ cluster_items = {'node': 'master-node',
                  'intervals': {'worker': {'connection_retry': 1, "sync_integrity": 2, "sync_agent_info": 5},
                                "communication": {"timeout_receiving_file": 1, "timeout_dapi_request": 1},
                                'master': {'max_locked_integrity_time': 0, 'timeout_agent_info': 0,
-                                          'timeout_extra_valid': 0, 'process_pool_size': 10,
+                                          'timeout_agent_groups': 0, 'timeout_extra_valid': 0, 'process_pool_size': 10,
                                           'recalculate_integrity': 0, 'sync_agent_groups': 1}},
                  "files": {"cluster_item_key": {"remove_subdirs_if_empty": True, "permissions": "value"},
                            'queue/agent-groups/': {'permissions': ''}}}
@@ -885,14 +885,14 @@ async def test_master_handler_setup_sync_wazuh_db_information(sync_wazuh_db_info
     sync_wazuh_db_information_mock.assert_called_once_with(
         task_id=b'17', info_type='agent-groups', error_command=b'syn_m_g_err',
         logger=master_handler.task_loggers['Agent-groups sync'], command=b'syn_m_g_e',
-        sync_dict=master_handler.sync_agent_groups_status)
+        sync_dict=master_handler.sync_agent_groups_status, timeout=0)
     sync_wazuh_db_information_mock.reset_mock()
 
     assert await master_handler.setup_sync_wazuh_db_information(task_id=b'17', info_type='agent-info') == 'check'
     sync_wazuh_db_information_mock.assert_called_once_with(
         task_id=b'17', info_type='agent-info', error_command=b'syn_m_a_err',
         logger=master_handler.task_loggers['Agent-info sync'], command=b'syn_m_a_e',
-        sync_dict=master_handler.sync_agent_info_status)
+        sync_dict=master_handler.sync_agent_info_status, timeout=0)
 
 
 @pytest.mark.asyncio

--- a/framework/wazuh/core/cluster/tests/test_server.py
+++ b/framework/wazuh/core/cluster/tests/test_server.py
@@ -340,6 +340,7 @@ async def test_AbstractServer_echo(loop_mock, sleep_mock):
             mock_info.assert_called_once_with("keepalive worker_test mock")
 
 
+@pytest.mark.asyncio
 @freeze_time("2022-01-01")
 @patch("asyncio.sleep", side_effect=IndexError)
 @patch("asyncio.get_running_loop", return_value=loop)
@@ -364,6 +365,7 @@ async def test_AbstractServer_performance_test(loop_mock, sleep_mock):
         mock_info.assert_called_once_with("Received size: 20 // Time: 0.0")
 
 
+@pytest.mark.asyncio
 @freeze_time("2022-01-01")
 @patch("asyncio.sleep", side_effect=IndexError)
 @patch("asyncio.get_running_loop", return_value=loop)

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -177,7 +177,7 @@ def test_get_cluster_items():
                                               'extra_valid': False, 'description': 'user CDB lists'},
                                'excluded_files': ['ar.conf', 'ossec.conf'],
                                'excluded_extensions': ['~', '.tmp', '.lock', '.swp']},
-                     'intervals': {'worker': {'sync_integrity': 9, 'sync_agent_info': 10, 'sync_agent_groups': 10,
+                     'intervals': {'worker': {'sync_integrity': 9, 'sync_agent_info': 10, 'sync_agent_groups': 30,
                                               'keep_alive': 60, 'connection_retry': 10, 'timeout_agent_groups': 40,
                                               'max_failed_keepalive_attempts': 2},
                                    'master': {'timeout_extra_valid': 40, 'recalculate_integrity': 8,

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -7,6 +7,7 @@ import json
 import os
 import shutil
 from datetime import datetime
+from time import perf_counter
 from typing import Tuple, Dict, Callable, List
 from typing import Union
 
@@ -16,6 +17,42 @@ from wazuh.core.cluster.dapi import dapi
 from wazuh.core.exception import WazuhClusterError
 from wazuh.core.utils import safe_move
 from wazuh.core.wdb import WazuhDBConnection
+
+
+class ReceiveAgentGroupsTask(c_common.ReceiveStringTask):
+    """
+    Define the process and variables necessary to receive and process Agent groups from the master.
+
+    This task is created when the master finishes sending Agent groups chunks and its destroyed once the worker has
+    updated all the received information.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Class constructor.
+
+        Parameters
+        ----------
+        args
+            Positional arguments for parent constructor class.
+        kwargs
+            Keyword arguments for parent constructor class.
+        """
+        super().__init__(*args, **kwargs, info_type='agent-groups')
+
+    def set_up_coro(self) -> Callable:
+        """Set up the function to be called when the worker sends its Agent groups."""
+        return self.wazuh_common.setup_sync_wazuh_db_information
+
+    def done_callback(self, future=None):
+        """Check whether the synchronization process was correct and free its lock.
+
+        Parameters
+        ----------
+        future : asyncio.Future object
+            Synchronization process result.
+        """
+        super().done_callback(future)
+        self.wazuh_common.sync_agent_groups_free = True
 
 
 class ReceiveIntegrityTask(c_common.ReceiveFileTask):
@@ -38,249 +75,6 @@ class ReceiveIntegrityTask(c_common.ReceiveFileTask):
         """
         self.wazuh_common.check_integrity_free = True
         super().done_callback(future)
-
-
-class SyncTask:
-    """
-    Common class for all worker sync tasks.
-    """
-
-    def __init__(self, cmd: bytes, logger, worker):
-        """Class constructor.
-
-        Parameters
-        ----------
-        cmd : bytes
-            Request command to send to the master.
-        logger : Logger object
-            Logger to use during synchronization process.
-        worker : WorkerHandler object
-            The WorkerHandler object that creates this one.
-        """
-        self.cmd = cmd
-        self.logger = logger
-        self.worker = worker
-
-    async def request_permission(self):
-        """Request permission to start synchronization process with the master.
-
-        Returns
-        -------
-        bool
-            Whether permission is granted.
-        """
-        result = await self.worker.send_request(command=self.cmd + b'_p', data=b'')
-
-        if isinstance(result, Exception):
-            self.logger.error(f"Error asking for permission: {result}")
-        elif result == b'True':
-            self.logger.debug("Permission to synchronize granted.")
-            return True
-        else:
-            self.logger.debug(f"Master didn't grant permission to start a new synchronization: {result}")
-
-        return False
-
-    async def sync(self, *args, **kwargs):
-        """Define sync() method. It is implemented differently for files and strings synchronization.
-
-        Parameters
-        ----------
-        args
-            Positional arguments for parent constructor class.
-        kwargs
-            Keyword arguments for parent constructor class.
-
-        Raises
-        -------
-        NotImplementedError
-            If the method is not implemented.
-        """
-        raise NotImplementedError
-
-
-class SyncFiles(SyncTask):
-    """
-    Define methods to synchronize files with master.
-    """
-
-    async def sync(self, files_to_sync: Dict, files_metadata: Dict):
-        """Send metadata and files to the master node.
-
-        Parameters
-        ----------
-        files_to_sync : dict
-            Paths (keys) and metadata (values) of the files to send to the master. Keys in this dictionary
-            will be iterated to add the files they refer to the zip file that the master will receive.
-        files_metadata : dict
-            Paths (keys) and metadata (values) of the files to send to the master. This dict will be included as
-            a JSON file named files_metadata.json.
-
-        Returns
-        -------
-        bool
-            True if files were correctly sent to the master node, None otherwise.
-        """
-        # Start the synchronization process with the master and get a taskID.
-        task_id = await self.worker.send_request(command=self.cmd, data=b'')
-        if isinstance(task_id, Exception):
-            raise task_id
-        elif task_id.startswith(b'Error'):
-            self.logger.error(task_id.decode())
-            exc_info = json.dumps(exception.WazuhClusterError(3016, extra_message=str(task_id)),
-                                  cls=c_common.WazuhJSONEncoder).encode()
-            await self.worker.send_request(command=self.cmd + b'_r', data=b'None ' + exc_info)
-            return
-
-        self.logger.debug(
-            f"Compressing {'files and ' if files_to_sync else ''}'files_metadata.json' of {len(files_metadata)} files."
-        )
-        compressed_data_path = cluster.compress_files(name=self.worker.name, list_path=files_to_sync,
-                                                      cluster_control_json=files_metadata)
-
-        try:
-            # Send zip file to the master into chunks.
-            self.logger.debug("Sending zip file to master.")
-            await self.worker.send_file(filename=compressed_data_path)
-            self.logger.debug("Zip file sent to master.")
-
-            # Finish the synchronization process and notify where the file corresponding to the taskID is located.
-            result = await self.worker.send_request(command=self.cmd + b'_e', data=task_id + b' ' +
-                                                                                   os.path.relpath(compressed_data_path,
-                                                                                                   common.wazuh_path).encode())
-            if isinstance(result, Exception):
-                raise result
-            elif result.startswith(b'Error'):
-                raise WazuhClusterError(3016, extra_message=result.decode())
-            return True
-        except exception.WazuhException as e:
-            # Notify error to master and delete its received file.
-            self.logger.error(f"Error sending zip file: {e}")
-            await self.worker.send_request(command=self.cmd + b'_r', data=task_id + b' ' +
-                                                                          json.dumps(e,
-                                                                                     cls=c_common.WazuhJSONEncoder).encode())
-        except Exception as e:
-            # Notify error to master and delete its received file.
-            self.logger.error(f"Error sending zip file: {e}")
-            exc_info = json.dumps(exception.WazuhClusterError(1000, extra_message=str(e)),
-                                  cls=c_common.WazuhJSONEncoder).encode()
-            await self.worker.send_request(command=self.cmd + b'_r', data=task_id + b' ' + exc_info)
-        finally:
-            os.unlink(compressed_data_path)
-
-
-class SyncWazuhdb(SyncTask):
-    """
-    Define methods to send information to the master node (wazuh-db) through send_string protocol.
-    """
-
-    def __init__(self, worker, logger, cmd: bytes, get_data_command: str, set_data_command: str,
-                 data_retriever: Callable, get_payload: dict = None, set_payload: dict = None, pivot_key: str = ''):
-        """Class constructor.
-
-        Parameters
-        ----------
-        worker : WorkerHandler object
-            The WorkerHandler object that creates this one.
-        cmd : bytes
-            Request command to send to the master.
-        get_data_command : str
-            Command to retrieve data from local wazuh-db.
-        set_data_command : str
-            Command to set data in master's wazuh-db.
-        logger : Logger object
-            Logger to use during synchronization process.
-        data_retriever : Callable
-            Function to be called to obtain chunks of data. It must return a list of chunks.
-        get_payload : dict
-            Payload to request information with "get" command.
-        set_payload : dict
-            Payload to write the information with the "set" command.
-        pivot_key : str
-            Key to request the information from the database in case it is not fully contained in a single request.
-        """
-        super().__init__(worker=worker, logger=logger, cmd=cmd)
-        self.get_data_command = get_data_command
-        if get_payload is None:
-            get_payload = {}
-        self.get_payload = get_payload
-        self.set_data_command = set_data_command
-        if set_payload is None:
-            set_payload = {}
-        self.set_payload = set_payload
-        self.pivot_key = pivot_key
-        self.data_retriever = data_retriever
-
-    async def retrieve_information(self):
-        """Collect the required information from the local node's database. This function will collect
-        information until the status is 'ok' or 'err', in which case an exception will be raised.
-
-        The function will determine when it is necessary to use a parameter in the request payload
-        to specify the first value to get in the next query to WDB.
-
-        Returns
-        -------
-        chunks : list
-            List of results obtained from WDB.
-        """
-        pivoting = self.get_payload != {} and self.pivot_key != ''
-        status = ''
-        chunks = []
-        last_pivot_value = 0
-        if pivoting:
-            self.get_payload[self.pivot_key] = last_pivot_value
-
-        while status != 'ok':
-            command = self.get_data_command + json.dumps(self.get_payload)
-            result = self.data_retriever(command=command)
-            status = result[0]
-            chunks.append(result[1])
-            if pivoting:
-                try:
-                    last_pivot_value = json.loads(result[1])[-1]['data'][-1]['id']
-                    self.get_payload[self.pivot_key] = last_pivot_value
-                except (IndexError, KeyError):
-                    pass
-
-        return chunks
-
-    async def sync(self, start_time: float):
-        """Start sending information to master node.
-
-        Parameters
-        ----------
-        start_time : float
-            Start time to be used when logging task duration if master's response is not expected.
-
-        Returns
-        -------
-        bool
-            True if data was correctly sent to the master node, None otherwise.
-        """
-        try:
-            # Retrieve information from local wazuh-db
-            get_chunks_start_time = datetime.utcnow().timestamp()
-            chunks = await self.retrieve_information()
-            self.logger.debug(
-                f"Obtained {len(chunks)} chunks of data in {(datetime.utcnow().timestamp() - get_chunks_start_time):.3f}s.")
-        except exception.WazuhException as e:
-            self.logger.error(f"Error obtaining data from wazuh-db: {e}")
-            return
-
-        if chunks:
-            # Send list of chunks as a JSON string
-            data = json.dumps({"set_data_command": self.set_data_command, "chunks": chunks}).encode()
-            task_id = await self.worker.send_string(data)
-            if task_id.startswith(b'Error'):
-                raise WazuhClusterError(3016, extra_message=f'agent-info string could not be sent to the master '
-                                                            f'node: {task_id}')
-
-            # Specify under which task_id the JSON can be found in the master.
-            await self.worker.send_request(command=self.cmd, data=task_id)
-            self.logger.debug(f"All chunks sent.")
-        else:
-            self.logger.info(f"Finished in {(datetime.utcnow().timestamp() - start_time):.3f}s (0 chunks sent).")
-        return True
 
 
 class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
@@ -315,10 +109,13 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         # [Worker name] [Integrity] Log information
         # this way the same code can be shared among all sync tasks and logs will differentiate.
         self.task_loggers = {'Agent-info sync': self.setup_task_logger('Agent-info sync'),
+                             'Agent-groups recv': self.setup_task_logger('Agent-groups recv'),
                              'Agent-groups sync': self.setup_task_logger('Agent-groups sync'),
                              'Integrity check': self.setup_task_logger('Integrity check'),
                              'Integrity sync': self.setup_task_logger('Integrity sync')}
-
+        default_date = datetime.utcfromtimestamp(0)
+        self.sync_agent_groups_from_master = {'date_start_worker': default_date, 'date_end_worker': default_date,
+                                              'n_synced_chunks': 0}
         self.agent_info_sync_status = {'date_start': 0.0}
         self.agent_groups_sync_status = {'date_start': 0.0}
         self.integrity_check_status = {'date_start': 0.0}
@@ -365,10 +162,22 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             return self.end_receiving_integrity(data.decode())
         elif command == b'syn_m_c_r':
             return self.error_receiving_integrity(data.decode())
+        elif command == b'syn_g_m_w':
+            return self.setup_sync_integrity(command, data)
         elif command == b'syn_m_a_e':
-            return self.sync_agent_info_from_master(data.decode())
+            logger = self.setup_task_logger('Agent-info sync')
+            start_time = self.agent_info_sync_status['date_start']
+            return c_common.end_sending_agent_information(logger, start_time, data.decode())
+        elif command == b'syn_m_g_e':
+            logger = self.setup_task_logger('Agent-groups sync')
+            start_time = self.agent_groups_sync_status['date_start']
+            return c_common.end_sending_agent_information(logger, start_time, data.decode())
         elif command == b'syn_m_a_err':
-            return self.error_receiving_agent_info(data.decode())
+            logger = self.task_loggers['Agent-info sync']
+            return c_common.error_receiving_agent_information(logger, data.decode(), info_type='agent-info')
+        elif command == b'syn_m_g_err':
+            logger = self.task_loggers['Agent-groups sync']
+            return c_common.error_receiving_agent_information(logger, data.decode(), info_type='agent-groups')
         elif command == b'dapi_res':
             asyncio.create_task(self.forward_dapi_response(data))
             return b'ok', b'Response forwarded to worker'
@@ -379,20 +188,20 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             dapi_client, error_msg = data.split(b' ', 1)
             try:
                 asyncio.create_task(
-                    self.manager.local_server.clients[dapi_client.decode()].send_request(command, error_msg))
-            except WazuhClusterError as e:
+                    self.server.local_server.clients[dapi_client.decode()].send_request(command, error_msg))
+            except WazuhClusterError:
                 raise WazuhClusterError(3025)
             return b'ok', b'DAPI error forwarded to worker'
         elif command == b'sendsyn_err':
             sendsync_client, error_msg = data.split(b' ', 1)
             try:
                 asyncio.create_task(
-                    self.manager.local_server.clients[sendsync_client.decode()].send_request(b'err', error_msg))
-            except WazuhClusterError as e:
+                    self.server.local_server.clients[sendsync_client.decode()].send_request(b'err', error_msg))
+            except WazuhClusterError:
                 raise WazuhClusterError(3025)
             return b'ok', b'SendSync error forwarded to worker'
         elif command == b'dapi':
-            self.manager.dapi.add_request(b'master*' + data)
+            self.server.dapi.add_request(b'master*' + data)
             return b'ok', b'Added request to API requests queue'
         else:
             return super().process_request(command, data)
@@ -405,7 +214,31 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         AbstractClientManager
             Worker object.
         """
-        return self.manager
+        return self.server
+
+    def setup_sync_integrity(self, sync_type: bytes, data: bytes = None) -> Tuple[bytes, bytes]:
+        """Start synchronization process.
+
+        Parameters
+        ----------
+        sync_type : bytes
+            Sync process to start.
+        data : bytes
+            Data to be sent.
+
+        Returns
+        -------
+        bytes
+            Result.
+        bytes
+            Response message.
+        """
+        if sync_type == b'syn_g_m_w':
+            sync_function = ReceiveAgentGroupsTask
+        else:
+            sync_function = None
+
+        return super().setup_receive_file(sync_function, data)
 
     def setup_receive_files_from_master(self):
         """Set up a task to wait until integrity information has been received from the master and process it.
@@ -477,53 +310,32 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             f"Sync not required.")
         return b'ok', b'Thanks'
 
-    def sync_agent_info_from_master(self, response) -> Tuple[bytes, bytes]:
-        """Function called when the master sends the "syn_m_a_e" command.
-
-        This method is called once the master finishes processing the agent-info. It logs
-        information like the number of chunks that were updated and any error message.
+    async def setup_sync_wazuh_db_information(self, task_id: bytes, info_type: str):
+        """Create a process to send to the local wazuh-db the chunks of data received from master.
 
         Parameters
         ----------
-        response : str
-            JSON containing information about agent-info sync status.
+        task_id : bytes
+            ID of the string where the JSON chunks are stored.
+        info_type : str
+            Information type handled.
 
         Returns
         -------
-        bytes
-            Result.
-        bytes
-            Response message.
+        result : bytes
+            Master's response after finishing the synchronization.
         """
-        logger = self.task_loggers['Agent-info sync']
-        data = json.loads(response)
-        msg = f"Finished in {(datetime.utcnow().timestamp() - self.agent_info_sync_status['date_start']):.3f}s" \
-              f" ({data['updated_chunks']} " \
-              f"chunks updated)."
-        logger.info(msg) if not data['error_messages'] else logger.error(
-            msg + f" There were {len(data['error_messages'])} chunks with errors: {data['error_messages']}")
+        # Guess information type
+        logger = ''
+        command = ''
+        error_command = ''
+        if info_type == 'agent-groups':
+            logger = self.task_loggers['Agent-groups recv']
+            command = b'syn_w_g_e'
+            error_command = b'syn_w_g_err'
 
-        return b'ok', b'Thanks'
-
-    def error_receiving_agent_info(self, response):
-        """Function called when the master sends the "syn_m_a_err" command.
-
-        Parameters
-        ----------
-        response : str
-            Message with extra information of the error.
-
-        Returns
-        -------
-        bytes
-            Result.
-        bytes
-            Response message.
-        """
-        logger = self.task_loggers['Agent-info sync']
-        logger.error(f"There was an error while processing agent-info on the master: {response}")
-
-        return b'ok', b'Thanks'
+        return await super().sync_wazuh_db_information(task_id=task_id, info_type=info_type, error_command=error_command,
+                                                       logger=logger, command=command)
 
     async def sync_integrity(self):
         """Obtain files status and send it to the master.
@@ -536,7 +348,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         compares it with its own information.
         """
         logger = self.task_loggers["Integrity check"]
-        integrity_check = SyncFiles(cmd=b'syn_i_w_m', logger=logger, worker=self)
+        integrity_check = c_common.SyncFiles(cmd=b'syn_i_w_m', logger=logger, manager=self)
 
         while True:
             try:
@@ -545,7 +357,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                     if self.check_integrity_free and await integrity_check.request_permission():
                         logger.info("Starting.")
                         self.integrity_check_status['date_start'] = start_time
-                        self.integrity_control = await cluster.run_in_pool(self.loop, self.manager.task_pool,
+                        self.integrity_control = await cluster.run_in_pool(self.loop, self.server.task_pool,
                                                                            cluster.get_files_status,
                                                                            self.integrity_control)
                         await integrity_check.sync(files_metadata=self.integrity_control, files_to_sync={})
@@ -563,7 +375,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
 
             await asyncio.sleep(self.cluster_items['intervals']['worker']['sync_integrity'])
 
-    async def sync_agent_info(self):
+    async def setup_sync_agent_info(self):
         """Obtain information from agents reporting this worker and send it to the master.
 
         Asynchronous task that is started when the worker connects to the master. It starts an agent-info
@@ -574,14 +386,15 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         """
         logger = self.task_loggers["Agent-info sync"]
         wdb_conn = WazuhDBConnection()
-        agent_info = SyncWazuhdb(worker=self, logger=logger, cmd=b'syn_a_w_m', data_retriever=wdb_conn.run_wdb_command,
-                                 get_data_command='global sync-agent-info-get ',
-                                 set_data_command='global sync-agent-info-set')
+        sync_object = c_common.SyncWazuhdb(manager=self, logger=logger, cmd=b'syn_a_w_m',
+                                           data_retriever=wdb_conn.run_wdb_command,
+                                           get_data_command='global sync-agent-info-get ',
+                                           set_data_command='global sync-agent-info-set')
 
-        await self.general_agent_sync_task(sync_object=agent_info, timer=self.agent_info_sync_status,
+        await self.general_agent_sync_task(sync_object=sync_object, timer=self.agent_info_sync_status,
                                            sleep_interval=self.cluster_items['intervals']['worker']['sync_agent_info'])
 
-    async def sync_agent_groups(self):
+    async def setup_sync_agent_groups(self):
         """Obtain information about groups from agents reporting this worker and send it to the master.
 
         Asynchronous task that is started when the worker connects to the master. It starts an agent-groups
@@ -592,14 +405,16 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         """
         logger = self.task_loggers["Agent-groups sync"]
         wdb_conn = WazuhDBConnection()
-        agent_groups = SyncWazuhdb(worker=self, logger=logger, cmd=b'syn_g_w_m',
-                                   data_retriever=wdb_conn.run_wdb_command,
-                                   get_data_command='global sync-agent-groups-get ',
-                                   get_payload={"condition": "sync_status", "last_id": 0}, pivot_key='last_id',
-                                   set_data_command='global set-agent-groups')
+        sync_object = c_common.SyncWazuhdb(manager=self, logger=logger, cmd=b'syn_g_w_m',
+                                           data_retriever=wdb_conn.run_wdb_command,
+                                           get_data_command='global sync-agent-groups-get ',
+                                           get_payload={'condition': 'sync_status', 'last_id': 0}, pivot_key='last_id',
+                                           set_data_command='global set-agent-groups',
+                                           set_payload={'mode': 'empty_only', 'sync_status': 'syncreq'})
 
-        await self.general_agent_sync_task(sync_object=agent_groups, timer=self.agent_groups_sync_status,
-                                           sleep_interval=self.cluster_items['intervals']['worker']['sync_agent_groups'])
+        await self.general_agent_sync_task(sync_object=sync_object, timer=self.agent_groups_sync_status,
+                                           sleep_interval=self.cluster_items['intervals']['worker'][
+                                               'sync_agent_groups'])
 
     async def general_agent_sync_task(self, sync_object, timer, sleep_interval):
         """General body of the database synchronization tasks. Constant loop that performs the task
@@ -607,7 +422,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
 
         Parameters
         ----------
-        sync_object : SyncWazuhdb
+        sync_object : c_common.SyncWazuhdb
             Object in charge of synchronization with the database.
         timer : dict
             Dictionary with initial task time.
@@ -617,11 +432,12 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         while True:
             try:
                 if self.connected:
-                    start_time = datetime.utcnow().timestamp()
+                    start_time = perf_counter()
                     if await sync_object.request_permission():
                         sync_object.logger.info("Starting.")
                         timer['date_start'] = start_time
-                        await sync_object.sync(start_time=start_time)
+                        chunks = await sync_object.retrieve_information()
+                        await sync_object.sync(start_time=start_time, chunks=chunks)
             except Exception as e:
                 sync_object.logger.error(f"Error synchronizing agent information: {e}")
 
@@ -643,7 +459,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         try:
             before = datetime.utcnow().timestamp()
             logger.debug("Starting sending extra valid files to master.")
-            extra_valid_sync = SyncFiles(cmd=b'syn_e_w_m', logger=logger, worker=self)
+            extra_valid_sync = c_common.SyncFiles(cmd=b'syn_e_w_m', logger=logger, manager=self)
 
             # Merge all agent-groups files into one and create metadata dict with it (key->filepath, value->metadata).
             n_files, merged_file = cluster.merge_info(merge_type='agent-groups', node_name=self.name,
@@ -713,7 +529,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
               {'missing': {'<file_path>': {<MD5, merged, merged_name, etc>}, ...},
                'shared': {...}, 'extra': {...}, 'extra_valid': {...}}
             """
-            ko_files, zip_path = await cluster.run_in_pool(self.loop, self.manager.task_pool, cluster.decompress_files,
+            ko_files, zip_path = await cluster.run_in_pool(self.loop, self.server.task_pool, cluster.decompress_files,
                                                            received_filename)
             logger.info("Files to create: {} | Files to update: {} | Files to delete: {} | Files to send: {}".format(
                 len(ko_files['missing']), len(ko_files['shared']), len(ko_files['extra']), len(ko_files['extra_valid']))
@@ -723,7 +539,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                 # Update or remove files in this worker node according to their status (missing, extra or shared).
                 logger.debug("Worker does not meet integrity checks. Actions required.")
                 logger.debug("Updating local files: Start.")
-                await cluster.run_in_pool(self.loop, self.manager.task_pool, self.update_master_files_in_worker,
+                await cluster.run_in_pool(self.loop, self.server.task_pool, self.update_master_files_in_worker,
                                           ko_files, zip_path, self.cluster_items, self.task_loggers['Integrity sync'])
                 logger.debug("Updating local files: End.")
 
@@ -763,7 +579,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             Logger to use.
         """
 
-        def overwrite_or_create_files(filename: str, data: Dict):
+        def overwrite_or_create_files(filename_: str, data_: Dict):
             """Update a file coming from the master.
 
             Move a file which is inside the unzipped directory that comes from master to the path
@@ -772,25 +588,25 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
 
             Parameters
             ----------
-            filename : str
+            filename_ : str
                 Filename inside unzipped dir to update.
-            data : dict
+            data_ : dict
                 File metadata such as modification time, whether it's a merged file or not, etc.
             """
-            full_filename_path = os.path.join(common.wazuh_path, filename)
+            full_filename_path = os.path.join(common.wazuh_path, filename_)
 
-            if data['merged']:  # worker nodes can only receive agent-groups files
+            if data_['merged']:  # worker nodes can only receive agent-groups files
                 # Split merged file into individual files inside zipdir (directory containing unzipped files),
                 # and then move each one to the destination directory (<wazuh_path>/filename).
                 # The TYPE string used in the 'unmerge_info' function is a placeholder. It corresponds to the
                 # directory inside '{wazuh_path}/queue/' path.
-                for name, content, _ in cluster.unmerge_info('TYPE', zip_path, filename):
+                for name, content, _ in cluster.unmerge_info('TYPE', zip_path, filename_):
                     full_unmerged_name = os.path.join(common.wazuh_path, name)
                     tmp_unmerged_path = full_unmerged_name + '.tmp'
                     with open(tmp_unmerged_path, 'wb') as f:
                         f.write(content)
                     safe_move(tmp_unmerged_path, full_unmerged_name,
-                              permissions=cluster_items['files'][data['cluster_item_key']]['permissions'],
+                              permissions=cluster_items['files'][data_['cluster_item_key']]['permissions'],
                               ownership=(common.wazuh_uid(), common.wazuh_gid())
                               )
             else:
@@ -798,8 +614,8 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                 if not os.path.exists(os.path.dirname(full_filename_path)):
                     utils.mkdir_with_mode(os.path.dirname(full_filename_path))
                 # Move the file from zipdir (directory containing unzipped files) to <wazuh_path>/filename.
-                safe_move(os.path.join(zip_path, filename), full_filename_path,
-                          permissions=cluster_items['files'][data['cluster_item_key']]['permissions'],
+                safe_move(os.path.join(zip_path, filename_), full_filename_path,
+                          permissions=cluster_items['files'][data_['cluster_item_key']]['permissions'],
                           ownership=(common.wazuh_uid(), common.wazuh_gid())
                           )
 
@@ -901,8 +717,9 @@ class Worker(client.AbstractClientManager):
             The first item is the coroutine to run and the second is the arguments it needs. In this case,
             all coroutines don't need arguments.
         """
-        return super().add_tasks() + [(self.client.sync_integrity, tuple()), (self.client.sync_agent_info, tuple()),
-                                      (self.client.sync_agent_groups, tuple()), (self.dapi.run, tuple())]
+        return super().add_tasks() + [(self.client.sync_integrity, tuple()),
+                                      (self.client.setup_sync_agent_info, tuple()),
+                                      (self.client.setup_sync_agent_groups, tuple()), (self.dapi.run, tuple())]
 
     def get_node(self) -> Dict:
         """Get basic information about the worker node. Used in the GET/cluster/node API call.


### PR DESCRIPTION
|Related issue|
|---|
|#11792|

## Description

This issue closes #11792. In this PR we have added the group information reception task on the worker nodes side. When there is new group information, the master node sends this information to each of the worker nodes and these update their database through this task.

These are the results of the unit tests:
```
python3 -m coverage run --source=wazuh.core.cluster -m pytest -x framework/wazuh/core/cluster/tests/. --disable-warnings
============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.5, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
rootdir: /mnt/c/Users/adr_i/git/wazuh/framework
plugins: asyncio-0.15.1, trio-0.7.0, cov-2.12.0, metadata-1.11.0, tavern-1.19.0, testinfra-6.4.0, html-3.1.1, aiohttp-0.3.0
collected 259 items

framework/wazuh/core/cluster/tests/test_client.py ................                                                                                                                                         [  6%]
framework/wazuh/core/cluster/tests/test_cluster.py .............................                                                                                                                           [ 17%]
framework/wazuh/core/cluster/tests/test_common.py ..........................................................................                                                                               [ 45%]
framework/wazuh/core/cluster/tests/test_control.py .....                                                                                                                                                   [ 47%]
framework/wazuh/core/cluster/tests/test_local_client.py .............                                                                                                                                      [ 52%]
framework/wazuh/core/cluster/tests/test_local_server.py .......................                                                                                                                            [ 61%]
framework/wazuh/core/cluster/tests/test_master.py .............................................                                                                                                            [ 79%]
framework/wazuh/core/cluster/tests/test_server.py ...................                                                                                                                                      [ 86%]
framework/wazuh/core/cluster/tests/test_utils.py ........                                                                                                                                                  [ 89%]
framework/wazuh/core/cluster/tests/test_worker.py ...........................                                                                                                                              [100%]

======================================================================================= 259 passed, 22 warnings in 42.13s ========================================================================================
```

```
python3 -m coverage report -m   
Name                                                      Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------------------
framework/wazuh/core/cluster/client.py                      145      0   100%
framework/wazuh/core/cluster/cluster.py                     241      1    99%   160
framework/wazuh/core/cluster/common.py                      604      1    99%   451
framework/wazuh/core/cluster/control.py                      69      1    99%   203
framework/wazuh/core/cluster/local_client.py                 95      0   100%
framework/wazuh/core/cluster/local_server.py                146      0   100%
framework/wazuh/core/cluster/master.py                      436      0   100%
framework/wazuh/core/cluster/server.py                      146      0   100%
framework/wazuh/core/cluster/utils.py                       132      0   100%
framework/wazuh/core/cluster/worker.py                      293      3    99%   307-311
---------------------------------------------------------------------------------------
TOTAL                                                      2307      6    99%
```