### PR TITLE
Clear SQLAlchemy mappers after importing orm in security framework unit test

### DIFF
--- a/framework/wazuh/tests/test_security.py
+++ b/framework/wazuh/tests/test_security.py
@@ -6,13 +6,13 @@
 
 import glob
 import os
-from contextvars import ContextVar
 from importlib import reload
 from unittest.mock import patch
 
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import clear_mappers
 from yaml import safe_load
 
 from wazuh.core.exception import WazuhError
@@ -72,6 +72,8 @@ def db_setup():
             with patch('shutil.chown'), patch('os.chmod'):
                 with patch('api.constants.SECURITY_PATH', new=test_data_path):
                     import wazuh.rbac.orm as orm
+                    # Clear mappers
+                    clear_mappers()
                     # Invalidate in-memory database
                     conn = orm._engine.connect()
                     orm._Session().close()
@@ -216,6 +218,7 @@ def test_add_new_default_policies(new_default_resources):
 def test_migrate_default_policies(new_default_resources):
     """Check that the migration process overwrites default policies in the user range including their relationships
     and positions."""
+
     def mock_open_default_resources(*args, **kwargs):
         args = list(args)
         file_path = args[0]

--- a/framework/wazuh/tests/test_security.py
+++ b/framework/wazuh/tests/test_security.py
@@ -11,8 +11,8 @@ from unittest.mock import patch
 
 import pytest
 from sqlalchemy import create_engine
+from sqlalchemy import orm as sqlalchemy_orm
 from sqlalchemy.exc import OperationalError
-from sqlalchemy.orm import clear_mappers
 from yaml import safe_load
 
 from wazuh.core.exception import WazuhError
@@ -73,7 +73,7 @@ def db_setup():
                 with patch('api.constants.SECURITY_PATH', new=test_data_path):
                     import wazuh.rbac.orm as orm
                     # Clear mappers
-                    clear_mappers()
+                    sqlalchemy_orm.clear_mappers()
                     # Invalidate in-memory database
                     conn = orm._engine.connect()
                     orm._Session().close()


### PR DESCRIPTION
|Related issue|
|---|
| #11957 |

This PR closes #11957 .

In this pull request, I have modified the db_setup fixture to call clear_mappers() after importing the form module. As explained in the related issue's comments, when using this function, we fix the problem regarding failures when initializing mappers, which was causing test_security.py to fail randomly.

 ### Test results

```
$ pytest framework/wazuh/tests/test_security.py 
============================================================= test session starts =============================================================
platform linux -- Python 3.9.2, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/manuel/git/wazuh/framework
plugins: html-3.1.1, metadata-1.11.0, cov-2.12.0, testinfra-5.0.0, asyncio-0.14.0
collected 73 items                                                                                                                            

framework/wazuh/tests/test_security.py .........................................................................                        [100%]

============================================================== warnings summary ===============================================================
wazuh/tests/test_security.py::test_security[get_users-params0-expected_result0]
wazuh/tests/test_security.py::test_security[get_users-params0-expected_result0]
  /home/manuel/.venvs/unittest-env/lib/python3.9/site-packages/jsonschema/compat.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    from collections import MutableMapping, Sequence  # noqa

wazuh/tests/test_security.py::test_security[get_users-params0-expected_result0]
  /home/manuel/git/wazuh/framework/wazuh/core/utils.py:799: DeprecationWarning: invalid escape sequence \g
    data = re.sub(r'^&backslash;<(.*[^>])$', '&backslash;&lt;\g<1>', data)

wazuh/tests/test_security.py::test_security[get_users-params0-expected_result0]
  /home/manuel/.venvs/unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:48: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def problems_middleware(request, handler):

wazuh/tests/test_security.py::test_security[get_users-params0-expected_result0]
  /home/manuel/.venvs/unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:169: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_openapi_json(self, request):

wazuh/tests/test_security.py::test_security[get_users-params0-expected_result0]
  /home/manuel/.venvs/unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:177: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_openapi_yaml(self, request):

wazuh/tests/test_security.py::test_security[get_users-params0-expected_result0]
  /home/manuel/.venvs/unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:236: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_swagger_ui_home(self, req):

wazuh/tests/test_security.py::test_security[get_users-params0-expected_result0]
  /home/manuel/.venvs/unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:246: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_swagger_ui_config(self, req):

wazuh/tests/test_security.py::test_security[get_users-params0-expected_result0]
  /home/manuel/.venvs/unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:295: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def get_request(cls, req):

wazuh/tests/test_security.py::test_security[get_users-params0-expected_result0]
  /home/manuel/.venvs/unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:324: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def get_response(cls, response, mimetype=None, request=None):

-- Docs: https://docs.pytest.org/en/stable/warnings.html
====================================================== 73 passed, 10 warnings in 52.90s =======================================================

```