### PR TITLE
Arithmetic computation helper

### DIFF
--- a/src/engine/source/builder/CMakeLists.txt
+++ b/src/engine/source/builder/CMakeLists.txt
@@ -53,6 +53,7 @@ target_sources(main PRIVATE
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderConditionValue.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderConditionReference.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/OpBuilderHelperFilter.cpp
+  ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/OpBuilderHelperMap.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/assetBuilderOutput.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderFileOutput.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/stageBuilderNormalize.cpp

--- a/src/engine/source/builder/builders/OpBuilderHelperFilter.cpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperFilter.cpp
@@ -350,70 +350,34 @@ bool opBuilderHelperIntComparison(const std::string field, char op, types::Event
 
 types::Lifter opBuilderHelperIntEqual(const types::DocumentValue & def) //{field: +int/10} $ref
 {
-    // Get field
-    std::string field = def.MemberBegin()->name.GetString();
-    std::string rawValue = def.MemberBegin()->value.GetString();
 
-    std::vector<std::string> parameters = utils::string::split(rawValue, '/');
+    auto [field, refValue, valuestr] = getCompOpParameter(def);
 
-    if (parameters.size() != 2)
-    {
-        throw std::runtime_error("Invalid parameters");
-    }
-
-    std::optional<std::string> refValue;
-    std::optional<int> value;
-
-    if (parameters[1][0] == '$')
-    {
-        // Check case `+int/$`
-        refValue = parameters[1].substr(1, std::string::npos);
-    }
-    else
-    {
-        value = std::stoi(parameters[1]);
-    }
+    std::optional<int> value = valuestr.has_value()
+                                   ? std::optional<int>{std::stoi(valuestr.value())}
+                                   : std::nullopt;
 
     // Return Lifter
-    return [refValue, value, field](types::Observable o)
+    return [field, refValue, value](types::Observable o)
     {
         // Append rxcpp operation
         return o.filter(
             [=](types::Event e)
-            {
-                return opBuilderHelperIntComparison(field, '=', e, refValue, value);
-            });
+            { return opBuilderHelperIntComparison(field, '=', e, refValue, value); });
     };
 }
 
 types::Lifter opBuilderHelperIntNotEqual(const types::DocumentValue & def)
 {
-    // Get field
-    std::string field = def.MemberBegin()->name.GetString();
-    std::string rawValue = def.MemberBegin()->value.GetString();
 
-    std::vector<std::string> parameters = utils::string::split(rawValue, '/');
+    auto [field, refValue, valuestr] = getCompOpParameter(def);
 
-    if (parameters.size() != 2)
-    {
-        throw std::runtime_error("Invalid parameters");
-    }
-
-    std::optional<std::string> refValue;
-    std::optional<int> value;
-
-    if (parameters[1][0] == '$')
-    {
-        // Check case `+int/$`
-        refValue = parameters[1].substr(1, std::string::npos);
-    }
-    else
-    {
-        value = std::stoi(parameters[1]);
-    }
+    std::optional<int> value = valuestr.has_value()
+                                   ? std::optional<int>{std::stoi(valuestr.value())}
+                                   : std::nullopt;
 
     // Return Lifter
-    return [refValue, value, field](types::Observable o)
+    return [field, refValue, value](types::Observable o)
     {
         // Append rxcpp operation
         return o.filter(
@@ -427,32 +391,15 @@ types::Lifter opBuilderHelperIntNotEqual(const types::DocumentValue & def)
 
 types::Lifter opBuilderHelperIntLessThan(const types::DocumentValue & def)
 {
-    // Get field
-    std::string field = def.MemberBegin()->name.GetString();
-    std::string rawValue = def.MemberBegin()->value.GetString();
 
-    std::vector<std::string> parameters = utils::string::split(rawValue, '/');
+    auto [field, refValue, valuestr] = getCompOpParameter(def);
 
-    if (parameters.size() != 2)
-    {
-        throw std::runtime_error("Invalid parameters");
-    }
-
-    std::optional<std::string> refValue;
-    std::optional<int> value;
-
-    if (parameters[1][0] == '$')
-    {
-        // Check case `+int/$`
-        refValue = parameters[1].substr(1, std::string::npos);
-    }
-    else
-    {
-        value = std::stoi(parameters[1]);
-    }
+    std::optional<int> value = valuestr.has_value()
+                                   ? std::optional<int>{std::stoi(valuestr.value())}
+                                   : std::nullopt;
 
     // Return Lifter
-    return [refValue, value, field](types::Observable o)
+    return [field, refValue, value](types::Observable o)
     {
         // Append rxcpp operation
         return o.filter(
@@ -466,32 +413,15 @@ types::Lifter opBuilderHelperIntLessThan(const types::DocumentValue & def)
 
 types::Lifter opBuilderHelperIntLessThanEqual(const types::DocumentValue & def)
 {
-    // Get field
-    std::string field = def.MemberBegin()->name.GetString();
-    std::string rawValue = def.MemberBegin()->value.GetString();
 
-    std::vector<std::string> parameters = utils::string::split(rawValue, '/');
+    auto [field, refValue, valuestr] = getCompOpParameter(def);
 
-    if (parameters.size() != 2)
-    {
-        throw std::runtime_error("Invalid parameters");
-    }
-
-    std::optional<std::string> refValue;
-    std::optional<int> value;
-
-    if (parameters[1][0] == '$')
-    {
-        // Check case `+int/$`
-        refValue = parameters[1].substr(1, std::string::npos);
-    }
-    else
-    {
-        value = std::stoi(parameters[1]);
-    }
+    std::optional<int> value = valuestr.has_value()
+                                   ? std::optional<int>{std::stoi(valuestr.value())}
+                                   : std::nullopt;
 
     // Return Lifter
-    return [refValue, value, field](types::Observable o)
+    return [field, refValue, value](types::Observable o)
     {
         // Append rxcpp operation
         return o.filter(
@@ -505,32 +435,15 @@ types::Lifter opBuilderHelperIntLessThanEqual(const types::DocumentValue & def)
 
 types::Lifter opBuilderHelperIntGreaterThan(const types::DocumentValue & def)
 {
-    // Get field
-    std::string field = def.MemberBegin()->name.GetString();
-    std::string rawValue = def.MemberBegin()->value.GetString();
 
-    std::vector<std::string> parameters = utils::string::split(rawValue, '/');
+    auto [field, refValue, valuestr] = getCompOpParameter(def);
 
-    if (parameters.size() != 2)
-    {
-        throw std::runtime_error("Invalid parameters");
-    }
-
-    std::optional<std::string> refValue;
-    std::optional<int> value;
-
-    if (parameters[1][0] == '$')
-    {
-        // Check case `+int/$`
-        refValue = parameters[1].substr(1, std::string::npos);
-    }
-    else
-    {
-        value = std::stoi(parameters[1]);
-    }
+    std::optional<int> value = valuestr.has_value()
+                                   ? std::optional<int>{std::stoi(valuestr.value())}
+                                   : std::nullopt;
 
     // Return Lifter
-    return [refValue, value, field](types::Observable o)
+    return [field, refValue, value](types::Observable o)
     {
         // Append rxcpp operation
         return o.filter(
@@ -544,32 +457,15 @@ types::Lifter opBuilderHelperIntGreaterThan(const types::DocumentValue & def)
 
 types::Lifter opBuilderHelperIntGreaterThanEqual(const types::DocumentValue & def)
 {
-    // Get field
-    std::string field = def.MemberBegin()->name.GetString();
-    std::string rawValue = def.MemberBegin()->value.GetString();
 
-    std::vector<std::string> parameters = utils::string::split(rawValue, '/');
+    auto [field, refValue, valuestr] = getCompOpParameter(def);
 
-    if (parameters.size() != 2)
-    {
-        throw std::runtime_error("Invalid parameters");
-    }
-
-    std::optional<std::string> refValue;
-    std::optional<int> value;
-
-    if (parameters[1][0] == '$')
-    {
-        // Check case `+int/$`
-        refValue = parameters[1].substr(1, std::string::npos);
-    }
-    else
-    {
-        value = std::stoi(parameters[1]);
-    }
+    std::optional<int> value = valuestr.has_value()
+                                   ? std::optional<int>{std::stoi(valuestr.value())}
+                                   : std::nullopt;
 
     // Return Lifter
-    return [refValue, value, field](types::Observable o)
+    return [field, refValue, value](types::Observable o)
     {
         // Append rxcpp operation
         return o.filter(

--- a/src/engine/source/builder/builders/OpBuilderHelperFilter.cpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperFilter.cpp
@@ -107,7 +107,7 @@ bool opBuilderHelperStringComparison(const std::string key, char op, types::Even
     {
         fieldToCompare = e.get("/" + key);
     }
-    catch (std::exception & e)
+    catch (std::exception & ex)
     {
         // TODO Check exception type
         return false;
@@ -281,12 +281,12 @@ bool opBuilderHelperIntComparison(const std::string field, char op, types::Event
 
     // TODO Remove try catch or if nullptr after fix get method of document class
     // Get value to compare
-    const rapidjson::Value * fieldValue{};
+    const rapidjson::Value * fieldValue {};
     try
     {
         fieldValue = e.get("/" + field);
     }
-    catch (std::exception & e)
+    catch (std::exception & ex)
     {
         // TODO Check exception type
         return false;
@@ -302,7 +302,7 @@ bool opBuilderHelperIntComparison(const std::string field, char op, types::Event
     {
         // Get reference to json event
         // TODO Remove try catch or if nullptr after fix get method of document class
-        const rapidjson::Value * refValueToCheck{};
+        const rapidjson::Value * refValueToCheck {};
         try
         {
             refValueToCheck = e.get("/" + refValue.value());
@@ -352,7 +352,7 @@ bool opBuilderHelperIntComparison(const std::string field, char op, types::Event
 types::Lifter opBuilderHelperIntEqual(const types::DocumentValue & def)
 {
 
-    auto [field, refValue, valuestr] = getCompOpParameter(def);
+    auto [field, refValue, valuestr] {getCompOpParameter(def)};
 
     std::optional<int> value = valuestr.has_value()
                                    ? std::optional<int>{std::stoi(valuestr.value())}
@@ -372,7 +372,7 @@ types::Lifter opBuilderHelperIntEqual(const types::DocumentValue & def)
 types::Lifter opBuilderHelperIntNotEqual(const types::DocumentValue & def)
 {
 
-    auto [field, refValue, valuestr] = getCompOpParameter(def);
+    auto [field, refValue, valuestr] {getCompOpParameter(def)};
 
     std::optional<int> value = valuestr.has_value()
                                    ? std::optional<int>{std::stoi(valuestr.value())}
@@ -395,7 +395,7 @@ types::Lifter opBuilderHelperIntNotEqual(const types::DocumentValue & def)
 types::Lifter opBuilderHelperIntLessThan(const types::DocumentValue & def)
 {
 
-    auto [field, refValue, valuestr] = getCompOpParameter(def);
+    auto [field, refValue, valuestr] {getCompOpParameter(def)};
 
     std::optional<int> value = valuestr.has_value()
                                    ? std::optional<int>{std::stoi(valuestr.value())}
@@ -418,7 +418,7 @@ types::Lifter opBuilderHelperIntLessThan(const types::DocumentValue & def)
 types::Lifter opBuilderHelperIntLessThanEqual(const types::DocumentValue & def)
 {
 
-    auto [field, refValue, valuestr] = getCompOpParameter(def);
+    auto [field, refValue, valuestr] {getCompOpParameter(def)};
 
     std::optional<int> value = valuestr.has_value()
                                    ? std::optional<int>{std::stoi(valuestr.value())}
@@ -441,7 +441,7 @@ types::Lifter opBuilderHelperIntLessThanEqual(const types::DocumentValue & def)
 types::Lifter opBuilderHelperIntGreaterThan(const types::DocumentValue & def)
 {
 
-    auto [field, refValue, valuestr] = getCompOpParameter(def);
+    auto [field, refValue, valuestr] {getCompOpParameter(def)};
 
     std::optional<int> value = valuestr.has_value()
                                    ? std::optional<int>{std::stoi(valuestr.value())}
@@ -464,7 +464,7 @@ types::Lifter opBuilderHelperIntGreaterThan(const types::DocumentValue & def)
 types::Lifter opBuilderHelperIntGreaterThanEqual(const types::DocumentValue & def)
 {
 
-    auto [field, refValue, valuestr] = getCompOpParameter(def);
+    auto [field, refValue, valuestr] {getCompOpParameter(def)};
 
     std::optional<int> value = valuestr.has_value()
                                    ? std::optional<int>{std::stoi(valuestr.value())}

--- a/src/engine/source/builder/builders/OpBuilderHelperFilter.cpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperFilter.cpp
@@ -348,7 +348,8 @@ bool opBuilderHelperIntComparison(const std::string field, char op, types::Event
     return false;
 }
 
-types::Lifter opBuilderHelperIntEqual(const types::DocumentValue & def) //{field: +int/10} $ref
+// field: +i_eq/int|$ref/
+types::Lifter opBuilderHelperIntEqual(const types::DocumentValue & def)
 {
 
     auto [field, refValue, valuestr] = getCompOpParameter(def);
@@ -367,6 +368,7 @@ types::Lifter opBuilderHelperIntEqual(const types::DocumentValue & def) //{field
     };
 }
 
+// field: +i_ne/int|$ref/
 types::Lifter opBuilderHelperIntNotEqual(const types::DocumentValue & def)
 {
 
@@ -389,6 +391,7 @@ types::Lifter opBuilderHelperIntNotEqual(const types::DocumentValue & def)
     };
 }
 
+// field: +i_lt/int|$ref/
 types::Lifter opBuilderHelperIntLessThan(const types::DocumentValue & def)
 {
 
@@ -411,6 +414,7 @@ types::Lifter opBuilderHelperIntLessThan(const types::DocumentValue & def)
     };
 }
 
+// field: +i_le/int|$ref/
 types::Lifter opBuilderHelperIntLessThanEqual(const types::DocumentValue & def)
 {
 
@@ -433,6 +437,7 @@ types::Lifter opBuilderHelperIntLessThanEqual(const types::DocumentValue & def)
     };
 }
 
+// field: +i_gt/int|$ref/
 types::Lifter opBuilderHelperIntGreaterThan(const types::DocumentValue & def)
 {
 
@@ -455,6 +460,7 @@ types::Lifter opBuilderHelperIntGreaterThan(const types::DocumentValue & def)
     };
 }
 
+// field: +i_ge/int|$ref/
 types::Lifter opBuilderHelperIntGreaterThanEqual(const types::DocumentValue & def)
 {
 

--- a/src/engine/source/builder/builders/OpBuilderHelperFilter.cpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperFilter.cpp
@@ -464,4 +464,43 @@ types::Lifter opBuilderHelperIntLessThan(const types::DocumentValue & def)
     };
 }
 
+types::Lifter opBuilderHelperIntLessThanEqual(const types::DocumentValue & def)
+{
+    // Get field
+    std::string field = def.MemberBegin()->name.GetString();
+    std::string rawValue = def.MemberBegin()->value.GetString();
+
+    std::vector<std::string> parameters = utils::string::split(rawValue, '/');
+
+    if (parameters.size() != 2)
+    {
+        throw std::runtime_error("Invalid parameters");
+    }
+
+    std::optional<std::string> refValue;
+    std::optional<int> value;
+
+    if (parameters[1][0] == '$')
+    {
+        // Check case `+int/$`
+        refValue = parameters[1].substr(1, std::string::npos);
+    }
+    else
+    {
+        value = std::stoi(parameters[1]);
+    }
+
+    // Return Lifter
+    return [refValue, value, field](types::Observable o)
+    {
+        // Append rxcpp operation
+        return o.filter(
+            [=](types::Event e)
+            {
+                // try and catche, return false
+                return opBuilderHelperIntComparison(field, 'l', e, refValue, value);
+            });
+    };
+}
+
 } // namespace builder::internals::builders

--- a/src/engine/source/builder/builders/OpBuilderHelperFilter.cpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperFilter.cpp
@@ -425,4 +425,43 @@ types::Lifter opBuilderHelperIntNotEqual(const types::DocumentValue & def)
     };
 }
 
+types::Lifter opBuilderHelperIntLessThan(const types::DocumentValue & def)
+{
+    // Get field
+    std::string field = def.MemberBegin()->name.GetString();
+    std::string rawValue = def.MemberBegin()->value.GetString();
+
+    std::vector<std::string> parameters = utils::string::split(rawValue, '/');
+
+    if (parameters.size() != 2)
+    {
+        throw std::runtime_error("Invalid parameters");
+    }
+
+    std::optional<std::string> refValue;
+    std::optional<int> value;
+
+    if (parameters[1][0] == '$')
+    {
+        // Check case `+int/$`
+        refValue = parameters[1].substr(1, std::string::npos);
+    }
+    else
+    {
+        value = std::stoi(parameters[1]);
+    }
+
+    // Return Lifter
+    return [refValue, value, field](types::Observable o)
+    {
+        // Append rxcpp operation
+        return o.filter(
+            [=](types::Event e)
+            {
+                // try and catche, return false
+                return opBuilderHelperIntComparison(field, '<', e, refValue, value);
+            });
+    };
+}
+
 } // namespace builder::internals::builders

--- a/src/engine/source/builder/builders/OpBuilderHelperFilter.cpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperFilter.cpp
@@ -282,7 +282,7 @@ types::Lifter opBuilderHelperIntEqual(const types::DocumentValue & def) //{field
 
     std::vector<std::string> parameters = utils::string::split(rawValue, '/');
 
-    if(parameters.size() != 2)
+    if (parameters.size() != 2)
     {
         throw std::runtime_error("Invalid parameters");
     }
@@ -290,7 +290,7 @@ types::Lifter opBuilderHelperIntEqual(const types::DocumentValue & def) //{field
     std::optional<std::string> refValue;
     std::optional<int> value;
 
-    if(parameters[1][0] == '$')
+    if (parameters[1][0] == '$')
     {
         // Check case `+int/$`
         refValue = parameters[1].substr(1, std::string::npos);
@@ -304,25 +304,29 @@ types::Lifter opBuilderHelperIntEqual(const types::DocumentValue & def) //{field
     return [refValue, value, field](types::Observable o)
     {
         // Append rxcpp operation
-        return o.filter([=](types::Event e) {
-            if(e.exists("/" + field))
+        return o.filter(
+            [=](types::Event e)
             {
-                auto fieldToCheck = e.getObject().FindMember(field.c_str());
-                if(fieldToCheck->value.IsInt())
+                if (e.exists("/" + field))
                 {
-                    if(value.has_value())
+                    auto fieldToCheck = e.getObject().FindMember(field.c_str());
+                    if (fieldToCheck->value.IsInt())
                     {
-                        return fieldToCheck->value.GetInt() == value.value();
-                    }
-                    auto refValueToCheck = e.getObject().FindMember(refValue.value().c_str());
-                    if(refValueToCheck->value.IsInt())
-                    {
-                        return fieldToCheck->value.GetInt() == refValueToCheck->value.GetInt();
+                        if (value.has_value())
+                        {
+                            return fieldToCheck->value.GetInt() == value.value();
+                        }
+                        auto refValueToCheck =
+                            e.getObject().FindMember(refValue.value().c_str());
+                        if (refValueToCheck->value.IsInt())
+                        {
+                            return fieldToCheck->value.GetInt() ==
+                                   refValueToCheck->value.GetInt();
+                        }
                     }
                 }
-            }
-            return false;
-        });
+                return false;
+            });
     };
 }
 
@@ -334,7 +338,7 @@ types::Lifter opBuilderHelperIntNotEqual(const types::DocumentValue & def)
 
     std::vector<std::string> parameters = utils::string::split(rawValue, '/');
 
-    if(parameters.size() != 2)
+    if (parameters.size() != 2)
     {
         throw std::runtime_error("Invalid parameters");
     }
@@ -342,7 +346,7 @@ types::Lifter opBuilderHelperIntNotEqual(const types::DocumentValue & def)
     std::optional<std::string> refValue;
     std::optional<int> value;
 
-    if(parameters[1][0] == '$')
+    if (parameters[1][0] == '$')
     {
         // Check case `+int/$`
         refValue = parameters[1].substr(1, std::string::npos);
@@ -356,25 +360,29 @@ types::Lifter opBuilderHelperIntNotEqual(const types::DocumentValue & def)
     return [refValue, value, field](types::Observable o)
     {
         // Append rxcpp operation
-        return o.filter([=](types::Event e) {
-            if(e.exists("/" + field))
+        return o.filter(
+            [=](types::Event e)
             {
-                auto fieldToCheck = e.getObject().FindMember(field.c_str());
-                if(fieldToCheck->value.IsInt())
+                if (e.exists("/" + field))
                 {
-                    if(value.has_value())
+                    auto fieldToCheck = e.getObject().FindMember(field.c_str());
+                    if (fieldToCheck->value.IsInt())
                     {
-                        return fieldToCheck->value.GetInt() != value.value();
-                    }
-                    auto refValueToCheck = e.getObject().FindMember(refValue.value().c_str());
-                    if(refValueToCheck->value.IsInt())
-                    {
-                        return fieldToCheck->value.GetInt() != refValueToCheck->value.GetInt();
+                        if (value.has_value())
+                        {
+                            return fieldToCheck->value.GetInt() != value.value();
+                        }
+                        auto refValueToCheck =
+                            e.getObject().FindMember(refValue.value().c_str());
+                        if (refValueToCheck->value.IsInt())
+                        {
+                            return fieldToCheck->value.GetInt() !=
+                                   refValueToCheck->value.GetInt();
+                        }
                     }
                 }
-            }
-            return false;
-        });
+                return false;
+            });
     };
 }
 

--- a/src/engine/source/builder/builders/OpBuilderHelperFilter.cpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperFilter.cpp
@@ -542,4 +542,43 @@ types::Lifter opBuilderHelperIntGreaterThan(const types::DocumentValue & def)
     };
 }
 
+types::Lifter opBuilderHelperIntGreaterThanEqual(const types::DocumentValue & def)
+{
+    // Get field
+    std::string field = def.MemberBegin()->name.GetString();
+    std::string rawValue = def.MemberBegin()->value.GetString();
+
+    std::vector<std::string> parameters = utils::string::split(rawValue, '/');
+
+    if (parameters.size() != 2)
+    {
+        throw std::runtime_error("Invalid parameters");
+    }
+
+    std::optional<std::string> refValue;
+    std::optional<int> value;
+
+    if (parameters[1][0] == '$')
+    {
+        // Check case `+int/$`
+        refValue = parameters[1].substr(1, std::string::npos);
+    }
+    else
+    {
+        value = std::stoi(parameters[1]);
+    }
+
+    // Return Lifter
+    return [refValue, value, field](types::Observable o)
+    {
+        // Append rxcpp operation
+        return o.filter(
+            [=](types::Event e)
+            {
+                // try and catche, return false
+                return opBuilderHelperIntComparison(field, 'g', e, refValue, value);
+            });
+    };
+}
+
 } // namespace builder::internals::builders

--- a/src/engine/source/builder/builders/OpBuilderHelperFilter.cpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperFilter.cpp
@@ -274,6 +274,80 @@ types::Lifter opBuilderHelperStringLE(const DocumentValue & def)
 //*               Int filters                     *
 //*************************************************
 
+bool opBuilderHelperIntComparison(const std::string field, char op, types::Event & e,
+                                  std::optional<std::string> refValue,
+                                  std::optional<int> value)
+{
+
+    // TODO Remove try catch or if nullptr after fix get method of document class
+    // Get value to compare
+    const rapidjson::Value * fieldValue{};
+    try
+    {
+        fieldValue = e.get("/" + field);
+    }
+    catch (std::exception & e)
+    {
+        // TODO Check exception type
+        return false;
+    }
+
+    if (fieldValue == nullptr || !fieldValue->IsInt())
+    {
+        return false;
+    }
+
+    // get str to compare
+    if (refValue.has_value())
+    {
+        // Get reference to json event
+        // TODO Remove try catch or if nullptr after fix get method of document class
+        const rapidjson::Value * refValueToCheck{};
+        try
+        {
+            refValueToCheck = e.get("/" + refValue.value());
+        }
+        catch (std::exception & ex)
+        {
+            // TODO Check exception type
+            return false;
+        }
+
+        if (refValueToCheck == nullptr || !refValueToCheck->IsInt())
+        {
+            return false;
+        }
+        value = refValueToCheck->GetInt();
+    }
+
+    // Int operation
+    switch (op)
+    {
+        // case '==':
+        case '=':
+            return fieldValue->GetInt() == value.value();
+        // case '!=':
+        case '!':
+            return fieldValue->GetInt() != value.value();
+        case '>':
+            return fieldValue->GetInt() > value.value();
+        // case '>=':
+        case 'g':
+            return fieldValue->GetInt() >= value.value();
+        case '<':
+            return fieldValue->GetInt() < value.value();
+        // case '<=':
+        case 'l':
+            return fieldValue->GetInt() <= value.value();
+
+        default:
+            // if raise here, then the source code is wrong
+            throw std::invalid_argument("Invalid operator: '" + std::string{op} + "' ");
+    }
+
+    return false;
+}
+
 types::Lifter opBuilderHelperIntEqual(const types::DocumentValue & def) //{field: +int/10} $ref
 {
     // Get field
@@ -307,25 +381,7 @@ types::Lifter opBuilderHelperIntEqual(const types::DocumentValue & def) //{field
         return o.filter(
             [=](types::Event e)
             {
-                if (e.exists("/" + field))
-                {
-                    auto fieldToCheck = e.getObject().FindMember(field.c_str());
-                    if (fieldToCheck->value.IsInt())
-                    {
-                        if (value.has_value())
-                        {
-                            return fieldToCheck->value.GetInt() == value.value();
-                        }
-                        auto refValueToCheck =
-                            e.getObject().FindMember(refValue.value().c_str());
-                        if (refValueToCheck->value.IsInt())
-                        {
-                            return fieldToCheck->value.GetInt() ==
-                                   refValueToCheck->value.GetInt();
-                        }
-                    }
-                }
-                return false;
+                return opBuilderHelperIntComparison(field, '=', e, refValue, value);
             });
     };
 }
@@ -363,25 +419,8 @@ types::Lifter opBuilderHelperIntNotEqual(const types::DocumentValue & def)
         return o.filter(
             [=](types::Event e)
             {
-                if (e.exists("/" + field))
-                {
-                    auto fieldToCheck = e.getObject().FindMember(field.c_str());
-                    if (fieldToCheck->value.IsInt())
-                    {
-                        if (value.has_value())
-                        {
-                            return fieldToCheck->value.GetInt() != value.value();
-                        }
-                        auto refValueToCheck =
-                            e.getObject().FindMember(refValue.value().c_str());
-                        if (refValueToCheck->value.IsInt())
-                        {
-                            return fieldToCheck->value.GetInt() !=
-                                   refValueToCheck->value.GetInt();
-                        }
-                    }
-                }
-                return false;
+                // try and catche, return false
+                return opBuilderHelperIntComparison(field, '!', e, refValue, value);
             });
     };
 }

--- a/src/engine/source/builder/builders/OpBuilderHelperFilter.cpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperFilter.cpp
@@ -503,4 +503,43 @@ types::Lifter opBuilderHelperIntLessThanEqual(const types::DocumentValue & def)
     };
 }
 
+types::Lifter opBuilderHelperIntGreaterThan(const types::DocumentValue & def)
+{
+    // Get field
+    std::string field = def.MemberBegin()->name.GetString();
+    std::string rawValue = def.MemberBegin()->value.GetString();
+
+    std::vector<std::string> parameters = utils::string::split(rawValue, '/');
+
+    if (parameters.size() != 2)
+    {
+        throw std::runtime_error("Invalid parameters");
+    }
+
+    std::optional<std::string> refValue;
+    std::optional<int> value;
+
+    if (parameters[1][0] == '$')
+    {
+        // Check case `+int/$`
+        refValue = parameters[1].substr(1, std::string::npos);
+    }
+    else
+    {
+        value = std::stoi(parameters[1]);
+    }
+
+    // Return Lifter
+    return [refValue, value, field](types::Observable o)
+    {
+        // Append rxcpp operation
+        return o.filter(
+            [=](types::Event e)
+            {
+                // try and catche, return false
+                return opBuilderHelperIntComparison(field, '>', e, refValue, value);
+            });
+    };
+}
+
 } // namespace builder::internals::builders

--- a/src/engine/source/builder/builders/OpBuilderHelperFilter.hpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperFilter.hpp
@@ -151,6 +151,31 @@ types::Lifter opBuilderHelperStringLE(const types::DocumentValue & def);
 //*************************************************
 
 /**
+ * @brief Compares a integer of the event against another integer that may or may not
+ * belong to the event `e`
+ *
+ * @param field The key/path of the field to be compared
+ * @param op The operator to be used for the comparison. Operators are:
+ * - `=`: checks if the field is equal to the value
+ * - `!`: checks if the field is not equal to the value
+ * - `<`: checks if the field is less than the value
+ * - `>`: checks if the field is greater than the value
+ * - `m`: checks if the field is less than or equal to the value
+ * - `n`: checks if the field is greater than or equal to the value
+ * @param e The event containing the field to be compared
+ * @param refValue The key/path of the field to be compared against (optional)
+ * @param value The integer to be compared against (optional)
+ * @return true if the comparison is true
+ * @return false if the comparison is false
+ * @note If `refValue` is not provided, the comparison will be against the value of
+ * `value`
+ */
+inline bool opBuilderHelperIntComparison(const std::string field, char op,
+                                         types::Event & e,
+                                         std::optional<std::string> refValue,
+                                         std::optional<int> value);
+
+/**
  * @brief Builds helper integer equal operation.
  * Checks that the field is equal to an integer or another numeric field
  *

--- a/src/engine/source/builder/builders/OpBuilderHelperFilter.hpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperFilter.hpp
@@ -220,6 +220,15 @@ types::Lifter opBuilderHelperIntLessThanEqual(const types::DocumentValue & def);
  */
 types::Lifter opBuilderHelperIntGreaterThan(const types::DocumentValue & def);
 
+/**
+ * @brief Builds helper integer greater than equal operation.
+ * Checks that the field is greater than equal to an integer or another numeric field
+ *
+ * @param def Definition of the operation to be built
+ * @return types::Lifter
+ */
+types::Lifter opBuilderHelperIntGreaterThanEqual(const types::DocumentValue & def);
+
 } // namespace builder::internals::builders
 
 #endif // _OP_BUILDER_HELPER_FILTER_H

--- a/src/engine/source/builder/builders/OpBuilderHelperFilter.hpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperFilter.hpp
@@ -104,7 +104,6 @@ types::Lifter opBuilderHelperStringNE(const types::DocumentValue & def);
  */
 types::Lifter opBuilderHelperStringGT(const types::DocumentValue & def);
 
-
 /**
  * @brief Create `s_ge` helper function that filters events with a string
  * field less or equals than a value.
@@ -118,7 +117,6 @@ types::Lifter opBuilderHelperStringGT(const types::DocumentValue & def);
  */
 types::Lifter opBuilderHelperStringGE(const types::DocumentValue & def);
 
-
 /**
  * @brief Create `s_lt` helper function that filters events with a string
  * field less than a value.
@@ -131,7 +129,6 @@ types::Lifter opBuilderHelperStringGE(const types::DocumentValue & def);
  * @throw std::runtime_error if the parameter is not a string.
  */
 types::Lifter opBuilderHelperStringLT(const types::DocumentValue & def);
-
 
 /**
  * @brief Create `s_le` helper function that filters events with a string
@@ -179,8 +176,11 @@ inline bool opBuilderHelperIntComparison(const std::string field, char op,
  * @brief Builds helper integer equal operation.
  * Checks that the field is equal to an integer or another numeric field
  *
+ * The filter checks if a field in the JSON event `wazuh` is equal to a value.
+ * Only pass events if the fields are equal and the values are a integer.
  * @param def Definition of the operation to be built
- * @return types::Lifter
+ * @return types::Lifter The lifter with the `i_eq` filter.
+ * @throw std::runtime_error if the parameter is not a integer.
  */
 types::Lifter opBuilderHelperIntEqual(const types::DocumentValue & def);
 
@@ -188,8 +188,11 @@ types::Lifter opBuilderHelperIntEqual(const types::DocumentValue & def);
  * @brief Builds helper integer not equal operation.
  * Checks that the field is not equal to an integer or another numeric field
  *
+ * The filter checks if a field in the JSON event `wazuh` is not equal to a value.
+ * Only pass events if the fields are not equal and the values are a integer.
  * @param def Definition of the operation to be built
- * @return types::Lifter
+ * @return types::Lifter The lifter with the `i_ne` filter.
+ * @throw std::runtime_error if the parameter is not a integer.
  */
 types::Lifter opBuilderHelperIntNotEqual(const types::DocumentValue & def);
 
@@ -197,8 +200,11 @@ types::Lifter opBuilderHelperIntNotEqual(const types::DocumentValue & def);
  * @brief Builds helper integer less than operation.
  * Checks that the field is less than to an integer or another numeric field
  *
+ * The filter checks if a field in the JSON event `wazuh` is less than a value.
+ * Only pass events if the fields are less than and the values are a integer.
  * @param def Definition of the operation to be built
- * @return types::Lifter
+ * @return types::Lifter The lifter with the `i_lt` filter.
+ * @throw std::runtime_error if the parameter is not a integer.
  */
 types::Lifter opBuilderHelperIntLessThan(const types::DocumentValue & def);
 
@@ -206,8 +212,11 @@ types::Lifter opBuilderHelperIntLessThan(const types::DocumentValue & def);
  * @brief Builds helper integer less than equal operation.
  * Checks that the field is less than equal to an integer or another numeric field
  *
+ * The filter checks if a field in the JSON event `wazuh` is less than equal a value.
+ * Only pass events if the fields are less than equal and the values are a integer.
  * @param def Definition of the operation to be built
- * @return types::Lifter
+ * @return types::Lifter The lifter with the `i_le` filter.
+ * @throw std::runtime_error if the parameter is not a integer.
  */
 types::Lifter opBuilderHelperIntLessThanEqual(const types::DocumentValue & def);
 
@@ -215,17 +224,24 @@ types::Lifter opBuilderHelperIntLessThanEqual(const types::DocumentValue & def);
  * @brief Builds helper integer greater than operation.
  * Checks that the field is greater than to an integer or another numeric field
  *
+ * The filter checks if a field in the JSON event `wazuh` is greater than a value.
+ * Only pass events if the fields are greater than and the values are a integer.
  * @param def Definition of the operation to be built
- * @return types::Lifter
+ * @return types::Lifter The lifter with the `i_gt` filter.
+ * @throw std::runtime_error if the parameter is not a integer.
  */
+
 types::Lifter opBuilderHelperIntGreaterThan(const types::DocumentValue & def);
 
 /**
  * @brief Builds helper integer greater than equal operation.
  * Checks that the field is greater than equal to an integer or another numeric field
  *
+ * The filter checks if a field in the JSON event `wazuh` is greater than equal a value.
+ * Only pass events if the fields are greater than equal and the values are a integer.
  * @param def Definition of the operation to be built
- * @return types::Lifter
+ * @return types::Lifter The lifter with the `i_ge` filter.
+ * @throw std::runtime_error if the parameter is not a integer.
  */
 types::Lifter opBuilderHelperIntGreaterThanEqual(const types::DocumentValue & def);
 

--- a/src/engine/source/builder/builders/OpBuilderHelperFilter.hpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperFilter.hpp
@@ -193,6 +193,15 @@ types::Lifter opBuilderHelperIntEqual(const types::DocumentValue & def);
  */
 types::Lifter opBuilderHelperIntNotEqual(const types::DocumentValue & def);
 
+/**
+ * @brief Builds helper integer less than operation.
+ * Checks that the field is less than to an integer or another numeric field
+ *
+ * @param def Definition of the operation to be built
+ * @return types::Lifter
+ */
+types::Lifter opBuilderHelperIntLessThan(const types::DocumentValue & def);
+
 } // namespace builder::internals::builders
 
 #endif // _OP_BUILDER_HELPER_FILTER_H

--- a/src/engine/source/builder/builders/OpBuilderHelperFilter.hpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperFilter.hpp
@@ -159,6 +159,15 @@ types::Lifter opBuilderHelperStringLE(const types::DocumentValue & def);
  */
 types::Lifter opBuilderHelperIntEqual(const types::DocumentValue & def);
 
+/**
+ * @brief Builds helper integer not equal operation.
+ * Checks that the field is not equal to an integer or another numeric field
+ *
+ * @param def Definition of the operation to be built
+ * @return types::Lifter
+ */
+types::Lifter opBuilderHelperIntNotEqual(const types::DocumentValue & def);
+
 } // namespace builder::internals::builders
 
 #endif // _OP_BUILDER_HELPER_FILTER_H

--- a/src/engine/source/builder/builders/OpBuilderHelperFilter.hpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperFilter.hpp
@@ -211,6 +211,15 @@ types::Lifter opBuilderHelperIntLessThan(const types::DocumentValue & def);
  */
 types::Lifter opBuilderHelperIntLessThanEqual(const types::DocumentValue & def);
 
+/**
+ * @brief Builds helper integer greater than operation.
+ * Checks that the field is greater than to an integer or another numeric field
+ *
+ * @param def Definition of the operation to be built
+ * @return types::Lifter
+ */
+types::Lifter opBuilderHelperIntGreaterThan(const types::DocumentValue & def);
+
 } // namespace builder::internals::builders
 
 #endif // _OP_BUILDER_HELPER_FILTER_H

--- a/src/engine/source/builder/builders/OpBuilderHelperFilter.hpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperFilter.hpp
@@ -11,6 +11,7 @@
 #define _OP_BUILDER_HELPER_FILTER_H
 
 #include "builderTypes.hpp"
+#include "stringUtils.hpp"
 
 /*
  * The helper filter, builds a lifter that will chain rxcpp filter operation

--- a/src/engine/source/builder/builders/OpBuilderHelperFilter.hpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperFilter.hpp
@@ -54,13 +54,13 @@ types::Lifter opBuilderHelperNotExists(const types::DocumentValue & def);
  * - `!`: checks if the field is not equal to the value
  * - `<`: checks if the field is less than the value
  * - `>`: checks if the field is greater than the value
- * - `m`: checks if the field is less than or equal to the value
- * - `n`: checks if the field is greater than or equal to the value
+ * - `l`: checks if the field is less than or equal to the value
+ * - `g`: checks if the field is greater than or equal to the value
  * @param e The event containing the field to be compared
  * @param refValue The key/path of the field to be compared against (optional)
  * @param value The string to be compared against (optional)
  * @return true if the comparison is true
- * @return false if the comparison is false
+ * @return false in other case
  * @note If `refExpStr` is not provided, the comparison will be against the value of `expectedStr`
  */
 inline bool opBuilderHelperStringComparison(const std::string  key, char op, types::Event& e,
@@ -157,13 +157,13 @@ types::Lifter opBuilderHelperStringLE(const types::DocumentValue & def);
  * - `!`: checks if the field is not equal to the value
  * - `<`: checks if the field is less than the value
  * - `>`: checks if the field is greater than the value
- * - `m`: checks if the field is less than or equal to the value
- * - `n`: checks if the field is greater than or equal to the value
+ * - `l`: checks if the field is less than or equal to the value
+ * - `g`: checks if the field is greater than or equal to the value
  * @param e The event containing the field to be compared
  * @param refValue The key/path of the field to be compared against (optional)
  * @param value The integer to be compared against (optional)
  * @return true if the comparison is true
- * @return false if the comparison is false
+ * @return false in other case
  * @note If `refValue` is not provided, the comparison will be against the value of
  * `value`
  */
@@ -176,7 +176,7 @@ inline bool opBuilderHelperIntComparison(const std::string field, char op,
  * @brief Builds helper integer equal operation.
  * Checks that the field is equal to an integer or another numeric field
  *
- * The filter checks if a field in the JSON event `wazuh` is equal to a value.
+ * The filter checks if a field in the JSON event is equal to a value.
  * Only pass events if the fields are equal and the values are a integer.
  * @param def Definition of the operation to be built
  * @return types::Lifter The lifter with the `i_eq` filter.
@@ -188,7 +188,7 @@ types::Lifter opBuilderHelperIntEqual(const types::DocumentValue & def);
  * @brief Builds helper integer not equal operation.
  * Checks that the field is not equal to an integer or another numeric field
  *
- * The filter checks if a field in the JSON event `wazuh` is not equal to a value.
+ * The filter checks if a field in the JSON event is not equal to a value.
  * Only pass events if the fields are not equal and the values are a integer.
  * @param def Definition of the operation to be built
  * @return types::Lifter The lifter with the `i_ne` filter.
@@ -200,7 +200,7 @@ types::Lifter opBuilderHelperIntNotEqual(const types::DocumentValue & def);
  * @brief Builds helper integer less than operation.
  * Checks that the field is less than to an integer or another numeric field
  *
- * The filter checks if a field in the JSON event `wazuh` is less than a value.
+ * The filter checks if a field in the JSON event is less than a value.
  * Only pass events if the fields are less than and the values are a integer.
  * @param def Definition of the operation to be built
  * @return types::Lifter The lifter with the `i_lt` filter.
@@ -212,7 +212,7 @@ types::Lifter opBuilderHelperIntLessThan(const types::DocumentValue & def);
  * @brief Builds helper integer less than equal operation.
  * Checks that the field is less than equal to an integer or another numeric field
  *
- * The filter checks if a field in the JSON event `wazuh` is less than equal a value.
+ * The filter checks if a field in the JSON event is less than equal a value.
  * Only pass events if the fields are less than equal and the values are a integer.
  * @param def Definition of the operation to be built
  * @return types::Lifter The lifter with the `i_le` filter.
@@ -224,7 +224,7 @@ types::Lifter opBuilderHelperIntLessThanEqual(const types::DocumentValue & def);
  * @brief Builds helper integer greater than operation.
  * Checks that the field is greater than to an integer or another numeric field
  *
- * The filter checks if a field in the JSON event `wazuh` is greater than a value.
+ * The filter checks if a field in the JSON event is greater than a value.
  * Only pass events if the fields are greater than and the values are a integer.
  * @param def Definition of the operation to be built
  * @return types::Lifter The lifter with the `i_gt` filter.
@@ -237,7 +237,7 @@ types::Lifter opBuilderHelperIntGreaterThan(const types::DocumentValue & def);
  * @brief Builds helper integer greater than equal operation.
  * Checks that the field is greater than equal to an integer or another numeric field
  *
- * The filter checks if a field in the JSON event `wazuh` is greater than equal a value.
+ * The filter checks if a field in the JSON event is greater than equal a value.
  * Only pass events if the fields are greater than equal and the values are a integer.
  * @param def Definition of the operation to be built
  * @return types::Lifter The lifter with the `i_ge` filter.

--- a/src/engine/source/builder/builders/OpBuilderHelperFilter.hpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperFilter.hpp
@@ -202,6 +202,15 @@ types::Lifter opBuilderHelperIntNotEqual(const types::DocumentValue & def);
  */
 types::Lifter opBuilderHelperIntLessThan(const types::DocumentValue & def);
 
+/**
+ * @brief Builds helper integer less than equal operation.
+ * Checks that the field is less than equal to an integer or another numeric field
+ *
+ * @param def Definition of the operation to be built
+ * @return types::Lifter
+ */
+types::Lifter opBuilderHelperIntLessThanEqual(const types::DocumentValue & def);
+
 } // namespace builder::internals::builders
 
 #endif // _OP_BUILDER_HELPER_FILTER_H

--- a/src/engine/source/builder/builders/OpBuilderHelperMap.cpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperMap.cpp
@@ -343,7 +343,12 @@ types::Lifter opBuilderHelperIntCalc(const types::DocumentValue & def)
         case '+':
         case '-':
         case '*':
+            break;
         case '%':
+            if (parameters[2] == "0")
+            {
+                throw std::runtime_error("Division by zero");
+            }
             break;
         default:
             throw std::runtime_error("Invalid operator");

--- a/src/engine/source/builder/builders/OpBuilderHelperMap.cpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperMap.cpp
@@ -9,10 +9,12 @@
 
 #include <algorithm>
 #include <string>
+#include <optional>
 
 #include "OpBuilderHelperMap.hpp"
 #include "stringUtils.hpp"
 
+using namespace std;
 namespace {
 
     using DocumentValue = builder::internals::types::DocumentValue;
@@ -21,7 +23,7 @@ namespace {
 /**
  * @brief Tranform the string in `field` path in the event `e` according to the
  * `op` definition and the `value` or the `refValue`
- * 
+ *
  * @param field The field path to transform
  * @param op The operator to use:
  * - `u`: Upper case
@@ -104,8 +106,6 @@ namespace builder::internals::builders
 //*************************************************
 //*           String tranform                     *
 //*************************************************
-
-
 
 // <field>: +s_up/<str>|$<ref>
 types::Lifter opBuilderHelperStringUP(const types::DocumentValue & def)
@@ -305,6 +305,135 @@ types::Lifter opBuilderHelperStringTrim(const types::DocumentValue & def)
                     return e;
                 }
 
+                return e;
+            });
+    };
+}
+
+//*************************************************
+//*           Int tranform                        *
+//*************************************************
+
+types::Lifter opBuilderHelperIntCalc(const types::DocumentValue & def)
+{
+    // Get field
+    std::string field = def.MemberBegin()->name.GetString();
+    std::string rawValue = def.MemberBegin()->value.GetString();
+
+    std::vector<std::string> parameters = utils::string::split(rawValue, '/');
+
+    if (parameters.size() != 3)
+    {
+        throw std::runtime_error("Invalid parameters");
+    }
+
+    std::optional<std::string> refValue;
+    std::optional<int> value;
+
+    // Take operator parameter
+    if (parameters[1].size() != 1)
+    {
+        throw std::runtime_error("Invalid operator");
+    }
+
+    char op = parameters[1][0];
+
+    switch (op)
+    {
+        case '+':
+        case '-':
+        case '*':
+        case '%':
+            break;
+        default:
+            throw std::runtime_error("Invalid operator");
+    }
+
+    if (parameters[2][0] == '$')
+    {
+        // Check case `+i_calc/op/$`
+        refValue = parameters[2].substr(1, std::string::npos);
+    }
+    else
+    {
+        value = std::stoi(parameters[2]);
+    }
+
+    // Return Lifter
+    return [op, refValue, value, field](types::Observable o)
+    {
+        // Append rxcpp operation
+        return o.map(
+            [=](types::Event e)
+            {
+                if (e.exists("/" + field))
+                {
+                    auto fieldToCheck = e.getObject().FindMember(field.c_str());
+                    if (fieldToCheck->value.IsInt())
+                    {
+                        if (value.has_value())
+                        {
+                            switch (op)
+                            {
+                                case '+':
+                                    fieldToCheck->value.SetInt(
+                                        fieldToCheck->value.GetInt() + value.value());
+                                    return e;
+                                case '-':
+                                    fieldToCheck->value.SetInt(
+                                        fieldToCheck->value.GetInt() - value.value());
+                                    return e;
+                                case '*':
+                                    fieldToCheck->value.SetInt(
+                                        fieldToCheck->value.GetInt() * value.value());
+                                    return e;
+                                case '%': // TODO: Check if this is correct
+                                    if (value.value() != 0)
+                                    {
+                                        fieldToCheck->value.SetInt(
+                                            fieldToCheck->value.GetInt() / value.value());
+                                    }
+                                    return e;
+                                default:
+                                    throw std::runtime_error("Invalid operator");
+                            }
+                            return e;
+                        }
+                        auto refValueToCheck =
+                            e.getObject().FindMember(refValue.value().c_str());
+                        if (refValueToCheck->value.IsInt())
+                        {
+                            switch (op)
+                            {
+                                case '+':
+                                    fieldToCheck->value.SetInt(
+                                        fieldToCheck->value.GetInt() +
+                                        refValueToCheck->value.GetInt());
+                                    return e;
+                                case '-':
+                                    fieldToCheck->value.SetInt(
+                                        fieldToCheck->value.GetInt() -
+                                        refValueToCheck->value.GetInt());
+                                    return e;
+                                case '*':
+                                    fieldToCheck->value.SetInt(
+                                        fieldToCheck->value.GetInt() *
+                                        refValueToCheck->value.GetInt());
+                                    return e;
+                                case '%': // TODO: divide by zero
+                                    if (refValueToCheck->value.GetInt() != 0)
+                                    {
+                                        fieldToCheck->value.SetInt(
+                                            fieldToCheck->value.GetInt() /
+                                            refValueToCheck->value.GetInt());
+                                    }
+                                    return e;
+                                default:
+                                    throw std::runtime_error("Invalid operator");
+                            }
+                        }
+                    }
+                }
                 return e;
             });
     };

--- a/src/engine/source/builder/builders/OpBuilderHelperMap.hpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperMap.hpp
@@ -7,11 +7,11 @@
  * Foundation.
  */
 
-
 #ifndef _OP_BUILDER_HELPER_MAP_H
 #define _OP_BUILDER_HELPER_MAP_H
 
 #include "builderTypes.hpp"
+#include "stringUtils.hpp"
 
 /*
  * The helper Map (Transformation), builds a lifter that will chain rxcpp map operation
@@ -47,7 +47,20 @@ types::Lifter opBuilderHelperStringLO(const types::DocumentValue & def);
  * @param def The transformation definition. i.e : `<field>: +s_trim/[begin | end | both]/char`
  * @return types::Lifter The lifter with the `trim` transformation.
  */
+
+//*************************************************
+//*           Int tranform                        *
+//*************************************************
+
 types::Lifter opBuilderHelperStringTrim(const types::DocumentValue & def);
+/**
+ * @brief Builds helper map operation.
+ * Maps a field to a new field.
+ *
+ * @param def Definition of the operation to be built
+ * @return types::Lifter
+ */
+types::Lifter opBuilderHelperIntCalc(const types::DocumentValue & def);
 
 } // namespace builder::internals::builders
 

--- a/src/engine/source/builder/builders/OpBuilderHelperMap.hpp
+++ b/src/engine/source/builder/builders/OpBuilderHelperMap.hpp
@@ -11,7 +11,6 @@
 #define _OP_BUILDER_HELPER_MAP_H
 
 #include "builderTypes.hpp"
-#include "stringUtils.hpp"
 
 /*
  * The helper Map (Transformation), builds a lifter that will chain rxcpp map operation
@@ -30,6 +29,7 @@ namespace builder::internals::builders
  *
  * @param def The transformation definition. i.e : `<field>: +s_up/<str>|$<ref>`
  * @return types::Lifter The lifter with the `uppercase` transformation.
+ * @throw std::runtime_error if the parameter is not a string.
  */
 types::Lifter opBuilderHelperStringUP(const types::DocumentValue & def);
 
@@ -38,27 +38,31 @@ types::Lifter opBuilderHelperStringUP(const types::DocumentValue & def);
  *
  * @param def The transformation definition. i.e : `<field>: +s_lo/<str>|$<ref>`
  * @return types::Lifter The lifter with the `lowercase` transformation.
+ * @throw std::runtime_error if the parameter is not a string.
  */
 types::Lifter opBuilderHelperStringLO(const types::DocumentValue & def);
 
 /**
  * @brief Transforms a string, trim it and append or remplace it in the event `e`
  *
- * @param def The transformation definition. i.e : `<field>: +s_trim/[begin | end | both]/char`
+ * @param def The transformation definition.
+ * i.e : `<field>: +s_trim/[begin | end | both]/char`
  * @return types::Lifter The lifter with the `trim` transformation.
+ * @throw std::runtime_error if the parameter is not a string.
  */
+types::Lifter opBuilderHelperStringTrim(const types::DocumentValue & def);
 
 //*************************************************
 //*           Int tranform                        *
 //*************************************************
 
-types::Lifter opBuilderHelperStringTrim(const types::DocumentValue & def);
 /**
- * @brief Builds helper map operation.
- * Maps a field to a new field.
+ * @brief Transforms an integer. Performs a mathematical operation on an event field.
  *
- * @param def Definition of the operation to be built
+ * @param def The transformation definition.
+ * i.e : `<field>: +icalcm/[sum|sub|mul|div]/[value|$<ref>]`
  * @return types::Lifter
+ * @throw std::runtime_error if the parameter is not a integer.
  */
 types::Lifter opBuilderHelperIntCalc(const types::DocumentValue & def);
 

--- a/src/engine/test/source/builder/CMakeLists.txt
+++ b/src/engine/test/source/builder/CMakeLists.txt
@@ -224,6 +224,12 @@ add_executable(opBuilderHelperIntLessThan_test
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/OpBuilderHelperFilter.cpp)
 gtest_discover_tests(opBuilderHelperIntLessThan_test)
 
+add_executable(opBuilderHelperIntLessThanEqual_test
+  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntLessThanEqual_test.cpp
+  ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/OpBuilderHelperFilter.cpp)
+gtest_discover_tests(opBuilderHelperIntLessThanEqual_test)
+
 add_executable(opBuilderHelperIntCalc_test
   ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntCalc_test.cpp

--- a/src/engine/test/source/builder/CMakeLists.txt
+++ b/src/engine/test/source/builder/CMakeLists.txt
@@ -218,6 +218,12 @@ add_executable(opBuilderHelperIntNotEqual_test
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/OpBuilderHelperFilter.cpp)
 gtest_discover_tests(opBuilderHelperIntNotEqual_test)
 
+add_executable(opBuilderHelperIntLessThan_test
+  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntLessThan_test.cpp
+  ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/OpBuilderHelperFilter.cpp)
+gtest_discover_tests(opBuilderHelperIntLessThan_test)
+
 add_executable(opBuilderHelperIntCalc_test
   ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntCalc_test.cpp

--- a/src/engine/test/source/builder/CMakeLists.txt
+++ b/src/engine/test/source/builder/CMakeLists.txt
@@ -236,6 +236,12 @@ add_executable(opBuilderHelperIntGreaterThan_test
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/OpBuilderHelperFilter.cpp)
 gtest_discover_tests(opBuilderHelperIntGreaterThan_test)
 
+add_executable(opBuilderHelperIntGreaterThanEqual_test
+  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntGreaterThanEqual_test.cpp
+  ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/OpBuilderHelperFilter.cpp)
+gtest_discover_tests(opBuilderHelperIntGreaterThanEqual_test)
+
 add_executable(opBuilderHelperIntCalc_test
   ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntCalc_test.cpp

--- a/src/engine/test/source/builder/CMakeLists.txt
+++ b/src/engine/test/source/builder/CMakeLists.txt
@@ -203,6 +203,10 @@ add_executable(opBuilderHelperStringTrim_test
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperStringTrim_test.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/OpBuilderHelperMap.cpp)
 gtest_discover_tests(opBuilderHelperStringTrim_test)
+add_executable(opBuilderHelperIntEqual_test
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntEqual_test.cpp
+  ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/OpBuilderHelperFilter.cpp)
+gtest_discover_tests(opBuilderHelperIntEqual_test)
 
 add_executable(opBuilderConditionTest
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderConditionTest.cpp

--- a/src/engine/test/source/builder/CMakeLists.txt
+++ b/src/engine/test/source/builder/CMakeLists.txt
@@ -204,6 +204,7 @@ add_executable(opBuilderHelperStringTrim_test
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/OpBuilderHelperMap.cpp)
 gtest_discover_tests(opBuilderHelperStringTrim_test)
 add_executable(opBuilderHelperIntEqual_test
+  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntEqual_test.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/OpBuilderHelperFilter.cpp)
 gtest_discover_tests(opBuilderHelperIntEqual_test)

--- a/src/engine/test/source/builder/CMakeLists.txt
+++ b/src/engine/test/source/builder/CMakeLists.txt
@@ -78,7 +78,6 @@ add_executable(builderTest
   ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_TEST_SOURCE_DIR}/builderTest.cpp
   ${BUILDER_ENGINE_SOURCE_DIR}/registry.cpp
-  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/combinatorBuilderBroadcast.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/stageBuilderOutputs.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/combinatorBuilderChain.cpp
@@ -111,7 +110,6 @@ add_executable(registerTest
   ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_TEST_SOURCE_DIR}/registerTest.cpp
   ${BUILDER_ENGINE_SOURCE_DIR}/registry.cpp
-  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/combinatorBuilderBroadcast.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/stageBuilderOutputs.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/combinatorBuilderChain.cpp
@@ -206,6 +204,7 @@ add_executable(opBuilderHelperStringTrim_test
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperStringTrim_test.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/OpBuilderHelperMap.cpp)
 gtest_discover_tests(opBuilderHelperStringTrim_test)
+
 add_executable(opBuilderHelperIntEqual_test
   ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntEqual_test.cpp
@@ -273,7 +272,6 @@ add_executable(opBuilderMapTest
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderMap.cpp
   ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_ENGINE_SOURCE_DIR}/registry.cpp
-  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderMapValue.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderMapReference.cpp)
 gtest_discover_tests(opBuilderMapTest)
@@ -288,7 +286,6 @@ add_executable(stageBuilderCheckTest
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/stageBuilderCheckTest.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/stageBuilderCheck.cpp
   ${BUILDER_ENGINE_SOURCE_DIR}/registry.cpp
-  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderCondition.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderConditionValue.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderConditionReference.cpp
@@ -301,7 +298,6 @@ add_executable(stageBuilderNormalizeTest
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/stageBuilderNormalize.cpp
   ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_ENGINE_SOURCE_DIR}/registry.cpp
-  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderMap.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderMapValue.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderMapReference.cpp
@@ -313,7 +309,6 @@ add_executable(assetBuilderDecoderTest
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/assetBuilderDecoder.cpp
   ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_ENGINE_SOURCE_DIR}/registry.cpp
-  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/stageBuilderNormalize.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderMap.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderMapValue.cpp
@@ -331,7 +326,6 @@ add_executable(assetBuilderRuleTest
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/assetBuilderRule.cpp
   ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_ENGINE_SOURCE_DIR}/registry.cpp
-  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/stageBuilderNormalize.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderMap.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderMapValue.cpp
@@ -349,7 +343,6 @@ add_executable(assetBuilderFilterTest
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/assetBuilderFilter.cpp
   ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_ENGINE_SOURCE_DIR}/registry.cpp
-  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/combinatorBuilderChain.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/stageBuilderCheck.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderCondition.cpp

--- a/src/engine/test/source/builder/CMakeLists.txt
+++ b/src/engine/test/source/builder/CMakeLists.txt
@@ -87,6 +87,7 @@ add_executable(builderTest
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderConditionValue.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderConditionReference.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/OpBuilderHelperFilter.cpp
+  ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/OpBuilderHelperMap.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/assetBuilderOutput.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderFileOutput.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/stageBuilderNormalize.cpp
@@ -216,6 +217,12 @@ add_executable(opBuilderHelperIntNotEqual_test
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntNotEqual_test.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/OpBuilderHelperFilter.cpp)
 gtest_discover_tests(opBuilderHelperIntNotEqual_test)
+
+add_executable(opBuilderHelperIntCalc_test
+  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntCalc_test.cpp
+  ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/OpBuilderHelperMap.cpp)
+gtest_discover_tests(opBuilderHelperIntCalc_test)
 
 add_executable(opBuilderConditionTest
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderConditionTest.cpp

--- a/src/engine/test/source/builder/CMakeLists.txt
+++ b/src/engine/test/source/builder/CMakeLists.txt
@@ -78,6 +78,7 @@ add_executable(builderTest
   ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_TEST_SOURCE_DIR}/builderTest.cpp
   ${BUILDER_ENGINE_SOURCE_DIR}/registry.cpp
+  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/combinatorBuilderBroadcast.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/stageBuilderOutputs.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/combinatorBuilderChain.cpp
@@ -109,6 +110,7 @@ add_executable(registerTest
   ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_TEST_SOURCE_DIR}/registerTest.cpp
   ${BUILDER_ENGINE_SOURCE_DIR}/registry.cpp
+  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/combinatorBuilderBroadcast.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/stageBuilderOutputs.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/combinatorBuilderChain.cpp
@@ -209,6 +211,12 @@ add_executable(opBuilderHelperIntEqual_test
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/OpBuilderHelperFilter.cpp)
 gtest_discover_tests(opBuilderHelperIntEqual_test)
 
+add_executable(opBuilderHelperIntNotEqual_test
+  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntNotEqual_test.cpp
+  ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/OpBuilderHelperFilter.cpp)
+gtest_discover_tests(opBuilderHelperIntNotEqual_test)
+
 add_executable(opBuilderConditionTest
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderConditionTest.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderCondition.cpp
@@ -234,6 +242,7 @@ add_executable(opBuilderMapTest
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderMap.cpp
   ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_ENGINE_SOURCE_DIR}/registry.cpp
+  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderMapValue.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderMapReference.cpp)
 gtest_discover_tests(opBuilderMapTest)
@@ -248,6 +257,7 @@ add_executable(stageBuilderCheckTest
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/stageBuilderCheckTest.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/stageBuilderCheck.cpp
   ${BUILDER_ENGINE_SOURCE_DIR}/registry.cpp
+  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderCondition.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderConditionValue.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderConditionReference.cpp
@@ -260,6 +270,7 @@ add_executable(stageBuilderNormalizeTest
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/stageBuilderNormalize.cpp
   ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_ENGINE_SOURCE_DIR}/registry.cpp
+  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderMap.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderMapValue.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderMapReference.cpp
@@ -271,6 +282,7 @@ add_executable(assetBuilderDecoderTest
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/assetBuilderDecoder.cpp
   ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_ENGINE_SOURCE_DIR}/registry.cpp
+  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/stageBuilderNormalize.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderMap.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderMapValue.cpp
@@ -288,6 +300,7 @@ add_executable(assetBuilderRuleTest
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/assetBuilderRule.cpp
   ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_ENGINE_SOURCE_DIR}/registry.cpp
+  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/stageBuilderNormalize.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderMap.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderMapValue.cpp
@@ -305,6 +318,7 @@ add_executable(assetBuilderFilterTest
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/assetBuilderFilter.cpp
   ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_ENGINE_SOURCE_DIR}/registry.cpp
+  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/combinatorBuilderChain.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/stageBuilderCheck.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderCondition.cpp

--- a/src/engine/test/source/builder/CMakeLists.txt
+++ b/src/engine/test/source/builder/CMakeLists.txt
@@ -230,6 +230,12 @@ add_executable(opBuilderHelperIntLessThanEqual_test
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/OpBuilderHelperFilter.cpp)
 gtest_discover_tests(opBuilderHelperIntLessThanEqual_test)
 
+add_executable(opBuilderHelperIntGreaterThan_test
+  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntGreaterThan_test.cpp
+  ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/OpBuilderHelperFilter.cpp)
+gtest_discover_tests(opBuilderHelperIntGreaterThan_test)
+
 add_executable(opBuilderHelperIntCalc_test
   ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntCalc_test.cpp

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
@@ -1,0 +1,513 @@
+/* Copyright (C) 2015-2021, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <gtest/gtest.h>
+#include <testUtils.hpp>
+
+#include <vector>
+
+#include "OpBuilderHelperMap.hpp"
+
+using namespace builder::internals::builders;
+
+TEST(opBuilderHelperIntCalc, Builds)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_calc/+/10"}
+    })"};
+    ASSERT_NO_THROW(opBuilderHelperIntCalc(*doc.get("/check")));
+}
+
+TEST(opBuilderHelperIntCalc, Builds_error_bad_parameter)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_calc/test/test"}
+    })"};
+    ASSERT_THROW(opBuilderHelperIntCalc(*doc.get("/check")), std::runtime_error);
+}
+
+TEST(opBuilderHelperIntCalc, Builds_error_less_parameters)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_calc/10"}
+    })"};
+    ASSERT_THROW(opBuilderHelperIntCalc(*doc.get("/check")), std::runtime_error);
+}
+
+
+TEST(opBuilderHelperIntCalc, Builds_error_more_parameters)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_calc/10/10/10"}
+    })"};
+    ASSERT_THROW(opBuilderHelperIntCalc(*doc.get("/check")), std::runtime_error);
+}
+
+TEST(opBuilderHelperIntCalc, Builds_error_bad_operator)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_calc/^/10"}
+    })"};
+    ASSERT_THROW(opBuilderHelperIntCalc(*doc.get("/check")), std::runtime_error);
+}
+
+//TODO test division by zero
+TEST(opBuilderHelperIntCalc, Builds_error_zero_division)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_calc/%/0"}
+    })"};
+    ASSERT_THROW(opBuilderHelperIntCalc(*doc.get("/check")), std::runtime_error);
+}
+
+TEST(opBuilderHelperIntCalc, Exec_equal_ok)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_calc/+/10"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test":9}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 4);
+    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),19);
+    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),20);
+    ASSERT_EQ(expected[2].get("/field_test")->GetInt(),20);
+    ASSERT_EQ(expected[3].get("/field_test")->GetInt(),21);
+
+}
+
+TEST(opBuilderHelperIntCalc, Exec_sum_int)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_calc/+/10"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test":0}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":9}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":100}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":-100}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 6);
+    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),10);
+    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),19);
+    ASSERT_EQ(expected[2].get("/field_test")->GetInt(),20);
+    ASSERT_EQ(expected[3].get("/field_test")->GetInt(),21);
+    ASSERT_EQ(expected[4].get("/field_test")->GetInt(),110);
+    ASSERT_EQ(expected[5].get("/field_test")->GetInt(),-90);
+
+}
+
+TEST(opBuilderHelperIntCalc, Exec_sub_int)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_calc/-/10"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test":0}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":9}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":100}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":-100}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 6);
+    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),-10);
+    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),-1);
+    ASSERT_EQ(expected[2].get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[3].get("/field_test")->GetInt(),1);
+    ASSERT_EQ(expected[4].get("/field_test")->GetInt(),90);
+    ASSERT_EQ(expected[5].get("/field_test")->GetInt(),-110);
+
+}
+
+TEST(opBuilderHelperIntCalc, Exec_mult_int)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_calc/*/10"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test":0}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":9}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":100}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":-100}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 6);
+    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),90);
+    ASSERT_EQ(expected[2].get("/field_test")->GetInt(),100);
+    ASSERT_EQ(expected[3].get("/field_test")->GetInt(),110);
+    ASSERT_EQ(expected[4].get("/field_test")->GetInt(),1000);
+    ASSERT_EQ(expected[5].get("/field_test")->GetInt(),-1000);
+
+}
+
+TEST(opBuilderHelperIntCalc, Exec_div_int)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_calc/%/10"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test":0}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":9}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":100}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":-100}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 6);
+    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[2].get("/field_test")->GetInt(),1);
+    ASSERT_EQ(expected[3].get("/field_test")->GetInt(),1);
+    ASSERT_EQ(expected[4].get("/field_test")->GetInt(),10);
+    ASSERT_EQ(expected[5].get("/field_test")->GetInt(),-10);
+
+}
+
+TEST(opBuilderHelperIntCalc, Exec_sum_ref)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_calc/+/$field_src"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test": 0,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":9,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test": 10,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test": 0,"field_src":-10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":9,"field_src":-10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test": 10,"field_src":-10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src":-10}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    auto str2Int = [](std::string s) {
+        return std::stoi(s);
+    };
+
+    ASSERT_EQ(expected.size(), 8);
+    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),10);
+    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),19);
+    ASSERT_EQ(expected[2].get("/field_test")->GetInt(),20);
+    ASSERT_EQ(expected[3].get("/field_test")->GetInt(),21);
+    ASSERT_EQ(expected[4].get("/field_test")->GetInt(),-10);
+    ASSERT_EQ(expected[5].get("/field_test")->GetInt(),-1);
+    ASSERT_EQ(expected[6].get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[7].get("/field_test")->GetInt(),1);
+
+}
+
+TEST(opBuilderHelperIntCalc, Exec_sub_ref)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_calc/-/$field_src"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test": 0,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":9,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test": 10,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test": 0,"field_src":-10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":9,"field_src":-10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test": 10,"field_src":-10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src":-10}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    auto str2Int = [](std::string s) {
+        return std::stoi(s);
+    };
+
+    ASSERT_EQ(expected.size(), 8);
+    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),-10);
+    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),-1);
+    ASSERT_EQ(expected[2].get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[3].get("/field_test")->GetInt(),1);
+    ASSERT_EQ(expected[4].get("/field_test")->GetInt(),10);
+    ASSERT_EQ(expected[5].get("/field_test")->GetInt(),19);
+    ASSERT_EQ(expected[6].get("/field_test")->GetInt(),20);
+    ASSERT_EQ(expected[7].get("/field_test")->GetInt(),21);
+
+}
+
+TEST(opBuilderHelperIntCalc, Exec_mult_ref)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_calc/*/$field_src"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test": 0,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":9,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test": 10,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test": 0,"field_src":-10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":9,"field_src":-10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test": 10,"field_src":-10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src":-10}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    auto str2Int = [](std::string s) {
+        return std::stoi(s);
+    };
+
+    ASSERT_EQ(expected.size(), 8);
+    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),90);
+    ASSERT_EQ(expected[2].get("/field_test")->GetInt(),100);
+    ASSERT_EQ(expected[3].get("/field_test")->GetInt(),110);
+    ASSERT_EQ(expected[4].get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[5].get("/field_test")->GetInt(),-90);
+    ASSERT_EQ(expected[6].get("/field_test")->GetInt(),-100);
+    ASSERT_EQ(expected[7].get("/field_test")->GetInt(),-110);
+
+}
+
+TEST(opBuilderHelperIntCalc, Exec_div_ref)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_calc/%/$field_src"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test": 0,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":9,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test": 10,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test": 0,"field_src":-10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":9,"field_src":-10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test": 10,"field_src":-10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src":-10}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    auto str2Int = [](std::string s) {
+        return std::stoi(s);
+    };
+
+    ASSERT_EQ(expected.size(), 8);
+    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[2].get("/field_test")->GetInt(),1);
+    ASSERT_EQ(expected[3].get("/field_test")->GetInt(),1);
+    ASSERT_EQ(expected[4].get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[5].get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[6].get("/field_test")->GetInt(),-1);
+    ASSERT_EQ(expected[7].get("/field_test")->GetInt(),-1);
+
+}

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
@@ -511,3 +511,60 @@ TEST(opBuilderHelperIntCalc, Exec_div_ref)
     ASSERT_EQ(expected[7].get("/field_test")->GetInt(),-1);
 
 }
+
+TEST(opBuilderHelperIntCalc, Exec_div_ref_zero)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_calc/%/$field_src"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test": 0,"field_src":0}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":9,"field_src":0}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test": 10,"field_src":0}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src":0}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test": 0,"field_src":0}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":9,"field_src":0}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test": 10,"field_src":0}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src":0}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    auto str2Int = [](std::string s) {
+        return std::stoi(s);
+    };
+
+    ASSERT_EQ(expected.size(), 8);
+    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),9);
+    ASSERT_EQ(expected[2].get("/field_test")->GetInt(),10);
+    ASSERT_EQ(expected[3].get("/field_test")->GetInt(),11);
+    ASSERT_EQ(expected[4].get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[5].get("/field_test")->GetInt(),9);
+    ASSERT_EQ(expected[6].get("/field_test")->GetInt(),10);
+    ASSERT_EQ(expected[7].get("/field_test")->GetInt(),11);
+
+}

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
@@ -20,7 +20,7 @@ TEST(opBuilderHelperIntCalc, Builds)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+i_calc/+/10"}
+            {"field_test": "+i_calc/sum/10"}
     })"};
     ASSERT_NO_THROW(opBuilderHelperIntCalc(*doc.get("/check")));
 }
@@ -67,7 +67,7 @@ TEST(opBuilderHelperIntCalc, Builds_error_zero_division)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+i_calc/%/0"}
+            {"field_test": "+i_calc/div/0"}
     })"};
     ASSERT_THROW(opBuilderHelperIntCalc(*doc.get("/check")), std::runtime_error);
 }
@@ -76,7 +76,7 @@ TEST(opBuilderHelperIntCalc, Exec_equal_ok)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+i_calc/+/10"}
+            {"field_test": "+i_calc/sum/10"}
     })"};
 
     Observable input = observable<>::create<Event>(
@@ -112,7 +112,7 @@ TEST(opBuilderHelperIntCalc, Exec_sum_int)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+i_calc/+/10"}
+            {"field_test": "+i_calc/sum/10"}
     })"};
 
     Observable input = observable<>::create<Event>(
@@ -156,7 +156,7 @@ TEST(opBuilderHelperIntCalc, Exec_sub_int)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+i_calc/-/10"}
+            {"field_test": "+i_calc/sub/10"}
     })"};
 
     Observable input = observable<>::create<Event>(
@@ -200,7 +200,7 @@ TEST(opBuilderHelperIntCalc, Exec_mult_int)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+i_calc/*/10"}
+            {"field_test": "+i_calc/mul/10"}
     })"};
 
     Observable input = observable<>::create<Event>(
@@ -244,7 +244,7 @@ TEST(opBuilderHelperIntCalc, Exec_div_int)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+i_calc/%/10"}
+            {"field_test": "+i_calc/div/10"}
     })"};
 
     Observable input = observable<>::create<Event>(
@@ -288,7 +288,7 @@ TEST(opBuilderHelperIntCalc, Exec_sum_ref)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+i_calc/+/$field_src"}
+            {"field_test": "+i_calc/sum/$field_src"}
     })"};
 
     Observable input = observable<>::create<Event>(
@@ -345,7 +345,7 @@ TEST(opBuilderHelperIntCalc, Exec_sub_ref)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+i_calc/-/$field_src"}
+            {"field_test": "+i_calc/sub/$field_src"}
     })"};
 
     Observable input = observable<>::create<Event>(
@@ -402,7 +402,7 @@ TEST(opBuilderHelperIntCalc, Exec_mult_ref)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+i_calc/*/$field_src"}
+            {"field_test": "+i_calc/mul/$field_src"}
     })"};
 
     Observable input = observable<>::create<Event>(
@@ -459,7 +459,7 @@ TEST(opBuilderHelperIntCalc, Exec_div_ref)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+i_calc/%/$field_src"}
+            {"field_test": "+i_calc/div/$field_src"}
     })"};
 
     Observable input = observable<>::create<Event>(
@@ -516,7 +516,7 @@ TEST(opBuilderHelperIntCalc, Exec_div_ref_zero)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+i_calc/%/$field_src"}
+            {"field_test": "+i_calc/div/$field_src"}
     })"};
 
     Observable input = observable<>::create<Event>(

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
@@ -568,3 +568,199 @@ TEST(opBuilderHelperIntCalc, Exec_div_ref_zero)
     ASSERT_EQ(expected[7].get("/field_test")->GetInt(),11);
 
 }
+
+TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sum)
+{
+    Document doc{R"({
+        "check":
+            {"parentObjt_1.field2check": "+i_calc/sum/$parentObjt_2.ref_key"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            // sorted
+            s.on_next(Event{R"(
+                {
+                    "parentObjt_1": {
+                        "field2check": 10,
+                        "ref_key": 10
+                    },
+                    "parentObjt_2": {
+                        "field2check": 11,
+                        "ref_key": 11
+                    }
+                }
+            )"});
+            // not sorted
+            s.on_next(Event{R"(
+                {
+                    "parentObjt_2": {
+                        "field2check": 11,
+                        "ref_key": 10
+                    },
+                    "parentObjt_1": {
+                        "field2check": 10,
+                        "ref_key": 11
+                    }
+                }
+            )"});
+            s.on_completed();
+        });
+
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    ASSERT_EQ(expected.size(), 2);
+    ASSERT_EQ(expected[0].get("/parentObjt_1/field2check")->GetInt(), 21);
+    ASSERT_EQ(expected[1].get("/parentObjt_1/field2check")->GetInt(), 20);
+}
+
+TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sub)
+{
+    Document doc{R"({
+        "check":
+            {"parentObjt_1.field2check": "+i_calc/sub/$parentObjt_2.ref_key"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            // sorted
+            s.on_next(Event{R"(
+                {
+                    "parentObjt_1": {
+                        "field2check": 10,
+                        "ref_key": 10
+                    },
+                    "parentObjt_2": {
+                        "field2check": 11,
+                        "ref_key": 11
+                    }
+                }
+            )"});
+            // not sorted
+            s.on_next(Event{R"(
+                {
+                    "parentObjt_2": {
+                        "field2check": 11,
+                        "ref_key": 10
+                    },
+                    "parentObjt_1": {
+                        "field2check": 10,
+                        "ref_key": 11
+                    }
+                }
+            )"});
+            s.on_completed();
+        });
+
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    ASSERT_EQ(expected.size(), 2);
+    ASSERT_EQ(expected[0].get("/parentObjt_1/field2check")->GetInt(), -1);
+    ASSERT_EQ(expected[1].get("/parentObjt_1/field2check")->GetInt(), 0);
+}
+
+TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_mul)
+{
+    Document doc{R"({
+        "check":
+            {"parentObjt_1.field2check": "+i_calc/mul/$parentObjt_2.ref_key"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            // sorted
+            s.on_next(Event{R"(
+                {
+                    "parentObjt_1": {
+                        "field2check": 10,
+                        "ref_key": 10
+                    },
+                    "parentObjt_2": {
+                        "field2check": 11,
+                        "ref_key": 11
+                    }
+                }
+            )"});
+            // not sorted
+            s.on_next(Event{R"(
+                {
+                    "parentObjt_2": {
+                        "field2check": 11,
+                        "ref_key": 10
+                    },
+                    "parentObjt_1": {
+                        "field2check": 10,
+                        "ref_key": 11
+                    }
+                }
+            )"});
+            s.on_completed();
+        });
+
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    ASSERT_EQ(expected.size(), 2);
+    ASSERT_EQ(expected[0].get("/parentObjt_1/field2check")->GetInt(), 110);
+    ASSERT_EQ(expected[1].get("/parentObjt_1/field2check")->GetInt(), 100);
+}
+
+TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_div)
+{
+    Document doc{R"({
+        "check":
+            {"parentObjt_1.field2check": "+i_calc/div/$parentObjt_2.ref_key"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            // sorted
+            s.on_next(Event{R"(
+                {
+                    "parentObjt_1": {
+                        "field2check": 10,
+                        "ref_key": 10
+                    },
+                    "parentObjt_2": {
+                        "field2check": 11,
+                        "ref_key": 11
+                    }
+                }
+            )"});
+            // not sorted
+            s.on_next(Event{R"(
+                {
+                    "parentObjt_2": {
+                        "field2check": 11,
+                        "ref_key": 10
+                    },
+                    "parentObjt_1": {
+                        "field2check": 10,
+                        "ref_key": 11
+                    }
+                }
+            )"});
+            s.on_completed();
+        });
+
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    ASSERT_EQ(expected.size(), 2);
+    ASSERT_EQ(expected[0].get("/parentObjt_1/field2check")->GetInt(), 0);
+    ASSERT_EQ(expected[1].get("/parentObjt_1/field2check")->GetInt(), 1);
+}

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
@@ -8,10 +8,9 @@
  */
 
 #include <gtest/gtest.h>
-#include <testUtils.hpp>
-
 #include <vector>
 
+#include "testUtils.hpp"
 #include "OpBuilderHelperMap.hpp"
 
 using namespace builder::internals::builders;
@@ -19,63 +18,68 @@ using namespace builder::internals::builders;
 TEST(opBuilderHelperIntCalc, Builds)
 {
     Document doc{R"({
-        "check":
+        "normalice":
             {"field_test": "+i_calc/sum/10"}
     })"};
-    ASSERT_NO_THROW(opBuilderHelperIntCalc(*doc.get("/check")));
+
+    ASSERT_NO_THROW(opBuilderHelperIntCalc(*doc.get("/normalice")));
 }
 
 TEST(opBuilderHelperIntCalc, Builds_error_bad_parameter)
 {
     Document doc{R"({
-        "check":
+        "normalice":
             {"field_test": "+i_calc/test/test"}
     })"};
-    ASSERT_THROW(opBuilderHelperIntCalc(*doc.get("/check")), std::runtime_error);
+
+    ASSERT_THROW(opBuilderHelperIntCalc(*doc.get("/normalice")), std::runtime_error);
 }
 
 TEST(opBuilderHelperIntCalc, Builds_error_less_parameters)
 {
     Document doc{R"({
-        "check":
+        "normalice":
             {"field_test": "+i_calc/10"}
     })"};
-    ASSERT_THROW(opBuilderHelperIntCalc(*doc.get("/check")), std::runtime_error);
+
+    ASSERT_THROW(opBuilderHelperIntCalc(*doc.get("/normalice")), std::runtime_error);
 }
 
 
 TEST(opBuilderHelperIntCalc, Builds_error_more_parameters)
 {
     Document doc{R"({
-        "check":
+        "normalice":
             {"field_test": "+i_calc/10/10/10"}
     })"};
-    ASSERT_THROW(opBuilderHelperIntCalc(*doc.get("/check")), std::runtime_error);
+
+    ASSERT_THROW(opBuilderHelperIntCalc(*doc.get("/normalice")), std::runtime_error);
 }
 
 TEST(opBuilderHelperIntCalc, Builds_error_bad_operator)
 {
     Document doc{R"({
-        "check":
+        "normalice":
             {"field_test": "+i_calc/^/10"}
     })"};
-    ASSERT_THROW(opBuilderHelperIntCalc(*doc.get("/check")), std::runtime_error);
+
+    ASSERT_THROW(opBuilderHelperIntCalc(*doc.get("/normalice")), std::runtime_error);
 }
 
-//TODO test division by zero
 TEST(opBuilderHelperIntCalc, Builds_error_zero_division)
 {
     Document doc{R"({
-        "check":
+        "normalice":
             {"field_test": "+i_calc/div/0"}
     })"};
-    ASSERT_THROW(opBuilderHelperIntCalc(*doc.get("/check")), std::runtime_error);
+
+    ASSERT_THROW(opBuilderHelperIntCalc(*doc.get("/normalice")), std::runtime_error);
 }
 
 TEST(opBuilderHelperIntCalc, Exec_equal_ok)
 {
     Document doc{R"({
-        "check":
+        "normalice":
             {"field_test": "+i_calc/sum/10"}
     })"};
 
@@ -96,10 +100,12 @@ TEST(opBuilderHelperIntCalc, Exec_equal_ok)
             )"});
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
+
     ASSERT_EQ(expected.size(), 4);
     ASSERT_EQ(expected[0].get("/field_test")->GetInt(),19);
     ASSERT_EQ(expected[1].get("/field_test")->GetInt(),20);
@@ -111,7 +117,7 @@ TEST(opBuilderHelperIntCalc, Exec_equal_ok)
 TEST(opBuilderHelperIntCalc, Exec_sum_int)
 {
     Document doc{R"({
-        "check":
+        "normalice":
             {"field_test": "+i_calc/sum/10"}
     })"};
 
@@ -138,10 +144,12 @@ TEST(opBuilderHelperIntCalc, Exec_sum_int)
             )"});
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
+
     ASSERT_EQ(expected.size(), 6);
     ASSERT_EQ(expected[0].get("/field_test")->GetInt(),10);
     ASSERT_EQ(expected[1].get("/field_test")->GetInt(),19);
@@ -155,7 +163,7 @@ TEST(opBuilderHelperIntCalc, Exec_sum_int)
 TEST(opBuilderHelperIntCalc, Exec_sub_int)
 {
     Document doc{R"({
-        "check":
+        "normalice":
             {"field_test": "+i_calc/sub/10"}
     })"};
 
@@ -182,10 +190,12 @@ TEST(opBuilderHelperIntCalc, Exec_sub_int)
             )"});
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
+
     ASSERT_EQ(expected.size(), 6);
     ASSERT_EQ(expected[0].get("/field_test")->GetInt(),-10);
     ASSERT_EQ(expected[1].get("/field_test")->GetInt(),-1);
@@ -199,7 +209,7 @@ TEST(opBuilderHelperIntCalc, Exec_sub_int)
 TEST(opBuilderHelperIntCalc, Exec_mult_int)
 {
     Document doc{R"({
-        "check":
+        "normalice":
             {"field_test": "+i_calc/mul/10"}
     })"};
 
@@ -226,10 +236,12 @@ TEST(opBuilderHelperIntCalc, Exec_mult_int)
             )"});
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
+
     ASSERT_EQ(expected.size(), 6);
     ASSERT_EQ(expected[0].get("/field_test")->GetInt(),0);
     ASSERT_EQ(expected[1].get("/field_test")->GetInt(),90);
@@ -243,7 +255,7 @@ TEST(opBuilderHelperIntCalc, Exec_mult_int)
 TEST(opBuilderHelperIntCalc, Exec_div_int)
 {
     Document doc{R"({
-        "check":
+        "normalice":
             {"field_test": "+i_calc/div/10"}
     })"};
 
@@ -270,10 +282,12 @@ TEST(opBuilderHelperIntCalc, Exec_div_int)
             )"});
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
+
     ASSERT_EQ(expected.size(), 6);
     ASSERT_EQ(expected[0].get("/field_test")->GetInt(),0);
     ASSERT_EQ(expected[1].get("/field_test")->GetInt(),0);
@@ -287,7 +301,7 @@ TEST(opBuilderHelperIntCalc, Exec_div_int)
 TEST(opBuilderHelperIntCalc, Exec_sum_ref)
 {
     Document doc{R"({
-        "check":
+        "normalice":
             {"field_test": "+i_calc/sum/$field_src"}
     })"};
 
@@ -320,14 +334,11 @@ TEST(opBuilderHelperIntCalc, Exec_sum_ref)
             )"});
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
     Observable output = lift(input);
     vector<Event> expected;
-    output.subscribe([&](Event e) { expected.push_back(e); });
 
-    auto str2Int = [](std::string s) {
-        return std::stoi(s);
-    };
+    output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 8);
     ASSERT_EQ(expected[0].get("/field_test")->GetInt(),10);
@@ -344,7 +355,7 @@ TEST(opBuilderHelperIntCalc, Exec_sum_ref)
 TEST(opBuilderHelperIntCalc, Exec_sub_ref)
 {
     Document doc{R"({
-        "check":
+        "normalice":
             {"field_test": "+i_calc/sub/$field_src"}
     })"};
 
@@ -377,14 +388,11 @@ TEST(opBuilderHelperIntCalc, Exec_sub_ref)
             )"});
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
     Observable output = lift(input);
     vector<Event> expected;
-    output.subscribe([&](Event e) { expected.push_back(e); });
 
-    auto str2Int = [](std::string s) {
-        return std::stoi(s);
-    };
+    output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 8);
     ASSERT_EQ(expected[0].get("/field_test")->GetInt(),-10);
@@ -401,7 +409,7 @@ TEST(opBuilderHelperIntCalc, Exec_sub_ref)
 TEST(opBuilderHelperIntCalc, Exec_mult_ref)
 {
     Document doc{R"({
-        "check":
+        "normalice":
             {"field_test": "+i_calc/mul/$field_src"}
     })"};
 
@@ -434,14 +442,11 @@ TEST(opBuilderHelperIntCalc, Exec_mult_ref)
             )"});
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
     Observable output = lift(input);
     vector<Event> expected;
-    output.subscribe([&](Event e) { expected.push_back(e); });
 
-    auto str2Int = [](std::string s) {
-        return std::stoi(s);
-    };
+    output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 8);
     ASSERT_EQ(expected[0].get("/field_test")->GetInt(),0);
@@ -458,7 +463,7 @@ TEST(opBuilderHelperIntCalc, Exec_mult_ref)
 TEST(opBuilderHelperIntCalc, Exec_div_ref)
 {
     Document doc{R"({
-        "check":
+        "normalice":
             {"field_test": "+i_calc/div/$field_src"}
     })"};
 
@@ -491,14 +496,11 @@ TEST(opBuilderHelperIntCalc, Exec_div_ref)
             )"});
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
     Observable output = lift(input);
     vector<Event> expected;
-    output.subscribe([&](Event e) { expected.push_back(e); });
 
-    auto str2Int = [](std::string s) {
-        return std::stoi(s);
-    };
+    output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 8);
     ASSERT_EQ(expected[0].get("/field_test")->GetInt(),0);
@@ -515,7 +517,7 @@ TEST(opBuilderHelperIntCalc, Exec_div_ref)
 TEST(opBuilderHelperIntCalc, Exec_div_ref_zero)
 {
     Document doc{R"({
-        "check":
+        "normalice":
             {"field_test": "+i_calc/div/$field_src"}
     })"};
 
@@ -548,14 +550,11 @@ TEST(opBuilderHelperIntCalc, Exec_div_ref_zero)
             )"});
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
     Observable output = lift(input);
     vector<Event> expected;
-    output.subscribe([&](Event e) { expected.push_back(e); });
 
-    auto str2Int = [](std::string s) {
-        return std::stoi(s);
-    };
+    output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 8);
     ASSERT_EQ(expected[0].get("/field_test")->GetInt(),0);
@@ -572,7 +571,7 @@ TEST(opBuilderHelperIntCalc, Exec_div_ref_zero)
 TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sum)
 {
     Document doc{R"({
-        "check":
+        "normalice":
             {"parentObjt_1.field2check": "+i_calc/sum/$parentObjt_2.ref_key"}
     })"};
 
@@ -608,9 +607,10 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sum)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
@@ -621,7 +621,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sum)
 TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sub)
 {
     Document doc{R"({
-        "check":
+        "normalice":
             {"parentObjt_1.field2check": "+i_calc/sub/$parentObjt_2.ref_key"}
     })"};
 
@@ -657,9 +657,10 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sub)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
@@ -670,7 +671,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sub)
 TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_mul)
 {
     Document doc{R"({
-        "check":
+        "normalice":
             {"parentObjt_1.field2check": "+i_calc/mul/$parentObjt_2.ref_key"}
     })"};
 
@@ -706,9 +707,10 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_mul)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
@@ -719,7 +721,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_mul)
 TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_div)
 {
     Document doc{R"({
-        "check":
+        "normalice":
             {"parentObjt_1.field2check": "+i_calc/div/$parentObjt_2.ref_key"}
     })"};
 
@@ -755,9 +757,10 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_div)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperIntCalc(*doc.get("/check"));
+    Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntEqual_test.cpp
@@ -31,7 +31,7 @@ TEST(opBuilderHelperIntEqual, Builds_error_bad_parameter)
         "check":
             {"field_test": "+int/test"}
     })"};
-    ASSERT_THROW(opBuilderHelperIntEqual(*doc.get("/check")), std::runtime_error);
+    ASSERT_THROW(opBuilderHelperIntEqual(*doc.get("/check")), std::invalid_argument);
 }
 
 TEST(opBuilderHelperIntEqual, Builds_error_more_parameters)
@@ -154,28 +154,28 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ref_true)
         [=](auto s)
         {
             s.on_next(Event{R"(
-                {{"field_test":9},{"field_src":10}}
+                {"field_test": 9,"field_src": 10}
             )"});
             s.on_next(Event{R"(
-                {{"field_test":10},{"field_src":10}}
+                {"field_test":10,"field_src":10}
             )"});
             s.on_next(Event{R"(
-                {{"field_test":10},{"field_src":10}}
+                {"field_test":10,"field_src":10}
             )"});
             s.on_next(Event{R"(
-                {{"field_test":10},{"field_src":"10"}}
+                {"field_test":10,"field_src":"10"}
             )"});
             s.on_next(Event{R"(
-                {{"field_test":"10"},{"field_src":10}}
+                {"field_test":"10","field_src":10}
             )"});
             s.on_next(Event{R"(
-                {{"field_test":"10"},{"field_src":"10"}}
+                {"field_test":"10","field_src":"10"}
             )"});
             s.on_next(Event{R"(
-                {{"field_test":11},{"field_src":"10"}}
+                {"field_test":11,"field_src":"10"}
             )"});
             s.on_next(Event{R"(
-                {{"field_test":10},{"field_src":"test"}}
+                {"field_test":10,"field_src":"test"}
             )"});
             s.on_completed();
         });
@@ -188,17 +188,11 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ref_true)
         return std::stoi(s);
     };
 
-    ASSERT_EQ(expected.size(), 5);
+    ASSERT_EQ(expected.size(), 2);
     ASSERT_EQ(expected[0].get("/field_test")->GetInt(),
               expected[0].get("/field_src")->GetInt());
     ASSERT_EQ(expected[1].get("/field_test")->GetInt(),
               expected[0].get("/field_src")->GetInt());
-    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),
-              str2Int(expected[0].get("/field_src")->GetString()));
-    ASSERT_EQ(str2Int(expected[1].get("/field_test")->GetString()),
-              expected[0].get("/field_src")->GetInt());
-    ASSERT_EQ(str2Int(expected[1].get("/field_test")->GetString()),
-              str2Int(expected[0].get("/field_src")->GetString()));
 
 }
 
@@ -213,28 +207,28 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ref_false)
         [=](auto s)
         {
             s.on_next(Event{R"(
-                {{"field_test2":9},{"field_src":10}}
+                {"field_test2":9,"field_src":10}
             )"});
             s.on_next(Event{R"(
-                {{"field_test":10},{"field_src3":10}}
+                {"field_test":10,"field_src3":10}
             )"});
             s.on_next(Event{R"(
-                {{"field_test":10},{"field_src4":10}}
+                {"field_test":10,"field_src4":10}
             )"});
             s.on_next(Event{R"(
-                {{"field_test5":10},{"field_src":"10"}}
+                {"field_test5":10,"field_src":"10"}
             )"});
             s.on_next(Event{R"(
-                {{"field_test6":"10"},{"field_src2":10}}
+                {"field_test6":"10","field_src2":10}
             )"});
             s.on_next(Event{R"(
-                {{"field_":"10"},{"field_src":"10"}}
+                {"field_":"10","field_src":"10"}
             )"});
             s.on_next(Event{R"(
-                {{"field_test":11},{"field_src2":"10"}}
+                {"field_test":11,"field_src2":"10"}
             )"});
             s.on_next(Event{R"(
-                {{"field_test2":10},{"field_src2":"test"}}
+                {"field_test2":10,"field_src2":"test"}
             )"});
             s.on_completed();
         });

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntEqual_test.cpp
@@ -1,0 +1,252 @@
+/* Copyright (C) 2015-2021, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <gtest/gtest.h>
+#include <testUtils.hpp>
+
+#include <vector>
+
+#include "OpBuilderHelperFilter.hpp"
+
+using namespace builder::internals::builders;
+
+TEST(opBuilderHelperIntEqual, Builds)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+int/10"}
+    })"};
+    ASSERT_NO_THROW(opBuilderHelperIntEqual(*doc.get("/check")));
+}
+
+TEST(opBuilderHelperIntEqual, Builds_error_bad_parameter)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+int/test"}
+    })"};
+    ASSERT_THROW(opBuilderHelperIntEqual(*doc.get("/check")), std::runtime_error);
+}
+
+TEST(opBuilderHelperIntEqual, Builds_error_more_parameters)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+int/10/10"}
+    })"};
+    ASSERT_THROW(opBuilderHelperIntEqual(*doc.get("/check")), std::runtime_error);
+}
+
+TEST(opBuilderHelperIntEqual, Exec_equal_ok)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+int/10"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test":9}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 2);
+    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),10);
+    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),10);
+
+}
+
+TEST(opBuilderHelperIntEqual, Exec_equal_true)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+int/10"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test":9}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 2);
+    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),10);
+    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),10);
+
+}
+
+TEST(opBuilderHelperIntEqual, Exec_equal_false)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+int/10"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test":9}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test2":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test3":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 0);
+
+}
+
+TEST(opBuilderHelperIntEqual, Exec_equal_ref_true)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+int/$field_src"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {{"field_test":9},{"field_src":10}}
+            )"});
+            s.on_next(Event{R"(
+                {{"field_test":10},{"field_src":10}}
+            )"});
+            s.on_next(Event{R"(
+                {{"field_test":10},{"field_src":10}}
+            )"});
+            s.on_next(Event{R"(
+                {{"field_test":10},{"field_src":"10"}}
+            )"});
+            s.on_next(Event{R"(
+                {{"field_test":"10"},{"field_src":10}}
+            )"});
+            s.on_next(Event{R"(
+                {{"field_test":"10"},{"field_src":"10"}}
+            )"});
+            s.on_next(Event{R"(
+                {{"field_test":11},{"field_src":"10"}}
+            )"});
+            s.on_next(Event{R"(
+                {{"field_test":10},{"field_src":"test"}}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    auto str2Int = [](std::string s) {
+        return std::stoi(s);
+    };
+
+    ASSERT_EQ(expected.size(), 5);
+    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),
+              expected[0].get("/field_src")->GetInt());
+    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),
+              expected[0].get("/field_src")->GetInt());
+    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),
+              str2Int(expected[0].get("/field_src")->GetString()));
+    ASSERT_EQ(str2Int(expected[1].get("/field_test")->GetString()),
+              expected[0].get("/field_src")->GetInt());
+    ASSERT_EQ(str2Int(expected[1].get("/field_test")->GetString()),
+              str2Int(expected[0].get("/field_src")->GetString()));
+
+}
+
+TEST(opBuilderHelperIntEqual, Exec_equal_ref_false)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+int/$field_src"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {{"field_test2":9},{"field_src":10}}
+            )"});
+            s.on_next(Event{R"(
+                {{"field_test":10},{"field_src3":10}}
+            )"});
+            s.on_next(Event{R"(
+                {{"field_test":10},{"field_src4":10}}
+            )"});
+            s.on_next(Event{R"(
+                {{"field_test5":10},{"field_src":"10"}}
+            )"});
+            s.on_next(Event{R"(
+                {{"field_test6":"10"},{"field_src2":10}}
+            )"});
+            s.on_next(Event{R"(
+                {{"field_":"10"},{"field_src":"10"}}
+            )"});
+            s.on_next(Event{R"(
+                {{"field_test":11},{"field_src2":"10"}}
+            )"});
+            s.on_next(Event{R"(
+                {{"field_test2":10},{"field_src2":"test"}}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    auto str2Int = [](std::string s) {
+        return std::stoi(s);
+    };
+
+    ASSERT_EQ(expected.size(), 0);
+
+}

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntEqual_test.cpp
@@ -8,10 +8,9 @@
  */
 
 #include <gtest/gtest.h>
-#include <testUtils.hpp>
-
 #include <vector>
 
+#include "testUtils.hpp"
 #include "OpBuilderHelperFilter.hpp"
 
 using namespace builder::internals::builders;
@@ -22,6 +21,7 @@ TEST(opBuilderHelperIntEqual, Builds)
         "check":
             {"field_test": "+i_eq/10"}
     })"};
+
     ASSERT_NO_THROW(opBuilderHelperIntEqual(*doc.get("/check")));
 }
 
@@ -31,6 +31,7 @@ TEST(opBuilderHelperIntEqual, Builds_error_bad_parameter)
         "check":
             {"field_test": "+i_eq/test"}
     })"};
+
     ASSERT_THROW(opBuilderHelperIntEqual(*doc.get("/check")), std::invalid_argument);
 }
 
@@ -40,6 +41,7 @@ TEST(opBuilderHelperIntEqual, Builds_error_more_parameters)
         "check":
             {"field_test": "+i_eq/10/10"}
     })"};
+
     ASSERT_THROW(opBuilderHelperIntEqual(*doc.get("/check")), std::runtime_error);
 }
 
@@ -70,7 +72,9 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ok)
     Lifter lift = opBuilderHelperIntEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
+
     ASSERT_EQ(expected.size(), 2);
     ASSERT_EQ(expected[0].get("/field_test")->GetInt(), 10);
     ASSERT_EQ(expected[1].get("/field_test")->GetInt(), 10);
@@ -103,7 +107,9 @@ TEST(opBuilderHelperIntEqual, Exec_equal_true)
     Lifter lift = opBuilderHelperIntEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
+
     ASSERT_EQ(expected.size(), 2);
     ASSERT_EQ(expected[0].get("/field_test")->GetInt(), 10);
     ASSERT_EQ(expected[1].get("/field_test")->GetInt(), 10);
@@ -136,7 +142,9 @@ TEST(opBuilderHelperIntEqual, Exec_equal_false)
     Lifter lift = opBuilderHelperIntEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
+
     ASSERT_EQ(expected.size(), 0);
 }
 
@@ -180,8 +188,6 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ref_true)
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
-
-    auto str2Int = [](std::string s) { return std::stoi(s); };
 
     ASSERT_EQ(expected.size(), 2);
     ASSERT_EQ(expected[0].get("/field_test")->GetInt(),
@@ -231,8 +237,6 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ref_false)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
 
-    auto str2Int = [](std::string s) { return std::stoi(s); };
-
     ASSERT_EQ(expected.size(), 0);
 }
 
@@ -273,6 +277,7 @@ TEST(opBuilderHelperIntEqual, Exec_dynamics_int_ok)
     Lifter lift = opBuilderHelperIntEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
@@ -347,6 +352,7 @@ TEST(opBuilderHelperIntEqual, Exec_multilevel_dynamics_int_ok)
     Lifter lift = opBuilderHelperIntEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntEqual_test.cpp
@@ -72,9 +72,8 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),10);
-    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),10);
-
+    ASSERT_EQ(expected[0].get("/field_test")->GetInt(), 10);
+    ASSERT_EQ(expected[1].get("/field_test")->GetInt(), 10);
 }
 
 TEST(opBuilderHelperIntEqual, Exec_equal_true)
@@ -106,9 +105,8 @@ TEST(opBuilderHelperIntEqual, Exec_equal_true)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),10);
-    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),10);
-
+    ASSERT_EQ(expected[0].get("/field_test")->GetInt(), 10);
+    ASSERT_EQ(expected[1].get("/field_test")->GetInt(), 10);
 }
 
 TEST(opBuilderHelperIntEqual, Exec_equal_false)
@@ -140,7 +138,6 @@ TEST(opBuilderHelperIntEqual, Exec_equal_false)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 0);
-
 }
 
 TEST(opBuilderHelperIntEqual, Exec_equal_ref_true)
@@ -184,16 +181,13 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ref_true)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
 
-    auto str2Int = [](std::string s) {
-        return std::stoi(s);
-    };
+    auto str2Int = [](std::string s) { return std::stoi(s); };
 
     ASSERT_EQ(expected.size(), 2);
     ASSERT_EQ(expected[0].get("/field_test")->GetInt(),
               expected[0].get("/field_src")->GetInt());
     ASSERT_EQ(expected[1].get("/field_test")->GetInt(),
               expected[0].get("/field_src")->GetInt());
-
 }
 
 TEST(opBuilderHelperIntEqual, Exec_equal_ref_false)
@@ -237,10 +231,125 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ref_false)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
 
-    auto str2Int = [](std::string s) {
-        return std::stoi(s);
-    };
+    auto str2Int = [](std::string s) { return std::stoi(s); };
 
     ASSERT_EQ(expected.size(), 0);
+}
 
+TEST(opBuilderHelperIntEqual, Exec_dynamics_int_ok)
+{
+    Document doc{R"({
+        "check":
+            {"field2check": "+i_eq/$ref_key"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            // Greater
+            s.on_next(Event{R"(
+                {
+                    "field2check":11,
+                    "ref_key":10
+                }
+            )"});
+            // Equal
+            s.on_next(Event{R"(
+                {
+                    "field2check":10,
+                    "ref_key":10
+                }
+            )"});
+            // Less
+            s.on_next(Event{R"(
+                {
+                    "field2check":10,
+                    "ref_key":11
+                }
+            )"});
+            s.on_completed();
+        });
+
+    Lifter lift = opBuilderHelperIntEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    ASSERT_EQ(expected.size(), 1);
+    ASSERT_EQ(expected[0].get("/field2check")->GetInt(),
+              expected[0].get("/ref_key")->GetInt());
+}
+
+TEST(opBuilderHelperIntEqual, Exec_multilevel_dynamics_int_ok)
+{
+    Document doc{R"({
+        "check":
+            {"parentObjt_1.field2check": "+i_eq/$parentObjt_2.ref_key"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {
+                    "parentObjt_2": {
+                        "field2check": 10,
+                        "ref_key": 10
+                    },
+                    "parentObjt_1": {
+                        "field2check": 11,
+                        "ref_key": 11
+                    }
+                }
+            )"});
+
+            s.on_next(Event{R"(
+                {
+                    "parentObjt_2": {
+                        "field2check": 11,
+                        "ref_key": 10
+                    },
+                    "parentObjt_1": {
+                        "field2check": 10,
+                        "ref_key": 11
+                    }
+                }
+            )"});
+
+            s.on_next(Event{R"(
+                {
+                    "parentObjt_2": {
+                        "field2check":10,
+                        "ref_key":10
+                    },
+                    "parentObjt_1": {
+                        "otherfield":12,
+                        "ref_key":11
+                    }
+                }
+            )"});
+
+            s.on_next(Event{R"(
+                {
+                    "parentObjt_2": {
+                        "field2check":10,
+                        "otherfield":10
+                    },
+                    "parentObjt_1": {
+                        "field2check":12,
+                        "ref_key":11
+                    }
+                }
+            )"});
+            s.on_completed();
+        });
+
+    Lifter lift = opBuilderHelperIntEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    ASSERT_EQ(expected.size(), 1);
+    ASSERT_EQ(expected[0].get("/parentObjt_1/field2check")->GetInt(),
+              expected[0].get("/parentObjt_2/ref_key")->GetInt());
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThanEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThanEqual_test.cpp
@@ -1,0 +1,248 @@
+/* Copyright (C) 2015-2021, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <gtest/gtest.h>
+#include <testUtils.hpp>
+
+#include <vector>
+
+#include "OpBuilderHelperFilter.hpp"
+
+using namespace builder::internals::builders;
+
+TEST(opBuilderHelperIntGreaterThanEqual, Builds)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/10"}
+    })"};
+    ASSERT_NO_THROW(opBuilderHelperIntGreaterThanEqual(*doc.get("/check")));
+}
+
+TEST(opBuilderHelperIntGreaterThanEqual, Builds_error_bad_parameter)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/test"}
+    })"};
+    ASSERT_THROW(opBuilderHelperIntGreaterThanEqual(*doc.get("/check")), std::invalid_argument);
+}
+
+TEST(opBuilderHelperIntGreaterThanEqual, Builds_error_more_parameters)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/10/10"}
+    })"};
+    ASSERT_THROW(opBuilderHelperIntGreaterThanEqual(*doc.get("/check")), std::runtime_error);
+}
+
+TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ok)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/10"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test":9}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntGreaterThanEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 3);
+    ASSERT_GE(expected[0].get("/field_test")->GetInt(),10);
+    ASSERT_GE(expected[1].get("/field_test")->GetInt(),10);
+    ASSERT_GE(expected[2].get("/field_test")->GetInt(),10);
+
+}
+
+TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_true)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/10"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test":9}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntGreaterThanEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 3);
+    ASSERT_GE(expected[0].get("/field_test")->GetInt(), 10);
+    ASSERT_GE(expected[1].get("/field_test")->GetInt(), 10);
+    ASSERT_GE(expected[2].get("/field_test")->GetInt(), 11);
+
+}
+
+TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_false)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/10"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test":9}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test2":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test3":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":8}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntGreaterThanEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 0);
+
+}
+
+TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ref_true)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/$field_src"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test": 10,"field_src": 10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":"11","field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":"11","field_src":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src":"test"}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntGreaterThanEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    auto str2Int = [](std::string s) {
+        return std::stoi(s);
+    };
+
+    ASSERT_EQ(expected.size(), 3);
+    ASSERT_GE(expected[0].get("/field_test")->GetInt(),
+              expected[0].get("/field_src")->GetInt());
+    ASSERT_GE(expected[1].get("/field_test")->GetInt(),
+              expected[1].get("/field_src")->GetInt());
+
+}
+
+TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ref_false)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/$field_src"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test2":11,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src3":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src4":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test5":11,"field_src":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test6":"11","field_src2":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_":"11","field_src":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src2":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test2":11,"field_src2":"test"}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntGreaterThanEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    auto str2Int = [](std::string s) {
+        return std::stoi(s);
+    };
+
+    ASSERT_EQ(expected.size(), 0);
+
+}

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThanEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThanEqual_test.cpp
@@ -8,10 +8,9 @@
  */
 
 #include <gtest/gtest.h>
-#include <testUtils.hpp>
-
 #include <vector>
 
+#include "testUtils.hpp"
 #include "OpBuilderHelperFilter.hpp"
 
 using namespace builder::internals::builders;
@@ -22,6 +21,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Builds)
         "check":
             {"field_test": "+i_lt/10"}
     })"};
+
     ASSERT_NO_THROW(opBuilderHelperIntGreaterThanEqual(*doc.get("/check")));
 }
 
@@ -31,6 +31,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Builds_error_bad_parameter)
         "check":
             {"field_test": "+i_lt/test"}
     })"};
+
     ASSERT_THROW(opBuilderHelperIntGreaterThanEqual(*doc.get("/check")),
                  std::invalid_argument);
 }
@@ -41,6 +42,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Builds_error_more_parameters)
         "check":
             {"field_test": "+i_lt/10/10"}
     })"};
+
     ASSERT_THROW(opBuilderHelperIntGreaterThanEqual(*doc.get("/check")),
                  std::runtime_error);
 }
@@ -72,7 +74,9 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ok)
     Lifter lift = opBuilderHelperIntGreaterThanEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
+
     ASSERT_EQ(expected.size(), 3);
     ASSERT_GE(expected[0].get("/field_test")->GetInt(), 10);
     ASSERT_GE(expected[1].get("/field_test")->GetInt(), 10);
@@ -106,7 +110,9 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_true)
     Lifter lift = opBuilderHelperIntGreaterThanEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
+
     ASSERT_EQ(expected.size(), 3);
     ASSERT_GE(expected[0].get("/field_test")->GetInt(), 10);
     ASSERT_GE(expected[1].get("/field_test")->GetInt(), 10);
@@ -140,7 +146,9 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_false)
     Lifter lift = opBuilderHelperIntGreaterThanEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
+
     ASSERT_EQ(expected.size(), 0);
 }
 
@@ -183,9 +191,8 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ref_true)
     Lifter lift = opBuilderHelperIntGreaterThanEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
-    output.subscribe([&](Event e) { expected.push_back(e); });
 
-    auto str2Int = [](std::string s) { return std::stoi(s); };
+    output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
     ASSERT_GE(expected[0].get("/field_test")->GetInt(),
@@ -233,9 +240,8 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ref_false)
     Lifter lift = opBuilderHelperIntGreaterThanEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
-    output.subscribe([&](Event e) { expected.push_back(e); });
 
-    auto str2Int = [](std::string s) { return std::stoi(s); };
+    output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 0);
 }
@@ -277,6 +283,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_dynamics_int_ok)
     Lifter lift = opBuilderHelperIntGreaterThanEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
@@ -353,6 +360,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_multilevel_dynamics_int_ok)
     Lifter lift = opBuilderHelperIntGreaterThanEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThanEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThanEqual_test.cpp
@@ -31,7 +31,8 @@ TEST(opBuilderHelperIntGreaterThanEqual, Builds_error_bad_parameter)
         "check":
             {"field_test": "+i_lt/test"}
     })"};
-    ASSERT_THROW(opBuilderHelperIntGreaterThanEqual(*doc.get("/check")), std::invalid_argument);
+    ASSERT_THROW(opBuilderHelperIntGreaterThanEqual(*doc.get("/check")),
+                 std::invalid_argument);
 }
 
 TEST(opBuilderHelperIntGreaterThanEqual, Builds_error_more_parameters)
@@ -40,7 +41,8 @@ TEST(opBuilderHelperIntGreaterThanEqual, Builds_error_more_parameters)
         "check":
             {"field_test": "+i_lt/10/10"}
     })"};
-    ASSERT_THROW(opBuilderHelperIntGreaterThanEqual(*doc.get("/check")), std::runtime_error);
+    ASSERT_THROW(opBuilderHelperIntGreaterThanEqual(*doc.get("/check")),
+                 std::runtime_error);
 }
 
 TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ok)
@@ -72,10 +74,9 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_GE(expected[0].get("/field_test")->GetInt(),10);
-    ASSERT_GE(expected[1].get("/field_test")->GetInt(),10);
-    ASSERT_GE(expected[2].get("/field_test")->GetInt(),10);
-
+    ASSERT_GE(expected[0].get("/field_test")->GetInt(), 10);
+    ASSERT_GE(expected[1].get("/field_test")->GetInt(), 10);
+    ASSERT_GE(expected[2].get("/field_test")->GetInt(), 10);
 }
 
 TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_true)
@@ -110,7 +111,6 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_true)
     ASSERT_GE(expected[0].get("/field_test")->GetInt(), 10);
     ASSERT_GE(expected[1].get("/field_test")->GetInt(), 10);
     ASSERT_GE(expected[2].get("/field_test")->GetInt(), 11);
-
 }
 
 TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_false)
@@ -142,7 +142,6 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_false)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 0);
-
 }
 
 TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ref_true)
@@ -186,16 +185,13 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ref_true)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
 
-    auto str2Int = [](std::string s) {
-        return std::stoi(s);
-    };
+    auto str2Int = [](std::string s) { return std::stoi(s); };
 
     ASSERT_EQ(expected.size(), 3);
     ASSERT_GE(expected[0].get("/field_test")->GetInt(),
               expected[0].get("/field_src")->GetInt());
     ASSERT_GE(expected[1].get("/field_test")->GetInt(),
               expected[1].get("/field_src")->GetInt());
-
 }
 
 TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ref_false)
@@ -239,10 +235,129 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ref_false)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
 
-    auto str2Int = [](std::string s) {
-        return std::stoi(s);
-    };
+    auto str2Int = [](std::string s) { return std::stoi(s); };
 
     ASSERT_EQ(expected.size(), 0);
+}
 
+TEST(opBuilderHelperIntGreaterThanEqual, Exec_dynamics_int_ok)
+{
+    Document doc{R"({
+        "check":
+            {"field2check": "+i_eq/$ref_key"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            // Greater
+            s.on_next(Event{R"(
+                {
+                    "field2check":11,
+                    "ref_key":10
+                }
+            )"});
+            // Equal
+            s.on_next(Event{R"(
+                {
+                    "field2check":10,
+                    "ref_key":10
+                }
+            )"});
+            // Less
+            s.on_next(Event{R"(
+                {
+                    "field2check":10,
+                    "ref_key":11
+                }
+            )"});
+            s.on_completed();
+        });
+
+    Lifter lift = opBuilderHelperIntGreaterThanEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    ASSERT_EQ(expected.size(), 2);
+    ASSERT_GE(expected[0].get("/field2check")->GetInt(),
+              expected[0].get("/ref_key")->GetInt());
+    ASSERT_GE(expected[1].get("/field2check")->GetInt(),
+              expected[1].get("/ref_key")->GetInt());
+}
+
+TEST(opBuilderHelperIntGreaterThanEqual, Exec_multilevel_dynamics_int_ok)
+{
+    Document doc{R"({
+        "check":
+            {"parentObjt_1.field2check": "+i_eq/$parentObjt_2.ref_key"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {
+                    "parentObjt_2": {
+                        "field2check": 10,
+                        "ref_key": 10
+                    },
+                    "parentObjt_1": {
+                        "field2check": 11,
+                        "ref_key": 11
+                    }
+                }
+            )"});
+
+            s.on_next(Event{R"(
+                {
+                    "parentObjt_2": {
+                        "field2check": 11,
+                        "ref_key": 10
+                    },
+                    "parentObjt_1": {
+                        "field2check": 10,
+                        "ref_key": 11
+                    }
+                }
+            )"});
+
+            s.on_next(Event{R"(
+                {
+                    "parentObjt_2": {
+                        "field2check":10,
+                        "ref_key":10
+                    },
+                    "parentObjt_1": {
+                        "otherfield":12,
+                        "ref_key":11
+                    }
+                }
+            )"});
+
+            s.on_next(Event{R"(
+                {
+                    "parentObjt_2": {
+                        "field2check":10,
+                        "otherfield":10
+                    },
+                    "parentObjt_1": {
+                        "field2check":12,
+                        "ref_key":11
+                    }
+                }
+            )"});
+            s.on_completed();
+        });
+
+    Lifter lift = opBuilderHelperIntGreaterThanEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    ASSERT_EQ(expected.size(), 2);
+    ASSERT_GE(expected[0].get("/parentObjt_1/field2check")->GetInt(),
+              expected[0].get("/parentObjt_2/ref_key")->GetInt());
+    ASSERT_GE(expected[1].get("/parentObjt_1/field2check")->GetInt(),
+              expected[1].get("/parentObjt_2/ref_key")->GetInt());
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThan_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThan_test.cpp
@@ -1,0 +1,244 @@
+/* Copyright (C) 2015-2021, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <gtest/gtest.h>
+#include <testUtils.hpp>
+
+#include <vector>
+
+#include "OpBuilderHelperFilter.hpp"
+
+using namespace builder::internals::builders;
+
+TEST(opBuilderHelperIntGreaterThan, Builds)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/10"}
+    })"};
+    ASSERT_NO_THROW(opBuilderHelperIntGreaterThan(*doc.get("/check")));
+}
+
+TEST(opBuilderHelperIntGreaterThan, Builds_error_bad_parameter)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/test"}
+    })"};
+    ASSERT_THROW(opBuilderHelperIntGreaterThan(*doc.get("/check")), std::invalid_argument);
+}
+
+TEST(opBuilderHelperIntGreaterThan, Builds_error_more_parameters)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/10/10"}
+    })"};
+    ASSERT_THROW(opBuilderHelperIntGreaterThan(*doc.get("/check")), std::runtime_error);
+}
+
+TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ok)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/10"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test":9}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntGreaterThan(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 1);
+    ASSERT_GT(expected[0].get("/field_test")->GetInt(),10);
+
+}
+
+TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_true)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/10"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test":9}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntGreaterThan(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 1);
+    ASSERT_GT(expected[0].get("/field_test")->GetInt(), 10);
+
+}
+
+TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_false)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/10"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test":9}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test2":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test3":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":8}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntGreaterThan(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 0);
+
+}
+
+TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ref_true)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/$field_src"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test": 10,"field_src": 10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":"11","field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":"11","field_src":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src":"test"}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntGreaterThan(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    auto str2Int = [](std::string s) {
+        return std::stoi(s);
+    };
+
+    ASSERT_EQ(expected.size(), 2);
+    ASSERT_GT(expected[0].get("/field_test")->GetInt(),
+              expected[0].get("/field_src")->GetInt());
+    ASSERT_GT(expected[1].get("/field_test")->GetInt(),
+              expected[1].get("/field_src")->GetInt());
+
+}
+
+TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ref_false)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/$field_src"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test2":11,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src3":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src4":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test5":11,"field_src":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test6":"11","field_src2":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_":"11","field_src":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src2":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test2":11,"field_src2":"test"}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntGreaterThan(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    auto str2Int = [](std::string s) {
+        return std::stoi(s);
+    };
+
+    ASSERT_EQ(expected.size(), 0);
+
+}

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThan_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThan_test.cpp
@@ -8,10 +8,9 @@
  */
 
 #include <gtest/gtest.h>
-#include <testUtils.hpp>
-
 #include <vector>
 
+#include "testUtils.hpp"
 #include "OpBuilderHelperFilter.hpp"
 
 using namespace builder::internals::builders;
@@ -22,6 +21,7 @@ TEST(opBuilderHelperIntGreaterThan, Builds)
         "check":
             {"field_test": "+i_lt/10"}
     })"};
+
     ASSERT_NO_THROW(opBuilderHelperIntGreaterThan(*doc.get("/check")));
 }
 
@@ -31,6 +31,7 @@ TEST(opBuilderHelperIntGreaterThan, Builds_error_bad_parameter)
         "check":
             {"field_test": "+i_lt/test"}
     })"};
+
     ASSERT_THROW(opBuilderHelperIntGreaterThan(*doc.get("/check")),
                  std::invalid_argument);
 }
@@ -41,6 +42,7 @@ TEST(opBuilderHelperIntGreaterThan, Builds_error_more_parameters)
         "check":
             {"field_test": "+i_lt/10/10"}
     })"};
+
     ASSERT_THROW(opBuilderHelperIntGreaterThan(*doc.get("/check")), std::runtime_error);
 }
 
@@ -71,7 +73,9 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ok)
     Lifter lift = opBuilderHelperIntGreaterThan(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
+
     ASSERT_EQ(expected.size(), 1);
     ASSERT_GT(expected[0].get("/field_test")->GetInt(), 10);
 }
@@ -103,7 +107,9 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_true)
     Lifter lift = opBuilderHelperIntGreaterThan(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
+
     ASSERT_EQ(expected.size(), 1);
     ASSERT_GT(expected[0].get("/field_test")->GetInt(), 10);
 }
@@ -135,7 +141,9 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_false)
     Lifter lift = opBuilderHelperIntGreaterThan(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
+
     ASSERT_EQ(expected.size(), 0);
 }
 
@@ -178,9 +186,8 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ref_true)
     Lifter lift = opBuilderHelperIntGreaterThan(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
-    output.subscribe([&](Event e) { expected.push_back(e); });
 
-    auto str2Int = [](std::string s) { return std::stoi(s); };
+    output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
     ASSERT_GT(expected[0].get("/field_test")->GetInt(),
@@ -228,9 +235,8 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ref_false)
     Lifter lift = opBuilderHelperIntGreaterThan(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
-    output.subscribe([&](Event e) { expected.push_back(e); });
 
-    auto str2Int = [](std::string s) { return std::stoi(s); };
+    output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 0);
 }
@@ -272,6 +278,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_dynamics_int_ok)
     Lifter lift = opBuilderHelperIntGreaterThan(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
@@ -346,6 +353,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_multilevel_dynamics_int_ok)
     Lifter lift = opBuilderHelperIntGreaterThan(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThan_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThan_test.cpp
@@ -31,7 +31,8 @@ TEST(opBuilderHelperIntGreaterThan, Builds_error_bad_parameter)
         "check":
             {"field_test": "+i_lt/test"}
     })"};
-    ASSERT_THROW(opBuilderHelperIntGreaterThan(*doc.get("/check")), std::invalid_argument);
+    ASSERT_THROW(opBuilderHelperIntGreaterThan(*doc.get("/check")),
+                 std::invalid_argument);
 }
 
 TEST(opBuilderHelperIntGreaterThan, Builds_error_more_parameters)
@@ -72,8 +73,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_GT(expected[0].get("/field_test")->GetInt(),10);
-
+    ASSERT_GT(expected[0].get("/field_test")->GetInt(), 10);
 }
 
 TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_true)
@@ -106,7 +106,6 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
     ASSERT_GT(expected[0].get("/field_test")->GetInt(), 10);
-
 }
 
 TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_false)
@@ -138,7 +137,6 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_false)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 0);
-
 }
 
 TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ref_true)
@@ -182,23 +180,20 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ref_true)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
 
-    auto str2Int = [](std::string s) {
-        return std::stoi(s);
-    };
+    auto str2Int = [](std::string s) { return std::stoi(s); };
 
     ASSERT_EQ(expected.size(), 2);
     ASSERT_GT(expected[0].get("/field_test")->GetInt(),
               expected[0].get("/field_src")->GetInt());
     ASSERT_GT(expected[1].get("/field_test")->GetInt(),
               expected[1].get("/field_src")->GetInt());
-
 }
 
 TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ref_false)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+i_lt/$field_src"}
+            {"field_test": "+i_ne/$field_src"}
     })"};
 
     Observable input = observable<>::create<Event>(
@@ -208,25 +203,25 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ref_false)
                 {"field_test2":11,"field_src":10}
             )"});
             s.on_next(Event{R"(
-                {"field_test":11,"field_src3":10}
+                {"field_test":10,"field_src3":10}
             )"});
             s.on_next(Event{R"(
-                {"field_test":11,"field_src4":10}
+                {"field_test":10,"field_src4":10}
             )"});
             s.on_next(Event{R"(
-                {"field_test5":11,"field_src":"10"}
+                {"field_test5":10,"field_src":"10"}
             )"});
             s.on_next(Event{R"(
-                {"field_test6":"11","field_src2":10}
+                {"field_test6":"10","field_src2":10}
             )"});
             s.on_next(Event{R"(
-                {"field_":"11","field_src":"10"}
+                {"field_":"10","field_src":"10"}
             )"});
             s.on_next(Event{R"(
                 {"field_test":11,"field_src2":"10"}
             )"});
             s.on_next(Event{R"(
-                {"field_test2":11,"field_src2":"test"}
+                {"field_test2":10,"field_src2":"test"}
             )"});
             s.on_completed();
         });
@@ -235,10 +230,125 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ref_false)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
 
-    auto str2Int = [](std::string s) {
-        return std::stoi(s);
-    };
+    auto str2Int = [](std::string s) { return std::stoi(s); };
 
     ASSERT_EQ(expected.size(), 0);
+}
 
+TEST(opBuilderHelperIntGreaterThan, Exec_dynamics_int_ok)
+{
+    Document doc{R"({
+        "check":
+            {"field2check": "+i_eq/$ref_key"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            // Greater
+            s.on_next(Event{R"(
+                {
+                    "field2check":11,
+                    "ref_key":10
+                }
+            )"});
+            // Equal
+            s.on_next(Event{R"(
+                {
+                    "field2check":10,
+                    "ref_key":10
+                }
+            )"});
+            // Less
+            s.on_next(Event{R"(
+                {
+                    "field2check":10,
+                    "ref_key":11
+                }
+            )"});
+            s.on_completed();
+        });
+
+    Lifter lift = opBuilderHelperIntGreaterThan(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    ASSERT_EQ(expected.size(), 1);
+    ASSERT_GT(expected[0].get("/field2check")->GetInt(),
+              expected[0].get("/ref_key")->GetInt());
+}
+
+TEST(opBuilderHelperIntGreaterThan, Exec_multilevel_dynamics_int_ok)
+{
+    Document doc{R"({
+        "check":
+            {"parentObjt_1.field2check": "+i_eq/$parentObjt_2.ref_key"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {
+                    "parentObjt_2": {
+                        "field2check": 10,
+                        "ref_key": 10
+                    },
+                    "parentObjt_1": {
+                        "field2check": 11,
+                        "ref_key": 11
+                    }
+                }
+            )"});
+
+            s.on_next(Event{R"(
+                {
+                    "parentObjt_2": {
+                        "field2check": 11,
+                        "ref_key": 10
+                    },
+                    "parentObjt_1": {
+                        "field2check": 10,
+                        "ref_key": 11
+                    }
+                }
+            )"});
+
+            s.on_next(Event{R"(
+                {
+                    "parentObjt_2": {
+                        "field2check":10,
+                        "ref_key":10
+                    },
+                    "parentObjt_1": {
+                        "otherfield":12,
+                        "ref_key":11
+                    }
+                }
+            )"});
+
+            s.on_next(Event{R"(
+                {
+                    "parentObjt_2": {
+                        "field2check":10,
+                        "otherfield":10
+                    },
+                    "parentObjt_1": {
+                        "field2check":12,
+                        "ref_key":11
+                    }
+                }
+            )"});
+            s.on_completed();
+        });
+
+    Lifter lift = opBuilderHelperIntGreaterThan(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    ASSERT_EQ(expected.size(), 1);
+    ASSERT_GT(expected[0].get("/parentObjt_1/field2check")->GetInt(),
+              expected[0].get("/parentObjt_2/ref_key")->GetInt());
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntLessThanEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntLessThanEqual_test.cpp
@@ -1,0 +1,250 @@
+/* Copyright (C) 2015-2021, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <gtest/gtest.h>
+#include <testUtils.hpp>
+
+#include <vector>
+
+#include "OpBuilderHelperFilter.hpp"
+
+using namespace builder::internals::builders;
+
+TEST(opBuilderHelperIntLessThanEqual, Builds)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/10"}
+    })"};
+    ASSERT_NO_THROW(opBuilderHelperIntLessThanEqual(*doc.get("/check")));
+}
+
+TEST(opBuilderHelperIntLessThanEqual, Builds_error_bad_parameter)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/test"}
+    })"};
+    ASSERT_THROW(opBuilderHelperIntLessThanEqual(*doc.get("/check")), std::invalid_argument);
+}
+
+TEST(opBuilderHelperIntLessThanEqual, Builds_error_more_parameters)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/10/10"}
+    })"};
+    ASSERT_THROW(opBuilderHelperIntLessThanEqual(*doc.get("/check")), std::runtime_error);
+}
+
+TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ok)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/10"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test":9}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntLessThanEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 3);
+    ASSERT_LE(expected[0].get("/field_test")->GetInt(),10);
+    ASSERT_LE(expected[1].get("/field_test")->GetInt(),10);
+    ASSERT_LE(expected[2].get("/field_test")->GetInt(),10);
+
+}
+
+TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_true)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/10"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test":9}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntLessThanEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 3);
+    ASSERT_LE(expected[0].get("/field_test")->GetInt(), 10);
+    ASSERT_LE(expected[1].get("/field_test")->GetInt(), 10);
+    ASSERT_LE(expected[2].get("/field_test")->GetInt(), 10);
+
+}
+
+TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_false)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/10"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test":20}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test2":100}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test3":100}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntLessThanEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 0);
+
+}
+
+TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ref_true)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/$field_src"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test": 10,"field_src": 10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":9,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":9,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":9,"field_src":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":"9","field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":"9","field_src":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":9,"field_src":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":9,"field_src":"test"}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntLessThanEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    auto str2Int = [](std::string s) {
+        return std::stoi(s);
+    };
+
+    ASSERT_EQ(expected.size(), 3);
+    ASSERT_LE(expected[0].get("/field_test")->GetInt(),
+              expected[0].get("/field_src")->GetInt());
+    ASSERT_LE(expected[1].get("/field_test")->GetInt(),
+              expected[1].get("/field_src")->GetInt());
+    ASSERT_LE(expected[2].get("/field_test")->GetInt(),
+              expected[2].get("/field_src")->GetInt());
+
+}
+
+TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ref_false)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+i_lt/$field_src"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test2":9,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":9,"field_src3":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":9,"field_src4":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test5":9,"field_src":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test6":"9","field_src2":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_":"9","field_src":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":9,"field_src2":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test2":9,"field_src2":"test"}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntLessThanEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    auto str2Int = [](std::string s) {
+        return std::stoi(s);
+    };
+
+    ASSERT_EQ(expected.size(), 0);
+
+}

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntLessThanEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntLessThanEqual_test.cpp
@@ -8,10 +8,9 @@
  */
 
 #include <gtest/gtest.h>
-#include <testUtils.hpp>
-
 #include <vector>
 
+#include "testUtils.hpp"
 #include "OpBuilderHelperFilter.hpp"
 
 using namespace builder::internals::builders;
@@ -22,6 +21,7 @@ TEST(opBuilderHelperIntLessThanEqual, Builds)
         "check":
             {"field_test": "+i_lt/10"}
     })"};
+
     ASSERT_NO_THROW(opBuilderHelperIntLessThanEqual(*doc.get("/check")));
 }
 
@@ -31,6 +31,7 @@ TEST(opBuilderHelperIntLessThanEqual, Builds_error_bad_parameter)
         "check":
             {"field_test": "+i_lt/test"}
     })"};
+
     ASSERT_THROW(opBuilderHelperIntLessThanEqual(*doc.get("/check")),
                  std::invalid_argument);
 }
@@ -41,6 +42,7 @@ TEST(opBuilderHelperIntLessThanEqual, Builds_error_more_parameters)
         "check":
             {"field_test": "+i_lt/10/10"}
     })"};
+
     ASSERT_THROW(opBuilderHelperIntLessThanEqual(*doc.get("/check")), std::runtime_error);
 }
 
@@ -71,7 +73,9 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ok)
     Lifter lift = opBuilderHelperIntLessThanEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
+
     ASSERT_EQ(expected.size(), 3);
     ASSERT_LE(expected[0].get("/field_test")->GetInt(), 10);
     ASSERT_LE(expected[1].get("/field_test")->GetInt(), 10);
@@ -105,7 +109,9 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_true)
     Lifter lift = opBuilderHelperIntLessThanEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
+
     ASSERT_EQ(expected.size(), 3);
     ASSERT_LE(expected[0].get("/field_test")->GetInt(), 10);
     ASSERT_LE(expected[1].get("/field_test")->GetInt(), 10);
@@ -139,7 +145,9 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_false)
     Lifter lift = opBuilderHelperIntLessThanEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
+
     ASSERT_EQ(expected.size(), 0);
 }
 
@@ -182,9 +190,8 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ref_true)
     Lifter lift = opBuilderHelperIntLessThanEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
-    output.subscribe([&](Event e) { expected.push_back(e); });
 
-    auto str2Int = [](std::string s) { return std::stoi(s); };
+    output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
     ASSERT_LE(expected[0].get("/field_test")->GetInt(),
@@ -234,9 +241,8 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ref_false)
     Lifter lift = opBuilderHelperIntLessThanEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
-    output.subscribe([&](Event e) { expected.push_back(e); });
 
-    auto str2Int = [](std::string s) { return std::stoi(s); };
+    output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 0);
 }
@@ -278,6 +284,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_dynamics_int_ok)
     Lifter lift = opBuilderHelperIntLessThanEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
@@ -354,6 +361,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_multilevel_dynamics_int_ok)
     Lifter lift = opBuilderHelperIntLessThanEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntLessThan_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntLessThan_test.cpp
@@ -16,38 +16,38 @@
 
 using namespace builder::internals::builders;
 
-TEST(opBuilderHelperIntEqual, Builds)
+TEST(opBuilderHelperIntLessThan, Builds)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+i_eq/10"}
+            {"field_test": "+i_lt/10"}
     })"};
-    ASSERT_NO_THROW(opBuilderHelperIntEqual(*doc.get("/check")));
+    ASSERT_NO_THROW(opBuilderHelperIntLessThan(*doc.get("/check")));
 }
 
-TEST(opBuilderHelperIntEqual, Builds_error_bad_parameter)
+TEST(opBuilderHelperIntLessThan, Builds_error_bad_parameter)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+i_eq/test"}
+            {"field_test": "+i_lt/test"}
     })"};
-    ASSERT_THROW(opBuilderHelperIntEqual(*doc.get("/check")), std::invalid_argument);
+    ASSERT_THROW(opBuilderHelperIntLessThan(*doc.get("/check")), std::invalid_argument);
 }
 
-TEST(opBuilderHelperIntEqual, Builds_error_more_parameters)
+TEST(opBuilderHelperIntLessThan, Builds_error_more_parameters)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+i_eq/10/10"}
+            {"field_test": "+i_lt/10/10"}
     })"};
-    ASSERT_THROW(opBuilderHelperIntEqual(*doc.get("/check")), std::runtime_error);
+    ASSERT_THROW(opBuilderHelperIntLessThan(*doc.get("/check")), std::runtime_error);
 }
 
-TEST(opBuilderHelperIntEqual, Exec_equal_ok)
+TEST(opBuilderHelperIntLessThan, Exec_less_than_ok)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+i_eq/10"}
+            {"field_test": "+i_lt/10"}
     })"};
 
     Observable input = observable<>::create<Event>(
@@ -67,21 +67,20 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ok)
             )"});
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntEqual(*doc.get("/check"));
+    Lifter lift = opBuilderHelperIntLessThan(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
-    ASSERT_EQ(expected.size(), 2);
-    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),10);
-    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),10);
+    ASSERT_EQ(expected.size(), 1);
+    ASSERT_LT(expected[0].get("/field_test")->GetInt(),10);
 
 }
 
-TEST(opBuilderHelperIntEqual, Exec_equal_true)
+TEST(opBuilderHelperIntLessThan, Exec_less_than_true)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+i_eq/10"}
+            {"field_test": "+i_lt/10"}
     })"};
 
     Observable input = observable<>::create<Event>(
@@ -101,28 +100,27 @@ TEST(opBuilderHelperIntEqual, Exec_equal_true)
             )"});
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntEqual(*doc.get("/check"));
+    Lifter lift = opBuilderHelperIntLessThan(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
-    ASSERT_EQ(expected.size(), 2);
-    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),10);
-    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),10);
+    ASSERT_EQ(expected.size(), 1);
+    ASSERT_LT(expected[0].get("/field_test")->GetInt(), 10);
 
 }
 
-TEST(opBuilderHelperIntEqual, Exec_equal_false)
+TEST(opBuilderHelperIntLessThan, Exec_less_than_false)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+i_eq/10"}
+            {"field_test": "+i_lt/10"}
     })"};
 
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
             s.on_next(Event{R"(
-                {"field_test":9}
+                {"field_test":20}
             )"});
             s.on_next(Event{R"(
                 {"field_test2":10}
@@ -135,7 +133,7 @@ TEST(opBuilderHelperIntEqual, Exec_equal_false)
             )"});
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntEqual(*doc.get("/check"));
+    Lifter lift = opBuilderHelperIntLessThan(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -143,43 +141,43 @@ TEST(opBuilderHelperIntEqual, Exec_equal_false)
 
 }
 
-TEST(opBuilderHelperIntEqual, Exec_equal_ref_true)
+TEST(opBuilderHelperIntLessThan, Exec_less_than_ref_true)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+i_eq/$field_src"}
+            {"field_test": "+i_lt/$field_src"}
     })"};
 
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
             s.on_next(Event{R"(
-                {"field_test": 9,"field_src": 10}
+                {"field_test": 10,"field_src": 10}
             )"});
             s.on_next(Event{R"(
-                {"field_test":10,"field_src":10}
+                {"field_test":9,"field_src":10}
             )"});
             s.on_next(Event{R"(
-                {"field_test":10,"field_src":10}
+                {"field_test":9,"field_src":10}
             )"});
             s.on_next(Event{R"(
-                {"field_test":10,"field_src":"10"}
+                {"field_test":9,"field_src":"10"}
             )"});
             s.on_next(Event{R"(
-                {"field_test":"10","field_src":10}
+                {"field_test":"9","field_src":10}
             )"});
             s.on_next(Event{R"(
-                {"field_test":"10","field_src":"10"}
+                {"field_test":"9","field_src":"10"}
             )"});
             s.on_next(Event{R"(
-                {"field_test":11,"field_src":"10"}
+                {"field_test":9,"field_src":"10"}
             )"});
             s.on_next(Event{R"(
-                {"field_test":10,"field_src":"test"}
+                {"field_test":9,"field_src":"test"}
             )"});
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntEqual(*doc.get("/check"));
+    Lifter lift = opBuilderHelperIntLessThan(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -189,18 +187,18 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ref_true)
     };
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),
+    ASSERT_LT(expected[0].get("/field_test")->GetInt(),
               expected[0].get("/field_src")->GetInt());
-    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),
-              expected[0].get("/field_src")->GetInt());
+    ASSERT_LT(expected[1].get("/field_test")->GetInt(),
+              expected[1].get("/field_src")->GetInt());
 
 }
 
-TEST(opBuilderHelperIntEqual, Exec_equal_ref_false)
+TEST(opBuilderHelperIntLessThan, Exec_less_than_ref_false)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+i_eq/$field_src"}
+            {"field_test": "+i_lt/$field_src"}
     })"};
 
     Observable input = observable<>::create<Event>(
@@ -210,29 +208,29 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ref_false)
                 {"field_test2":9,"field_src":10}
             )"});
             s.on_next(Event{R"(
-                {"field_test":10,"field_src3":10}
+                {"field_test":9,"field_src3":10}
             )"});
             s.on_next(Event{R"(
-                {"field_test":10,"field_src4":10}
+                {"field_test":9,"field_src4":10}
             )"});
             s.on_next(Event{R"(
-                {"field_test5":10,"field_src":"10"}
+                {"field_test5":9,"field_src":"10"}
             )"});
             s.on_next(Event{R"(
-                {"field_test6":"10","field_src2":10}
+                {"field_test6":"9","field_src2":10}
             )"});
             s.on_next(Event{R"(
-                {"field_":"10","field_src":"10"}
+                {"field_":"9","field_src":"10"}
             )"});
             s.on_next(Event{R"(
-                {"field_test":11,"field_src2":"10"}
+                {"field_test":9,"field_src2":"10"}
             )"});
             s.on_next(Event{R"(
-                {"field_test2":10,"field_src2":"test"}
+                {"field_test2":9,"field_src2":"test"}
             )"});
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntEqual(*doc.get("/check"));
+    Lifter lift = opBuilderHelperIntLessThan(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntLessThan_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntLessThan_test.cpp
@@ -8,10 +8,9 @@
  */
 
 #include <gtest/gtest.h>
-#include <testUtils.hpp>
-
 #include <vector>
 
+#include "testUtils.hpp"
 #include "OpBuilderHelperFilter.hpp"
 
 using namespace builder::internals::builders;
@@ -22,6 +21,7 @@ TEST(opBuilderHelperIntLessThan, Builds)
         "check":
             {"field_test": "+i_lt/10"}
     })"};
+
     ASSERT_NO_THROW(opBuilderHelperIntLessThan(*doc.get("/check")));
 }
 
@@ -31,6 +31,7 @@ TEST(opBuilderHelperIntLessThan, Builds_error_bad_parameter)
         "check":
             {"field_test": "+i_lt/test"}
     })"};
+
     ASSERT_THROW(opBuilderHelperIntLessThan(*doc.get("/check")), std::invalid_argument);
 }
 
@@ -40,6 +41,7 @@ TEST(opBuilderHelperIntLessThan, Builds_error_more_parameters)
         "check":
             {"field_test": "+i_lt/10/10"}
     })"};
+
     ASSERT_THROW(opBuilderHelperIntLessThan(*doc.get("/check")), std::runtime_error);
 }
 
@@ -70,7 +72,9 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_ok)
     Lifter lift = opBuilderHelperIntLessThan(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
+
     ASSERT_EQ(expected.size(), 1);
     ASSERT_LT(expected[0].get("/field_test")->GetInt(), 10);
 }
@@ -102,7 +106,9 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_true)
     Lifter lift = opBuilderHelperIntLessThan(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
+
     ASSERT_EQ(expected.size(), 1);
     ASSERT_LT(expected[0].get("/field_test")->GetInt(), 10);
 }
@@ -134,7 +140,9 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_false)
     Lifter lift = opBuilderHelperIntLessThan(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
+
     ASSERT_EQ(expected.size(), 0);
 }
 
@@ -177,9 +185,8 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_ref_true)
     Lifter lift = opBuilderHelperIntLessThan(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
-    output.subscribe([&](Event e) { expected.push_back(e); });
 
-    auto str2Int = [](std::string s) { return std::stoi(s); };
+    output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
     ASSERT_LT(expected[0].get("/field_test")->GetInt(),
@@ -227,9 +234,8 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_ref_false)
     Lifter lift = opBuilderHelperIntLessThan(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
-    output.subscribe([&](Event e) { expected.push_back(e); });
 
-    auto str2Int = [](std::string s) { return std::stoi(s); };
+    output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 0);
 }
@@ -271,6 +277,7 @@ TEST(opBuilderHelperIntLessThan, Exec_dynamics_int_ok)
     Lifter lift = opBuilderHelperIntLessThan(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
@@ -345,6 +352,7 @@ TEST(opBuilderHelperIntLessThan, Exec_multilevel_dynamics_int_ok)
     Lifter lift = opBuilderHelperIntLessThan(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntNotEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntNotEqual_test.cpp
@@ -1,0 +1,246 @@
+/* Copyright (C) 2015-2021, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <gtest/gtest.h>
+#include <testUtils.hpp>
+
+#include <vector>
+
+#include "OpBuilderHelperFilter.hpp"
+
+using namespace builder::internals::builders;
+
+TEST(opBuilderHelperIntNotEqual, Builds)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+int/10"}
+    })"};
+    ASSERT_NO_THROW(opBuilderHelperIntNotEqual(*doc.get("/check")));
+}
+
+TEST(opBuilderHelperIntNotEqual, Builds_error_bad_parameter)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+int/test"}
+    })"};
+    ASSERT_THROW(opBuilderHelperIntNotEqual(*doc.get("/check")), std::invalid_argument);
+}
+
+TEST(opBuilderHelperIntNotEqual, Builds_error_more_parameters)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+int/10/10"}
+    })"};
+    ASSERT_THROW(opBuilderHelperIntNotEqual(*doc.get("/check")), std::runtime_error);
+}
+
+TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ok)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+int/10"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test":9}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntNotEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 2);
+    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),9);
+    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),11);
+
+}
+
+TEST(opBuilderHelperIntNotEqual, Exec_not_equal_true)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+int/10"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test":9}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntNotEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 2);
+    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),9);
+    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),11);
+
+}
+
+TEST(opBuilderHelperIntNotEqual, Exec_not_equal_false)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+int/10"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test2":9}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test3":11}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntNotEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 0);
+
+}
+
+TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ref_true)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+int/$field_src"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test": 9,"field_src": 10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10,"field_src":11}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10,"field_src":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":"10","field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":"10","field_src":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10,"field_src":"test"}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntNotEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    auto str2Int = [](std::string s) {
+        return std::stoi(s);
+    };
+
+    ASSERT_EQ(expected.size(), 2);
+    ASSERT_EQ(expected[0].get("/field_test")->GetInt(), 9);
+    ASSERT_EQ(10, expected[0].get("/field_src")->GetInt());
+    ASSERT_EQ(expected[1].get("/field_test")->GetInt(), 10);
+    ASSERT_EQ(11, expected[1].get("/field_src")->GetInt());
+
+}
+
+TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ref_false)
+{
+    Document doc{R"({
+        "check":
+            {"field_test": "+int/$field_src"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(Event{R"(
+                {"field_test2":9,"field_src":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10,"field_src3":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":10,"field_src4":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test5":10,"field_src":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test6":"10","field_src2":10}
+            )"});
+            s.on_next(Event{R"(
+                {"field_":"10","field_src":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test":11,"field_src2":"10"}
+            )"});
+            s.on_next(Event{R"(
+                {"field_test2":10,"field_src2":"test"}
+            )"});
+            s.on_completed();
+        });
+    Lifter lift = opBuilderHelperIntNotEqual(*doc.get("/check"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+
+    auto str2Int = [](std::string s) {
+        return std::stoi(s);
+    };
+
+    ASSERT_EQ(expected.size(), 0);
+
+}

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntNotEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntNotEqual_test.cpp
@@ -20,7 +20,7 @@ TEST(opBuilderHelperIntNotEqual, Builds)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+int/10"}
+            {"field_test": "+i_ne/10"}
     })"};
     ASSERT_NO_THROW(opBuilderHelperIntNotEqual(*doc.get("/check")));
 }
@@ -29,7 +29,7 @@ TEST(opBuilderHelperIntNotEqual, Builds_error_bad_parameter)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+int/test"}
+            {"field_test": "+i_ne/test"}
     })"};
     ASSERT_THROW(opBuilderHelperIntNotEqual(*doc.get("/check")), std::invalid_argument);
 }
@@ -38,7 +38,7 @@ TEST(opBuilderHelperIntNotEqual, Builds_error_more_parameters)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+int/10/10"}
+            {"field_test": "+i_ne/10/10"}
     })"};
     ASSERT_THROW(opBuilderHelperIntNotEqual(*doc.get("/check")), std::runtime_error);
 }
@@ -47,7 +47,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ok)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+int/10"}
+            {"field_test": "+i_ne/10"}
     })"};
 
     Observable input = observable<>::create<Event>(
@@ -81,7 +81,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_true)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+int/10"}
+            {"field_test": "+i_ne/10"}
     })"};
 
     Observable input = observable<>::create<Event>(
@@ -115,7 +115,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_false)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+int/10"}
+            {"field_test": "+i_ne/10"}
     })"};
 
     Observable input = observable<>::create<Event>(
@@ -147,7 +147,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ref_true)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+int/$field_src"}
+            {"field_test": "+i_ne/$field_src"}
     })"};
 
     Observable input = observable<>::create<Event>(
@@ -200,7 +200,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ref_false)
 {
     Document doc{R"({
         "check":
-            {"field_test": "+int/$field_src"}
+            {"field_test": "+i_ne/$field_src"}
     })"};
 
     Observable input = observable<>::create<Event>(

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntNotEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntNotEqual_test.cpp
@@ -8,10 +8,9 @@
  */
 
 #include <gtest/gtest.h>
-#include <testUtils.hpp>
-
 #include <vector>
 
+#include "testUtils.hpp"
 #include "OpBuilderHelperFilter.hpp"
 
 using namespace builder::internals::builders;
@@ -22,6 +21,7 @@ TEST(opBuilderHelperIntNotEqual, Builds)
         "check":
             {"field_test": "+i_ne/10"}
     })"};
+
     ASSERT_NO_THROW(opBuilderHelperIntNotEqual(*doc.get("/check")));
 }
 
@@ -31,6 +31,7 @@ TEST(opBuilderHelperIntNotEqual, Builds_error_bad_parameter)
         "check":
             {"field_test": "+i_ne/test"}
     })"};
+
     ASSERT_THROW(opBuilderHelperIntNotEqual(*doc.get("/check")), std::invalid_argument);
 }
 
@@ -40,6 +41,7 @@ TEST(opBuilderHelperIntNotEqual, Builds_error_more_parameters)
         "check":
             {"field_test": "+i_ne/10/10"}
     })"};
+
     ASSERT_THROW(opBuilderHelperIntNotEqual(*doc.get("/check")), std::runtime_error);
 }
 
@@ -70,7 +72,9 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ok)
     Lifter lift = opBuilderHelperIntNotEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
+
     ASSERT_EQ(expected.size(), 2);
     ASSERT_EQ(expected[0].get("/field_test")->GetInt(), 9);
     ASSERT_EQ(expected[1].get("/field_test")->GetInt(), 11);
@@ -103,7 +107,9 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_true)
     Lifter lift = opBuilderHelperIntNotEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
+
     ASSERT_EQ(expected.size(), 2);
     ASSERT_EQ(expected[0].get("/field_test")->GetInt(), 9);
     ASSERT_EQ(expected[1].get("/field_test")->GetInt(), 11);
@@ -136,7 +142,9 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_false)
     Lifter lift = opBuilderHelperIntNotEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
+
     ASSERT_EQ(expected.size(), 0);
 }
 
@@ -179,9 +187,8 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ref_true)
     Lifter lift = opBuilderHelperIntNotEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
-    output.subscribe([&](Event e) { expected.push_back(e); });
 
-    auto str2Int = [](std::string s) { return std::stoi(s); };
+    output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
     ASSERT_NE(expected[0].get("/field_test")->GetInt(),
@@ -229,9 +236,8 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ref_false)
     Lifter lift = opBuilderHelperIntNotEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
-    output.subscribe([&](Event e) { expected.push_back(e); });
 
-    auto str2Int = [](std::string s) { return std::stoi(s); };
+    output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 0);
 }
@@ -273,6 +279,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_dynamics_int_ok)
     Lifter lift = opBuilderHelperIntNotEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
@@ -349,6 +356,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_multilevel_dynamics_int_ok)
     Lifter lift = opBuilderHelperIntNotEqual(*doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
+
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/12161|

This PR adds the following helper functions:

### Filtering

Compares the value <value> or the value of the $<ref> field of the event with the <field> field.

- `<field>: i_le/<value>|$<ref>`: True if `<field>` < `<value>|$<ref>`
- `<field>: i_lt/<value>|$<ref>`:  True if `<field>` <= `<value>|$<ref>`
- `<field>: i_ge/<value>|$<ref>`:  True if `<field>` > `<value>|$<ref>`
- `<field>: i_gt/<value>|$<ref>`:  True if `<field>` >= `<value>|$<ref>`
- `<field>: i_eq/<value>`:  True if `<field>` == `<value>|$<ref>`
- `<field>: i_ne/<value>`:  True if `<field>` != `<value>|$<ref>`

### Transformation
- `field: +i_calc/[+|-|*|/]/val|$ref/` : Sets field value as the sum (+), sub (-), mult (*) or div(/) of its value and the value or reference provided.

- [x] Gtest
- [ ] Test on file output