### PR TITLE
Validate groups to be assigned + UTs

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -7537,7 +7537,7 @@ void test_wdb_global_validate_groups_fail_group_with_comma(void **state) {
     will_return(__wrap_wdb_exec_stmt, j_groups_number);
     expect_function_call(__wrap_cJSON_Delete);
 
-    expect_string(__wrap__mwarn, formatted_msg, "Invalid group name. Group contains comma in its name");
+    expect_string(__wrap__mwarn, formatted_msg, "Invalid character in the group name. The group 'GROUP,WITH_COMMA' contains comma.");
 
     wdbc_result result = wdb_global_validate_groups(data->wdb, j_groups, agent_id);
 
@@ -7569,7 +7569,11 @@ void test_wdb_global_validate_groups_fail_group_exceeds_max_length(void **state)
     will_return(__wrap_wdb_exec_stmt, j_groups_number);
     expect_function_call(__wrap_cJSON_Delete);
 
-    expect_string(__wrap__mwarn, formatted_msg, "Invalid group name. Group name exceeds maximum length (255 characters) permitted");
+    expect_string(__wrap__mwarn, formatted_msg, "Invalid group name. The group 'zrosiZrfyMMKt9Lw9qMTCO45OsaFG0NOiHn8noYsuuXHCqPCeDpFE3NxZt8mb44g"
+                                                                               "6G36xL4y59TA_7obQfkSwjczMp9vrNZI9Jltc_8k322ZApibRftAi_T6SD9-AD0Y"
+                                                                               "wY_eWbG-uSfYw7BFX2OAgkD2vp3Z9AgZsN3NQNiDG1ng5WNm5H_bbLh6_BtotzJf"
+                                                                               "NYr8awmZ62IuhTH6eNLN9yzn4ZhWt_XxaHUe6O-uf68PNh4HMv3NuvDGFFXBkysN'"
+                                                " exceeds the maximum length of 255 characters permitted");
 
     wdbc_result result = wdb_global_validate_groups(data->wdb, j_groups, agent_id);
 
@@ -7597,7 +7601,7 @@ void test_wdb_global_validate_groups_fail_groups_exceeds_max_number(void **state
     will_return(__wrap_wdb_exec_stmt, j_groups_number);
     expect_function_call(__wrap_cJSON_Delete);
 
-    expect_string(__wrap__mwarn, formatted_msg, "Invalid groups number. Groups exceed maximum number (128) permitted");
+    expect_string(__wrap__mwarn, formatted_msg, "The groups assigned to agent 001 exceed the maximum of 128 permitted.");
 
     wdbc_result result = wdb_global_validate_groups(data->wdb, j_groups, agent_id);
 

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -6974,35 +6974,6 @@ void test_wdb_global_assign_agent_group_success(void **state) {
     __real_cJSON_Delete(find_group_resp);
 }
 
-void test_wdb_global_assign_agent_group_invalid_group_name(void **state) {
-    test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
-    int initial_priority = 0;
-    cJSON* find_group_resp = cJSON_Parse("[{}]");
-
-    cJSON* j_groups = __real_cJSON_CreateArray();
-
-    cJSON_AddItemToArray(j_groups, cJSON_CreateString("group_name,with_comma"));
-
-    // wdb_global_find_group
-    will_return(__wrap_wdb_begin2, 1);
-    will_return(__wrap_wdb_stmt_cache, 1);
-    expect_value(__wrap_sqlite3_bind_text, pos, 1);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "group_name,with_comma");
-    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    will_return(__wrap_wdb_exec_stmt, find_group_resp);
-
-    expect_function_call(__wrap_cJSON_Delete);
-
-    expect_string(__wrap__mwarn, formatted_msg, "The group 'group_name,with_comma' does not exist");
-
-    wdbc_result result = wdb_global_assign_agent_group(data->wdb, agent_id, j_groups, initial_priority);
-
-    assert_int_equal(result, WDBC_OK);
-    __real_cJSON_Delete(j_groups);
-    __real_cJSON_Delete(find_group_resp);
-}
-
 void test_wdb_global_assign_agent_group_insert_belong_error(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
@@ -7465,7 +7436,219 @@ void test_wdb_global_set_agent_group_context_exec_stmt_error(void **state)
     assert_int_equal(result, WDBC_ERROR);
 }
 
-/* wdb_global_set_agent_groups */
+/* Tests wdb_global_groups_number_get */
+
+void test_wdb_global_groups_number_get_stmt_error(void **state)
+{
+    int result = OS_INVALID;
+    test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_AGENT_GROUPS_NUMBER_GET);
+    will_return(__wrap_wdb_init_stmt_in_cache, NULL);
+
+    result = wdb_global_groups_number_get(data->wdb, agent_id);
+
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_groups_number_get_bind_fail(void **state)
+{
+    int result = OS_INVALID;
+    test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_AGENT_GROUPS_NUMBER_GET);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1);
+
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
+
+    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
+
+    result = wdb_global_groups_number_get(data->wdb, agent_id);
+
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_groups_number_get_exec_fail(void **state)
+{
+    int result = OS_INVALID;
+    test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_AGENT_GROUPS_NUMBER_GET);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1);
+
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+
+    will_return(__wrap_wdb_exec_stmt, NULL);
+    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
+    expect_string(__wrap__mdebug1, formatted_msg, "wdb_exec_stmt(): ERROR MESSAGE");
+
+    result = wdb_global_groups_number_get(data->wdb, agent_id);
+
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_groups_number_get_success(void **state)
+{
+    int result = OS_INVALID;
+    test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
+    cJSON *j_groups_number = cJSON_Parse("[{\"groups_number\":100}]");
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_AGENT_GROUPS_NUMBER_GET);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1);
+
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+
+    will_return(__wrap_wdb_exec_stmt, j_groups_number);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    result = wdb_global_groups_number_get(data->wdb, agent_id);
+
+    assert_int_equal(result, 100);
+    __real_cJSON_Delete(j_groups_number);
+}
+
+/* wdb_global_validate_groups */
+
+void test_wdb_global_validate_groups_fail_group_with_comma(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
+    cJSON* j_groups = __real_cJSON_CreateArray();
+
+    cJSON_AddItemToArray(j_groups, cJSON_CreateString("GROUP,WITH_COMMA"));
+
+    /* wdb_global_groups_number_get */
+    cJSON *j_groups_number = cJSON_Parse("[{\"groups_number\":0}]");
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_AGENT_GROUPS_NUMBER_GET);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1);
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    will_return(__wrap_wdb_exec_stmt, j_groups_number);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    expect_string(__wrap__merror, formatted_msg, "Invalid group name. Group contains comma in its name");
+
+    wdbc_result result = wdb_global_validate_groups(data->wdb, j_groups, agent_id);
+
+    assert_int_equal(result, WDBC_ERROR);
+    __real_cJSON_Delete(j_groups);
+    __real_cJSON_Delete(j_groups_number);
+}
+
+void test_wdb_global_validate_groups_fail_group_exceeds_max_length(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
+    cJSON* j_groups = __real_cJSON_CreateArray();
+
+    cJSON_AddItemToArray(j_groups,
+                         /* Random 256 characters long group name */
+                         cJSON_CreateString("zrosiZrfyMMKt9Lw9qMTCO45OsaFG0NOiHn8noYsuuXHCqPCeDpFE3NxZt8mb44g6G36xL4y59TA_7obQfkSwjczMp9vrNZI9Jltc_8k322ZApibRftAi_T6SD9-AD0YwY_eWbG-uSfYw7BFX2OAgkD2vp3Z9AgZsN3NQNiDG1ng5WNm5H_bbLh6_BtotzJfNYr8awmZ62IuhTH6eNLN9yzn4ZhWt_XxaHUe6O-uf68PNh4HMv3NuvDGFFXBkysN")
+                        );
+
+    /* wdb_global_groups_number_get */
+    cJSON *j_groups_number = cJSON_Parse("[{\"groups_number\":0}]");
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_AGENT_GROUPS_NUMBER_GET);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1);
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    will_return(__wrap_wdb_exec_stmt, j_groups_number);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    expect_string(__wrap__merror, formatted_msg, "Invalid group name. Group name exceeds maximum length (255 characters) permitted");
+
+    wdbc_result result = wdb_global_validate_groups(data->wdb, j_groups, agent_id);
+
+    assert_int_equal(result, WDBC_ERROR);
+    __real_cJSON_Delete(j_groups);
+    __real_cJSON_Delete(j_groups_number);
+}
+
+void test_wdb_global_validate_groups_fail_groups_exceeds_max_number(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
+    cJSON* j_groups = __real_cJSON_CreateArray();
+    char group_name[MAX_GROUP_NAME] = {0};
+
+    snprintf(group_name, MAX_GROUP_NAME, "RANDOM_GROUP");
+    cJSON_AddItemToArray(j_groups, cJSON_CreateString(group_name));
+
+    /* wdb_global_groups_number_get */
+    cJSON *j_groups_number = cJSON_Parse("[{\"groups_number\":128}]");
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_AGENT_GROUPS_NUMBER_GET);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1);
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    will_return(__wrap_wdb_exec_stmt, j_groups_number);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    expect_string(__wrap__merror, formatted_msg, "Invalid groups number. Groups exceed maximum number (128) permitted");
+
+    wdbc_result result = wdb_global_validate_groups(data->wdb, j_groups, agent_id);
+
+    assert_int_equal(result, WDBC_ERROR);
+    __real_cJSON_Delete(j_groups);
+    __real_cJSON_Delete(j_groups_number);
+}
+
+void test_wdb_global_validate_groups_success(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
+    cJSON* j_groups = __real_cJSON_CreateArray();
+    char group_name[MAX_GROUP_NAME+1] = {0};
+
+    snprintf(group_name, MAX_GROUP_NAME+1,
+            /* Random 255 characters long group name */
+            "uw4I8IF9cNhrQ5k9r_JApsK8HbwmxbtS5yv2OqR4PH-GF4Da5lbQ5ofi3d9UbcahRXgGrSFhs0ePre64hYokp12rW7NTpeytrqo149Qohn6nhpqhTZTXfEa8ArPy8_u2Z-iooTM1DXsXRSxi2f_AG2nriukDL9ZMziTq07DeSoRqo-SyVNTt4_0RjBkyI6Xk8Bk-EgNzV5lioDQPl6VB7h-SYsOYN7ux-uNXRFZX_0GquwAqbzWd4sPojez_Rn6"
+            );
+    cJSON_AddItemToArray(j_groups, cJSON_CreateString(group_name));
+
+    /* wdb_global_groups_number_get */
+    cJSON *j_groups_number = cJSON_Parse("[{\"groups_number\":127}]");
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_AGENT_GROUPS_NUMBER_GET);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1);
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    will_return(__wrap_wdb_exec_stmt, j_groups_number);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    wdbc_result result = wdb_global_validate_groups(data->wdb, j_groups, agent_id);
+
+    assert_int_equal(result, WDBC_OK);
+    __real_cJSON_Delete(j_groups);
+    __real_cJSON_Delete(j_groups_number);
+}
+
+/**
+ * @brief Configure all the wrappers to simulate a successful call to create_wdb_global_validate_groups_success_call() method
+ *
+ * @param agent_id The agent ID the new groups will be assigned to.
+ * @param j_groups_number Existent groups number of agent_id.
+ * @param j_groups Groups to be assigned to agent_id
+ */
+void create_wdb_global_validate_groups_success_call(int agent_id, cJSON *j_groups_number) {
+    /* wdb_global_groups_number_get */
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_AGENT_GROUPS_NUMBER_GET);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1);
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    will_return(__wrap_wdb_exec_stmt, j_groups_number);
+    expect_function_call(__wrap_cJSON_Delete);
+}
 
 /**
  * @brief Configure all the wrappers to simulate a successful call to wdb_global_delete_agent_belong() method
@@ -7549,6 +7732,8 @@ void create_wdb_global_set_agent_group_context_success_call(int agent_id, char* 
     will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
 }
 
+/* wdb_global_set_agent_groups */
+
 void test_wdb_global_set_agent_groups_override_success(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
@@ -7561,6 +7746,7 @@ void test_wdb_global_set_agent_groups_override_success(void **state) {
     cJSON_AddItemToArray(j_group_array, cJSON_CreateString(group_name));
     cJSON* j_find_group_resp = cJSON_Parse("[{\"id\":1}]");
     cJSON* j_agents_group_info = __real_cJSON_CreateArray();
+    cJSON* j_groups_number = cJSON_Parse("[{\"groups_number\":0}]");
 
     for (int i=0; i<AGENTS_SIZE; i++) {
         cJSON* j_agent_group = cJSON_CreateObject();
@@ -7570,6 +7756,9 @@ void test_wdb_global_set_agent_groups_override_success(void **state) {
 
         /* wdb_global_delete_agent_belong */
         create_wdb_global_delete_agent_belong_success_call(agent_id);
+
+        /* wdb_global_validate_groups_success_call */
+        create_wdb_global_validate_groups_success_call(agent_id, j_groups_number);
 
         /* wdb_global_assign_agent_group */
         create_wdb_global_assign_agent_group_success_call(agent_id, group_id, group_name, j_find_group_resp);
@@ -7587,6 +7776,7 @@ void test_wdb_global_set_agent_groups_override_success(void **state) {
     __real_cJSON_Delete(j_agents_group_info);
     __real_cJSON_Delete(j_find_group_resp);
     __real_cJSON_Delete(j_group_array);
+    __real_cJSON_Delete(j_groups_number);
 }
 
 void test_wdb_global_set_agent_groups_override_delete_error(void **state) {
@@ -7601,6 +7791,7 @@ void test_wdb_global_set_agent_groups_override_delete_error(void **state) {
     cJSON_AddItemToArray(j_group_array, cJSON_CreateString(group_name));
     cJSON* j_find_group_resp = cJSON_Parse("[{\"id\":1}]");
     cJSON* j_agents_group_info = __real_cJSON_CreateArray();
+    cJSON* j_groups_number = cJSON_Parse("[{\"groups_number\":0}]");
 
     for (int i=0; i<AGENTS_SIZE; i++) {
         cJSON* j_agent_group = cJSON_CreateObject();
@@ -7612,6 +7803,9 @@ void test_wdb_global_set_agent_groups_override_delete_error(void **state) {
         will_return(__wrap_wdb_begin2, -1);
         expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
         expect_string(__wrap__merror, formatted_msg, "There was an error cleaning the previous agent groups");
+
+        /* wdb_global_validate_groups_success_call */
+        create_wdb_global_validate_groups_success_call(agent_id, j_groups_number);
 
         /* wdb_global_assign_agent_group */
         create_wdb_global_assign_agent_group_success_call(agent_id, group_id, group_name, j_find_group_resp);
@@ -7629,6 +7823,7 @@ void test_wdb_global_set_agent_groups_override_delete_error(void **state) {
     __real_cJSON_Delete(j_agents_group_info);
     __real_cJSON_Delete(j_find_group_resp);
     __real_cJSON_Delete(j_group_array);
+    __real_cJSON_Delete(j_groups_number);
 }
 
 void test_wdb_global_set_agent_groups_add_modes_assign_error(void **state) {
@@ -7644,6 +7839,7 @@ void test_wdb_global_set_agent_groups_add_modes_assign_error(void **state) {
     cJSON_AddItemToArray(j_group_array_invalid, cJSON_CreateNumber(-1)); //Invalid group information
     cJSON* j_find_group_resp = cJSON_Parse("[{\"id\":1}]");
     cJSON* j_agents_group_info = __real_cJSON_CreateArray();
+    cJSON* j_groups_number = cJSON_Parse("[{\"groups_number\":0}]");
 
     for (int i=0; i<AGENTS_SIZE; i++) {
         cJSON* j_agent_group = cJSON_CreateObject();
@@ -7653,6 +7849,9 @@ void test_wdb_global_set_agent_groups_add_modes_assign_error(void **state) {
 
         /* wdb_global_delete_agent_belong */
         create_wdb_global_delete_agent_belong_success_call(agent_id);
+
+        /* wdb_global_validate_groups_success_call */
+        create_wdb_global_validate_groups_success_call(agent_id, j_groups_number);
 
         /* wdb_global_assign_agent_group */
         expect_string(__wrap__mdebug1, formatted_msg, "Invalid groups set information");
@@ -7672,6 +7871,7 @@ void test_wdb_global_set_agent_groups_add_modes_assign_error(void **state) {
     __real_cJSON_Delete(j_find_group_resp);
     __real_cJSON_Delete(j_group_array);
     __real_cJSON_Delete(j_group_array_invalid);
+    __real_cJSON_Delete(j_groups_number);
 }
 
 void test_wdb_global_set_agent_groups_append_success(void **state) {
@@ -7687,6 +7887,7 @@ void test_wdb_global_set_agent_groups_append_success(void **state) {
     cJSON* j_find_group_resp = cJSON_Parse("[{\"id\":1}]");
     cJSON* j_priority_resp = cJSON_Parse("[]");
     cJSON* j_agents_group_info = __real_cJSON_CreateArray();
+    cJSON* j_groups_number = cJSON_Parse("[{\"groups_number\":0}]");
 
     for (int i=0; i<AGENTS_SIZE; i++) {
         cJSON* j_agent_group = cJSON_CreateObject();
@@ -7696,6 +7897,9 @@ void test_wdb_global_set_agent_groups_append_success(void **state) {
 
         /* wdb_global_get_agent_max_group_priority */
         create_wdb_global_get_agent_max_group_priority_success_call(agent_id, j_priority_resp);
+
+        /* wdb_global_validate_groups_success_call */
+        create_wdb_global_validate_groups_success_call(agent_id, j_groups_number);
 
         /* wdb_global_assign_agent_group */
         create_wdb_global_assign_agent_group_success_call(agent_id, group_id, group_name, j_find_group_resp);
@@ -7714,6 +7918,7 @@ void test_wdb_global_set_agent_groups_append_success(void **state) {
     __real_cJSON_Delete(j_find_group_resp);
     __real_cJSON_Delete(j_priority_resp);
     __real_cJSON_Delete(j_group_array);
+    __real_cJSON_Delete(j_groups_number);
 }
 
 void test_wdb_global_set_agent_groups_empty_only_success(void **state) {
@@ -7729,6 +7934,7 @@ void test_wdb_global_set_agent_groups_empty_only_success(void **state) {
     cJSON* j_find_group_resp = cJSON_Parse("[{\"id\":1}]");
     cJSON* j_priority_resp = cJSON_Parse("[]");
     cJSON* j_agents_group_info = __real_cJSON_CreateArray();
+    cJSON* j_groups_number = cJSON_Parse("[{\"groups_number\":0}]");
 
     for (int i=0; i<AGENTS_SIZE; i++) {
         cJSON* j_agent_group = cJSON_CreateObject();
@@ -7738,6 +7944,9 @@ void test_wdb_global_set_agent_groups_empty_only_success(void **state) {
 
         /* wdb_global_get_agent_max_group_priority */
         create_wdb_global_get_agent_max_group_priority_success_call(agent_id, j_priority_resp);
+
+        /* wdb_global_validate_groups_success_call */
+        create_wdb_global_validate_groups_success_call(agent_id, j_groups_number);
 
         /* wdb_global_assign_agent_group */
         create_wdb_global_assign_agent_group_success_call(agent_id, group_id, group_name, j_find_group_resp);
@@ -7756,6 +7965,7 @@ void test_wdb_global_set_agent_groups_empty_only_success(void **state) {
     __real_cJSON_Delete(j_find_group_resp);
     __real_cJSON_Delete(j_priority_resp);
     __real_cJSON_Delete(j_group_array);
+    __real_cJSON_Delete(j_groups_number);
 }
 
 void test_wdb_global_set_agent_groups_empty_only_not_empty_error(void **state) {
@@ -8411,7 +8621,6 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_global_calculate_agent_group_csv_success, test_setup, test_teardown),
         /* wdb_global_assign_agent_group */
         cmocka_unit_test_setup_teardown(test_wdb_global_assign_agent_group_success, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_assign_agent_group_invalid_group_name, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_assign_agent_group_insert_belong_error,
                                         test_setup,
                                         test_teardown),
@@ -8430,6 +8639,16 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_global_set_agent_group_context_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_set_agent_group_context_init_stmt_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_set_agent_group_context_exec_stmt_error, test_setup, test_teardown),
+        /* Tests wdb_global_groups_number_get */
+        cmocka_unit_test_setup_teardown(test_wdb_global_groups_number_get_stmt_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_groups_number_get_bind_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_groups_number_get_exec_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_groups_number_get_success, test_setup, test_teardown),
+        /* wdb_global_validate_groups */
+        cmocka_unit_test_setup_teardown(test_wdb_global_validate_groups_fail_group_with_comma, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_validate_groups_fail_group_exceeds_max_length, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_validate_groups_fail_groups_exceeds_max_number, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_validate_groups_success, test_setup, test_teardown),
         /* wdb_global_set_agent_group */
         cmocka_unit_test_setup_teardown(test_wdb_global_set_agent_groups_override_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_set_agent_groups_override_delete_error, test_setup, test_teardown),

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -7537,7 +7537,7 @@ void test_wdb_global_validate_groups_fail_group_with_comma(void **state) {
     will_return(__wrap_wdb_exec_stmt, j_groups_number);
     expect_function_call(__wrap_cJSON_Delete);
 
-    expect_string(__wrap__merror, formatted_msg, "Invalid group name. Group contains comma in its name");
+    expect_string(__wrap__mwarn, formatted_msg, "Invalid group name. Group contains comma in its name");
 
     wdbc_result result = wdb_global_validate_groups(data->wdb, j_groups, agent_id);
 
@@ -7553,7 +7553,10 @@ void test_wdb_global_validate_groups_fail_group_exceeds_max_length(void **state)
 
     cJSON_AddItemToArray(j_groups,
                          /* Random 256 characters long group name */
-                         cJSON_CreateString("zrosiZrfyMMKt9Lw9qMTCO45OsaFG0NOiHn8noYsuuXHCqPCeDpFE3NxZt8mb44g6G36xL4y59TA_7obQfkSwjczMp9vrNZI9Jltc_8k322ZApibRftAi_T6SD9-AD0YwY_eWbG-uSfYw7BFX2OAgkD2vp3Z9AgZsN3NQNiDG1ng5WNm5H_bbLh6_BtotzJfNYr8awmZ62IuhTH6eNLN9yzn4ZhWt_XxaHUe6O-uf68PNh4HMv3NuvDGFFXBkysN")
+                         cJSON_CreateString("zrosiZrfyMMKt9Lw9qMTCO45OsaFG0NOiHn8noYsuuXHCqPCeDpFE3NxZt8mb44g"
+                                            "6G36xL4y59TA_7obQfkSwjczMp9vrNZI9Jltc_8k322ZApibRftAi_T6SD9-AD0Y"
+                                            "wY_eWbG-uSfYw7BFX2OAgkD2vp3Z9AgZsN3NQNiDG1ng5WNm5H_bbLh6_BtotzJf"
+                                            "NYr8awmZ62IuhTH6eNLN9yzn4ZhWt_XxaHUe6O-uf68PNh4HMv3NuvDGFFXBkysN")
                         );
 
     /* wdb_global_groups_number_get */
@@ -7566,7 +7569,7 @@ void test_wdb_global_validate_groups_fail_group_exceeds_max_length(void **state)
     will_return(__wrap_wdb_exec_stmt, j_groups_number);
     expect_function_call(__wrap_cJSON_Delete);
 
-    expect_string(__wrap__merror, formatted_msg, "Invalid group name. Group name exceeds maximum length (255 characters) permitted");
+    expect_string(__wrap__mwarn, formatted_msg, "Invalid group name. Group name exceeds maximum length (255 characters) permitted");
 
     wdbc_result result = wdb_global_validate_groups(data->wdb, j_groups, agent_id);
 
@@ -7594,7 +7597,7 @@ void test_wdb_global_validate_groups_fail_groups_exceeds_max_number(void **state
     will_return(__wrap_wdb_exec_stmt, j_groups_number);
     expect_function_call(__wrap_cJSON_Delete);
 
-    expect_string(__wrap__merror, formatted_msg, "Invalid groups number. Groups exceed maximum number (128) permitted");
+    expect_string(__wrap__mwarn, formatted_msg, "Invalid groups number. Groups exceed maximum number (128) permitted");
 
     wdbc_result result = wdb_global_validate_groups(data->wdb, j_groups, agent_id);
 

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -167,6 +167,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_GROUP_SYNC_REQ_GET] = "SELECT id FROM agent WHERE id > ? AND group_sync_status = 'syncreq' LIMIT 1;",
     [WDB_STMT_GLOBAL_GROUP_SYNC_ALL_GET] = "SELECT id FROM agent WHERE id > ? LIMIT 1;",
     [WDB_STMT_GLOBAL_GROUP_SYNCREQ_FIND] = "SELECT 1 FROM agent WHERE group_sync_status = 'syncreq';",
+    [WDB_STMT_GLOBAL_AGENT_GROUPS_NUMBER_GET] = "SELECT count(id_group) groups_number from belongs WHERE id_agent = ?;",
     [WDB_STMT_GLOBAL_GROUP_SYNC_SET] = "UPDATE agent SET group_sync_status = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_GROUP_PRIORITY_GET] = "SELECT MAX(priority) FROM belongs WHERE id_agent=?;",
     [WDB_STMT_GLOBAL_GROUP_CSV_GET] = "SELECT `group` from agent where id = ?;",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -2058,16 +2058,17 @@ wdbc_result wdb_global_assign_agent_group(wdb_t *wdb, int id, cJSON* j_groups, i
 wdbc_result wdb_global_unassign_agent_group(wdb_t *wdb, int id, cJSON* j_groups);
 
 /**
- * @brief Return the number of groups are assigned to agent_id
+ * @brief Returns the number of groups that are assigned to an agent.
  *
- * @param wdb The Global struct database.
- * @param agent_id ID of the agent to get the groups number from.
+ * @param [in] wdb The Global struct database.
+ * @param [in] agent_id ID of the agent to get the groups number from.
  * @return int Returns the groups number or -1 on error.
  */
 int wdb_global_groups_number_get(wdb_t *wdb, int agent_id);
 
 /**
- * @brief Verifies that groups to be asigned are not more are
+ * @brief Verifies that the number of groups to be assigned is less or equal to 128 and
+ *        there's no group longer than 255 characters nor contains a comma as part of its name.
  *
  * @param [in] wdb The Global struct database.
  * @param [in] j_groups JSON array with all the groups to be assigned to an agent.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -224,6 +224,7 @@ typedef enum wdb_stmt {
     WDB_STMT_GLOBAL_GROUP_SYNC_REQ_GET,
     WDB_STMT_GLOBAL_GROUP_SYNC_ALL_GET,
     WDB_STMT_GLOBAL_GROUP_SYNCREQ_FIND,
+    WDB_STMT_GLOBAL_AGENT_GROUPS_NUMBER_GET,
     WDB_STMT_GLOBAL_GROUP_SYNC_SET,
     WDB_STMT_GLOBAL_GROUP_PRIORITY_GET,
     WDB_STMT_GLOBAL_GROUP_CSV_GET,
@@ -2055,6 +2056,25 @@ wdbc_result wdb_global_assign_agent_group(wdb_t *wdb, int id, cJSON* j_groups, i
  * @return wdbc_result representing the status of the command.
  */
 wdbc_result wdb_global_unassign_agent_group(wdb_t *wdb, int id, cJSON* j_groups);
+
+/**
+ * @brief Return the number of groups are assigned to agent_id
+ *
+ * @param wdb The Global struct database.
+ * @param agent_id ID of the agent to get the groups number from.
+ * @return int Returns the groups number or -1 on error.
+ */
+int wdb_global_groups_number_get(wdb_t *wdb, int agent_id);
+
+/**
+ * @brief Verifies that groups to be asigned are not more are
+ *
+ * @param [in] wdb The Global struct database.
+ * @param [in] j_groups JSON array with all the groups to be assigned to an agent.
+ * @param [in] agent_id ID of the agent to add new groups.
+ * @return wdbc_result representing the status of the command.
+ */
+wdbc_result wdb_global_validate_groups(wdb_t *wdb, cJSON *j_groups, int agent_id);
 
 /**
  * @brief Sets the belongship af a set of agents.

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1334,18 +1334,18 @@ wdbc_result wdb_global_validate_groups(wdb_t *wdb, cJSON *j_groups, int agent_id
             if (cJSON_IsString(j_group_name)) {
                 ++groups_number;
                 if ((groups_number + existent_groups_number) > MAX_GROUPS_PER_MULTIGROUP) {
-                    merror("Invalid groups number. Groups exceed maximum number (%d) permitted", MAX_GROUPS_PER_MULTIGROUP);
+                    mwarn("Invalid groups number. Groups exceed maximum number (%d) permitted", MAX_GROUPS_PER_MULTIGROUP);
                     ret = WDBC_ERROR;
                     break;
                 }
                 char* group_name = j_group_name->valuestring;
                 if (strchr(group_name, MULTIGROUP_SEPARATOR)) {
-                    merror("Invalid group name. Group contains comma in its name");
+                    mwarn("Invalid group name. Group contains comma in its name");
                     ret = WDBC_ERROR;
                     break;
                 }
                 if (strlen(group_name) > MAX_GROUP_NAME) {
-                    merror("Invalid group name. Group name exceeds maximum length (%d characters) permitted", MAX_GROUP_NAME);
+                    mwarn("Invalid group name. Group name exceeds maximum length (%d characters) permitted", MAX_GROUP_NAME);
                     ret = WDBC_ERROR;
                     break;
                 }

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1324,28 +1324,27 @@ int wdb_global_groups_number_get(wdb_t *wdb, int agent_id) {
 wdbc_result wdb_global_validate_groups(wdb_t *wdb, cJSON *j_groups, int agent_id) {
     cJSON* j_group_name = NULL;
     wdbc_result ret = WDBC_OK;
-    int groups_number = 0;
+    int groups_counter = 0;
 
-    /* Returns the existent groups number for the agent_id */
-    int existent_groups_number = wdb_global_groups_number_get(wdb, agent_id);
+    int groups_number = wdb_global_groups_number_get(wdb, agent_id);
 
-    if (existent_groups_number != OS_INVALID) {
+    if (groups_number != OS_INVALID) {
         cJSON_ArrayForEach (j_group_name, j_groups) {
             if (cJSON_IsString(j_group_name)) {
-                ++groups_number;
-                if ((groups_number + existent_groups_number) > MAX_GROUPS_PER_MULTIGROUP) {
-                    mwarn("Invalid groups number. Groups exceed maximum number (%d) permitted", MAX_GROUPS_PER_MULTIGROUP);
+                ++groups_counter;
+                if ((groups_counter + groups_number) > MAX_GROUPS_PER_MULTIGROUP) {
+                    mwarn("The groups assigned to agent %03d exceed the maximum of %d permitted.", agent_id, MAX_GROUPS_PER_MULTIGROUP);
                     ret = WDBC_ERROR;
                     break;
                 }
                 char* group_name = j_group_name->valuestring;
                 if (strchr(group_name, MULTIGROUP_SEPARATOR)) {
-                    mwarn("Invalid group name. Group contains comma in its name");
+                    mwarn("Invalid character in the group name. The group '%s' contains comma.", group_name);
                     ret = WDBC_ERROR;
                     break;
                 }
                 if (strlen(group_name) > MAX_GROUP_NAME) {
-                    mwarn("Invalid group name. Group name exceeds maximum length (%d characters) permitted", MAX_GROUP_NAME);
+                    mwarn("Invalid group name. The group '%s' exceeds the maximum length of %d characters permitted", group_name, MAX_GROUP_NAME);
                     ret = WDBC_ERROR;
                     break;
                 }


### PR DESCRIPTION
|Related issue|
|---|
|#12306|

## Description

This PR adds the following checks to validate the groups information the agents will be assigned.
- The groups number doesn't exceed the maximum of 128.
- There's no group with more than 255 characters.
- There's no group that contains a comma in its name.

## Scan-build report

![image](https://user-images.githubusercontent.com/13010397/154282163-99b1a664-052f-4c37-91e8-038588bba4b7.png)

## Coverage

![image](https://user-images.githubusercontent.com/13010397/154286843-20ebee28-e584-4554-add2-03ed27d01a1c.png)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->

- [x] Added unit tests (for new features)