### PR TITLE
Add `group_config_status` field and filter to `GET /agents` endpoint

### DIFF
--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -100,29 +100,55 @@ async def delete_agents(request, pretty=False, wait_for_complete=False, agents_l
 
 async def get_agents(request, pretty=False, wait_for_complete=False, agents_list=None, offset=0, limit=database_limit,
                      select=None, sort=None, search=None, status=None, q=None, older_than=None,
-                     manager=None, version=None, group=None, node_name=None, name=None, ip=None):
-    """Get information about all agents or a list of them
+                     manager=None, version=None, group=None, node_name=None, name=None, ip=None,
+                     group_config_status=None):
+    """Get information about all agents or a list of them.
+    
+    Parameters
+    ----------
+    pretty : bool
+        Show results in human-readable format.
+    wait_for_complete : bool
+        Disable timeout response.
+    agents_list : list
+        List of agent's IDs.
+    offset : int
+        First element to return in the collection.
+    limit : int
+        Maximum number of elements to return.
+    select : str
+        Select which fields to return (separated by comma).
+    sort : str
+        Sort the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
+        ascending or descending order.
+    search : str
+        Look for elements with the specified string.
+    status : str
+        Filter by agent status. Use commas to enter multiple statuses.
+    q : str
+        Query to filter results by. For example "q&#x3D;&amp;quot;status&#x3D;active&amp;quot;".
+    older_than : str
+        Filter out disconnected agents for longer than specified. Time in seconds, ‘[n_days]d’,
+        ‘[n_hours]h’, ‘[n_minutes]m’ or ‘[n_seconds]s’. For never_connected agents, uses the register date.
+    manager : str
+        Filter by manager hostname to which agents are connected.
+    version : str
+        Filter by agents version.
+    group : str
+        Filter by agent group.
+    node_name : str
+        Filter by node name.
+    name : str
+        Filter by agent name.
+    ip : str
+        Filter by agent IP.
+    group_config_status : str
+        Filter by agent groups configuration sync status.
 
-    :param pretty: Show results in human-readable format
-    :param wait_for_complete: Disable timeout response
-    :param agents_list: List of agent's IDs.
-    :param offset: First element to return in the collection
-    :param limit: Maximum number of elements to return
-    :param select: Select which fields to return (separated by comma)
-    :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
-    ascending or descending order.
-    :param search: Looks for elements with the specified string
-    :param status: Filters by agent status. Use commas to enter multiple statuses.
-    :param q: Query to filter results by. For example q&#x3D;&amp;quot;status&#x3D;active&amp;quot;
-    :param older_than: Filters out disconnected agents for longer than specified. Time in seconds, ‘[n_days]d’,
-    ‘[n_hours]h’, ‘[n_minutes]m’ or ‘[n_seconds]s’. For never_connected agents, uses the register date.
-    :param manager: Filters by manager hostname to which agents are connected.
-    :param version: Filters by agents version.
-    :param group: Filters by group of agents.
-    :param node_name: Filters by node name.
-    :param name: Filters by agent name.
-    :param ip: Filters by agent IP
-    :return: AllItemsResponseAgents
+    Returns
+    -------
+    AffectedItemWazuhResult
+        Response with all selected agents information.
     """
     f_kwargs = {'agent_list': agents_list,
                 'offset': offset,
@@ -139,7 +165,8 @@ async def get_agents(request, pretty=False, wait_for_complete=False, agents_list
                     'node_name': node_name,
                     'name': name,
                     'ip': ip,
-                    'registerIP': request.query.get('registerIP', None)
+                    'registerIP': request.query.get('registerIP', None),
+                    'group_config_status': group_config_status
                 },
                 'q': q
                 }

--- a/api/api/controllers/test/test_agent_controller.py
+++ b/api/api/controllers/test/test_agent_controller.py
@@ -101,7 +101,8 @@ async def test_get_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_exp
                     'node_name': None,
                     'name': None,
                     'ip': None,
-                    'registerIP': mock_request.query.get('registerIP', None)
+                    'registerIP': mock_request.query.get('registerIP', None),
+                    'group_config_status': None
                 },
                 'q': None
                 }

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -5298,6 +5298,15 @@ components:
       schema:
         type: string
         format: alphanumeric
+    group_config_status:
+      in: query
+      name: group_config_status
+      description: "Agent groups configuration sync status"
+      schema:
+        type: string
+        enum:
+          - "synced"
+          - "not synced"
     force_single_group:
       in: query
       name: force_single_group
@@ -5617,6 +5626,7 @@ paths:
         - $ref: '#/components/parameters/name'
         - $ref: '#/components/parameters/ip'
         - $ref: '#/components/parameters/registerIP'
+        - $ref: '#/components/parameters/group_config_status'
       responses:
         '200':
           description: "List of agents or error description"
@@ -5655,6 +5665,7 @@ paths:
                       mergedSum: 9a016508cea1e997ab8569f5cfab30f5
                       version: Wazuh v4.3.0
                       node_name: worker2
+                      group_config_status: "synced"
                     - os:
                         arch: x86_64
                         codename: Focal Fossa
@@ -5678,6 +5689,7 @@ paths:
                       mergedSum: 9a016508cea1e997ab8569f5cfab30f5
                       version: Wazuh v4.3.0
                       node_name: worker2
+                      group_config_status: "synced"
                     - os:
                         arch: x86_64
                         codename: Focal Fossa
@@ -5701,6 +5713,7 @@ paths:
                       mergedSum: 9a016508cea1e997ab8569f5cfab30f5
                       version: Wazuh v4.3.0
                       node_name: worker1
+                      group_config_status: "not synced"
                   total_affected_items: 3
                   total_failed_items: 0
                   failed_items: []

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -762,6 +762,62 @@ stages:
       json:
         <<: *error_spec
 
+  - name: Filter agents by group_config_status (synced)
+    request:
+      verify: False
+      <<: *get_agents
+      params:
+        group_config_status: "synced"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - id: '000'
+            - id: '001'
+            - id: '002'
+            - id: '003'
+            - id: '004'
+            - id: '005'
+            - id: '006'
+            - id: '007'
+            - id: '008'
+          failed_items: []
+          total_affected_items: 9
+          total_failed_items: 0
+
+  - name: Filter agents by group_config_status (not synced)
+    request:
+      verify: False
+      <<: *get_agents
+      params:
+        group_config_status: "not synced"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - id: '009'
+            - id: '010'
+            - id: '011'
+            - id: '012'
+          failed_items: []
+          total_affected_items: 4
+          total_failed_items: 0
+
+  - name: Try show agents using an invalid group_config_status
+    request:
+      verify: False
+      <<: *get_agents
+      params:
+        group_config_status: invalid
+    response:
+      status_code: 400
+      json:
+        <<: *error_spec
+
   - name: Filter agents by query
     request:
       verify: False

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -325,7 +325,8 @@ class Agent:
               'os.codename': 'os_codename', 'os.major': 'os_major', 'os.minor': 'os_minor',
               'os.uname': 'os_uname', 'os.arch': 'os_arch', 'os.build': 'os_build',
               'node_name': 'node_name', 'lastKeepAlive': 'last_keepalive', 'internal_key': 'internal_key',
-              'registerIP': 'register_ip', 'disconnection_time': 'disconnection_time'}
+              'registerIP': 'register_ip', 'disconnection_time': 'disconnection_time',
+              'group_config_status': 'group_config_status'}
 
     def __init__(self, id=None, name=None, ip=None, key=None, force=None):
         """Initialize an agent.
@@ -367,6 +368,7 @@ class Agent:
         self.node_name = None
         self.registerIP = ip
         self.disconnection_time = None
+        self.group_config_status = None
 
         # If the method has only been called with an ID parameter, no new agent should be added.
         # Otherwise, a new agent must be added
@@ -381,7 +383,7 @@ class Agent:
                       'version': self.version, 'dateAdd': self.dateAdd, 'lastKeepAlive': self.lastKeepAlive,
                       'status': self.status, 'key': self.key, 'configSum': self.configSum, 'mergedSum': self.mergedSum,
                       'group': self.group, 'manager': self.manager, 'node_name': self.node_name,
-                      'disconnection_time': self.disconnection_time}
+                      'disconnection_time': self.disconnection_time, 'group_config_status': self.group_config_status}
 
         return dictionary
 

--- a/framework/wazuh/core/tests/data/test_agent/schema_global_test.sql
+++ b/framework/wazuh/core/tests/data/test_agent/schema_global_test.sql
@@ -33,7 +33,8 @@ CREATE TABLE IF NOT EXISTS agent (
     fim_offset INTEGER NOT NULL DEFAULT 0,
     reg_offset INTEGER NOT NULL DEFAULT 0,
     `group` TEXT DEFAULT 'default',
-    disconnection_time INTEGER DEFAULT 0
+    disconnection_time INTEGER DEFAULT 0,
+    group_config_status TEXT NOT NULL CHECK (group_config_status IN ('synced', 'not synced')) DEFAULT 'not synced'
 );
 
 CREATE INDEX IF NOT EXISTS agent_name ON agent (name);
@@ -54,83 +55,83 @@ CREATE TABLE IF NOT EXISTS belongs
 
 -- manager
 INSERT INTO agent (id, name, ip, os_name, os_version, os_major, os_minor, os_codename, os_platform, os_uname, os_arch,
-                   version, manager_host, node_name, date_add, last_keepalive, status, connection_status, `group`) VALUES
+                   version, manager_host, node_name, date_add, last_keepalive, status, connection_status, `group`, group_config_status) VALUES
                    (0,'master','127.0.0.1','Ubuntu','18.04.1 LTS','18','04','Bionic Beaver','ubuntu',
                    'Linux |master |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
                    'Wazuh v3.9.0','master','node01',strftime('%s','now','-10 days'),253402300799,
-                    'updated','active','group-1');
+                    'updated','active','group-1', 'synced');
 
 -- Connected agent with IP and Registered IP filled
 INSERT INTO agent (id, name, ip, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
                    os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add,
-                   last_keepalive, status, connection_status, `group`) VALUES (1,'agent-1','172.17.0.202','any',
+                   last_keepalive, status, connection_status, `group`, group_config_status) VALUES (1,'agent-1','172.17.0.202','any',
                    'b3650e11eba2f27er4d160c69de533ee7eed601636a85ba2455d53a90927747f', 'Ubuntu','18.04.1 LTS','18','04',
                    'Bionic Beaver','ubuntu',
                    'Linux |agent-1 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
                    'Wazuh v4.2.0','ab73af41699f13fdd81903b5f23d8d00','f8d49771911ed9d5c45b03a40babd065','master',
                    'node01',strftime('%s','now','-4 days'),
-                    strftime('%s','now','-5 seconds'),'updated', 'active', 'group-2');
+                    strftime('%s','now','-5 seconds'),'updated', 'active', 'group-2', 'synced');
 
 -- Connected agent with just Registered IP filled
 INSERT INTO agent (id, name, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
                    os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add,
-                   last_keepalive, status, connection_status) VALUES (2,'agent-2','172.17.0.201',
+                   last_keepalive, status, connection_status, group_config_status) VALUES (2,'agent-2','172.17.0.201',
                    'b3650e11eba2f27er4d160c69de533ee7eed6016fga85ba2455d53a90927747f', 'Ubuntu','16.04.1 LTS','16','04',
                    'Xenial','ubuntu',
                    'Linux |agent-1 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
                    'Wazuh v3.6.2','ab73af41699f13fgt81903b5f23d8d00','f8d49771911ed9d5c45bdfa40babd065','master',
                    'node01',strftime('%s','now','-3 days'),
-                    strftime('%s','now','-10 minutes'),'updated','active');
+                    strftime('%s','now','-10 minutes'),'updated','active', 'synced');
 
 -- Never connected agent
-INSERT INTO agent (id, name, register_ip, internal_key, date_add, `group`) VALUES (3,'nc-agent','any',
+INSERT INTO agent (id, name, register_ip, internal_key, date_add, `group`, group_config_status) VALUES (3,'nc-agent','any',
                    'f304f582f2417a3fddad69d9ae2b4f3b6e6fda788229668af9a6934d454ef44d',
-                   strftime('%s','now','-3 days'), NULL);
+                   strftime('%s','now','-3 days'), NULL, 'not synced');
 
 -- Pending agent
-INSERT INTO agent (id, name, register_ip, internal_key, manager_host, date_add, last_keepalive, `group`, connection_status) VALUES
+INSERT INTO agent (id, name, register_ip, internal_key, manager_host, date_add, last_keepalive, `group`, connection_status, group_config_status) VALUES
                   (4,'pending-agent', 'any', '2855bcf49273c759ef5b116829cc582f153c6c199df7676e53d5937855ff5902', '',
-                   strftime('%s','now','-1 minute'), strftime('%s','now','-10 seconds'), NULL,'pending');
+                   strftime('%s','now','-1 minute'), strftime('%s','now','-10 seconds'), NULL,'pending', 'not synced');
 
 
 -- Disconnected agent
 INSERT INTO agent (id, name, ip, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
                    os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add,
-                   last_keepalive, status, connection_status, disconnection_time) VALUES (5,'agent-5','172.17.0.300','172.17.0.300',
+                   last_keepalive, status, connection_status, disconnection_time, group_config_status) VALUES (5,'agent-5','172.17.0.300','172.17.0.300',
                    'b3650e11eba2f27er4d160c69de533ee7eed601636a42ba2455d53a90927747f', 'Ubuntu','18.04.1 LTS','18','04',
                    'Bionic Beaver','ubuntu',
                    'Linux |agent-1 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
                    'Wazuh v3.8.2','ab73af41699f13fdd81903b5f23d8d00','f8d49771911ed9d5c45b03a40babd065','master',
                    'node01',strftime('%s','now','-5 days'),
-                    strftime('%s','now','-2 hour'),'updated','disconnected', strftime('%s','now','-2 hour'));
+                    strftime('%s','now','-2 hour'),'updated','disconnected', strftime('%s','now','-2 hour'), 'not synced');
 
 -- Windows agent
 INSERT INTO agent (id, name, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
                    os_platform, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add,
-                   last_keepalive, status, connection_status) VALUES (6,'agent-6','172.19.0.157',
+                   last_keepalive, status, connection_status, group_config_status) VALUES (6,'agent-6','172.19.0.157',
                    'b3650e11eba2f27er4d160c69de533ee7eed6016fga85ba2455d53a90927747f', 'Windows','5.2','5','2',
                    'XP','windows','x86_64',
                    'Wazuh v3.6.2','ab73af41699f13fgt81903b5f23d8d00','f8d49771911ed9d5c45bdfa40babd065','master',
                    'node01',strftime('%s','now','-3 days'),
-                    strftime('%s','now','-15 minutes'),'updated','active');
+                    strftime('%s','now','-15 minutes'),'updated','active', 'synced');
 
 INSERT INTO agent (id, name, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
                    os_platform, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add,
-                   last_keepalive, status, connection_status) VALUES (7,'agent-7','172.19.0.157',
+                   last_keepalive, status, connection_status, group_config_status) VALUES (7,'agent-7','172.19.0.157',
                    'b3650e11eba2f27er4d160c69de533ee7eed6016fga85ba2455d53a90927747f', 'Windows','5.2','5','2',
                    'XP','windows','x86_64',
                    'Wazuh v2.0.0','ab73af41699f13fgt81903b5f23d8d00','f8d49771911ed9d5c45bdfa40babd065','master',
                    'node01',strftime('%s','now','-3 days'),
-                    strftime('%s','now','-15 minutes'),'updated','active');
+                    strftime('%s','now','-15 minutes'),'updated','active', 'synced');
 
 INSERT INTO agent (id, name, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
                    os_platform, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add,
-                   last_keepalive, status, connection_status) VALUES (8,'agent-8','172.19.0.157',
+                   last_keepalive, status, connection_status, group_config_status) VALUES (8,'agent-8','172.19.0.157',
                    'b3650e11eba2f27er4d160c69de533ee7eed6016fga85ba2455d53a90927747f', 'Windows','7.2','7','2',
                    'XP','windows','x86_64',
                    'Wazuh v3.8.2','ab73af41699f13fgt81903b5f23d8d00','f8d49771911ed9d5c45bdfa40babd065','master',
                    'node01',strftime('%s','now','-3 days'),
-                    strftime('%s','now','-15 minutes'),'updated','active');
+                    strftime('%s','now','-15 minutes'),'updated','active', 'synced');
 
 -- Create group-1 and group-2
 INSERT INTO `group` (id, name) VALUES (1, 'group-1');

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -78,11 +78,12 @@ class InitAgent:
         with open(os.path.join(data_path, db_name)) as f:
             self.cur.executescript(f.read())
 
-        self.never_connected_fields = {'status', 'name', 'ip', 'registerIP', 'node_name', 'dateAdd', 'id'}
+        self.never_connected_fields = {'status', 'name', 'ip', 'registerIP', 'node_name', 'dateAdd', 'id',
+                                       'group_config_status'}
         self.pending_fields = self.never_connected_fields | {'manager', 'lastKeepAlive'}
         self.manager_fields = self.pending_fields | {'version', 'os', 'group'}
         self.active_fields = self.manager_fields | {'group', 'mergedSum', 'configSum'}
-        self.disconnected_fields = self.active_fields | {"disconnection_time"}
+        self.disconnected_fields = self.active_fields | {'disconnection_time'}
         self.manager_fields -= {'registerIP'}
 
 

--- a/framework/wazuh/tests/data/schema_global_test.sql
+++ b/framework/wazuh/tests/data/schema_global_test.sql
@@ -33,7 +33,8 @@ CREATE TABLE IF NOT EXISTS agent (
     fim_offset INTEGER NOT NULL DEFAULT 0,
     reg_offset INTEGER NOT NULL DEFAULT 0,
     `group` TEXT DEFAULT 'default',
-    disconnection_time INTEGER DEFAULT 0
+    disconnection_time INTEGER DEFAULT 0,
+    group_config_status TEXT NOT NULL CHECK (group_config_status IN ('synced', 'not synced')) DEFAULT 'not synced'
 );
 
 CREATE INDEX IF NOT EXISTS agent_name ON agent (name);
@@ -54,103 +55,103 @@ CREATE TABLE IF NOT EXISTS belongs
 
 -- manager
 INSERT INTO agent (id, name, ip, os_name, os_version, os_major, os_minor, os_codename, os_platform, os_uname, os_arch,
-                   version, manager_host, node_name, date_add, last_keepalive, status, connection_status, `group`) VALUES
+                   version, manager_host, node_name, date_add, last_keepalive, status, connection_status, `group`, group_config_status) VALUES
                    (0,'master','127.0.0.1','Ubuntu','20.04.1 LTS','20','04','Bionic Beaver','ubuntu',
                    'Linux |master |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
                    'Wazuh v3.9.0','master','node01',strftime('%s','now','-10 days'),253402300799,
-                    'updated','active',NULL);
+                    'updated','active',NULL, 'synced');
 
 -- Connected agent with IP and Registered IP filled
 INSERT INTO agent (id, name, ip, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
                    os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add,
-                   last_keepalive, status, connection_status, `group`) VALUES (1,'agent-1','172.17.0.202','any',
+                   last_keepalive, status, connection_status, `group`, group_config_status) VALUES (1,'agent-1','172.17.0.202','any',
                    'b3650e11eba2f27er4d160c69de533ee7eed601636a85ba2455d53a90927747f', 'Ubuntu','16.06.1 LTS','16','06',
                    'Bionic Beaver','ubuntu',
                    'Linux |agent-1 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
                    'Wazuh v3.8.2','ab73af41699f13fdd81903b5f23d8d00','f8d49771911ed9d5c45b03a40babd065','master',
                    'node01',strftime('%s','now','-4 days'),
-                    strftime('%s','now','-5 seconds'),'updated','active', 'default,group-0');
+                    strftime('%s','now','-5 seconds'),'updated','active', 'default,group-0', 'synced');
 
 -- Connected agent with just Registered IP filled
 INSERT INTO agent (id, name, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
                    os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add,
-                   last_keepalive, status, connection_status, `group`) VALUES (2,'agent-2','172.17.0.201',
+                   last_keepalive, status, connection_status, `group`, group_config_status) VALUES (2,'agent-2','172.17.0.201',
                    'b3650e11eba2f27er4d160c69de533ee7eed6016fga85ba2455d53a90927747f', 'Ubuntu','16.04.1 LTS','16','04',
                    'Xenial','ubuntu',
                    'Linux |agent-1 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
                    'Wazuh v3.6.2','ab73af41699f13fgt81903b5f23d8d00','f8d49771911ed9d5c45bdfa40babd065','master',
                    'node01',strftime('%s','now','-3 days'),
-                    strftime('%s','now','-10 minutes'),'updated','active', 'default,group-0');
+                    strftime('%s','now','-10 minutes'),'updated','active', 'default,group-0', 'synced');
 
 -- Never connected agent
-INSERT INTO agent (id, name, register_ip, internal_key, date_add, `group`) VALUES (3,'nc-agent','any',
+INSERT INTO agent (id, name, register_ip, internal_key, date_add, `group`, group_config_status) VALUES (3,'nc-agent','any',
                    'f304f582f2417a3fddad69d9ae2b4f3b6e6fda788229668af9a6934d454ef44d',
-                   strftime('%s','now','-4 days'), NULL);
+                   strftime('%s','now','-4 days'), NULL, 'not synced');
 
 -- Pending agent
-INSERT INTO agent (id, name, register_ip, internal_key, manager_host, date_add, last_keepalive, `group`, connection_status) VALUES
+INSERT INTO agent (id, name, register_ip, internal_key, manager_host, date_add, last_keepalive, `group`, connection_status, group_config_status) VALUES
                   (4,'pending-agent', 'any', '2855bcf49273c759ef5b116829cc582f153c6c199df7676e53d5937855ff5902', '',
-                   strftime('%s','now','-1 minute'), strftime('%s','now','-10 seconds'), NULL,'pending');
+                   strftime('%s','now','-1 minute'), strftime('%s','now','-10 seconds'), NULL,'pending', 'not synced');
 
 
 -- Disconnected agent
 INSERT INTO agent (id, name, ip, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
                    os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add,
-                   last_keepalive, status, connection_status, disconnection_time) VALUES (5,'agent-5','172.17.0.300','172.17.0.300',
+                   last_keepalive, status, connection_status, disconnection_time, group_config_status) VALUES (5,'agent-5','172.17.0.300','172.17.0.300',
                    'b3650e11eba2f27er4d160c69de533ee7eed601636a42ba2455d53a90927747f', 'Ubuntu','18.08.1 LTS','18','08',
                    'Bionic Beaver','ubuntu',
                    'Linux |agent-1 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
                    'Wazuh v3.8.2','ab73af41699f13fdd81903b5f23d8d00','f8d49771911ed9d5c45b03a40babd065','master',
                    'node01',strftime('%s','now','-5 days'),
-                    strftime('%s','now','-2 hour'),'updated','disconnected', strftime('%s','now','-2 hour'));
+                    strftime('%s','now','-2 hour'),'updated','disconnected', strftime('%s','now','-2 hour'), 'not synced');
 
 
 -- Connected agent in group-1
 INSERT INTO agent (id, name, ip, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
                    os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add,
-                   last_keepalive, status, connection_status, `group`) VALUES (6,'agent-6','172.17.0.401','any',
+                   last_keepalive, status, connection_status, `group`, group_config_status) VALUES (6,'agent-6','172.17.0.401','any',
                    'b3650e11eba2f27er4d160c69de533ee7eed601636a85ba2455d53a90927747f', 'Xubuntu','21.04.1 LTS','21','04',
                    'Bionic Beaver','xubuntu',
                    'Linux |agent-1 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
                    'Wazuh v3.8.2','ab73af41699f13fdd81903b5f23d8d00','f8d49771911ed9d5c45b03a40babd065','master',
                    'node01',strftime('%s','now','-4 days'),
-                    strftime('%s','now','-7 seconds'),'updated','active','group-1');
+                    strftime('%s','now','-7 seconds'),'updated','active','group-1', 'synced');
 
 
 -- Connected agent in group-2
 INSERT INTO agent (id, name, ip, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
                    os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add,
-                   last_keepalive, status, connection_status, `group`) VALUES (7,'agent-7','172.17.0.501','any',
+                   last_keepalive, status, connection_status, `group`, group_config_status) VALUES (7,'agent-7','172.17.0.501','any',
                    'b3650e11eba2f27er4d160c69de533ee7eed601636a85ba2455d53a90927747f', 'Ubuntu','18.04.1 LTS','18','04',
                    'Bionic Beaver','ubuntu',
                    'Linux |agent-1 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
                    'Wazuh v3.8.2','ab73af41699f13fdd81903b5f23d8d00','f8d49771911ed9d5c45b03a40babd065','master',
                    'node01',strftime('%s','now','-4 days'),
-                    strftime('%s','now','-4 seconds'),'updated','active','group-2');
+                    strftime('%s','now','-4 seconds'),'updated','active','group-2', 'synced');
 
 
 -- Connected agent in group-2
 INSERT INTO agent (id, name, ip, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
                    os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add,
-                   last_keepalive, status, connection_status, `group`) VALUES (8,'agent-8','172.17.0.502','any',
+                   last_keepalive, status, connection_status, `group`, group_config_status) VALUES (8,'agent-8','172.17.0.502','any',
                    'b3650e11eba2f27er4d160c69de533ee7eed601636a85ba2455d53a90927747f', 'Xubuntu','18.04.1 LTS','18','04',
                    'Bionic Beaver','xubuntu',
                    'Linux |agent-1 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
                    'Wazuh v3.8.2','ab73af41699f13fdd81903b5f23d8d00','f8d49771911ed9d5c45b03a40babd065','master',
                    'node01',strftime('%s','now','-4 days'),
-                    strftime('%s','now','-12 seconds'),'updated','active','group-2,group-1');
+                    strftime('%s','now','-12 seconds'),'updated','active','group-2,group-1', 'synced');
 
 
 -- Connected agent with a different OS
 INSERT INTO agent (id, name, ip, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename,
                    os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add,
-                   last_keepalive, status, connection_status, `group`) VALUES (9,'agent-9','172.17.0.503','any',
+                   last_keepalive, status, connection_status, `group`, group_config_status) VALUES (9,'agent-9','172.17.0.503','any',
                    'b3650e11eba2f27er4d160c69de533ee7ffd601636a85ba2455d53a90927747f', 'Windows','10.0.0 XP','10','00',
                    'XP classic','windows',
                    'Windows |agent-9 |3.14-45 |#46-Windows SMP Thu Dec 32 24:45:28 UTC 2022 |x86_64','x86_64',
                    'Wazuh v3.8.2','ab73af41699f13fdd81903b5f23d8d00','f8d49771911ed9d5c45b03a40babd065','master',
                    'node01',strftime('%s','now','-4 days'),
-                    strftime('%s','now','-5 seconds'),'updated','active','default');
+                    strftime('%s','now','-5 seconds'),'updated','active','default', 'synced');
 
 
 -- Create group-1 and group-2


### PR DESCRIPTION
|Related issue|
|---|
|closes #12362 |

## Description

This PR adds a new field in the `GET /agents` API response and its own filter. Having an environment with 5 real agents, forcing the last to unsync its group configuration:

`GET /agents - select=group_config_status`

```json
{
  "data": {
    "affected_items": [
      {
        "group_config_status": "synced",
        "id": "000"
      },
      {
        "group_config_status": "synced",
        "id": "001"
      },
      {
        "group_config_status": "synced",
        "id": "002"
      },
      {
        "group_config_status": "synced",
        "id": "003"
      },
      {
        "group_config_status": "synced",
        "id": "004"
      },
      {
        "group_config_status": "not synced",
        "id": "005"
      }
    ],
    "total_affected_items": 6,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information was returned",
  "error": 0
}
```

`GET /agents - group_config_status=not synced`

```json
{
  "data": {
    "affected_items": [
      {
        "group_config_status": "not synced",
        "id": "005"
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information was returned",
  "error": 0
}
```

## Tests performed
```
================================================================================================================================== test session starts ===================================================================================================================================
platform linux -- Python 3.9.9, pytest-7.0.0, pluggy-1.0.0
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.18.1, cov-3.0.0
asyncio: mode=legacy
collected 259 items                                                                                                                                                                                                                                                                      

wazuh/core/tests/test_agent.py ..............................................................................................................................................                                                                                                      [ 54%]
wazuh/tests/test_agent.py .....................................................................................................................                                                                                                                                    [100%]

============================================================================================================================ 259 passed, 10 warnings in 4.47s ============================================================================================================================

```

Regards,
Víctor