### PR TITLE
Add changes to run Test tool for Windows inside RTR

### DIFF
--- a/src/ci/utils.py
+++ b/src/ci/utils.py
@@ -730,6 +730,8 @@ def runReadyToReview(moduleName, clean=False):
     runAStyleCheck(str(moduleName))
     if str(moduleName) != 'shared_modules/utils':
         runASAN(moduleName)
+    if str(moduleName) == 'syscheckd':
+        runTestToolForWindows(moduleName)
 
     printGreen(f'<{moduleName}>[RTR: PASSED]<{moduleName}>')
     if clean:
@@ -760,7 +762,7 @@ def runTestToolForWindows(moduleName):
     for element in module:
         path = os.path.join(rootPath, element['test_tool_name'])
         args = ' '.join(element['args'])
-        testToolCommand = f'WINEPATH="/usr/i686-w64-mingw32/lib;{currentBuildDir.parent}" WINEARCH=win32 wine {path}.exe {args}'
+        testToolCommand = f'WINEPATH="/usr/i686-w64-mingw32/lib;{currentBuildDir.parent}" WINEARCH=win64 /usr/bin/wine {path}.exe {args}'
         runTestTool(str(moduleName), testToolCommand, element, True)
 
     printGreen(f'<{moduleName}>[ASAN for Windows: PASSED]<{moduleName}>')

--- a/src/ci/utils.py
+++ b/src/ci/utils.py
@@ -32,7 +32,7 @@ headerDic = {
     'valgrind':         '=================== Running Valgrind    ===================',
     'cppcheck':         '=================== Running cppcheck    ===================',
     'asan':             '=================== Running ASAN        ===================',
-    'winasan':          '=================== Running TESTTOOL for Windows ==========',
+    'winasan':          '=================== Running TEST TOOL for Windows =========',
     'scanbuild':        '=================== Running Scanbuild   ===================',
     'testtool':         '=================== Running TEST TOOL   ===================',
     'cleanfolder':      '=================== Clean build Folders ===================',
@@ -42,7 +42,7 @@ headerDic = {
     'rtr':              '=================== Running RTR checks  ===================',
     'coverage':         '=================== Running Coverage    ===================',
     'AStyle':           '=================== Running AStyle      ===================',
-    'deletelogs':       '=================== Clean result folders===================',
+    'deletelogs':       '=================== Clean result folders ==================',
 }
 
 smokeTestsDic = {
@@ -765,7 +765,7 @@ def runTestToolForWindows(moduleName):
         testToolCommand = f'WINEPATH="/usr/i686-w64-mingw32/lib;{currentBuildDir.parent}" WINEARCH=win64 /usr/bin/wine {path}.exe {args}'
         runTestTool(str(moduleName), testToolCommand, element, True)
 
-    printGreen(f'<{moduleName}>[ASAN for Windows: PASSED]<{moduleName}>')
+    printGreen(f'<{moduleName}>[TEST TOOL for Windows: PASSED]<{moduleName}>')
 
 def find(name, path):
     for root, dirs, files in os.walk(path):


### PR DESCRIPTION
|EPIC|Component|
|---|---|
| https://github.com/wazuh/wazuh/issues/9103 | FIM |

### Description
Add some changes to test registry transactions inside RTR

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Unit tests passed
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] cppcheck (static code analysis)
  - [x] Coverage (unit tests coverage code)
  - [x] Sformat (code style)
  - [x] Scan build