### PR TITLE
Prevent Authd from exiting due to a pipe signal

### DIFF
--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -405,6 +405,9 @@ int main(int argc, char **argv)
         sigaction(SIGTERM, &action, NULL);
         sigaction(SIGHUP, &action, NULL);
         sigaction(SIGINT, &action, NULL);
+
+        action.sa_handler = SIG_IGN;
+        sigaction(SIGPIPE, &action, NULL);
     }
 
     /* Create PID files */


### PR DESCRIPTION
|Related issue|
|---|
|#12366|

This PR aims to set Authd to ignore the pipe signal, as other daemons like Analysisd, Remoted or Wazuh DB already do.

With this change, we expect Authd to print the following error **and continue working normally** if we restart Wazuh DB while Authd is running:

```
2022/02/18 13:05:36 wazuh-authd: ERROR: Cannot send message: (32) 'Broken pipe'.
2022/02/18 13:05:36 wazuh-authd: ERROR: Connection with wazuh-db lost. Reconnecting.
```

## Tests

- [x] Valgrind does not report any crashes or memory leaks.
- [x] This issue is no longer reproducible with the steps described at #12366.

### Valgrind report

```
==25431== Memcheck, a memory error detector
==25431== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==25431== Using Valgrind-3.17.0 and LibVEX; rerun with -h for copyright info
==25431== Command: wazuh-authd -f
==25431==
2022/02/18 13:10:31 wazuh-authd: INFO: Started (pid: 25431).
2022/02/18 13:10:32 wazuh-authd: INFO: Accepting connections on port 1515. No password required.
2022/02/18 13:10:32 wazuh-authd: INFO: Setting network timeout to 1.000000 sec.
2022/02/18 13:23:42 wazuh-authd: INFO: New connection from 172.20.208.1
2022/02/18 13:23:42 wazuh-authd: INFO: Received request for a new agent (centos8) from: 172.20.208.1
2022/02/18 13:23:42 wazuh-authd: INFO: Duplicate name. Removing old agent 'centos8' (id '031').
2022/02/18 13:23:42 wazuh-authd: INFO: Agent key generated for 'centos8' (requested by any)
^C
2022/02/18 13:24:13 wazuh-authd: INFO: (1225): SIGNAL [(2)-(Interrupt)] Received. Exit Cleaning...
2022/02/18 13:24:14 wazuh-authd: INFO: Exiting...
==25431==
==25431== HEAP SUMMARY:
==25431==     in use at exit: 1,040 bytes in 26 blocks
==25431==   total heap usage: 17,433 allocs, 17,407 frees, 46,983,727 bytes allocated
==25431==
==25431== LEAK SUMMARY:
==25431==    definitely lost: 0 bytes in 0 blocks
==25431==    indirectly lost: 0 bytes in 0 blocks
==25431==      possibly lost: 0 bytes in 0 blocks
==25431==    still reachable: 1,040 bytes in 26 blocks
==25431==         suppressed: 0 bytes in 0 blocks