### PR TITLE
Fix warnings in read_postgresql_log.c file

### DIFF
--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -46,23 +46,24 @@
 #define LOGLEVEL_INFO 1
 #define LOGLEVEL_DEBUG 0
 
-#define OS_MAXSTR       OS_SIZE_65536       /* Size for logs, sockets, etc      */
-#define OS_BUFFER_SIZE  OS_SIZE_2048        /* Size of general buffers          */
-#define OS_FLSIZE       OS_SIZE_256         /* Maximum file size                */
-#define OS_HEADER_SIZE  OS_SIZE_128         /* Maximum header size              */
-#define OS_LOG_HEADER   OS_SIZE_256         /* Maximum log header size          */
-#define OS_SK_HEADER    OS_SIZE_6144        /* Maximum syscheck header size     */
-#define IPSIZE          INET6_ADDRSTRLEN    /* IP Address size                  */
-#define AUTH_POOL       1000                /* Max number of connections        */
-#define BACKLOG         128                 /* Socket input queue length        */
-#define MAX_EVENTS      1024                /* Max number of epoll events       */
-#define EPOLL_MILLIS    -1                  /* Epoll wait time                  */
-#define MAX_TAG_COUNTER 256                 /* Max retrying counter             */
-#define SOCK_RECV_TIME0 300                 /* Socket receiving timeout (s)     */
-#define MIN_ORDER_SIZE  32                  /* Minimum size of orders array     */
-#define KEEPALIVE_SIZE  700                 /* Random keepalive string size     */
-#define MAX_DYN_STR     4194304             /* Max message size received 4MiB   */
-#define DATE_LENGTH     64                  /* Format date time %D %T           */
+#define OS_MAXSTR       OS_SIZE_65536               /* Size for logs, sockets, etc      */
+#define OS_BUFFER_SIZE  OS_SIZE_2048                /* Size of general buffers          */
+#define OS_FLSIZE       OS_SIZE_256                 /* Maximum file size                */
+#define OS_HEADER_SIZE  OS_SIZE_128                 /* Maximum header size              */
+#define OS_LOG_HEADER   OS_SIZE_256                 /* Maximum log header size          */
+#define OS_SK_HEADER    OS_SIZE_6144                /* Maximum syscheck header size     */
+#define IPSIZE          INET6_ADDRSTRLEN            /* IP Address size                  */
+#define AUTH_POOL       1000                        /* Max number of connections        */
+#define BACKLOG         128                         /* Socket input queue length        */
+#define MAX_EVENTS      1024                        /* Max number of epoll events       */
+#define EPOLL_MILLIS    -1                          /* Epoll wait time                  */
+#define MAX_TAG_COUNTER 256                         /* Max retrying counter             */
+#define SOCK_RECV_TIME0 300                         /* Socket receiving timeout (s)     */
+#define MIN_ORDER_SIZE  32                          /* Minimum size of orders array     */
+#define KEEPALIVE_SIZE  700                         /* Random keepalive string size     */
+#define MAX_DYN_STR     4194304                     /* Max message size received 4MiB   */
+#define DATE_LENGTH     64                          /* Format date time %D %T           */
+#define OS_MAX_LOG_SIZE OS_MAXSTR - OS_LOG_HEADER   /* Maximum log size with a header protection */
 
 /* Some global names */
 #define __ossec_name    "Wazuh"

--- a/src/logcollector/read_postgresql_log.c
+++ b/src/logcollector/read_postgresql_log.c
@@ -28,14 +28,14 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
     size_t str_len = 0;
     int need_clear = 0;
     char *p;
-    char str[OS_MAXSTR + 1];
-    char buffer[OS_MAXSTR + 1];
+    char str[OS_MAXSTR - OS_LOG_HEADER];
+    char buffer[OS_MAXSTR - OS_LOG_HEADER];
     int lines = 0;
 
     /* Zero buffer and str */
     buffer[0] = '\0';
-    buffer[OS_MAXSTR] = '\0';
-    str[OS_MAXSTR] = '\0';
+    buffer[OS_MAXSTR - OS_LOG_HEADER - 1] = '\0';
+    str[OS_MAXSTR - OS_LOG_HEADER - 1] = '\0';
     *rc = 0;
 
     /* Obtain context to calculate hash */
@@ -103,7 +103,7 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
 
             /* If the saved message is empty, set it and continue */
             if (buffer[0] == '\0') {
-                strncpy(buffer, str, str_len + 2);
+                snprintf(buffer, OS_MAXSTR - OS_LOG_HEADER, "%s", str);
                 continue;
             }
 
@@ -111,7 +111,7 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
             else {
                 __send_pgsql_msg(lf, drop_it, buffer);
                 /* Store current one at the buffer */
-                strncpy(buffer, str, str_len + 2);
+                snprintf(buffer, OS_MAXSTR - OS_LOG_HEADER, "%s", str);
             }
         }
 
@@ -131,7 +131,7 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
             }
 
             /* Add additional message to the saved buffer */
-            if (sizeof(buffer) - buffer_len > str_len + 256) {
+            if (sizeof(buffer) - buffer_len > str_len) {
                 /* Here we make sure that the size of the buffer
                  * minus what was used (strlen) is greater than
                  * the length of the received message.

--- a/src/logcollector/read_postgresql_log.c
+++ b/src/logcollector/read_postgresql_log.c
@@ -28,14 +28,10 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
     size_t str_len = 0;
     int need_clear = 0;
     char *p;
-    char str[OS_MAX_LOG_SIZE];
-    char buffer[OS_MAX_LOG_SIZE];
+    char str[OS_MAX_LOG_SIZE] = {0};
+    char buffer[OS_MAX_LOG_SIZE] = {0};
     int lines = 0;
 
-    /* Zero buffer and str */
-    buffer[0] = '\0';
-    buffer[sizeof(buffer) - 1] = '\0';
-    str[sizeof(str) - 1] = '\0';
     *rc = 0;
 
     /* Obtain context to calculate hash */

--- a/src/logcollector/read_postgresql_log.c
+++ b/src/logcollector/read_postgresql_log.c
@@ -34,8 +34,8 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
 
     /* Zero buffer and str */
     buffer[0] = '\0';
-    buffer[OS_MAXSTR - OS_LOG_HEADER - 1] = '\0';
-    str[OS_MAXSTR - OS_LOG_HEADER - 1] = '\0';
+    buffer[sizeof(buffer) - 1] = '\0';
+    str[sizeof(str) - 1] = '\0';
     *rc = 0;
 
     /* Obtain context to calculate hash */
@@ -44,7 +44,7 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     /* Get new entry */
-    while (can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
+    while (can_read() && fgets(str, sizeof(str), lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
 
         lines++;
         /* Get buffer size */
@@ -103,7 +103,7 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
 
             /* If the saved message is empty, set it and continue */
             if (buffer[0] == '\0') {
-                snprintf(buffer, OS_MAXSTR - OS_LOG_HEADER, "%s", str);
+                snprintf(buffer, sizeof(buffer), "%s", str);
                 continue;
             }
 
@@ -111,7 +111,7 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
             else {
                 __send_pgsql_msg(lf, drop_it, buffer);
                 /* Store current one at the buffer */
-                snprintf(buffer, OS_MAXSTR - OS_LOG_HEADER, "%s", str);
+                snprintf(buffer, sizeof(buffer), "%s", str);
             }
         }
 

--- a/src/logcollector/read_postgresql_log.c
+++ b/src/logcollector/read_postgresql_log.c
@@ -28,8 +28,8 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
     size_t str_len = 0;
     int need_clear = 0;
     char *p;
-    char str[OS_MAXSTR - OS_LOG_HEADER];
-    char buffer[OS_MAXSTR - OS_LOG_HEADER];
+    char str[OS_MAX_LOG_SIZE];
+    char buffer[OS_MAX_LOG_SIZE];
     int lines = 0;
 
     /* Zero buffer and str */


### PR DESCRIPTION
|Related issue|
|---|
|#12100|


## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh agent project in read_postgresql_log.c. . The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Agent</summary>

```
    CC analysisd/logmsg.o
addagent/validate.c: In function ‘OS_AddNewAgent’:
addagent/validate.c:49:27: warning: ‘%03d’ directive output may be truncated writing between 3 and 11 bytes into a region of size 9 [-Wformat-truncation=]
   49 |         snprintf(_id, 9, "%03d", ++keys->id_counter);
      |                           ^~~~
addagent/validate.c:49:26: note: directive argument in the range [-2147483647, 2147483647]
   49 |         snprintf(_id, 9, "%03d", ++keys->id_counter);
      |                          ^~~~~~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from addagent/manage_agents.h:14,
                 from addagent/validate.c:12:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 4 and 12 bytes into a destination of size 9
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC os_auth/main-client.o
    CC logcollector/read_ossecalert.o
    CC logcollector/state.o
    CC logcollector/config.o
    CC logcollector/logcollector.o
    CC logcollector/read_djb_multilog.o
    CC logcollector/read_postgresql_log.o
    CC logcollector/read_ucs2_le.o
    CC logcollector/read_mssql_log.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from logcollector/read_mssql_log.c:13:
In function ‘strncpy’,
    inlined from ‘read_mssql_log’ at logcollector/read_mssql_log.c:117:17:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin___strncpy_chk’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘read_mssql_log’ at logcollector/read_mssql_log.c:108:17:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin___strncpy_chk’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_win_el.o
    CC logcollector/lccom.o
    CC logcollector/read_macos.o
    CC logcollector/read_json.o

```

</details>

## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Agent</summary>

```
    CC logcollector/read_mysql_log.o
logcollector/read_multiline.c: In function ‘read_multiline’:
logcollector/read_multiline.c:96:9: warning: ‘strncpy’ output may be truncated copying between 0 and 65534 bytes from a string of length 65536 [-Wstringop-truncation]
   96 |         strncpy(buffer + buffer_size, str, OS_MAXSTR - buffer_size - 2);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_nmapg.o
    CC logcollector/read_ossecalert.o
    CC logcollector/read_postgresql_log.o
logcollector/read_mysql_log.c: In function ‘read_mysql_log’:
logcollector/read_mysql_log.c:105:56: warning: ‘%s’ directive output may be truncated writing up to 65521 bytes into a region of size between 65489 and 65524 [-Wformat-truncation=]
  105 |             snprintf(buffer, OS_MAXSTR, "MySQL log: %s %s",
      |                                                        ^~
logcollector/read_mysql_log.c:105:13: note: ‘snprintf’ output between 13 and 65569 bytes into a destination of size 65536
  105 |             snprintf(buffer, OS_MAXSTR, "MySQL log: %s %s",
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  106 |                      __mysql_last_time, p);
      |                      ~~~~~~~~~~~~~~~~~~~~~
logcollector/read_mysql_log.c:158:55: warning: ‘%s’ directive output may be truncated writing up to 65504 bytes into a region of size between 65489 and 65524 [-Wformat-truncation=]
  158 |            snprintf(buffer, OS_MAXSTR, "MySQL log: %s %s",
      |                                                       ^~
logcollector/read_mysql_log.c:158:12: note: ‘snprintf’ output between 13 and 65552 bytes into a destination of size 65536
  158 |            snprintf(buffer, OS_MAXSTR, "MySQL log: %s %s",
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  159 |                     __mysql_last_time, p);
      |                     ~~~~~~~~~~~~~~~~~~~~~
logcollector/read_mysql_log.c:206:54: warning: ‘%s’ directive output may be truncated writing up to 65509 bytes into a region of size between 65489 and 65524 [-Wformat-truncation=]
  206 |           snprintf(buffer, OS_MAXSTR, "MySQL log: %s %s",
      |                                                      ^~
logcollector/read_mysql_log.c:206:11: note: ‘snprintf’ output between 13 and 65557 bytes into a destination of size 65536
  206 |           snprintf(buffer, OS_MAXSTR, "MySQL log: %s %s",
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  207 |                    __mysql_last_time, p);
      |                    ~~~~~~~~~~~~~~~~~~~~~
logcollector/read_nmapg.c: In function ‘read_nmapg’:
logcollector/read_nmapg.c:222:49: warning: ‘, open ports:’ directive output may be truncated writing 13 bytes into a region of size between 0 and 65530 [-Wformat-truncation=]
  222 |         snprintf(final_msg, OS_MAXSTR, "Host: %s, open ports:",
      |                                                 ^~~~~~~~~~~~~
logcollector/read_nmapg.c:222:9: note: ‘snprintf’ output between 20 and 65550 bytes into a destination of size 65536
  222 |         snprintf(final_msg, OS_MAXSTR, "Host: %s, open ports:",
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  223 |                  ip);
      |                  ~~~
logcollector/read_nmapg.c:246:13: warning: ‘strncat’ output may be truncated copying between 27 and 65533 bytes from a string of length 65536 [-Wstringop-truncation]
  246 |             strncat(final_msg, buffer, final_msg_s);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_snortfull.o
    CC logcollector/read_syslog.o

```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors