### PR TITLE
Leave process state blank on macOS

### DIFF
--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -55,7 +55,7 @@ static nlohmann::json getProcessInfo(const ProcessTaskInfo& taskInfo, const pid_
     jsProcessInfo["pid"]        = std::to_string(pid);
     jsProcessInfo["name"]       = taskInfo.pbsd.pbi_name;
 
-    jsProcessInfo["state"]      = " ";
+    jsProcessInfo["state"]      = UNKNOWN_VALUE;
     jsProcessInfo["ppid"]       = taskInfo.pbsd.pbi_ppid;
 
     const auto eUser { getpwuid(taskInfo.pbsd.pbi_uid) };

--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -31,15 +31,6 @@ const std::string MAC_UTILITIES_PATH{"/Applications/Utilities"};
 
 using ProcessTaskInfo = struct proc_taskallinfo;
 
-static const std::map<int, std::string> s_mapTaskInfoState =
-{
-    { 1, "I"},  // Idle
-    { 2, "R"},  // Running
-    { 3, "S"},  // Sleep
-    { 4, "T"},  // Stopped
-    { 5, "Z"}   // Zombie
-};
-
 static const std::vector<int> s_validFDSock =
 {
     {
@@ -64,10 +55,7 @@ static nlohmann::json getProcessInfo(const ProcessTaskInfo& taskInfo, const pid_
     jsProcessInfo["pid"]        = std::to_string(pid);
     jsProcessInfo["name"]       = taskInfo.pbsd.pbi_name;
 
-    const auto procState { s_mapTaskInfoState.find(taskInfo.pbsd.pbi_status) };
-    jsProcessInfo["state"]      = (procState != s_mapTaskInfoState.end())
-                                  ? procState->second
-                                  : "E";   // Internal error
+    jsProcessInfo["state"]      = " ";
     jsProcessInfo["ppid"]       = taskInfo.pbsd.pbi_ppid;
 
     const auto eUser { getpwuid(taskInfo.pbsd.pbi_uid) };


### PR DESCRIPTION
|Related issue|
|---|
|#11855|

This PR offers an alternative solution to us not being able to show processes state correctly: simply not showing them at all.
## Description
A previous attempt to fix this was made but wasn't feasible. More details on https://github.com/wazuh/wazuh/pull/12299.


