### PR TITLE
Fix warnings in read_snortfull.c file

### DIFF
--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -46,23 +46,24 @@
 #define LOGLEVEL_INFO 1
 #define LOGLEVEL_DEBUG 0
 
-#define OS_MAXSTR       OS_SIZE_65536       /* Size for logs, sockets, etc      */
-#define OS_BUFFER_SIZE  OS_SIZE_2048        /* Size of general buffers          */
-#define OS_FLSIZE       OS_SIZE_256         /* Maximum file size                */
-#define OS_HEADER_SIZE  OS_SIZE_128         /* Maximum header size              */
-#define OS_LOG_HEADER   OS_SIZE_256         /* Maximum log header size          */
-#define OS_SK_HEADER    OS_SIZE_6144        /* Maximum syscheck header size     */
-#define IPSIZE          INET6_ADDRSTRLEN    /* IP Address size                  */
-#define AUTH_POOL       1000                /* Max number of connections        */
-#define BACKLOG         128                 /* Socket input queue length        */
-#define MAX_EVENTS      1024                /* Max number of epoll events       */
-#define EPOLL_MILLIS    -1                  /* Epoll wait time                  */
-#define MAX_TAG_COUNTER 256                 /* Max retrying counter             */
-#define SOCK_RECV_TIME0 300                 /* Socket receiving timeout (s)     */
-#define MIN_ORDER_SIZE  32                  /* Minimum size of orders array     */
-#define KEEPALIVE_SIZE  700                 /* Random keepalive string size     */
-#define MAX_DYN_STR     4194304             /* Max message size received 4MiB   */
-#define DATE_LENGTH     64                  /* Format date time %D %T           */
+#define OS_MAXSTR       OS_SIZE_65536               /* Size for logs, sockets, etc      */
+#define OS_BUFFER_SIZE  OS_SIZE_2048                /* Size of general buffers          */
+#define OS_FLSIZE       OS_SIZE_256                 /* Maximum file size                */
+#define OS_HEADER_SIZE  OS_SIZE_128                 /* Maximum header size              */
+#define OS_LOG_HEADER   OS_SIZE_256                 /* Maximum log header size          */
+#define OS_SK_HEADER    OS_SIZE_6144                /* Maximum syscheck header size     */
+#define IPSIZE          INET6_ADDRSTRLEN            /* IP Address size                  */
+#define AUTH_POOL       1000                        /* Max number of connections        */
+#define BACKLOG         128                         /* Socket input queue length        */
+#define MAX_EVENTS      1024                        /* Max number of epoll events       */
+#define EPOLL_MILLIS    -1                          /* Epoll wait time                  */
+#define MAX_TAG_COUNTER 256                         /* Max retrying counter             */
+#define SOCK_RECV_TIME0 300                         /* Socket receiving timeout (s)     */
+#define MIN_ORDER_SIZE  32                          /* Minimum size of orders array     */
+#define KEEPALIVE_SIZE  700                         /* Random keepalive string size     */
+#define MAX_DYN_STR     4194304                     /* Max message size received 4MiB   */
+#define DATE_LENGTH     64                          /* Format date time %D %T           */
+#define OS_MAX_LOG_SIZE OS_MAXSTR - OS_LOG_HEADER   /* Maximum log size with a header protection */
 
 /* Some global names */
 #define __ossec_name    "Wazuh"

--- a/src/logcollector/read_snortfull.c
+++ b/src/logcollector/read_snortfull.c
@@ -12,6 +12,7 @@
 #include "logcollector.h"
 #include "os_crypto/sha1/sha1_op.h"
 
+#define LABEL_PREPROCÉSSOR_MESSAGE  "[Classification: Preprocessor] [Priority: 3] "
 
 /* Read snort_full files */
 void *read_snortfull(logreader *lf, int *rc, int drop_it) {
@@ -61,9 +62,8 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
                     f_msg_size -= strlen(str);
                     p = two;
                 } else if (strncmp(str, "[Priority: ", 10) == 0) {
-                    strncat(f_msg, "[Classification: Preprocessor] "
-                            "[Priority: 3] ", f_msg_size);
-                    f_msg_size -= sizeof("[Classification: Preprocessor] [Priority: 3] ") - 1;
+                    strncat(f_msg, LABEL_PREPROCÉSSOR_MESSAGE, f_msg_size);
+                    f_msg_size -= sizeof(LABEL_PREPROCÉSSOR_MESSAGE) - 1;
                     p = two;
                 }
 
@@ -71,9 +71,8 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
                  * the classification.
                  */
                 else if ((str[2] == '/') && (str[5] == '-') && (q = strchr(str, ' '))) {
-                    strncat(f_msg, "[Classification: Preprocessor] "
-                            "[Priority: 3] ", f_msg_size);
-                    f_msg_size -= sizeof("[Classification: Preprocessor] [Priority: 3] ") - 1;
+                    strncat(f_msg, LABEL_PREPROCÉSSOR_MESSAGE, f_msg_size);
+                    f_msg_size -= sizeof(LABEL_PREPROCÉSSOR_MESSAGE) - 1;
                     strncat(f_msg, ++q, f_msg_size - 40);
 
                     /* Clean for next event */

--- a/src/logcollector/read_snortfull.c
+++ b/src/logcollector/read_snortfull.c
@@ -20,13 +20,11 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
     const char *two = "two";
     const char *p = NULL;
     char *q;
-    char str[OS_MAX_LOG_SIZE];
-    char f_msg[OS_MAX_LOG_SIZE];
+    char str[OS_MAX_LOG_SIZE] = {0};
+    char f_msg[OS_MAX_LOG_SIZE] = {0};
     int lines = 0;
 
     *rc = 0;
-    str[sizeof(str) - 1] = '\0';
-    f_msg[sizeof(f_msg) - 1] = '\0';
 
     /* Obtain context to calculate hash */
     SHA_CTX context;
@@ -65,7 +63,7 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
                 } else if (strncmp(str, "[Priority: ", 10) == 0) {
                     strncat(f_msg, "[Classification: Preprocessor] "
                             "[Priority: 3] ", f_msg_size);
-                    f_msg_size -= strlen("[Classification: Preprocessor] [Priority: 3] ");
+                    f_msg_size -= sizeof("[Classification: Preprocessor] [Priority: 3] ") - 1;
                     p = two;
                 }
 
@@ -75,7 +73,7 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
                 else if ((str[2] == '/') && (str[5] == '-') && (q = strchr(str, ' '))) {
                     strncat(f_msg, "[Classification: Preprocessor] "
                             "[Priority: 3] ", f_msg_size);
-                    f_msg_size -= strlen("[Classification: Preprocessor] [Priority: 3] ");
+                    f_msg_size -= sizeof("[Classification: Preprocessor] [Priority: 3] ") - 1;
                     strncat(f_msg, ++q, f_msg_size - 40);
 
                     /* Clean for next event */

--- a/src/logcollector/read_snortfull.c
+++ b/src/logcollector/read_snortfull.c
@@ -12,7 +12,7 @@
 #include "logcollector.h"
 #include "os_crypto/sha1/sha1_op.h"
 
-#define LABEL_PREPROCÉSSOR_MESSAGE  "[Classification: Preprocessor] [Priority: 3] "
+#define LABEL_PREPROCESSOR_MESSAGE  "[Classification: Preprocessor] [Priority: 3] "
 
 /* Read snort_full files */
 void *read_snortfull(logreader *lf, int *rc, int drop_it) {
@@ -62,8 +62,8 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
                     f_msg_size -= strlen(str);
                     p = two;
                 } else if (strncmp(str, "[Priority: ", 10) == 0) {
-                    strncat(f_msg, LABEL_PREPROCÉSSOR_MESSAGE, f_msg_size);
-                    f_msg_size -= sizeof(LABEL_PREPROCÉSSOR_MESSAGE) - 1;
+                    strncat(f_msg, LABEL_PREPROCESSOR_MESSAGE, f_msg_size);
+                    f_msg_size -= sizeof(LABEL_PREPROCESSOR_MESSAGE) - 1;
                     p = two;
                 }
 
@@ -71,8 +71,8 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
                  * the classification.
                  */
                 else if ((str[2] == '/') && (str[5] == '-') && (q = strchr(str, ' '))) {
-                    strncat(f_msg, LABEL_PREPROCÉSSOR_MESSAGE, f_msg_size);
-                    f_msg_size -= sizeof(LABEL_PREPROCÉSSOR_MESSAGE) - 1;
+                    strncat(f_msg, LABEL_PREPROCESSOR_MESSAGE, f_msg_size);
+                    f_msg_size -= sizeof(LABEL_PREPROCESSOR_MESSAGE) - 1;
                     strncat(f_msg, ++q, f_msg_size - 40);
 
                     /* Clean for next event */

--- a/src/logcollector/read_snortfull.c
+++ b/src/logcollector/read_snortfull.c
@@ -15,25 +15,25 @@
 
 /* Read snort_full files */
 void *read_snortfull(logreader *lf, int *rc, int drop_it) {
-    int f_msg_size = OS_MAXSTR;
+    int f_msg_size = OS_MAXSTR - OS_LOG_HEADER - 1;
     const char *one = "one";
     const char *two = "two";
     const char *p = NULL;
     char *q;
-    char str[OS_MAXSTR + 1];
-    char f_msg[OS_MAXSTR + 1];
+    char str[OS_MAXSTR - OS_LOG_HEADER];
+    char f_msg[OS_MAXSTR - OS_LOG_HEADER];
     int lines = 0;
 
     *rc = 0;
-    str[OS_MAXSTR] = '\0';
-    f_msg[OS_MAXSTR] = '\0';
+    str[sizeof(str) - 1] = '\0';
+    f_msg[sizeof(f_msg) - 1] = '\0';
 
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
-    while (can_read() && fgets(str, OS_MAXSTR, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
+    while (can_read() && fgets(str, sizeof(str), lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
 
         lines++;
 
@@ -51,8 +51,8 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
         /* First part of the message */
         if (p == NULL) {
             if (strncmp(str, "[**] [", 6) == 0) {
-                strncpy(f_msg, str, OS_MAXSTR);
-                f_msg_size -= strlen(str) + 1;
+                snprintf(f_msg, sizeof(f_msg), "%s", str);
+                f_msg_size -= strlen(str);
                 p = one;
             }
         } else {
@@ -60,12 +60,12 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
                 /* Second line has the [Classification: */
                 if (strncmp(str, "[Classification: ", 16) == 0) {
                     strncat(f_msg, str, f_msg_size);
-                    f_msg_size -= strlen(str) + 1;
+                    f_msg_size -= strlen(str);
                     p = two;
                 } else if (strncmp(str, "[Priority: ", 10) == 0) {
                     strncat(f_msg, "[Classification: Preprocessor] "
                             "[Priority: 3] ", f_msg_size);
-                    f_msg_size -= strlen(str) + 1;
+                    f_msg_size -= strlen("[Classification: Preprocessor] [Priority: 3] ");
                     p = two;
                 }
 
@@ -75,6 +75,7 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
                 else if ((str[2] == '/') && (str[5] == '-') && (q = strchr(str, ' '))) {
                     strncat(f_msg, "[Classification: Preprocessor] "
                             "[Priority: 3] ", f_msg_size);
+                    f_msg_size -= strlen("[Classification: Preprocessor] [Priority: 3] ");
                     strncat(f_msg, ++q, f_msg_size - 40);
 
                     /* Clean for next event */
@@ -86,7 +87,7 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
                     }
 
                     f_msg[0] = '\0';
-                    f_msg_size = OS_MAXSTR;
+                    f_msg_size = OS_MAXSTR - OS_LOG_HEADER - 1;
                     str[0] = '\0';
                 } else {
                     goto file_error;
@@ -103,7 +104,7 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
                     }
 
                     f_msg[0] = '\0';
-                    f_msg_size = OS_MAXSTR;
+                    f_msg_size = OS_MAXSTR - OS_LOG_HEADER - 1;
                     str[0] = '\0';
                 } else {
                     goto file_error;

--- a/src/logcollector/read_snortfull.c
+++ b/src/logcollector/read_snortfull.c
@@ -15,13 +15,13 @@
 
 /* Read snort_full files */
 void *read_snortfull(logreader *lf, int *rc, int drop_it) {
-    int f_msg_size = OS_MAXSTR - OS_LOG_HEADER - 1;
+    int f_msg_size = OS_MAX_LOG_SIZE - 1;
     const char *one = "one";
     const char *two = "two";
     const char *p = NULL;
     char *q;
-    char str[OS_MAXSTR - OS_LOG_HEADER];
-    char f_msg[OS_MAXSTR - OS_LOG_HEADER];
+    char str[OS_MAX_LOG_SIZE];
+    char f_msg[OS_MAX_LOG_SIZE];
     int lines = 0;
 
     *rc = 0;
@@ -87,7 +87,7 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
                     }
 
                     f_msg[0] = '\0';
-                    f_msg_size = OS_MAXSTR - OS_LOG_HEADER - 1;
+                    f_msg_size = OS_MAX_LOG_SIZE - 1;
                     str[0] = '\0';
                 } else {
                     goto file_error;
@@ -104,7 +104,7 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
                     }
 
                     f_msg[0] = '\0';
-                    f_msg_size = OS_MAXSTR - OS_LOG_HEADER - 1;
+                    f_msg_size = OS_MAX_LOG_SIZE - 1;
                     str[0] = '\0';
                 } else {
                     goto file_error;


### PR DESCRIPTION
|Related issue|
|---|
|#12100|


## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh agent project in read_snortfull.c. . The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Agent</summary>

```
                 from ./headers/shared.h:67,
                 from logcollector/read_multiline.c:11:
In function ‘strncpy’,
    inlined from ‘read_multiline’ at logcollector/read_multiline.c:96:9:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output may be truncated copying between 0 and 65534 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/macos_log.o
    CC logcollector/read_fullcommand.o
    CC logcollector/read_snortfull.o
    CC syscheckd/db/schema_fim_db.o
    CC syscheckd/run_realtime.o
    CC syscheckd/config.o
    CC syscheckd/create_db.o
    CC syscheckd/run_check.o
    CC syscheckd/syscheck.o
    CC syscheckd/fim_diff_changes.o
    CC syscheckd/fim_sync.o
    CC syscheckd/syscom.o
    CC syscheckd/main.o
    CC syscheckd/db/fim_db.o
    CC syscheckd/db/fim_db_files.o
    CC syscheckd/db/fim_db_registries.o
    CC syscheckd/whodata/audit_healthcheck.o
    CC syscheckd/whodata/audit_rule_handling.o
    CC syscheckd/whodata/syscheck_audit.o
    CC syscheckd/whodata/audit_parse.o
    CC syscheckd/whodata/win_whodata.o
    CC syscheckd/registry/registry.o
    CC syscheckd/registry/events.o
    CC rootcheck/common_rcl.o
    CC rootcheck/config.o
    CC rootcheck/check_rc_files.o
    CC rootcheck/check_rc_ports.o
rootcheck/check_rc_files.c: In function ‘check_rc_files’:
rootcheck/check_rc_files.c:171:52: warning: ‘%s’ directive output may be truncated writing up to 1024 bytes into a region of size 1023 [-Wformat-truncation=]
  171 |             snprintf(file_path, OS_SIZE_1024, "%s%c%s", basedir, PATH_SEP, file);

```

</details>


## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Agent</summary>

```
      |                                                 ^~~~~~~~~~~~~
logcollector/read_nmapg.c:222:9: note: ‘snprintf’ output between 20 and 65550 bytes into a destination of size 65536
  222 |         snprintf(final_msg, OS_MAXSTR, "Host: %s, open ports:",
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  223 |                  ip);
      |                  ~~~
logcollector/read_nmapg.c:246:13: warning: ‘strncat’ output may be truncated copying between 27 and 65533 bytes from a string of length 65536 [-Wstringop-truncation]
  246 |             strncat(final_msg, buffer, final_msg_s);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_postgresql_log.o
    CC logcollector/read_snortfull.o
    CC logcollector/read_syslog.o
    CC logcollector/read_ucs2_be.o
    CC logcollector/read_ucs2_le.o
    CC logcollector/read_win_el.o
logcollector/read_postgresql_log.c: In function ‘read_postgresql_log’:
logcollector/read_postgresql_log.c:114:17: warning: ‘strncpy’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  114 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_postgresql_log.c:106:17: warning: ‘strncpy’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_win_event_channel.o
    CC logcollector/state.o
    CC syscheckd/db/schema_fim_db.o
    CC syscheckd/config.o
    CC syscheckd/create_db.o
    CC syscheckd/fim_diff_changes.o
    CC syscheckd/fim_sync.o
    CC syscheckd/main.o
    CC syscheckd/run_check.o
    CC syscheckd/run_realtime.o
    CC syscheckd/syscheck.o
    CC syscheckd/syscom.o
    CC syscheckd/db/fim_db.o
    CC syscheckd/db/fim_db_files.o
    CC syscheckd/db/fim_db_registries.o
    CC syscheckd/whodata/audit_healthcheck.o

```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors