### PR TITLE
Remove deprecated settings related to FIM synchronization

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -8531,7 +8531,6 @@ paths:
                         synchronization:
                           enabled: yes
                           interval: "5m"
-                          max_interval: "1h"
                           max_eps: 10
                       command:
                         - name: disable-account

--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -113,8 +113,6 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
-      <response_timeout>30</response_timeout>
-      <queue_size>16384</queue_size>
       <max_eps>10</max_eps>
     </synchronization>
   </syscheck>

--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -130,8 +130,6 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
-      <response_timeout>30</response_timeout>
-      <queue_size>16384</queue_size>
       <max_eps>10</max_eps>
     </synchronization>
   </syscheck>

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -130,8 +130,6 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
-      <response_timeout>30</response_timeout>
-      <queue_size>16384</queue_size>
       <max_eps>10</max_eps>
     </synchronization>
   </syscheck>

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -151,8 +151,6 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
-      <response_timeout>30</response_timeout>
-      <queue_size>16384</queue_size>
       <max_eps>10</max_eps>
     </synchronization>
   </syscheck>

--- a/etc/templates/config/darwin/syscheck.agent.template
+++ b/etc/templates/config/darwin/syscheck.agent.template
@@ -46,7 +46,6 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
-      <max_interval>1h</max_interval>
       <max_eps>10</max_eps>
     </synchronization>
   </syscheck>

--- a/etc/templates/config/darwin/syscheck.manager.template
+++ b/etc/templates/config/darwin/syscheck.manager.template
@@ -54,7 +54,6 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
-      <max_interval>1h</max_interval>
       <max_eps>10</max_eps>
     </synchronization>
   </syscheck>

--- a/etc/templates/config/generic/syscheck.agent.template
+++ b/etc/templates/config/generic/syscheck.agent.template
@@ -46,7 +46,6 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
-      <max_interval>1h</max_interval>
       <max_eps>10</max_eps>
     </synchronization>
   </syscheck>

--- a/etc/templates/config/generic/syscheck.manager.template
+++ b/etc/templates/config/generic/syscheck.manager.template
@@ -52,7 +52,6 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
-      <max_interval>1h</max_interval>
       <max_eps>10</max_eps>
     </synchronization>
   </syscheck>

--- a/etc/templates/config/windows/2003/syscheck.template
+++ b/etc/templates/config/windows/2003/syscheck.template
@@ -1,5 +1,5 @@
   <syscheck>
-  
+
     <disabled>no</disabled>
 
     <!-- Frequency that syscheck is executed default every 12 hours -->
@@ -67,8 +67,6 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
-      <max_interval>1h</max_interval>
       <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
-  

--- a/etc/templates/config/windows/xp/syscheck.template
+++ b/etc/templates/config/windows/xp/syscheck.template
@@ -1,5 +1,5 @@
   <syscheck>
-  
+
     <disabled>no</disabled>
 
     <!-- Frequency that syscheck is executed default every 12 hours -->
@@ -67,7 +67,6 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
-      <max_interval>1h</max_interval>
       <max_eps>10</max_eps>
     </synchronization>
   </syscheck>

--- a/framework/wazuh/core/tests/data/configuration/default/synchronization.conf
+++ b/framework/wazuh/core/tests/data/configuration/default/synchronization.conf
@@ -1,8 +1,5 @@
 <synchronization>
   <enabled>yes</enabled>
   <interval>5m</interval>
-  <max_interval>1h</max_interval>
-  <response_timeout>30</response_timeout>
-  <sync_queue_size>16384</sync_queue_size>
   <max_eps>10</max_eps>
 </synchronization>

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -114,7 +114,6 @@ int initialize_syscheck_configuration(syscheck_config *syscheck) {
 #endif
     syscheck->prefilter_cmd                   = NULL;
     syscheck->sync_interval                   = 300;
-    syscheck->max_sync_interval               = 3600;
     syscheck->sync_max_eps                    = 10;
     syscheck->max_eps                         = 100;
     syscheck->max_files_per_second            = 0;
@@ -1197,30 +1196,11 @@ static void parse_synchronization(syscheck_config * syscheck, XML_NODE node) {
                 syscheck->sync_interval = t;
             }
         } else if (strcmp(node[i]->element, xml_max_sync_interval) == 0) {
-            long t = w_parse_time(node[i]->content);
-
-            if (t <= 0) {
-                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
-            } else {
-                syscheck->max_sync_interval = t;
-            }
+            mdebug1("'%s' has been deprecated. This setting is skipped.", xml_max_sync_interval);
         } else if (strcmp(node[i]->element, xml_response_timeout) == 0) {
-            long t = w_parse_time(node[i]->content);
-
-            if (t == -1) {
-                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
-            } else {
-                mwarn("This configuration variable has been deprecated. It will have no effect.");
-            }
+            mdebug1("'%s' has been deprecated. This setting is skipped.", xml_response_timeout);
         } else if (strcmp(node[i]->element, xml_sync_queue_size) == 0) {
-            char * end;
-            long value = strtol(node[i]->content, &end, 10);
-
-            if (value < 2 || value > 1000000 || *end) {
-                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
-            } else {
-                mwarn("This configuration variable has been deprecated. It will have no effect.");
-            }
+            mdebug1("'%s' has been deprecated. This setting is skipped.", xml_sync_queue_size);
         } else if (strcmp(node[i]->element, xml_max_eps) == 0) {
             char * end;
             long value = strtol(node[i]->content, &end, 10);
@@ -1231,15 +1211,7 @@ static void parse_synchronization(syscheck_config * syscheck, XML_NODE node) {
                 syscheck->sync_max_eps = value;
             }
         } else if (strcmp(node[i]->element, xml_registry_enabled) == 0) {
-#ifdef WIN32
-            int r = w_parse_bool(node[i]->content);
-
-            if (r < 0) {
-                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
-            } else {
-                syscheck->enable_registry_synchronization = r;
-            }
-#endif
+            mdebug1("'%s' has been deprecated. This setting is skipped.", xml_registry_enabled);
         } else {
             mwarn(XML_INVELEM, node[i]->element);
         }

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -115,8 +115,6 @@ int initialize_syscheck_configuration(syscheck_config *syscheck) {
     syscheck->prefilter_cmd                   = NULL;
     syscheck->sync_interval                   = 300;
     syscheck->max_sync_interval               = 3600;
-    syscheck->sync_response_timeout           = 30;
-    syscheck->sync_queue_size                 = 16384;
     syscheck->sync_max_eps                    = 10;
     syscheck->max_eps                         = 100;
     syscheck->max_files_per_second            = 0;
@@ -1212,7 +1210,7 @@ static void parse_synchronization(syscheck_config * syscheck, XML_NODE node) {
             if (t == -1) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
-                syscheck->sync_response_timeout = t;
+                mwarn("This configuration variable has been deprecated. It will have no effect.");
             }
         } else if (strcmp(node[i]->element, xml_sync_queue_size) == 0) {
             char * end;
@@ -1221,7 +1219,7 @@ static void parse_synchronization(syscheck_config * syscheck, XML_NODE node) {
             if (value < 2 || value > 1000000 || *end) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
-                syscheck->sync_queue_size = value;
+                mwarn("This configuration variable has been deprecated. It will have no effect.");
             }
         } else if (strcmp(node[i]->element, xml_max_eps) == 0) {
             char * end;

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1211,7 +1211,15 @@ static void parse_synchronization(syscheck_config * syscheck, XML_NODE node) {
                 syscheck->sync_max_eps = value;
             }
         } else if (strcmp(node[i]->element, xml_registry_enabled) == 0) {
-            mdebug1("'%s' has been deprecated. This setting is skipped.", xml_registry_enabled);
+#ifdef WIN32
+            int r = w_parse_bool(node[i]->content);
+
+            if (r < 0) {
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
+            } else {
+                syscheck->enable_registry_synchronization = r;
+            }
+#endif
         } else {
             mwarn(XML_INVELEM, node[i]->element);
         }

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -401,7 +401,6 @@ typedef struct _config {
     char **nodiff;                                     /* list of files/dirs to never output diff */
     OSMatch **nodiff_regex;                            /* regex of files/dirs to never output diff */
 
-    long max_sync_interval;                            /* Maximum Synchronization interval (seconds) */
     long sync_interval;                                /* Synchronization interval (seconds) */
     long sync_max_eps;                                 /* Maximum events per second for synchronization messages. */
     int max_eps;                                       /* Maximum events per second. */

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -403,8 +403,6 @@ typedef struct _config {
 
     long max_sync_interval;                            /* Maximum Synchronization interval (seconds) */
     long sync_interval;                                /* Synchronization interval (seconds) */
-    long sync_response_timeout;                        /* Minimum time between receiving a sync response and starting a new sync session */
-    long sync_queue_size;                              /* Data synchronization message queue size */
     long sync_max_eps;                                 /* Maximum events per second for synchronization messages. */
     int max_eps;                                       /* Maximum events per second. */
 

--- a/src/syscheckd/src/config.c
+++ b/src/syscheckd/src/config.c
@@ -473,8 +473,6 @@ cJSON *getSyscheckConfig(void) {
 #endif
     cJSON_AddNumberToObject(synchronization, "max_interval", syscheck.max_sync_interval);
     cJSON_AddNumberToObject(synchronization, "interval", syscheck.sync_interval);
-    cJSON_AddNumberToObject(synchronization, "response_timeout", syscheck.sync_response_timeout);
-    cJSON_AddNumberToObject(synchronization, "queue_size", syscheck.sync_queue_size);
     cJSON_AddNumberToObject(synchronization, "max_eps", syscheck.sync_max_eps);
     cJSON_AddItemToObject(syscfg, "synchronization", synchronization);
 

--- a/src/syscheckd/src/config.c
+++ b/src/syscheckd/src/config.c
@@ -467,11 +467,6 @@ cJSON *getSyscheckConfig(void) {
 
     cJSON * synchronization = cJSON_CreateObject();
     cJSON_AddStringToObject(synchronization, "enabled", syscheck.enable_synchronization ? "yes" : "no");
-#ifdef WIN32
-    cJSON_AddStringToObject(synchronization, "registry_enabled",
-                            syscheck.enable_registry_synchronization ? "yes" : "no");
-#endif
-    cJSON_AddNumberToObject(synchronization, "max_interval", syscheck.max_sync_interval);
     cJSON_AddNumberToObject(synchronization, "interval", syscheck.sync_interval);
     cJSON_AddNumberToObject(synchronization, "max_eps", syscheck.sync_max_eps);
     cJSON_AddItemToObject(syscfg, "synchronization", synchronization);

--- a/src/syscheckd/src/config.c
+++ b/src/syscheckd/src/config.c
@@ -467,6 +467,10 @@ cJSON *getSyscheckConfig(void) {
 
     cJSON * synchronization = cJSON_CreateObject();
     cJSON_AddStringToObject(synchronization, "enabled", syscheck.enable_synchronization ? "yes" : "no");
+#ifdef WIN32
+    cJSON_AddStringToObject(synchronization, "registry_enabled",
+                            syscheck.enable_registry_synchronization ? "yes" : "no");
+#endif
     cJSON_AddNumberToObject(synchronization, "interval", syscheck.sync_interval);
     cJSON_AddNumberToObject(synchronization, "max_eps", syscheck.sync_max_eps);
     cJSON_AddItemToObject(syscfg, "synchronization", synchronization);

--- a/src/unit_tests/config_files/test_syscheck.conf
+++ b/src/unit_tests/config_files/test_syscheck.conf
@@ -70,8 +70,6 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>10m</interval>
-      <max_interval>1h</max_interval>
-      <queue_size>64</queue_size>
     </synchronization>
     <database>disk</database>
   </syscheck>

--- a/src/unit_tests/config_files/test_syscheck2.conf
+++ b/src/unit_tests/config_files/test_syscheck2.conf
@@ -58,8 +58,6 @@
     <synchronization>
       <enabled>no</enabled>
       <interval>10m</interval>
-      <max_interval>1h</max_interval>
-      <queue_size>64</queue_size>
     </synchronization>
     <database>memory</database>
   </syscheck>

--- a/src/unit_tests/config_files/test_syscheck_config_win.conf
+++ b/src/unit_tests/config_files/test_syscheck_config_win.conf
@@ -157,8 +157,6 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>10m</interval>
-      <max_interval>1h</max_interval>
-      <queue_size>64</queue_size>
     </synchronization>
     <database>disk</database>
   </syscheck>

--- a/src/unit_tests/config_files/test_syscheck_max_dir.conf
+++ b/src/unit_tests/config_files/test_syscheck_max_dir.conf
@@ -72,8 +72,6 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>10m</interval>
-      <max_interval>1h</max_interval>
-      <queue_size>64</queue_size>
     </synchronization>
     <database>disk</database>
   </syscheck>

--- a/src/unit_tests/config_files/test_syscheck_top_level.conf
+++ b/src/unit_tests/config_files/test_syscheck_top_level.conf
@@ -69,8 +69,6 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>10m</interval>
-      <max_interval>1h</max_interval>
-      <queue_size>64</queue_size>
     </synchronization>
     <database>disk</database>
   </syscheck>

--- a/src/unit_tests/config_files/test_syscheck_top_level_win.conf
+++ b/src/unit_tests/config_files/test_syscheck_top_level_win.conf
@@ -100,8 +100,6 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>10m</interval>
-      <max_interval>1h</max_interval>
-      <queue_size>64</queue_size>
     </synchronization>
     <database>disk</database>
   </syscheck>

--- a/src/unit_tests/config_files/test_syscheck_win.conf
+++ b/src/unit_tests/config_files/test_syscheck_win.conf
@@ -113,8 +113,6 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>10m</interval>
-      <max_interval>1h</max_interval>
-      <queue_size>64</queue_size>
     </synchronization>
     <database>disk</database>
   </syscheck>

--- a/src/unit_tests/config_files/test_syscheck_win2.conf
+++ b/src/unit_tests/config_files/test_syscheck_win2.conf
@@ -115,8 +115,6 @@
     <synchronization>
       <enabled>no</enabled>
       <interval>10m</interval>
-      <max_interval>1h</max_interval>
-      <queue_size>64</queue_size>
     </synchronization>
     <database>memory</database>
   </syscheck>

--- a/src/unit_tests/config_files/test_syscheck_win_max_dir.conf
+++ b/src/unit_tests/config_files/test_syscheck_win_max_dir.conf
@@ -115,8 +115,6 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>10m</interval>
-      <max_interval>1h</max_interval>
-      <queue_size>64</queue_size>
     </synchronization>
     <database>disk</database>
   </syscheck>

--- a/src/unit_tests/syscheckd/test_config.c
+++ b/src/unit_tests/syscheckd/test_config.c
@@ -138,8 +138,6 @@ void test_Read_Syscheck_Config_success(void **state)
     assert_int_equal(syscheck.allow_remote_prefilter_cmd, true);
     assert_non_null(syscheck.prefilter_cmd);    // It should be a valid binary absolute path
     assert_int_equal(syscheck.sync_interval, 600);
-    assert_int_equal(syscheck.sync_response_timeout, 30);
-    assert_int_equal(syscheck.sync_queue_size, 64);
     assert_int_equal(syscheck.max_eps, 200);
     assert_int_equal(syscheck.disk_quota_enabled, true);
     assert_int_equal(syscheck.disk_quota_limit, 1024 * 1024);
@@ -207,8 +205,6 @@ void test_Read_Syscheck_Config_undefined(void **state)
     assert_int_equal(syscheck.allow_remote_prefilter_cmd, false);
     assert_null(syscheck.prefilter_cmd);
     assert_int_equal(syscheck.sync_interval, 600);
-    assert_int_equal(syscheck.sync_response_timeout, 30);
-    assert_int_equal(syscheck.sync_queue_size, 64);
     assert_int_equal(syscheck.max_eps, 200);
     assert_int_equal(syscheck.disk_quota_enabled, true);
     assert_int_equal(syscheck.disk_quota_limit, 2 * 1024 * 1024);
@@ -262,8 +258,6 @@ void test_Read_Syscheck_Config_unparsed(void **state)
     assert_int_equal(syscheck.allow_remote_prefilter_cmd, false);
     assert_null(syscheck.prefilter_cmd);
     assert_int_equal(syscheck.sync_interval, 300);
-    assert_int_equal(syscheck.sync_response_timeout, 30);
-    assert_int_equal(syscheck.sync_queue_size, 16384);
     assert_int_equal(syscheck.max_eps, 100);
     assert_int_equal(syscheck.disk_quota_enabled, true);
     assert_int_equal(syscheck.disk_quota_limit, 1024 * 1024);

--- a/src/unit_tests/syscheckd/test_config.c
+++ b/src/unit_tests/syscheckd/test_config.c
@@ -392,14 +392,8 @@ void test_getSyscheckConfig(void **state)
     cJSON *sys_synchronization = cJSON_GetObjectItem(sys_items, "synchronization");
     cJSON *synchronization_enabled = cJSON_GetObjectItem(sys_synchronization, "enabled");
     assert_string_equal(cJSON_GetStringValue(synchronization_enabled), "yes");
-    cJSON *synchronization_max_interval = cJSON_GetObjectItem(sys_synchronization, "max_interval");
-    assert_int_equal(synchronization_max_interval->valueint, 3600);
     cJSON *synchronization_interval = cJSON_GetObjectItem(sys_synchronization, "interval");
     assert_int_equal(synchronization_interval->valueint, 600);
-    cJSON *synchronization_response_timeout = cJSON_GetObjectItem(sys_synchronization, "response_timeout");
-    assert_int_equal(synchronization_response_timeout->valueint, 30);
-    cJSON *synchronization_queue_size = cJSON_GetObjectItem(sys_synchronization, "queue_size");
-    assert_int_equal(synchronization_queue_size->valueint, 64);
 
     cJSON *sys_max_eps = cJSON_GetObjectItem(sys_items, "max_eps");
     assert_int_equal(sys_max_eps->valueint, 200);
@@ -514,14 +508,8 @@ void test_getSyscheckConfig_no_audit(void **state)
     cJSON *sys_synchronization = cJSON_GetObjectItem(sys_items, "synchronization");
     cJSON *synchronization_enabled = cJSON_GetObjectItem(sys_synchronization, "enabled");
     assert_string_equal(cJSON_GetStringValue(synchronization_enabled), "no");
-    cJSON *synchronization_max_interval = cJSON_GetObjectItem(sys_synchronization, "max_interval");
-    assert_int_equal(synchronization_max_interval->valueint, 3600);
     cJSON *synchronization_interval = cJSON_GetObjectItem(sys_synchronization, "interval");
     assert_int_equal(synchronization_interval->valueint, 600);
-    cJSON *synchronization_response_timeout = cJSON_GetObjectItem(sys_synchronization, "response_timeout");
-    assert_int_equal(synchronization_response_timeout->valueint, 30);
-    cJSON *synchronization_queue_size = cJSON_GetObjectItem(sys_synchronization, "queue_size");
-    assert_int_equal(synchronization_queue_size->valueint, 64);
 
     cJSON *database = cJSON_GetObjectItem(sys_items, "database");
     assert_string_equal(cJSON_GetStringValue(database), "memory");
@@ -618,17 +606,11 @@ void test_getSyscheckConfig_no_directories(void **state)
     assert_int_equal(process_priority->valueint, 10);
 
     cJSON *synchronization = cJSON_GetObjectItem(sys_items, "synchronization");
-    assert_int_equal(cJSON_GetArraySize(synchronization), 7);
+    assert_int_equal(cJSON_GetArraySize(synchronization), 4);
     cJSON *enabled = cJSON_GetObjectItem(synchronization, "enabled");
     assert_string_equal(cJSON_GetStringValue(enabled), "yes");
-    cJSON *max_interval = cJSON_GetObjectItem(synchronization, "max_interval");
-    assert_int_equal(max_interval->valueint, 3600);
     cJSON *interval = cJSON_GetObjectItem(synchronization, "interval");
     assert_int_equal(interval->valueint, 300);
-    cJSON *response_timeout = cJSON_GetObjectItem(synchronization, "response_timeout");
-    assert_int_equal(response_timeout->valueint, 30);
-    cJSON *queue_size = cJSON_GetObjectItem(synchronization, "queue_size");
-    assert_int_equal(queue_size->valueint, 16384);
     cJSON *sync_max_eps = cJSON_GetObjectItem(synchronization, "max_eps");
     assert_int_equal(sync_max_eps->valueint, 10);
 }

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -150,7 +150,6 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
-      <max_interval>1h</max_interval>
       <max_eps>10</max_eps>
     </synchronization>
   </syscheck>


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/12473|


## Description
Removed from the code two requested variables from the FIM synchronization configuration.

## Configuration options
FIM synchronization block:
```
<synchronization>
      <enabled>yes</enabled>
      <interval>5m</interval>
      <max_eps>10</max_eps>
</synchronization>
```

## Logs/Alerts example

```
2022/03/01 16:41:36 wazuh-syscheckd[58076] syscheck-config.c:1213 at parse_synchronization(): WARNING: This configuration variable has been deprecated. It will have no effect.
2022/03/01 16:41:36 wazuh-syscheckd[58076] syscheck-config.c:1222 at parse_synchronization(): WARNING: This configuration variable has been deprecated. It will have no effect.
```


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Review logs syntax and correct language