### PR TITLE
File path parser implemention

### DIFF
--- a/src/engine/source/hlp/src/LogQLParser.cpp
+++ b/src/engine/source/hlp/src/LogQLParser.cpp
@@ -24,6 +24,7 @@ static const std::unordered_map<std::string_view, ParserType> kTempTypeMapper {
     { "MAP", ParserType::Map},
     { "timestamp", ParserType::Ts},
     { "domain", ParserType::Domain},
+    { "FilePath", ParserType::FilePath},
 };
 
 struct Tokenizer {

--- a/src/engine/source/hlp/src/SpecificParsers.cpp
+++ b/src/engine/source/hlp/src/SpecificParsers.cpp
@@ -63,18 +63,24 @@ bool matchLiteral(const char **it, std::string const& literal) {
     return literal[i] == '\0';
 }
 
-void parseFilePath(const char **it, char endToken, FilePathResult &result) {
+void parseFilePath(const char **it, char endToken, std::vector<std::string> const& captureOpts, FilePathResult &result) {
     const char *start = *it;
     while (**it != endToken && **it != '\0') { (*it)++; }
     std::string_view file_path { start, (size_t)((*it) - start) };
+    std::string folder_separator = "/\\";
+    bool search_drive_letter = true;
+    if (!captureOpts.empty() && captureOpts[0] == "UNIX") {
+        search_drive_letter = false;
+        folder_separator = "/";
+    }
 
     result.path = file_path;
-    auto folder_end = file_path.find_last_of("/\\");
+    auto folder_end = file_path.find_last_of(folder_separator);
     result.folder = folder_end == std::string::npos ? "" : file_path.substr(0, folder_end);
     result.name = folder_end == std::string::npos ? file_path : file_path.substr(folder_end + 1);
     auto extension_start = result.name.find_last_of('.');
     result.extension = extension_start == std::string::npos ? "" : result.name.substr(extension_start + 1);
-    if (file_path[1] == ':' && (file_path[2] == '\\' || file_path[2] == '/')) {
+    if (search_drive_letter && file_path[1] == ':' && (file_path[2] == '\\' || file_path[2] == '/')) {
         result.drive_letter = std::toupper(file_path[0]);
     }
 }

--- a/src/engine/source/hlp/src/SpecificParsers.cpp
+++ b/src/engine/source/hlp/src/SpecificParsers.cpp
@@ -38,13 +38,6 @@ static const std::unordered_map<std::string, const char *>
         { "UnixDate", "%a %b %d %T %Z %Y" },
     };
 
-bool parseFilePath(const char **it, char endToken) {
-    const char *start = *it;
-    while (**it != endToken && **it != '\0') { (*it)++; }
-    (void)start;
-    return true;
-}
-
 std::string parseAny(const char **it, char endToken) {
     const char *start = *it;
     while (**it != endToken && **it != '\0') { (*it)++; }
@@ -68,6 +61,22 @@ bool matchLiteral(const char **it, std::string const& literal) {
     }
 
     return literal[i] == '\0';
+}
+
+void parseFilePath(const char **it, char endToken, FilePathResult &result) {
+    const char *start = *it;
+    while (**it != endToken && **it != '\0') { (*it)++; }
+    std::string_view file_path { start, (size_t)((*it) - start) };
+
+    result.path = file_path;
+    auto folder_end = file_path.find_last_of("/\\");
+    result.folder = folder_end == std::string::npos ? "" : file_path.substr(0, folder_end);
+    result.name = folder_end == std::string::npos ? file_path : file_path.substr(folder_end + 1);
+    auto extension_start = result.name.find_last_of('.');
+    result.extension = extension_start == std::string::npos ? "" : result.name.substr(extension_start + 1);
+    if (file_path[1] == ':' && (file_path[2] == '\\' || file_path[2] == '/')) {
+        result.drive_letter = std::toupper(file_path[0]);
+    }
 }
 
 std::string parseJson(const char **it) {

--- a/src/engine/source/hlp/src/SpecificParsers.hpp
+++ b/src/engine/source/hlp/src/SpecificParsers.hpp
@@ -48,7 +48,7 @@ std::string parseAny(const char **it, char endToken);
 
 bool matchLiteral(const char **it, std::string const& literal);
 
-void parseFilePath(const char **it, char endToken, FilePathResult &result);
+void parseFilePath(const char **it, char endToken, std::vector<std::string> const& captureOpts, FilePathResult &result);
 
 std::string parseJson(const char **it);
 

--- a/src/engine/source/hlp/src/SpecificParsers.hpp
+++ b/src/engine/source/hlp/src/SpecificParsers.hpp
@@ -36,12 +36,19 @@ struct DomainResult{
     std::string registered_domain;
     std::string route;
 };
-
-bool parseFilePath(const char **it, char endToken);
+struct FilePathResult{
+    std::string path;           //"file.path": "keyword",
+    std::string drive_letter;   //"file.drive_letter": "keyword",
+    std::string folder;         //"file.directory": "keyword",
+    std::string name;           //"file.name": "keyword",
+    std::string extension;      //"file.extension": "keyword",
+};
 
 std::string parseAny(const char **it, char endToken);
 
 bool matchLiteral(const char **it, std::string const& literal);
+
+void parseFilePath(const char **it, char endToken, FilePathResult &result);
 
 std::string parseJson(const char **it);
 

--- a/src/engine/source/hlp/src/hlp.cpp
+++ b/src/engine/source/hlp/src/hlp.cpp
@@ -125,7 +125,7 @@ static void executeParserList(std::string const &event, ParserList const &parser
             }
             case ParserType::FilePath: {
                 FilePathResult filePathResult;
-                parseFilePath(&eventIt, parser.endToken, filePathResult);
+                parseFilePath(&eventIt, parser.endToken, parser.captureOpts, filePathResult);
                 result[parser.name + ".path"] = std::move(filePathResult.path);
                 result[parser.name + ".drive_letter"] = std::move(filePathResult.drive_letter);
                 result[parser.name + ".folder"] = std::move(filePathResult.folder);

--- a/src/engine/source/hlp/src/hlp.cpp
+++ b/src/engine/source/hlp/src/hlp.cpp
@@ -123,6 +123,16 @@ static void executeParserList(std::string const &event, ParserList const &parser
                     result[parser.name + ".address"] = std::move(domainResult.address);
                 }
             }
+            case ParserType::FilePath: {
+                FilePathResult filePathResult;
+                parseFilePath(&eventIt, parser.endToken, filePathResult);
+                result[parser.name + ".path"] = std::move(filePathResult.path);
+                result[parser.name + ".drive_letter"] = std::move(filePathResult.drive_letter);
+                result[parser.name + ".folder"] = std::move(filePathResult.folder);
+                result[parser.name + ".name"] = std::move(filePathResult.name);
+                result[parser.name + ".extension"] = std::move(filePathResult.extension);
+                break;
+            }
             default: {
                 fprintf(stderr,
                         "Missing implementation for parser type: [%i]\n",

--- a/src/engine/source/hlp/src/hlpDetails.hpp
+++ b/src/engine/source/hlp/src/hlpDetails.hpp
@@ -18,6 +18,7 @@ enum class ParserType {
     JSON,
     Map,
     Domain,
+    FilePath,
     Invalid,
 };
 

--- a/src/engine/test/source/hlp/hlp_test.cpp
+++ b/src/engine/test/source/hlp/hlp_test.cpp
@@ -526,4 +526,88 @@ TEST(domain_test, valid_content)
     std::string invalid_label_domain = "www." + invalid_label + ".com";
     result = parseOp(invalid_label_domain);
     ASSERT_TRUE(result.empty());
+TEST(filepath_test, windows_path)
+{
+    const char *logQl ="<_file/FilePath>";
+    ParserFn parseOp = getParserOp(logQl);
+    ParseResult result;
+
+    const char *full_path = "C:\\Users\\Name\\Desktop\\test.txt";
+    result = parseOp(full_path);
+    ASSERT_EQ("C:\\Users\\Name\\Desktop\\test.txt", result["_file.path"]);
+    ASSERT_EQ("C", result["_file.drive_letter"]);
+    ASSERT_EQ("C:\\Users\\Name\\Desktop", result["_file.folder"]);
+    ASSERT_EQ("test.txt", result["_file.name"]);
+    ASSERT_EQ("txt", result["_file.extension"]);
+
+    const char *relative_path = "Desktop\\test.txt";
+    result = parseOp(relative_path);
+    ASSERT_EQ("Desktop\\test.txt", result["_file.path"]);
+    ASSERT_EQ("", result["_file.drive_letter"]);
+    ASSERT_EQ("Desktop", result["_file.folder"]);
+    ASSERT_EQ("test.txt", result["_file.name"]);
+    ASSERT_EQ("txt", result["_file.extension"]);
+
+    const char *file_without_ext = "Desktop\\test";
+    result = parseOp(file_without_ext);
+    ASSERT_EQ("Desktop\\test", result["_file.path"]);
+    ASSERT_EQ("", result["_file.drive_letter"]);
+    ASSERT_EQ("Desktop", result["_file.folder"]);
+    ASSERT_EQ("test", result["_file.name"]);
+    ASSERT_EQ("", result["_file.extension"]);
+
+    const char *only_file = "test.txt";
+    result = parseOp(only_file);
+    ASSERT_EQ("test.txt", result["_file.path"]);
+    ASSERT_EQ("", result["_file.drive_letter"]);
+    ASSERT_EQ("", result["_file.folder"]);
+    ASSERT_EQ("test.txt", result["_file.name"]);
+    ASSERT_EQ("txt", result["_file.extension"]);
+
+    const char *folder_path = "C:\\Users\\Name\\Desktop\\";
+    result = parseOp(folder_path);
+    ASSERT_EQ("C:\\Users\\Name\\Desktop\\", result["_file.path"]);
+    ASSERT_EQ("C", result["_file.drive_letter"]);
+    ASSERT_EQ("C:\\Users\\Name\\Desktop", result["_file.folder"]);
+    ASSERT_EQ("", result["_file.name"]);
+    ASSERT_EQ("", result["_file.extension"]);
+
+    const char *lower_case_drive = "c:\\test.txt";
+    result = parseOp(lower_case_drive);
+    ASSERT_EQ("c:\\test.txt", result["_file.path"]);
+    ASSERT_EQ("C", result["_file.drive_letter"]);
+    ASSERT_EQ("c:", result["_file.folder"]);
+    ASSERT_EQ("test.txt", result["_file.name"]);
+    ASSERT_EQ("txt", result["_file.extension"]);
+}
+
+TEST(filepath_test, unix_path)
+{
+    const char *logQl ="<_file/FilePath>";
+    ParserFn parseOp = getParserOp(logQl);
+    ParseResult result;
+
+    const char *full_path = "/Desktop/test.txt";
+    result = parseOp(full_path);
+    ASSERT_EQ("/Desktop/test.txt", result["_file.path"]);
+    ASSERT_EQ("", result["_file.drive_letter"]);
+    ASSERT_EQ("/Desktop", result["_file.folder"]);
+    ASSERT_EQ("test.txt", result["_file.name"]);
+    ASSERT_EQ("txt", result["_file.extension"]);
+
+    const char *relative_path = "Desktop/test.txt";
+    result = parseOp(relative_path);
+    ASSERT_EQ("Desktop/test.txt", result["_file.path"]);
+    ASSERT_EQ("", result["_file.drive_letter"]);
+    ASSERT_EQ("Desktop", result["_file.folder"]);
+    ASSERT_EQ("test.txt", result["_file.name"]);
+    ASSERT_EQ("txt", result["_file.extension"]);
+
+    const char *folder_path = "/Desktop/";
+    result = parseOp(folder_path);
+    ASSERT_EQ("/Desktop/", result["_file.path"]);
+    ASSERT_EQ("", result["_file.drive_letter"]);
+    ASSERT_EQ("/Desktop", result["_file.folder"]);
+    ASSERT_EQ("", result["_file.name"]);
+    ASSERT_EQ("", result["_file.extension"]);
 }

--- a/src/engine/test/source/hlp/hlp_test.cpp
+++ b/src/engine/test/source/hlp/hlp_test.cpp
@@ -611,3 +611,26 @@ TEST(filepath_test, unix_path)
     ASSERT_EQ("", result["_file.name"]);
     ASSERT_EQ("", result["_file.extension"]);
 }
+
+TEST(filepath_test, force_unix_format)
+{
+    const char *logQl ="<_file/FilePath/UNIX>";
+    ParserFn parseOp = getParserOp(logQl);
+    ParseResult result;
+
+    const char *drive_like_file = "C:\\_test.txt";
+    result = parseOp(drive_like_file);
+    ASSERT_EQ("C:\\_test.txt", result["_file.path"]);
+    ASSERT_EQ("", result["_file.drive_letter"]);
+    ASSERT_EQ("", result["_file.folder"]);
+    ASSERT_EQ("C:\\_test.txt", result["_file.name"]);
+    ASSERT_EQ("txt", result["_file.extension"]);
+
+    const char *file_with_back_slash = "/Desktop/test\\1:2.txt";
+    result = parseOp(file_with_back_slash);
+    ASSERT_EQ("/Desktop/test\\1:2.txt", result["_file.path"]);
+    ASSERT_EQ("", result["_file.drive_letter"]);
+    ASSERT_EQ("/Desktop", result["_file.folder"]);
+    ASSERT_EQ("test\\1:2.txt", result["_file.name"]);
+    ASSERT_EQ("txt", result["_file.extension"]);
+}


### PR DESCRIPTION
|Related issue|
|---|
|#12177|
## Description
This PR adds a parser for FilePaths.
It´s a custom implementation that searches for a folder separator (**/** or **\**) to separate the file name from the folder name.
It also searches for an extension separator (**.**) to identify the extension of the file.
Drive letter is extracted by searching for **:\** or **:/**.
Finally, a UNIX format forcer can be set using optional captures like **<_file_field/FilePath/UNIX>** to only search for UNIX-like separators (**/**) and doesn´t search for the drive letter (only valid in Windows).

The resulting values are loaded in a struct extracted from https://www.elastic.co/guide/en/ecs/current/ecs-file.html#field-file-target-path:
    - path;              //"file.path": "keyword",
    - drive_letter;   //"file.drive_letter": "keyword",
    - folder;           //"file.directory": "keyword",
    - name;           //"file.name": "keyword",
    - extension;     //"file.extension": "keyword",
