### PR TITLE
Fix the `group_sync_status` set in the `master` nodes after the final design of the groups data synchronization algorithm - Implementation

### DIFF
--- a/src/headers/cluster_utils.h
+++ b/src/headers/cluster_utils.h
@@ -15,6 +15,16 @@
 // Returns 1 if the node is a worker, 0 if it is not and -1 if error.
 int w_is_worker(void);
 
+/**
+ * @brief Method to read the configuration file and determine if the cluster is enabled or not. It's also possible
+ *        to know if the current node is a worker or the master.
+ *
+ * @param [out] is_worker If the cluster is enabled, a 1 will be written in case it's a worker node and 0 if it's the master.
+ *                        OS_INVALID otherwise.
+ * @return int It'll return 1 if the cluster is enabled or 0 if it isn't. OS_INVALID if the information isn't available.
+ */
+int w_is_single_node(int* is_worker);
+
 // Returns the master node or "undefined" if any node is specified. The memory should be freed by the caller.
 char *get_master_node(void);
 

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -856,7 +856,7 @@ void* run_writer(__attribute__((unused)) void *arg) {
                 if (wdb_set_agent_groups_csv(atoi(cur->id),
                                              cur->group,
                                              WDB_GROUP_MODE_OVERRIDE,
-                                             "synced",
+                                             w_is_single_node(NULL) ? "synced" : "syncreq",
                                              &wdb_sock)) {
                     merror("Unable to set agent centralized group: %s (internal error)", cur->group);
                 }

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -785,7 +785,7 @@ static void c_files()
             cJSON* j_agent_info = wdb_get_agent_info(agents_array[i], NULL);
             if(j_agent_info) {
                 char* agent_groups = cJSON_GetStringValue(cJSON_GetObjectItem(j_agent_info->child, "group"));
-                char* agent_groups_hash = cJSON_GetStringValue(cJSON_DetachItemFromObject(j_agent_info->child, "groups_hash"));
+                char* agent_groups_hash = cJSON_GetStringValue(cJSON_DetachItemFromObject(j_agent_info->child, "group_hash"));
 
                 // If it's not a multigroup, skip it
                 if(agent_groups && agent_groups_hash && strstr(agent_groups, ",")) {
@@ -1068,7 +1068,7 @@ STATIC int lookfor_agent_group(const char *agent_id, char *msg, char **r_group, 
         wdb_set_agent_groups_csv(atoi(agent_id),
                                  group,
                                  WDB_GROUP_MODE_EMPTY_ONLY,
-                                 w_is_worker() ? "syncreq" : "synced",
+                                 w_is_single_node(NULL) ? "synced" : "syncreq",
                                  NULL);
 
         *r_group = group;

--- a/src/shared/cluster_utils.c
+++ b/src/shared/cluster_utils.c
@@ -59,6 +59,61 @@ int w_is_worker(void) {
     return is_worker;
 }
 
+int w_is_single_node(int* is_worker) {
+    OS_XML xml;
+    const char * xmlf[] = {"ossec_config", "cluster", NULL};
+    const char * xmlf2[] = {"ossec_config", "cluster", "node_type", NULL};
+    const char * xmlf3[] = {"ossec_config", "cluster", "disabled", NULL};
+    const char *cfgfile = OSSECCONF;
+    int _is_worker = OS_INVALID;
+    int is_single_node = OS_INVALID;
+
+    if (OS_ReadXML(cfgfile, &xml) < 0) {
+        mdebug1(XML_ERROR, cfgfile, xml.err, xml.err_line);
+    } else {
+        char * cl_config = OS_GetOneContentforElement(&xml, xmlf);
+        if (cl_config && cl_config[0] != '\0') {
+            char * cl_type = OS_GetOneContentforElement(&xml, xmlf2);
+            if (cl_type && cl_type[0] != '\0') {
+                char * cl_status = OS_GetOneContentforElement(&xml, xmlf3);
+                if(cl_status && cl_status[0] != '\0'){
+                    if (!strcmp(cl_status, "no")) {
+                        is_single_node = 0;
+                        if (!strcmp(cl_type, "client") || !strcmp(cl_type, "worker")) {
+                            _is_worker = 1;
+                        } else {
+                            _is_worker = 0;
+                        }
+                    } else {
+                        is_single_node = 1;
+                    }
+                } else {
+                    is_single_node = 0;
+                    if (!strcmp(cl_type, "client") || !strcmp(cl_type, "worker")) {
+                        _is_worker = 1;
+                    } else {
+                        _is_worker = 0;
+                    }
+                }
+                free(cl_status);
+                free(cl_type);
+            } else {
+                is_single_node = 1;
+            }
+            free(cl_config);
+        } else {
+            is_single_node = 1;
+        }
+    }
+    OS_ClearXML(&xml);
+
+    if (is_worker) {
+        *is_worker = _is_worker;
+    }
+
+    return is_single_node;
+}
+
 
 char *get_master_node(void) {
     OS_XML xml;

--- a/src/shared/cluster_utils.c
+++ b/src/shared/cluster_utils.c
@@ -88,12 +88,7 @@ int w_is_single_node(int* is_worker) {
                         is_single_node = 1;
                     }
                 } else {
-                    is_single_node = 0;
-                    if (!strcmp(cl_type, "client") || !strcmp(cl_type, "worker")) {
-                        _is_worker = 1;
-                    } else {
-                        _is_worker = 0;
-                    }
+                    is_single_node = 1;
                 }
                 free(cl_status);
                 free(cl_type);
@@ -113,7 +108,6 @@ int w_is_single_node(int* is_worker) {
 
     return is_single_node;
 }
-
 
 char *get_master_node(void) {
     OS_XML xml;

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -25,7 +25,7 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 # Generate remoted tests
 list(APPEND remoted_names "test_manager")
 list(APPEND remoted_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,wdb_get_agent_group \
--Wl,--wrap,wdb_set_agent_groups_csv -Wl,--wrap,_merror -Wl,--wrap,w_is_worker")
+-Wl,--wrap,wdb_set_agent_groups_csv -Wl,--wrap,_merror -Wl,--wrap,w_is_single_node")
 
 list(APPEND remoted_names "test_secure")
 list(APPEND remoted_flags "-Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose -Wl,--wrap,remove \

--- a/src/unit_tests/remoted/test_manager.c
+++ b/src/unit_tests/remoted/test_manager.c
@@ -57,7 +57,7 @@ void test_lookfor_agent_group_null_groups()
 
     expect_string(__wrap__mdebug2, formatted_msg, "Agent '001' with group 'default' file 'merged.mg' MD5 'c2305e0ac17e7176e924294c69cc7a24'");
 
-    will_return(__wrap_w_is_worker, 0);
+    will_return(__wrap_w_is_single_node, 0);
 
     expect_value(__wrap_wdb_set_agent_groups_csv, id, agent_id);
     will_return(__wrap_wdb_set_agent_groups_csv, 0);
@@ -81,7 +81,7 @@ void test_lookfor_agent_group_set_default_group()
 
     expect_string(__wrap__mdebug2, formatted_msg, "Agent '001' with group 'default' file 'merged.mg' MD5 'c2305e0ac17e7176e924294c69cc7a24'");
 
-    will_return(__wrap_w_is_worker, 0);
+    will_return(__wrap_w_is_single_node, 0);
 
     expect_value(__wrap_wdb_set_agent_groups_csv, id, agent_id);
     will_return(__wrap_wdb_set_agent_groups_csv, 0);

--- a/src/unit_tests/wazuh_modules/database/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/database/CMakeLists.txt
@@ -10,7 +10,7 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 
 list(APPEND wmdb_tests_names "test_wm_database")
 list(APPEND wmdb_tests_flags "-Wl,--wrap,wdb_set_agent_groups -Wl,--wrap,opendir -Wl,--wrap,readdir -Wl,--wrap,strerror -Wl,--wrap,unlink \
-                              -Wl,--wrap,closedir -Wl,--wrap,rmdir_ex -Wl,--wrap,getpid ${DEBUG_OP_WRAPPERS} ${STDIO_OP_WRAPPERS}")
+                              -Wl,--wrap,closedir -Wl,--wrap,rmdir_ex -Wl,--wrap,getpid  -Wl,--wrap,w_is_single_node ${DEBUG_OP_WRAPPERS} ${STDIO_OP_WRAPPERS}")
 
 # Add extra compiling flags
 add_compile_options(-Wall)

--- a/src/unit_tests/wazuh_modules/database/test_wm_database.c
+++ b/src/unit_tests/wazuh_modules/database/test_wm_database.c
@@ -149,6 +149,7 @@ void test_wm_sync_group_file_success_more_than_max_groups(void **state)
     will_return(__wrap_fgets, groups_in_file);
     expect_value(__wrap_fgets, __stream, fp_group_file);
     // Setting groups
+    will_return(__wrap_w_is_single_node, 1);
     expect_value(__wrap_wdb_set_agent_groups, id, agent_id);
     expect_string(__wrap_wdb_set_agent_groups, mode, "override");
     expect_string(__wrap_wdb_set_agent_groups, sync_status, "synced");
@@ -182,6 +183,7 @@ void test_wm_sync_group_file_success_max_groups(void **state)
     will_return(__wrap_fgets, groups_in_file);
     expect_value(__wrap_fgets, __stream, fp_group_file);
     // Setting groups
+    will_return(__wrap_w_is_single_node, 1);
     expect_value(__wrap_wdb_set_agent_groups, id, agent_id);
     expect_string(__wrap_wdb_set_agent_groups, mode, "override");
     expect_string(__wrap_wdb_set_agent_groups, sync_status, "synced");
@@ -272,6 +274,7 @@ void test_wm_sync_legacy_groups_files_success_files_success_dir(void **state)
     will_return(__wrap_fgets, groups_in_file);
     expect_value(__wrap_fgets, __stream, fp_group_file);
     // Setting groups
+    will_return(__wrap_w_is_single_node, 1);
     expect_value(__wrap_wdb_set_agent_groups, id, agent_id);
     expect_string(__wrap_wdb_set_agent_groups, mode, "override");
     expect_string(__wrap_wdb_set_agent_groups, sync_status, "synced");

--- a/src/unit_tests/wrappers/wazuh/shared/cluster_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/cluster_op_wrappers.c
@@ -16,3 +16,11 @@
 int __wrap_w_is_worker(void) {
     return mock();
 }
+
+int __wrap_w_is_single_node(int* is_worker) {
+    if(is_worker) {
+        *is_worker = mock();
+    }
+
+    return mock();
+}

--- a/src/unit_tests/wrappers/wazuh/shared/cluster_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/cluster_op_wrappers.h
@@ -13,4 +13,6 @@
 
 int __wrap_w_is_worker(void);
 
+int __wrap_w_is_single_node(int* is_worker);
+
 #endif

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -617,7 +617,12 @@ int wm_sync_group_file(const char* group_file, const char* group_file_path) {
         else {
             truncated_groups_array = groups_array;
         }
-        result = wdb_set_agent_groups(id_agent, truncated_groups_array, "override", "synced", &wdb_wmdb_sock);
+        result = wdb_set_agent_groups(id_agent,
+                                      truncated_groups_array,
+                                      "override",
+                                      w_is_single_node(NULL) ? "synced" : "syncreq",
+                                      &wdb_wmdb_sock);
+
         free_strarray(groups_array);
     } else {
         mtdebug1(WM_DATABASE_LOGTAG, "Empty group file '%s'.", group_file_path);


### PR DESCRIPTION
|Related issue|
|---|
|#12335|

## Description

This PR sets the `group_sync_status` column to **syncreq** in the following cases
- During an upgrade, if any group assignation is found in legacy group files
- In the agent registration
- In the group guess mechanism

But if the cluster isn't enabled, the value is set to **synced**.

Also, a typo in a column name is fixed.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
 
- [x] Working on cluster environments
- [x] Added unit tests (for new features)
