### PR TITLE
Fix AWS Config's date parsing

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -537,7 +537,7 @@ class AWSBucket(WazuhIntegration):
         self.prefix_regex= re.compile("^\d{12}$")
         self.check_prefix = False
         self.date_format = "%Y/%m/%d"
-        self._db_date_format = "%Y%m%d"
+        self.db_date_format = "%Y%m%d"
 
     def _same_prefix(self, match_start: int or None, aws_account_id: str, aws_region: str) -> bool:
         """
@@ -1235,7 +1235,7 @@ class AWSConfigBucket(AWSLogsBucket):
         str
             Date with the format used by the database.
         """
-        return datetime.strftime(datetime.strptime(date, self.date_format), self._db_date_format)
+        return datetime.strftime(datetime.strptime(date, self.date_format), self.db_date_format)
 
     def _remove_padding_zeros_from_marker(self, marker: str) -> str:
         """Remove the leading zeros from the month and day of a given marker.

--- a/wodles/aws/tests/test_aws.py
+++ b/wodles/aws/tests/test_aws.py
@@ -191,9 +191,9 @@ def test_config_format_created_date(date: str, expected_date: str):
     expected_date : str
         The date that the method should return.
     """
-    with patch(f'aws_s3.AWSConfigBucket.get_client'), \
-        patch(f'aws_s3.AWSConfigBucket.get_sts_client'), \
-        patch(f'sqlite3.connect'):
+    with patch('aws_s3.AWSConfigBucket.get_client'), \
+        patch('aws_s3.AWSConfigBucket.get_sts_client'), \
+        patch('sqlite3.connect'):
         bucket = aws_s3.AWSConfigBucket(**{'reparse': False, 'access_key': None, 'secret_key': None,
                         'profile': None, 'iam_role_arn': None, 'bucket': 'test',
                         'only_logs_after': '19700101', 'skip_on_error': True,

--- a/wodles/aws/tests/test_aws.py
+++ b/wodles/aws/tests/test_aws.py
@@ -172,3 +172,33 @@ def test_db_maintenance(class_, sql_file, db_name):
         last_log_key_after = query.fetchone()[0]
 
         assert(last_log_key_before == last_log_key_after)
+
+@pytest.mark.parametrize('date, expected_date', [
+    ('2021/1/19','20210119'),
+    ('2021/1/1', '20210101'),
+    ('2021/01/01', '20210101'),
+    ('2000/2/12', '20000212'),
+    ('2022/02/1', '20220201')
+])
+def test_config_format_created_date(date: str, expected_date: str):
+    """
+    Test AWSConfigBucket's format_created_date method.
+
+    Parameters
+    ----------
+    date : str
+        The date introduced.
+    expected_date : str
+        The date that the method should return.
+    """
+    with patch(f'aws_s3.AWSConfigBucket.get_client'), \
+        patch(f'aws_s3.AWSConfigBucket.get_sts_client'), \
+        patch(f'sqlite3.connect'):
+        bucket = aws_s3.AWSConfigBucket(**{'reparse': False, 'access_key': None, 'secret_key': None,
+                        'profile': None, 'iam_role_arn': None, 'bucket': 'test',
+                        'only_logs_after': '19700101', 'skip_on_error': True,
+                        'account_alias': None, 'prefix': 'test',
+                        'delete_file': False, 'aws_organization_id': None,
+                        'region': None, 'suffix': '', 'discard_field': None,
+                        'discard_regex': None, 'sts_endpoint': None, 'service_endpoint': None})
+    assert bucket._format_created_date(date) == expected_date


### PR DESCRIPTION
|Related issue|
|---|
|Closes #12245|

## Description
In this PR we fix the way the AWS Config integration parse the dates used to search in the database for previous records. Under heavily loaded environments, the wrong behavior could end up generating duplicates.


That's because the date that was being parsed could be ambiguous after removing the `/` from it. For example, `2021102` could be read as either `2021/10/2` or `2021/1/02`. The error was introduced in this method:
https://github.com/wazuh/wazuh/blob/ec0be6fcb834ec2b1d9eb4b2cd0760e9b904a055/wodles/aws/aws_s3.py#L1223-L1227

We fixed the error and also renamed the method since its name was not accurate enough -months aren't either 0-padded in Config paths, so they could also need a zero to be added-:
https://github.com/wazuh/wazuh/blob/7bcc55ff9f98b7451c89d4ea434d05c29e653219/wodles/aws/aws_s3.py#L1224-L1238

## Tests performed
All the tests passed without any further problems.

### Unit tests
All the tests passed.

```
(wazuh-unit) ➜  aws git:(12245-config-instance) ✗ pytest
==================================== test session starts ====================================
platform linux -- Python 3.10.2, pytest-6.2.5, py-1.11.0, pluggy-0.13.1
rootdir: /home/gonzz/git/wazuh/wodles/aws
plugins: asyncio-0.15.1
collected 16 items                                                                          

tests/test_aws.py ................                                                    [100%]

==================================== 16 passed in 0.07s =====================================
```
### First execution without specifying an only_logs_after value
Upload one log file to the bucket with the date of execution. Then execute the command. It should use as marker a string with the date of execution and collect the uploaded log.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@edb6a6e29b07:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/16
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/16/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20220216T004303Z_20220216T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

#### Conclusions
The module worked as expected.

### First execution specifying an only_logs_after value set in the past
Remove the database file and run the command using `2021-DEC-30` date as `only_logs_after`. 6 logs should be collected and sent to analysisd.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -s 2021-DEC-30 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@edb6a6e29b07:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -s 2021-DEC-30 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/30
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/30/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211230T004303Z_20211230T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20211231T004303Z_20211231T025123Z_1.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20211231T034303Z_20211231T035123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/1
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/2
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/3
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/4
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/5
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/6
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/7
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/8
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/9
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/10
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/11
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/12
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/13
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/14
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/15
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/16
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/17
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/18
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/19
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/20
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/21
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/22
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/23
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/24
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/25
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/25/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20220125T004303Z_20220125T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/26
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/27
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/28
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/29
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/30
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/31
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/1
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/2
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/3
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/4
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/5
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/6
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/7
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/8
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/9
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/10
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/11
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/11/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20220211T004303Z_20220211T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/12
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/13
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/14
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/15
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/16
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/16/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20220216T004303Z_20220216T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

Keep the database file and run the same command again to ensure no duplicate logs have been processed.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -s 2021-DEC-30 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@edb6a6e29b07:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -s 2021-DEC-30 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/16/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20220216T004303Z_20220216T025123Z_1.json.gz
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ DB Maintenance

</details>

#### Conclusions
The module worked as expected.

### Execute the command again with an only_logs_after value set earlier in the past

Run the module again, keeping the database file, using the `2021-NOV-06` date as `only_logs_after`. It should use as marker a string with the date of execution and not consider the `only_logs_after` value.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -s 2021-NOV-06 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@edb6a6e29b07:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -s 2021-NOV-06 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/16/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20220216T004303Z_20220216T025123Z_1.json.gz
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ DB Maintenance

</details>

#### Conclusions
The module worked as expected.

### Execute the module having a last key set and no only_logs_after value
Without removing the database, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from config where created_date in (select max(created_date) from config);'`. This command will remove the more recent logs. Then execute the module without specifying an `only_logs_after` value. It should only collect the previously uploaded log.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@edb6a6e29b07:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/11/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20220211T004303Z_20220211T025123Z_1.json.gz
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/12
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/13
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/14
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/15
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/16
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/16/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20220216T004303Z_20220216T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

#### Conclusions
The module is working as expected.

### Execute the module having an only_logs_after later than the last key
The module should only fetch the logs corresponding to the days set by the only_logs_after date onwards, and it should skip the logs in between. 1 log should be processed.
Keeping the database file, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from config where created_date > (select min(created_date) from config);'`. 

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2 -s YYYY-MMM-DD
```
Being `YYYY-MMM-DD` the data corresponding to the date of execution.

<details><summary>Command output</summary>

	root@edb6a6e29b07:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2 -s 2022-feb-16
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/16
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/16/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20220216T004303Z_20220216T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

#### Conclusions
The module worked as expected.

### Execute the module having an only_logs_after earlier than the last key
Without removing the database, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from config where created_date not in (select min(created_date) from config);'`. This command will remove all the logs but the older ones. The execution of the module must result in collecting 5 logs, using as marker the last key.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2 -s 2021-Oct-01
```

<details>
    <summary>Command output</summary>

	root@edb6a6e29b07:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2 -s 2021-Oct-01
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/30/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211230T004303Z_20211230T025123Z_1.json.gz
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20211231T004303Z_20211231T025123Z_1.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20211231T034303Z_20211231T035123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/1
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/2
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/3
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/4
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/5
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/6
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/7
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/8
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/9
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/10
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/11
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/12
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/13
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/14
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/15
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/16
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/17
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/18
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/19
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/20
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/21
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/22
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/23
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/24
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/25
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/25/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20220125T004303Z_20220125T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/26
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/27
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/28
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/29
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/30
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/31
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/1
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/2
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/3
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/4
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/5
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/6
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/7
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/8
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/9
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/10
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/11
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/11/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20220211T004303Z_20220211T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/12
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/13
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/14
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/15
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/16
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/2/16/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20220216T004303Z_20220216T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

#### Conclusions
The module worked as expected.

