### PR TITLE
Fix warnings in read_nmapg.c file

### DIFF
--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -46,23 +46,24 @@
 #define LOGLEVEL_INFO 1
 #define LOGLEVEL_DEBUG 0
 
-#define OS_MAXSTR       OS_SIZE_65536       /* Size for logs, sockets, etc      */
-#define OS_BUFFER_SIZE  OS_SIZE_2048        /* Size of general buffers          */
-#define OS_FLSIZE       OS_SIZE_256         /* Maximum file size                */
-#define OS_HEADER_SIZE  OS_SIZE_128         /* Maximum header size              */
-#define OS_LOG_HEADER   OS_SIZE_256         /* Maximum log header size          */
-#define OS_SK_HEADER    OS_SIZE_6144        /* Maximum syscheck header size     */
-#define IPSIZE          INET6_ADDRSTRLEN    /* IP Address size                  */
-#define AUTH_POOL       1000                /* Max number of connections        */
-#define BACKLOG         128                 /* Socket input queue length        */
-#define MAX_EVENTS      1024                /* Max number of epoll events       */
-#define EPOLL_MILLIS    -1                  /* Epoll wait time                  */
-#define MAX_TAG_COUNTER 256                 /* Max retrying counter             */
-#define SOCK_RECV_TIME0 300                 /* Socket receiving timeout (s)     */
-#define MIN_ORDER_SIZE  32                  /* Minimum size of orders array     */
-#define KEEPALIVE_SIZE  700                 /* Random keepalive string size     */
-#define MAX_DYN_STR     4194304             /* Max message size received 4MiB   */
-#define DATE_LENGTH     64                  /* Format date time %D %T           */
+#define OS_MAXSTR       OS_SIZE_65536               /* Size for logs, sockets, etc      */
+#define OS_BUFFER_SIZE  OS_SIZE_2048                /* Size of general buffers          */
+#define OS_FLSIZE       OS_SIZE_256                 /* Maximum file size                */
+#define OS_HEADER_SIZE  OS_SIZE_128                 /* Maximum header size              */
+#define OS_LOG_HEADER   OS_SIZE_256                 /* Maximum log header size          */
+#define OS_SK_HEADER    OS_SIZE_6144                /* Maximum syscheck header size     */
+#define IPSIZE          INET6_ADDRSTRLEN            /* IP Address size                  */
+#define AUTH_POOL       1000                        /* Max number of connections        */
+#define BACKLOG         128                         /* Socket input queue length        */
+#define MAX_EVENTS      1024                        /* Max number of epoll events       */
+#define EPOLL_MILLIS    -1                          /* Epoll wait time                  */
+#define MAX_TAG_COUNTER 256                         /* Max retrying counter             */
+#define SOCK_RECV_TIME0 300                         /* Socket receiving timeout (s)     */
+#define MIN_ORDER_SIZE  32                          /* Minimum size of orders array     */
+#define KEEPALIVE_SIZE  700                         /* Random keepalive string size     */
+#define MAX_DYN_STR     4194304                     /* Max message size received 4MiB   */
+#define DATE_LENGTH     64                          /* Format date time %D %T           */
+#define OS_MAX_LOG_SIZE OS_MAXSTR - OS_LOG_HEADER   /* Maximum log size with a header protection */
 
 /* Some global names */
 #define __ossec_name    "Wazuh"

--- a/src/logcollector/read_nmapg.c
+++ b/src/logcollector/read_nmapg.c
@@ -127,11 +127,11 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
     int final_msg_s;
     int need_clear = 0;
 
-    char str[OS_MAX_LOG_SIZE];
-    char final_msg[OS_MAX_LOG_SIZE];
-    char port[17];
-    char proto[17];
-    char buffer[sizeof(port) + sizeof(proto) + 4];
+    char str[OS_MAX_LOG_SIZE] = {0};
+    char final_msg[OS_MAX_LOG_SIZE] = {0};
+    char port[17] = {0};
+    char proto[17] = {0};
+    char buffer[sizeof(port) + sizeof(proto) + 4] = {0};
 
     char *ip = NULL;
     char *p;
@@ -141,12 +141,6 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
     int bytes_written = 0;
 
     *rc = 0;
-    str[sizeof(str) -1] = '\0';
-    final_msg[sizeof(final_msg) - 1] = '\0';
-    buffer[sizeof(buffer) - 1] = '\0';
-
-    port[16] = '\0';
-    proto[16] = '\0';
 
     /* Obtain context to calculate hash */
     SHA_CTX context;

--- a/src/logcollector/read_nmapg.c
+++ b/src/logcollector/read_nmapg.c
@@ -223,7 +223,11 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
         bytes_written = snprintf(final_msg, sizeof(final_msg), "Host: %s, open ports:",
                  ip);
 
-        if (bytes_written < (int)sizeof(final_msg)) {
+        if (bytes_written < 0) {
+            final_msg_s = 0;
+            merror("Error %d (%s) formatting string from file '%s' (length = " FTELL_TT "): '%s'...", errno, strerror(errno), lf->file, FTELL_INT64 bytes_written, final_msg);
+        }
+        else if ((size_t)bytes_written < sizeof(final_msg)) {
             final_msg_s = OS_MAX_LOG_SIZE - 1 - strlen(final_msg);
         }
         else {

--- a/src/logcollector/read_nmapg.c
+++ b/src/logcollector/read_nmapg.c
@@ -126,13 +126,13 @@ static char *__go_after(char *x, const char *y)
 /* Read Nmap grepable files */
 void *read_nmapg(logreader *lf, int *rc, int drop_it) {
     int final_msg_s;
+    int index = 0;
     int need_clear = 0;
 
     char str[OS_MAX_LOG_SIZE] = {0};
     char final_msg[OS_MAX_LOG_SIZE] = {0};
     char port[17] = {0};
     char proto[17] = {0};
-    char buffer[sizeof(port) + sizeof(proto) + sizeof(PORT_PROTO)] = {0};
 
     char *ip = NULL;
     char *p;
@@ -222,7 +222,7 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
             final_msg_s = 0;
             merror("Error %d (%s) formatting string from file '%s' (length = " FTELL_TT "): '%s'...", errno, strerror(errno), lf->file, FTELL_INT64 bytes_written, final_msg);
         } else if ((size_t)bytes_written < sizeof(final_msg)) {
-            final_msg_s = OS_MAX_LOG_SIZE - 1 - strlen(final_msg);
+            final_msg_s = OS_MAX_LOG_SIZE - strlen(final_msg);
         } else {
             final_msg_s = 0;
             merror("Large message size from file '%s' (length = " FTELL_TT "): '%s'...", lf->file, FTELL_INT64 bytes_written, final_msg);
@@ -247,9 +247,9 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
             }
 
             /* Add ports */
-            snprintf(buffer, sizeof(buffer), PORT_PROTO, port, proto);
-            strncat(final_msg, buffer, final_msg_s);
-            final_msg_s -= strlen(buffer);
+            index = strlen(final_msg);
+            index = snprintf((final_msg + index), final_msg_s, PORT_PROTO, port, proto);
+            final_msg_s -= index;
 
         } while (*p == ',' && (p++));
 

--- a/src/logcollector/read_nmapg.c
+++ b/src/logcollector/read_nmapg.c
@@ -16,6 +16,7 @@
 #define NMAPG_PORT  "Ports:"
 #define NMAPG_OPEN  "open/"
 #define NMAPG_STAT  "Status:"
+#define PORT_PROTO  " %s(%s)"
 
 /* Prototypes */
 static char *__go_after(char *x, const char *y);
@@ -131,7 +132,7 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
     char final_msg[OS_MAX_LOG_SIZE] = {0};
     char port[17] = {0};
     char proto[17] = {0};
-    char buffer[sizeof(port) + sizeof(proto) + 4] = {0};
+    char buffer[sizeof(port) + sizeof(proto) + sizeof(PORT_PROTO)] = {0};
 
     char *ip = NULL;
     char *p;
@@ -246,7 +247,7 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
             }
 
             /* Add ports */
-            snprintf(buffer, sizeof(buffer), " %s(%s)", port, proto);
+            snprintf(buffer, sizeof(buffer), PORT_PROTO, port, proto);
             strncat(final_msg, buffer, final_msg_s);
             final_msg_s -= strlen(buffer);
 

--- a/src/logcollector/read_nmapg.c
+++ b/src/logcollector/read_nmapg.c
@@ -141,9 +141,9 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
     int bytes_written = 0;
 
     *rc = 0;
-    str[OS_MAXSTR - OS_LOG_HEADER -1] = '\0';
-    final_msg[OS_MAXSTR - OS_LOG_HEADER - 1] = '\0';
-    buffer[sizeof(port) + sizeof(proto) + 3] = '\0';
+    str[sizeof(str) -1] = '\0';
+    final_msg[sizeof(final_msg) - 1] = '\0';
+    buffer[sizeof(buffer) - 1] = '\0';
 
     port[16] = '\0';
     proto[16] = '\0';
@@ -153,7 +153,7 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
-    while (can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
+    while (can_read() && fgets(str, sizeof(str), lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
 
         lines++;
 
@@ -220,10 +220,10 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
         }
 
         /* Generate final msg */
-        bytes_written = snprintf(final_msg, OS_MAXSTR - OS_LOG_HEADER, "Host: %s, open ports:",
+        bytes_written = snprintf(final_msg, sizeof(final_msg), "Host: %s, open ports:",
                  ip);
 
-        if (bytes_written < OS_MAXSTR - OS_LOG_HEADER) {
+        if (bytes_written < (int)sizeof(final_msg)) {
             final_msg_s = OS_MAXSTR - OS_LOG_HEADER - 1 - strlen(final_msg);
         }
         else {

--- a/src/logcollector/read_nmapg.c
+++ b/src/logcollector/read_nmapg.c
@@ -220,11 +220,9 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
         if (bytes_written < 0) {
             final_msg_s = 0;
             merror("Error %d (%s) formatting string from file '%s' (length = " FTELL_TT "): '%s'...", errno, strerror(errno), lf->file, FTELL_INT64 bytes_written, final_msg);
-        }
-        else if ((size_t)bytes_written < sizeof(final_msg)) {
+        } else if ((size_t)bytes_written < sizeof(final_msg)) {
             final_msg_s = OS_MAX_LOG_SIZE - 1 - strlen(final_msg);
-        }
-        else {
+        } else {
             final_msg_s = 0;
             merror("Large message size from file '%s' (length = " FTELL_TT "): '%s'...", lf->file, FTELL_INT64 bytes_written, final_msg);
         }

--- a/src/logcollector/read_nmapg.c
+++ b/src/logcollector/read_nmapg.c
@@ -127,8 +127,8 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
     int final_msg_s;
     int need_clear = 0;
 
-    char str[OS_MAXSTR - OS_LOG_HEADER];
-    char final_msg[OS_MAXSTR - OS_LOG_HEADER];
+    char str[OS_MAX_LOG_SIZE];
+    char final_msg[OS_MAX_LOG_SIZE];
     char port[17];
     char proto[17];
     char buffer[sizeof(port) + sizeof(proto) + 4];
@@ -224,7 +224,7 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
                  ip);
 
         if (bytes_written < (int)sizeof(final_msg)) {
-            final_msg_s = OS_MAXSTR - OS_LOG_HEADER - 1 - strlen(final_msg);
+            final_msg_s = OS_MAX_LOG_SIZE - 1 - strlen(final_msg);
         }
         else {
             final_msg_s = 0;


### PR DESCRIPTION
|Related issue|
|---|
|#12100|


## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh agent project in read_nmapg.c. . The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Agent</summary>

```
    CC logcollector/read_audit.o
    CC logcollector/read_multiline_regex.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from logcollector/read_audit.c:10:
In function ‘strncpy’,
    inlined from ‘audit_send_msg’ at logcollector/read_audit.c:31:13:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_audit.c: In function ‘audit_send_msg’:
logcollector/read_audit.c:25:13: note: length computed here
   25 |         z = strlen(cache[i]);
      |             ^~~~~~~~~~~~~~~~
    CC logcollector/read_nmapg.o
    CC logcollector/read_command.o
    CC logcollector/read_mysql_log.o
    CC logcollector/read_ucs2_be.o
    CC logcollector/read_multiline.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from logcollector/read_multiline.c:11:
In function ‘strncpy’,
    inlined from ‘read_multiline’ at logcollector/read_multiline.c:96:9:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output may be truncated copying between 0 and 65534 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/macos_log.o

```
</details>

## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Agent</summary>

```
   CC logcollector/read_multiline.o
    CC logcollector/read_multiline_regex.o
logcollector/read_mssql_log.c: In function ‘read_mssql_log’:
logcollector/read_mssql_log.c:117:17: warning: ‘strncpy’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  117 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_mssql_log.c:108:17: warning: ‘strncpy’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  108 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_multiline.c: In function ‘read_multiline’:
logcollector/read_multiline.c:96:9: warning: ‘strncpy’ output may be truncated copying between 0 and 65534 bytes from a string of length 65536 [-Wstringop-truncation]
   96 |         strncpy(buffer + buffer_size, str, OS_MAXSTR - buffer_size - 2);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_mysql_log.o
    CC logcollector/read_nmapg.o
    CC logcollector/read_ossecalert.o
    CC logcollector/read_postgresql_log.o
logcollector/read_mysql_log.c: In function ‘read_mysql_log’:
logcollector/read_mysql_log.c:105:56: warning: ‘%s’ directive output may be truncated writing up to 65521 bytes into a region of size between 65489 and 65524 [-Wformat-truncation=]
  105 |             snprintf(buffer, OS_MAXSTR, "MySQL log: %s %s",
      |                                                        ^~
logcollector/read_mysql_log.c:105:13: note: ‘snprintf’ output between 13 and 65569 bytes into a destination of size 65536
  105 |             snprintf(buffer, OS_MAXSTR, "MySQL log: %s %s",
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  106 |                      __mysql_last_time, p);
      |                      ~~~~~~~~~~~~~~~~~~~~~
logcollector/read_mysql_log.c:158:55: warning: ‘%s’ directive output may be truncated writing up to 65504 bytes into a region of size between 65489 and 65524 [-Wformat-truncation=]
  158 |            snprintf(buffer, OS_MAXSTR, "MySQL log: %s %s",
      |                                                       ^~

```
</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors