### PR TITLE
Fix compiler warnings in common_rcl.c file

### DIFF
--- a/src/rootcheck/common_rcl.c
+++ b/src/rootcheck/common_rcl.c
@@ -44,7 +44,12 @@ char *_rkcl_getrootdir(char *root_dir, int dir_size)
     tmp = strchr(final_file, '\\');
     if (tmp) {
         *tmp = '\0';
-        strncpy(root_dir, final_file, dir_size);
+        int bytes_written = snprintf(root_dir, dir_size, "%s", final_file);
+
+        if (bytes_written + 1 > dir_size) {
+            return (NULL);
+        }
+
         return (root_dir);
     }
 
@@ -267,23 +272,17 @@ int rkcl_get_entry(FILE *fp, const char *msg, OSList *p_list)
 {
     int type = 0, condition = 0;
     char *nbuf;
-    char buf[OS_SIZE_1024 + 2];
-    char root_dir[OS_SIZE_1024 + 2];
-    char final_file[2048 + 1];
-    char ref[255 + 1];
+    char buf[OS_SIZE_1024 + 2] = {0};
+    char root_dir[OS_SIZE_1024 + 2] = {0};
+    char final_file[2048 + 1] = {0};
+    char ref[255 + 1] = {0};
     char *value;
     char *name = NULL;
     OSStore *vars;
 
-    /* Initialize variables */
-    memset(buf, '\0', sizeof(buf));
-    memset(root_dir, '\0', sizeof(root_dir));
-    memset(final_file, '\0', sizeof(final_file));
-    memset(ref, '\0', sizeof(ref));
-
 #ifdef WIN32
     /* Get Windows rootdir */
-    _rkcl_getrootdir(root_dir, sizeof(root_dir) - 1);
+    _rkcl_getrootdir(root_dir, sizeof(root_dir));
     if (root_dir[0] == '\0') {
         mterror(ARGV0, INVALID_ROOTDIR);
     }

--- a/src/rootcheck/common_rcl.c
+++ b/src/rootcheck/common_rcl.c
@@ -44,9 +44,9 @@ char *_rkcl_getrootdir(char *root_dir, int dir_size)
     tmp = strchr(final_file, '\\');
     if (tmp) {
         *tmp = '\0';
-        int bytes_written = snprintf(root_dir, dir_size, "%s", final_file);
+        const int bytes_written = snprintf(root_dir, dir_size, "%s", final_file);
 
-        if (bytes_written + 1 > dir_size) {
+        if (bytes_written < 0 || bytes_written >= dir_size) {
             return (NULL);
         }
 


### PR DESCRIPTION
|Related issue|
|---|
|#12099|


## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh windows agent project in common_rcl.c. . The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Windows Agent</summary>

```
    CC syscheckd/create_db.o
    CC syscheckd/run_check.o
syscheckd/create_db.c: In function ‘fim_directory’:
syscheckd/create_db.c:397:9: warning: ‘strncpy’ output may be truncated copying between 0 and 258 bytes from a string of length 259 [-Wstringop-truncation]
  397 |         strncpy(s_name, entry->d_name, PATH_MAX - path_size - 2);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC syscheckd/syscheck.o
    CC syscheckd/fim_diff_changes.o
    CC syscheckd/fim_sync.o
    CC syscheckd/syscom.o
    CC syscheckd/main.o
    CC syscheckd/db/fim_db.o
    CC syscheckd/db/fim_db_files.o
    CC syscheckd/db/fim_db_registries.o
    CC syscheckd/whodata/audit_healthcheck.o
    CC syscheckd/whodata/audit_rule_handling.o
    CC syscheckd/whodata/syscheck_audit.o
    CC syscheckd/whodata/audit_parse.o
    CC syscheckd/whodata/win_whodata.o
    CC syscheckd/registry/registry.o
    CC syscheckd/registry/events.o
    CC rootcheck/common_rcl.o
    CC rootcheck/rootcheck-config.o
    CC rootcheck/config.o
    CC rootcheck/check_rc_files.o
    CC rootcheck/check_rc_ports.o
    CC rootcheck/win-process.o
    CC rootcheck/unix-process.o
    CC rootcheck/common.o
    CC rootcheck/rootcheck.o
In file included from ./headers/shared.h:220,
                 from rootcheck/common.c:11:
In function ‘is_file’,
    inlined from ‘is_file’ at rootcheck/common.c:446:5:
./headers/debug_op.h:46:32: warning: argument 6 null where non-null expected [-Wnonnull]
   46 | #define mterror(tag, msg, ...) _mterror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./headers/debug_op.h:46:32: note: in definition of macro ‘mterror’
   46 | #define mterror(tag, msg, ...) _mterror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
      |                                ^~~~~~~~
In file included from ./headers/shared.h:220,
                 from rootcheck/common.c:11:
rootcheck/common.c: In function ‘is_file’:
./headers/debug_op.h:61:6: note: in a call to function ‘_mterror’ declared here
   61 | void _mterror(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull));
      |      ^~~~~~~~
    CC rootcheck/check_rc_if.o
    CC rootcheck/check_open_ports.o
    CC rootcheck/os_string.o
    CC rootcheck/win-common.o
    CC rootcheck/check_rc_readproc.o
    CC rootcheck/check_rc_dev.o
    CC rootcheck/check_rc_sys.o
rootcheck/win-common.c: In function ‘__os_winreg_querykey’:
rootcheck/win-common.c:265:29: warning: ‘strncat’ output may be truncated copying between 3 and 16381 bytes from a string of length 16383 [-Wstringop-truncation]
  265 |                             strncat(var_storage, mt_data, size_available);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC rootcheck/run_rk_check.o

```

</details>

## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Windows Agent</summary>

```
    CC syscheckd/main.o
    CC syscheckd/run_check.o
    CC syscheckd/run_realtime.o
    CC syscheckd/syscheck.o
syscheckd/create_db.c: In function ‘fim_directory’:
syscheckd/create_db.c:397:9: warning: ‘strncpy’ output may be truncated copying between 0 and 258 bytes from a string of length 259 [-Wstringop-truncation]
  397 |         strncpy(s_name, entry->d_name, PATH_MAX - path_size - 2);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC syscheckd/syscom.o
    CC syscheckd/db/fim_db.o
    CC syscheckd/db/fim_db_files.o
    CC syscheckd/db/fim_db_registries.o
    CC syscheckd/whodata/audit_healthcheck.o
    CC syscheckd/whodata/audit_parse.o
    CC syscheckd/whodata/audit_rule_handling.o
    CC syscheckd/whodata/syscheck_audit.o
    CC syscheckd/whodata/win_whodata.o
    CC syscheckd/registry/events.o
    CC syscheckd/registry/registry.o
    CC rootcheck/check_open_ports.o
    CC rootcheck/check_rc_dev.o
    CC rootcheck/check_rc_files.o
    CC rootcheck/check_rc_if.o
    CC rootcheck/check_rc_pids.o
    CC rootcheck/check_rc_policy.o
    CC rootcheck/check_rc_ports.o
    CC rootcheck/check_rc_readproc.o
    CC rootcheck/check_rc_sys.o
    CC rootcheck/check_rc_trojans.o
    CC rootcheck/common.o
    CC rootcheck/common_rcl.o
    CC rootcheck/config.o
    CC rootcheck/os_string.o
    CC rootcheck/rootcheck.o
In file included from ./headers/shared.h:220,
                 from rootcheck/common.c:11:
rootcheck/common.c: In function ‘is_file’:
./headers/debug_op.h:46:32: warning: argument 6 null where non-null expected [-Wnonnull]
   46 | #define mterror(tag, msg, ...) _mterror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./headers/debug_op.h:46:32: note: in definition of macro ‘mterror’
   46 | #define mterror(tag, msg, ...) _mterror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
      |                                ^~~~~~~~
In file included from ./headers/shared.h:220,
                 from rootcheck/common.c:11:
./headers/debug_op.h:61:6: note: in a call to function ‘_mterror’ declared here
   61 | void _mterror(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull));
      |      ^~~~~~~~
    CC rootcheck/rootcheck-config.o
    CC rootcheck/run_rk_check.o
    CC rootcheck/unix-process.o
    CC rootcheck/win-common.o
    CC rootcheck/win-process.o
    CC client-agent/agcom.o
    CC client-agent/buffer.o
rootcheck/win-common.c: In function ‘__os_winreg_querykey’:
rootcheck/win-common.c:265:29: warning: ‘strncat’ output may be truncated copying between 3 and 16381 bytes from a string of length 16383 [-Wstringop-truncation]
  265 |                             strncat(var_storage, mt_data, size_available);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC client-agent/config.o

```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors