### PR TITLE
Fix warnings in wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c

### DIFF
--- a/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
+++ b/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
@@ -230,7 +230,7 @@ STATIC char * wm_agent_upgrade_com_open(const cJSON* json_object) {
     }
 
     if (file.fp = fopen(final_path, mode_obj->valuestring), file.fp) {
-        strncpy(file.path, final_path, PATH_MAX);
+        snprintf(file.path, PATH_MAX + 1, "%s", final_path);
         return wm_agent_upgrade_command_ack(ERROR_OK, error_messages[ERROR_OK]);
     } else {
         mterror(WM_AGENT_UPGRADE_LOGTAG, FOPEN_ERROR, file_path_obj->valuestring, errno, strerror(errno));

--- a/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
+++ b/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
@@ -230,7 +230,7 @@ STATIC char * wm_agent_upgrade_com_open(const cJSON* json_object) {
     }
 
     if (file.fp = fopen(final_path, mode_obj->valuestring), file.fp) {
-        snprintf(file.path, PATH_MAX + 1, "%s", final_path);
+        snprintf(file.path, sizeof(file.path), "%s", final_path);
         return wm_agent_upgrade_command_ack(ERROR_OK, error_messages[ERROR_OK]);
     } else {
         mterror(WM_AGENT_UPGRADE_LOGTAG, FOPEN_ERROR, file_path_obj->valuestring, errno, strerror(errno));


### PR DESCRIPTION
|Related issue|
|---|
|#12100|

## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh agent project in wm_agent_upgrade_com.c. . The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Agent</summary>

```

grep: /etc/redhat-release: No such file or directory
    CC client-agent/state.o
    CC client-agent/sendmsg.o
    CC client-agent/request.o
    CC client-agent/agentd.o
    CC client-agent/config.o
    CC client-agent/event-forward.o
    CC client-agent/rotate_log.o
    CC client-agent/receiver-win.o
    CC client-agent/main.o
    CC client-agent/restart_agent.o
    CC client-agent/receiver.o
    CC client-agent/buffer.o
    CC client-agent/start_agent.o
    CC client-agent/agcom.o
    CC client-agent/notify.o
    CC monitord/rotate_log.o
    CC monitord/compress_log.o
monitord/rotate_log.c: In function ‘w_rotate_log’:
monitord/rotate_log.c:211:42: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  211 |             snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                          ^~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from monitord/rotate_log.c:10:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 2 and 4352 bytes into a destination of size 4096
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
monitord/rotate_log.c:244:38: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  244 |         snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                      ^~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from monitord/rotate_log.c:10:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 2 and 4352 bytes into a destination of size 4096
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
monitord/rotate_log.c:244:38: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  244 |         snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                      ^~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from monitord/rotate_log.c:10:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 2 and 4352 bytes into a destination of size 4096
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
monitord/rotate_log.c:288:46: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  288 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                              ^~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from monitord/rotate_log.c:10:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 2 and 4352 bytes into a destination of size 4096
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
monitord/rotate_log.c:298:46: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  298 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                              ^~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from monitord/rotate_log.c:10:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 2 and 4352 bytes into a destination of size 4096
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
monitord/rotate_log.c:308:46: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  308 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                              ^~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from monitord/rotate_log.c:10:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 2 and 4352 bytes into a destination of size 4096
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
monitord/rotate_log.c:318:46: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  318 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                              ^~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from monitord/rotate_log.c:10:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 2 and 4352 bytes into a destination of size 4096
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC config/wmodules-aws.o
    CC config/localfile-config.o
    CC config/rootcheck-config.o
    CC config/remote-config.o
    CC config/active-response.o
    CC config/wmodules-osquery-monitor.o
    CC config/integrator-config.o
    CC config/wmodules-agent-upgrade.o
    CC config/socket-config.o
    CC config/reports-config.o
    CC config/alerts-config.o
    CC config/agentlessd-config.o
    CC config/wmodules_syscollector.o
    CC config/wmodules-oscap.o
    CC config/config.o
    CC config/wmodules-github.o
    CC config/wmodules-docker.o
    CC config/syscheck-config.o
    CC config/global-config.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from config/syscheck-config.c:11:
In function ‘strncpy’,
    inlined from ‘read_data_unit’ at config/syscheck-config.c:1261:13:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
config/syscheck-config.c: In function ‘read_data_unit’:
config/syscheck-config.c:1251:28: note: length computed here
 1251 |     size_t len_value_str = strlen(content);
      |                            ^~~~~~~~~~~~~~~
    CC config/client-config.o
    CC config/labels-config.o
    CC config/email-alerts-config.o
    CC config/wmodules-sca.o
    CC config/wmodules-fluent.o
    CC config/wmodules-office365.o
    CC config/cluster-config.o
    CC config/rules-config.o
    CC config/dbd-config.o
    CC config/wmodules-key-request.o
    CC config/wmodules-vuln-detector.o
    CC config/wmodules-azure.o
    CC config/authd-config.o
    CC config/wmodules-task-manager.o
    CC config/buffer-config.o
    CC config/wmodules-command.o
    CC config/csyslogd-config.o
    CC config/wmodules-ciscat.o
    CC config/wmodules-gcp.o
    CC config/logtest-config.o
    CC config/wmodules-config.o
    CC wazuh_modules/wm_control.o
    CC wazuh_modules/wmcom.o
    CC wazuh_modules/wm_oscap.o
    CC wazuh_modules/wm_gcp.o
    CC wazuh_modules/wmodules.o
    CC wazuh_modules/wm_azure.o
    CC wazuh_modules/wm_office365.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from wazuh_modules/wmodules.h:15,
                 from wazuh_modules/wm_office365.c:23:
In function ‘strncpy’,
    inlined from ‘wm_office365_execute_scan’ at wazuh_modules/wm_office365.c:432:33:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin___strncpy_chk’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
wazuh_modules/wm_office365.c: In function ‘wm_office365_execute_scan’:
wazuh_modules/wm_office365.c:432:33: note: length computed here
  432 |                                 strncpy(url, next_page, strlen(next_page));
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_modules/wm_exec.o
    CC wazuh_modules/wm_osquery_monitor.o
    CC wazuh_modules/wm_task_general.o
    CC wazuh_modules/wm_aws.o
    CC wazuh_modules/wm_syscollector.o
    CC wazuh_modules/wm_keyrequest.o
    CC wazuh_modules/wm_github.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from wazuh_modules/wmodules.h:15,
                 from wazuh_modules/wm_github.c:23:
In function ‘strncpy’,
    inlined from ‘wm_github_execute_scan’ at wazuh_modules/wm_github.c:308:33:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin___strncpy_chk’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
wazuh_modules/wm_github.c: In function ‘wm_github_execute_scan’:
wazuh_modules/wm_github.c:308:33: note: length computed here
  308 |                                 strncpy(url, next_page, strlen(next_page));
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_modules/wm_database.o
    CC wazuh_modules/wm_download.o
    CC wazuh_modules/wm_docker.o
    CC wazuh_modules/wm_sca.o
    CC wazuh_modules/wm_fluent.o
    CC wazuh_modules/wm_command.o
    CC wazuh_modules/wm_ciscat.o
    CC wazuh_modules/agent_upgrade/wm_agent_upgrade.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.o
    CC wazuh_db/wdb_metadata.o

```

</details>

## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Agent</summary>

```

grep: /etc/redhat-release: No such file or directory
    CC client-agent/agcom.o
    CC client-agent/agentd.o
    CC client-agent/buffer.o
    CC client-agent/config.o
    CC client-agent/event-forward.o
    CC client-agent/main.o
    CC client-agent/notify.o
    CC client-agent/receiver.o
    CC client-agent/receiver-win.o
    CC client-agent/request.o
    CC client-agent/restart_agent.o
    CC client-agent/rotate_log.o
    CC client-agent/sendmsg.o
    CC client-agent/start_agent.o
    CC client-agent/state.o
    CC monitord/rotate_log.o
    CC monitord/compress_log.o
    CC config/active-response.o
    CC config/agentlessd-config.o
    CC config/alerts-config.o
monitord/rotate_log.c: In function ‘w_rotate_log’:
monitord/rotate_log.c:211:42: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  211 |             snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                          ^~
monitord/rotate_log.c:211:13: note: ‘snprintf’ output between 2 and 4352 bytes into a destination of size 4096
  211 |             snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
monitord/rotate_log.c:244:38: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  244 |         snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                      ^~
monitord/rotate_log.c:244:9: note: ‘snprintf’ output between 2 and 4352 bytes into a destination of size 4096
  244 |         snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
monitord/rotate_log.c:244:38: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  244 |         snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                      ^~
monitord/rotate_log.c:244:9: note: ‘snprintf’ output between 2 and 4352 bytes into a destination of size 4096
  244 |         snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
monitord/rotate_log.c:288:46: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  288 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                              ^~
monitord/rotate_log.c:288:17: note: ‘snprintf’ output between 2 and 4352 bytes into a destination of size 4096
  288 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
monitord/rotate_log.c:298:46: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  298 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                              ^~
monitord/rotate_log.c:298:17: note: ‘snprintf’ output between 2 and 4352 bytes into a destination of size 4096
  298 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
monitord/rotate_log.c:308:46: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  308 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                              ^~
monitord/rotate_log.c:308:17: note: ‘snprintf’ output between 2 and 4352 bytes into a destination of size 4096
  308 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
monitord/rotate_log.c:318:46: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  318 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                              ^~
monitord/rotate_log.c:318:17: note: ‘snprintf’ output between 2 and 4352 bytes into a destination of size 4096
  318 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC config/authd-config.o
    CC config/buffer-config.o
    CC config/client-config.o
    CC config/cluster-config.o
    CC config/config.o
    CC config/csyslogd-config.o
    CC config/dbd-config.o
    CC config/email-alerts-config.o
    CC config/global-config.o
    CC config/integrator-config.o
    CC config/labels-config.o
    CC config/localfile-config.o
    CC config/logtest-config.o
    CC config/remote-config.o
    CC config/reports-config.o
    CC config/rootcheck-config.o
    CC config/rules-config.o
    CC config/socket-config.o
    CC config/syscheck-config.o
    CC config/wmodules-agent-upgrade.o
    CC config/wmodules-aws.o
    CC config/wmodules-azure.o
    CC config/wmodules-ciscat.o
config/syscheck-config.c: In function ‘read_data_unit’:
config/syscheck-config.c:1261:13: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
 1261 |             strncpy(value_str, content, len_value_str - 2);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
config/syscheck-config.c:1251:28: note: length computed here
 1251 |     size_t len_value_str = strlen(content);
      |                            ^~~~~~~~~~~~~~~
    CC config/wmodules-command.o
    CC config/wmodules-config.o
    CC config/wmodules-docker.o
    CC config/wmodules-fluent.o
    CC config/wmodules-gcp.o
    CC config/wmodules-github.o
    CC config/wmodules-key-request.o
    CC config/wmodules-office365.o
    CC config/wmodules-oscap.o
    CC config/wmodules-osquery-monitor.o
    CC config/wmodules-sca.o
    CC config/wmodules_syscollector.o
    CC config/wmodules-task-manager.o
    CC config/wmodules-vuln-detector.o
    CC wazuh_modules/wm_aws.o
    CC wazuh_modules/wm_azure.o
    CC wazuh_modules/wm_ciscat.o
    CC wazuh_modules/wmcom.o
    CC wazuh_modules/wm_command.o
    CC wazuh_modules/wm_control.o
    CC wazuh_modules/wm_database.o
    CC wazuh_modules/wm_docker.o
    CC wazuh_modules/wm_download.o
    CC wazuh_modules/wm_exec.o
    CC wazuh_modules/wm_fluent.o
wazuh_modules/wm_exec.c: In function ‘wm_exec’:
wazuh_modules/wm_exec.c:334:58: warning: ‘%s’ directive output may be truncated writing up to 6143 bytes into a region of size 6142 [-Wformat-truncation=]
  334 |                 snprintf(new_path, OS_SIZE_6144 - 1, "%s:%s", add_path, env_path);
      |                                                          ^~
wazuh_modules/wm_exec.c:334:17: note: ‘snprintf’ output 2 or more bytes (assuming 6145) into a destination of size 6143
  334 |                 snprintf(new_path, OS_SIZE_6144 - 1, "%s:%s", add_path, env_path);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_modules/wm_gcp.o
    CC wazuh_modules/wm_github.o
    CC wazuh_modules/wm_keyrequest.o
wazuh_modules/wm_github.c: In function ‘wm_github_execute_scan’:
wazuh_modules/wm_github.c:308:33: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  308 |                                 strncpy(url, next_page, strlen(next_page));
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_modules/wmodules.o
    CC wazuh_modules/wm_office365.o
    CC wazuh_modules/wm_oscap.o
    CC wazuh_modules/wm_osquery_monitor.o
    CC wazuh_modules/wm_sca.o
wazuh_modules/wm_office365.c: In function ‘wm_office365_execute_scan’:
wazuh_modules/wm_office365.c:432:33: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  432 |                                 strncpy(url, next_page, strlen(next_page));
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_modules/wm_syscollector.o
    CC wazuh_modules/wm_task_general.o
    CC wazuh_modules/agent_upgrade/wm_agent_upgrade.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.o

```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors