### PR TITLE
Restrict sysinfo module load by Logcollector to macOS

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -144,11 +144,13 @@ void LogCollectorStart()
     IT_control duplicates_removed = 0;
     logreader *current;
 
+#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
     w_sysinfo_helpers_t * sysinfo = NULL;
     os_calloc(1, sizeof(w_sysinfo_helpers_t), sysinfo);
     if (!w_sysinfo_init(sysinfo)) {
         merror(SYSINFO_DYNAMIC_INIT_ERROR);
     }
+#endif
 
     /* Create store data */
     excluded_files = OSHash_Create();


### PR DESCRIPTION
|Related issue|
|---|
|#12230|

This PR aims to remove this log by Logcollector found on HP-UX:

```
2022/02/21 12:34:41 wazuh-logcollector: ERROR: (9000): Error loading sysinfo module.
```

## Rationale

Logcollector requires the `sysinfo` data provider for system information, in order to find the current version of macOS when using the ULS log reader. In other words, Logcollector requires the `sysinfo` module on macOS only.

However, it's trying to load the module on every platform. Since Sysinfo is not implemented on HP-UX, Logcollector fails to find the module and produces that error (with no impact). On the remaining platforms, the agent succeeds to load the module but does not use it.

## Proposed fix

Let Logcollector load and use the `sysinfo` module on macOS agents only. This will avoid the error above, and will also save some memory on other platforms.

## Logs

```
2022/02/21 12:34:41 wazuh-logcollector: INFO: (1950): Analyzing file: '/var/ossec/logs/active-responses.log'.
2022/02/21 12:34:41 wazuh-logcollector: INFO: Started (pid: 979).
```

The error above no longer appears.

## Tests

- [x] Logcollector does not try to load the module on Linux.
- [x] Logcollector does not print the error even deleting _lib/libsysinfo.so_ on Linux.
- [ ] Logcollector does not try to load the module on HP-UX.