### PR TITLE
Fix for rolling OS versions on WPK upgrade

### DIFF
--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
@@ -260,6 +260,32 @@ void test_wm_agent_upgrade_validate_system_invalid_arch(void **state)
     assert_int_equal(ret, WM_UPGRADE_GLOBAL_DB_FAILURE);
 }
 
+void test_wm_agent_upgrade_validate_system_rolling_opensuse(void **state)
+{
+    (void) state;
+    char *platform = "opensuse-tumbleweed";
+    char *os_major = "";
+    char *os_minor = "";
+    char *arch = "x64";
+
+    int ret = wm_agent_upgrade_validate_system(platform, os_major, os_minor, arch);
+
+    assert_int_equal(ret, WM_UPGRADE_SUCCESS);
+}
+
+void test_wm_agent_upgrade_validate_system_rolling_archlinux(void **state)
+{
+    (void) state;
+    char *platform = "arch";
+    char *os_major = "";
+    char *os_minor = "";
+    char *arch = "x64";
+
+    int ret = wm_agent_upgrade_validate_system(platform, os_major, os_minor, arch);
+
+    assert_int_equal(ret, WM_UPGRADE_SUCCESS);
+}
+
 void test_wm_agent_upgrade_compare_versions_equal_patch(void **state)
 {
     (void) state;
@@ -1295,6 +1321,8 @@ int main(void) {
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_invalid_platform_rhel),
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_invalid_platform_centos),
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_invalid_arch),
+        cmocka_unit_test(test_wm_agent_upgrade_validate_system_rolling_opensuse),
+        cmocka_unit_test(test_wm_agent_upgrade_validate_system_rolling_archlinux),
         // wm_agent_upgrade_compare_versions
         cmocka_unit_test(test_wm_agent_upgrade_compare_versions_equal_patch),
         cmocka_unit_test(test_wm_agent_upgrade_compare_versions_equal_minor),

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
@@ -29,6 +29,11 @@ static const char* invalid_platforms[] = {
     "bsd"
 };
 
+static const char* rolling_platforms[] = {
+    "opensuse-tumbleweed",
+    "arch"
+};
+
 int wm_agent_upgrade_validate_id(int agent_id) {
     int return_code = WM_UPGRADE_SUCCESS;
 
@@ -51,16 +56,18 @@ int wm_agent_upgrade_validate_status(const char* connection_status) {
 
 int wm_agent_upgrade_validate_system(const char *platform, const char *os_major, const char *os_minor, const char *arch) {
     int invalid_platforms_len = 0;
-    int invalid_platforms_it = 0;
+    int rolling_platforms_len = 0;
+    int platforms_it = 0;
     int return_code = WM_UPGRADE_GLOBAL_DB_FAILURE;
 
     if (platform) {
         if (!strcmp(platform, "windows") || (os_major && arch && (strcmp(platform, "ubuntu") || os_minor))) {
             return_code = WM_UPGRADE_SUCCESS;
-            invalid_platforms_len = sizeof(invalid_platforms) / sizeof(invalid_platforms[0]);
 
-            for(invalid_platforms_it = 0; invalid_platforms_it < invalid_platforms_len; ++invalid_platforms_it) {
-                if(!strcmp(invalid_platforms[invalid_platforms_it], platform)) {
+            // Blacklist for invalid OS platforms
+            invalid_platforms_len = sizeof(invalid_platforms) / sizeof(invalid_platforms[0]);
+            for(platforms_it = 0; platforms_it < invalid_platforms_len; ++platforms_it) {
+                if(!strcmp(invalid_platforms[platforms_it], platform)) {
                     return_code = WM_UPGRADE_SYSTEM_NOT_SUPPORTED;
                     break;
                 }
@@ -72,6 +79,15 @@ int wm_agent_upgrade_validate_system(const char *platform, const char *os_major,
                     (!strcmp(platform, "centos") && !strcmp(os_major, "5"))) {
                     return_code = WM_UPGRADE_SYSTEM_NOT_SUPPORTED;
                 }
+            }
+        }
+
+        // Whitelist for OS platforms with 'rolling' version
+        rolling_platforms_len = sizeof(rolling_platforms) / sizeof(rolling_platforms[0]);
+        for(platforms_it = 0; platforms_it < rolling_platforms_len; ++platforms_it) {
+            if(!strcmp(rolling_platforms[platforms_it], platform)) {
+                return_code = WM_UPGRADE_SUCCESS;
+                break;
             }
         }
     }

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
@@ -65,7 +65,7 @@ int wm_agent_upgrade_validate_system(const char *platform, const char *os_major,
             return_code = WM_UPGRADE_SUCCESS;
 
             // Blacklist for invalid OS platforms
-            invalid_platforms_len = sizeof(invalid_platforms) / sizeof(invalid_platforms[0]);
+            invalid_platforms_len = array_size(invalid_platforms);
             for(platforms_it = 0; platforms_it < invalid_platforms_len; ++platforms_it) {
                 if(!strcmp(invalid_platforms[platforms_it], platform)) {
                     return_code = WM_UPGRADE_SYSTEM_NOT_SUPPORTED;
@@ -83,7 +83,7 @@ int wm_agent_upgrade_validate_system(const char *platform, const char *os_major,
         }
 
         // Whitelist for OS platforms with 'rolling' version
-        rolling_platforms_len = sizeof(rolling_platforms) / sizeof(rolling_platforms[0]);
+        rolling_platforms_len = array_size(rolling_platforms);
         for(platforms_it = 0; platforms_it < rolling_platforms_len; ++platforms_it) {
             if(!strcmp(rolling_platforms[platforms_it], platform)) {
                 return_code = WM_UPGRADE_SUCCESS;


### PR DESCRIPTION
|Related issue|
|---|
|Closes #12301|


## Description

After the changes made in https://github.com/wazuh/wazuh/pull/11207 to correctly display the `OS name` and `version`, _`NULL`_ was assigned to the version of the OS that was type `rolling`, causing the failure when trying to obtain it in the following condition:
https://github.com/wazuh/wazuh/blob/700b0c9bcff6346f1afb4ca86eb304868ea43e61/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c#L58

To fix this problem, a whitelist with OSs with a `rolling` version, such as **_openSUSE tumbleweed_** and **_Arch Linux_**, has been added so that it no longer causes any failure when trying to upgrade the agent via WPK.

## Logs/Alerts example

```
# /var/ossec/bin/agent_upgrade -a 003 -f wazuh_agent_v4.3.0_linux_x86_64.wpk -x upgrade.sh

Upgrading...

Upgraded agents:
	Agent 003 upgraded: Wazuh v4.3.0 -> Wazuh v4.3.0
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
<!--
- [ ] QA templates contemplate the added capabilities
-->

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for `wm_agent_upgrade_validate_system`)
 - `100% tests passed, 0 tests failed out of 138` and 100% coverage
- [ ] Stress test for affected components

---
# TEST: openSUSE Tumbleweed

## From Wazuh-Agent v4.3 (same version)
### :green_circle: UPGRADE FAIL  

- [x] The wazuh home backup is restored correctly (no traces of the installation, but only the `.tar.gz` backup and the logs).
- [x] The permissions and owners of the following directories did NOT change:
      - `/`
      - `/var`
      - `/usr`, `/usr/lib/`, `/usr/lib/systemd/`, `/usr/lib/systemd/system/`
      - `/etc`, `/etc/systemd/`, `/etc/systemd/system/`, `/etc/rc.d`, `/etc/initd.d/`, `/etc/initd.d/rc.d/`
- [x] ~Wazuh service runs wazuh-control (`systemctl cat wazuh-agent.service`)~
- [x] Wazuh service runs ossec-control (`systemctl cat wazuh-agent.service`)
- [x] The service was enabled (`systemctl is-enabled wazuh-agent.service`)
- [x] ~Init file runs wazuh-control (`cat /etc/rc.d/init.d/wazuh-agent`)~
- [x] Init file runs ossec-control (`cat /etc/rc.d/init.d/wazuh-agent`)
- [x] ~Wazuh as service is enabled `chkconfig --list`~ 
- [x] Wazuh starts and connects when the backup is restored (`cat /var/ossec/var/run/ossec-agentd.state`)
- [x] Wazuh starts and connects automatically when the system is rebooted.
- [x] Restore SELinux policies (`semodule -l | grep -i wazuh`) (DISABLED)

### :green_circle: UPGRADE OK

- [x] Upgrade is performed successfully (agent connects to the manager after upgrading)
- [x] Service starts automatically after rebooting
- [x] Agent connects to the manager after rebooting

[Download report 4.3](https://github.com/wazuh/wazuh/files/8118461/4.3.zip)

