### PR TITLE
Added checks for dot and double dot directories

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -4554,11 +4554,11 @@ void test_wdb_global_insert_agent_group_invalid_group_name(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    char *group_name = "group-name,with_comma";
+    char *group_name = "group_name,with_comma";
 
-    expect_string(__wrap__mwarn, formatted_msg, "Invalid group name. 'group-name,with_comma' "
+    expect_string(__wrap__mwarn, formatted_msg, "Invalid group name. 'group_name,with_comma' "
                                                 "contains invalid characters");
-    expect_string(__wrap__mdebug1, formatted_msg, "Cannot insert 'group-name,with_comma'");
+    expect_string(__wrap__mdebug1, formatted_msg, "Cannot insert 'group_name,with_comma'");
 
     result = wdb_global_insert_agent_group(data->wdb, group_name);
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -2068,7 +2068,7 @@ wdbc_result wdb_global_unassign_agent_group(wdb_t *wdb, int id, cJSON* j_groups)
 int wdb_global_groups_number_get(wdb_t *wdb, int agent_id);
 
 /**
- * @brief Verifies that the group name complies with a predefined pattern.
+ * @brief Verifies that the group name satisfies with a predefined pattern.
  *
  * @param group_name Group name to be validated.
  * @return w_err_t OS_SUCCESS if valid. OS_INVALID otherwise.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -19,6 +19,7 @@
 #include "syscheck_op.h"
 #include "rootcheck_op.h"
 #include "wazuhdb_op.h"
+#include "regex_op.h"
 
 #define WDB_AGENT_EMPTY 0
 #define WDB_AGENT_PENDING 1
@@ -2067,6 +2068,14 @@ wdbc_result wdb_global_unassign_agent_group(wdb_t *wdb, int id, cJSON* j_groups)
 int wdb_global_groups_number_get(wdb_t *wdb, int agent_id);
 
 /**
+ * @brief Verifies that the group name complies with a predefined pattern.
+ *
+ * @param group_name Group name to be validated.
+ * @return w_err_t OS_SUCCESS if valid. OS_INVALID otherwise.
+ */
+w_err_t wdb_global_validate_group_name(const char *group_name);
+
+/**
  * @brief Verifies that the number of groups to be assigned is less or equal to 128 and
  *        there's no group longer than 255 characters nor contains a comma as part of its name.
  *
@@ -2075,7 +2084,7 @@ int wdb_global_groups_number_get(wdb_t *wdb, int agent_id);
  * @param [in] agent_id ID of the agent to add new groups.
  * @return wdbc_result representing the status of the command.
  */
-wdbc_result wdb_global_validate_groups(wdb_t *wdb, cJSON *j_groups, int agent_id);
+w_err_t wdb_global_validate_groups(wdb_t *wdb, cJSON *j_groups, int agent_id);
 
 /**
  * @brief Sets the belongship af a set of agents.

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1329,26 +1329,25 @@ int wdb_global_groups_number_get(wdb_t *wdb, int agent_id) {
 w_err_t wdb_global_validate_group_name(const char *group_name) {
     const char *current_directory = ".";
     const char *parent_directory = "..";
-    w_err_t result = OS_SUCCESS;
 
     if (strlen(group_name) > MAX_GROUP_NAME) {
         mwarn("Invalid group name. The group '%s' exceeds the maximum length of %d characters permitted", group_name, MAX_GROUP_NAME);
-        result = OS_INVALID;
-    } else if (!w_regexec("^[a-zA-Z0-9_\\.\\-]+$", group_name, 0, NULL)) {
+        return OS_INVALID;
+    }
+    if (!w_regexec("^[a-zA-Z0-9_\\.\\-]+$", group_name, 0, NULL)) {
         mwarn("Invalid group name. '%s' contains invalid characters", group_name);
-        result = OS_INVALID;
-    } else {
-        if (!strcmp(group_name, parent_directory)) {
-            mwarn("Invalid group name. '%s' represents the parent directory in unix systems", group_name);
-            result = OS_INVALID;
-        }
-        if (!strcmp(group_name, current_directory)) {
-            mwarn("Invalid group name. '%s' represents the current directory in unix systems", group_name);
-            result = OS_INVALID;
-        }
+        return OS_INVALID;
+    }
+    if (!strcmp(group_name, parent_directory)) {
+        mwarn("Invalid group name. '%s' represents the parent directory in unix systems", group_name);
+        return OS_INVALID;
+    }
+    if (!strcmp(group_name, current_directory)) {
+        mwarn("Invalid group name. '%s' represents the current directory in unix systems", group_name);
+        return OS_INVALID;
     }
 
-    return result;
+    return OS_SUCCESS;
 }
 
 w_err_t wdb_global_validate_groups(wdb_t *wdb, cJSON *j_groups, int agent_id) {
@@ -1368,8 +1367,7 @@ w_err_t wdb_global_validate_groups(wdb_t *wdb, cJSON *j_groups, int agent_id) {
                     break;
                 }
                 char* group_name = j_group_name->valuestring;
-                if (OS_INVALID == wdb_global_validate_group_name(group_name)) {
-                    ret = OS_INVALID;
+                if (ret = wdb_global_validate_group_name(group_name), ret) {
                     break;
                 }
             }
@@ -1422,7 +1420,7 @@ wdbc_result wdb_global_set_agent_groups(wdb_t *wdb, wdb_groups_set_mode_t mode, 
                     ret = WDBC_ERROR;
                 }
             }
-            if (WDBC_OK == valid_groups) {
+            if (OS_SUCCESS == valid_groups) {
                 char* agent_groups_csv = wdb_global_calculate_agent_group_csv(wdb, agent_id);
                 if (agent_groups_csv) {
                     char groups_hash[WDB_GROUP_HASH_SIZE+1] = {0};


### PR DESCRIPTION
|Related issue|
|---|
|#12306|

## Description

This PR verifies that groups: 

- Match the following regex: `"^[a-zA-Z0-9_\-\.]+$"`
- Are not called '.' nor '..' which are reserved for UNIX systems

## Scan-build report

![10](https://user-images.githubusercontent.com/13010397/155004532-a207a931-730b-4411-bde9-1a09054b9f30.png)

## Valgrind

![9](https://user-images.githubusercontent.com/13010397/155003586-f0428cb9-6a10-417c-b801-df86f29bcacb.png)


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)