### PR TITLE
Fix warnings in check_rc_dev.c file

### DIFF
--- a/src/rootcheck/check_rc_dev.c
+++ b/src/rootcheck/check_rc_dev.c
@@ -13,7 +13,7 @@
 #include "rootcheck.h"
 
 /* Prototypes */
-static int read_dev_file(const char *file_name);
+static int read_dev_file(const char *file_name, const size_t size_name);
 static int read_dev_dir(const char *dir_name);
 
 /* Global variables */
@@ -21,7 +21,7 @@ static int _dev_errors;
 static int _dev_total;
 
 
-static int read_dev_file(const char *file_name)
+static int read_dev_file(const char *file_name, const size_t size_name)
 {
     struct stat statbuf;
 
@@ -36,9 +36,9 @@ static int read_dev_file(const char *file_name)
     }
 
     else if (S_ISREG(statbuf.st_mode)) {
-        char op_msg[OS_SIZE_1024 + 1];
+        char op_msg[size_name + strlen("File '' present on /dev. Possible hidden file.")  + 1];
 
-        snprintf(op_msg, OS_SIZE_1024, "File '%s' present on /dev."
+        snprintf(op_msg, sizeof(op_msg), "File '%s' present on /dev."
                  " Possible hidden file.", file_name);
         notify_rk(ALERT_SYSTEM_CRIT, op_msg);
 
@@ -137,7 +137,7 @@ static int read_dev_dir(const char *dir_name)
         }
 
         /* Found a non-ignored entry in the directory, so process it */
-        read_dev_file(f_name);
+        read_dev_file(f_name, sizeof(f_name));
     }
 
     closedir(dp);

--- a/src/rootcheck/check_rc_dev.c
+++ b/src/rootcheck/check_rc_dev.c
@@ -39,13 +39,14 @@ static int read_dev_file(const char *file_name)
         char op_msg[OS_SIZE_1024 + 1];
         const char op_msg_fmt[] = "File '%*s' present on /dev. Possible hidden file.";
 
-        int size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
+        const int size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
 
-        if (size < (int)sizeof(op_msg)) {
+        if (size >= 0 && (size_t)size < sizeof(op_msg)) {
             snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
         }
         else {
-            snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(sizeof(op_msg) - strlen(op_msg_fmt) + 2), file_name);
+            const unsigned int surplus = size - sizeof(op_msg) + 1;
+            snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(strlen(file_name) - surplus), file_name);
         }
 
         notify_rk(ALERT_SYSTEM_CRIT, op_msg);

--- a/src/rootcheck/check_rc_dev.c
+++ b/src/rootcheck/check_rc_dev.c
@@ -41,12 +41,14 @@ static int read_dev_file(const char *file_name)
 
         const int size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
 
-        if (size >= 0 && (size_t)size < sizeof(op_msg)) {
-            snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
-        }
-        else {
-            const unsigned int surplus = size - sizeof(op_msg) + 1;
-            snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(strlen(file_name) - surplus), file_name);
+        if (size >= 0) {
+            if ((size_t)size < sizeof(op_msg)) {
+                snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
+            }
+            else {
+                const unsigned int surplus = size - sizeof(op_msg) + 1;
+                snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(strlen(file_name) - surplus), file_name);
+            }
         }
 
         notify_rk(ALERT_SYSTEM_CRIT, op_msg);

--- a/src/rootcheck/check_rc_dev.c
+++ b/src/rootcheck/check_rc_dev.c
@@ -49,10 +49,9 @@ static int read_dev_file(const char *file_name)
                 const unsigned int surplus = size - sizeof(op_msg) + 1;
                 snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(strlen(file_name) - surplus), file_name);
             }
+
+            notify_rk(ALERT_SYSTEM_CRIT, op_msg);
         }
-
-        notify_rk(ALERT_SYSTEM_CRIT, op_msg);
-
         _dev_errors++;
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|#12100|


## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh agent project in check_rc_dev.c. . The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Agent</summary>

```
rootcheck/common.c:454:9: note: in expansion of macro ‘mterror’
  454 |         mterror(ARGV0, "RK: Invalid file name: %s!", file_name);
      |         ^~~~~~~
rootcheck/common.c: In function ‘is_file’:
rootcheck/common.c:454:48: note: format string is defined here
  454 |         mterror(ARGV0, "RK: Invalid file name: %s!", file_name);
      |                                                ^~
    CC rootcheck/check_rc_if.o
    CC rootcheck/check_open_ports.o
In file included from /usr/include/string.h:495,
                 from ./headers/shared.h:67,
                 from rootcheck/check_rc_if.c:12:
In function ‘strncpy’,
    inlined from ‘check_rc_if’ at rootcheck/check_rc_if.c:87:9:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output may be truncated copying 16 bytes from a string of length 639 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC rootcheck/os_string.o
    CC rootcheck/win-common.o
    CC rootcheck/check_rc_readproc.o
    CC rootcheck/check_rc_dev.o
    CC rootcheck/check_rc_sys.o
    CC rootcheck/run_rk_check.o
rootcheck/check_rc_sys.c: In function ‘read_sys_dir’:
rootcheck/check_rc_sys.c:93:52: warning: ‘%s’ directive output may be truncated writing up to 4097 bytes into a region of size 998 [-Wformat-truncation=]
   93 |                     snprintf(op_msg, OS_SIZE_1024, "Anomaly detected in file "
      |                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~
......
  284 |         read_sys_file(f_name, do_read);
      |                       ~~~~~~                        
rootcheck/check_rc_sys.c:94:32: note: format string is defined here
   94 |                              "'%s'. File size doesn't match what we found. "
      |                                ^~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from rootcheck/check_rc_sys.c:11:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 99 and 4196 bytes into a destination of size 1024
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORT
```

</details>

## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Agent</summary>

```
    CC logcollector/read_win_event_channel.o
    CC logcollector/state.o
logcollector/read_snortfull.c: In function ‘read_snortfull’:
logcollector/read_snortfull.c:54:17: warning: ‘strncpy’ output may be truncated copying 65536 bytes from a string of length 65536 [-Wstringop-truncation]
   54 |                 strncpy(f_msg, str, OS_MAXSTR);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC syscheckd/db/schema_fim_db.o
    CC syscheckd/config.o
    CC syscheckd/create_db.o
    CC syscheckd/fim_diff_changes.o
    CC syscheckd/fim_sync.o
    CC syscheckd/main.o
    CC syscheckd/run_check.o
    CC syscheckd/run_realtime.o
    CC syscheckd/syscheck.o
    CC syscheckd/syscom.o
    CC syscheckd/db/fim_db.o
    CC syscheckd/db/fim_db_files.o
    CC syscheckd/db/fim_db_registries.o
    CC syscheckd/whodata/audit_healthcheck.o
    CC syscheckd/whodata/audit_parse.o
    CC syscheckd/whodata/audit_rule_handling.o
    CC syscheckd/whodata/syscheck_audit.o
    CC syscheckd/whodata/win_whodata.o
    CC syscheckd/registry/events.o
    CC syscheckd/registry/registry.o
    CC rootcheck/check_open_ports.o
    CC rootcheck/check_rc_dev.o
    CC rootcheck/check_rc_files.o
    CC rootcheck/check_rc_if.o
    CC rootcheck/check_rc_pids.o
rootcheck/check_rc_if.c: In function ‘check_rc_if’:
rootcheck/check_rc_if.c:87:9: warning: ‘strncpy’ output may be truncated copying 16 bytes from a string of length 639 [-Wstringop-truncation]
   87 |         strncpy(_ifr.ifr_name, _ir->ifr_name, sizeof(_ifr.ifr_name));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rootcheck/check_rc_files.c: In function ‘check_rc_files’:
rootcheck/check_rc_files.c:171:52: warning: ‘%s’ directive output may be truncated writing up to 1024 bytes into a region of size 1023 [-Wformat-truncation=]
  171 |             snprintf(file_path, OS_SIZE_1024, "%s%c%s", basedir, PATH_SEP, file);
      |                                                    ^~
rootcheck/check_rc_files.c:171:13: note: ‘snprintf’ output 2 or more bytes (assuming 1026) into a destination of size 1024
  171 |             snprintf(file_path, OS_SIZE_1024, "%s%c%s", basedir, PATH_SEP, file);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rootcheck/check_rc_files.c:169:50: warning: ‘snprintf’ output may be truncated before the last format character [-Wformat-truncation=]
  169 |             snprintf(file_path, OS_SIZE_1024, "%s", file);
      |                                                  ^
rootcheck/check_rc_files.c:169:13: note: ‘snprintf’ output between 1 and 1025 bytes into a destination of size 1024
  169 |             snprintf(file_path, OS_SIZE_1024, "%s", file);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors