### PR TITLE
Fixed false positives in FIMDB second scan

### DIFF
--- a/src/syscheckd/cppcheckSuppress.txt
+++ b/src/syscheckd/cppcheckSuppress.txt
@@ -2,4 +2,4 @@
 *:*src/syscheckd/src/db/src/file.cpp:393
 *:*src/db/testtool/action.h:378
 *:*src/syscheckd/src/db/src/db.cpp:97
-*:*src/syscheckd/src/create_db.c:747
+*:*src/syscheckd/src/create_db.c:741

--- a/src/syscheckd/include/syscheck.h
+++ b/src/syscheckd/include/syscheck.h
@@ -106,7 +106,6 @@ typedef struct create_json_event_ctx {
 typedef struct fim_txn_context_s {
     event_data_t* evt_data;
     fim_entry* latest_entry;
-    volatile bool db_full;
 } fim_txn_context_t;
 
 #ifdef WIN32

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -260,12 +260,10 @@ static void transaction_callback(ReturnTypeCallback resultType, const cJSON* res
             }
 
             txn_context->evt_data->type = FIM_DELETE;
-            txn_context->db_full = false;
 
             break;
 
         case MAX_ROWS:
-            txn_context->db_full = true;
             mdebug1("Couldn't insert '%s' entry into DB. The DB is full, please check your configuration.", path);
 
         // Fallthrough
@@ -382,7 +380,7 @@ time_t fim_scan() {
     OSListNode *node_it;
     directory_t *dir_it;
     event_data_t evt_data = { .report_event = true, .mode = FIM_SCHEDULED, .w_evt = NULL };
-    fim_txn_context_t txn_ctx = { .evt_data = &evt_data, .latest_entry = NULL, .db_full = false };
+    fim_txn_context_t txn_ctx = { .evt_data = &evt_data, .latest_entry = NULL };
 
     static fim_state_db _files_db_state = FIM_STATE_DB_EMPTY;
 #ifdef WIN32
@@ -443,10 +441,6 @@ time_t fim_scan() {
 
         w_rwlock_rdlock(&syscheck.directories_lock);
         OSList_foreach(node_it, syscheck.directories) {
-            if (txn_ctx.db_full == true) {
-                break;
-            }
-
             dir_it = node_it->data;
             char *path;
             event_data_t evt_data = { .mode = FIM_SCHEDULED, .report_event = true, .w_evt = NULL };

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -3821,7 +3821,6 @@ static void test_transaction_callback_delete_full_db(void **state) {
 #endif
 
     fim_txn_context_t *txn_context = data->txn_context;
-    txn_context->db_full = true;
     data->dbsync_event = result;
 
     // These functions are called every time transaction_callback calls fim_configuration_directory
@@ -3843,7 +3842,6 @@ static void test_transaction_callback_delete_full_db(void **state) {
 
     transaction_callback(DELETED, result, txn_context);
     assert_int_equal(txn_context->evt_data->type, FIM_DELETE);
-    assert_int_equal(txn_context->db_full, false);
 }
 
 static void test_transaction_callback_full_db(void **state) {
@@ -3860,7 +3858,6 @@ static void test_transaction_callback_full_db(void **state) {
     fim_txn_context_t *txn_context = data->txn_context;
     fim_entry entry = {.type = FIM_TYPE_FILE, .file_entry.path = path, .file_entry.data=&DEFAULT_FILE_DATA};
 
-    txn_context->db_full = true;
     txn_context->latest_entry = &entry;
     data->dbsync_event = result;
 
@@ -3883,7 +3880,6 @@ static void test_transaction_callback_full_db(void **state) {
     expect_string(__wrap__mdebug1, formatted_msg, debug_msg);
 
     transaction_callback(MAX_ROWS, result, txn_context);
-    assert_int_equal(txn_context->db_full, true);
 }
 
 static void test_fim_event_callback(void **state) {


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/12447|

This PR is to fix the problem of false positive deletion alerts found in the second FIM scan, caused by the db_full check that occurred and could leave all monitored files unprocessed, thus producing deletion alerts.

Closes #12447 