### PR TITLE
Fix DB maintenance for LB buckets

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2144,7 +2144,7 @@ class AWSCustomBucket(AWSBucket):
     def mark_complete(self, aws_account_id, aws_region, log_file):
         AWSBucket.mark_complete(self, self.aws_account_id, aws_region, log_file)
 
-    def db_count_custom(self):
+    def db_count_custom(self, aws_account_id=None):
         """Counts the number of rows in DB for a region
         :param aws_account_id: AWS account ID
         :type aws_account_id: str
@@ -2155,7 +2155,7 @@ class AWSCustomBucket(AWSBucket):
                 self.sql_count_custom.format(
                     table_name=self.db_table_name,
                     bucket_path=self.bucket_path,
-                    aws_account_id=self.aws_account_id,
+                    aws_account_id= aws_account_id if aws_account_id else self.aws_account_id,
                     retain_db_records=self.retain_db_records
                 ))
             return query_count_custom.fetchone()[0]
@@ -2166,14 +2166,14 @@ class AWSCustomBucket(AWSBucket):
                     error_msg=e))
             sys.exit(10)
 
-    def db_maintenance(self, **kwargs):
+    def db_maintenance(self, aws_account_id=None, **kwargs):
         debug("+++ DB Maintenance", 1)
         try:
-            if self.db_count_custom() > self.retain_db_records:
+            if self.db_count_custom(aws_account_id) > self.retain_db_records:
                 self.db_connector.execute(self.sql_db_maintenance.format(
                     table_name=self.db_table_name,
                     bucket_path=self.bucket_path,
-                    aws_account_id=self.aws_account_id,
+                    aws_account_id= aws_account_id if aws_account_id else self.aws_account_id,
                     retain_db_records=self.retain_db_records
                 ))
         except Exception as e:

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2318,40 +2318,6 @@ class AWSLBBucket(AWSCustomBucket):
         self.service = 'elasticloadbalancing'
         AWSCustomBucket.__init__(self, *args, **kwargs)
 
-    def db_count_custom(self, aws_account_id):
-        try:
-            query_count_custom = self.db_connector.execute(
-                    self.sql_count_custom.format(
-                        table_name=self.db_table_name,
-                        bucket_path=self.bucket_path,
-                        aws_account_id=aws_account_id,
-                        retain_db_records=self.retain_db_records
-                        ))
-            return query_count_custom.fetchone()[0]
-        except Exception as e:
-            print("ERROR: Failed to execute DB cleanup - Path: {bucket_path}: {error_msg}".format(
-                bucket_path=self.bucket_path,
-                error_msg=e))
-            sys.exit(10)
-
-    def db_maintenance(self, aws_account_id=None, aws_region=None):
-        debug("+++ DB Maintenance", 1)
-        try:
-            if self.db_count_custom(aws_account_id) > self.retain_db_records:
-                self.db_connector.execute(self.sql_db_maintenance.format(
-                    bucket_path=self.bucket_path,
-                    table_name=self.db_table_name,
-                    aws_account_id=aws_account_id,
-                    aws_region=aws_region,
-                    retain_db_records=self.retain_db_records
-                    ))
-        except Exception as e:
-            print("ERROR: Failed to execute DB cleanup - AWS Account ID: {aws_account_id}  Region: {aws_region}: {error_msg}".format(
-                aws_account_id=aws_account_id,
-                aws_region=aws_region,
-                error_msg=e))
-            sys.exit(10)
-
     def get_base_prefix(self):
         return f'{self.prefix}AWSLogs/{self.suffix}'
 


### PR DESCRIPTION
| Related issue |
|---|
|Closes #11826 |

## Description
In this PR we solve the problem with the load balancer buckets `ALB`, `NLB`, and `CLB` and the DB maintenance. 

This change adds a new `db_maintenance` method to the `AWSLBBucket` class ensuring that unnecessary entries from the database are now removed when we are working with LB Buckets.


## Tests performed
To ensure that this update works correctly we decided to test the three balancer buckets: `ALB` `NLB` `CLB`.

We modified the self.retain_db_records attribute from 500 to 5 and we checked that 5 logs are stored in the database once the module has been executed. Obviously the module will have found more than 5 logs previously.


### ALB

<details><summary>ALB command output</summary>

	root@wazuh-master:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-alb -d2 -t alb -s 2020-nov-24 -p dev
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on 166157441623 - us-west-1
	DEBUG: +++ Marker: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0000Z_52.52.208.49_14pczeay.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0005Z_52.52.208.49_4ufjauyv.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0010Z_52.52.208.49_3y3kmwy9.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0035Z_54.183.224.192_2pvouvk5.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0050Z_54.183.224.192_3y2rm8x8.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0105Z_52.52.208.49_hqtwz2fm.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0115Z_52.52.208.49_5e69fblu.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0115Z_54.183.224.192_3szj8oof.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0220Z_52.52.208.49_4g2aq7gx.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0235Z_54.183.224.192_66qzj35g.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0245Z_52.52.208.49_ze3001l8.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0305Z_52.52.208.49_6c4lz8qi.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0320Z_54.183.224.192_40azmfe3.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0335Z_52.52.208.49_1sdyrgsu.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0405Z_52.52.208.49_3cjalv3z.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0405Z_54.183.224.192_5bnjpiry.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0410Z_52.52.208.49_5sd9sa85.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0420Z_52.52.208.49_3srmgupa.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0440Z_54.183.224.192_3ya2fg97.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0510Z_54.183.224.192_83fcbx9t.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0550Z_52.52.208.49_28kcbdji.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0600Z_54.183.224.192_5meem9vr.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0610Z_54.183.224.192_25mjfiv6.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0625Z_54.183.224.192_1urf21p5.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0640Z_54.183.224.192_4f9mqbp4.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0645Z_52.52.208.49_5uw230pl.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0725Z_52.52.208.49_1u80gfhx.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0750Z_52.52.208.49_5bev8b0n.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0805Z_54.183.224.192_183fpwud.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0820Z_54.183.224.192_392iruuw.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0850Z_54.183.224.192_1f5apg8y.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0855Z_54.183.224.192_1cfug8w1.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0900Z_52.52.208.49_2rwkh8x0.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0925Z_52.52.208.49_5lnvwjm1.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0945Z_52.52.208.49_2pjaq5nm.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1035Z_52.52.208.49_ap2j49xo.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1050Z_52.52.208.49_2snajfgx.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1105Z_52.52.208.49_zxr5l6dz.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1115Z_52.52.208.49_66lcfnew.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1135Z_54.183.224.192_2k4fb5kb.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1145Z_54.183.224.192_210b62hd.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1150Z_52.52.208.49_4rpcaukt.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/12/21/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20211221T0000Z_52.52.208.49_14pczeay.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/12/22/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20211222T0000Z_52.52.208.49_14pczeay.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/12/23/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20211223T0000Z_52.52.208.49_14pczeay.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/12/23/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20211230T0000Z_52.52.208.49_14pczeay.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/12/23/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20211230T0000Z_52.52.208.49_14pczeay.log.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

After processing 47 files, the number of entries stored in the database is 5:

```
root@wazuh-master:/var/ossec/wodles/aws# sqlite3 ./s3_cloudtrail.db 'select count(*) from alb'
5
```


### NLB

<details><summary>NLB command output</summary>

	root@wazuh-master:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-nlb -d2 -t nlb -s 2019-may-11 -p dev
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on 166157441623 - us-west-1
	DEBUG: +++ Marker: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2019/05/11
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/12/166157441623_elasticloadbalancing_us-west-1_net.fram-dev-N-Wazuh.9d0fcf192ea215c3_20201112T1800Z_2989bd16.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/12/166157441623_elasticloadbalancing_us-west-1_net.fram-dev-N-Wazuh.9d0fcf192ea215c3_20201112T1800Z_345ed9f8.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/15/166157441623_elasticloadbalancing_us-west-1_net.fram-dev-N-Wazuh.9d0fcf192ea215c3_20201115T1505Z_f1bd4443.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/16/166157441623_elasticloadbalancing_us-west-1_net.fram-dev-N-Wazuh.9d0fcf192ea215c3_20201116T1405Z_41f52bce.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/18/166157441623_elasticloadbalancing_us-west-1_net.fram-dev-N-Wazuh.9d0fcf192ea215c3_20201118T1800Z_454c703f.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/18/166157441623_elasticloadbalancing_us-west-1_net.fram-dev-N-Wazuh.9d0fcf192ea215c3_20201118T1925Z_26b8100d.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/20/166157441623_elasticloadbalancing_us-west-1_net.fram-dev-N-Wazuh.9d0fcf192ea215c3_20201120T0335Z_dd7134bf.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/20/166157441623_elasticloadbalancing_us-west-1_net.fram-dev-N-Wazuh.9d0fcf192ea215c3_20201120T0830Z_55d9eb1b.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/21/166157441623_elasticloadbalancing_us-west-1_net.fram-dev-N-Wazuh.9d0fcf192ea215c3_20201121T1615Z_82b208f9.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/21/166157441623_elasticloadbalancing_us-west-1_net.fram-dev-N-Wazuh.9d0fcf192ea215c3_20201121T1935Z_5600ba6a.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_net.fram-dev-N-Wazuh.9d0fcf192ea215c3_20201124T0305Z_beb2c861.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_net.fram-dev-N-Wazuh.9d0fcf192ea215c3_20201124T0800Z_6755103b.log.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/12/23/166157441623_elasticloadbalancing_us-west-1_net.fram-dev-N-Wazuh.9d0fcf192ea215c3_20201124T0305Z_beb2c861.log.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

After processing 13 files, the number of entries stored in the database is 5:

```
root@wazuh-master:/var/ossec/wodles/aws# sqlite3 ./s3_cloudtrail.db 'select count(*) from nlb'
5
```

### CLB

<details><summary>CLB command output</summary>

	root@wazuh-master:/var/ossec/wodles/aws# rm s3_cloudtrail.db; ./aws-s3 -b wazuh-aws-wodle-clb -d2 -t clb -s 2018-feb-26 -p dev
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on 166157441623 - us-west-1
	DEBUG: +++ Marker: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2018/02/26
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/12/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20201112T1735Z_18.144.142.112_2helnha7.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/12/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20201112T1755Z_18.144.142.112_165qjxzh.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/12/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20201112T1755Z_50.18.204.220_1054crg1.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/17/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20201117T0825Z_13.57.171.118_54zoepib.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/18/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20201118T1500Z_52.8.103.172_11tt9lgg.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/18/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20201118T1735Z_52.8.103.172_3jgaspo5.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/18/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20201118T1750Z_13.57.171.118_3bvb558x.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/18/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20201118T1850Z_52.8.103.172_4c6hfdtg.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/18/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20201118T1905Z_13.57.171.118_dvimgc7p.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/19/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20201119T2345Z_52.8.103.172_c36puibv.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/20/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20201120T0420Z_52.8.103.172_2hmz5gge.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/20/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20201120T0540Z_13.57.171.118_2ygwcxmk.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/20/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20201120T0915Z_52.8.103.172_xisr6wvj.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/20/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20201120T1405Z_52.8.103.172_4dh8k1hw.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/21/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20201121T0750Z_52.8.103.172_4icx3uf6.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/21/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20201121T1600Z_13.57.171.118_2n8hea24.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/21/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20201121T1850Z_13.57.171.118_nwjdy9qw.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20201124T0350Z_52.8.103.172_1pnal677.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/24/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20201124T0510Z_13.57.171.118_5h6gk9w0.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/11/09/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211109T1735Z_18.144.142.112_2helnha7.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/11/10/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211110T1735Z_18.144.142.112_2helnha7.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/11/11/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211111T1735Z_18.144.142.112_2helnha7.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/11/12/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211112T1735Z_18.144.142.112_2helnha7.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/12/23/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211223T1735Z_18.144.142.112_2helnha7.log
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

After processing 24 files, the number of entries stored in the database is 5:

```
root@wazuh-master:/var/ossec/wodles/aws# sqlite3 ./s3_cloudtrail.db 'select count(*) from clb'
5
```

## Conclusions

Everything is working as expected