### PR TITLE
Add Regex Extract Function Helper

### DIFF
--- a/src/engine/source/builder/builders/OpBuilderHelperMap.cpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperMap.cpp
@@ -463,4 +463,37 @@ types::Lifter opBuilderHelperIntCalc(const types::DocumentValue & def)
     };
 }
 
+//*************************************************
+//*           Regex tranform                      *
+//*************************************************
+
+types::Lifter opBuilderHelperRegexExtract(const types::DocumentValue & def)
+{
+    // Get fields
+    std::string base_field = def.MemberBegin()->name.GetString();
+    std::string value = def.MemberBegin()->value.GetString();
+    std::vector<std::string> parameters = utils::string::split(value, '/');
+    if (parameters.size() != 3)
+    {
+        throw std::invalid_argument("Wrong number of arguments passed");
+    }
+    std::string map_field = parameters[1];
+    std::string regexp = parameters[2];
+
+    // Return Lifter
+    return [=](types::Observable o)
+    {
+        // Append rxcpp operation
+        return o.map(
+
+            [=](types::Event e)
+            {
+                std::string match;
+                if (RE2::PartialMatch(e.get("/" + base_field)->GetString(), regexp, &match))
+                {
+                    auto aux_string = "{ \"" + map_field + "\": \"" + match + "\"}";
+                    types::Document doc{aux_string.c_str()};
+                    e.set(doc);
+                }
+
 } // namespace builder::internals::builders

--- a/src/engine/source/builder/builders/OpBuilderHelperMap.cpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperMap.cpp
@@ -489,13 +489,16 @@ types::Lifter opBuilderHelperRegexExtract(const types::DocumentValue & def)
 
             [=](types::Event e)
             {
-                std::string match;
-                if (RE2::PartialMatch(e.get("/" + base_field)->GetString(), *regex_ptr,
-                                      &match))
+                auto field_str = e.get("/" + base_field)->GetString();
+                if (field_str)
                 {
-                    auto aux_string = "{ \"" + map_field + "\": \"" + match + "\"}";
-                    types::Document doc{aux_string.c_str()};
-                    e.set(doc);
+                    std::string match;
+                    if (RE2::PartialMatch(field_str, *regex_ptr, &match))
+                    {
+                        auto aux_string = "{ \"" + map_field + "\": \"" + match + "\"}";
+                        types::Document doc{aux_string.c_str()};
+                        e.set(doc);
+                    }
                 }
 
 } // namespace builder::internals::builders

--- a/src/engine/source/builder/builders/OpBuilderHelperMap.cpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperMap.cpp
@@ -489,11 +489,11 @@ types::Lifter opBuilderHelperRegexExtract(const types::DocumentValue & def)
 
             [=](types::Event e)
             {
-                auto field_str = e.get("/" + base_field)->GetString();
+                auto field_str = e.get("/" + base_field);
                 if (field_str)
                 {
                     std::string match;
-                    if (RE2::PartialMatch(field_str, *regex_ptr, &match))
+                    if (RE2::PartialMatch(field_str->GetString(), *regex_ptr, &match))
                     {
                         auto aux_string = "{ \"" + map_field + "\": \"" + match + "\"}";
                         types::Document doc{aux_string.c_str()};

--- a/src/engine/source/builder/builders/OpBuilderHelperMap.cpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperMap.cpp
@@ -479,6 +479,7 @@ types::Lifter opBuilderHelperRegexExtract(const types::DocumentValue & def)
     }
     std::string map_field = parameters[1];
     std::string regexp = parameters[2];
+    auto regex_ptr = std::make_shared<RE2>(regexp);
 
     // Return Lifter
     return [=](types::Observable o)
@@ -489,7 +490,8 @@ types::Lifter opBuilderHelperRegexExtract(const types::DocumentValue & def)
             [=](types::Event e)
             {
                 std::string match;
-                if (RE2::PartialMatch(e.get("/" + base_field)->GetString(), regexp, &match))
+                if (RE2::PartialMatch(e.get("/" + base_field)->GetString(), *regex_ptr,
+                                      &match))
                 {
                     auto aux_string = "{ \"" + map_field + "\": \"" + match + "\"}";
                     types::Document doc{aux_string.c_str()};

--- a/src/engine/source/builder/builders/OpBuilderHelperMap.cpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperMap.cpp
@@ -493,6 +493,7 @@ types::Lifter opBuilderHelperRegexExtract(const types::DocumentValue & def)
 
             [=](types::Event e)
             {
+                // TODO Remove try catch
                 const rapidjson::Value * field_str{};
                 try
                 {

--- a/src/engine/source/builder/builders/OpBuilderHelperMap.hpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperMap.hpp
@@ -71,8 +71,8 @@ types::Lifter opBuilderHelperIntCalc(const types::DocumentValue & def);
 //*************************************************
 
 /**
- * @brief Builds helper exists operation.
- * Checks that a field is present in the event.
+ * @brief Builds regex extract operation.
+ * Maps into an auxiliary field the part of the field value that matches a regexp
  *
  * @param def Definition of the operation to be built
  * @return types::Lifter

--- a/src/engine/source/builder/builders/OpBuilderHelperMap.hpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperMap.hpp
@@ -61,7 +61,7 @@ types::Lifter opBuilderHelperStringTrim(const types::DocumentValue & def);
  *
  * @param def The transformation definition.
  * i.e : `<field>: +icalcm/[sum|sub|mul|div]/[value|$<ref>]`
- * @return types::Lifter
+ * @return types::Lifter The lifter with the `mathematical operation` transformation.
  * @throw std::runtime_error if the parameter is not a integer.
  */
 types::Lifter opBuilderHelperIntCalc(const types::DocumentValue & def);
@@ -75,7 +75,8 @@ types::Lifter opBuilderHelperIntCalc(const types::DocumentValue & def);
  * Maps into an auxiliary field the part of the field value that matches a regexp
  *
  * @param def Definition of the operation to be built
- * @return types::Lifter
+ * @return types::Lifter The lifter with the `regex extract` transformation.
+ * @throw std::runtime_error if the parameter is the regex is invalid.
  */
 types::Lifter opBuilderHelperRegexExtract(const types::DocumentValue & def);
 

--- a/src/engine/source/builder/builders/OpBuilderHelperMap.hpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperMap.hpp
@@ -66,6 +66,19 @@ types::Lifter opBuilderHelperStringTrim(const types::DocumentValue & def);
  */
 types::Lifter opBuilderHelperIntCalc(const types::DocumentValue & def);
 
+//*************************************************
+//*           Regex tranform                      *
+//*************************************************
+
+/**
+ * @brief Builds helper exists operation.
+ * Checks that a field is present in the event.
+ *
+ * @param def Definition of the operation to be built
+ * @return types::Lifter
+ */
+types::Lifter opBuilderHelperRegexExtract(const types::DocumentValue & def);
+
 } // namespace builder::internals::builders
 
 #endif // _OP_BUILDER_HELPER_MAP_H

--- a/src/engine/test/source/builder/CMakeLists.txt
+++ b/src/engine/test/source/builder/CMakeLists.txt
@@ -303,6 +303,12 @@ add_executable(opBuilderHelperRegexNotMatch_test
   ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp)
 gtest_discover_tests(opBuilderHelperRegexNotMatch_test)
 
+add_executable(opBuilderHelperRegexExtract_test
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperRegexExtract_test.cpp
+  ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/OpBuilderHelperMap.cpp
+  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp)
+gtest_discover_tests(opBuilderHelperRegexExtract_test)
+
 # add_executable(combinatorBuilderChainTest)
 # gtest_discover_tests(combinatorBuilderChainTest)
 # add_executable(combinatorBuilderBroadcastTest)
@@ -386,6 +392,7 @@ gtest_discover_tests(opBuilderFileOutputTest)
 
 add_executable(stageBuilderOutputsTest
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/stageBuilderOutputsTest.cpp
+  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_ENGINE_SOURCE_DIR}/registry.cpp
   ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/combinatorBuilderBroadcast.cpp

--- a/src/engine/test/source/builder/CMakeLists.txt
+++ b/src/engine/test/source/builder/CMakeLists.txt
@@ -394,7 +394,6 @@ add_executable(stageBuilderOutputsTest
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/stageBuilderOutputsTest.cpp
   ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_ENGINE_SOURCE_DIR}/registry.cpp
-  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/combinatorBuilderBroadcast.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/stageBuilderOutputs.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderFileOutput.cpp)

--- a/src/engine/test/source/builder/builders/opBuilderHelperRegexExtract_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperRegexExtract_test.cpp
@@ -43,6 +43,15 @@ TEST(opBuilderHelperRegexExtract, TooManyArgumentsError)
     ASSERT_THROW(opBuilderHelperRegexExtract(*doc.get("/map")), std::invalid_argument);
 }
 
+TEST(opBuilderHelperRegexExtract, RegularExpresionEmptyError)
+{
+    Document doc{R"({
+        "map":
+            {"field": "+r_ext/_field//"}
+    })"};
+    ASSERT_THROW(opBuilderHelperRegexExtract(*doc.get("/map")), std::invalid_argument);
+}
+
 TEST(opBuilderHelperRegexExtract, StringRegexExtract)
 {
     Document doc{R"~~({

--- a/src/engine/test/source/builder/builders/opBuilderHelperRegexExtract_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperRegexExtract_test.cpp
@@ -136,3 +136,33 @@ TEST(opBuilderHelperRegexExtract, AdvancedRegexMatch)
     ASSERT_TRUE(
         RE2::PartialMatch(expected[1].get("/_field")->GetString(), "engine@wazuh.com"));
 }
+
+TEST(opBuilderHelperRegexExtract, NestedFieldRegexMatch)
+{
+    Document doc{R"~~({
+        "map":
+            {"test/field": "+r_ext/_field/(exp)/"}
+    })~~"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"~~({
+            "test":
+                {"field": "exp"}
+            })~~"});
+            s.on_next(Event{R"~~({
+            "test":
+                {"field": "this is a test exp"}
+            })~~"});
+            s.on_completed();
+        });
+
+    Lifter lift = opBuilderHelperRegexExtract(*doc.get("/map"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 2);
+    ASSERT_TRUE(RE2::PartialMatch(expected[0].get("/_field")->GetString(), "exp"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[1].get("/_field")->GetString(), "exp"));
+}

--- a/src/engine/test/source/builder/builders/opBuilderHelperRegexExtract_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperRegexExtract_test.cpp
@@ -1,0 +1,136 @@
+/* Copyright (C) 2015-2021, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <gtest/gtest.h>
+#include <testUtils.hpp>
+
+#include <vector>
+
+#include "OpBuilderHelperMap.hpp"
+
+using namespace builder::internals::builders;
+
+TEST(opBuilderHelperRegexExtract, Builds)
+{
+    Document doc{R"({
+        "map":
+            {"field": "+r_ext/_field/regexp/"}
+    })"};
+    ASSERT_NO_THROW(opBuilderHelperRegexExtract(*doc.get("/map")));
+}
+
+TEST(opBuilderHelperRegexExtract, NotEnoughArgumentsError)
+{
+    Document doc{R"({
+        "map":
+            {"field": "+r_ext/_field/"}
+    })"};
+    ASSERT_THROW(opBuilderHelperRegexExtract(*doc.get("/map")), std::invalid_argument);
+}
+
+TEST(opBuilderHelperRegexExtract, TooManyArgumentsError)
+{
+    Document doc{R"({
+        "map":
+            {"field": "+r_ext/_field/regexp/arg/"}
+    })"};
+    ASSERT_THROW(opBuilderHelperRegexExtract(*doc.get("/map")), std::invalid_argument);
+}
+
+TEST(opBuilderHelperRegexExtract, StringRegexMatch)
+{
+    Document doc{R"~~({
+        "map":
+            {"field": "+r_ext/_field/(exp)/"}
+    })~~"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field":"exp"}
+            )"});
+            s.on_next(Event{R"(
+                {"field":"expregex"}
+            )"});
+            s.on_next(Event{R"(
+                {"field":"this is a test exp"}
+            )"});
+            s.on_completed();
+        });
+
+    Lifter lift = opBuilderHelperRegexExtract(*doc.get("/map"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 3);
+    ASSERT_TRUE(RE2::PartialMatch(expected[0].get("/_field")->GetString(), "exp"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[1].get("/_field")->GetString(), "exp"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[2].get("/_field")->GetString(), "exp"));
+}
+
+TEST(opBuilderHelperRegexExtract, NumericRegexMatch)
+{
+    Document doc{R"~~({
+        "map":
+            {"field": "+r_ext/_field/(123)/"}
+    })~~"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field":"123"}
+            )"});
+            s.on_next(Event{R"(
+                {"field":"123"}
+            )"});
+            s.on_next(Event{R"(
+                {"field":"123"}
+            )"});
+            s.on_completed();
+        });
+
+    Lifter lift = opBuilderHelperRegexExtract(*doc.get("/map"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 3);
+    ASSERT_TRUE(RE2::PartialMatch(expected[0].get("/_field")->GetString(), "123"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[1].get("/_field")->GetString(), "123"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[2].get("/_field")->GetString(), "123"));
+}
+
+TEST(opBuilderHelperRegexExtract, AdvancedRegexMatch)
+{
+    Document doc{R"~~({
+        "map":
+            {"field": "+r_ext/_field/(([^ @]+)@([^ @]+))"}
+    })~~"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field":"client@wazuh.com"}
+            )"});
+            s.on_next(Event{R"(
+                {"field":"engine@wazuh.com"}
+            )"});
+            s.on_completed();
+        });
+
+    Lifter lift = opBuilderHelperRegexExtract(*doc.get("/map"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 2);
+    ASSERT_TRUE(RE2::PartialMatch(expected[0].get("/_field")->GetString(), "client@wazuh.com"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[1].get("/_field")->GetString(), "engine@wazuh.com"));
+}

--- a/src/engine/test/source/builder/builders/opBuilderHelperRegexExtract_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperRegexExtract_test.cpp
@@ -131,6 +131,8 @@ TEST(opBuilderHelperRegexExtract, AdvancedRegexMatch)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_TRUE(RE2::PartialMatch(expected[0].get("/_field")->GetString(), "client@wazuh.com"));
-    ASSERT_TRUE(RE2::PartialMatch(expected[1].get("/_field")->GetString(), "engine@wazuh.com"));
+    ASSERT_TRUE(
+        RE2::PartialMatch(expected[0].get("/_field")->GetString(), "client@wazuh.com"));
+    ASSERT_TRUE(
+        RE2::PartialMatch(expected[1].get("/_field")->GetString(), "engine@wazuh.com"));
 }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/12164|

This PR implements the regexp extract capability to the new engine via a funtion helper. 

```yml
field: +r_ext/_field/regexp/
```

Extracts values from regexp and put them in _field as an array of results to be processed by other operations.

The field name must be an auxiliary type, always starting with ```_```.
