### PR TITLE
Prevent Vulnerability Detector from crashing

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5012,7 +5012,9 @@ int wm_vuldet_collect_agent_software(scan_agent *agent, sqlite3 *db, scan_ctx_t*
 
                 if (cpe_str) {
                     s_cpe = wm_vuldet_decode_cpe(cpe_str);
-                    w_strdup(msu_name, s_cpe->msu_name);
+                    if (s_cpe) {
+                        w_strdup(msu_name, s_cpe->msu_name);
+                    }
                 }
 
                 if (agent->dist != FEED_WIN && agent->dist != FEED_MAC) {


### PR DESCRIPTION
|Related issue|
|---|
|Fix #7272|

## Description

This PR re-adds the condition that was added in #7272 to prevent the _Vulnerability Detector_ module from crashing the `wazuh-modulesd` daemon.

This segmentation fault was caused when trying to parse a package that does not have any vendor, showing the following log and then crashing the module:

```
2022/02/23 09:51:27 wazuh-modulesd:vulnerability-detector: ERROR: (5535): Could not parse the 'vendor' term of ''
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Added unit tests 
