### PR TITLE
Fix warnings in sysInfoLinux.cpp file

### DIFF
--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -201,7 +201,7 @@ int SysInfo::getCpuMHz() const
         constexpr auto CPU_FREQ_DIRNAME_PATTERN {"cpu[0-9]+"};
         const std::regex cpuDirectoryRegex {CPU_FREQ_DIRNAME_PATTERN};
 
-        for (const auto cpu : cpusInfo)
+        for (const auto& cpu : cpusInfo)
         {
             if (std::regex_match(cpu, cpuDirectoryRegex))
             {


### PR DESCRIPTION
|Related issue|
|---|
|#12100|

## Description

This PR aims to resolve the warnings when compiling the Wazuh agent project in sysInfoLinux.cpp. The output of the compilation after the changes was:


## Compilation using GCC 11.1.0

<details>
<summary>Wazuh Agent</summary>

```
~/wazuh/src$ make -j2 TARGET=agent
grep: /etc/redhat-release: No such file or directory
make build_sysinfo build_shared_modules build_syscollector
make[1]: Entering directory '/home/hanes/wazuh/src'
grep: /etc/redhat-release: No such file or directory
    CC libwazuhext.so
/usr/bin/ld: missing --end-group; added as last command line option
cd data_provider/ && mkdir -p build && cd build && cmake     .. && make
cd shared_modules/dbsync/ && mkdir -p build && cd build && cmake    .. && make
-- The C compiler identification is GNU 11.1.0
-- The C compiler identification is GNU 11.1.0
-- The CXX compiler identification is GNU 11.1.0
-- Detecting C compiler ABI info
-- The CXX compiler identification is GNU 11.1.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Generating done
-- Detecting CXX compile features - done
-- Build files have been written to: /home/hanes/wazuh/src/shared_modules/dbsync/build
-- Configuring done
make[2]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/data_provider/build
make[2]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
make[3]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync
make[3]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
Scanning dependencies of target sysinfo
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 10%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync.cpp.o
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
[  7%] Building CXX object CMakeFiles/sysinfo.dir/src/network/networkInterfaceLinux.cpp.o
[ 15%] Building CXX object CMakeFiles/sysinfo.dir/src/osinfo/sysOsParsers.cpp.o
[ 20%] Building CXX object CMakeFiles/dbsync.dir/src/dbsyncPipelineFactory.cpp.o
[ 30%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync_implementation.cpp.o
[ 23%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserDeb.cpp.o
[ 40%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_dbengine.cpp.o
[ 30%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserExtra.cpp.o
[ 38%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserRpm.cpp.o
[ 46%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserRpmLegacy.cpp.o
[ 50%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_wrapper.cpp.o
[ 60%] Linking CXX shared library lib/libdbsync.so
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 60%] Built target dbsync
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync_example
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 70%] Building CXX object example/CMakeFiles/dbsync_example.dir/main.cpp.o
[ 80%] Linking CXX executable ../bin/dbsync_example
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 80%] Built target dbsync_example
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 90%] Building CXX object testtool/CMakeFiles/dbsync_test_tool.dir/main.cpp.o
[ 53%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/rpmPackageManager.cpp.o
[ 61%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfoLinux.cpp.o
[ 69%] Building CXX object CMakeFiles/sysinfo.dir/src/utilsWrapperLinux.cpp.o
[ 76%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfo.cpp.o
[100%] Linking CXX executable ../bin/dbsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[100%] Built target dbsync_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
cd shared_modules/rsync/ && mkdir -p build && cd build && cmake     .. && make
-- The C compiler identification is GNU 11.1.0
-- The CXX compiler identification is GNU 11.1.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/shared_modules/rsync/build
make[2]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[3]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
Scanning dependencies of target rsync
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[ 12%] Building CXX object CMakeFiles/rsync.dir/src/rsync.cpp.o
[ 84%] Linking CXX shared library lib/libsysinfo.so
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
[ 84%] Built target sysinfo
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
Scanning dependencies of target sysinfo_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
[ 92%] Building CXX object testtool/CMakeFiles/sysinfo_test_tool.dir/main.cpp.o
[ 25%] Building CXX object CMakeFiles/rsync.dir/src/rsyncImplementation.cpp.o
[100%] Linking CXX executable ../bin/sysinfo_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
[100%] Built target sysinfo_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
[ 37%] Linking CXX shared library lib/librsync.so
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[ 37%] Built target rsync
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
Scanning dependencies of target rsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[ 62%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/main.cpp.o
[ 62%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/agentEmulator.cpp.o
[ 75%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/oneTimeSync.cpp.o
[ 87%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/managerEmulator.cpp.o
[100%] Linking CXX executable ../bin/rsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[100%] Built target rsync_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
cd wazuh_modules/syscollector/ && mkdir -p build && cd build && cmake     .. && make
-- The C compiler identification is GNU 11.1.0
-- The CXX compiler identification is GNU 11.1.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/wazuh_modules/syscollector/build
make[2]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[3]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
Scanning dependencies of target syscollector
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[ 33%] Building CXX object CMakeFiles/syscollector.dir/src/syscollector.cpp.o
[ 33%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorImp.cpp.o
[ 50%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorNormalizer.cpp.o
[ 66%] Linking CXX shared library lib/libsyscollector.so
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[ 66%] Built target syscollector
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
Scanning dependencies of target syscollector_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[ 83%] Building CXX object testtool/CMakeFiles/syscollector_test_tool.dir/main.cpp.o
[100%] Linking CXX executable ../bin/syscollector_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[100%] Built target syscollector_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[1]: Leaving directory '/home/hanes/wazuh/src'
make wazuh-agentd agent-auth wazuh-logcollector wazuh-syscheckd wazuh-execd manage_agents active-responses wazuh-modulesd
make[1]: Entering directory '/home/hanes/wazuh/src'
grep: /etc/redhat-release: No such file or directory
    CC client-agent/state.o
    CC client-agent/sendmsg.o

```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors