### PR TITLE
Fix Archlinux unsupported os during Vulnerability Detector scan.

### DIFF
--- a/src/shared/remoted_op.c
+++ b/src/shared/remoted_op.c
@@ -107,8 +107,6 @@ void parse_uname_string (char *uname,
                     match_size = match[1].rm_eo - match[1].rm_so;
                     os_malloc(match_size +1, osd->os_major);
                     snprintf(osd->os_major, match_size + 1, "%.*s", match_size, osd->os_version + match[1].rm_so);
-                } else {
-                    os_strdup("", osd->os_major);
                 }
 
                 // Get os_minor

--- a/src/shared/remoted_op.c
+++ b/src/shared/remoted_op.c
@@ -83,8 +83,7 @@ void parse_uname_string (char *uname,
 
         os_strdup(str_tmp, osd->os_version);
         os_strdup("windows", osd->os_platform);
-    }
-    else {
+    } else {
         if (str_tmp = strstr(uname, " ["), str_tmp) {
             *str_tmp = '\0';
             str_tmp += 2;
@@ -108,6 +107,8 @@ void parse_uname_string (char *uname,
                     match_size = match[1].rm_eo - match[1].rm_so;
                     os_malloc(match_size +1, osd->os_major);
                     snprintf(osd->os_major, match_size + 1, "%.*s", match_size, osd->os_version + match[1].rm_so);
+                } else {
+                    os_strdup("", osd->os_major);
                 }
 
                 // Get os_minor

--- a/src/unit_tests/shared/test_remoted_op.c
+++ b/src/unit_tests/shared/test_remoted_op.c
@@ -384,7 +384,7 @@ merged.mg\n#\"_agent_ip\":192.168.33.18\n";
     assert_int_equal(OS_SUCCESS, result);
     assert_string_equal("Wazuh v4.3.0", agent_data->version);
     assert_string_equal("Arch Linux", agent_data->osd->os_name);
-    assert_string_equal("", agent_data->osd->os_major);
+    assert_null(agent_data->osd->os_major);
     assert_null(agent_data->osd->os_minor);
     assert_null(agent_data->osd->os_build);
     assert_string_equal("", agent_data->osd->os_version);

--- a/src/unit_tests/shared/test_remoted_op.c
+++ b/src/unit_tests/shared/test_remoted_op.c
@@ -322,7 +322,7 @@ merged.mg\n#\"_agent_ip\":192.168.0.143\n";
     os_calloc(1, sizeof(agent_info_data), agent_data);
 
     int result = parse_agent_update_msg(msg, agent_data);
-    
+
     assert_int_equal(OS_SUCCESS, result);
     assert_string_equal("Wazuh v3.13.0", agent_data->version);
     assert_string_equal("Debian GNU/Linux", agent_data->osd->os_name);
@@ -370,6 +370,35 @@ merged.mg\n#\"_agent_ip\":192.168.0.133\n";
     wdb_free_agent_info_data(agent_data);
 }
 
+void test_parse_agent_update_msg_ok_archlinux(void **state)
+{
+    char *msg = "Linux |archlinux |5.15.2-arch1-1 |#1 SMP PREEMPT Fri, 12 Nov 2021 19:22:10 +0000 |x86_64 \
+[Arch Linux|arch: ] - Wazuh v4.3.0 / ab73af41699f13fdd81903b5f23d8d00\n4a8724b20dee0124ff9656783c490c4e \
+merged.mg\n#\"_agent_ip\":192.168.33.18\n";
+
+    agent_info_data *agent_data = NULL;
+    os_calloc(1, sizeof(agent_info_data), agent_data);
+
+    int result = parse_agent_update_msg(msg, agent_data);
+
+    assert_int_equal(OS_SUCCESS, result);
+    assert_string_equal("Wazuh v4.3.0", agent_data->version);
+    assert_string_equal("Arch Linux", agent_data->osd->os_name);
+    assert_string_equal("", agent_data->osd->os_major);
+    assert_null(agent_data->osd->os_minor);
+    assert_null(agent_data->osd->os_build);
+    assert_string_equal("", agent_data->osd->os_version);
+    assert_null(agent_data->osd->os_codename);
+    assert_string_equal("arch", agent_data->osd->os_platform);
+    assert_string_equal("x86_64", agent_data->osd->os_arch);
+    assert_string_equal("Linux |archlinux |5.15.2-arch1-1 |#1 SMP PREEMPT Fri, 12 Nov 2021 19:22:10 +0000 |x86_64", agent_data->osd->os_uname);
+    assert_string_equal("ab73af41699f13fdd81903b5f23d8d00", agent_data->config_sum);
+    assert_string_equal("4a8724b20dee0124ff9656783c490c4e", agent_data->merged_sum);
+    assert_string_equal("192.168.33.18", agent_data->agent_ip);
+
+    wdb_free_agent_info_data(agent_data);
+}
+
 void test_parse_agent_update_msg_ok_solaris(void **state)
 {
     char *msg = "SunOS |solaris10 |5.10 |Generic_147148-26 |i86pc [SunOS|sunos: 10] - \
@@ -409,7 +438,7 @@ ab73af41699f13fdd81903b5f23d8d00\nfd756ba04d9c32c8848d4608bec41251 merged.mg\n#\
     os_calloc(1, sizeof(agent_info_data), agent_data);
 
     int result = parse_agent_update_msg(msg, agent_data);
-    
+
     assert_int_equal(OS_SUCCESS, result);
     assert_string_equal("Wazuh v3.13.1", agent_data->version);
     assert_string_equal("Mac OS X", agent_data->osd->os_name);
@@ -438,7 +467,7 @@ merged.mg\n#\"_agent_ip\":192.168.0.164\n";
     os_calloc(1, sizeof(agent_info_data), agent_data);
 
     int result = parse_agent_update_msg(msg, agent_data);
-    
+
     assert_int_equal(OS_SUCCESS, result);
     assert_string_equal("Wazuh v3.13.1", agent_data->version);
     assert_string_equal("Microsoft Windows 10 Enterprise", agent_data->osd->os_name);
@@ -490,7 +519,7 @@ void test_parse_agent_update_msg_ok_labels(void **state)
 
 int main()
 {
-    const struct CMUnitTest tests[] = 
+    const struct CMUnitTest tests[] =
     {
         // Tests get_os_arch
         cmocka_unit_test_setup_teardown(test_get_os_arch_x86_64, setup_remoted_op, teardown_remoted_op),
@@ -512,6 +541,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_parse_agent_update_msg_missing_merged_sum, setup_remoted_op, teardown_remoted_op),
         cmocka_unit_test_setup_teardown(test_parse_agent_update_msg_ok_debian, setup_remoted_op, teardown_remoted_op),
         cmocka_unit_test_setup_teardown(test_parse_agent_update_msg_ok_ubuntu, setup_remoted_op, teardown_remoted_op),
+        cmocka_unit_test_setup_teardown(test_parse_agent_update_msg_ok_archlinux, setup_remoted_op, teardown_remoted_op),
         cmocka_unit_test_setup_teardown(test_parse_agent_update_msg_ok_solaris, setup_remoted_op, teardown_remoted_op),
         cmocka_unit_test_setup_teardown(test_parse_agent_update_msg_ok_macos, setup_remoted_op, teardown_remoted_op),
         cmocka_unit_test_setup_teardown(test_parse_agent_update_msg_ok_windows, setup_remoted_op, teardown_remoted_op),

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -418,6 +418,10 @@ const wm_context WM_VULNDETECTOR_CONTEXT = {
 
 const char *version_null = "0:0";
 
+const char *vu_os_platform_rolling_distros[] = {
+    "arch"
+};
+
 const char *vu_vendor_list[] = {
     "canonical",
     "debian",
@@ -5182,6 +5186,7 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
         bool is_centos = FALSE;
         int dist_error = -1;
         int id = 0;
+        bool is_rolling = FALSE;
 
         if (set_manager) {
             id = --set_manager;
@@ -5245,12 +5250,22 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
                 mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_NEVER_CON, agti_name);
             }
             goto next;
-        } else if (!agti_os_major) {
-            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UNS_OS_VERSION, id, agti_name?agti_name:"");
-            goto next;
         } else if (!agti_os_platform) {
             mtdebug1(WM_VULNDETECTOR_LOGTAG, "Failed to read platform from agent '%.3d'", id);
             goto next;
+        } else if (!agti_os_major) {
+            int rolling_distros_len = array_size(vu_os_platform_rolling_distros);
+            for (int distro_it = 0; distro_it < rolling_distros_len; ++distro_it) {
+                if (!strcmp(agti_os_platform, vu_os_platform_rolling_distros[distro_it])) {
+                    is_rolling = TRUE;
+                }
+            }
+            if (!is_rolling) {
+                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UNS_OS_VERSION, id, agti_name?agti_name:"");
+                goto next;
+            } else {
+                agti_os_major = "";
+            }
         }
 
         if (strcasestr(agti_os_name, vu_feed_ext[FEED_UBUNTU])) {
@@ -5478,7 +5493,9 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
         }
         else {
             w_strdup(osinfo_release, agents->kernel_release);
-            wm_vuldet_build_unix_os_release(agents, osinfo_major, osinfo_minor, osinfo_patch);
+            if (!is_rolling) {
+                wm_vuldet_build_unix_os_release(agents, osinfo_major, osinfo_minor, osinfo_patch);
+            }
         }
 
 next:


### PR DESCRIPTION
|Related issue|
|---|
|#12429|

## Description

As a consequence of the changes of https://github.com/wazuh/wazuh/pull/11207 the `os_major` information can't be parsed from `os_version` when it arrives at the manager and it is set as NULL in the global database for rolling distributions. Due to the case previously mentioned vulnerability detector skips the scan. 

## Scan-build report

![image](https://user-images.githubusercontent.com/13010397/155745828-5b3fc6a1-faeb-480f-b375-b097f539c5ad.png)

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report