### PR TITLE
Update Azure module logging functionality

### DIFF
--- a/src/wazuh_modules/wm_azure.c
+++ b/src/wazuh_modules/wm_azure.c
@@ -152,6 +152,14 @@ void wm_azure_log_analytics(wm_azure_api_t *log_analytics) {
             wm_strcat(&command, "--la_time_offset", ' ');
             wm_strcat(&command, curr_request->time_offset, ' ');
         }
+        if (isDebug()) {
+            char *int_to_string;
+            os_malloc(OS_SIZE_1024, int_to_string);
+            sprintf(int_to_string, "%d", isDebug());
+            wm_strcat(&command, "--debug", ' ');
+            wm_strcat(&command, int_to_string, ' ');
+            os_free(int_to_string);
+        }
 
         // Check timeout defined
         if (curr_request->timeout)
@@ -164,8 +172,8 @@ void wm_azure_log_analytics(wm_azure_api_t *log_analytics) {
         switch (wm_exec(command, &output, &status, timeout, NULL)) {
             case 0:
                 if (status > 0) {
-                    mtwarn(WM_AZURE_LOGTAG, "%s: Returned error code: '%d'.", curr_request->tag, status);
-                    mtdebug2(WM_AZURE_LOGTAG, "OUTPUT: %s", output);
+                    mterror(WM_AZURE_LOGTAG, "%s: Returned error code: '%d'.", curr_request->tag, status);
+                    mtdebug1(WM_AZURE_LOGTAG, "OUTPUT: %s", output);
                 }
                 break;
             case WM_ERROR_TIMEOUT:
@@ -231,6 +239,15 @@ void wm_azure_graphs(wm_azure_api_t *graph) {
             wm_strcat(&command, curr_request->time_offset, ' ');
         }
 
+        if (isDebug()) {
+            char *int_to_string;
+            os_malloc(OS_SIZE_1024, int_to_string);
+            sprintf(int_to_string, "%d", isDebug());
+            wm_strcat(&command, "--debug", ' ');
+            wm_strcat(&command, int_to_string, ' ');
+            os_free(int_to_string);
+        }
+
         // Check timeout defined
         if (curr_request->timeout)
             timeout = curr_request->timeout;
@@ -242,8 +259,8 @@ void wm_azure_graphs(wm_azure_api_t *graph) {
         switch (wm_exec(command, &output, &status, timeout, NULL)) {
             case 0:
                 if (status > 0) {
-                    mtwarn(WM_AZURE_LOGTAG, "%s: Returned error code: '%d'.", curr_request->tag, status);
-                    mtdebug2(WM_AZURE_LOGTAG, "OUTPUT: %s", output);
+                    mterror(WM_AZURE_LOGTAG, "%s: Returned error code: '%d'.", curr_request->tag, status);
+                    mtdebug1(WM_AZURE_LOGTAG, "OUTPUT: %s", output);
                 }
                 break;
             case WM_ERROR_TIMEOUT:
@@ -322,6 +339,15 @@ void wm_azure_storage(wm_azure_storage_t *storage) {
             wm_strcat(&command, curr_container->time_offset, ' ');
         }
 
+        if (isDebug()) {
+            char *int_to_string;
+            os_malloc(OS_SIZE_1024, int_to_string);
+            sprintf(int_to_string, "%d", isDebug());
+            wm_strcat(&command, "--debug", ' ');
+            wm_strcat(&command, int_to_string, ' ');
+            os_free(int_to_string);
+        }
+
         // Check timeout defined
         if (curr_container->timeout)
             timeout = curr_container->timeout;
@@ -333,8 +359,8 @@ void wm_azure_storage(wm_azure_storage_t *storage) {
         switch (wm_exec(command, &output, &status, timeout, NULL)) {
             case 0:
                 if (status > 0) {
-                    mtwarn(WM_AZURE_LOGTAG, "%s: Returned error code: '%d'.", curr_container->name, status);
-                    mtdebug2(WM_AZURE_LOGTAG, "OUTPUT: %s", output);
+                    mterror(WM_AZURE_LOGTAG, "%s: Returned error code: '%d'.", curr_container->name, status);
+                    mtdebug1(WM_AZURE_LOGTAG, "OUTPUT: %s", output);
                 }
                 break;
             case WM_ERROR_TIMEOUT:

--- a/wodles/azure/azure-logs.py
+++ b/wodles/azure/azure-logs.py
@@ -47,26 +47,25 @@ url_graph = 'https://graph.microsoft.com'
 
 socket_header = '1:Azure:'
 
+# Logger parameters
+logging_msg_format = '%(asctime)s azure: %(levelname)s: %(message)s'
+logging_date_format = '%Y/%m/%d %I:%M:%S'
+log_levels = {0: logging.WARNING,
+              1: logging.INFO,
+              2: logging.DEBUG}
+
 
 def set_logger():
     """Set the logger configuration."""
-    if args.verbose:
-        logging.basicConfig(level=logging.DEBUG,
-                            format='%(asctime)s %(levelname)s: AZURE %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
-        logging.getLogger('azure').setLevel(logging.DEBUG)
-
-    else:
-        log_path = f"{find_wazuh_path()}/logs/azure_logs.log"
-        logging.basicConfig(filename=log_path, level=logging.DEBUG,
-                            format='%(asctime)s %(levelname)s: AZURE %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
-        logging.getLogger('azure').setLevel(logging.ERROR)
-        logging.getLogger('urllib3').setLevel(logging.ERROR)
+    logging.basicConfig(level=log_levels.get(args.debug_level, logging.WARNING), format=logging_msg_format,
+                        datefmt=logging_date_format)
+    logging.getLogger('azure').setLevel(log_levels.get(args.debug_level, logging.WARNING))
+    logging.getLogger('urllib3').setLevel(logging.ERROR)
 
 
 def get_script_arguments():
     """Read and parse arguments."""
     parser = ArgumentParser()
-    parser.add_argument("-v", "--verbose", action='store_true', required=False, help="Debug mode.")
 
     # only one must be present (log_analytics, graph or storage)
     group = parser.add_mutually_exclusive_group(required=True)
@@ -133,6 +132,8 @@ def get_script_arguments():
     # General parameters #
     parser.add_argument('--reparse', action='store_true', dest='reparse',
                         help='Parse the log, even if its been parsed before', default=False)
+    parser.add_argument('-d', '--debug', action='store', type=int, dest='debug_level', default=0,
+                        help='Specify debug level. Admits values from 0 to 2.')
 
     return parser.parse_args()
 


### PR DESCRIPTION

|Related issue|
|---|
| Closes #11938 |

# Description

This PR updates our Azure module integration to send the output (debug, info, warning and error messages) to the `ossec.log` file instead of using a separate file called `azure-logs.log`. This makes it more consistent with the other external integrations (AWS and GCP).

The most important changes are detailed below:


- The message management is now handled by the `logging` library, in a similar way to how the `gcloud` module works. The `logging` module has been configured to send the different debug messages to `stdout`, since the core part is designed to capture this `stdout` and show it in the `ossec.log`. The rest of the modules are also implemented this way, so it is consistent.

- The `-v` or `--verbosity` parameter has been deprecated. This parameter was used to set the module to send the different debug messages to the `stdout`. When it was not present, they were sent to the `azure-logs.log` file instead. This parameter is no longer needed. It has been kept in the module to mantain compatibility and to show a warning to the user when trying to use it.

- A new debug level parameter called `--debug` or `-d` has been added. It works ìn a similar way to the other modules. The higher the value indicated, the higher the verbosity, being the accepted values 0, 1 or 2. 

- The Core code has been updated to make use of the new debug parameter. The value of the `wazuh_modules.debug` will be provided to the module.

- The Core Unit Tests have been revised to ensure that no compatibility is broken after the changes. No changes were required.



# Tests


## Wazuh_modules Unit tests

To run the Unit Teps the following steps were followed in a clean Ubuntu host:


<details>
  <summary>Setup</summary>

	git clone https://git.cryptomilk.org/projects/cmocka.git
	cd cmocka
	git checkout stable-1.1
	vi DefineOptions.cmake 
	mkdir build
	cd build
	cmake -DCMAKE_BUILD_TYPE=Release ..
	make
	make install
	git clone https://github.com/wazuh/wazuh.git
	cd wazuh/src/
	git checkout feature/11938-azure-logging
	make deps TARGET=server
	make TARGET=server DEBUG=1 TEST=1
	cd unit_tests/
	mkdir build
	cd build/
	cmake -DTARGET=server ..
	make
	cd wazuh_modules/azure/
	./test_wm_azure
</details>


<details>
  <summary>Results</summary>

	[==========] tests_with_startup: Running 1 test(s).
	[ RUN      ] test_interval_execution
	[       OK ] test_interval_execution
	[==========] tests_with_startup: 1 test(s) run.
	[  PASSED  ] 1 test(s).
	[==========] tests_without_startup: Running 5 test(s).
	[ RUN      ] test_fake_tag
	[       OK ] test_fake_tag
	[ RUN      ] test_read_scheduling_monthday_configuration
	[       OK ] test_read_scheduling_monthday_configuration
	[ RUN      ] test_read_scheduling_weekday_configuration
	[       OK ] test_read_scheduling_weekday_configuration
	[ RUN      ] test_read_scheduling_daytime_configuration
	[       OK ] test_read_scheduling_daytime_configuration
	[ RUN      ] test_read_scheduling_interval_configuration
	[       OK ] test_read_scheduling_interval_configuration
	[==========] tests_without_startup: 5 test(s) run.
	[  PASSED  ] 5 test(s).
</details>


## Manual testing

For testing purposes, the following configuration has been executed. It was designed to fail, since it does not indicate any of the mandatory parameters for authentication:

<details>
  <summary>Azure configuration</summary>

	<wodle name="azure-logs">
		<disabled>no</disabled>
		<interval>10m</interval>
		<run_on_start>yes</run_on_start>

		<storage>
			<tag>storage</tag>
			<auth_path>invalid</auth_path>
			<container name="invalid">
				<time_offset>50d</time_offset>
			</container>
		</storage>

		<log_analytics>
			<auth_path>invalid</auth_path>
			<tenantdomain>invalid</tenantdomain>
			<request>
				<tag>log-analytics</tag>
				<query>AzureDiagnostics</query>
				<workspace>invalid</workspace>
			</request>
		</log_analytics>

	    <graph>
			<auth_path>invalid</auth_path>
			<tenantdomain>invalid</tenantdomain>
	        <request>
	        	<tag>graph</tag>
	            <query>invalid</query>
	            <time_offset>1d</time_offset>
	        </request>
	    </graph>
	</wodle>
</details>


Here is the output of the module when using the different modules debug modes available:


<details>
  <summary>modules.debug=0</summary>

	2022/02/24 14:54:04 wazuh-modulesd:azure-logs: INFO: Module started.
	2022/02/24 14:54:04 wazuh-modulesd:azure-logs: INFO: Starting fetching of logs.
	2022/02/24 14:54:04 wazuh-modulesd:azure-logs: INFO: Starting Log Analytics collection for the domain 'invalid'.
	2022/02/24 14:54:05 wazuh-modulesd:azure-logs: ERROR: log-analytics: Returned error code: '1'.
	2022/02/24 14:54:05 wazuh-modulesd:azure-logs: INFO: Finished Log Analytics collection for request 'log-analytics'.
	2022/02/24 14:54:05 wazuh-modulesd:azure-logs: INFO: Finished Log Analytics collection for the domain 'invalid'.
	2022/02/24 14:54:05 wazuh-modulesd:azure-logs: INFO: Starting Graphs log collection for the domain 'invalid'.
	2022/02/24 14:54:05 wazuh-modulesd:azure-logs: ERROR: graph: Returned error code: '1'.
	2022/02/24 14:54:05 wazuh-modulesd:azure-logs: INFO: Finished Graphs log collection for request 'graph'.
	2022/02/24 14:54:05 wazuh-modulesd:azure-logs: INFO: Finished Graphs log collection for the domain 'invalid'.
	2022/02/24 14:54:05 wazuh-modulesd:azure-logs: INFO: Starting Storage log collection for 'storage'.
	2022/02/24 14:54:05 wazuh-modulesd:azure-logs: ERROR: invalid: Returned error code: '1'.
	2022/02/24 14:54:05 wazuh-modulesd:azure-logs: INFO: Finished Storage log collection for container 'invalid'.
	2022/02/24 14:54:05 wazuh-modulesd:azure-logs: INFO: Finished Storage log collection for 'storage'.
</details>

<details>
  <summary>modules.debug=1</summary>

	2022/02/24 14:53:12 wazuh-modulesd:azure-logs[30520] wm_azure.c:53 at wm_azure_main(): INFO: Module started.
	2022/02/24 14:53:12 wazuh-modulesd:azure-logs[30520] wm_azure.c:73 at wm_azure_main(): INFO: Starting fetching of logs.
	2022/02/24 14:53:12 wazuh-modulesd:azure-logs[30520] wm_azure.c:80 at wm_azure_main(): INFO: Starting Log Analytics collection for the domain 'invalid'.
	2022/02/24 14:53:12 wazuh-modulesd:azure-logs[30520] wm_azure.c:171 at wm_azure_log_analytics(): DEBUG: Launching command: wodles/azure/azure-logs --log_analytics --la_auth_path invalid --la_tenant_domain invalid --la_tag log-analytics --la_query "AzureDiagnostics" --workspace invalid --debug 1
	2022/02/24 14:53:12 wazuh-modulesd:azure-logs[30520] wm_azure.c:175 at wm_azure_log_analytics(): ERROR: log-analytics: Returned error code: '1'.
	2022/02/24 14:53:12 wazuh-modulesd:azure-logs[30520] wm_azure.c:176 at wm_azure_log_analytics(): DEBUG: OUTPUT: 2022/02/24 02:53:12 azure: INFO: Sample message
	2022/02/24 02:53:12 azure: WARNING: Sample message
	2022/02/24 02:53:12 azure: ERROR: Sample message
	2022/02/24 02:53:12 azure: CRITICAL: Sample message
	2022/02/24 02:53:12 azure: INFO: Getting the data from /var/ossec/wodles/azure/last_dates.json.
	2022/02/24 02:53:12 azure: INFO: Azure Log Analytics starting.
	2022/02/24 02:53:12 azure: ERROR: Error: The authentication file could not be opened: [Errno 2] No such file or directory: 'invalid'
	2022/02/24 14:53:12 wazuh-modulesd:azure-logs[30520] wm_azure.c:188 at wm_azure_log_analytics(): INFO: Finished Log Analytics collection for request 'log-analytics'.
	2022/02/24 14:53:12 wazuh-modulesd:azure-logs[30520] wm_azure.c:82 at wm_azure_main(): INFO: Finished Log Analytics collection for the domain 'invalid'.
	2022/02/24 14:53:12 wazuh-modulesd:azure-logs[30520] wm_azure.c:84 at wm_azure_main(): INFO: Starting Graphs log collection for the domain 'invalid'.
	2022/02/24 14:53:12 wazuh-modulesd:azure-logs[30520] wm_azure.c:258 at wm_azure_graphs(): DEBUG: Launching command: wodles/azure/azure-logs --graph --graph_auth_path invalid --graph_tenant_domain invalid --graph_tag graph --graph_query 'invalid' --graph_time_offset 1d --debug 1
	2022/02/24 14:53:13 wazuh-modulesd:azure-logs[30520] wm_azure.c:262 at wm_azure_graphs(): ERROR: graph: Returned error code: '1'.
	2022/02/24 14:53:13 wazuh-modulesd:azure-logs[30520] wm_azure.c:263 at wm_azure_graphs(): DEBUG: OUTPUT: 2022/02/24 02:53:13 azure: INFO: Sample message
	2022/02/24 02:53:13 azure: WARNING: Sample message
	2022/02/24 02:53:13 azure: ERROR: Sample message
	2022/02/24 02:53:13 azure: CRITICAL: Sample message
	2022/02/24 02:53:13 azure: INFO: Getting the data from /var/ossec/wodles/azure/last_dates.json.
	2022/02/24 02:53:13 azure: INFO: Azure Graph starting.
	2022/02/24 02:53:13 azure: ERROR: Error: The authentication file could not be opened: [Errno 2] No such file or directory: 'invalid'
	2022/02/24 14:53:13 wazuh-modulesd:azure-logs[30520] wm_azure.c:275 at wm_azure_graphs(): INFO: Finished Graphs log collection for request 'graph'.
	2022/02/24 14:53:13 wazuh-modulesd:azure-logs[30520] wm_azure.c:86 at wm_azure_main(): INFO: Finished Graphs log collection for the domain 'invalid'.
	2022/02/24 14:53:13 wazuh-modulesd:azure-logs[30520] wm_azure.c:91 at wm_azure_main(): INFO: Starting Storage log collection for 'storage'.
	2022/02/24 14:53:13 wazuh-modulesd:azure-logs[30520] wm_azure.c:358 at wm_azure_storage(): DEBUG: Launching command: wodles/azure/azure-logs --storage --storage_auth_path invalid --container "invalid" --blobs "*" --storage_tag storage --storage_time_offset 50d --debug 1
	2022/02/24 14:53:13 wazuh-modulesd:azure-logs[30520] wm_azure.c:362 at wm_azure_storage(): ERROR: invalid: Returned error code: '1'.
	2022/02/24 14:53:13 wazuh-modulesd:azure-logs[30520] wm_azure.c:363 at wm_azure_storage(): DEBUG: OUTPUT: 2022/02/24 02:53:13 azure: INFO: Sample message
	2022/02/24 02:53:13 azure: WARNING: Sample message
	2022/02/24 02:53:13 azure: ERROR: Sample message
	2022/02/24 02:53:13 azure: CRITICAL: Sample message
	2022/02/24 02:53:13 azure: INFO: Getting the data from /var/ossec/wodles/azure/last_dates.json.
	2022/02/24 02:53:13 azure: INFO: Azure Storage starting.
	2022/02/24 02:53:13 azure: INFO: Storage: Authenticating.
	2022/02/24 02:53:13 azure: ERROR: Error: The authentication file could not be opened: [Errno 2] No such file or directory: 'invalid'
	2022/02/24 14:53:13 wazuh-modulesd:azure-logs[30520] wm_azure.c:375 at wm_azure_storage(): INFO: Finished Storage log collection for container 'invalid'.
	2022/02/24 14:53:13 wazuh-modulesd:azure-logs[30520] wm_azure.c:93 at wm_azure_main(): INFO: Finished Storage log collection for 'storage'.
	2022/02/24 14:53:13 wazuh-modulesd:azure-logs[30520] wm_azure.c:99 at wm_azure_main(): DEBUG: Fetching logs finished.
</details>

<details>
  <summary>modules debug 2</summary>

	2022/02/24 14:49:37 wazuh-modulesd[29994] main.c:94 at main(): DEBUG: Created new thread for the 'azure-logs' module.
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:53 at wm_azure_main(): INFO: Module started.
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:73 at wm_azure_main(): INFO: Starting fetching of logs.
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:80 at wm_azure_main(): INFO: Starting Log Analytics collection for the domain 'invalid'.
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:119 at wm_azure_log_analytics(): DEBUG: Creating argument list.
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:171 at wm_azure_log_analytics(): DEBUG: Launching command: wodles/azure/azure-logs --log_analytics --la_auth_path invalid --la_tenant_domain invalid --la_tag log-analytics --la_query "AzureDiagnostics" --workspace invalid --debug 2
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:175 at wm_azure_log_analytics(): ERROR: log-analytics: Returned error code: '1'.
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:176 at wm_azure_log_analytics(): DEBUG: OUTPUT: 2022/02/24 02:49:37 azure: INFO: Sample message
	2022/02/24 02:49:37 azure: DEBUG: Sample message
	2022/02/24 02:49:37 azure: WARNING: Sample message
	2022/02/24 02:49:37 azure: ERROR: Sample message
	2022/02/24 02:49:37 azure: CRITICAL: Sample message
	2022/02/24 02:49:37 azure: INFO: Getting the data from /var/ossec/wodles/azure/last_dates.json.
	2022/02/24 02:49:37 azure: INFO: Azure Log Analytics starting.
	2022/02/24 02:49:37 azure: ERROR: Error: The authentication file could not be opened: [Errno 2] No such file or directory: 'invalid'
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:188 at wm_azure_log_analytics(): INFO: Finished Log Analytics collection for request 'log-analytics'.
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:82 at wm_azure_main(): INFO: Finished Log Analytics collection for the domain 'invalid'.
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:84 at wm_azure_main(): INFO: Starting Graphs log collection for the domain 'invalid'.
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:208 at wm_azure_graphs(): DEBUG: Creating argument list.
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:258 at wm_azure_graphs(): DEBUG: Launching command: wodles/azure/azure-logs --graph --graph_auth_path invalid --graph_tenant_domain invalid --graph_tag graph --graph_query 'invalid' --graph_time_offset 1d --debug 2
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:262 at wm_azure_graphs(): ERROR: graph: Returned error code: '1'.
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:263 at wm_azure_graphs(): DEBUG: OUTPUT: 2022/02/24 02:49:37 azure: INFO: Sample message
	2022/02/24 02:49:37 azure: DEBUG: Sample message
	2022/02/24 02:49:37 azure: WARNING: Sample message
	2022/02/24 02:49:37 azure: ERROR: Sample message
	2022/02/24 02:49:37 azure: CRITICAL: Sample message
	2022/02/24 02:49:37 azure: INFO: Getting the data from /var/ossec/wodles/azure/last_dates.json.
	2022/02/24 02:49:37 azure: INFO: Azure Graph starting.
	2022/02/24 02:49:37 azure: ERROR: Error: The authentication file could not be opened: [Errno 2] No such file or directory: 'invalid'
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:275 at wm_azure_graphs(): INFO: Finished Graphs log collection for request 'graph'.
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:86 at wm_azure_main(): INFO: Finished Graphs log collection for the domain 'invalid'.
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:91 at wm_azure_main(): INFO: Starting Storage log collection for 'storage'.
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:296 at wm_azure_storage(): DEBUG: Creating argument list.
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:358 at wm_azure_storage(): DEBUG: Launching command: wodles/azure/azure-logs --storage --storage_auth_path invalid --container "invalid" --blobs "*" --storage_tag storage --storage_time_offset 50d --debug 2
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:362 at wm_azure_storage(): ERROR: invalid: Returned error code: '1'.
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:363 at wm_azure_storage(): DEBUG: OUTPUT: 2022/02/24 02:49:37 azure: INFO: Sample message
	2022/02/24 02:49:37 azure: DEBUG: Sample message
	2022/02/24 02:49:37 azure: WARNING: Sample message
	2022/02/24 02:49:37 azure: ERROR: Sample message
	2022/02/24 02:49:37 azure: CRITICAL: Sample message
	2022/02/24 02:49:37 azure: INFO: Getting the data from /var/ossec/wodles/azure/last_dates.json.
	2022/02/24 02:49:37 azure: INFO: Azure Storage starting.
	2022/02/24 02:49:37 azure: INFO: Storage: Authenticating.
	2022/02/24 02:49:37 azure: ERROR: Error: The authentication file could not be opened: [Errno 2] No such file or directory: 'invalid'
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:375 at wm_azure_storage(): INFO: Finished Storage log collection for container 'invalid'.
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:93 at wm_azure_main(): INFO: Finished Storage log collection for 'storage'.
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:99 at wm_azure_main(): DEBUG: Fetching logs finished.
	2022/02/24 14:49:37 wazuh-modulesd:azure-logs[29994] wm_azure.c:69 at wm_azure_main(): DEBUG: Sleeping until: 2022/02/24 14:59:37
</details>



As a reference, here is the output provided by the module when using the same configuration but without the changes introduced in this issue:

<details>
  <summary>modules.debug=0</summary>
</details>

<details>
  <summary>modules.debug=1</summary>
</details>

<details>
  <summary>modules.debug=2</summary>
</details>
