### PR TITLE
Download jemalloc when target is not present on make deps.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1196,13 +1196,10 @@ endif
 
 # Agent dependencies
 EXTERNAL_RES := cJSON curl libdb libffi libyaml openssl procps sqlite zlib audit-userspace msgpack bzip2 nlohmann googletest libpcre2 libplist pacman libarchive popt rpm
-ifeq (${TARGET},server)
-	EXTERNAL_RES += jemalloc
-endif
 ifneq (${TARGET},agent)
 ifneq (${TARGET},winagent)
 	# Manager extra dependency
-	EXTERNAL_RES += $(CPYTHON)
+	EXTERNAL_RES += $(CPYTHON) jemalloc
 endif
 endif
 EXTERNAL_DIR := $(EXTERNAL_RES:%=external/%)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #12378|

## Description

When the TARGET variable is not set when downloading dependencies, this should download all the dependencies needed to build a server. This is currently not working.

### Actual
```
root@tomas-VirtualBox:/home/tomas/wazuh/wazuh/src# make deps -j4
....
```

```
root@tomas-VirtualBox:/home/tomas/wazuh/wazuh/src# make TARGET=server DEBUG=1 -j4
grep: /etc/redhat-release: No such file or directory
cd external/jemalloc/ && LDFLAGS=-s ./autogen.sh --disable-static --disable-cxx && make
checkmodule -M -m -o selinux/wazuh.mod selinux/wazuh.te
/bin/sh: 1: cd: can't cd to external/jemalloc/
make: *** [Makefile:1142: external/jemalloc/lib/libjemalloc.so.2] Error 2
make: *** Waiting for unfinished jobs....
```

### Expected
Build successfully


## Tests
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors