### PR TITLE
Fix warnings in read_mysql_log.c file

### DIFF
--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -46,23 +46,24 @@
 #define LOGLEVEL_INFO 1
 #define LOGLEVEL_DEBUG 0
 
-#define OS_MAXSTR       OS_SIZE_65536       /* Size for logs, sockets, etc      */
-#define OS_BUFFER_SIZE  OS_SIZE_2048        /* Size of general buffers          */
-#define OS_FLSIZE       OS_SIZE_256         /* Maximum file size                */
-#define OS_HEADER_SIZE  OS_SIZE_128         /* Maximum header size              */
-#define OS_LOG_HEADER   OS_SIZE_256         /* Maximum log header size          */
-#define OS_SK_HEADER    OS_SIZE_6144        /* Maximum syscheck header size     */
-#define IPSIZE          INET6_ADDRSTRLEN    /* IP Address size                  */
-#define AUTH_POOL       1000                /* Max number of connections        */
-#define BACKLOG         128                 /* Socket input queue length        */
-#define MAX_EVENTS      1024                /* Max number of epoll events       */
-#define EPOLL_MILLIS    -1                  /* Epoll wait time                  */
-#define MAX_TAG_COUNTER 256                 /* Max retrying counter             */
-#define SOCK_RECV_TIME0 300                 /* Socket receiving timeout (s)     */
-#define MIN_ORDER_SIZE  32                  /* Minimum size of orders array     */
-#define KEEPALIVE_SIZE  700                 /* Random keepalive string size     */
-#define MAX_DYN_STR     4194304             /* Max message size received 4MiB   */
-#define DATE_LENGTH     64                  /* Format date time %D %T           */
+#define OS_MAXSTR       OS_SIZE_65536               /* Size for logs, sockets, etc      */
+#define OS_BUFFER_SIZE  OS_SIZE_2048                /* Size of general buffers          */
+#define OS_FLSIZE       OS_SIZE_256                 /* Maximum file size                */
+#define OS_HEADER_SIZE  OS_SIZE_128                 /* Maximum header size              */
+#define OS_LOG_HEADER   OS_SIZE_256                 /* Maximum log header size          */
+#define OS_SK_HEADER    OS_SIZE_6144                /* Maximum syscheck header size     */
+#define IPSIZE          INET6_ADDRSTRLEN            /* IP Address size                  */
+#define AUTH_POOL       1000                        /* Max number of connections        */
+#define BACKLOG         128                         /* Socket input queue length        */
+#define MAX_EVENTS      1024                        /* Max number of epoll events       */
+#define EPOLL_MILLIS    -1                          /* Epoll wait time                  */
+#define MAX_TAG_COUNTER 256                         /* Max retrying counter             */
+#define SOCK_RECV_TIME0 300                         /* Socket receiving timeout (s)     */
+#define MIN_ORDER_SIZE  32                          /* Minimum size of orders array     */
+#define KEEPALIVE_SIZE  700                         /* Random keepalive string size     */
+#define MAX_DYN_STR     4194304                     /* Max message size received 4MiB   */
+#define DATE_LENGTH     64                          /* Format date time %D %T           */
+#define OS_MAX_LOG_SIZE OS_MAXSTR - OS_LOG_HEADER   /* Maximum log size with a header protection */
 
 /* Some global names */
 #define __ossec_name    "Wazuh"

--- a/src/logcollector/read_mysql_log.c
+++ b/src/logcollector/read_mysql_log.c
@@ -22,8 +22,8 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
     size_t str_len = 0;
     int need_clear = 0;
     char *p;
-    char str[OS_MAXSTR - OS_LOG_HEADER];
-    char buffer[OS_MAXSTR - OS_LOG_HEADER];
+    char str[OS_MAX_LOG_SIZE];
+    char buffer[OS_MAX_LOG_SIZE];
     int lines = 0;
     int bytes_written = 0;
 

--- a/src/logcollector/read_mysql_log.c
+++ b/src/logcollector/read_mysql_log.c
@@ -233,10 +233,11 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
             continue;
         }
 
-        if (bytes_written > (int)(sizeof(buffer) - 1)) {
+        if (bytes_written < 0) {
+            merror("Error %d (%s) while reading message: '%s' (length = " FTELL_TT "): '%s'...", errno, strerror(errno), lf->file, FTELL_INT64 bytes_written, buffer);
+        } else if ((size_t)bytes_written >= sizeof(buffer)) {
             merror("Message size too big on file '%s' (length = " FTELL_TT "): '%s'...", lf->file, FTELL_INT64 bytes_written, buffer);
         }
-
 
         mdebug2("Reading mysql messages: '%s'", buffer);
 

--- a/src/logcollector/read_mysql_log.c
+++ b/src/logcollector/read_mysql_log.c
@@ -27,8 +27,8 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
     int lines = 0;
     int bytes_written = 0;
 
-    str[OS_MAXSTR - OS_LOG_HEADER - 1] = '\0';
-    buffer[OS_MAXSTR - OS_LOG_HEADER - 1] = '\0';
+    str[sizeof(str) - 1] = '\0';
+    buffer[sizeof(buffer) - 1] = '\0';
     *rc = 0;
 
     /* Obtain context to calculate hash */
@@ -37,7 +37,7 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     /* Get new entry */
-    while (can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
+    while (can_read() && fgets(str, sizeof(str), lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
 
         lines++;
         /* Get buffer size */
@@ -104,7 +104,7 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
             }
 
             /* Valid MySQL message */
-            bytes_written = snprintf(buffer, OS_MAXSTR - OS_LOG_HEADER, "MySQL log: %s %s",
+            bytes_written = snprintf(buffer, sizeof(buffer), "MySQL log: %s %s",
                      __mysql_last_time, p);
         }
 
@@ -157,7 +157,7 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
            }
 
            /* Valid MySQL message */
-           bytes_written = snprintf(buffer, OS_MAXSTR - OS_LOG_HEADER, "MySQL log: %s %s",
+           bytes_written = snprintf(buffer, sizeof(buffer), "MySQL log: %s %s",
                     __mysql_last_time, p);
        }
 
@@ -205,7 +205,7 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
           }
 
           /* Valid MySQL message */
-          bytes_written = snprintf(buffer, OS_MAXSTR - OS_LOG_HEADER, "MySQL log: %s %s",
+          bytes_written = snprintf(buffer, sizeof(buffer), "MySQL log: %s %s",
                    __mysql_last_time, p);
       }
 
@@ -229,14 +229,14 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
             }
 
             /* Valid MySQL message */
-            bytes_written = snprintf(buffer, OS_MAXSTR - OS_LOG_HEADER, "MySQL log: %s %s",
+            bytes_written = snprintf(buffer, sizeof(buffer), "MySQL log: %s %s",
                      __mysql_last_time, p);
         } else {
             continue;
         }
 
-        if (bytes_written + 1 > OS_MAXSTR - OS_LOG_HEADER) {
-            merror("Large message size from file '%s' (length = " FTELL_TT "): '%s'...", lf->file, FTELL_INT64 bytes_written, buffer);
+        if (bytes_written > (int)(sizeof(buffer) - 1)) {
+            merror("Message size too big on file '%s' (length = " FTELL_TT "): '%s'...", lf->file, FTELL_INT64 bytes_written, buffer);
         }
 
 

--- a/src/logcollector/read_mysql_log.c
+++ b/src/logcollector/read_mysql_log.c
@@ -22,13 +22,11 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
     size_t str_len = 0;
     int need_clear = 0;
     char *p;
-    char str[OS_MAX_LOG_SIZE];
-    char buffer[OS_MAX_LOG_SIZE];
+    char str[OS_MAX_LOG_SIZE] = {0};
+    char buffer[OS_MAX_LOG_SIZE] = {0};
     int lines = 0;
     int bytes_written = 0;
 
-    str[sizeof(str) - 1] = '\0';
-    buffer[sizeof(buffer) - 1] = '\0';
     *rc = 0;
 
     /* Obtain context to calculate hash */


### PR DESCRIPTION
|Related issue|
|---|
|#12100|

## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh agent project in read_mysql_log.c. . The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Agent</summary>

```

logcollector/read_audit.c:25:13: note: length computed here
   25 |         z = strlen(cache[i]);
      |             ^~~~~~~~~~~~~~~~
    CC logcollector/read_nmapg.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from logcollector/read_nmapg.c:11:
In function ‘strncat’,
    inlined from ‘read_nmapg’ at logcollector/read_nmapg.c:246:13:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:136:10: warning: ‘__builtin___strncat_chk’ output may be truncated copying between 27 and 65533 bytes from a string of length 65536 [-Wstringop-truncation]
  136 |   return __builtin___strncat_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_command.o
    CC logcollector/read_mysql_log.o
    CC logcollector/read_ucs2_be.o
    CC logcollector/read_multiline.o
    CC logcollector/macos_log.o
    CC logcollector/read_fullcommand.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from logcollector/read_multiline.c:11:
In function ‘strncpy’,
    inlined from ‘read_multiline’ at logcollector/read_multiline.c:96:9:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output may be truncated copying between 0 and 65534 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_snortfull.o

```

</details>

## Compilation using GCC 10.2.1


<details>
<summary>Wazuh Agent</summary>

```
 117 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_mssql_log.c:108:17: warning: ‘strncpy’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  108 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_multiline_regex.o
logcollector/read_multiline.c: In function ‘read_multiline’:
logcollector/read_multiline.c:96:9: warning: ‘strncpy’ output may be truncated copying between 0 and 65534 bytes from a string of length 65536 [-Wstringop-truncation]
   96 |         strncpy(buffer + buffer_size, str, OS_MAXSTR - buffer_size - 2);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_mysql_log.o
    CC logcollector/read_nmapg.o
    CC logcollector/read_ossecalert.o
logcollector/read_nmapg.c: In function ‘read_nmapg’:
logcollector/read_nmapg.c:222:49: warning: ‘, open ports:’ directive output may be truncated writing 13 bytes into a region of size between 0 and 65530 [-Wformat-truncation=]
  222 |         snprintf(final_msg, OS_MAXSTR, "Host: %s, open ports:",
      |                                                 ^~~~~~~~~~~~~
logcollector/read_nmapg.c:222:9: note: ‘snprintf’ output between 20 and 65550 bytes into a destination of size 65536
  222 |         snprintf(final_msg, OS_MAXSTR, "Host: %s, open ports:",
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  223 |                  ip);
      |                  ~~~
logcollector/read_nmapg.c:246:13: warning: ‘strncat’ output may be trun
```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors