### PR TITLE
Fix warnings in read_mssql_log.c file

### DIFF
--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -46,23 +46,24 @@
 #define LOGLEVEL_INFO 1
 #define LOGLEVEL_DEBUG 0
 
-#define OS_MAXSTR       OS_SIZE_65536       /* Size for logs, sockets, etc      */
-#define OS_BUFFER_SIZE  OS_SIZE_2048        /* Size of general buffers          */
-#define OS_FLSIZE       OS_SIZE_256         /* Maximum file size                */
-#define OS_HEADER_SIZE  OS_SIZE_128         /* Maximum header size              */
-#define OS_LOG_HEADER   OS_SIZE_256         /* Maximum log header size          */
-#define OS_SK_HEADER    OS_SIZE_6144        /* Maximum syscheck header size     */
-#define IPSIZE          INET6_ADDRSTRLEN    /* IP Address size                  */
-#define AUTH_POOL       1000                /* Max number of connections        */
-#define BACKLOG         128                 /* Socket input queue length        */
-#define MAX_EVENTS      1024                /* Max number of epoll events       */
-#define EPOLL_MILLIS    -1                  /* Epoll wait time                  */
-#define MAX_TAG_COUNTER 256                 /* Max retrying counter             */
-#define SOCK_RECV_TIME0 300                 /* Socket receiving timeout (s)     */
-#define MIN_ORDER_SIZE  32                  /* Minimum size of orders array     */
-#define KEEPALIVE_SIZE  700                 /* Random keepalive string size     */
-#define MAX_DYN_STR     4194304             /* Max message size received 4MiB   */
-#define DATE_LENGTH     64                  /* Format date time %D %T           */
+#define OS_MAXSTR       OS_SIZE_65536               /* Size for logs, sockets, etc      */
+#define OS_BUFFER_SIZE  OS_SIZE_2048                /* Size of general buffers          */
+#define OS_FLSIZE       OS_SIZE_256                 /* Maximum file size                */
+#define OS_HEADER_SIZE  OS_SIZE_128                 /* Maximum header size              */
+#define OS_LOG_HEADER   OS_SIZE_256                 /* Maximum log header size          */
+#define OS_SK_HEADER    OS_SIZE_6144                /* Maximum syscheck header size     */
+#define IPSIZE          INET6_ADDRSTRLEN            /* IP Address size                  */
+#define AUTH_POOL       1000                        /* Max number of connections        */
+#define BACKLOG         128                         /* Socket input queue length        */
+#define MAX_EVENTS      1024                        /* Max number of epoll events       */
+#define EPOLL_MILLIS    -1                          /* Epoll wait time                  */
+#define MAX_TAG_COUNTER 256                         /* Max retrying counter             */
+#define SOCK_RECV_TIME0 300                         /* Socket receiving timeout (s)     */
+#define MIN_ORDER_SIZE  32                          /* Minimum size of orders array     */
+#define KEEPALIVE_SIZE  700                         /* Random keepalive string size     */
+#define MAX_DYN_STR     4194304                     /* Max message size received 4MiB   */
+#define DATE_LENGTH     64                          /* Format date time %D %T           */
+#define OS_MAX_LOG_SIZE OS_MAXSTR - OS_LOG_HEADER   /* Maximum log size with a header protection */
 
 /* Some global names */
 #define __ossec_name    "Wazuh"

--- a/src/logcollector/read_mssql_log.c
+++ b/src/logcollector/read_mssql_log.c
@@ -105,7 +105,7 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
 
             /* If the saved message is empty, set it and continue */
             if (buffer[0] == '\0') {
-                snprintf(buffer, OS_MAXSTR - OS_LOG_HEADER, "%s", str);
+                snprintf(buffer, sizeof(buffer), "%s", str);
                 continue;
             }
 
@@ -114,7 +114,7 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
                 __send_mssql_msg(lf, drop_it, buffer);
 
                 /* Store current one at the buffer */
-                snprintf(buffer, OS_MAXSTR - OS_LOG_HEADER, "%s", str);
+                snprintf(buffer, sizeof(buffer), "%s", str);
             }
         }
 

--- a/src/logcollector/read_mssql_log.c
+++ b/src/logcollector/read_mssql_log.c
@@ -28,13 +28,13 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
     size_t str_len = 0;
     int need_clear = 0;
     char *p;
-    char str[OS_MAXSTR + 1];
-    char buffer[OS_MAXSTR + 1];
+    char str[OS_MAXSTR - OS_LOG_HEADER];
+    char buffer[OS_MAXSTR - OS_LOG_HEADER];
     int lines = 0;
     /* Zero buffer and str */
     buffer[0] = '\0';
-    buffer[OS_MAXSTR] = '\0';
-    str[OS_MAXSTR] = '\0';
+    buffer[OS_MAXSTR - OS_LOG_HEADER - 1] = '\0';
+    str[OS_MAXSTR - OS_LOG_HEADER - 1] = '\0';
     *rc = 0;
 
     /* Obtain context to calculate hash */
@@ -105,7 +105,7 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
 
             /* If the saved message is empty, set it and continue */
             if (buffer[0] == '\0') {
-                strncpy(buffer, str, str_len + 2);
+                snprintf(buffer, OS_MAXSTR - OS_LOG_HEADER, "%s", str);
                 continue;
             }
 
@@ -114,7 +114,7 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
                 __send_mssql_msg(lf, drop_it, buffer);
 
                 /* Store current one at the buffer */
-                strncpy(buffer, str, str_len + 2);
+                snprintf(buffer, OS_MAXSTR - OS_LOG_HEADER, "%s", str);
             }
         }
 
@@ -133,7 +133,7 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
             }
 
             /* Add additional message to the saved buffer */
-            if (sizeof(buffer) - buffer_len > str_len + 256) {
+            if (sizeof(buffer) - buffer_len > str_len) {
                 /* Here we make sure that the size of the buffer
                  * minus what was used (strlen) is greater than
                  * the length of the received message.

--- a/src/logcollector/read_mssql_log.c
+++ b/src/logcollector/read_mssql_log.c
@@ -28,13 +28,13 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
     size_t str_len = 0;
     int need_clear = 0;
     char *p;
-    char str[OS_MAXSTR - OS_LOG_HEADER];
-    char buffer[OS_MAXSTR - OS_LOG_HEADER];
+    char str[OS_MAX_LOG_SIZE];
+    char buffer[OS_MAX_LOG_SIZE];
     int lines = 0;
     /* Zero buffer and str */
     buffer[0] = '\0';
-    buffer[OS_MAXSTR - OS_LOG_HEADER - 1] = '\0';
-    str[OS_MAXSTR - OS_LOG_HEADER - 1] = '\0';
+    buffer[OS_MAX_LOG_SIZE - 1] = '\0';
+    str[OS_MAX_LOG_SIZE - 1] = '\0';
     *rc = 0;
 
     /* Obtain context to calculate hash */
@@ -43,7 +43,7 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     /* Get new entry */
-    while (can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
+    while (can_read() && fgets(str, OS_MAX_LOG_SIZE, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
 
         lines++;
         /* Get buffer size */


### PR DESCRIPTION
|Related issue|
|---|
|#12100|

## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh agent project in read_mssql_log.c. . The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Agent</summary>

```

    CC os_auth/main-client.o
    CC logcollector/read_ossecalert.o
    CC logcollector/state.o
    CC logcollector/config.o
    CC logcollector/logcollector.o
    CC logcollector/read_djb_multilog.o
    CC logcollector/read_postgresql_log.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from logcollector/read_postgresql_log.c:13:
In function ‘strncpy’,
    inlined from ‘read_postgresql_log’ at logcollector/read_postgresql_log.c:114:17:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin___strncpy_chk’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘read_postgresql_log’ at logcollector/read_postgresql_log.c:106:17:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin___strncpy_chk’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_ucs2_le.o
    CC logcollector/read_mssql_log.o
    CC logcollector/read_win_el.o
    CC logcollector/lccom.o
    CC logcollector/read_macos.o
    CC logcollector/read_json.o
    CC logcollector/read_win_event_channel.o
    CC logcollector/read_syslog.o

```

</details>

## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Agent</summary>

```
    CC logcollector/lccom.o
    CC logcollector/logcollector.o
    CC logcollector/macos_log.o
    CC logcollector/main.o
    CC logcollector/read_audit.o
    CC logcollector/read_command.o
    CC logcollector/read_djb_multilog.o
    CC logcollector/read_fullcommand.o
logcollector/read_djb_multilog.c: In function ‘read_djbmultilog’:
logcollector/read_djb_multilog.c:158:76: warning: ‘%s’ directive output may be truncated writing up to 65510 bytes into a region of size between 65008 and 65520 [-Wformat-truncation=]
  158 |                 snprintf(buffer, OS_MAXSTR, "%s %02d %02d:%02d:%02d %s %s: %s",
      |                                                                            ^~
logcollector/read_djb_multilog.c:158:17: note: ‘snprintf’ output 17 or more bytes (assuming 66039) into a destination of size 65536
  158 |                 snprintf(buffer, OS_MAXSTR, "%s %02d %02d:%02d:%02d %s %s: %s",
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  159 |                          djb_month[tm_result.tm_mon],
      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  160 |                          tm_result.tm_mday,
      |                          ~~~~~~~~~~~~~~~~~~
  161 |                          tm_result.tm_hour,
      |                          ~~~~~~~~~~~~~~~~~~
  162 |                          tm_result.tm_min,
      |                          ~~~~~~~~~~~~~~~~~
  163 |                          tm_result.tm_sec,
      |                          ~~~~~~~~~~~~~~~~~
  164 |                          djb_host,
      |                          ~~~~~~~~~
  165 |                          lf->djb_program_name,
      |                          ~~~~~~~~~~~~~~~~~~~~~
  166 |                          p);
      |                          ~~
    CC logcollector/read_json.o
    CC logcollector/read_macos.o
    CC logcollector/read_mssql_log.o
    CC logcollector/read_multiline.o
    CC logcollector/read_multiline_regex.o

```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors