### PR TITLE
Fix warnings in check_rc_sys.c file

### DIFF
--- a/src/rootcheck/check_rc_dev.c
+++ b/src/rootcheck/check_rc_dev.c
@@ -37,11 +37,21 @@ static int read_dev_file(const char *file_name)
 
     else if (S_ISREG(statbuf.st_mode)) {
         char op_msg[OS_SIZE_1024 + 1];
+        const char op_msg_fmt[] = "File '%*s' present on /dev. Possible hidden file.";
 
-        snprintf(op_msg, OS_SIZE_1024, "File '%s' present on /dev."
-                 " Possible hidden file.", file_name);
-        notify_rk(ALERT_SYSTEM_CRIT, op_msg);
+        const int size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
 
+        if (size >= 0) {
+            if ((size_t)size < sizeof(op_msg)) {
+                snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
+            }
+            else {
+                const unsigned int surplus = size - sizeof(op_msg) + 1;
+                snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(strlen(file_name) - surplus), file_name);
+            }
+
+            notify_rk(ALERT_SYSTEM_CRIT, op_msg);
+        }
         _dev_errors++;
     }
 

--- a/src/rootcheck/check_rc_dev.c
+++ b/src/rootcheck/check_rc_dev.c
@@ -44,8 +44,7 @@ static int read_dev_file(const char *file_name)
         if (size >= 0) {
             if ((size_t)size < sizeof(op_msg)) {
                 snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
-            }
-            else {
+            } else {
                 const unsigned int surplus = size - sizeof(op_msg) + 1;
                 snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(strlen(file_name) - surplus), file_name);
             }

--- a/src/rootcheck/check_rc_dev.c
+++ b/src/rootcheck/check_rc_dev.c
@@ -51,8 +51,8 @@ static int read_dev_file(const char *file_name)
             }
 
             notify_rk(ALERT_SYSTEM_CRIT, op_msg);
+            _dev_errors++;
         }
-        _dev_errors++;
     }
 
     return (0);

--- a/src/rootcheck/check_rc_dev.c
+++ b/src/rootcheck/check_rc_dev.c
@@ -51,8 +51,11 @@ static int read_dev_file(const char *file_name)
             }
 
             notify_rk(ALERT_SYSTEM_CRIT, op_msg);
-            _dev_errors++;
+        } else {
+            mtdebug2(ARGV0, "Error %d (%s) with snprintf with file %s\n", errno, strerror(errno), file_name);
         }
+
+        _dev_errors++;
     }
 
     return (0);

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -36,13 +36,18 @@ static int read_sys_file(const char *file_name, int do_read)
 #endif
     if (lstat(file_name, &statbuf) < 0) {
 #ifndef WIN32
-        const size_t size_buffer = strlen(file_name) + strlen("Anomaly detected in file ''. Hidden from stats, but showing up on readdir. Possible kernel level rootkit.") + 1;
-        char op_msg[size_buffer];
+        const char op_msg_fmt[] = "Anomaly detected in file '%*s'. Hidden from stats, but showing up on readdir. Possible kernel level rootkit.";
+        char op_msg[OS_SIZE_1024 + 1];
 
-        snprintf(op_msg, size_buffer, "Anomaly detected in file '%s'. "
-                 "Hidden from stats, but showing up on readdir. "
-                 "Possible kernel level rootkit.",
-                 file_name);
+        int size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
+
+        if (size < (int)sizeof(op_msg)) {
+            snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
+        }
+        else {
+            snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(sizeof(op_msg) - strlen(op_msg_fmt) + 2), file_name);
+        }
+
         notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
         _sys_errors++;
 #endif
@@ -91,12 +96,18 @@ static int read_sys_file(const char *file_name, int do_read)
                 if ((lstat(file_name, &statbuf2) == 0) &&
                         (total != statbuf2.st_size) &&
                         (statbuf.st_size == statbuf2.st_size)) {
-                    const size_t size_buffer = strlen(file_name) + strlen("Anomaly detected in file ''. File size doesn't match what we found. Possible kernel level rootkit.") + 1;
-                    char op_msg[size_buffer];
-                    snprintf(op_msg, size_buffer, "Anomaly detected in file "
-                             "'%s'. File size doesn't match what we found. "
-                             "Possible kernel level rootkit.",
-                             file_name);
+                    const char op_msg_fmt[] = "Anomaly detected in file '%*s'. File size doesn't match what we found. Possible kernel level rootkit.";
+                    char op_msg[OS_SIZE_1024 + 1];
+
+                    int size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
+
+                    if (size < (int)sizeof(op_msg)) {
+                        snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
+                    }
+                    else {
+                        snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(sizeof(op_msg) - strlen(op_msg_fmt) + 2), file_name);
+                    }
+
                     notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
                     _sys_errors++;
                 }

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -131,16 +131,30 @@ static int read_sys_file(const char *file_name, int do_read)
         }
 
         if (statbuf.st_uid == 0) {
-            int size_buffer = strlen(file_name) + strlen("File '' is: \n          - owned by root,\n          - has write permissions to anyone.")  + 1;
-            char op_msg[size_buffer];
+            int size = 0;
+            char op_msg[OS_SIZE_1024 + 1];
 #ifdef OSSECHIDS
-            snprintf(op_msg, size_buffer, "File '%s' is owned by root "
-                     "and has written permissions to anyone.", file_name);
+            const char op_msg_fmt[] = "File '%*s' is owned by root and has written permissions to anyone.";
+
+            size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
+
+            if (size < (int)sizeof(op_msg)) {
+                snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
+            }
+            else {
+                snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(sizeof(op_msg) - strlen(op_msg_fmt) + 2), file_name);
+            }
 #else
-            snprintf(op_msg, size_buffer, "File '%s' is: \n"
-                     "          - owned by root,\n"
-                     "          - has write permissions to anyone.",
-                     file_name);
+            const char op_msg_fmt[] = "File '%*s' is: \n          - owned by root,\n          - has write permissions to anyone.";
+
+            size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
+
+            if (size < (int)sizeof(op_msg)) {
+                snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
+            }
+            else {
+                snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(sizeof(op_msg) - strlen(op_msg_fmt) + 2), file_name);
+            }
 #endif
             notify_rk(ALERT_SYSTEM_CRIT, op_msg);
 

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -36,8 +36,10 @@ static int read_sys_file(const char *file_name, int do_read)
 #endif
     if (lstat(file_name, &statbuf) < 0) {
 #ifndef WIN32
-        char op_msg[OS_SIZE_1024 + 1];
-        snprintf(op_msg, OS_SIZE_1024, "Anomaly detected in file '%s'. "
+        const size_t size_buffer = strlen(file_name) + strlen("Anomaly detected in file ''. Hidden from stats, but showing up on readdir. Possible kernel level rootkit.") + 1;
+        char op_msg[size_buffer];
+
+        snprintf(op_msg, size_buffer, "Anomaly detected in file '%s'. "
                  "Hidden from stats, but showing up on readdir. "
                  "Possible kernel level rootkit.",
                  file_name);
@@ -89,8 +91,9 @@ static int read_sys_file(const char *file_name, int do_read)
                 if ((lstat(file_name, &statbuf2) == 0) &&
                         (total != statbuf2.st_size) &&
                         (statbuf.st_size == statbuf2.st_size)) {
-                    char op_msg[OS_SIZE_1024 + 1];
-                    snprintf(op_msg, OS_SIZE_1024, "Anomaly detected in file "
+                    const size_t size_buffer = strlen(file_name) + strlen("Anomaly detected in file ''. File size doesn't match what we found. Possible kernel level rootkit.") + 1;
+                    char op_msg[size_buffer];
+                    snprintf(op_msg, size_buffer, "Anomaly detected in file "
                              "'%s'. File size doesn't match what we found. "
                              "Possible kernel level rootkit.",
                              file_name);
@@ -117,12 +120,13 @@ static int read_sys_file(const char *file_name, int do_read)
         }
 
         if (statbuf.st_uid == 0) {
-            char op_msg[OS_SIZE_1024 + 1];
+            int size_buffer = strlen(file_name) + strlen("File '' is: \n          - owned by root,\n          - has write permissions to anyone.")  + 1;
+            char op_msg[size_buffer];
 #ifdef OSSECHIDS
-            snprintf(op_msg, OS_SIZE_1024, "File '%s' is owned by root "
+            snprintf(op_msg, size_buffer, "File '%s' is owned by root "
                      "and has written permissions to anyone.", file_name);
 #else
-            snprintf(op_msg, OS_SIZE_1024, "File '%s' is: \n"
+            snprintf(op_msg, size_buffer, "File '%s' is: \n"
                      "          - owned by root,\n"
                      "          - has write permissions to anyone.",
                      file_name);

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -41,15 +41,18 @@ static int read_sys_file(const char *file_name, int do_read)
 
         int size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
 
-        if (size < (int)sizeof(op_msg)) {
-            snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
-        }
-        else {
-            snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(sizeof(op_msg) - strlen(op_msg_fmt) + 2), file_name);
-        }
+        if (size >= 0) {
+            if ((size_t)size < sizeof(op_msg)) {
+                snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
+            }
+            else {
+                const unsigned int surplus = size - sizeof(op_msg) + 1;
+                snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(strlen(file_name) - surplus), file_name);
+            }
 
-        notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
-        _sys_errors++;
+            notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
+            _sys_errors++;
+        }
 #endif
         return (-1);
     }
@@ -101,15 +104,18 @@ static int read_sys_file(const char *file_name, int do_read)
 
                     int size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
 
-                    if (size < (int)sizeof(op_msg)) {
-                        snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
-                    }
-                    else {
-                        snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(sizeof(op_msg) - strlen(op_msg_fmt) + 2), file_name);
-                    }
+                    if (size >= 0) {
+                        if ((size_t)size < sizeof(op_msg)) {
+                            snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
+                        }
+                        else {
+                            const unsigned int surplus = size - sizeof(op_msg) + 1;
+                            snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(strlen(file_name) - surplus), file_name);
+                        }
 
-                    notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
-                    _sys_errors++;
+                        notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
+                        _sys_errors++;
+                    }
                 }
             }
         }
@@ -138,28 +144,37 @@ static int read_sys_file(const char *file_name, int do_read)
 
             size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
 
-            if (size < (int)sizeof(op_msg)) {
-                snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
-            }
-            else {
-                snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(sizeof(op_msg) - strlen(op_msg_fmt) + 2), file_name);
+            if (size >= 0) {
+                if ((size_t)size < sizeof(op_msg)) {
+                    snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
+                }
+                else {
+                    const unsigned int surplus = size - sizeof(op_msg) + 1;
+                    snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(strlen(file_name) - surplus), file_name);
+                }
+
+                notify_rk(ALERT_SYSTEM_CRIT, op_msg);
+                _sys_errors++;
             }
 #else
             const char op_msg_fmt[] = "File '%*s' is: \n          - owned by root,\n          - has write permissions to anyone.";
 
             size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
 
-            if (size < (int)sizeof(op_msg)) {
-                snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
-            }
-            else {
-                snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(sizeof(op_msg) - strlen(op_msg_fmt) + 2), file_name);
+            if (size >= 0) {
+                if ((size_t)size < sizeof(op_msg)) {
+                    snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
+                }
+                else {
+                    const unsigned int surplus = size - sizeof(op_msg) + 1;
+                    snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(strlen(file_name) - surplus), file_name);
+                }
+
+                notify_rk(ALERT_SYSTEM_CRIT, op_msg);
+                _sys_errors++;
             }
 #endif
-            notify_rk(ALERT_SYSTEM_CRIT, op_msg);
-
         }
-        _sys_errors++;
     } else if ((statbuf.st_mode & S_ISUID) == S_ISUID) {
         if (_suid) {
             fprintf(_suid, "%s\n", file_name);

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -39,20 +39,22 @@ static int read_sys_file(const char *file_name, int do_read)
         const char op_msg_fmt[] = "Anomaly detected in file '%*s'. Hidden from stats, but showing up on readdir. Possible kernel level rootkit.";
         char op_msg[OS_SIZE_1024 + 1];
 
-        int size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
+        const int size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
 
         if (size >= 0) {
             if ((size_t)size < sizeof(op_msg)) {
                 snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
-            }
-            else {
+            } else {
                 const unsigned int surplus = size - sizeof(op_msg) + 1;
                 snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(strlen(file_name) - surplus), file_name);
             }
 
             notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
-            _sys_errors++;
+        } else {
+            mtdebug2(ARGV0, "Error %d (%s) with snprintf with file %s", errno, strerror(errno), file_name);
         }
+
+        _sys_errors++;
 #endif
         return (-1);
     }
@@ -102,20 +104,22 @@ static int read_sys_file(const char *file_name, int do_read)
                     const char op_msg_fmt[] = "Anomaly detected in file '%*s'. File size doesn't match what we found. Possible kernel level rootkit.";
                     char op_msg[OS_SIZE_1024 + 1];
 
-                    int size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
+                    const int size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
 
                     if (size >= 0) {
                         if ((size_t)size < sizeof(op_msg)) {
                             snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
-                        }
-                        else {
+                        } else {
                             const unsigned int surplus = size - sizeof(op_msg) + 1;
                             snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(strlen(file_name) - surplus), file_name);
                         }
 
                         notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
-                        _sys_errors++;
+                    } else {
+                        mtdebug2(ARGV0, "Error %d (%s) with snprintf with file %s", errno, strerror(errno), file_name);
                     }
+
+                    _sys_errors++;
                 }
             }
         }
@@ -137,42 +141,46 @@ static int read_sys_file(const char *file_name, int do_read)
         }
 
         if (statbuf.st_uid == 0) {
-            int size = 0;
             char op_msg[OS_SIZE_1024 + 1];
 #ifdef OSSECHIDS
             const char op_msg_fmt[] = "File '%*s' is owned by root and has written permissions to anyone.";
 
-            size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
+            const int size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
 
             if (size >= 0) {
                 if ((size_t)size < sizeof(op_msg)) {
                     snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
-                }
-                else {
+                } else {
                     const unsigned int surplus = size - sizeof(op_msg) + 1;
                     snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(strlen(file_name) - surplus), file_name);
                 }
 
                 notify_rk(ALERT_SYSTEM_CRIT, op_msg);
-                _sys_errors++;
+            } else {
+                mtdebug2(ARGV0, "Error %d (%s) with snprintf with file %s", errno, strerror(errno), file_name);
             }
+
+            _sys_errors++;
+
 #else
             const char op_msg_fmt[] = "File '%*s' is: \n          - owned by root,\n          - has write permissions to anyone.";
 
-            size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
+            const int size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
 
             if (size >= 0) {
                 if ((size_t)size < sizeof(op_msg)) {
                     snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
-                }
-                else {
+                } else {
                     const unsigned int surplus = size - sizeof(op_msg) + 1;
                     snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(strlen(file_name) - surplus), file_name);
                 }
 
                 notify_rk(ALERT_SYSTEM_CRIT, op_msg);
-                _sys_errors++;
+            } else {
+                mtdebug2(ARGV0, "Error %d (%s) with snprintf with file %s", errno, strerror(errno), file_name);
             }
+
+            _sys_errors++;
 #endif
         }
     } else if ((statbuf.st_mode & S_ISUID) == S_ISUID) {


### PR DESCRIPTION
|Related issue|
|---|
|#12100|


## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh agent project in check_rc_sys.c. . The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Agent</summary>

```
    CC rootcheck/check_rc_if.o
    CC rootcheck/check_open_ports.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from rootcheck/check_rc_if.c:12:
In function ‘strncpy’,
    inlined from ‘check_rc_if’ at rootcheck/check_rc_if.c:87:9:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output may be truncated copying 16 bytes from a string of length 639 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC rootcheck/os_string.o
    CC rootcheck/win-common.o
    CC rootcheck/check_rc_readproc.o
    CC rootcheck/check_rc_dev.o
    CC rootcheck/check_rc_sys.o
rootcheck/check_rc_dev.c: In function ‘read_dev_dir’:
rootcheck/check_rc_dev.c:41:47: warning: ‘%s’ directive output may be truncated writing up to 4097 bytes into a region of size 1018 [-Wformat-truncation=]
   41 |         snprintf(op_msg, OS_SIZE_1024, "File '%s' present on /dev."
      |                                               ^~
......
  140 |         read_dev_file(f_name);
      |                       ~~~~~~                   
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from rootcheck/check_rc_dev.c:12:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 47 and 4144 bytes into a destination of size 1024
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC rootcheck/run_rk_check.o
    CC rootcheck/check_rc_policy.o
    CC rootcheck/check_rc_pids.o
    CC rootcheck/check_rc_trojans.o
    CC os_execd/exec.o
    CC os_execd/config.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from os_execd/exec.c:11:
In function ‘strncpy’,
    inlined from ‘ReadExecConfig’ at os_execd/exec.c:72:9:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output may be truncated copying 256 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

</details>

## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Agent</summary>

```
    CC rootcheck/check_rc_files.o
    CC rootcheck/check_rc_if.o
    CC rootcheck/check_rc_pids.o
rootcheck/check_rc_if.c: In function ‘check_rc_if’:
rootcheck/check_rc_if.c:87:9: warning: ‘strncpy’ output may be truncated copying 16 bytes from a string of length 639 [-Wstringop-truncation]
   87 |         strncpy(_ifr.ifr_name, _ir->ifr_name, sizeof(_ifr.ifr_name));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rootcheck/check_rc_files.c: In function ‘check_rc_files’:
rootcheck/check_rc_files.c:171:52: warning: ‘%s’ directive output may be truncated writing up to 1024 bytes into a region of size 1023 [-Wformat-truncation=]
  171 |             snprintf(file_path, OS_SIZE_1024, "%s%c%s", basedir, PATH_SEP, file);
      |                                                    ^~
rootcheck/check_rc_files.c:171:13: note: ‘snprintf’ output 2 or more bytes (assuming 1026) into a destination of size 1024
  171 |             snprintf(file_path, OS_SIZE_1024, "%s%c%s", basedir, PATH_SEP, file);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rootcheck/check_rc_files.c:169:50: warning: ‘snprintf’ output may be truncated before the last format character [-Wformat-truncation=]
  169 |             snprintf(file_path, OS_SIZE_1024, "%s", file);
      |                                                  ^
rootcheck/check_rc_files.c:169:13: note: ‘snprintf’ output between 1 and 1025 bytes into a destination of size 1024
  169 |             snprintf(file_path, OS_SIZE_1024, "%s", file);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC rootcheck/check_rc_policy.o
    CC rootcheck/check_rc_ports.o
    CC rootcheck/check_rc_readproc.o
    CC rootcheck/check_rc_sys.o
    CC rootcheck/check_rc_trojans.o
    CC rootcheck/common.o
    CC rootcheck/common_rcl.o
    CC rootcheck/config.o
    CC rootcheck/os_string.o
    CC rootcheck/rootcheck.o
In file included from ./headers/shared.h:220,
                 from rootcheck/common.c:11:
rootcheck/common.c: In function ‘is_file’:
./headers/debug_op.h:46:32: warning: argument 6 null where non-null expected [-Wnonnull]
   46 | #define mterror(tag, msg, ...) _mterror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rootcheck/common.c:454:9: note: in expansion of macro ‘mterror’
  454 |         mterror(ARGV0, "RK: Invalid file name: %s!", file_name);
      |         ^~~~~~~
In file included from ./headers/shared.h:220,

```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors