### PR TITLE
Fix warnings in read_djb_multilog.c file

### DIFF
--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -46,23 +46,24 @@
 #define LOGLEVEL_INFO 1
 #define LOGLEVEL_DEBUG 0
 
-#define OS_MAXSTR       OS_SIZE_65536       /* Size for logs, sockets, etc      */
-#define OS_BUFFER_SIZE  OS_SIZE_2048        /* Size of general buffers          */
-#define OS_FLSIZE       OS_SIZE_256         /* Maximum file size                */
-#define OS_HEADER_SIZE  OS_SIZE_128         /* Maximum header size              */
-#define OS_LOG_HEADER   OS_SIZE_256         /* Maximum log header size          */
-#define OS_SK_HEADER    OS_SIZE_6144        /* Maximum syscheck header size     */
-#define IPSIZE          INET6_ADDRSTRLEN    /* IP Address size                  */
-#define AUTH_POOL       1000                /* Max number of connections        */
-#define BACKLOG         128                 /* Socket input queue length        */
-#define MAX_EVENTS      1024                /* Max number of epoll events       */
-#define EPOLL_MILLIS    -1                  /* Epoll wait time                  */
-#define MAX_TAG_COUNTER 256                 /* Max retrying counter             */
-#define SOCK_RECV_TIME0 300                 /* Socket receiving timeout (s)     */
-#define MIN_ORDER_SIZE  32                  /* Minimum size of orders array     */
-#define KEEPALIVE_SIZE  700                 /* Random keepalive string size     */
-#define MAX_DYN_STR     4194304             /* Max message size received 4MiB   */
-#define DATE_LENGTH     64                  /* Format date time %D %T           */
+#define OS_MAXSTR       OS_SIZE_65536               /* Size for logs, sockets, etc      */
+#define OS_BUFFER_SIZE  OS_SIZE_2048                /* Size of general buffers          */
+#define OS_FLSIZE       OS_SIZE_256                 /* Maximum file size                */
+#define OS_HEADER_SIZE  OS_SIZE_128                 /* Maximum header size              */
+#define OS_LOG_HEADER   OS_SIZE_256                 /* Maximum log header size          */
+#define OS_SK_HEADER    OS_SIZE_6144                /* Maximum syscheck header size     */
+#define IPSIZE          INET6_ADDRSTRLEN            /* IP Address size                  */
+#define AUTH_POOL       1000                        /* Max number of connections        */
+#define BACKLOG         128                         /* Socket input queue length        */
+#define MAX_EVENTS      1024                        /* Max number of epoll events       */
+#define EPOLL_MILLIS    -1                          /* Epoll wait time                  */
+#define MAX_TAG_COUNTER 256                         /* Max retrying counter             */
+#define SOCK_RECV_TIME0 300                         /* Socket receiving timeout (s)     */
+#define MIN_ORDER_SIZE  32                          /* Minimum size of orders array     */
+#define KEEPALIVE_SIZE  700                         /* Random keepalive string size     */
+#define MAX_DYN_STR     4194304                     /* Max message size received 4MiB   */
+#define DATE_LENGTH     64                          /* Format date time %D %T           */
+#define OS_MAX_LOG_SIZE OS_MAXSTR - OS_LOG_HEADER   /* Maximum log size with a header protection */
 
 /* Some global names */
 #define __ossec_name    "Wazuh"

--- a/src/logcollector/read_djb_multilog.c
+++ b/src/logcollector/read_djb_multilog.c
@@ -145,7 +145,7 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
                     (p[12] == ':') &&
                     (p[15] == ' ')) {
                 p += 16;
-                snprintf(buffer, OS_MAXSTR - OS_LOG_HEADER, "%s", p);
+                snprintf(buffer, sizeof(buffer), "%s", p);
             } else {
                 /* We will add a proper syslog header */
                 time_t djbtime;
@@ -155,7 +155,7 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
                 localtime_r(&djbtime, &tm_result);
 
                 /* Syslog time: Apr 27 14:50:32  */
-                int size = snprintf(buffer, OS_MAXSTR - OS_LOG_HEADER, "%s %02d %02d:%02d:%02d %s %s: %s",
+                int size = snprintf(buffer, sizeof(buffer), "%s %02d %02d:%02d:%02d %s %s: %s",
                          djb_month[tm_result.tm_mon],
                          tm_result.tm_mday,
                          tm_result.tm_hour,
@@ -167,7 +167,7 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
 
 
                 if (size + 1 > OS_MAXSTR - OS_LOG_HEADER) {
-                    merror("Large message size from file '%s' (length = " FTELL_TT "): '%s'...", lf->file, FTELL_INT64 size, buffer);
+                    merror("Message size too big on file '%s' (length = " FTELL_TT "): '%s'...", lf->file, FTELL_INT64 size, buffer);
                 }
             }
         }

--- a/src/logcollector/read_djb_multilog.c
+++ b/src/logcollector/read_djb_multilog.c
@@ -166,7 +166,7 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
                          p);
 
 
-                if (size + 1 > OS_MAXSTR - OS_LOG_HEADER) {
+                if (size + 1 > (int)sizeof(buffer)) {
                     merror("Message size too big on file '%s' (length = " FTELL_TT "): '%s'...", lf->file, FTELL_INT64 size, buffer);
                 }
             }

--- a/src/logcollector/read_djb_multilog.c
+++ b/src/logcollector/read_djb_multilog.c
@@ -166,8 +166,7 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
 
                 if (size < 0) {
                     merror("Error %d (%s) while reading message: '%s' (length = " FTELL_TT "): '%s'...", errno, strerror(errno), lf->file, FTELL_INT64 size, buffer);
-                }
-                else if ((size_t)size >= sizeof(buffer)) {
+                } else if ((size_t)size >= sizeof(buffer)) {
                     merror("Message size too big on file '%s' (length = " FTELL_TT "): '%s'...", lf->file, FTELL_INT64 size, buffer);
                 }
             }

--- a/src/logcollector/read_djb_multilog.c
+++ b/src/logcollector/read_djb_multilog.c
@@ -81,10 +81,10 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
     size_t str_len = 0;
     int need_clear = 0;
     char *p;
-    char str[OS_MAXSTR - OS_LOG_HEADER];
-    char buffer[OS_MAXSTR - OS_LOG_HEADER];
+    char str[OS_MAX_LOG_SIZE];
+    char buffer[OS_MAX_LOG_SIZE];
     int lines = 0;
-    str[OS_MAXSTR - OS_LOG_HEADER -1] = '\0';
+    str[OS_MAX_LOG_SIZE -1] = '\0';
     *rc = 0;
 
     /* Must have a valid program name */
@@ -98,7 +98,7 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     /* Get new entry */
-    while (can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
+    while (can_read() && fgets(str, OS_MAX_LOG_SIZE, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
 
         if (is_valid_context_file) {
             OS_SHA1_Stream(&context, NULL, str);

--- a/src/logcollector/read_djb_multilog.c
+++ b/src/logcollector/read_djb_multilog.c
@@ -81,10 +81,9 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
     size_t str_len = 0;
     int need_clear = 0;
     char *p;
-    char str[OS_MAX_LOG_SIZE];
-    char buffer[OS_MAX_LOG_SIZE];
+    char str[OS_MAX_LOG_SIZE] = {0};
+    char buffer[OS_MAX_LOG_SIZE] = {0};
     int lines = 0;
-    str[OS_MAX_LOG_SIZE -1] = '\0';
     *rc = 0;
 
     /* Must have a valid program name */

--- a/src/logcollector/read_djb_multilog.c
+++ b/src/logcollector/read_djb_multilog.c
@@ -154,7 +154,7 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
                 localtime_r(&djbtime, &tm_result);
 
                 /* Syslog time: Apr 27 14:50:32  */
-                int size = snprintf(buffer, sizeof(buffer), "%s %02d %02d:%02d:%02d %s %s: %s",
+                const int size = snprintf(buffer, sizeof(buffer), "%s %02d %02d:%02d:%02d %s %s: %s",
                          djb_month[tm_result.tm_mon],
                          tm_result.tm_mday,
                          tm_result.tm_hour,
@@ -164,8 +164,10 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
                          lf->djb_program_name,
                          p);
 
-
-                if (size + 1 > (int)sizeof(buffer)) {
+                if (size < 0) {
+                    merror("Error %d (%s) while reading message: '%s' (length = " FTELL_TT "): '%s'...", errno, strerror(errno), lf->file, FTELL_INT64 size, buffer);
+                }
+                else if ((size_t)size >= sizeof(buffer)) {
                     merror("Message size too big on file '%s' (length = " FTELL_TT "): '%s'...", lf->file, FTELL_INT64 size, buffer);
                 }
             }


### PR DESCRIPTION
|Related issue|
|---|
|#12100|

## Description

This PR aims to resolve the warnings when compiling the Wazuh agent project in ead_djb_multilog.c. The output of the compilation after the changes was:


## Compilation using GCC 9.3

<details>
<summary>Wazuh Agent</summary>

```

grep: /etc/redhat-release: No such file or directory
    CC client-agent/state.o
    CC client-agent/sendmsg.o
    CC client-agent/request.o
    CC client-agent/agentd.o
    CC client-agent/config.o
    CC client-agent/event-forward.o
    CC client-agent/rotate_log.o
    CC client-agent/receiver-win.o
    CC client-agent/main.o
    CC client-agent/restart_agent.o
    CC client-agent/receiver.o
    CC client-agent/buffer.o
    CC client-agent/start_agent.o
    CC client-agent/agcom.o
    CC client-agent/notify.o
    CC monitord/rotate_log.o
monitord/rotate_log.c: In function ‘w_rotate_log’:
monitord/rotate_log.c:211:42: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  211 |             snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                          ^~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from monitord/rotate_log.c:10:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 2 and 4352 bytes into a destination of size 4096
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
monitord/rotate_log.c:244:38: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  244 |         snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                      ^~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from monitord/rotate_log.c:10:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 2 and 4352 bytes into a destination of size 4096
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
monitord/rotate_log.c:244:38: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  244 |         snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                      ^~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from monitord/rotate_log.c:10:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 2 and 4352 bytes into a destination of size 4096
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
monitord/rotate_log.c:288:46: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  288 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                              ^~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from monitord/rotate_log.c:10:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 2 and 4352 bytes into a destination of size 4096
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
monitord/rotate_log.c:298:46: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  298 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                              ^~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from monitord/rotate_log.c:10:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 2 and 4352 bytes into a destination of size 4096
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
monitord/rotate_log.c:308:46: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  308 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                              ^~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from monitord/rotate_log.c:10:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 2 and 4352 bytes into a destination of size 4096
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
monitord/rotate_log.c:318:46: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  318 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                              ^~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from monitord/rotate_log.c:10:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 2 and 4352 bytes into a destination of size 4096
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC monitord/compress_log.o
    CC config/wmodules-aws.o
    CC config/localfile-config.o
    CC config/rootcheck-config.o
    CC config/remote-config.o
    CC config/active-response.o
    CC config/wmodules-osquery-monitor.o
    CC config/integrator-config.o
    CC config/wmodules-agent-upgrade.o
    CC config/socket-config.o
    CC config/reports-config.o
    CC config/alerts-config.o
    CC config/agentlessd-config.o
    CC config/wmodules_syscollector.o
    CC config/wmodules-oscap.o
    CC config/config.o
    CC config/wmodules-github.o
    CC config/wmodules-docker.o
    CC config/syscheck-config.o
    CC config/global-config.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from config/syscheck-config.c:11:
In function ‘strncpy’,
    inlined from ‘read_data_unit’ at config/syscheck-config.c:1261:13:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
config/syscheck-config.c: In function ‘read_data_unit’:
config/syscheck-config.c:1251:28: note: length computed here
 1251 |     size_t len_value_str = strlen(content);
      |                            ^~~~~~~~~~~~~~~
    CC config/client-config.o
    CC config/labels-config.o
    CC config/email-alerts-config.o
    CC config/wmodules-sca.o
    CC config/wmodules-fluent.o
    CC config/wmodules-office365.o
    CC config/cluster-config.o
    CC config/rules-config.o
    CC config/dbd-config.o
    CC config/wmodules-key-request.o
    CC config/wmodules-vuln-detector.o
    CC config/wmodules-azure.o
    CC config/authd-config.o
    CC config/wmodules-task-manager.o
    CC config/buffer-config.o
    CC config/wmodules-command.o
    CC config/csyslogd-config.o
    CC config/wmodules-ciscat.o
    CC config/wmodules-gcp.o
    CC config/logtest-config.o
    CC config/wmodules-config.o
    CC wazuh_modules/wm_control.o
    CC wazuh_modules/wmcom.o
    CC wazuh_modules/wm_oscap.o
    CC wazuh_modules/wm_gcp.o
    CC wazuh_modules/wmodules.o
    CC wazuh_modules/wm_azure.o
    CC wazuh_modules/wm_office365.o
    CC wazuh_modules/wm_exec.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from wazuh_modules/wmodules.h:15,
                 from wazuh_modules/wm_office365.c:23:
In function ‘strncpy’,
    inlined from ‘wm_office365_execute_scan’ at wazuh_modules/wm_office365.c:432:33:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin___strncpy_chk’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
wazuh_modules/wm_office365.c: In function ‘wm_office365_execute_scan’:
wazuh_modules/wm_office365.c:432:33: note: length computed here
  432 |                                 strncpy(url, next_page, strlen(next_page));
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_modules/wm_osquery_monitor.o
    CC wazuh_modules/wm_task_general.o
    CC wazuh_modules/wm_aws.o
    CC wazuh_modules/wm_syscollector.o
    CC wazuh_modules/wm_keyrequest.o
    CC wazuh_modules/wm_github.o
    CC wazuh_modules/wm_database.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from wazuh_modules/wmodules.h:15,
                 from wazuh_modules/wm_github.c:23:
In function ‘strncpy’,
    inlined from ‘wm_github_execute_scan’ at wazuh_modules/wm_github.c:308:33:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin___strncpy_chk’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
wazuh_modules/wm_github.c: In function ‘wm_github_execute_scan’:
wazuh_modules/wm_github.c:308:33: note: length computed here
  308 |                                 strncpy(url, next_page, strlen(next_page));
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_modules/wm_download.o
    CC wazuh_modules/wm_docker.o
    CC wazuh_modules/wm_fluent.o
    CC wazuh_modules/wm_sca.o
    CC wazuh_modules/wm_command.o
    CC wazuh_modules/wm_ciscat.o
    CC wazuh_modules/agent_upgrade/wm_agent_upgrade.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.o
    CC wazuh_db/wdb_metadata.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c:23:
In function ‘strncpy’,
    inlined from ‘wm_agent_upgrade_com_open’ at wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c:233:9:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output may be truncated copying 4096 bytes from a string of length 4096 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_db/wdb_agents.o
    CC wazuh_db/wdb_integrity.o
    CC wazuh_db/wdb_global.o
    CC wazuh_db/wdb_syscollector.o
    CC wazuh_db/wdb_upgrade.o
    CC wazuh_db/wdb_task.o
    CC wazuh_db/wdb_delta_event.o
    CC wazuh_db/wdb_scan_info.o
    CC wazuh_db/wdb.o
    CC wazuh_db/wdb_parser.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from ./headers/wazuhdb_op.h:13,
                 from wazuh_db/wdb_parser.c:12:
In function ‘strncpy’,
    inlined from ‘wdb_parse_syscheck’ at wazuh_db/wdb_parser.c:1278:13:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
wazuh_db/wdb_parser.c: In function ‘wdb_parse_syscheck’:
wazuh_db/wdb_parser.c:1276:32: note: length computed here
 1276 |             size_t mark_size = strlen(mark);
      |                                ^~~~~~~~~~~~
    CC wazuh_db/wdb_fim.o
    CC wazuh_db/wdb_sca.o
    CC wazuh_db/wdb_rootcheck.o
    CC wazuh_db/wdb_ciscat.o
    CC wazuh_db/helpers/wdb_global_helpers.o
    CC wazuh_db/helpers/wdb_agents_helpers.o
    CC wazuh_db/schema_global_upgrade_v2.o
    CC wazuh_db/schema_upgrade_v3.o
    CC wazuh_db/schema_upgrade_v1.o
    CC wazuh_db/schema_upgrade_v8.o
    CC wazuh_db/schema_agents.o
    CC wazuh_db/schema_upgrade_v6.o
    CC wazuh_db/schema_global_upgrade_v1.o
    CC wazuh_db/schema_task_manager.o
    CC wazuh_db/schema_upgrade_v4.o
    CC wazuh_db/schema_global.o
    CC wazuh_db/schema_upgrade_v2.o
    CC wazuh_db/schema_global_upgrade_v3.o
    CC wazuh_db/schema_upgrade_v5.o
    CC wazuh_db/schema_vuln_detector.o
    CC wazuh_db/schema_upgrade_v7.o
    CC os_crypto/blowfish/bf_op.o
    CC os_crypto/md5/md5_op.o
    CC os_crypto/sha1/sha1_op.o
    CC os_crypto/shared/keys.o
    CC os_crypto/shared/msgs.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from os_crypto/shared/keys.c:11:
In function ‘strncpy’,
    inlined from ‘OS_ReadKeys’ at os_crypto/shared/keys.c:251:13:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output may be truncated copying 127 bytes from a string of length 2048 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC os_crypto/md5_sha1/md5_sha1_op.o
    CC os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.o
    CC os_crypto/sha256/sha256_op.o
    CC os_crypto/sha512/sha512_op.o
    CC os_crypto/aes/aes_op.o
    CC os_crypto/hmac/hmac.o
    CC os_crypto/signature/signature.o
    CC shared/json-queue.o
    CC shared/read-alert.o
    CC shared/rootcheck_op.o
    CC shared/notify_op.o
    CC shared/regex_op.o
    CC shared/store_op.o
    CC shared/bzip2_op.o
    CC shared/exec_op.o
    CC shared/mem_op.o
    CC shared/request_op.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from shared/mem_op.c:12:
In function ‘strncat’,
    inlined from ‘os_LoadString’ at shared/mem_op.c:112:9:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:136:10: warning: ‘__builtin_strncat’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  136 |   return __builtin___strncat_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
shared/mem_op.c: In function ‘os_LoadString’:
shared/mem_op.c:101:26: note: length computed here
  101 |         size_t strsize = strlen(str);
      |                          ^~~~~~~~~~~
    CC shared/log_builder.o
    CC shared/time_op.o
    CC shared/file_op.o
    CC shared/pthreads_op.o
    CC shared/integrity_op.o
    CC shared/queue_linked_op.o
    CC shared/os_utils.o
    CC shared/rbtree_op.o
    CC shared/fs_op.o
    CC shared/cluster_utils.o
    CC shared/read-agents.o
    CC shared/audit_op.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from shared/read-agents.c:11:
In function ‘strncpy’,
    inlined from ‘_do_print_syscheck’ at shared/read-agents.c:431:17:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output may be truncated copying 23 bytes from a string of length 24 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC shared/syscheck_op.o
    CC shared/yaml2json.o
    CC shared/buffer_op.o
    CC shared/report_op.o
    CC shared/sig_op.o
    CC shared/sym_load.o
    CC shared/wait_op.o
    CC shared/help.o
    CC shared/labels_op.o
    CC shared/auth_client.o
    CC shared/list_op.o
    CC shared/privsep_op.o
    CC shared/hash_op.o
    CC shared/b64.o
    CC shared/file-queue.o
    CC shared/math_op.o
    CC shared/atomic.o
    CC shared/rules_op.o
    CC shared/string_op.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from shared/string_op.c:11:
In function ‘strncpy’,
    inlined from ‘wstr_split’ at shared/string_op.c:612:17:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
shared/string_op.c: In function ‘wstr_split’:
shared/string_op.c:612:17: note: length computed here
  612 |                 strncpy(new_term_it, acc_strs[count], strlen(acc_strs[count]));
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from shared/string_op.c:11:
In function ‘strncpy’,
    inlined from ‘wstr_split’ at shared/string_op.c:609:21:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
shared/string_op.c: In function ‘wstr_split’:
shared/string_op.c:569:29: note: length computed here
  569 |     size_t new_delim_size = strlen(replace_delim ? replace_delim : delim);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC shared/url.o
    CC shared/version_op.o
    CC shared/enrollment_op.o
    CC shared/vector_op.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from ./addagent/manage_agents.h:14,
                 from ./os_auth/auth.h:33,
                 from shared/enrollment_op.c:11:
In function ‘strncat’,
    inlined from ‘w_enrollment_concat_src_ip’ at shared/enrollment_op.c:547:13:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:136:10: warning: ‘__builtin_strncat’ output may be truncated copying 254 bytes from a string of length 255 [-Wstringop-truncation]
  136 |   return __builtin___strncat_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC shared/mq_op.o
    CC shared/sysinfo_utils.o
    CC shared/custom_output_search_replace.o
    CC shared/validate_op.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from shared/custom_output_search_replace.c:11:
In function ‘strncpy’,
    inlined from ‘searchAndReplace’ at shared/custom_output_search_replace.c:51:9:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
shared/custom_output_search_replace.c: In function ‘searchAndReplace’:
shared/custom_output_search_replace.c:19:30: note: length computed here
   19 |     const size_t value_len = strlen(value);
      |                              ^~~~~~~~~~~~~
    CC shared/json_op.o
shared/validate_op.c: In function ‘__gethour’:
shared/validate_op.c:541:38: warning: ‘%02d’ directive output may be truncated writing between 2 and 11 bytes into a region of size 6 [-Wformat-truncation=]
  541 |             snprintf(ossec_hour, 6, "%02d:%02d", chour, cmin);
      |                                      ^~~~
shared/validate_op.c:541:37: note: directive argument in the range [-2147483636, 2147483647]
  541 |             snprintf(ossec_hour, 6, "%02d:%02d", chour, cmin);
      |                                     ^~~~~~~~~~~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from shared/validate_op.c:11:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 6 and 24 bytes into a destination of size 6
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC shared/schedule_scan.o
    CC shared/expression.o
    CC shared/debug_op.o
    CC shared/remoted_op.o
    CC shared/bqueue_op.o
    CC shared/queue_op.o
    CC shared/utf8_op.o
    CC shared/randombytes.o
    CC shared/agent_op.o
    CC shared/wazuhdb_op.o
    CC os_net/os_net.o
    CC os_regex/os_regex_match.o
    CC os_regex/os_regex.o
    CC os_regex/os_regex_str.o
    CC os_regex/os_match.o
    CC os_regex/os_regex_compile.o
    CC os_regex/os_regex_startswith.o
    CC os_regex/os_regex_free_pattern.o
    CC os_regex/os_match_compile.o
    CC os_regex/os_regex_strbreak.o
    CC os_regex/os_match_free_pattern.o
    CC os_regex/os_regex_maps.o
    CC os_regex/os_regex_execute.o
    CC os_regex/os_match_execute.o
    CC os_xml/os_xml_variables.o
    CC os_xml/os_xml.o
    CC os_xml/os_xml_access.o
    CC os_xml/os_xml_node_access.o
    CC os_xml/os_xml_writer.o
    CC os_zlib/os_zlib.o
    CC os_auth/ssl.o
    CC os_auth/check_cert.o
    CC addagent/validate.o
    CC analysisd/logmsg.o
addagent/validate.c: In function ‘OS_AddNewAgent’:
addagent/validate.c:49:27: warning: ‘%03d’ directive output may be truncated writing between 3 and 11 bytes into a region of size 9 [-Wformat-truncation=]
   49 |         snprintf(_id, 9, "%03d", ++keys->id_counter);
      |                           ^~~~
addagent/validate.c:49:26: note: directive argument in the range [-2147483647, 2147483647]
   49 |         snprintf(_id, 9, "%03d", ++keys->id_counter);
      |                          ^~~~~~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from addagent/manage_agents.h:14,
                 from addagent/validate.c:12:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 4 and 12 bytes into a destination of size 9
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC os_auth/main-client.o
    CC logcollector/read_ossecalert.o
    CC logcollector/state.o
    CC logcollector/config.o
    CC logcollector/logcollector.o
    CC logcollector/read_djb_multilog.o
    CC logcollector/read_postgresql_log.o

```

</details>

## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Agent</summary>

```

grep: /etc/redhat-release: No such file or directory
    CC client-agent/agcom.o
    CC client-agent/agentd.o
    CC client-agent/buffer.o
    CC client-agent/config.o
    CC client-agent/event-forward.o
    CC client-agent/main.o
    CC client-agent/notify.o
    CC client-agent/receiver.o
    CC client-agent/receiver-win.o
    CC client-agent/request.o
    CC client-agent/restart_agent.o
    CC client-agent/rotate_log.o
    CC client-agent/sendmsg.o
    CC client-agent/start_agent.o
    CC client-agent/state.o
    CC monitord/rotate_log.o
    CC monitord/compress_log.o
monitord/rotate_log.c: In function ‘w_rotate_log’:
monitord/rotate_log.c:211:42: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  211 |             snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                          ^~
monitord/rotate_log.c:211:13: note: ‘snprintf’ output between 2 and 4352 bytes into a destination of size 4096
  211 |             snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
monitord/rotate_log.c:244:38: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  244 |         snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                      ^~
monitord/rotate_log.c:244:9: note: ‘snprintf’ output between 2 and 4352 bytes into a destination of size 4096
  244 |         snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
monitord/rotate_log.c:244:38: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  244 |         snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                      ^~
monitord/rotate_log.c:244:9: note: ‘snprintf’ output between 2 and 4352 bytes into a destination of size 4096
  244 |         snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
monitord/rotate_log.c:288:46: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  288 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                              ^~
monitord/rotate_log.c:288:17: note: ‘snprintf’ output between 2 and 4352 bytes into a destination of size 4096
  288 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC config/active-response.o
monitord/rotate_log.c:298:46: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  298 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                              ^~
monitord/rotate_log.c:298:17: note: ‘snprintf’ output between 2 and 4352 bytes into a destination of size 4096
  298 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
monitord/rotate_log.c:308:46: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  308 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                              ^~
monitord/rotate_log.c:308:17: note: ‘snprintf’ output between 2 and 4352 bytes into a destination of size 4096
  308 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
monitord/rotate_log.c:318:46: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  318 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                                              ^~
monitord/rotate_log.c:318:17: note: ‘snprintf’ output between 2 and 4352 bytes into a destination of size 4096
  318 |                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC config/agentlessd-config.o
    CC config/alerts-config.o
    CC config/authd-config.o
    CC config/buffer-config.o
    CC config/client-config.o
    CC config/cluster-config.o
    CC config/config.o
    CC config/csyslogd-config.o
    CC config/dbd-config.o
    CC config/email-alerts-config.o
    CC config/global-config.o
    CC config/integrator-config.o
    CC config/labels-config.o
    CC config/localfile-config.o
    CC config/logtest-config.o
    CC config/remote-config.o
    CC config/reports-config.o
    CC config/rootcheck-config.o
    CC config/rules-config.o
    CC config/socket-config.o
    CC config/syscheck-config.o
    CC config/wmodules-agent-upgrade.o
    CC config/wmodules-aws.o
    CC config/wmodules-azure.o
    CC config/wmodules-ciscat.o
config/syscheck-config.c: In function ‘read_data_unit’:
config/syscheck-config.c:1261:13: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
 1261 |             strncpy(value_str, content, len_value_str - 2);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
config/syscheck-config.c:1251:28: note: length computed here
 1251 |     size_t len_value_str = strlen(content);
      |                            ^~~~~~~~~~~~~~~
    CC config/wmodules-command.o
    CC config/wmodules-config.o
    CC config/wmodules-docker.o
    CC config/wmodules-fluent.o
    CC config/wmodules-gcp.o
    CC config/wmodules-github.o
    CC config/wmodules-key-request.o
    CC config/wmodules-office365.o
    CC config/wmodules-oscap.o
    CC config/wmodules-osquery-monitor.o
    CC config/wmodules-sca.o
    CC config/wmodules_syscollector.o
    CC config/wmodules-task-manager.o
    CC config/wmodules-vuln-detector.o
    CC wazuh_modules/wm_aws.o
    CC wazuh_modules/wm_azure.o
    CC wazuh_modules/wm_ciscat.o
    CC wazuh_modules/wmcom.o
    CC wazuh_modules/wm_command.o
    CC wazuh_modules/wm_control.o
    CC wazuh_modules/wm_database.o
    CC wazuh_modules/wm_docker.o
    CC wazuh_modules/wm_download.o
    CC wazuh_modules/wm_exec.o
    CC wazuh_modules/wm_fluent.o
wazuh_modules/wm_exec.c: In function ‘wm_exec’:
wazuh_modules/wm_exec.c:334:58: warning: ‘%s’ directive output may be truncated writing up to 6143 bytes into a region of size 6142 [-Wformat-truncation=]
  334 |                 snprintf(new_path, OS_SIZE_6144 - 1, "%s:%s", add_path, env_path);
      |                                                          ^~
wazuh_modules/wm_exec.c:334:17: note: ‘snprintf’ output 2 or more bytes (assuming 6145) into a destination of size 6143
  334 |                 snprintf(new_path, OS_SIZE_6144 - 1, "%s:%s", add_path, env_path);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_modules/wm_gcp.o
    CC wazuh_modules/wm_github.o
    CC wazuh_modules/wm_keyrequest.o
wazuh_modules/wm_github.c: In function ‘wm_github_execute_scan’:
wazuh_modules/wm_github.c:308:33: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  308 |                                 strncpy(url, next_page, strlen(next_page));
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_modules/wmodules.o
    CC wazuh_modules/wm_office365.o
    CC wazuh_modules/wm_oscap.o
    CC wazuh_modules/wm_osquery_monitor.o
    CC wazuh_modules/wm_sca.o
wazuh_modules/wm_office365.c: In function ‘wm_office365_execute_scan’:
wazuh_modules/wm_office365.c:432:33: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  432 |                                 strncpy(url, next_page, strlen(next_page));
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_modules/wm_syscollector.o
    CC wazuh_modules/wm_task_general.o
    CC wazuh_modules/agent_upgrade/wm_agent_upgrade.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.o
    CC wazuh_db/wdb_agents.o
    CC wazuh_db/wdb.o
wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c: In function ‘wm_agent_upgrade_com_open’:
wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c:233:9: warning: ‘strncpy’ output may be truncated copying 4096 bytes from a string of length 4096 [-Wstringop-truncation]
  233 |         strncpy(file.path, final_path, PATH_MAX);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_db/wdb_ciscat.o
    CC wazuh_db/wdb_delta_event.o
    CC wazuh_db/wdb_fim.o
    CC wazuh_db/wdb_global.o
    CC wazuh_db/wdb_integrity.o
    CC wazuh_db/wdb_metadata.o
    CC wazuh_db/wdb_parser.o
    CC wazuh_db/wdb_rootcheck.o
    CC wazuh_db/wdb_sca.o
    CC wazuh_db/wdb_scan_info.o
    CC wazuh_db/wdb_syscollector.o
    CC wazuh_db/wdb_task.o
    CC wazuh_db/wdb_upgrade.o
    CC wazuh_db/helpers/wdb_agents_helpers.o
    CC wazuh_db/helpers/wdb_global_helpers.o
    CC wazuh_db/schema_agents.o
    CC wazuh_db/schema_global.o
    CC wazuh_db/schema_global_upgrade_v1.o
    CC wazuh_db/schema_global_upgrade_v2.o
    CC wazuh_db/schema_global_upgrade_v3.o
    CC wazuh_db/schema_task_manager.o
    CC wazuh_db/schema_upgrade_v1.o
    CC wazuh_db/schema_upgrade_v2.o
    CC wazuh_db/schema_upgrade_v3.o
    CC wazuh_db/schema_upgrade_v4.o
    CC wazuh_db/schema_upgrade_v5.o
    CC wazuh_db/schema_upgrade_v6.o
    CC wazuh_db/schema_upgrade_v7.o
    CC wazuh_db/schema_upgrade_v8.o
    CC wazuh_db/schema_vuln_detector.o
    CC os_crypto/blowfish/bf_op.o
    CC os_crypto/md5/md5_op.o
    CC os_crypto/sha1/sha1_op.o
    CC os_crypto/shared/keys.o
    CC os_crypto/shared/msgs.o
os_crypto/shared/keys.c: In function ‘OS_ReadKeys’:
os_crypto/shared/keys.c:251:13: warning: ‘strncpy’ output may be truncated copying 127 bytes from a string of length 2048 [-Wstringop-truncation]
  251 |             strncpy(id, valid_str, KEYSIZE - 1);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC os_crypto/md5_sha1/md5_sha1_op.o
    CC os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.o
    CC os_crypto/sha256/sha256_op.o
    CC os_crypto/sha512/sha512_op.o
    CC os_crypto/aes/aes_op.o
    CC os_crypto/hmac/hmac.o
    CC os_crypto/signature/signature.o
    CC shared/agent_op.o
    CC shared/atomic.o
    CC shared/audit_op.o
    CC shared/auth_client.o
    CC shared/b64.o
    CC shared/bqueue_op.o
    CC shared/buffer_op.o
    CC shared/bzip2_op.o
    CC shared/cluster_utils.o
    CC shared/custom_output_search_replace.o
    CC shared/debug_op.o
    CC shared/enrollment_op.o
    CC shared/exec_op.o
shared/custom_output_search_replace.c: In function ‘searchAndReplace’:
shared/custom_output_search_replace.c:51:9: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
   51 |         strncpy(tmp + tmp_offset, value, value_len);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
shared/custom_output_search_replace.c:19:30: note: length computed here
   19 |     const size_t value_len = strlen(value);
      |                              ^~~~~~~~~~~~~
    CC shared/expression.o
shared/enrollment_op.c: In function ‘w_enrollment_concat_src_ip’:
shared/enrollment_op.c:547:13: warning: ‘strncat’ output may be truncated copying 254 bytes from a string of length 255 [-Wstringop-truncation]
  547 |             strncat(buff,opt_buf,254);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~
    CC shared/file_op.o
    CC shared/file-queue.o
    CC shared/fs_op.o
    CC shared/hash_op.o
    CC shared/help.o
    CC shared/integrity_op.o
    CC shared/json_op.o
    CC shared/json-queue.o
    CC shared/labels_op.o
    CC shared/list_op.o
    CC shared/log_builder.o
    CC shared/math_op.o
    CC shared/mem_op.o
    CC shared/mq_op.o
    CC shared/notify_op.o
    CC shared/os_utils.o
    CC shared/privsep_op.o
    CC shared/pthreads_op.o
    CC shared/queue_linked_op.o
    CC shared/queue_op.o
    CC shared/randombytes.o
    CC shared/rbtree_op.o
    CC shared/read-agents.o
    CC shared/read-alert.o
    CC shared/regex_op.o
shared/read-agents.c: In function ‘_do_print_syscheck’:
shared/read-agents.c:431:17: warning: ‘strncpy’ output may be truncated copying 23 bytes from a string of length 24 [-Wstringop-truncation]
  431 |                 strncpy(saved_read_day, read_day, 23);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC shared/remoted_op.o
    CC shared/report_op.o
    CC shared/request_op.o
    CC shared/rootcheck_op.o
    CC shared/rules_op.o
    CC shared/schedule_scan.o
    CC shared/sig_op.o
    CC shared/store_op.o
    CC shared/string_op.o
    CC shared/sym_load.o
    CC shared/syscheck_op.o
    CC shared/sysinfo_utils.o
    CC shared/time_op.o
shared/string_op.c: In function ‘wstr_split’:
shared/string_op.c:612:17: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
  612 |                 strncpy(new_term_it, acc_strs[count], strlen(acc_strs[count]));
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
shared/string_op.c:609:21: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  609 |                     strncpy(new_term_it, new_delim, new_delim_size);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
shared/string_op.c:569:29: note: length computed here
  569 |     size_t new_delim_size = strlen(replace_delim ? replace_delim : delim);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC shared/url.o
    CC shared/utf8_op.o
    CC shared/validate_op.o
    CC shared/vector_op.o
    CC shared/version_op.o
    CC shared/wait_op.o
shared/validate_op.c: In function ‘__gethour’:
shared/validate_op.c:541:38: warning: ‘%02d’ directive output may be truncated writing between 2 and 11 bytes into a region of size 6 [-Wformat-truncation=]
  541 |             snprintf(ossec_hour, 6, "%02d:%02d", chour, cmin);
      |                                      ^~~~
shared/validate_op.c:541:37: note: directive argument in the range [-2147483636, 2147483647]
  541 |             snprintf(ossec_hour, 6, "%02d:%02d", chour, cmin);
      |                                     ^~~~~~~~~~~
shared/validate_op.c:541:13: note: ‘snprintf’ output between 6 and 24 bytes into a destination of size 6
  541 |             snprintf(ossec_hour, 6, "%02d:%02d", chour, cmin);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC shared/wazuhdb_op.o
    CC shared/yaml2json.o
    CC os_net/os_net.o
    CC os_regex/os_match.o
    CC os_regex/os_match_compile.o
    CC os_regex/os_match_execute.o
    CC os_regex/os_match_free_pattern.o
    CC os_regex/os_regex.o
    CC os_regex/os_regex_compile.o
    CC os_regex/os_regex_execute.o
    CC os_regex/os_regex_free_pattern.o
    CC os_regex/os_regex_maps.o
    CC os_regex/os_regex_match.o
    CC os_regex/os_regex_startswith.o
    CC os_regex/os_regex_strbreak.o
    CC os_regex/os_regex_str.o
    CC os_xml/os_xml_access.o
    CC os_xml/os_xml.o
    CC os_xml/os_xml_node_access.o
    CC os_xml/os_xml_variables.o
In function ‘_writecontent’,
    inlined from ‘_getattributes’ at os_xml/os_xml.c:609:17:
os_xml/os_xml.c:510:5: warning: ‘strncpy’ output may be truncated copying between 0 and 20479 bytes from a string of length 20480 [-Wstringop-truncation]
  510 |     strncpy(_lxml->ct[parent], str, size - 1);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC os_xml/os_xml_writer.o
    CC os_zlib/os_zlib.o
    CC os_auth/ssl.o
In function ‘_writecontent’,
    inlined from ‘_ReadElem’ at os_xml/os_xml.c:361:17:
os_xml/os_xml.c:510:5: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
  510 |     strncpy(_lxml->ct[parent], str, size - 1);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
os_xml/os_xml.c: In function ‘_ReadElem’:
os_xml/os_xml.c:361:37: note: length computed here
  361 |             if (_writecontent(cont, strlen(cont) + 1, _currentlycont, _lxml) < 0) {
      |                                     ^~~~~~~~~~~~
    CC os_auth/check_cert.o
    CC addagent/validate.o
    CC analysisd/logmsg.o
    CC os_auth/main-client.o
    CC logcollector/config.o
addagent/validate.c: In function ‘OS_AddNewAgent’:
addagent/validate.c:49:27: warning: ‘%03d’ directive output may be truncated writing between 3 and 11 bytes into a region of size 9 [-Wformat-truncation=]
   49 |         snprintf(_id, 9, "%03d", ++keys->id_counter);
      |                           ^~~~
addagent/validate.c:49:26: note: directive argument in the range [-2147483647, 2147483647]
   49 |         snprintf(_id, 9, "%03d", ++keys->id_counter);
      |                          ^~~~~~
addagent/validate.c:49:9: note: ‘snprintf’ output between 4 and 12 bytes into a destination of size 9
   49 |         snprintf(_id, 9, "%03d", ++keys->id_counter);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/lccom.o
    CC logcollector/logcollector.o
    CC logcollector/macos_log.o
    CC logcollector/main.o
    CC logcollector/read_audit.o
    CC logcollector/read_command.o
    CC logcollector/read_djb_multilog.o
    CC logcollector/read_fullcommand.o
    CC logcollector/read_json.o

```

</details>

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [x] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors