### PR TITLE
Add support for Windows 11 in Vulnerability Detector

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -505,6 +505,7 @@ const char *vu_feed_tag[] = {
     "W8",
     "W81",
     "W10",
+    "W11",
     "WS2008",
     "WS2008R2",
     "WS2012",
@@ -558,6 +559,7 @@ const char *vu_feed_ext[] = {
     "Windows 8",
     "Windows 8.1",
     "Windows 10",
+    "Windows 11",
     "Windows Server 2008",
     "Windows Server 2008 R2",
     "Windows Server 2012",
@@ -5736,6 +5738,7 @@ int wm_vuldet_generate_win_cpe(scan_agent *agent) {
     STATIC const char *PR_WIN8 = "windows_8";
     STATIC const char *PR_WIN81 = "windows_8.1";
     STATIC const char *PR_WIN10 = "windows_10";
+    STATIC const char *PR_WIN11 = "windows_11";
     STATIC const char *PR_WIN2003 = "windows_server_2003";
     STATIC const char *PR_WIN2008 = "windows_server_2008";
     STATIC const char *PR_WIN2012 = "windows_server_2012";
@@ -5792,6 +5795,10 @@ int wm_vuldet_generate_win_cpe(scan_agent *agent) {
         break;
         case FEED_W10:
             win_pr = PR_WIN10;
+            win_ver = ver_aux;
+        break;
+        case FEED_W11:
+            win_pr = PR_WIN11;
             win_ver = ver_aux;
         break;
         case FEED_WS2008:
@@ -6026,6 +6033,8 @@ vu_feed wm_vuldet_decode_win_os(char *os_raw) {
         return FEED_W8;
     } else if (strcasestr(os_raw, vu_feed_ext[FEED_W10])) {
         return FEED_W10;
+    } else if (strcasestr(os_raw, vu_feed_ext[FEED_W11])) {
+        return FEED_W11;
     } else if (strcasestr(os_raw, vu_feed_ext[FEED_WS2008R2])) {
         return FEED_WS2008R2;
     } else if (strcasestr(os_raw, vu_feed_ext[FEED_WS2008])) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -283,6 +283,7 @@ typedef enum vu_feed {
     FEED_W8,
     FEED_W81,
     FEED_W10,
+    FEED_W11,
     FEED_WS2008,
     FEED_WS2008R2,
     FEED_WS2012,


### PR DESCRIPTION
|Related issue|
|---|
|#12444|

## Description

The purpose of this PR is to add support for **Windows 11** in the _vulnerability detector_ module.

It is already correctly detected that it is a supported OS, and generates the corresponding _CPE_:
`o:microsoft:windows_11:version::::::arch:`

So the vulnerabilities found with that CPE are correctly matched with the Windows 11 agent and inserted into the database.

And finally, the hotfixes are compared with the inserted vulnerabilities, to detect with the MSU if the W11 agent is vulnerable and needs to be updated with a hotfix.

## Configuration options

```xml
    <!-- Windows OS vulnerabilities -->
    <provider name="msu">
      <enabled>yes</enabled>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Aggregate vulnerabilities -->
    <provider name="nvd">
      <enabled>yes</enabled>
      <update_from_year>2010</update_from_year>
      <update_interval>1h</update_interval>
    </provider>
```

## Logs/Alerts example

```
2022/02/24 16:33:49 wazuh-modulesd:vulnerability-detector[9204] wm_vuln_detector.c:2511 at wm_vuldet_check_agent_vulnerabilities(): DEBUG: (5438): A full scan will be run on agent '007'
2022/02/24 16:33:49 wazuh-modulesd:vulnerability-detector[9204] wm_vuln_detector.c:4979 at wm_vuldet_collect_agent_software(): DEBUG: (5437): Collecting agent '007' software.
2022/02/24 16:33:49 wazuh-modulesd:vulnerability-detector[9204] wm_vuln_detector.c:6140 at wm_vuldet_insert_agent_data(): DEBUG: (5446): The CPE 'a' from the agent '007' was indexed.
2022/02/24 16:33:49 wazuh-modulesd:vulnerability-detector[9204] wm_vuln_detector.c:6140 at wm_vuldet_insert_agent_data(): DEBUG: (5446): The CPE 'o:microsoft:windows_11:2009::::::x86_64:' from the agent '007' was indexed.
2022/02/24 16:33:49 wazuh-modulesd:vulnerability-detector[9204] wm_vuln_detector_nvd.c:3182 at wm_vuldet_add_dic_cpe(): DEBUG: (5446): The CPE 'a:wazuh:wazuh:4.3.0::::::i686:' from the agent '007' was indexed.
2022/02/24 16:33:49 wazuh-modulesd:vulnerability-detector[9204] wm_vuln_detector.c:2534 at wm_vuldet_check_agent_vulnerabilities(): INFO: (5450): Analyzing agent '007' vulnerabilities.
2022/02/24 16:33:49 wazuh-modulesd:vulnerability-detector[9204] wm_vuln_detector_nvd.c:1822 at wm_vuldet_win_nvd_vulnerabilities(): DEBUG: (5451): Analyzing NVD vulnerabilities for agent '007'
2022/02/24 16:33:49 wazuh-modulesd:vulnerability-detector[9204] wm_vuln_detector_nvd.c:1834 at wm_vuldet_win_nvd_vulnerabilities(): DEBUG: (5470): It took '0' seconds to 'find NVD' vulnerabilities in agent '007'
2022/02/24 16:33:49 wazuh-modulesd:vulnerability-detector[9204] wm_vuln_detector_nvd.c:1836 at wm_vuldet_win_nvd_vulnerabilities(): DEBUG: (5466): Sending vulnerabilities report for agent '007'
2022/02/24 16:33:49 wazuh-modulesd:vulnerability-detector[9204] wm_vuln_detector_nvd.c:2323 at wm_vuldet_process_agent_nvd_vulnerabilities(): DEBUG: (5467): Agent '007' is vulnerable to 'CVE-2022-21883'. Condition: 'KB5009566 patch is not installed'
2022/02/24 16:33:49 wazuh-modulesd:vulnerability-detector[9204] wm_vuln_detector_nvd.c:2323 at wm_vuldet_process_agent_nvd_vulnerabilities(): DEBUG: (5467): Agent '007' is vulnerable to 'CVE-2021-43227'. Condition: 'KB5008215 patch is not installed'
2022/02/24 16:33:49 wazuh-modulesd:vulnerability-detector[9204] wm_vuln_detector_nvd.c:2323 at wm_vuldet_process_agent_nvd_vulnerabilities(): DEBUG: (5467): Agent '007' is vulnerable to 'CVE-2021-43226'. Condition: 'KB5008215 patch is not installed'
2022/02/24 16:33:49 wazuh-modulesd:vulnerability-detector[9204] wm_vuln_detector_nvd.c:2323 at wm_vuldet_process_agent_nvd_vulnerabilities(): DEBUG: (5467): Agent '007' is vulnerable to 'CVE-2021-43224'. Condition: 'KB5008215 patch is not installed'
2022/02/24 16:33:49 wazuh-modulesd:vulnerability-detector[9204] wm_vuln_detector_nvd.c:2323 at wm_vuldet_process_agent_nvd_vulnerabilities(): DEBUG: (5467): Agent '007' is vulnerable to 'CVE-2021-43217'. Condition: 'KB5008215 patch is not installed'
2022/02/24 16:33:49 wazuh-modulesd:vulnerability-detector[9204] wm_vuln_detector_nvd.c:2323 at wm_vuldet_process_agent_nvd_vulnerabilities(): DEBUG: (5467): Agent '007' is vulnerable to 'CVE-2021-40449'. Condition: 'KB5006674 patch is not installed'
2022/02/24 16:33:49 wazuh-modulesd:vulnerability-detector[9204] wm_vuln_detector_nvd.c:1846 at wm_vuldet_win_nvd_vulnerabilities(): DEBUG: (5470): It took '0' seconds to 'report' vulnerabilities in agent '007'
2022/02/24 16:33:49 wazuh-modulesd:vulnerability-detector[9204] wm_vuln_detector.c:2553 at wm_vuldet_check_agent_vulnerabilities(): INFO: (5471): Finished vulnerability assessment for agent '007'
2022/02/24 16:33:49 wazuh-modulesd:vulnerability-detector[9204] wm_vuln_detector.c:2554 at wm_vuldet_check_agent_vulnerabilities(): DEBUG: (5470): It took '0' seconds to 'scan' vulnerabilities in agent '007'
2022/02/24 16:33:49 wazuh-modulesd:vulnerability-detector[9204] wm_vuln_detector.c:7686 at wm_vuldet_run_scan(): INFO: (5472): Vulnerability scan finished.

```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
<!--
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
-->