### PR TITLE
Fix warnings in read_multiline.c file

### DIFF
--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -46,23 +46,24 @@
 #define LOGLEVEL_INFO 1
 #define LOGLEVEL_DEBUG 0
 
-#define OS_MAXSTR       OS_SIZE_65536       /* Size for logs, sockets, etc      */
-#define OS_BUFFER_SIZE  OS_SIZE_2048        /* Size of general buffers          */
-#define OS_FLSIZE       OS_SIZE_256         /* Maximum file size                */
-#define OS_HEADER_SIZE  OS_SIZE_128         /* Maximum header size              */
-#define OS_LOG_HEADER   OS_SIZE_256         /* Maximum log header size          */
-#define OS_SK_HEADER    OS_SIZE_6144        /* Maximum syscheck header size     */
-#define IPSIZE          INET6_ADDRSTRLEN    /* IP Address size                  */
-#define AUTH_POOL       1000                /* Max number of connections        */
-#define BACKLOG         128                 /* Socket input queue length        */
-#define MAX_EVENTS      1024                /* Max number of epoll events       */
-#define EPOLL_MILLIS    -1                  /* Epoll wait time                  */
-#define MAX_TAG_COUNTER 256                 /* Max retrying counter             */
-#define SOCK_RECV_TIME0 300                 /* Socket receiving timeout (s)     */
-#define MIN_ORDER_SIZE  32                  /* Minimum size of orders array     */
-#define KEEPALIVE_SIZE  700                 /* Random keepalive string size     */
-#define MAX_DYN_STR     4194304             /* Max message size received 4MiB   */
-#define DATE_LENGTH     64                  /* Format date time %D %T           */
+#define OS_MAXSTR       OS_SIZE_65536               /* Size for logs, sockets, etc      */
+#define OS_BUFFER_SIZE  OS_SIZE_2048                /* Size of general buffers          */
+#define OS_FLSIZE       OS_SIZE_256                 /* Maximum file size                */
+#define OS_HEADER_SIZE  OS_SIZE_128                 /* Maximum header size              */
+#define OS_LOG_HEADER   OS_SIZE_256                 /* Maximum log header size          */
+#define OS_SK_HEADER    OS_SIZE_6144                /* Maximum syscheck header size     */
+#define IPSIZE          INET6_ADDRSTRLEN            /* IP Address size                  */
+#define AUTH_POOL       1000                        /* Max number of connections        */
+#define BACKLOG         128                         /* Socket input queue length        */
+#define MAX_EVENTS      1024                        /* Max number of epoll events       */
+#define EPOLL_MILLIS    -1                          /* Epoll wait time                  */
+#define MAX_TAG_COUNTER 256                         /* Max retrying counter             */
+#define SOCK_RECV_TIME0 300                         /* Socket receiving timeout (s)     */
+#define MIN_ORDER_SIZE  32                          /* Minimum size of orders array     */
+#define KEEPALIVE_SIZE  700                         /* Random keepalive string size     */
+#define MAX_DYN_STR     4194304                     /* Max message size received 4MiB   */
+#define DATE_LENGTH     64                          /* Format date time %D %T           */
+#define OS_MAX_LOG_SIZE OS_MAXSTR - OS_LOG_HEADER   /* Maximum log size with a header protection */
 
 /* Some global names */
 #define __ossec_name    "Wazuh"

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -93,8 +93,8 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
             buffer_size++;
         }
 
-        strncat(buffer, str, OS_MAXSTR - OS_LOG_HEADER - 1 - buffer_size);
-        buffer[OS_MAXSTR - OS_LOG_HEADER - 1] = '\0';
+        strncat(buffer, str, sizeof(buffer) - 1 - buffer_size);
+        buffer[sizeof(buffer) - 1] = '\0';
 
 
         if (OS_MAXSTR - OS_LOG_HEADER - 1 - buffer_size < strlen(str)) {
@@ -124,7 +124,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
                 mdebug2("Large message size from file '%s' (length = " FTELL_TT "): '%.*s'...", lf->file, FTELL_INT64 rbytes, sample_log_length, str);
             }
 
-            for (offset += rbytes; fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL; offset += rbytes) {
+            for (offset += rbytes; fgets(str, sizeof(str), lf->fp) != NULL; offset += rbytes) {
                 rbytes = w_ftell(lf->fp) - offset;
 
                 /* Flow control */

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -19,15 +19,15 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
     int __ms_reported = 0;
     int linesgot = 0;
     size_t buffer_size = 0;
-    char str[OS_MAXSTR - OS_LOG_HEADER];
-    char buffer[OS_MAXSTR - OS_LOG_HEADER];
+    char str[OS_MAX_LOG_SIZE];
+    char buffer[OS_MAX_LOG_SIZE];
     int lines = 0;
     int64_t offset = 0;
     int64_t rbytes = 0;
 
     buffer[0] = '\0';
-    buffer[OS_MAXSTR - OS_LOG_HEADER - 1] = '\0';
-    str[OS_MAXSTR - OS_LOG_HEADER - 1] = '\0';
+    buffer[OS_MAX_LOG_SIZE - 1] = '\0';
+    str[OS_MAX_LOG_SIZE - 1] = '\0';
     *rc = 0;
 
     /* Obtain context to calculate hash */
@@ -35,7 +35,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
-    for (offset = w_ftell(lf->fp); can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
+    for (offset = w_ftell(lf->fp); can_read() && fgets(str, OS_MAX_LOG_SIZE, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;
         lines++;
         linesgot++;
@@ -62,7 +62,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
         /* If we didn't get the new line, because the
          * size is large, send what we got so far.
          */
-        else if (rbytes == OS_MAXSTR - OS_LOG_HEADER - 1) {
+        else if (rbytes == OS_MAX_LOG_SIZE - 1) {
             /* Message size > maximum allowed */
             if (is_valid_context_file) {
                 OS_SHA1_Stream(&context, NULL, str);
@@ -97,7 +97,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
         buffer[sizeof(buffer) - 1] = '\0';
 
 
-        if (OS_MAXSTR - OS_LOG_HEADER - 1 - buffer_size < strlen(str)) {
+        if (OS_MAX_LOG_SIZE - 1 - buffer_size < strlen(str)) {
             merror("Large message size from file '%s' (length = " FTELL_TT "): '%s'...", lf->file, FTELL_INT64 buffer_size + strlen(str), buffer);
         }
 

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -19,15 +19,12 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
     int __ms_reported = 0;
     int linesgot = 0;
     size_t buffer_size = 0;
-    char str[OS_MAX_LOG_SIZE];
-    char buffer[OS_MAX_LOG_SIZE];
+    char str[OS_MAX_LOG_SIZE] = {0};
+    char buffer[OS_MAX_LOG_SIZE] = {0};
     int lines = 0;
     int64_t offset = 0;
     int64_t rbytes = 0;
 
-    buffer[0] = '\0';
-    buffer[OS_MAX_LOG_SIZE - 1] = '\0';
-    str[OS_MAX_LOG_SIZE - 1] = '\0';
     *rc = 0;
 
     /* Obtain context to calculate hash */

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -22,6 +22,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
     char str[OS_MAX_LOG_SIZE] = {0};
     char buffer[OS_MAX_LOG_SIZE] = {0};
     int lines = 0;
+    int size = 0;
     int64_t offset = 0;
     int64_t rbytes = 0;
 
@@ -90,10 +91,10 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
             buffer_size++;
         }
 
-        snprintf(buffer + buffer_size, sizeof(buffer) - buffer_size, "%s", str);
+        size = snprintf(buffer + buffer_size, sizeof(buffer) - buffer_size, "%s", str);
 
-        if (OS_MAX_LOG_SIZE - 1 - buffer_size < strlen(str)) {
-            merror("Large message size from file '%s' (length = " FTELL_TT "): '%s'...", lf->file, FTELL_INT64 buffer_size + strlen(str), buffer);
+        if ((size_t)size >= sizeof(buffer) - buffer_size) {
+            __ms = 1;
         }
 
         if (linesgot < lf->linecount) {

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -90,9 +90,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
             buffer_size++;
         }
 
-        strncat(buffer, str, sizeof(buffer) - 1 - buffer_size);
-        buffer[sizeof(buffer) - 1] = '\0';
-
+        snprintf(buffer + buffer_size, sizeof(buffer) - buffer_size, "%s", str);
 
         if (OS_MAX_LOG_SIZE - 1 - buffer_size < strlen(str)) {
             merror("Large message size from file '%s' (length = " FTELL_TT "): '%s'...", lf->file, FTELL_INT64 buffer_size + strlen(str), buffer);


### PR DESCRIPTION
|Related issue|
|---|
|#12100|


## Description

This PR aims to resolve the warnings when compiling the Wazuh agent project in read_multiline.c. The output of the compilation after the changes was:

##  Compilation using GCC 9.3

<details>
<summary>Wazuh Agent</summary>

```

   CC logcollector/read_nmapg.o
    CC logcollector/read_command.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from logcollector/read_nmapg.c:11:
In function ‘strncat’,
    inlined from ‘read_nmapg’ at logcollector/read_nmapg.c:246:13:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:136:10: warning: ‘__builtin___strncat_chk’ output may be truncated copying between 27 and 65533 bytes from a string of length 65536 [-Wstringop-truncation]
  136 |   return __builtin___strncat_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_mysql_log.o
    CC logcollector/read_ucs2_be.o
    CC logcollector/read_multiline.o
    CC logcollector/macos_log.o
    CC logcollector/read_fullcommand.o
    CC logcollector/read_snortfull.o
    CC syscheckd/db/schema_fim_db.o
    CC syscheckd/run_realtime.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from logcollector/read_snortfull.c:11:
In function ‘strncpy’,
    inlined from ‘read_snortfull’ at logcollector/read_snortfull.c:54:17:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output may be truncated copying 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC syscheckd/config.o
    CC syscheckd/create_db.o

```

</details>

## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Agent</summary>

```

      |                          ~~~~~~~~~~~~~~~~~
  164 |                          djb_host,
      |                          ~~~~~~~~~
  165 |                          lf->djb_program_name,
      |                          ~~~~~~~~~~~~~~~~~~~~~
  166 |                          p);
      |                          ~~
    CC logcollector/read_json.o
    CC logcollector/read_macos.o
    CC logcollector/read_mssql_log.o
    CC logcollector/read_multiline.o
logcollector/read_mssql_log.c: In function ‘read_mssql_log’:
logcollector/read_mssql_log.c:117:17: warning: ‘strncpy’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  117 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_mssql_log.c:108:17: warning: ‘strncpy’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  108 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_multiline_regex.o
    CC logcollector/read_mysql_log.o
    CC logcollector/read_nmapg.o
logcollector/read_mysql_log.c: In function ‘read_mysql_log’:
logcollector/read_mysql_log.c:105:56: warning: ‘%s’ directive output may be truncated writing up to 65521 bytes into a region of size between 65489 and 65524 [-Wformat-truncation=]
  105 |             snprintf(buffer, OS_MAXSTR, "MySQ
```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors