### PR TITLE
Fix compiler warnings in win-common.c file

### DIFF
--- a/src/rootcheck/win-common.c
+++ b/src/rootcheck/win-common.c
@@ -253,19 +253,19 @@ int __os_winreg_querykey(HKEY hKey,
 
                 case REG_SZ:
                 case REG_EXPAND_SZ:
-                    snprintf(var_storage, MAX_VALUE_NAME, "%s", data_buffer);
+                    snprintf(var_storage, sizeof(var_storage), "%s", data_buffer);
                     break;
                 case REG_MULTI_SZ:
                     /* Printing multiple strings */
-                    size_available = MAX_VALUE_NAME - 3;
+                    size_available = MAX_VALUE_NAME;
                     mt_data = data_buffer;
 
                     while (*mt_data) {
-                        if (size_available > 2) {
+                        if (size_available >= (int)strlen(mt_data) + 1) {
                             strncat(var_storage, mt_data, size_available);
+                            size_available -= strlen(mt_data);
                             strncat(var_storage, " ", 2);
-                            size_available = MAX_VALUE_NAME -
-                                             (strlen(var_storage) + 2);
+                            size_available -= 1;
                         }
                         mt_data += strlen(mt_data) + 1;
                     }


### PR DESCRIPTION
## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh windows agent project in win-common.c. The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Windows Agent</summary>

```
./headers/debug_op.h:46:32: note: in definition of macro ‘mterror’
   46 | #define mterror(tag, msg, ...) _mterror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
      |                                ^~~~~~~~
In file included from ./headers/shared.h:220,
                 from rootcheck/common.c:11:
rootcheck/common.c: In function ‘is_file’:
./headers/debug_op.h:61:6: note: in a call to function ‘_mterror’ declared here
   61 | void _mterror(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull));
      |      ^~~~~~~~
    CC rootcheck/check_rc_if.o
    CC rootcheck/check_open_ports.o
    CC rootcheck/os_string.o
    CC rootcheck/win-common.o
    CC rootcheck/check_rc_readproc.o
    CC rootcheck/check_rc_dev.o
    CC rootcheck/check_rc_sys.o
    CC rootcheck/run_rk_check.o
    CC rootcheck/check_rc_policy.o
    CC rootcheck/check_rc_pids.o
    CC rootcheck/check_rc_trojans.o
    CC client-agent/state.o
    CC client-agent/sendmsg.o
    CC client-agent/request.o
    CC client-agent/config.o
    CC client-agent/rotate_log.o
    CC client-agent/receiver-win.o
    CC client-agent/restart_agent.o
    CC client-agent/receiver.o
    CC client-agent/buffer.o
    CC client-agent/start_agent.o
    CC client-agent/agcom.o
    CC client-agent/notify.o
    CC logcollector/read_ossecalert.o
    CC logcollector/state.o
    CC logcollector/config.o
    CC logcollector/logcollector.o
    CC logcollector/read_djb_multilog.o
    CC logcollector/read_postgresql_log.o
logcollector/read_postgresql_log.c: In function ‘read_postgresql_log’:
logcollector/read_postgresql_log.c:114:17: warning: ‘strncpy’ output may be truncated copying between 35 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  114 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_postgresql_log.c:106:17: warning: ‘strncpy’ output may be truncated copying between 35 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_ucs2_le.o
    CC logcollector/read_mssql_log.o
    CC logcollector/read_win_el.o
logcollector/read_mssql_log.c: In function ‘read_mssql_log’:
logcollector/read_mssql_log.c:117:17: warning: ‘strncpy’ output may be truncated copying between 22 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  117 |                 strncpy(buffer, str, str_len + 2);

```

</details>

## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Windows Agent</summary>

```
   61 | void _mterror(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull));
      |      ^~~~~~~~
    CC rootcheck/rootcheck-config.o
    CC rootcheck/run_rk_check.o
In function ‘_rkcl_getrootdir’,
    inlined from ‘rkcl_get_entry’ at rootcheck/common_rcl.c:286:5:
rootcheck/common_rcl.c:47:9: warning: ‘strncpy’ output may be truncated copying 1025 bytes from a string of length 2048 [-Wstringop-truncation]
   47 |         strncpy(root_dir, final_file, dir_size);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC rootcheck/unix-process.o
    CC rootcheck/win-common.o
    CC rootcheck/win-process.o
    CC client-agent/agcom.o
    CC client-agent/buffer.o
    CC client-agent/config.o
    CC client-agent/notify.o
    CC client-agent/receiver.o
    CC client-agent/receiver-win.o
    CC client-agent/request.o
    CC client-agent/restart_agent.o
    CC client-agent/rotate_log.o
    CC client-agent/sendmsg.o
    CC client-agent/start_agent.o
    CC client-agent/state.o
    CC logcollector/config.o
    CC logcollector/lccom.o
    CC logcollector/logcollector.o
    CC logcollector/macos_log.o
    CC logcollector/read_audit.o
    CC logcollector/read_command.o
    CC logcollector/read_djb_multilog.o
    CC logcollector/read_fullcommand.o
    CC logcollector/read_json.o
    CC logcollector/read_macos.o
    CC logcollector/read_mssql_log.o
    CC logcollector/read_multiline.o
    CC logcollector/read_multiline_regex.o
    CC logcollector/read_mysql_log.o
logcollector/read_mssql_log.c: In function ‘read_mssql_log’:
logcollector/read_mssql_log.c:117:17: warning: ‘strncpy’ output may be truncated copying between 22 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  117 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_mssql_log.c:108:17: warning: ‘strncpy’ output may be truncated copying between 22 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  108 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_nmapg.o
logcollector/read_multiline.c: In funct
```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors