### PR TITLE
Fix warnings read_audit.c file

### DIFF
--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -46,23 +46,24 @@
 #define LOGLEVEL_INFO 1
 #define LOGLEVEL_DEBUG 0
 
-#define OS_MAXSTR       OS_SIZE_65536       /* Size for logs, sockets, etc      */
-#define OS_BUFFER_SIZE  OS_SIZE_2048        /* Size of general buffers          */
-#define OS_FLSIZE       OS_SIZE_256         /* Maximum file size                */
-#define OS_HEADER_SIZE  OS_SIZE_128         /* Maximum header size              */
-#define OS_LOG_HEADER   OS_SIZE_256         /* Maximum log header size          */
-#define OS_SK_HEADER    OS_SIZE_6144        /* Maximum syscheck header size     */
-#define IPSIZE          INET6_ADDRSTRLEN    /* IP Address size                  */
-#define AUTH_POOL       1000                /* Max number of connections        */
-#define BACKLOG         128                 /* Socket input queue length        */
-#define MAX_EVENTS      1024                /* Max number of epoll events       */
-#define EPOLL_MILLIS    -1                  /* Epoll wait time                  */
-#define MAX_TAG_COUNTER 256                 /* Max retrying counter             */
-#define SOCK_RECV_TIME0 300                 /* Socket receiving timeout (s)     */
-#define MIN_ORDER_SIZE  32                  /* Minimum size of orders array     */
-#define KEEPALIVE_SIZE  700                 /* Random keepalive string size     */
-#define MAX_DYN_STR     4194304             /* Max message size received 4MiB   */
-#define DATE_LENGTH     64                  /* Format date time %D %T           */
+#define OS_MAXSTR       OS_SIZE_65536               /* Size for logs, sockets, etc      */
+#define OS_BUFFER_SIZE  OS_SIZE_2048                /* Size of general buffers          */
+#define OS_FLSIZE       OS_SIZE_256                 /* Maximum file size                */
+#define OS_HEADER_SIZE  OS_SIZE_128                 /* Maximum header size              */
+#define OS_LOG_HEADER   OS_SIZE_256                 /* Maximum log header size          */
+#define OS_SK_HEADER    OS_SIZE_6144                /* Maximum syscheck header size     */
+#define IPSIZE          INET6_ADDRSTRLEN            /* IP Address size                  */
+#define AUTH_POOL       1000                        /* Max number of connections        */
+#define BACKLOG         128                         /* Socket input queue length        */
+#define MAX_EVENTS      1024                        /* Max number of epoll events       */
+#define EPOLL_MILLIS    -1                          /* Epoll wait time                  */
+#define MAX_TAG_COUNTER 256                         /* Max retrying counter             */
+#define SOCK_RECV_TIME0 300                         /* Socket receiving timeout (s)     */
+#define MIN_ORDER_SIZE  32                          /* Minimum size of orders array     */
+#define KEEPALIVE_SIZE  700                         /* Random keepalive string size     */
+#define MAX_DYN_STR     4194304                     /* Max message size received 4MiB   */
+#define DATE_LENGTH     64                          /* Format date time %D %T           */
+#define OS_MAX_LOG_SIZE OS_MAXSTR - OS_LOG_HEADER   /* Maximum log size with a header protection */
 
 /* Some global names */
 #define __ossec_name    "Wazuh"

--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -19,19 +19,19 @@ static void audit_send_msg(char **cache, int top, const char *file, int drop_it,
     int i;
     size_t n = 0;
     size_t z;
-    char message[OS_MAXSTR];
+    char message[OS_MAXSTR - OS_LOG_HEADER] = {0};
 
     for (i = 0; i < top; i++) {
         z = strlen(cache[i]);
 
-        if (n + z + 1 < OS_MAXSTR) {
+        if (n + z + 1 < OS_MAXSTR - OS_LOG_HEADER) {
             if (n > 0)
                 message[n++] = ' ';
 
-            strncpy(message + n, cache[i], z);
+            strncat(message, cache[i], OS_MAXSTR - OS_LOG_HEADER - 1 - n);
+            n += z;
         }
 
-        n += z;
         free(cache[i]);
     }
 

--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -24,7 +24,7 @@ static void audit_send_msg(char **cache, int top, const char *file, int drop_it,
     for (i = 0; i < top; i++) {
         z = strlen(cache[i]);
 
-        if (n + z + 1 < OS_MAXSTR - OS_LOG_HEADER) {
+        if (n + z + 1 < sizeof(message)) {
             if (n > 0)
                 message[n++] = ' ';
 

--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -19,7 +19,7 @@ static void audit_send_msg(char **cache, int top, const char *file, int drop_it,
     int i;
     size_t n = 0;
     size_t z;
-    char message[OS_MAXSTR - OS_LOG_HEADER] = {0};
+    char message[OS_MAX_LOG_SIZE] = {0};
 
     for (i = 0; i < top; i++) {
         z = strlen(cache[i]);
@@ -28,7 +28,7 @@ static void audit_send_msg(char **cache, int top, const char *file, int drop_it,
             if (n > 0)
                 message[n++] = ' ';
 
-            strncat(message, cache[i], OS_MAXSTR - OS_LOG_HEADER - 1 - n);
+            strncat(message, cache[i], OS_MAX_LOG_SIZE - 1 - n);
             n += z;
         }
 

--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -28,7 +28,7 @@ static void audit_send_msg(char **cache, int top, const char *file, int drop_it,
             if (n > 0)
                 message[n++] = ' ';
 
-            strncat(message, cache[i], OS_MAX_LOG_SIZE - 1 - n);
+            strncat(message + n, cache[i], OS_MAX_LOG_SIZE - 1 - n);
             n += z;
         }
 

--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -45,7 +45,7 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
     char *cache[MAX_CACHE];
     char header[MAX_HEADER] = { '\0' };
     int icache = 0;
-    char buffer[OS_MAXSTR];
+    char buffer[OS_MAX_LOG_SIZE];
     char *id;
     char *p;
     size_t z;
@@ -61,7 +61,7 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
     offset = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, offset);
 
-    for (offset = w_ftell(lf->fp); can_read() && fgets(buffer, OS_MAXSTR, lf->fp) && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
+    for (offset = w_ftell(lf->fp); can_read() && fgets(buffer, OS_MAX_LOG_SIZE, lf->fp) && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;
 
         /* Flow control */
@@ -84,9 +84,9 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
                 continue;
             }
         } else {
-            if (rbytes == OS_MAXSTR - 1) {
+            if (rbytes == OS_MAX_LOG_SIZE - 1) {
                 // Message too large, discard line
-                for (offset += rbytes; fgets(buffer, OS_MAXSTR, lf->fp); offset += rbytes) {
+                for (offset += rbytes; fgets(buffer, OS_MAX_LOG_SIZE, lf->fp); offset += rbytes) {
                     rbytes = w_ftell(lf->fp) - offset;
 
                     /* Flow control */


### PR DESCRIPTION
|Related issue|
|---|
|#12100|


## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh agent project in read_audit.c. . The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Agent</summary>

```
    CC logcollector/read_ucs2_le.o
    CC logcollector/read_mssql_log.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from logcollector/read_mssql_log.c:13:
In function ‘strncpy’,
    inlined from ‘read_mssql_log’ at logcollector/read_mssql_log.c:117:17:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin___strncpy_chk’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘read_mssql_log’ at logcollector/read_mssql_log.c:108:17:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin___strncpy_chk’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_win_el.o
    CC logcollector/lccom.o
    CC logcollector/read_macos.o
    CC logcollector/read_json.o
    CC logcollector/read_win_event_channel.o
    CC logcollector/read_syslog.o
    CC logcollector/main.o
    CC logcollector/read_audit.o
    CC logcollector/read_multiline_regex.o
    CC logcollector/read_nmapg.o
    CC logcollector/read_command.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from logcollector/read_nmapg.c:11:
In function ‘strncat’,
    inlined from ‘read_nmapg’ at logcollector/read_nmapg.c:246:13:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:136:10: warning: ‘__builtin___strncat_chk’ output may be truncated copying between 27 and 65533 bytes from a string of length 65536 [-Wstringop-truncation]
  136 |   return __builtin___strncat_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_mysql_log.o
    CC logcollector/read_ucs2_be.o
    CC logcollector/read_multiline.o
    CC logcollector/macos_log.o
    CC logcollector/read_fullcommand.o
In file included from /usr/include/string.h:495,

```

</details>


## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Agent</summary>

```
    CC analysisd/logmsg.o
    CC os_auth/main-client.o
    CC logcollector/config.o
addagent/validate.c: In function ‘OS_AddNewAgent’:
addagent/validate.c:49:27: warning: ‘%03d’ directive output may be truncated writing between 3 and 11 bytes into a region of size 9 [-Wformat-truncation=]
   49 |         snprintf(_id, 9, "%03d", ++keys->id_counter);
      |                           ^~~~
addagent/validate.c:49:26: note: directive argument in the range [-2147483647, 2147483647]
   49 |         snprintf(_id, 9, "%03d", ++keys->id_counter);
      |                          ^~~~~~
addagent/validate.c:49:9: note: ‘snprintf’ output between 4 and 12 bytes into a destination of size 9
   49 |         snprintf(_id, 9, "%03d", ++keys->id_counter);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/lccom.o
    CC logcollector/logcollector.o
    CC logcollector/macos_log.o
    CC logcollector/main.o
    CC logcollector/read_audit.o
    CC logcollector/read_command.o
    CC logcollector/read_djb_multilog.o
    CC logcollector/read_fullcommand.o
    CC logcollector/read_json.o
logcollector/read_djb_multilog.c: In function ‘read_djbmultilog’:
logcollector/read_djb_multilog.c:158:76: warning: ‘%s’ directive output may be truncated writing up to 65510 bytes into a region of size between 65008 and 65520 [-Wformat-truncation=]
  158 |                 snprintf(buffer, OS_MAXSTR, "%s %02d %02d:%02d:%02d %s %s: %s",
      |                                                                            ^~
logcollector/read_djb_multilog.c:158:17: note: ‘snprintf’ output 17 or more bytes (assuming 66039) into a destination of size 65536
  158 |                 snprintf(buffer, OS_MAXSTR, "%s %02d %02d:%02d:%02d %s %s: %s",
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  159 |                          djb_month[tm_result.tm_mon],
      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  160 |                          tm_result.tm_mday,
      |                          ~~~~~~~~~~~~~~~~~~
  161 |                          tm_result.tm_hour,
      |                          ~~~~~~~~~~~~~~~~~~
  162 |                          tm_result.tm_min,
      |                          ~~~~~~~~~~~~~~~~~
  163 |                          tm_result.tm_sec,
      |                          ~~~~~~~~~~~~~~~~~
  164 |                          djb_host,
      |                          ~~~~~~~~~
  165 |                          lf->djb_program_name,
      |                          ~~~~~~~~~~~~~~~~~~~~~
  166 |                          p);
      |                          ~~
    CC logcollector/read_macos.o
    CC logcollector/read_mssql_log.o
    CC logcollector/read_multiline.o
    CC logcollector/read_multiline_regex.o
logcollector/read_mssql_log.c: In function ‘read_mssql_log’:
logcollector/read_mssql_log.c:117:17: warning: ‘strncpy’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  117 |                 strncpy(buffer, str, str_len + 2);

```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors