### PR TITLE
Add decorator to add deprecation headers to API response

### DIFF
--- a/api/api/util.py
+++ b/api/api/util.py
@@ -5,6 +5,7 @@
 import datetime
 import os
 import typing
+from functools import wraps
 
 import six
 from connexion import ProblemException
@@ -323,3 +324,27 @@ def get_invalid_keys(original_dict, des_dict):
                 invalid_keys.add(key)
 
     return invalid_keys
+
+
+def deprecate_endpoint(link: str = ''):
+    """Decorator to add deprecation headers to API response.
+
+    Parameters
+    ----------
+    link : str
+        Documentation related with this deprecation.
+    """
+    def add_deprecation_headers(func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            api_response = await func(*args, **kwargs)
+
+            api_response.headers['Deprecated'] = 'true'
+            if link:
+                api_response.headers['Link'] = f'<{link}>; rel="Deprecated"'
+
+            return api_response
+
+        return wrapper
+
+    return add_deprecation_headers


### PR DESCRIPTION
|Related issue|
|---|
|closes #12414 |

## Description

This PR implements a new python decorator to wrap API controllers that will be deprecated. It will add deprecation headers to the API response.

## Example

```yaml
Content-Type: application/json; charset=utf-8
Deprecated: true
Strict-Transport-Security: max-age=63072000; includeSubdomains
X-Frame-Options: DENY
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
Content-Security-Policy: none
Referrer-Policy: no-referrer, strict-origin-when-cross-origin
Pragma: no-cache
Expires: 0
Cache-control: no-cache, no-store, must-revalidate, max-age=0
Content-Length: 206
Date: Tue, 22 Feb 2022 09:06:08 GMT
```

## Tests performed
```shellsession
============================= test session starts =============================
platform linux -- Python 3.9.9, pytest-7.0.0, pluggy-1.0.0
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: asyncio-0.18.1, cov-3.0.0
asyncio: mode=legacy
collected 501 items                                                           

api/controllers/test/test_active_response_controller.py .               [  0%]
api/controllers/test/test_agent_controller.py ......................... [  5%]
.................                                                       [  8%]
api/controllers/test/test_cdb_list_controller.py ......                 [  9%]
api/controllers/test/test_ciscat_controller.py .                        [  9%]
api/controllers/test/test_cluster_controller.py ......................  [ 14%]
api/controllers/test/test_decoder_controller.py .......                 [ 15%]
api/controllers/test/test_default_controller.py .                       [ 15%]
api/controllers/test/test_experimental_controller.py ...............    [ 18%]
api/controllers/test/test_manager_controller.py .................       [ 22%]
api/controllers/test/test_mitre_controller.py .......                   [ 23%]
api/controllers/test/test_overview_controller.py .                      [ 23%]
api/controllers/test/test_rootcheck_controller.py ....                  [ 24%]
api/controllers/test/test_rule_controller.py ........                   [ 26%]
api/controllers/test/test_sca_controller.py ..                          [ 26%]
api/controllers/test/test_security_controller.py ...................... [ 31%]
.............................                                           [ 36%]
api/controllers/test/test_syscheck_controller.py ....                   [ 37%]
api/controllers/test/test_syscollector_controller.py .........          [ 39%]
api/controllers/test/test_task_controller.py .                          [ 39%]
api/controllers/test/test_vulnerability_controller.py ..                [ 40%]
api/models/test/test_model.py ...........................               [ 45%]
api/test/test_alogging.py ..........                                    [ 47%]
api/test/test_authentication.py ..........                              [ 49%]
api/test/test_configuration.py ........................................ [ 57%]
.                                                                       [ 57%]
api/test/test_encoder.py ...                                            [ 58%]
api/test/test_middlewares.py ............                               [ 60%]
api/test/test_uri_parser.py ...                                         [ 61%]
api/test/test_util.py ........................................          [ 69%]
api/test/test_validator.py ............................................ [ 78%]
....................................................................... [ 92%]
.......................................                                 [100%]

====================== 501 passed, 14 warnings in 2.59s =======================

```

Regards,
Víctor