### PR TITLE
Dev 12431 win vuldet fix

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5426,6 +5426,11 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
         if (cJSON_IsString(j_field))
             osinfo_os_release = j_field->valuestring;
 
+        j_field = cJSON_GetObjectItem(j_osinfo->child, "os_display_version");
+        char *osinfo_os_display_version = NULL;
+        if (cJSON_IsString(j_field))
+            osinfo_os_display_version = j_field->valuestring;
+
         j_field = cJSON_GetObjectItem(j_osinfo->child, "release");
         char *osinfo_release = NULL;
         if (cJSON_IsString(j_field))
@@ -5475,6 +5480,7 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
         w_strdup(agti_os_name, agents->os_name);
         if (agent_dist == FEED_WIN) {
             w_strdup(osinfo_os_release, agents->os_release);
+            w_strdup(osinfo_os_display_version, agents->os_display_version);
         }
         else {
             w_strdup(osinfo_release, agents->kernel_release);
@@ -7058,55 +7064,6 @@ void wm_vuldet_reset_tables(sqlite3 *db) {
     sqlite3_exec(db, vu_queries[VU_REMOVE_AGENTS_TABLE], NULL, NULL, NULL);
     sqlite3_exec(db, vu_queries[VU_REMOVE_AGENT_CPE], NULL, NULL, NULL);
     sqlite3_exec(db, vu_queries[VU_REMOVE_HOTFIXES_TABLE], NULL, NULL, NULL);
-}
-
-int wm_vuldet_get_oswindows_info(scan_agent *agent) {
-    int retval = OS_INVALID;
-    char request[OS_SIZE_128];
-    cJSON *obj = NULL;
-    cJSON *obj_it;
-
-    snprintf(request, OS_SIZE_128, vu_queries[VU_SYSC_OSWIN_INFO], agent->agent_id);
-
-    if (wm_vuldet_wdb_request(request, OS_SIZE_128)) {
-        goto end;
-    }
-
-    if (!wm_vuldet_wdb_valid_answ(request)) {
-        mterror(WM_VULNDETECTOR_LOGTAG, VU_INV_WAZUHDB_RES, request);
-        goto end;
-    }
-
-    // Check empty answers
-    if (wm_vuldet_wdb_empty_answ(request)) {
-       retval = 0;
-       goto end;
-    }
-
-    request[0] = request[1] = ' ';
-
-    if (obj = cJSON_Parse(request), !obj) {
-        goto end;
-    }
-
-    if ((obj_it = obj->child) && (obj_it = cJSON_GetObjectItem(obj_it, "os_release")) && obj_it->valuestring) {
-        w_strdup(obj_it->valuestring, agent->os_release);
-    }
-
-    if ((obj_it = obj->child) && (obj_it = cJSON_GetObjectItem(obj_it, "os_display_version")) && obj_it->valuestring) {
-        w_strdup(obj_it->valuestring, agent->os_display_version);
-    }
-
-    retval = 0;
-end:
-    if (obj) {
-        cJSON_Delete(obj);
-    }
-    if (retval) {
-        mterror(WM_VULNDETECTOR_LOGTAG, VU_CPE_CLEAN_REQUEST_ERROR, atoi(agent->agent_id));
-    }
-
-    return retval;
 }
 
 int wm_vuldet_build_unix_os_release(scan_agent *agent,

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5470,6 +5470,17 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
             os_strdup(agti_arch, agents->arch);
         }
 
+        // Correcting the achitecture string to generate a valid OS CPE
+        if(agents->arch) {
+            if(strcmp(agents->arch, "x86_64") == 0) {
+                os_free(agents->arch);
+                os_strdup("x64",agents->arch);
+            } else if(strcmp(agents->arch, "i686") == 0){
+                os_free(agents->arch);
+                os_strdup("x86",agents->arch);
+            }
+        }
+
         agents->dist = agent_dist;
         agents->dist_ver = agent_dist_ver;
         agents->flags.centos = is_centos;


### PR DESCRIPTION
|Related issue|
|---|
|#12431|

## Description

This PR fixes the following situations:

- The PR https://github.com/wazuh/wazuh/pull/10168 creates the new **os_display_version** to properly manage some Windows versions, like Win10 21H1. This fix was deactivated during the rebases for this development https://github.com/wazuh/wazuh/pull/8237. Now these agents are scanned by vulnerability detector as before
- The epic https://github.com/wazuh/wazuh/pull/8237 also considers the architecture for the CPE of the operative system. But it happens that the `x86_64` string that is read by **syscollector** isn't valid for the vulnerability scan. It was replaced to `x64`.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Valgrind (memcheck and descriptor leaks check)

- [ ] Added unit tests (for new features)
