### PR TITLE
Fix warnings in check_rc_files.c file

### DIFF
--- a/src/rootcheck/check_rc_files.c
+++ b/src/rootcheck/check_rc_files.c
@@ -195,7 +195,7 @@ void check_rc_files(const char *basedir, FILE *fp)
             char op_msg[size_msg];
 
             _errors = 1;
-            snprintf(op_msg, size_msg, "Rootkit '%s' detected "
+            snprintf(op_msg, sizeof(op_msg), "Rootkit '%s' detected "
                      "by the presence of file '%s'.", name, file_path);
 
             notify_rk(ALERT_ROOTKIT_FOUND, op_msg);

--- a/src/rootcheck/check_rc_files.c
+++ b/src/rootcheck/check_rc_files.c
@@ -159,17 +159,23 @@ void check_rc_files(const char *basedir, FILE *fp)
             }
             continue;
         }
-
+        int bytes_written = 0;
         // Check if it is a full path
 #ifdef WIN32
         if (strlen(file) > 3 && file[1] == ':' && file[2] == '\\') {
 #else
         if (*file == '/') {
 #endif
-            snprintf(file_path, OS_SIZE_1024, "%s", file);
+            bytes_written = snprintf(file_path, sizeof(file_path), "%s", file);
         } else {
-            snprintf(file_path, OS_SIZE_1024, "%s%c%s", basedir, PATH_SEP, file);
+            bytes_written = snprintf(file_path, sizeof(file_path), "%s%c%s", basedir, PATH_SEP, file);
         }
+
+       if (bytes_written > (int)(sizeof(file_path) - 1)) {
+           // Maybe print a warning in the log file will be a good parctice
+           continue;
+       }
+
 
         if (_file_name = strrchr(file_path, PATH_SEP), !_file_name) {
             continue;
@@ -185,10 +191,11 @@ void check_rc_files(const char *basedir, FILE *fp)
         }
 
         if (is_file(file_path)) {
-            char op_msg[OS_SIZE_2048];
+            int size_msg = strlen(file_path) + strlen(name) + strlen("Rootkit '' detected by the presence of file ''.")  + 1;
+            char op_msg[size_msg];
 
             _errors = 1;
-            snprintf(op_msg, OS_SIZE_2048, "Rootkit '%s' detected "
+            snprintf(op_msg, size_msg, "Rootkit '%s' detected "
                      "by the presence of file '%s'.", name, file_path);
 
             notify_rk(ALERT_ROOTKIT_FOUND, op_msg);

--- a/src/rootcheck/check_rc_files.c
+++ b/src/rootcheck/check_rc_files.c
@@ -172,7 +172,6 @@ void check_rc_files(const char *basedir, FILE *fp)
         }
 
        if (bytes_written < 0 || (size_t)bytes_written > (sizeof(file_path) - 1)) {
-           // Maybe print a warning in the log file will be a good parctice
            continue;
        }
 
@@ -191,7 +190,7 @@ void check_rc_files(const char *basedir, FILE *fp)
         }
 
         if (is_file(file_path)) {
-            int size_msg = strlen(file_path) + strlen(name) + sizeof("Rootkit '' detected by the presence of file ''.");
+            const int size_msg = strlen(file_path) + strlen(name) + sizeof("Rootkit '' detected by the presence of file ''.");
             char op_msg[size_msg];
 
             _errors = 1;

--- a/src/rootcheck/check_rc_files.c
+++ b/src/rootcheck/check_rc_files.c
@@ -171,7 +171,7 @@ void check_rc_files(const char *basedir, FILE *fp)
             bytes_written = snprintf(file_path, sizeof(file_path), "%s%c%s", basedir, PATH_SEP, file);
         }
 
-       if (bytes_written > (int)(sizeof(file_path) - 1)) {
+       if (bytes_written < 0 || (size_t)bytes_written > (sizeof(file_path) - 1)) {
            // Maybe print a warning in the log file will be a good parctice
            continue;
        }

--- a/src/rootcheck/check_rc_files.c
+++ b/src/rootcheck/check_rc_files.c
@@ -191,7 +191,7 @@ void check_rc_files(const char *basedir, FILE *fp)
         }
 
         if (is_file(file_path)) {
-            int size_msg = strlen(file_path) + strlen(name) + strlen("Rootkit '' detected by the presence of file ''.")  + 1;
+            int size_msg = strlen(file_path) + strlen(name) + sizeof("Rootkit '' detected by the presence of file ''.");
             char op_msg[size_msg];
 
             _errors = 1;


### PR DESCRIPTION
|Related issue|
|---|
|#12100|


## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh agent project in check_rc_files.c. . The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Agent</summary>

```
    CC logcollector/read_snortfull.o
    CC syscheckd/db/schema_fim_db.o
    CC syscheckd/run_realtime.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from logcollector/read_snortfull.c:11:
In function ‘strncpy’,
    inlined from ‘read_snortfull’ at logcollector/read_snortfull.c:54:17:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output may be truncated copying 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC syscheckd/config.o
    CC syscheckd/create_db.o
    CC syscheckd/run_check.o
    CC syscheckd/syscheck.o
    CC syscheckd/fim_diff_changes.o
    CC syscheckd/fim_sync.o
    CC syscheckd/syscom.o
    CC syscheckd/main.o
    CC syscheckd/db/fim_db.o
    CC syscheckd/db/fim_db_files.o
    CC syscheckd/db/fim_db_registries.o
    CC syscheckd/whodata/audit_healthcheck.o
    CC syscheckd/whodata/audit_rule_handling.o
    CC syscheckd/whodata/syscheck_audit.o
    CC syscheckd/whodata/audit_parse.o
    CC syscheckd/whodata/win_whodata.o
    CC syscheckd/registry/registry.o
    CC syscheckd/registry/events.o
    CC rootcheck/common_rcl.o
    CC rootcheck/config.o
    CC rootcheck/check_rc_files.o
    CC rootcheck/check_rc_ports.o
    CC rootcheck/win-process.o
    CC rootcheck/unix-process.o
    CC rootcheck/common.o
rootcheck/unix-process.c: In function ‘os_get_process_list’:
rootcheck/unix-process.c:28:40: warning: ‘ -p ’ directive output may be truncated writing 4 bytes into a region of size between 0 and 1024 [-Wformat-truncation=]
   28 |     snprintf(command, OS_SIZE_1024, "%s -p %d 2> /dev/null", ps, mpid);
      |                                        ^~~~
rootcheck/unix-process.c:28:37: note: directive argument in the range [1, 32768]
   28 |     snprintf(command, OS_SIZE_1024, "%s -p %d 2> /dev/null", ps, mpid);
      |                                     ^~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from rootcheck/unix-process.c:11:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 19 and 1047 bytes into a destination of size 1024
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC rootcheck/rootcheck.o
In file included from ./headers/shared.h:220,

```

</details>

## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Agent</summary>

```
logcollector/read_postgresql_log.c: In function ‘read_postgresql_log’:
logcollector/read_postgresql_log.c:114:17: warning: ‘strncpy’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  114 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_postgresql_log.c:106:17: warning: ‘strncpy’ output may be truncated copying between 2 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_win_event_channel.o
    CC logcollector/state.o
    CC syscheckd/db/schema_fim_db.o
    CC syscheckd/config.o
    CC syscheckd/create_db.o
    CC syscheckd/fim_diff_changes.o
    CC syscheckd/fim_sync.o
    CC syscheckd/main.o
    CC syscheckd/run_check.o
    CC syscheckd/run_realtime.o
    CC syscheckd/syscheck.o
    CC syscheckd/syscom.o
    CC syscheckd/db/fim_db.o
    CC syscheckd/db/fim_db_files.o
    CC syscheckd/db/fim_db_registries.o
    CC syscheckd/whodata/audit_healthcheck.o
    CC syscheckd/whodata/audit_parse.o
    CC syscheckd/whodata/audit_rule_handling.o
    CC syscheckd/whodata/syscheck_audit.o
    CC syscheckd/whodata/win_whodata.o
    CC syscheckd/registry/events.o
    CC syscheckd/registry/registry.o
    CC rootcheck/check_open_ports.o
    CC rootcheck/check_rc_dev.o
    CC rootcheck/check_rc_files.o
    CC rootcheck/check_rc_if.o
    CC rootcheck/check_rc_pids.o
    CC rootcheck/check_rc_policy.o
    CC rootcheck/check_rc_ports.o
    CC rootcheck/check_rc_readproc.o
rootcheck/check_rc_if.c: In function ‘check_rc_if’:
rootcheck/check_rc_if.c:87:9: warning: ‘strncpy’ output may be truncated copying 16 bytes from a string of length 639 [-Wstringop-truncation]
   87 |         strncpy(_ifr.ifr_name, _ir->ifr_name, sizeof(_ifr.ifr_name));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC rootcheck/check_rc_sys.o
    CC rootcheck/check_rc_trojans.o
    CC rootcheck/common.o
    CC rootcheck/common_rcl.o
rootcheck/check_rc_sys.c: In function ‘read_sys_dir.isra’:
rootcheck/check_rc_sys.c:93:52: warning: ‘%s’ directive output may be truncated writing up to 4097 bytes into a region of size 998 [-Wformat-truncation=]
   93 |                     snprintf(op_msg, OS_SIZE_1024, "Anomaly detected in file "
      |                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~
......
  284 |         read_sys_file(f_name, do_read);
      |                       ~~~~~~                        
rootcheck/check_rc_sys.c:94:32: note: format string is defined here

```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors