### PR TITLE
Fix active configuration error handling

### DIFF
--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -769,8 +769,36 @@ def upload_group_file(group_id, file_data, file_name='agent.conf'):
 
 
 def get_active_configuration(agent_id, component, configuration):
-    """
-    Reads agent loaded configuration in memory
+    """Get active configuration in a specific node.
+
+    Parameters
+    ----------
+    agent_id : str
+        Agent ID. All possible values from 000 onwards.
+    component : str
+        Selected agent's component.
+    configuration : str
+        Configuration to get, written on disk.
+
+    Returns
+    -------
+    str
+        The active configuration the agent is currently using.
+
+    Raises
+    ------
+    WazuhError
+        If the component or configuration are not specified.
+    WazuhError
+        If the specified component is not valid.
+    WazuhError
+        If the component is not properly configured.
+    WazuhInternalError
+        If the socket cant be created.
+    WazuhInternalError
+        If the socket is not able to receive a response.
+    WazuhError
+        If the reply from the node contains an error.
     """
     if not component or not configuration:
         raise WazuhError(1307)
@@ -790,6 +818,10 @@ def get_active_configuration(agent_id, component, configuration):
     else:
         dest_socket = os_path.join(sockets_path, "request")
         command = f"{str(agent_id).zfill(3)} {component} getconfig {configuration}"
+
+    # Verify component configuration
+    if not os.path.exists(dest_socket):
+        raise WazuhError(1121, extra_message=f"please verify that the component '{component}' is properly configured")
 
     # Socket connection
     try:

--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -815,13 +815,13 @@ def get_active_configuration(agent_id, component, configuration):
     if agent_id == '000':
         dest_socket = os_path.join(sockets_path, component)
         command = f"getconfig {configuration}"
+        # Verify component configuration
+        if not os.path.exists(dest_socket):
+            raise WazuhError(1121, extra_message=f"please verify that the component '{component}' \
+                is properly configured")
     else:
         dest_socket = os_path.join(sockets_path, "request")
         command = f"{str(agent_id).zfill(3)} {component} getconfig {configuration}"
-
-    # Verify component configuration
-    if not os.path.exists(dest_socket):
-        raise WazuhError(1121, extra_message=f"please verify that the component '{component}' is properly configured")
 
     # Socket connection
     try:

--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -769,7 +769,7 @@ def upload_group_file(group_id, file_data, file_name='agent.conf'):
 
 
 def get_active_configuration(agent_id, component, configuration):
-    """Get active configuration in a specific node.
+    """Get an agent's component active configuration.
 
     Parameters
     ----------
@@ -787,17 +787,19 @@ def get_active_configuration(agent_id, component, configuration):
 
     Raises
     ------
-    WazuhError
+    WazuhError(1307)
         If the component or configuration are not specified.
-    WazuhError
+    WazuhError(1101)
         If the specified component is not valid.
-    WazuhError
+    WazuhError(1121)
         If the component is not properly configured.
-    WazuhInternalError
+    WazuhInternalError(1121)
         If the socket cant be created.
-    WazuhInternalError
+    WazuhInternalError(1118)
         If the socket is not able to receive a response.
-    WazuhError
+    WazuhError(1117)
+        If there's no such file or directory in agent node, or the socket cannot send the request.
+    WazuhError(1116)
         If the reply from the node contains an error.
     """
     if not component or not configuration:

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -1229,7 +1229,8 @@ def test_agent_unset_single_group_agent_ko(socket_mock, send_mock):
 @patch('wazuh.core.configuration.WazuhSocket')
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
-def test_agent_getconfig(socket_mock, send_mock, mock_wazuh_socket):
+@patch('os.path.exists')
+def test_agent_getconfig(mock_exists, socket_mock, send_mock, mock_wazuh_socket):
     """Test getconfig method returns expected message."""
     agent = Agent('001')
     mock_wazuh_socket.return_value.receive.return_value = b'ok {"test": "conf"}'

--- a/framework/wazuh/core/tests/test_configuration.py
+++ b/framework/wazuh/core/tests/test_configuration.py
@@ -362,7 +362,7 @@ def test_get_active_configuration(mock_exists, agent_id, component, config, msg)
 
 @pytest.mark.parametrize("agent_id, component, config", [
     ('000', 'syscheck', 'syscheck'),
-    ('001', 'mail', 'global')
+    ('000', 'mail', 'global')
 ])
 @patch('os.path.exists', return_value=False)
 def test_get_active_configuration_not_configured(mock_exists, agent_id, component, config):

--- a/framework/wazuh/core/tests/test_configuration.py
+++ b/framework/wazuh/core/tests/test_configuration.py
@@ -341,7 +341,8 @@ def test_upload_group_file(mock_safe_move, mock_open, mock_wazuh_uid, mock_wazuh
     ('000', 'agent', 'given', '{"auth": {"use_password": "yes"}}'),
     ('000', 'agent', 'given', '{"auth": {"use_password": "no"}}')
 ])
-def test_get_active_configuration(agent_id, component, config, msg):
+@patch('os.path.exists')
+def test_get_active_configuration(mock_exists, agent_id, component, config, msg):
     """This test checks the propper working of get_active_configuration function."""
     with patch('wazuh.core.configuration.WazuhSocket.__init__', return_value=None):
         with patch('wazuh.core.configuration.WazuhSocket.send', side_effect=None):
@@ -359,6 +360,17 @@ def test_get_active_configuration(agent_id, component, config, msg):
                         assert 'authd.pass' not in result
 
 
+@pytest.mark.parametrize("agent_id, component, config", [
+    ('000', 'syscheck', 'syscheck'),
+    ('001', 'mail', 'global')
+])
+@patch('os.path.exists', return_value=False)
+def test_get_active_configuration_not_configured(mock_exists, agent_id, component, config):
+    """Test the raised exception regarding a non configured component"""
+    with pytest.raises(WazuhError, match=f".* 1121 .* component '{component}'"):
+        configuration.get_active_configuration(agent_id, component, config)
+
+
 @pytest.mark.parametrize("exception_type, agent_id, component, config, exception_", [
     (WazuhError, '000', None, None, 1307),
     (WazuhError, '000', None, 'given', 1307),
@@ -366,7 +378,8 @@ def test_get_active_configuration(agent_id, component, config, msg):
     (WazuhInternalError, '000', 'agent', 'given', 1121),
     (WazuhInternalError, '001', 'agent', 'given', 1121)
 ])
-def test_get_active_configuration_first_exceptions(exception_type, agent_id, component, config, exception_):
+@patch('os.path.exists')
+def test_get_active_configuration_first_exceptions(mock_exists, exception_type, agent_id, component, config, exception_):
     """This test checks the first three exceptions."""
     with patch('wazuh.core.configuration.WazuhSocket.__init__', return_value=Exception):
         with pytest.raises(exception_type, match=f".* {exception_} .*"):
@@ -376,7 +389,8 @@ def test_get_active_configuration_first_exceptions(exception_type, agent_id, com
 @pytest.mark.parametrize("agent_id, component, config, exception_", [
     ('000', 'agent', 'given', 1118)
 ])
-def test_get_active_configuration_second_exceptions(agent_id, component, config, exception_):
+@patch('os.path.exists')
+def test_get_active_configuration_second_exceptions(mock_exists, agent_id, component, config, exception_):
     """This test checks the fourth exception."""
     with patch('wazuh.core.configuration.WazuhSocket.__init__', return_value=None):
         with patch('wazuh.core.configuration.WazuhSocket.send', side_effect=None):
@@ -388,7 +402,8 @@ def test_get_active_configuration_second_exceptions(agent_id, component, config,
 @pytest.mark.parametrize("agent_id, component, config, exception_", [
     ('000', 'agent', 'given', 1116)
 ])
-def test_get_active_configuration_third_exceptions(agent_id, component, config, exception_):
+@patch('os.path.exists')
+def test_get_active_configuration_third_exceptions(mock_exists, agent_id, component, config, exception_):
     """This test checks the last exception."""
     with patch('wazuh.core.configuration.WazuhSocket.__init__', return_value=None):
         with patch('wazuh.core.configuration.WazuhSocket.send', side_effect=None):
@@ -401,7 +416,8 @@ def test_get_active_configuration_third_exceptions(agent_id, component, config, 
 @pytest.mark.parametrize("agent_id, component, config, exception_", [
     ('000', 'agent', 'given', None)
 ])
-def test_get_active_configuration_fourth_exception(agent_id, component, config, exception_):
+@patch('os.path.exists')
+def test_get_active_configuration_fourth_exception(mock_exists, agent_id, component, config, exception_):
     with patch('wazuh.core.configuration.WazuhSocket.__init__', return_value=None):
         with patch('wazuh.core.configuration.WazuhSocket.send', side_effect=None):
             with patch('wazuh.core.configuration.WazuhSocket.receive', return_value=b'ok {"a": "2"}'):

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -1282,7 +1282,8 @@ def test_agent_get_upgrade_result(mock_socket, mock_wdb, mock_client_keys, agent
 @patch('wazuh.core.configuration.WazuhSocket')
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
-def test_agent_get_agent_config(socket_mock, send_mock, wazuh_socket_mock, agent_list, component, configuration):
+@patch('os.path.exists')
+def test_agent_get_agent_config(mock_exists, socket_mock, send_mock, wazuh_socket_mock, agent_list, component, configuration):
     """Test `get_agent_config` function from agent module.
 
     Parameters


### PR DESCRIPTION
|Related issue|
|---|
| This PR closes #10775 |

## Description

The following error was found when trying to make a request to `GET /cluster/{node_id}/configuration/{component}/{configuration}` with a valid but non configured component.

* Before: `GET /cluster/master-node/configuration/mail/global`.
```json
{
  "title": "Wazuh Internal Error",
  "detail": "Error connecting with socket",
  "dapi_errors": {
    "master-node": {
      "error": "Error connecting with socket",
      "logfile": "WAZUH_HOME/logs/api.log"
    }
  },
  "error": 1121
}
```

* After: `GET /cluster/master-node/configuration/mail/global`.
```json
{
  "data": {
    "affected_items": [],
    "total_affected_items": 0,
    "total_failed_items": 1,
    "failed_items": [
      {
        "error": {
          "code": 1121,
          "message": "Error connecting with socket: please verify that the component 'mail' is properly configured"
        },
        "id": [
          "master-node"
        ]
      }
    ]
  },
  "message": "Could not read active configuration in specified node",
  "error": 1
}
```
---

However, if the component is configured but the socket is malfunctioning, we'll be getting the `WazuhInternal` error as it should be.
`GET /cluster/master-node/configuration/syscheck/syscheck`
```
--- Socket file with wrong ownership ---
root@f1656202220d:/var/ossec/queue/sockets# ll syscheck 
srw-rw---- 1 root root 0 Feb 24 17:46 syscheck=
```
```json
{
  "title": "Wazuh Internal Error",
  "detail": "Error connecting with socket",
  "dapi_errors": {
    "master-node": {
      "error": "Error connecting with socket",
      "logfile": "WAZUH_HOME/logs/api.log"
    }
  },
  "error": 1121
}
```
