### PR TITLE
Add security mechanisms to ensure the integrity of worker node databases

### DIFF
--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -1147,7 +1147,7 @@ class WazuhCommon:
         raise NotImplementedError
 
     def setup_send_info(self, SendTaskClass: Callable, data: bytes = b''):
-        """Create ReceiveTaskClass object and add it to sync_tasks dict.
+        """Create SendTaskClass object.
 
         Parameters
         ----------

--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -125,6 +125,48 @@ class InBuffer:
         return data[len_data:]
 
 
+class SendStringTask:
+    """
+    Create an asyncio task that can be identified by a task_id specified in advance.
+    """
+
+    def __init__(self, wazuh_common, logger):
+        """Class constructor.
+
+        Parameters
+        ----------
+        wazuh_common : WazuhCommon object
+            Instance of WazuhCommon.
+        logger : Logger object
+            Logger to use during the receive process.
+        """
+        self.wazuh_common = wazuh_common
+        self.coro = self.set_up_coro()
+        self.task = asyncio.create_task(self.coro())
+        self.task.add_done_callback(self.done_callback)
+        self.logger = logger
+
+    def set_up_coro(self) -> Callable:
+        """Define set_up_coro method. It is implemented differently for master, workers and synchronization types.
+
+        Raises
+        -------
+        NotImplementedError
+            If the method is not implemented.
+        """
+        raise NotImplementedError
+
+    def done_callback(self, future=None):
+        """Function to call when the task is finished.
+
+        Remove string and task_id (if exist) from sync_tasks dict. If task was not cancelled, raise stored exception.
+        """
+        if not self.task.cancelled():
+            task_exc = self.task.exception()
+            if task_exc:
+                self.logger.error(task_exc)
+
+
 class ReceiveStringTask:
     """
     Create an asyncio task that can be identified by a task_id specified in advance.
@@ -1104,6 +1146,26 @@ class WazuhCommon:
         """
         raise NotImplementedError
 
+    def setup_send_info(self, SendTaskClass: Callable, data: bytes = b''):
+        """Create ReceiveTaskClass object and add it to sync_tasks dict.
+
+        Parameters
+        ----------
+        SendTaskClass : Callable
+            Class used to create an object.
+        data : bytes
+            Information used to create the object.
+
+        Returns
+        -------
+        bytes
+            Result.
+        bytes
+            Task ID.
+        """
+        my_task = SendTaskClass(self, self.get_logger(self.logger_tag))
+        return b'ok', str(my_task).encode()
+
     def setup_receive_file(self, ReceiveTaskClass: Callable, data: bytes = b''):
         """Create ReceiveTaskClass object and add it to sync_tasks dict.
 
@@ -1248,7 +1310,7 @@ class SyncWazuhdb(SyncTask):
     Define methods to send information to the master/worker node (wazuh-db) through send_string protocol.
     """
 
-    def __init__(self, manager, logger, cmd: bytes, data_retriever: Callable, get_data_command: str = '',
+    def __init__(self, manager, logger, data_retriever: Callable, cmd: bytes = b'', get_data_command: str = '',
                  set_data_command: str = '', get_payload: dict = None, set_payload: dict = None, pivot_key: str = ''):
         """Class constructor.
 

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -1134,14 +1134,13 @@ class Master(server.AbstractServer):
             try:
                 before = perf_counter()
                 sync_object.logger.info("Starting.")
-                if len(self.agent_groups_control_workers) >= len(self.clients.keys()) and len(self.clients.keys()) > 0:
+                if len(self.agent_groups_control_workers) >= len(self.clients.keys()) > 0:
                     self.agent_groups_control = await sync_object.retrieve_information()
                     self.agent_groups_control_workers.clear()
                     after = perf_counter()
-                    logger.info(f"Finished in {(after - before):.3f}s. "
-                                f"Retrieved out-of-sync group information and global checksum from database.")
+                    logger.info(f"Finished in {(after - before):.3f}s.")
                 elif len(self.clients.keys()) == 0:
-                    logger.info("No clients connected. Skipping agent-groups obtaining task.")
+                    logger.info("No clients connected. Skipping.")
             except Exception as e:
                 sync_object.logger.error(f"Error getting agent-groups from WDB: {e}")
 

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -172,6 +172,30 @@ class ReceiveAgentGroupsTask(c_common.ReceiveStringTask):
         self.wazuh_common.sync_agent_groups_free = True
 
 
+class SendEntireAgentGroupsTask(c_common.SendStringTask):
+    """
+    Define the process and variables necessary to send the entire agent-groups from the master to the worker.
+
+    This task is created when the worker needs the entire agent-groups information.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Class constructor.
+
+        Parameters
+        ----------
+        args
+            Positional arguments for parent constructor class.
+        kwargs
+            Keyword arguments for parent constructor class.
+        """
+        super().__init__(*args, **kwargs)
+
+    def set_up_coro(self) -> Callable:
+        """Set up the function to be called when the worker needs the entire agent-groups information."""
+        return self.wazuh_common.send_entire_agent_groups_information
+
+
 class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
     """
     Handle incoming requests and sync processes with a worker.
@@ -257,6 +281,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             return self.get_permission(command)
         elif command == b'syn_i_w_m' or command == b'syn_e_w_m' or command == b'syn_a_w_m' or command == b'syn_g_w_m':
             return self.setup_sync_integrity(command, data)
+        elif command == b'syn_w_g_c':
+            return self.setup_send_info(command)
         elif command == b'syn_i_w_m_e' or command == b'syn_e_w_m_e':
             return self.end_receiving_integrity_checksums(data.decode())
         elif command == b'syn_i_w_m_r':
@@ -377,7 +403,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                              'Integrity sync': self.setup_task_logger('Integrity sync'),
                              'Agent-info sync': self.setup_task_logger('Agent-info sync'),
                              'Agent-groups sync': self.setup_task_logger('Agent-groups sync'),
-                             'Agent-groups send': self.setup_task_logger('Agent-groups send')}
+                             'Agent-groups send': self.setup_task_logger('Agent-groups send'),
+                             'Agent-groups full DB': self.setup_task_logger('Agent-groups full DB')}
 
         # Fill more information and check both name and version are correct.
         self.version, self.cluster_name, self.node_type = version.decode(), cluster_name.decode(), node_type.decode()
@@ -545,6 +572,28 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
 
         return super().setup_receive_file(sync_function, data)
 
+    def setup_send_info(self, sync_type: bytes) -> Tuple[bytes, bytes]:
+        """Start synchronization process.
+
+        Parameters
+        ----------
+        sync_type : bytes
+            Sync process to start.
+
+        Returns
+        -------
+        bytes
+            Result.
+        bytes
+            Response message.
+        """
+        if sync_type == b'syn_w_g_c':
+            sync_function = SendEntireAgentGroupsTask
+        else:
+            sync_function = None
+
+        return super().setup_send_info(sync_function)
+
     def process_sync_error_from_worker(self, error_msg: bytes) -> Tuple[bytes, bytes]:
         """Manage error during synchronization process reported by a worker.
 
@@ -619,6 +668,32 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             task_id=task_id, info_type=info_type, error_command=error_command,
             logger=logger, command=command, sync_dict=sync_dict, timeout=timeout)
 
+    async def send_entire_agent_groups_information(self):
+        """Method in charge of sending all the information related to
+        agent-groups from the master node database to the worker node database.
+
+        This method is activated when the worker node requests this information to the master node.
+        """
+        logger = self.task_loggers['Agent-groups full DB']
+        sync_object = c_common.SyncWazuhdb(manager=self, logger=logger,
+                                           data_retriever=WazuhDBConnection().run_wdb_command,
+                                           get_data_command='global sync-agent-groups-get ',
+                                           get_payload={"condition": "all", "set_synced": False,
+                                                        "get_global_hash": True})
+        local_agent_groups_information = await sync_object.retrieve_information()
+
+        sync_object = c_common.SyncWazuhdb(manager=self, logger=logger, cmd=b'syn_g_m_w',
+                                           data_retriever=WazuhDBConnection().run_wdb_command,
+                                           set_data_command='global set-agent-groups',
+                                           set_payload={'mode': 'override', 'sync_status': 'synced'})
+
+        logger.info("Requested entire agent-groups information by the worker node. Starting.")
+        start_time = perf_counter()
+        await sync_object.sync(start_time=start_time, chunks=local_agent_groups_information)
+        logger.info("Sent all agent-groups information from the master node database.")
+
+        return b'ok', b'Sent'
+
     async def send_agent_groups_information(self):
         """Function in charge of sending the group information to the worker node.
         Each time we get data it will be sent.
@@ -629,7 +704,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         sync_object = c_common.SyncWazuhdb(manager=self, logger=logger, cmd=b'syn_g_m_w',
                                            data_retriever=wdb_conn.run_wdb_command,
                                            set_data_command='global set-agent-groups',
-                                           set_payload={'mode': 'overwrite', 'sync_status': 'synced'})
+                                           set_payload={'mode': 'override', 'sync_status': 'synced'})
 
         while True:
             info = self.server.get_agent_groups_info(self.name)
@@ -637,8 +712,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                 try:
                     self.send_agent_groups_status['date_start'] = perf_counter()
                     logger.info("Starting.")
-                    await sync_object.sync(start_time=self.send_agent_groups_status['date_start'],
-                                           chunks=self.server.agent_groups_control)
+                    await sync_object.sync(start_time=self.send_agent_groups_status['date_start'], chunks=info)
                 except Exception as e:
                     logger.error(f'Error sending agent-groups information to {self.cluster_name}: {e}')
 
@@ -1036,9 +1110,6 @@ class Master(server.AbstractServer):
         if client not in self.agent_groups_control_workers:
             result = self.agent_groups_control
             self.agent_groups_control_workers.add(client)
-        elif set(self.clients.keys()).issubset(self.agent_groups_control_workers):
-            self.agent_groups_control = {}
-            self.agent_groups_control_workers.clear()
 
         return result
 
@@ -1051,26 +1122,26 @@ class Master(server.AbstractServer):
         This information will only be sent to the worker nodes when it contains data.
         It looks like this: ['[{"data":[{"id":1,"group":["default","group1"]}]}]'].
         """
-        empty_data = ['[{"data":[]}]']
         logger = self.setup_task_logger('Agent-groups get')
         wdb_conn = WazuhDBConnection()
         sync_object = c_common.SyncWazuhdb(manager=self, logger=logger, cmd=b'syn_g_m_w',
                                            data_retriever=wdb_conn.run_wdb_command,
                                            get_data_command='global sync-agent-groups-get ',
-                                           get_payload={"condition": "sync_status", "set_synced": True})
+                                           get_payload={"condition": "sync_status", "set_synced": True,
+                                                        "get_global_hash": True})
 
         while True:
             try:
                 before = perf_counter()
                 sync_object.logger.info("Starting.")
-                if self.agent_groups_control == {}:
+                if len(self.agent_groups_control_workers) >= len(self.clients.keys()) and len(self.clients.keys()) > 0:
                     self.agent_groups_control = await sync_object.retrieve_information()
+                    self.agent_groups_control_workers.clear()
                     after = perf_counter()
-                    no_need_sync = self.agent_groups_control == empty_data
                     logger.info(f"Finished in {(after - before):.3f}s. "
-                                f"Agent-group synchronization is {'not ' if no_need_sync else ''}required.")
-                    if no_need_sync:
-                        self.agent_groups_control = {}
+                                f"Retrieved out-of-sync group information and global checksum from database.")
+                elif len(self.clients.keys()) == 0:
+                    logger.info("No clients connected. Skipping agent-groups obtaining task.")
             except Exception as e:
                 sync_object.logger.error(f"Error getting agent-groups from WDB: {e}")
 

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -1816,8 +1816,7 @@ async def test_agent_groups_update(sleep_mock):
                     master_class.agent_groups_control_workers = {'worker1'}
                     await master_class.agent_groups_update()
                 assert "Starting." in logger_mock._info
-                assert "Finished in 0.000s. " \
-                       "Retrieved out-of-sync group information and global checksum from database." in logger_mock._info
+                assert "Finished in 0.000s." in logger_mock._info
                 assert "Error getting agent-groups from WDB: Stop while true" in logger_mock._error
                 assert master_class.agent_groups_control_workers == set()
                 setup_task_logger_mock.assert_called_once_with('Agent-groups get')
@@ -1826,7 +1825,7 @@ async def test_agent_groups_update(sleep_mock):
                     logger_mock.counter = 0
                     master_class.clients = {}
                     await master_class.agent_groups_update()
-                assert "No clients connected. Skipping agent-groups obtaining task." in logger_mock._info
+                assert "No clients connected. Skipping." in logger_mock._info
 
 
 @pytest.mark.asyncio

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -225,6 +225,19 @@ def test_rgit_init(set_up_coro_mock, create_task_mock):
 
 
 @patch("asyncio.create_task")
+@patch("wazuh.core.cluster.master.SendEntireAgentGroupsTask.set_up_coro")
+def test_seagt_init(set_up_coro_mock, create_task_mock):
+    """Test the initialization of the SendEntireAgentGroupsTask object."""
+
+    receive_agent_groups_task = master.SendEntireAgentGroupsTask(wazuh_common=cluster_common.WazuhCommon(),
+                                                                 logger=logging.getLogger("wazuh"))
+
+    assert isinstance(receive_agent_groups_task.wazuh_common, cluster_common.WazuhCommon)
+    set_up_coro_mock.assert_called_once()
+    create_task_mock.assert_called_once()
+
+
+@patch("asyncio.create_task")
 def test_rait_set_up_coro(create_task_mock):
     """Check if the function is called when the worker sends its agent-info information."""
 
@@ -851,6 +864,21 @@ def test_master_handler_setup_sync_integrity(setup_receive_file_mock):
          call(master.ReceiveAgentInfoTask, b"data"), call(master.ReceiveAgentGroupsTask, b"data"), call(None, b"data")])
 
 
+@patch("wazuh.core.cluster.common.WazuhCommon.setup_send_info", return_value=b"ok")
+def test_master_handler_setup_send_info(setup_receive_file_mock):
+    """Check if the send process was correctly started."""
+
+    master_handler = get_master_handler()
+
+    # Test the first condition
+    assert master_handler.setup_send_info(b'syn_w_g_c') == b"ok"
+
+    # Test the second condition
+    assert master_handler.setup_send_info(b'NONE') == b"ok"
+
+    setup_receive_file_mock.assert_has_calls([call(master.SendEntireAgentGroupsTask), call(None)])
+
+
 @patch("wazuh.core.cluster.common.WazuhCommon.error_receiving_file", return_value=b"ok")
 def test_master_handler_process_sync_error_from_worker(error_receiving_file_mock):
     """Check if an error is properly managed when it takes place."""
@@ -893,6 +921,50 @@ async def test_master_handler_setup_sync_wazuh_db_information(sync_wazuh_db_info
         task_id=b'17', info_type='agent-info', error_command=b'syn_m_a_err',
         logger=master_handler.task_loggers['Agent-info sync'], command=b'syn_m_a_e',
         sync_dict=master_handler.sync_agent_info_status, timeout=0)
+
+
+@pytest.mark.asyncio
+@patch("wazuh.core.cluster.master.WazuhDBConnection")
+async def test_manager_handler_send_entire_agent_groups_information(WazuhDBConnection_mock):
+    """Check if the data chunks are being properly forward to the Wazuh-db socket."""
+
+    class LoggerMock:
+        """Auxiliary class."""
+
+        def __init__(self):
+            self._info = []
+            self._error = []
+
+        def info(self, data):
+            """Auxiliary method."""
+            self._info.append(data)
+
+    class SyncWazuhdbMock:
+        """Auxiliary class."""
+
+        def __init__(self, manager, logger, data_retriever, get_data_command='',
+                     get_payload='', set_data_command='', set_payload='', cmd=''):
+            self.counter = 0
+            self.logger = logger
+
+        async def retrieve_information(self):
+            """Auxiliary method."""
+            self.counter += 1
+            if self.counter >= 2:
+                raise Exception('Testing')
+            return ['[{"data":[]}]']
+
+        async def sync(self, start_time, chunks):
+            """Auxiliary method."""
+            return True
+
+    master_handler = get_master_handler()
+    logger = LoggerMock()
+    master_handler.task_loggers["Agent-groups full DB"] = logger
+    with patch('wazuh.core.cluster.master.c_common.SyncWazuhdb', SyncWazuhdbMock):
+        assert await master_handler.send_entire_agent_groups_information() == (b'ok', b'Sent')
+    assert 'Requested entire agent-groups information by the worker node. Starting.' in logger._info
+    assert 'Sent all agent-groups information from the master node database.' in logger._info
 
 
 @pytest.mark.asyncio
@@ -953,7 +1025,7 @@ async def test_manager_handler_send_agent_groups_information(WazuhDBConnection_m
             return start_time, chunks
 
     def get_agent_groups_info(self, name):
-        return {'something': 'name'}
+        return 'testing'
 
     master_handler = get_master_handler()
     master_handler.server.agent_groups_control = 'testing'
@@ -1679,7 +1751,7 @@ def test_get_agent_groups_info():
 
     assert master_class.get_agent_groups_info('worker2') == {'testing': 'agent_groups_control'}
     assert master_class.get_agent_groups_info('worker2') == dict()
-    assert master_class.agent_groups_control_workers == set()
+    assert master_class.agent_groups_control_workers == {'worker1', 'worker2'}
 
 
 @pytest.mark.asyncio
@@ -1699,13 +1771,15 @@ async def test_agent_groups_update(sleep_mock):
         def info(self, data):
             """Auxiliary method."""
             self._info.append(data)
+            self.counter += 1
+            if self.counter >= 5:
+                raise Exception('Stop while true')
 
         def error(self, data):
             """Auxiliary method."""
             self._error.append(data)
-            self.counter += 1
-            if self.counter >= 1:
-                raise Exception('Stop while true')
+            raise Exception('Stop while true')
+
 
     class WazuhDBConnectionMock:
         """Auxiliary class."""
@@ -1738,11 +1812,21 @@ async def test_agent_groups_update(sleep_mock):
         with patch('wazuh.core.cluster.master.WazuhDBConnection', WazuhDBConnectionMock):
             with patch('wazuh.core.cluster.master.c_common.SyncWazuhdb', SyncWazuhdbMock):
                 with pytest.raises(Exception, match='Stop while true'):
+                    master_class.clients = {'worker1': 'worker1'}
+                    master_class.agent_groups_control_workers = {'worker1'}
                     await master_class.agent_groups_update()
                 assert "Starting." in logger_mock._info
-                assert "Finished in 0.000s. Agent-group synchronization is not required." in logger_mock._info
-                assert "Error getting agent-groups from WDB: Testing" in logger_mock._error
+                assert "Finished in 0.000s. " \
+                       "Retrieved out-of-sync group information and global checksum from database." in logger_mock._info
+                assert "Error getting agent-groups from WDB: Stop while true" in logger_mock._error
+                assert master_class.agent_groups_control_workers == set()
                 setup_task_logger_mock.assert_called_once_with('Agent-groups get')
+
+                with pytest.raises(Exception, match='Stop while true'):
+                    logger_mock.counter = 0
+                    master_class.clients = {}
+                    await master_class.agent_groups_update()
+                assert "No clients connected. Skipping agent-groups obtaining task." in logger_mock._info
 
 
 @pytest.mark.asyncio

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -449,10 +449,10 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                     f'Checksum comparison failed. '
                     f'Attempt {self.agent_groups_checksum_mismatch_counter}/{self.agent_groups_checksum_mismatch_limit}.')
 
-        if self.agent_groups_checksum_mismatch_counter >= self.agent_groups_checksum_mismatch_limit:
-            await super().send_result_to_manager(b'syn_w_g_c', {})
-            self.agent_groups_checksum_mismatch_counter = 0
-            logger.info('Sent request to obtain all agent-groups information from the master node.')
+            if self.agent_groups_checksum_mismatch_counter >= self.agent_groups_checksum_mismatch_limit:
+                await super().send_result_to_manager(b'syn_w_g_c', {})
+                self.agent_groups_checksum_mismatch_counter = 0
+                logger.info('Sent request to obtain all agent-groups information from the master node.')
 
     async def recv_agent_groups_local_information(self, task_id: bytes, info_type: str):
         """Create a process to receive the master agent-groups information.

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -6,7 +6,7 @@ import errno
 import json
 import os
 import shutil
-from datetime import datetime
+from datetime import datetime, timezone
 from time import perf_counter
 from typing import Tuple, Dict, Callable, List
 from typing import Union
@@ -41,7 +41,7 @@ class ReceiveAgentGroupsTask(c_common.ReceiveStringTask):
 
     def set_up_coro(self) -> Callable:
         """Set up the function to be called when the worker sends its Agent groups."""
-        return self.wazuh_common.setup_sync_wazuh_db_information
+        return self.wazuh_common.recv_agent_groups_local_information
 
     def done_callback(self, future=None):
         """Check whether the synchronization process was correct and free its lock.
@@ -187,6 +187,8 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         self.agent_groups_sync_status = {'date_start': 0.0}
         self.integrity_check_status = {'date_start': 0.0}
         self.integrity_sync_status = {'date_start': 0.0}
+        self.agent_groups_checksum_mismatch_counter = 0
+        self.agent_groups_checksum_mismatch_limit = 10
 
     def connection_result(self, future_result):
         """Callback function called when the master sends a response to the hello command sent by the worker.
@@ -377,8 +379,83 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             f"Sync not required.")
         return b'ok', b'Thanks'
 
-    async def setup_sync_wazuh_db_information(self, task_id: bytes, info_type: str):
-        """Create a process to send to the local wazuh-db the chunks of data received from master.
+    async def compare_agent_groups_checksums(self, master_checksum, logger):
+        """Compare the checksum of the local database with the checksum of the master node to check if these differ.
+
+        If the checksum differs, a counter is incremented which at a certain limit
+        will send a request to the master node asking for all the agent-groups information.
+
+        Parameters
+        ----------
+        master_checksum : str
+            Master node checksum.
+        logger : Logger object
+            Logger to use.
+
+        Returns
+        -------
+        bool
+            True if both checksums are equal, False if these differ or cannot be
+            compared because there are records that need to be synchronized in the local DB.
+        """
+        wdb_conn = WazuhDBConnection()
+        sync_object = c_common.SyncWazuhdb(manager=self, logger=logger, cmd=b'syn_g_m_w',
+                                           data_retriever=wdb_conn.run_wdb_command,
+                                           get_data_command='global sync-agent-groups-get ',
+                                           get_payload={"condition": "sync_status", "get_global_hash": True})
+
+        local_agent_groups = await sync_object.retrieve_information()
+        if not json.loads(local_agent_groups[0])[0]['data']:
+            # There is no syncreq agent-groups so, the checksums should match
+            local_checksum = json.loads(local_agent_groups[0])[0]['hash']
+            logger.debug2('There is no data requiring synchronization in the local database.')
+            ck_equal = master_checksum == json.loads(local_agent_groups[0])[0]['hash']
+            # If there are no records with syncreq and the checksums are different, it means that the worker database
+            # is in an incorrect state. Therefore, all the information will be requested directly to the master node.
+            if not ck_equal:
+                logger.debug(f'The master\'s checksum and the worker\'s checksum are different. '
+                             f'Local checksum: {local_checksum} | Master checksum: {master_checksum}.')
+                self.agent_groups_checksum_mismatch_counter = self.agent_groups_checksum_mismatch_limit
+
+            return ck_equal
+
+        return False
+
+    async def check_agent_groups_checksums(self, data, logger):
+        """Checksum comparison limit controller function for agent-groups.
+
+        This function is in charge of requesting to the master node the information of
+        the database related to agent-groups if the limit of comparative checksums is exceeded.
+
+        Parameters
+        ----------
+        data : dict
+            Dictionary with the data obtained through the task_id.
+        logger : Logger object
+            Logger to use.
+        """
+        master_checksum = json.loads(data['chunks'][0])[0]['hash']
+        same_checksum = await self.compare_agent_groups_checksums(master_checksum=master_checksum, logger=logger)
+        if same_checksum:
+            msg = 'The checksum of both databases match.'
+            if self.agent_groups_checksum_mismatch_counter != 0:
+                msg += ' Reset the attempt counter.'
+            logger.debug(msg)
+            self.agent_groups_checksum_mismatch_counter = 0
+        else:
+            self.agent_groups_checksum_mismatch_counter += 1
+            if self.agent_groups_checksum_mismatch_counter <= self.agent_groups_checksum_mismatch_limit:
+                logger.debug(
+                    f'Checksum comparison failed. '
+                    f'Attempt {self.agent_groups_checksum_mismatch_counter}/{self.agent_groups_checksum_mismatch_limit}.')
+
+        if self.agent_groups_checksum_mismatch_counter >= self.agent_groups_checksum_mismatch_limit:
+            await super().send_result_to_manager(b'syn_w_g_c', {})
+            self.agent_groups_checksum_mismatch_counter = 0
+            logger.info('Sent request to obtain all agent-groups information from the master node.')
+
+    async def recv_agent_groups_local_information(self, task_id: bytes, info_type: str):
+        """Create a process to receive the master agent-groups information.
 
         Parameters
         ----------
@@ -392,20 +469,23 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         result : bytes
             Master's response after finishing the synchronization.
         """
-        # Guess information type
-        logger = ''
-        command = ''
-        error_command = ''
-        timeout = 0
-        if info_type == 'agent-groups':
-            logger = self.task_loggers['Agent-groups recv']
-            command = b'syn_w_g_e'
-            error_command = b'syn_w_g_err'
-            timeout = self.cluster_items['intervals']['worker']['timeout_agent_groups']
+        logger = self.task_loggers['Agent-groups recv']
+        command = b'syn_w_g_e'
+        error_command = b'syn_w_g_err'
+        timeout = self.cluster_items['intervals']['worker']['timeout_agent_groups']
 
-        return await super().sync_wazuh_db_information(
-            task_id=task_id, info_type=info_type, error_command=error_command,
-            logger=logger, command=command, timeout=timeout)
+        logger.info('Starting.')
+        start_time = datetime.utcnow().replace(tzinfo=timezone.utc)
+        data = await super().get_chunks_in_task_id(task_id, error_command)
+        result = await super().update_chunks_wdb(data, info_type, logger, error_command, timeout)
+        response = await super().send_result_to_manager(command, result)
+        await self.check_agent_groups_checksums(data, logger)
+
+        end_time = datetime.utcnow().replace(tzinfo=timezone.utc)
+        logger.info(f'Finished in {(end_time - start_time).total_seconds():.3f}s. '
+                    f'Updated {result["updated_chunks"]} chunks.')
+
+        return response
 
     async def sync_integrity(self):
         """Obtain files status and send it to the master.
@@ -496,7 +576,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             Object in charge of synchronization with the database.
         timer : dict
             Dictionary with initial task time.
-        sleep_interval
+        sleep_interval : int
             Waiting time set between iterations.
         """
         while True:
@@ -507,7 +587,11 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                         sync_object.logger.info("Starting.")
                         timer['date_start'] = start_time
                         chunks = await sync_object.retrieve_information()
-                        await sync_object.sync(start_time=start_time, chunks=chunks)
+                        if chunks != ['[]'] and chunks != ['[{"data":[]}]']:
+                            await sync_object.sync(start_time=start_time, chunks=chunks)
+                        else:
+                            sync_object.logger.debug('There is no agent information that needs '
+                                                     'to be synchronized in the local database. Skipping...')
             except Exception as e:
                 sync_object.logger.error(f"Error synchronizing agent information: {e}")
 


### PR DESCRIPTION
|Related issue|
|---|
|#11834|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR closes #11834. In this PR we have added the ability to rectify the database of the worker nodes. The worker nodes will be able to determine when their database is not valid.

Once the anomaly is detected they will send a request to the master node to send all the group information.

### Examples:
#### There is syncreq data in the worker side so the checksums can not be compared
```
2022/02/21 09:51:50 DEBUG: [Worker worker1] [Main] Command received: 'b'syn_g_m_w''
2022/02/21 09:51:50 INFO: [Worker worker1] [Agent-groups recv] Starting.
2022/02/21 09:51:50 DEBUG: [Worker worker1] [Agent-groups recv] 1/1 chunks updated in wazuh-db in 0.000635s.
2022/02/21 09:51:50 DEBUG: [Worker worker1] [Agent-groups recv] Obtained 1 chunks of data in 0.000s.
2022/02/21 09:51:50 DEBUG: [Worker worker1] [Agent-groups recv] Checksum comparison failed. Attempt 10/10
2022/02/21 09:51:50 INFO: [Worker worker1] [Agent-groups recv] Sent request to obtain all agent-groups information from the master node.
2022/02/21 09:51:50 INFO: [Worker worker1] [Agent-groups recv] Finished in 0.008s. Updated 1 chunks.
2022/02/21 09:51:50 DEBUG: [Worker worker1] [Main] Command received: 'b'new_str''
2022/02/21 09:51:50 DEBUG: [Worker worker1] [Main] Command received: 'b'str_upd''
2022/02/21 09:51:50 DEBUG: [Worker worker1] [Main] Command received: 'b'syn_g_m_w''
2022/02/21 09:51:50 INFO: [Worker worker1] [Agent-groups recv] Starting.
2022/02/21 09:51:50 DEBUG: [Worker worker1] [Agent-groups recv] 1/1 chunks updated in wazuh-db in 0.001716s.
2022/02/21 09:51:50 DEBUG: [Worker worker1] [Agent-groups recv] Obtained 1 chunks of data in 0.001s.
2022/02/21 09:51:50 DEBUG2: [Worker worker1] [Agent-groups recv] There is no data requiring synchronization in the local database.
2022/02/21 09:51:50 DEBUG: [Worker worker1] [Agent-groups recv] The checksum of both databases match. Reset the attempt counter.
2022/02/21 09:51:50 INFO: [Worker worker1] [Agent-groups recv] Finished in 0.007s. Updated 1 chunks.
2022/02/21 09:51:54 DEBUG: [Worker worker1] [Agent-info sync] Permission to synchronize granted.
```

#### There is no syncreq data and the checksums differs so the worker database is in an invalid state
```
2022/02/21 10:11:01 DEBUG: [Worker worker1] [Main] Command received: 'b'syn_g_m_w''
2022/02/21 10:11:01 INFO: [Worker worker1] [Agent-groups recv] Starting.
2022/02/21 10:11:01 DEBUG: [Worker worker1] [Agent-groups recv] 1/1 chunks updated in wazuh-db in 0.000533s.
2022/02/21 10:11:01 DEBUG: [Worker worker1] [Agent-groups recv] Obtained 1 chunks of data in 0.001s.
2022/02/21 10:11:01 DEBUG2: [Worker worker1] [Agent-groups recv] There is no data requiring synchronization in the local database.
2022/02/21 10:11:01 DEBUG: [Worker worker1] [Agent-groups recv] The master's checksum and the worker's checksum are different. Local checksum: 70b0ac6e901f9b20fb4a79f7ee03e981868d34ff | Master checksum: 7f3fafd37c63ee7e224dc8c099686f3777d22fc6
2022/02/21 10:11:01 INFO: [Worker worker1] [Agent-groups recv] Sent request to obtain all agent-groups information from the master node.
2022/02/21 10:11:01 INFO: [Worker worker1] [Agent-groups recv] Finished in 0.008s. Updated 1 chunks.
2022/02/21 10:11:01 DEBUG: [Worker worker1] [Main] Command received: 'b'new_str''
2022/02/21 10:11:01 DEBUG: [Worker worker1] [Main] Command received: 'b'str_upd''
2022/02/21 10:11:01 DEBUG: [Worker worker1] [Main] Command received: 'b'syn_g_m_w''
2022/02/21 10:11:01 INFO: [Worker worker1] [Agent-groups recv] Starting.
2022/02/21 10:11:01 DEBUG: [Worker worker1] [Agent-groups recv] 1/1 chunks updated in wazuh-db in 0.001402s.
2022/02/21 10:11:01 DEBUG: [Worker worker1] [Agent-groups recv] Obtained 1 chunks of data in 0.001s.
2022/02/21 10:11:01 DEBUG2: [Worker worker1] [Agent-groups recv] There is no data requiring synchronization in the local database.
2022/02/21 10:11:01 DEBUG: [Worker worker1] [Agent-groups recv] The checksum of both databases match.
2022/02/21 10:11:01 INFO: [Worker worker1] [Agent-groups recv] Finished in 0.009s. Updated 1 chunks.
```

#### Checksum cannot be compared 10 times in a row
```
2022/02/22 15:52:23 INFO: [Worker worker1] [Agent-groups recv] Starting.
2022/02/22 15:52:23 DEBUG: [Worker worker1] [Agent-groups recv] 1/1 chunks updated in wazuh-db in 0.000567s.
2022/02/22 15:52:23 DEBUG: [Worker worker1] [Agent-groups recv] Obtained 1 chunks of data in 0.001s.
2022/02/22 15:52:23 DEBUG: [Worker worker1] [Agent-groups recv] Checksum comparison failed. Attempt 9/10.
2022/02/22 15:52:23 INFO: [Worker worker1] [Agent-groups recv] Finished in 0.008s. Updated 1 chunks.
2022/02/22 15:52:33 DEBUG: [Worker worker1] [Main] Command received: 'b'syn_g_m_w''
2022/02/22 15:52:33 INFO: [Worker worker1] [Agent-groups recv] Starting.
2022/02/22 15:52:33 DEBUG: [Worker worker1] [Agent-groups recv] 1/1 chunks updated in wazuh-db in 0.000407s.
2022/02/22 15:52:33 DEBUG: [Worker worker1] [Agent-groups recv] Obtained 1 chunks of data in 0.000s.
2022/02/22 15:52:33 DEBUG: [Worker worker1] [Agent-groups recv] Checksum comparison failed. Attempt 10/10.
2022/02/22 15:52:33 INFO: [Worker worker1] [Agent-groups recv] Sent request to obtain all agent-groups information from the master node.
2022/02/22 15:52:33 INFO: [Worker worker1] [Agent-groups recv] Finished in 0.006s. Updated 1 chunks.
2022/02/22 15:52:33 DEBUG: [Worker worker1] [Main] Command received: 'b'new_str''
2022/02/22 15:52:33 DEBUG: [Worker worker1] [Main] Command received: 'b'str_upd''
2022/02/22 15:52:33 DEBUG: [Worker worker1] [Main] Command received: 'b'syn_g_m_w''
2022/02/22 15:52:33 INFO: [Worker worker1] [Agent-groups recv] Starting.
2022/02/22 15:52:33 DEBUG: [Worker worker1] [Agent-groups recv] 1/1 chunks updated in wazuh-db in 0.001656s.
2022/02/22 15:52:33 DEBUG: [Worker worker1] [Agent-groups recv] Obtained 1 chunks of data in 0.000s.
2022/02/22 15:52:33 DEBUG2: [Worker worker1] [Agent-groups recv] There is no data requiring synchronization in the local database.
2022/02/22 15:52:33 DEBUG: [Worker worker1] [Agent-groups recv] The checksum of both databases match.
2022/02/22 15:52:33 INFO: [Worker worker1] [Agent-groups recv] Finished in 0.006s. Updated 1 chunks.
```
