### PR TITLE
Fix unnecessary DB queries for AWS

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -617,12 +617,7 @@ class AWSBucket(WazuhIntegration):
         raise NotImplementedError
 
     def mark_complete(self, aws_account_id, aws_region, log_file):
-        if self.reparse:
-            if self.already_processed(log_file['Key'], aws_account_id, aws_region):
-                debug(
-                    '+++ File already marked complete, but reparse flag set: {log_key}'.format(log_key=log_file['Key']),
-                    2)
-        else:
+        if not self.reparse:
             try:
                 self.db_connector.execute(self.sql_mark_complete.format(
                     bucket_path=self.bucket_path,
@@ -962,6 +957,8 @@ class AWSBucket(WazuhIntegration):
     def iter_files_in_bucket(self, aws_account_id=None, aws_region=None):
         try:
             bucket_files = self.client.list_objects_v2(**self.build_s3_filter_args(aws_account_id, aws_region))
+            if self.reparse:
+                debug('++ Reparse mode on', 2)
 
             while True:
                 if 'Contents' not in bucket_files:


### PR DESCRIPTION
| Related issue |
|---|
|Closes #11561 |

## Description

In this PR we have removed unnecessary database queries from the AWS integration. 

We decided not to check every file collected in the database when reparse option is up. We have also added a debug message that indicates the reparse mode. 

## Tests performed

Here are some examples where we can see that the `File previously processed` message does not appear. Now the message `Reparse mode on` is shown. 

### CLB

<details><summary>Output with CLB using reparse option</summary>

	root@wazuh-master:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-clb -t clb -s 2021-NOV-09 --reparse -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on 166157441623 - us-west-1
	DEBUG: +++ Marker: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/11/09
	DEBUG: ++ Reparse mode on
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/11/09/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211109T1735Z_18.144.142.112_2helnha7.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/11/10/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211110T1735Z_18.144.142.112_2helnha7.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/11/11/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211111T1735Z_18.144.142.112_2helnha7.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/11/12/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211112T1735Z_18.144.142.112_2helnha7.log
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/12/23/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211223T1735Z_18.144.142.112_2helnha7.log
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>


### Cloudtrail

<details><summary>Output with Cloudtrail using reparse option</summary>

	root@wazuh-master:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -s 2021-NOV-21 --reparse -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on 166157441623 - us-west-1
	DEBUG: +++ Marker: AWSLogs/166157441623/CloudTrail/us-west-1/2021/11/21
	DEBUG: ++ Reparse mode on
	DEBUG: ++ Found new log: AWSLogs/166157441623/CloudTrail/us-west-1/2021/11/21/166157441623_CloudTrail_us-west-1_20211121T0000Z_rUQtGNUqmrPZMCnu.json.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/CloudTrail/us-west-1/2021/11/22/166157441623_CloudTrail_us-west-1_20211122T0000Z_rUQtGNUqmrPZMCnu.json.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/CloudTrail/us-west-1/2021/11/23/166157441623_CloudTrail_us-west-1_20211123T0000Z_rUQtGNUqmrPZMCnu.json.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/CloudTrail/us-west-1/2021/12/01/166157441623_CloudTrail_us-west-1_20211201T0000Z_VZJxNKcpNdyJysGy.json.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/CloudTrail/us-west-1/2021/12/01/166157441623_CloudTrail_us-west-1_20211201T0000Z_ZKdiPZvOQPGUJMUh.json.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/CloudTrail/us-west-1/2021/12/01/166157441623_CloudTrail_us-west-1_20211201T0000Z_ZsQHQAHDMsYfvPHx.json.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/CloudTrail/us-west-1/2021/12/01/166157441623_CloudTrail_us-west-1_20211201T0000Z_wcnIRHvPJuYpSXZr.json.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/CloudTrail/us-west-1/2021/12/23/166157441623_CloudTrail_us-west-1_20211223T0000Z_HASDOtJxgfdNInHa.json.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/CloudTrail/us-west-1/2022/01/25/166157441623_CloudTrail_us-west-1_20220125T0000Z_HASDOtJxgfdNInHa.json.gz
	DEBUG: ++ Found new log: AWSLogs/166157441623/CloudTrail/us-west-1/2022/02/11/166157441623_CloudTrail_us-west-1_20220211T0000Z_HASDOtJxgfdNInHa.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Working on 166157449999 - us-west-1
	DEBUG: +++ Marker: AWSLogs/166157449999/CloudTrail/us-west-1/2021/11/21
	DEBUG: ++ Reparse mode on
	DEBUG: ++ Found new log: AWSLogs/166157449999/CloudTrail/us-west-1/2021/12/23/166157441623_CloudTrail_us-west-1_20211223T0000Z_HASDOtJxgfdNInHa.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance
</details>


## Conclusions

Everything worked as expected