### PR TITLE
Dual CPE generation for Windows Server 2022

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5765,10 +5765,14 @@ int wm_vuldet_generate_win_cpe(scan_agent *agent) {
     STATIC const char *PR_WIN2016 = "windows_server_2016";
     STATIC const char *PR_WIN2019 = "windows_server_2019";
     STATIC const char *PR_WIN2022 = "windows_server_2022";
+    STATIC const char *PR_WINSERVER = "windows_server";
     STATIC const char *VER_R2 = "r2";
+    STATIC const char *VER_2022 = "2022";
     const char *win_pr = NULL;
     const char *win_ver = NULL;
     const char *win_upd = NULL;
+    const char *ws_pr = NULL;
+    const char *ws_ver = NULL;
     char *ver_aux = NULL;
 
     if (!agent->os_release && agent->dist_ver != FEED_WS2012 && agent->dist_ver != FEED_WS2012R2) {
@@ -5848,30 +5852,33 @@ int wm_vuldet_generate_win_cpe(scan_agent *agent) {
         case FEED_WS2022:
             win_pr = PR_WIN2022;
             win_ver = ver_aux;
+            // Insert new 'windows_server' CPE to avoid false negatives
+            ws_pr = PR_WINSERVER;
+            ws_ver = VER_2022;
         break;
         default:
             return 1;
     }
 
-    // We will insert a double CPE for the following systems
+    // We will insert a double CPE for the following systems (WS_2022)
     int os_cpes = wm_vuldet_double_os_cpe(agent->dist_ver) ? 2 : 1;
     os_calloc(os_cpes + 1, sizeof(cpe *), agent->agent_os_cpe);
 
     int i;
     for (i = 0; i < os_cpes; i++) {
         agent->agent_os_cpe[i] = wm_vuldet_generate_cpe("o",
-                                                    "microsoft",
-                                                    win_pr,
-                                                    !i && win_ver ? win_ver : "-",
-                                                    !i ? win_upd : win_ver,
-                                                    NULL,
-                                                    NULL,
-                                                    NULL,
-                                                    NULL,
-                                                    agent->arch,
-                                                    NULL,
-                                                    0,
-                                                    vu_feed_ext[agent->dist_ver]);
+                                                        "microsoft",
+                                                        !i ? win_pr : ws_pr,
+                                                        !i && win_ver ? win_ver : (ws_ver ? ws_ver : "-"),
+                                                        !i ? win_upd : win_ver,
+                                                        NULL,
+                                                        NULL,
+                                                        NULL,
+                                                        NULL,
+                                                        agent->arch,
+                                                        NULL,
+                                                        0,
+                                                        vu_feed_ext[agent->dist_ver]);
     }
     return 0;
 }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5868,7 +5868,7 @@ int wm_vuldet_generate_win_cpe(scan_agent *agent) {
     for (i = 0; i < os_cpes; i++) {
         agent->agent_os_cpe[i] = wm_vuldet_generate_cpe("o",
                                                         "microsoft",
-                                                        !i ? win_pr : ws_pr,
+                                                        i && ws_pr ? ws_pr : win_pr,
                                                         !i && win_ver ? win_ver : (ws_ver ? ws_ver : "-"),
                                                         !i ? win_upd : win_ver,
                                                         NULL,

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -864,7 +864,7 @@ typedef struct scan_ctx_t {
 #define wm_vuldet_wdb_empty_answ(req) (!strncmp(req, "ok []", 5))
 #define wm_vuldet_wdb_valid_answ(x) (!strncmp(x, "ok", 2))
 // This condition may be needed in the future. By default is false
-#define wm_vuldet_double_os_cpe(x) (x == FEED_UNKNOWN)
+#define wm_vuldet_double_os_cpe(x) (x == FEED_UNKNOWN || x == FEED_WS2022)
 #define wm_vuldet_is_cpe_wc(x) (!strcmp(x, "*") || !strcmp(x, "-"))
 #define wm_vulndet_undefined_cond(x) (!x || !strcmp(x, "-"))
 #define wm_vulndet_without_r2(x) (x == FEED_WS2008 || x == FEED_WS2012)


### PR DESCRIPTION
|Related issue|
|---|
|#12472|

## Description

As the format of the CPE for Windows Server 2022 has been modified, a new CPE had to be added to find the new NVD vulnerabilities, in addition to keeping the old one to dispose of all existing system vulnerabilities.

For this, part of the logic in the creation of the CPEs for Windows OS has been modified, in such a way that now two CPEs are generated for the _Windows Server 2022_, and if the two new variables created (`ws_pr` and `ws_ver`) have a value, then substitute the following fields in the second CPE:
- `win_pr` -> `ws_pr`
- `-` -> `ws_ver`

And if they do not exist, the same existing logic for the creation of the second CPE is maintained.

## Configuration options

Have active Vulnerability Detector for scanning Windows agents (_MSU_ and _NVD_), and have a _Windows Server 2022_ agent connected.

## Logs/Alerts example

Below, you can see with debug2 active, the generation of the 2 CPEs:
```
2022/03/02 09:50:07 wazuh-modulesd:vulnerability-detector[19031] wm_vuln_detector.c:6167 at wm_vuldet_insert_agent_data(): DEBUG: (5446): The CPE 'o:microsoft:windows_server_2022:21h2::::::x64:' from the agent '018' was indexed.
2022/03/02 09:50:07 wazuh-modulesd:vulnerability-detector[19031] wm_vuln_detector.c:6167 at wm_vuldet_insert_agent_data(): DEBUG: (5446): The CPE 'o:microsoft:windows_server:2022:21h2:::::x64:' from the agent '018' was indexed.
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [ ] Added unit tests (for new features)
