### PR TITLE
Fix wrong changed attributes values.

### DIFF
--- a/src/syscheckd/cppcheckSuppress.txt
+++ b/src/syscheckd/cppcheckSuppress.txt
@@ -2,4 +2,4 @@
 *:*src/syscheckd/src/db/src/file.cpp:392
 *:*src/db/testtool/action.h:378
 *:*src/syscheckd/src/db/src/db.cpp:97
-*:*src/syscheckd/src/create_db.c:741
+*:*src/syscheckd/src/create_db.c:848

--- a/src/syscheckd/cppcheckSuppress.txt
+++ b/src/syscheckd/cppcheckSuppress.txt
@@ -1,5 +1,5 @@
 *:*src/syscheckd/src/db/src/file.cpp:78
-*:*src/syscheckd/src/db/src/file.cpp:393
+*:*src/syscheckd/src/db/src/file.cpp:392
 *:*src/db/testtool/action.h:378
 *:*src/syscheckd/src/db/src/db.cpp:97
 *:*src/syscheckd/src/create_db.c:741

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -69,7 +69,7 @@ cJSON * fim_calculate_dbsync_difference(const fim_file_data *data,
 
     if (data->options & CHECK_PERM) {
         if (aux = cJSON_GetObjectItem(changed_data, "perm"), aux != NULL) {
-            cJSON_AddStringToObject(old_attributes, "perm", aux->valuestring);
+            cJSON_AddStringToObject(old_attributes, "perm", cJSON_GetStringValue(aux));
             cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("permission"));
 
         } else {
@@ -83,7 +83,7 @@ cJSON * fim_calculate_dbsync_difference(const fim_file_data *data,
 
     if (data->options & CHECK_OWNER) {
         if (aux = cJSON_GetObjectItem(changed_data, "uid"), aux != NULL) {
-            cJSON_AddStringToObject(old_attributes, "uid", aux->valuestring);
+            cJSON_AddStringToObject(old_attributes, "uid", cJSON_GetStringValue(aux));
             cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("uid"));
 
         } else {
@@ -93,7 +93,7 @@ cJSON * fim_calculate_dbsync_difference(const fim_file_data *data,
 
     if (data->options & CHECK_GROUP) {
         if (aux = cJSON_GetObjectItem(changed_data, "gid"), aux != NULL) {
-            cJSON_AddStringToObject(old_attributes, "gid", aux->valuestring);
+            cJSON_AddStringToObject(old_attributes, "gid", cJSON_GetStringValue(aux));
             cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("gid"));
 
         } else {
@@ -103,7 +103,7 @@ cJSON * fim_calculate_dbsync_difference(const fim_file_data *data,
 
     if (data->user_name) {
         if (aux = cJSON_GetObjectItem(changed_data, "user_name"), aux != NULL) {
-            cJSON_AddStringToObject(old_attributes, "user_name", aux->valuestring);
+            cJSON_AddStringToObject(old_attributes, "user_name", cJSON_GetStringValue(aux));
             cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("user_name"));
 
         } else {
@@ -113,7 +113,7 @@ cJSON * fim_calculate_dbsync_difference(const fim_file_data *data,
 
     if (data->group_name) {
         if (aux = cJSON_GetObjectItem(changed_data, "group_name"), aux != NULL) {
-            cJSON_AddStringToObject(old_attributes, "group_name", aux->valuestring);
+            cJSON_AddStringToObject(old_attributes, "group_name", cJSON_GetStringValue(aux));
             cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("group_name"));
 
         } else {
@@ -143,7 +143,7 @@ cJSON * fim_calculate_dbsync_difference(const fim_file_data *data,
 
     if (data->options & CHECK_MD5SUM) {
         if (aux = cJSON_GetObjectItem(changed_data, "hash_md5"), aux != NULL) {
-            cJSON_AddStringToObject(old_attributes, "hash_md5", aux->valuestring);
+            cJSON_AddStringToObject(old_attributes, "hash_md5", cJSON_GetStringValue(aux));
             cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("md5"));
 
         } else {
@@ -153,7 +153,7 @@ cJSON * fim_calculate_dbsync_difference(const fim_file_data *data,
 
     if (data->options & CHECK_SHA1SUM) {
         if (aux = cJSON_GetObjectItem(changed_data, "hash_sha1"), aux != NULL) {
-            cJSON_AddStringToObject(old_attributes, "hash_sha1", aux->valuestring);
+            cJSON_AddStringToObject(old_attributes, "hash_sha1", cJSON_GetStringValue(aux));
             cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("sha1"));
 
         } else {
@@ -163,7 +163,7 @@ cJSON * fim_calculate_dbsync_difference(const fim_file_data *data,
 
     if (data->options & CHECK_SHA256SUM) {
         if (aux = cJSON_GetObjectItem(changed_data, "hash_sha256"), aux != NULL) {
-            cJSON_AddStringToObject(old_attributes, "hash_sha256", aux->valuestring);
+            cJSON_AddStringToObject(old_attributes, "hash_sha256", cJSON_GetStringValue(aux));
             cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("sha256"));
 
         } else {
@@ -174,7 +174,7 @@ cJSON * fim_calculate_dbsync_difference(const fim_file_data *data,
 #ifdef WIN32
     if (data->options & CHECK_ATTRS) {
         if (aux = cJSON_GetObjectItem(changed_data, "attributes"), aux != NULL) {
-            cJSON_AddStringToObject(old_attributes, "attributes", aux->valuestring);
+            cJSON_AddStringToObject(old_attributes, "attributes", cJSON_GetStringValue(aux));
             cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("attributes"));
 
         } else {
@@ -185,7 +185,7 @@ cJSON * fim_calculate_dbsync_difference(const fim_file_data *data,
 
     if (*data->checksum) {
         if (aux = cJSON_GetObjectItem(changed_data, "checksum"), aux != NULL) {
-            cJSON_AddStringToObject(old_attributes, "checksum", aux->valuestring);
+            cJSON_AddStringToObject(old_attributes, "checksum", cJSON_GetStringValue(aux));
         } else {
             cJSON_AddStringToObject(old_attributes, "checksum", data->checksum);
         }

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -193,6 +193,7 @@ cJSON * fim_calculate_dbsync_difference(const fim_file_data *data,
 
     return old_attributes;
 }
+// LCOV_EXCL_STOP
 
 /**
  * @brief Function to calculate the `attributes` field using the information returned by dbsync.
@@ -220,6 +221,7 @@ static void dbsync_attributes_json(const cJSON *dbsync_event, const directory_t 
 #ifndef WIN32
             cJSON_AddStringToObject(attributes, "perm", cJSON_GetStringValue(aux));
 #else
+
             cJSON_AddItemToObject(attributes, "perm", cJSON_Duplicate(aux, 1));
 #endif
         }
@@ -231,6 +233,7 @@ static void dbsync_attributes_json(const cJSON *dbsync_event, const directory_t 
             os_malloc(OS_SIZE_64, buffer);
             snprintf(buffer, OS_SIZE_64, "%d", aux->valueint);
             cJSON_AddStringToObject(attributes, "uid", buffer);
+            os_free(buffer);
         }
     }
 
@@ -241,6 +244,7 @@ static void dbsync_attributes_json(const cJSON *dbsync_event, const directory_t 
             snprintf(buffer, OS_SIZE_64, "%d", aux->valueint);
 
             cJSON_AddStringToObject(attributes, "gid", buffer);
+            os_free(buffer)
         }
     }
 
@@ -297,8 +301,6 @@ static void dbsync_attributes_json(const cJSON *dbsync_event, const directory_t 
     }
 }
 
-// LCOV_EXCL_STOP
-
 static void transaction_callback(ReturnTypeCallback resultType, const cJSON* result_json, void* user_data) {
     char *path = NULL;
     char *diff = NULL;
@@ -307,6 +309,7 @@ static void transaction_callback(ReturnTypeCallback resultType, const cJSON* res
     cJSON* old_attributes = NULL;
     cJSON* changed_attributes = NULL;
     cJSON* old_data = NULL;
+    cJSON *attributes = NULL;
     const cJSON *dbsync_event = NULL;
     cJSON* timestamp = NULL;
     directory_t *configuration = NULL;
@@ -398,7 +401,7 @@ static void transaction_callback(ReturnTypeCallback resultType, const cJSON* res
 
     if (resultType == DELETED || txn_context->latest_entry == NULL) {
         // We need to add the `type` field to the attributes JSON. This avoid modifying the dbsync event.
-        cJSON *attributes = cJSON_CreateObject();
+        attributes = cJSON_CreateObject();
         dbsync_attributes_json(dbsync_event, configuration, attributes);
         cJSON_AddItemToObject(data, "attributes", attributes);
     } else {

--- a/src/syscheckd/src/db/src/file.cpp
+++ b/src/syscheckd/src/db/src/file.cpp
@@ -181,7 +181,7 @@ nlohmann::json DB::createJsonEvent(const nlohmann::json& fileJson, const nlohman
             if (old_data.contains("perm"))
             {
                 jsonEvent["data"]["old_attributes"]["perm"] = old_data["perm"];
-                changed_attributes.push_back("perm");
+                changed_attributes.push_back("permission");
             }
             else
             {
@@ -272,7 +272,7 @@ nlohmann::json DB::createJsonEvent(const nlohmann::json& fileJson, const nlohman
             if (old_data.contains("hash_md5"))
             {
                 jsonEvent["data"]["old_attributes"]["hash_md5"] = old_data["hash_md5"];
-                changed_attributes.push_back("hash_md5");
+                changed_attributes.push_back("md5");
             }
             else
             {
@@ -285,7 +285,7 @@ nlohmann::json DB::createJsonEvent(const nlohmann::json& fileJson, const nlohman
             if (old_data.contains("hash_sha1"))
             {
                 jsonEvent["data"]["old_attributes"]["hash_sha1"] = old_data["hash_sha1"];
-                changed_attributes.push_back("hash_sha1");
+                changed_attributes.push_back("sha1");
             }
             else
             {
@@ -298,7 +298,7 @@ nlohmann::json DB::createJsonEvent(const nlohmann::json& fileJson, const nlohman
             if (old_data.contains("hash_sha256"))
             {
                 jsonEvent["data"]["old_attributes"]["hash_sha256"] = old_data["hash_sha256"];
-                changed_attributes.push_back("hash_sha256");
+                changed_attributes.push_back("sha256");
             }
             else
             {
@@ -324,7 +324,6 @@ nlohmann::json DB::createJsonEvent(const nlohmann::json& fileJson, const nlohman
             if (old_data.contains("checksum"))
             {
                 jsonEvent["data"]["old_attributes"]["checksum"] = old_data["checksum"];
-                changed_attributes.push_back("checksum");
             }
             else
             {

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -44,7 +44,7 @@ void update_wildcards_config();
 void fim_process_wildcard_removed(directory_t *configuration);
 void transaction_callback(ReturnTypeCallback resultType, const cJSON* result_json, void* user_data);
 void fim_event_callback(void* data, void * ctx);
-
+void dbsync_attributes_json(const cJSON *dbsync_event, const directory_t *configuration, cJSON *attributes);
 /* auxiliary structs */
 typedef struct __fim_data_s {
     event_data_t *evt_data;
@@ -64,6 +64,11 @@ typedef struct _txn_data_s {
     char *diff;
     cJSON *dbsync_event;
 } txn_data_t;
+
+typedef struct _json_struct_s {
+    cJSON *json1;
+    cJSON *json2;
+} json_struct_t;
 
 const struct stat DEFAULT_STATBUF = { .st_mode = S_IFREG | 00444,
                                       .st_size = 1000,
@@ -578,6 +583,28 @@ static int teardown_transaction_callback(void **state) {
     free(txn_data);
     return 0;
 }
+
+static int setup_json_event_attributes(void **state) {
+    json_struct_t *data = calloc(1, sizeof(json_struct_t));
+    if (data == NULL) {
+        return 1;
+    }
+
+    *state = data;
+    return 0;
+}
+
+static int teardown_json_event_attributes(void **state) {
+    json_struct_t *data = *state;
+
+    cJSON_Delete(data->json1);
+    cJSON_Delete(data->json2);
+
+    free(data);
+
+    return 0;
+}
+
 /* Auxiliar functions */
 void expect_get_data (char *user, char *group, char *file_path, int calculate_checksums) {
 #ifndef TEST_WINAGENT
@@ -3911,6 +3938,31 @@ static void test_fim_event_callback(void **state) {
     cJSON_Delete(json_event);
 }
 
+static void test_dbsync_attributes_json(void **state) {
+    directory_t configuration = { .options = -1, .tag = "tag_name" };
+    json_struct_t *data = *state;
+#ifndef TEST_WINAGENT
+    const char *result_str = "{\"type\":\"file\",\"size\":11,\"perm\":\"rw-r--r--\",\"uid\":\"0\",\"gid\":\"0\",\"user_name\":\"root\",\"group_name\":\"root\",\"inode\":271017,\"mtime\":1646124392,\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"checksum\":\"c0edc82c463da5f4ab8dd420a778a9688a923a72\"}";
+    cJSON *dbsync_event = cJSON_Parse("{\"attributes\":\"\",\"checksum\":\"c0edc82c463da5f4ab8dd420a778a9688a923a72\",\"dev\":64768,\"gid\":0,\"group_name\":\"root\",\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"inode\":271017,\"last_event\":1646124394,\"mode\":0,\"mtime\":1646124392,\"options\":131583,\"path\":\"/etc/testfile\",\"perm\":\"rw-r--r--\",\"scanned\":1,\"size\":11,\"uid\":0,\"user_name\":\"root\"}");
+#else
+    cJSON *perms = cJSON_Parse("{\"S-1-5-18\":{\"name\":\"SYSTEM\",\"allowed\":[\"delete\",\"read_control\",\"write_dac\",\"write_owner\",\"synchronize\",\"read_data\",\"write_data\",\"append_data\",\"read_ea\",\"write_ea\",\"execute\",\"read_attributes\",\"write_attributes\"]},\"S-1-5-32-544\":{\"name\":\"Administrators\",\"allowed\":[\"delete\",\"read_control\",\"write_dac\",\"write_owner\",\"synchronize\",\"read_data\",\"write_data\",\"append_data\",\"read_ea\",\"write_ea\",\"execute\",\"read_attributes\",\"write_attributes\"]},\"S-1-5-32-545\":{\"name\":\"Users\",\"allowed\":[\"read_control\",\"synchronize\",\"read_data\",\"read_ea\",\"execute\",\"read_attributes\"]}}");
+    cJSON *dbsync_event = cJSON_Parse("{\"attributes\":\"ARCHIVE\",\"checksum\":\"ac962fef86e12e656b882fc88170fff24bf10a77\",\"dev\":2,\"gid\":0,\"group_name\":\"\",\"hash_md5\":\"d41d8cd98f00b204e9800998ecf8427e\",\"hash_sha1\":\"da39a3ee5e6b4b0d3255bfef95601890afd80709\",\"hash_sha256\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"inode\":0,\"last_event\":1646145214,\"mode\":0,\"mtime\":1646145212,\"options\":135679,\"path\":\"c:\\test\\testfile\",\"scanned\":1,\"size\":0,\"uid\":0,\"user_name\":\"Administrators\"}");
+    cJSON_AddItemToObject(dbsync_event, "perm", perms);
+
+    char *result_str = "{\"type\":\"file\",\"size\":0,\"perm\":{\"S-1-5-18\":{\"name\":\"SYSTEM\",\"allowed\":[\"delete\",\"read_control\",\"write_dac\",\"write_owner\",\"synchronize\",\"read_data\",\"write_data\",\"append_data\",\"read_ea\",\"write_ea\",\"execute\",\"read_attributes\",\"write_attributes\"]},\"S-1-5-32-544\":{\"name\":\"Administrators\",\"allowed\":[\"delete\",\"read_control\",\"write_dac\",\"write_owner\",\"synchronize\",\"read_data\",\"write_data\",\"append_data\",\"read_ea\",\"write_ea\",\"execute\",\"read_attributes\",\"write_attributes\"]},\"S-1-5-32-545\":{\"name\":\"Users\",\"allowed\":[\"read_control\",\"synchronize\",\"read_data\",\"read_ea\",\"execute\",\"read_attributes\"]}},\"uid\":\"0\",\"gid\":\"0\",\"user_name\":\"Administrators\",\"group_name\":\"\",\"inode\":0,\"mtime\":1646145212,\"hash_md5\":\"d41d8cd98f00b204e9800998ecf8427e\",\"hash_sha1\":\"da39a3ee5e6b4b0d3255bfef95601890afd80709\",\"hash_sha256\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"attributes\":\"ARCHIVE\",\"checksum\":\"ac962fef86e12e656b882fc88170fff24bf10a77\"}";
+#endif
+    cJSON *attributes = cJSON_CreateObject();
+
+    data->json1 = dbsync_event;
+    data->json2 = attributes;
+
+    dbsync_attributes_json(dbsync_event, &configuration, attributes);
+    char * json_attributes_str = cJSON_PrintUnformatted(attributes);
+
+    assert_string_equal(json_attributes_str, result_str);
+    free(json_attributes_str);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         /* fim_json_event */
@@ -4073,6 +4125,9 @@ int main(void) {
 
         /* fim_event_callback */
         cmocka_unit_test(test_fim_event_callback),
+
+        /* dbsync_attributes_json */
+        cmocka_unit_test_setup_teardown(test_dbsync_attributes_json, setup_json_event_attributes, teardown_json_event_attributes),
     };
 
     const struct CMUnitTest root_monitor_tests[] = {


### PR DESCRIPTION
|Related issue|
|---|
|#12457|

## Description
This PR aims to fix the bug described in #12457 by changing the values of the changed_attributes enum.

Closes #12457

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
  - [ ] MAC OS X
- [X] Source installation
- [ ] Package installation
- [X] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer