### PR TITLE
Fixed several segfaults in windows registry scanning

### DIFF
--- a/src/syscheckd/src/db/src/dbFileItem.hpp
+++ b/src/syscheckd/src/db/src/dbFileItem.hpp
@@ -14,9 +14,7 @@
 #include "json.hpp"
 #include "dbItem.hpp"
 #include "fimCommonDefs.h"
-#ifdef WIN32
-#include "encodingWindowsHelper.h"
-#endif
+#include "fimDBSpecialization.h"
 
 struct FimFileDataDeleter
 {
@@ -60,16 +58,17 @@ class FileItem final : public DBItem
             m_size = fim->file_entry.data->size;
             m_dev = fim->file_entry.data->dev;
             m_inode = fim->file_entry.data->inode;
+
             m_attributes = fim->file_entry.data->attributes == NULL ? "" : fim->file_entry.data->attributes;
             m_username = fim->file_entry.data->user_name == NULL ? "" : fim->file_entry.data->user_name;
             m_groupname = fim->file_entry.data->group_name == NULL ? "" : fim->file_entry.data->group_name;
             m_perm = fim->file_entry.data->perm == NULL ? "" : fim->file_entry.data->perm;
-#ifdef WIN32
-            m_attributes = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(m_attributes);
-            m_username = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(m_username);
-            m_groupname = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(m_groupname);
-            m_perm = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(m_perm);
-#endif
+
+            FIMDBCreator<OS_TYPE>::encodeString(m_attributes);
+            FIMDBCreator<OS_TYPE>::encodeString(m_username);
+            FIMDBCreator<OS_TYPE>::encodeString(m_groupname);
+            FIMDBCreator<OS_TYPE>::encodeString(m_perm);
+
             m_md5 = fim->file_entry.data->hash_md5[0] == '\0' ? "" : fim->file_entry.data->hash_md5;
             m_sha1 = fim->file_entry.data->hash_sha1[0] == '\0' ? "" : fim->file_entry.data->hash_sha1;
             m_sha256 = fim->file_entry.data->hash_sha256[0] == '\0' ? "" : fim->file_entry.data->hash_sha256;

--- a/src/syscheckd/src/db/src/dbFileItem.hpp
+++ b/src/syscheckd/src/db/src/dbFileItem.hpp
@@ -14,6 +14,9 @@
 #include "json.hpp"
 #include "dbItem.hpp"
 #include "fimCommonDefs.h"
+#ifdef WIN32
+#include "encodingWindowsHelper.h"
+#endif
 
 struct FimFileDataDeleter
 {
@@ -58,14 +61,20 @@ class FileItem final : public DBItem
             m_dev = fim->file_entry.data->dev;
             m_inode = fim->file_entry.data->inode;
             m_attributes = fim->file_entry.data->attributes == NULL ? "" : fim->file_entry.data->attributes;
-            m_gid =  fim->file_entry.data->gid == NULL ? 0 : std::atoi(fim->file_entry.data->gid);
+            m_username = fim->file_entry.data->user_name == NULL ? "" : fim->file_entry.data->user_name;
             m_groupname = fim->file_entry.data->group_name == NULL ? "" : fim->file_entry.data->group_name;
-            m_md5 = fim->file_entry.data->hash_md5[0] == '\0' ? "" : fim->file_entry.data->hash_md5;
             m_perm = fim->file_entry.data->perm == NULL ? "" : fim->file_entry.data->perm;
+#ifdef WIN32
+            m_attributes = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(m_attributes);
+            m_username = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(m_username);
+            m_groupname = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(m_groupname);
+            m_perm = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(m_perm);
+#endif
+            m_md5 = fim->file_entry.data->hash_md5[0] == '\0' ? "" : fim->file_entry.data->hash_md5;
             m_sha1 = fim->file_entry.data->hash_sha1[0] == '\0' ? "" : fim->file_entry.data->hash_sha1;
             m_sha256 = fim->file_entry.data->hash_sha256[0] == '\0' ? "" : fim->file_entry.data->hash_sha256;
             m_uid = fim->file_entry.data->uid == NULL ? 0 : std::atoi(fim->file_entry.data->uid);
-            m_username = fim->file_entry.data->user_name == NULL ? "" : fim->file_entry.data->user_name;
+            m_gid =  fim->file_entry.data->gid == NULL ? 0 : std::atoi(fim->file_entry.data->gid);
             createJSON();
             createFimEntry();
         };

--- a/src/syscheckd/src/db/src/dbItem.hpp
+++ b/src/syscheckd/src/db/src/dbItem.hpp
@@ -13,6 +13,9 @@
 #define _DBITEM_HPP
 #include "syscheck.h"
 #include "json.hpp"
+#ifdef WIN32
+#include "encodingWindowsHelper.h"
+#endif
 
 class DBItem
 {
@@ -28,6 +31,9 @@ class DBItem
             , m_checksum( checksum )
             , m_mode( mode )
         {
+#ifdef WIN32
+            m_identifier = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(m_identifier);
+#endif
         }
 
         // LCOV_EXCL_START

--- a/src/syscheckd/src/db/src/dbItem.hpp
+++ b/src/syscheckd/src/db/src/dbItem.hpp
@@ -13,9 +13,7 @@
 #define _DBITEM_HPP
 #include "syscheck.h"
 #include "json.hpp"
-#ifdef WIN32
-#include "encodingWindowsHelper.h"
-#endif
+#include "fimDBSpecialization.h"
 
 class DBItem
 {
@@ -31,9 +29,7 @@ class DBItem
             , m_checksum( checksum )
             , m_mode( mode )
         {
-#ifdef WIN32
-            m_identifier = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(m_identifier);
-#endif
+            FIMDBCreator<OS_TYPE>::encodeString(m_identifier);
         }
 
         // LCOV_EXCL_START

--- a/src/syscheckd/src/db/src/dbRegistryKey.hpp
+++ b/src/syscheckd/src/db/src/dbRegistryKey.hpp
@@ -13,6 +13,7 @@
 #define _REGISTRYKEY_HPP
 #include "json.hpp"
 #include "dbItem.hpp"
+#include "fimDBSpecialization.h"
 
 struct FimRegistryKeyDeleter
 {
@@ -58,11 +59,11 @@ class RegistryKey final : public DBItem
             m_groupname = fim->registry_entry.key->group_name ? fim->registry_entry.key->group_name : "";
             m_perm = fim->registry_entry.key->perm ? fim->registry_entry.key->perm : "";
             m_username = fim->registry_entry.key->user_name ? fim->registry_entry.key->user_name : "";
-#ifdef WIN32
-            m_groupname = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(m_groupname);
-            m_perm = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(m_perm);
-            m_username = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(m_username);
-#endif
+
+            FIMDBCreator<OS_TYPE>::encodeString(m_groupname);
+            FIMDBCreator<OS_TYPE>::encodeString(m_perm);
+            FIMDBCreator<OS_TYPE>::encodeString(m_username);
+
             m_time = fim->registry_entry.key->mtime;
             createJSON();
             createFimEntry();

--- a/src/syscheckd/src/db/src/dbRegistryKey.hpp
+++ b/src/syscheckd/src/db/src/dbRegistryKey.hpp
@@ -54,9 +54,15 @@ class RegistryKey final : public DBItem
             m_arch = fim->registry_entry.key->arch;
             m_gid = std::atoi(fim->registry_entry.key->gid);
             m_uid = std::atoi(fim->registry_entry.key->uid);
-            m_groupname = std::string(fim->registry_entry.key->group_name);
-            m_perm = std::string(fim->registry_entry.key->perm);
-            m_username = std::string(fim->registry_entry.key->user_name);
+
+            m_groupname = fim->registry_entry.key->group_name ? fim->registry_entry.key->group_name : "";
+            m_perm = fim->registry_entry.key->perm ? fim->registry_entry.key->perm : "";
+            m_username = fim->registry_entry.key->user_name ? fim->registry_entry.key->user_name : "";
+#ifdef WIN32
+            m_groupname = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(m_groupname);
+            m_perm = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(m_perm);
+            m_username = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(m_username);
+#endif
             m_time = fim->registry_entry.key->mtime;
             createJSON();
             createFimEntry();

--- a/src/syscheckd/src/db/src/dbRegistryValue.hpp
+++ b/src/syscheckd/src/db/src/dbRegistryValue.hpp
@@ -43,6 +43,9 @@ class RegistryValue final : public DBItem
         {
             m_oldData = oldData;
             m_path = fim->registry_entry.value->path ? fim->registry_entry.value->path : "";
+#ifdef WIN32
+            m_path = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(m_path);
+#endif
             m_arch = fim->registry_entry.value->arch;
             m_size = fim->registry_entry.value->size;
             m_type = fim->registry_entry.value->type;

--- a/src/syscheckd/src/db/src/dbRegistryValue.hpp
+++ b/src/syscheckd/src/db/src/dbRegistryValue.hpp
@@ -14,6 +14,7 @@
 
 #include "json.hpp"
 #include "dbItem.hpp"
+#include "fimDBSpecialization.h"
 
 struct FimRegistryValueDeleter
 {
@@ -43,9 +44,7 @@ class RegistryValue final : public DBItem
         {
             m_oldData = oldData;
             m_path = fim->registry_entry.value->path ? fim->registry_entry.value->path : "";
-#ifdef WIN32
-            m_path = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(m_path);
-#endif
+            FIMDBCreator<OS_TYPE>::encodeString(m_path);
             m_arch = fim->registry_entry.value->arch;
             m_size = fim->registry_entry.value->size;
             m_type = fim->registry_entry.value->type;

--- a/src/syscheckd/src/db/src/fimDBSpecialization.h
+++ b/src/syscheckd/src/db/src/fimDBSpecialization.h
@@ -13,6 +13,7 @@
 
 #include "fimDB.hpp"
 #include "fimCommonDefs.h"
+#include "encodingWindowsHelper.h"
 
 
 constexpr auto FIM_FILE_SYNC_CONFIG_STATEMENT
@@ -201,7 +202,15 @@ class FIMDBCreator final
         {
             throw std::runtime_error
             {
-                "Error running synchronization ."
+                "Error running synchronization."
+            };
+        }
+
+        static void encodeString(std::string& stringToEncode)
+        {
+            throw std::runtime_error
+            {
+                "Error encoding strings."
             };
         }
 };
@@ -256,6 +265,13 @@ class FIMDBCreator<OSType::WINDOWS> final
                                     nlohmann::json::parse(FIM_REGISTRY_START_CONFIG_STATEMENT),
                                     syncRegistryMessageFunction);
         }
+
+        static void encodeString(__attribute__((unused)) std::string& stringToEncode)
+        {
+#ifdef WIN32
+            stringToEncode = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(stringToEncode);
+#endif
+        }
 };
 
 template <>
@@ -294,6 +310,8 @@ class FIMDBCreator<OSType::OTHERS> final
                                     nlohmann::json::parse(FIM_FILE_START_CONFIG_STATEMENT),
                                     syncFileMessageFunction);
         }
+
+        static void encodeString(__attribute__((unused)) std::string& stringToEncode){}
 };
 
 #endif // _FIMDB_OS_SPECIALIZATION_H

--- a/src/syscheckd/src/registry/registry.c
+++ b/src/syscheckd/src/registry/registry.c
@@ -239,7 +239,7 @@ static void registry_value_transaction_callback(ReturnTypeCallback resultType,
         if (json_arch = cJSON_GetObjectItem(dbsync_event, "arch"), json_arch == NULL) {
             goto end;
         }
-        if (json_name = cJSON_GetObjectItem(dbsync_event, "arch"), json_name == NULL) {
+        if (json_name = cJSON_GetObjectItem(dbsync_event, "name"), json_name == NULL) {
             goto end;
         }
         path = cJSON_GetStringValue(json_path);
@@ -903,7 +903,6 @@ void fim_read_values(HKEY key_handle,
     }
 
     fim_registry_free_value_data(new.registry_entry.value);
-    os_free(value_buffer);
     os_free(data_buffer);
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/12391|

## Description
Hello team, this PR contains the fix of several segfaults found in the windows registry scan. List each of them:
- Double free at the end of the fim_open_key, the value name was released twice.
- Last_events in the deletes caused segfault, but it is fixed in another PR.
- Encoding of some strings causing segfault due to tildes, fixed using Utils function: stringAnsiToStringUTF8
- Some value names were not being set correctly when generating deleted alerts.



## Tests
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
- Memory tests for Windows
  - [x] Scan-build report
  - [ ] DrMemory
  