### PR TITLE
Fix warnings in unix_process.c file

### DIFF
--- a/src/rootcheck/unix-process.c
+++ b/src/rootcheck/unix-process.c
@@ -27,7 +27,7 @@ static char *_os_get_runps(const char *ps, int mpid)
 
     const int size = snprintf(command, sizeof(command), "%s -p %d 2> /dev/null", ps, mpid);
 
-    if (size > (int)(sizeof(command) - 1)) {
+    if (size < 0 || (size_t)size >= sizeof(command)) {
         return (NULL);
     }
 

--- a/src/rootcheck/unix-process.c
+++ b/src/rootcheck/unix-process.c
@@ -19,13 +19,20 @@ static char *_os_get_runps(const char *ps, int mpid)
     char *tmp_str, *nbuf;
     char buf[OS_SIZE_2048 + 1];
     char command[OS_SIZE_1024 + 1];
+    int size = 0;
     FILE *fp;
 
     buf[0] = '\0';
     command[0] = '\0';
     command[OS_SIZE_1024] = '\0';
 
-    snprintf(command, OS_SIZE_1024, "%s -p %d 2> /dev/null", ps, mpid);
+    size = snprintf(command, sizeof(command), "%s -p %d 2> /dev/null", ps, mpid);
+
+    if (size > (int)(sizeof(command) - 1)) {
+        return (NULL);
+    }
+
+
     fp = popen(command, "r");
     if (fp) {
         while (fgets(buf, OS_SIZE_2048, fp) != NULL) {

--- a/src/rootcheck/unix-process.c
+++ b/src/rootcheck/unix-process.c
@@ -19,14 +19,13 @@ static char *_os_get_runps(const char *ps, int mpid)
     char *tmp_str, *nbuf;
     char buf[OS_SIZE_2048 + 1];
     char command[OS_SIZE_1024 + 1];
-    int size = 0;
     FILE *fp;
 
     buf[0] = '\0';
     command[0] = '\0';
     command[OS_SIZE_1024] = '\0';
 
-    size = snprintf(command, sizeof(command), "%s -p %d 2> /dev/null", ps, mpid);
+    const int size = snprintf(command, sizeof(command), "%s -p %d 2> /dev/null", ps, mpid);
 
     if (size > (int)(sizeof(command) - 1)) {
         return (NULL);


### PR DESCRIPTION
|Related issue|
|---|
|#12100|


## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh agent project in unix_process.c. . The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Agent</summary>

```
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin_snprintf’ output between 1 and 1025 bytes into a destination of size 1024
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rootcheck/check_rc_files.c:191:44: warning: ‘%s’ directive output may be truncated writing up to 1024 bytes into a region of size between 979 and 2003 [-Wformat-truncation=]
  191 |             snprintf(op_msg, OS_SIZE_2048, "Rootkit '%s' detected "
      |                                            ^~~~~~~~~~~~~~~~~~~~~~~~
  192 |                      "by the presence of file '%s'.", name, file_path);
      |                                                             ~~~~~~~~~
rootcheck/check_rc_files.c:192:48: note: format string is defined here
  192 |                      "by the presence of file '%s'.", name, file_path);
      |                                                ^~
In file included from /usr/include/stdio.h:867,
                 from ./headers/shared.h:64,
                 from rootcheck/check_rc_files.c:11:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 48 and 2096 bytes into a destination of size 2048
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC rootcheck/win-process.o
    CC rootcheck/unix-process.o
    CC rootcheck/common.o
    CC rootcheck/rootcheck.o
In file included from ./headers/shared.h:220,
                 from rootcheck/common.c:11:
In function ‘is_file’,
    inlined from ‘is_file’ at rootcheck/common.c:446:5:
./headers/debug_op.h:46:32: warning: argument 6 null where non-null expected [-Wnonnull]
   46 | #define mterror(tag, msg, ...) _mterror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rootcheck/common.c:454:9: note: in expansion of macro ‘mterror’
  454 |         mterror(ARGV0, "RK: Invalid file name: %s!", file_name);
      |         ^~~~~~~
In file included from ./headers/shared.h:220,
                 from rootcheck/common.c:11:
rootcheck/common.c: In function ‘is_file’:
./headers/debug_op.h:61:6: note: in a call to function ‘_mterror’ declared here
   61 | void _mterror(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull));
      |      ^~~~~~~~
In file included from ./headers/shared.h:220,
                 from rootcheck/common.c:11:
In function ‘is_file’,
    inlined from ‘is_file’ at rootcheck/common.c:446:5:
./headers/debug_op.h:46:32: warning: ‘%s’ directive argument is null [-Wformat-overflow=]
   46 | #define mterror(tag, msg, ...) _mterror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rootcheck/common.c:454:9: note: in expansion of macro ‘mterror’
  454 |         mterror(ARGV0, "RK: Invalid file name: %s!", file_name);
      |         ^~~~~~~
rootcheck/common.c: In function ‘is_file’:
rootcheck/common.c:454:48: note: format string is defined here
  454 |         mterror(ARGV0, "RK: Invalid file name: %s!", file_name);
      |                                                ^~
    CC rootcheck/check_rc_if.o
    CC rootcheck/check_open_ports.o
In file included from /usr/include/string.h:495,

```

</details>

## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Agent</summary>

```
    CC rootcheck/rootcheck.o
In file included from ./headers/shared.h:220,
                 from rootcheck/common.c:11:
rootcheck/common.c: In function ‘is_file’:
./headers/debug_op.h:46:32: warning: argument 6 null where non-null expected [-Wnonnull]
   46 | #define mterror(tag, msg, ...) _mterror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rootcheck/common.c:454:9: note: in expansion of macro ‘mterror’
  454 |         mterror(ARGV0, "RK: Invalid file name: %s!", file_name);
      |         ^~~~~~~
In file included from ./headers/shared.h:220,
                 from rootcheck/common.c:11:
./headers/debug_op.h:61:6: note: in a call to function ‘_mterror’ declared here
   61 | void _mterror(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull));
      |      ^~~~~~~~
In file included from ./headers/shared.h:220,
                 from rootcheck/common.c:11:
./headers/debug_op.h:46:32: warning: ‘%s’ directive argument is null [-Wformat-overflow=]
   46 | #define mterror(tag, msg, ...) _mterror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rootcheck/common.c:454:9: note: in expansion of macro ‘mterror’
  454 |         mterror(ARGV0, "RK: Invalid file name: %s!", file_name);
      |         ^~~~~~~
rootcheck/common.c:454:48: note: format string is defined here
  454 |         mterror(ARGV0, "RK: Invalid file name: %s!", file_name);
      |                                                ^~
    CC rootcheck/run_rk_check.o
    CC rootcheck/unix-process.o
    CC rootcheck/win-common.o
    CC rootcheck/win-process.o
    CC os_execd/config.o
    CC os_execd/exec.o
    CC os_execd/execd.o
    CC os_execd/wcom.o
os_execd/exec.c: In function ‘ReadExecConfig’:
os_execd/exec.c:72:9: warning: ‘strncpy’ output may be truncated copying 256 bytes from a string of length 65536 [-Wstringop-truncation]
   72 |         strncpy(exec_names[exec_size], str_pt, OS_FLSIZE);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC os_execd/win_execd.o
    CC active-response/active_responses.o
    CC addagent/main.o
    CC addagent/manage_agents.o
    CC addagent/manage_keys.o
    CC addagent/read_from_user.o
    CC active-response/firewalls/default-firewall-drop.o
    CC shared/file_op_proc.o
    CC shared/debug_op_proc.o
active-response/firewalls/default-firewall-drop.c: In function ‘main’:
active-response/firewalls/default-firewall-drop.c:102:13: warning: ‘strncpy’ output may be truncated copying 4095 bytes from a string of length 4095 [-Wstringop-truncation]
  102 |             strncpy(iptables, iptables_path, COMMANDSIZE_4096 - 1);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC active-response/firewalls/pf.o
    CC active-response/firewalls/npf.o
    CC active-response/firewalls/ipfw.o

```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors