### PR TITLE
Fix wrong buffer size management at Remoted Syslog TCP server

### DIFF
--- a/src/remoted/syslogtcp.c
+++ b/src/remoted/syslogtcp.c
@@ -21,7 +21,7 @@
 
 /**
  * @brief Get the offset of the syslog message, discarding the PRI header.
- * 
+ *
  * @param syslog_msg RAW syslog message
  * @return Length of the PRI header, 0 if not present
  */
@@ -53,10 +53,7 @@ static int OS_IPNotAllowed(char *srcip)
 void send_buffer(sockbuffer_t *socket_buffer, char *srcip) {
     char *data_pt = socket_buffer->data;
     int offset;
-    char * buffer_pt = NULL; 
-
-    // ignore syslog PRI header
-    data_pt += w_get_pri_header_len(data_pt);
+    char * buffer_pt = NULL;
 
     buffer_pt = strchr(data_pt, '\n');
 
@@ -65,7 +62,7 @@ void send_buffer(sockbuffer_t *socket_buffer, char *srcip) {
         offset = ((int)(buffer_pt - data_pt));
         *buffer_pt = '\0';
         // Send message to the queue
-        if (SendMSG(logr.m_queue, data_pt, srcip, SYSLOG_MQ) < 0) {
+        if (SendMSG(logr.m_queue, data_pt + w_get_pri_header_len(data_pt), srcip, SYSLOG_MQ) < 0) {
             merror(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
 
             if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
@@ -75,8 +72,6 @@ void send_buffer(sockbuffer_t *socket_buffer, char *srcip) {
         // Re-calculate the used size of buffer and remove the message from the buffer
         socket_buffer->data_len = socket_buffer->data_len - (offset + 1);
         data_pt += (offset + 1);
-        // ignore syslog PRI header
-        data_pt += w_get_pri_header_len(data_pt);
         // Find the next '\n'
         buffer_pt = strchr(data_pt, '\n');
     }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #12389|

This PR aims to fix a bug caused by #7633, when handling the Remoted syslog buffer.

## Rationale

The Remoted syslog TCP server uses a `sockbuf_t` structure to store incoming data from syslog clients. Such data may include a priority header (like `<13>`) that the server needs to remove after dequeuing the message. Then, the message length must be decreased from the member `data_len`. Unfortunately, the priority header was being picked from the buffer, but its size was not being decreased.

## Proposed fix

Fully handle syslog messages, including the priority queue. Skip it when sending the messages only.

## Behavior

### Before this fix

Remoted showed logs like this:

```
wazuh-remoted[18432] remoted.c:129 at HandleRemote(): INFO: Started (pid: 18435). Listening on port 514/TCP (syslog).
wazuh-remoted[18432] mq_op.c:46 at StartMQ(): DEBUG: Connected succesfully to 'queue/sockets/queue' after 0 attempts
wazuh-remoted[18432] mq_op.c:47 at StartMQ(): DEBUG: (unix_domain) Maximum send buffer set to: '212992'.
wazuh-remoted[18432] syslogtcp.c:97 at HandleClient(): DEBUG: recv(buffer[0], len=65536)
wazuh-remoted[18432] syslogtcp.c:99 at HandleClient(): DEBUG: recv(): 76
wazuh-remoted[18432] syslogtcp.c:114 at HandleClient(): DEBUG: Received 76 bytes from '172.20.208.1'
wazuh-remoted[18432] syslogtcp.c:97 at HandleClient(): DEBUG: recv(buffer[0], len=65536)
wazuh-remoted[18432] syslogtcp.c:99 at HandleClient(): DEBUG: recv(): 725
wazuh-remoted[18432] syslogtcp.c:114 at HandleClient(): DEBUG: Received 725 bytes from '172.20.208.1'
wazuh-remoted[18432] syslogtcp.c:97 at HandleClient(): DEBUG: recv(buffer[0], len=65536)
wazuh-remoted[18432] syslogtcp.c:99 at HandleClient(): DEBUG: recv(): 48
wazuh-remoted[18432] syslogtcp.c:114 at HandleClient(): DEBUG: Received 48 bytes from '172.20.208.1'
```

However, only the first two messages got delivered to Analysisd and printed into _archives.log_.

### After this fix

- Same logs in _ossec.log_.
- Every message transmitted to Remoted appeared at _archives.log_.

## Tests

- [x] Remoted delivers every syslog message to Analysisd.
- [x] Valgrind.

### Valgrind report

```
==24615== LEAK SUMMARY:
==24615==    definitely lost: 0 bytes in 0 blocks
==24615==    indirectly lost: 0 bytes in 0 blocks
==24615==      possibly lost: 0 bytes in 0 blocks
==24615==    still reachable: 66,222 bytes in 38 blocks
==24615==         suppressed: 0 bytes in 0 blocks
==24615== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```