### PR TITLE
The `set-agent-groups` command for Wazuh-DB doesn't filter an incorrect mode parameter - Implementation 

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -1961,6 +1961,22 @@ void test_wdb_parse_global_set_agent_groups_missing_field(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
+void test_wdb_parse_global_set_agent_groups_invalid_mode(void **state)
+{
+    int ret = 0;
+    test_struct_t *data = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global set-agent-groups {\"mode\":\"invalid_mode\",\"sync_status\":\"synced\",\"data\":[{\"id\":1,\"groups\":[\"default\"]}]}";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: set-agent-groups {\"mode\":\"invalid_mode\",\"sync_status\":\"synced\",\"data\":[{\"id\":1,\"groups\":[\"default\"]}]}");
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid mode 'invalid_mode' in set_agent_groups command.");
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Invalid mode 'invalid_mode' in set_agent_groups command");
+    assert_int_equal(ret, OS_INVALID);
+}
+
 void test_wdb_parse_global_set_agent_groups_fail(void **state)
 {
     int ret = 0;
@@ -2870,6 +2886,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_set_agent_groups_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_set_agent_groups_invalid_json, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_set_agent_groups_missing_field, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_set_agent_groups_invalid_mode, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_set_agent_groups_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_set_agent_groups_success, test_setup, test_teardown),
         /* Tests wdb_parse_global_sync_agent_groups_get */

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5313,15 +5313,21 @@ int wdb_parse_global_set_agent_groups(wdb_t* wdb, char* input, char* output) {
                 mode = WDB_GROUP_REMOVE;
             }
 
-            if (cJSON_IsString(j_sync_status)){
-                sync_status = j_sync_status->valuestring;
-            }
+            if (WDB_GROUP_INVALID_MODE != mode) {
+                if (cJSON_IsString(j_sync_status)){
+                    sync_status = j_sync_status->valuestring;
+                }
 
-            wdbc_result status = wdb_global_set_agent_groups(wdb, mode, sync_status, j_groups_data);
-            if (status == WDBC_OK) {
-                snprintf(output, OS_MAXSTR + 1, "%s",  WDBC_RESULT[status]);
+                wdbc_result status = wdb_global_set_agent_groups(wdb, mode, sync_status, j_groups_data);
+                if (status == WDBC_OK) {
+                    snprintf(output, OS_MAXSTR + 1, "%s",  WDBC_RESULT[status]);
+                } else {
+                    snprintf(output, OS_MAXSTR + 1, "%s An error occurred during the set of the groups",  WDBC_RESULT[status]);
+                    ret = OS_INVALID;
+                }
             } else {
-                snprintf(output, OS_MAXSTR + 1, "%s An error occurred during the set of the groups",  WDBC_RESULT[status]);
+                mdebug1("Invalid mode '%s' in set_agent_groups command.", j_mode->valuestring);
+                snprintf(output, OS_MAXSTR + 1, "err Invalid mode '%s' in set_agent_groups command", j_mode->valuestring);
                 ret = OS_INVALID;
             }
         } else {


### PR DESCRIPTION
|Related issue|
|---|
|#12371|

## Description

This PR adds a check for the `set-agent-groups` command to reject an invalid mode parameter.
It also update the UT with a new case to cover this.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
 
- [x] Added unit tests (for new features)
