### PR TITLE
Deprecate unused wdb setting

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -369,9 +369,6 @@ wazuh_database.max_queued_events=0
 # 1. Enabled (default)
 wazuh_download.enabled=1
 
-# Maximum pending connections (1..1024)
-wazuh_db.sock_queue_size=128
-
 # Number of worker threads (1..32)
 wazuh_db.worker_pool_size=8
 

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -83,7 +83,6 @@ int main(int argc, char ** argv)
 
     // Read internal options
 
-    wconfig.sock_queue_size = getDefine_Int("wazuh_db", "sock_queue_size", 1, 1024);
     wconfig.worker_pool_size = getDefine_Int("wazuh_db", "worker_pool_size", 1, 32);
     wconfig.commit_time_min = getDefine_Int("wazuh_db", "commit_time_min", 1, 3600);
     wconfig.commit_time_max = getDefine_Int("wazuh_db", "commit_time_max", 1, 3600);

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -293,7 +293,6 @@ typedef struct wdb_t {
 } wdb_t;
 
 typedef struct wdb_config {
-    int sock_queue_size;
     int worker_pool_size;
     int commit_time_min;
     int commit_time_max;


### PR DESCRIPTION
|Related issue|
|---|
|#12357|

## Description

This PR removes an unused wdb setting. `socket_queue_size`