### PR TITLE
Fix compiler warnings in create_db.c file

### DIFF
--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -394,7 +394,8 @@ int fim_directory(const char *dir, event_data_t *evt_data, const directory_t *co
             *s_name++ = PATH_SEP;
         }
         *(s_name) = '\0';
-        strncpy(s_name, entry->d_name, PATH_MAX - path_size - 2);
+        path_size = strlen(f_name);
+        snprintf(s_name, PATH_MAX + 2 - path_size, "%s", entry->d_name);
 
 #ifdef WIN32
         str_lowercase(f_name);


### PR DESCRIPTION
|Related issue|
|---|
|#12099|


## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh windows agent project in create_db.c. . The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Windows Agent</summary>

```
win32/win_utils.c:262:22: warning: cast between incompatible function types from ‘void * (*)(void *)’ to ‘DWORD (__attribute__((stdcall)) *)(void *)’ [-Wcast-function-type]
  262 |                      (LPTHREAD_START_ROUTINE)req_receiver,
      |                      ^
./headers/pthreads_op.h:17:84: note: in definition of macro ‘w_create_thread’
   17 | #define w_create_thread(x, y, z, a, b, c) ({HANDLE hd; if (!(hd = CreateThread(x,y,z,a,b,c))) merror_exit(THREAD_ERROR); hd;})
      |                                                                                    ^
win32/win_utils.c:275:29: warning: cast between incompatible function types from ‘wm_routine’ {aka ‘void * (* const)(void *)’} to ‘DWORD (__attribute__((stdcall)) *)(void *)’ [-Wcast-function-type]
  275 |                             (LPTHREAD_START_ROUTINE)cur_module->context->start,
      |                             ^
./headers/pthreads_op.h:17:84: note: in definition of macro ‘w_create_thread’
   17 | #define w_create_thread(x, y, z, a, b, c) ({HANDLE hd; if (!(hd = CreateThread(x,y,z,a,b,c))) merror_exit(THREAD_ERROR); hd;})
      |                                                                                    ^
    CC syscheckd/config.o
    CC syscheckd/create_db.o
    CC syscheckd/run_check.o
    CC syscheckd/syscheck.o
    CC syscheckd/fim_diff_changes.o
    CC syscheckd/fim_sync.o
    CC syscheckd/syscom.o
    CC syscheckd/main.o
    CC syscheckd/db/fim_db.o
    CC syscheckd/db/fim_db_files.o
    CC syscheckd/db/fim_db_registries.o
    CC syscheckd/whodata/audit_healthcheck.o
    CC syscheckd/whodata/audit_rule_handling.o
    CC syscheckd/whodata/syscheck_audit.o
    CC syscheckd/whodata/audit_parse.o
    CC syscheckd/whodata/win_whodata.o
    CC syscheckd/registry/registry.o
    CC syscheckd/registry/events.o
    CC rootcheck/common_rcl.o
    CC rootcheck/rootcheck-config.o
    CC rootcheck/config.o
    CC rootcheck/check_rc_files.o
    CC rootcheck/check_rc_ports.o
    CC rootcheck/win-process.o
    CC rootcheck/unix-process.o
    CC rootcheck/common.o
    CC rootcheck/rootcheck.o
In file included from ./headers/shared.h:220,
                 from rootcheck/common.c:11:
In function ‘is_file’,
    inlined from ‘is_file’ at rootcheck/common.c:446:5:
./headers/debug_op.h:46:32: warning: argument 6 null where non-null expected [-Wnonnull]
   46 | #define mterror(tag, msg, ...) _mterror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./headers/debug_op.h:46:32: note: in definition of macro ‘mterror’
   46 | #define mterror(tag, msg, ...) _mterror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
      |                                ^~~~~~~~
In file included from ./headers/shared.h:220,
                 from rootcheck/common.c:11:
rootcheck/common.c: In function ‘is_file’:
./headers/debug_op.h:61:6: note: in a call to function ‘_mterror’ declared here
   61 | void _mterror(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull));
      |      ^~~~~~~~
    CC rootcheck/check_rc_if.o
    CC rootcheck/check_open_ports.o
    CC rootcheck/os_string.o
    CC rootcheck/win-common.o

```

</details>

## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Windows Agent</summary>

```
  262 |                      (LPTHREAD_START_ROUTINE)req_receiver,
      |                      ^
./headers/pthreads_op.h:17:84: note: in definition of macro ‘w_create_thread’
   17 | #define w_create_thread(x, y, z, a, b, c) ({HANDLE hd; if (!(hd = CreateThread(x,y,z,a,b,c))) merror_exit(THREAD_ERROR); hd;})
      |                                                                                    ^
win32/win_utils.c:275:29: warning: cast between incompatible function types from ‘wm_routine’ {aka ‘void * (* const)(void *)’} to ‘DWORD (__attribute__((stdcall)) *)(void *)’ {aka ‘long unsigned int (__attribute__((stdcall)) *)(void *)’} [-Wcast-function-type]
  275 |                             (LPTHREAD_START_ROUTINE)cur_module->context->start,
      |                             ^
./headers/pthreads_op.h:17:84: note: in definition of macro ‘w_create_thread’
   17 | #define w_create_thread(x, y, z, a, b, c) ({HANDLE hd; if (!(hd = CreateThread(x,y,z,a,b,c))) merror_exit(THREAD_ERROR); hd;})
      |                                                                                    ^
    CC syscheckd/create_db.o
    CC syscheckd/fim_diff_changes.o
    CC syscheckd/fim_sync.o
    CC syscheckd/main.o
    CC syscheckd/run_check.o
    CC syscheckd/run_realtime.o
    CC syscheckd/syscheck.o
    CC syscheckd/syscom.o
    CC syscheckd/db/fim_db.o
    CC syscheckd/db/fim_db_files.o
    CC syscheckd/db/fim_db_registries.o
    CC syscheckd/whodata/audit_healthcheck.o
    CC syscheckd/whodata/audit_parse.o
    CC syscheckd/whodata/audit_rule_handling.o
    CC syscheckd/whodata/syscheck_audit.o
    CC syscheckd/whodata/win_whodata.o
    CC syscheckd/registry/events.o
    CC syscheckd/registry/registry.o
    CC rootcheck/check_open_ports.o
    CC rootcheck/check_rc_dev.o
    CC rootcheck/check_rc_files.o
    CC rootcheck/check_rc_if.o
    CC rootcheck/check_rc_pids.o
    CC rootcheck/check_rc_policy.o
    CC rootcheck/check_rc_ports.o
    CC rootcheck/check_rc_readproc.o
    CC rootcheck/check_rc_sys.o
    CC rootcheck/check_rc_trojans.o
    CC rootcheck/common.o
    CC rootcheck/common_rcl.o
    CC rootcheck/config.o
    CC rootcheck/os_string.o
    CC rootcheck/rootcheck.o
In file included from ./headers/shared.h:220,
                 from rootcheck/common.c:11:
rootcheck/common.c: In function ‘is_file’:
./headers/debug_op.h:46:32: warning: argument 6 null where non-null expected [-Wnonnull]
   46 | #define mterror(tag, msg, ...) _mterror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./headers/debug_op.h:46:32: note: in definition of macro ‘mterror’
   46 | #define mterror(tag, msg, ...) _mterror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
      |                                ^~~~~~~~
In file included from ./headers/shared.h:220,
                 from rootcheck/common.c:11:

```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors