### PR TITLE
Specify when getFile failed due to no entries in the DB.

### DIFF
--- a/src/syscheckd/src/db/include/db.hpp
+++ b/src/syscheckd/src/db/include/db.hpp
@@ -43,6 +43,24 @@ typedef enum FILE_SEARCH_TYPE
 
 using SearchData = std::tuple<FILE_SEARCH_TYPE, std::string, std::string, std::string>;
 
+class no_entry_found : public std::exception
+{
+    public:
+        __attribute__((__returns_nonnull__))
+        const char* what() const noexcept override
+        {
+            return m_error.what();
+        }
+
+        explicit no_entry_found(const std::string& whatArg)
+            : m_error{ whatArg }
+        {}
+
+    private:
+        /// an exception object as storage for error messages
+        std::runtime_error m_error;
+};
+
 class EXPORTED DB final
 {
     public:

--- a/src/syscheckd/src/db/src/file.cpp
+++ b/src/syscheckd/src/db/src/file.cpp
@@ -405,7 +405,7 @@ void DB::getFile(const std::string& path, std::function<void(const nlohmann::jso
     }
     else
     {
-        throw std::runtime_error{ "There are more or 0 rows" };
+        throw no_entry_found { "No entry found for " + path};
     }
 }
 
@@ -494,6 +494,10 @@ FIMDBErrorCode fim_db_get_path(const char* file_path, callback_context_t callbac
                 callback.callback(file->toFimEntry(), callback.context);
             });
             retVal = FIMDB_OK;
+        }
+        catch (const no_entry_found& err)
+        {
+            FIMDB::instance().logFunction(LOG_DEBUG_VERBOSE, err.what());
         }
         catch (const std::exception& err)
         {

--- a/src/syscheckd/src/db/tests/db/ComponentTest/fileInterface/fileTest.cpp
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/fileInterface/fileTest.cpp
@@ -351,7 +351,7 @@ TEST_F(DBTestFixture, TestFimDBFileUpdateNullParameters)
 TEST_F(DBTestFixture, TestFimDBGetPathNoFile)
 {
     callback_context_t callback_data {callBackTestFIMEntry, nullptr};
-    EXPECT_CALL(*mockLog, loggingFunction(LOG_ERROR, "There are more or 0 rows")).Times(testing::AtLeast(1));
+    EXPECT_CALL(*mockLog, loggingFunction(LOG_DEBUG_VERBOSE, "No entry found for /etc/wgetrc")).Times(testing::AtLeast(1));
     EXPECT_NO_THROW(
     {
         ASSERT_EQ(fim_db_get_path("/etc/wgetrc", callback_data), FIMDB_ERR);


### PR DESCRIPTION
|Related issue|
|---|
|#12476|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Hi team!!

In order to fix the error `There are more or 0 rows` getFile will throw the `no_entry_found` exception and it will be caught by the caller, suppressing the error and printing a new debug message

#Closes #12476
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

```xml
<syscheck>
    <disabled>no</disabled>

    <!-- Frequency that syscheck is executed default every 12 hours -->
    <frequency>900</frequency>

    <!-- Directories to check  (perform all possible verifications) -->
    <directories realtime="no" whodata="yes">/home/vagrant/test*</directories>

    <db_entry_limit>
      <files>90</files>
    </db_entry_limit>
```

## Logs/Alerts example

```
2022/03/02 10:40:01 wazuh-syscheckd[16623] audit_parse.c:504 at audit_parse(): INFO: (6027): Monitored directory '/home/vagrant/test' was removed: Audit rule removed.
2022/03/02 10:40:01 wazuh-syscheckd[16623] audit_parse.c:779 at audit_parse(): DEBUG: (6247): audit_event: uid=root, auid=vagrant, euid=root, gid=root, pid=17207, ppid=11466, inode=271160, path=/home/vagrant/test, pname=/usr/bin/rm
2022/03/02 10:40:01 wazuh-syscheckd[16623] audit_parse.c:789 at audit_parse(): DEBUG: (6213): Cannot get the real path of the link '/home/vagrant/test'
2022/03/02 10:40:01 wazuh-syscheckd[16623] logging_helper.c:65 at loggingFunction(): DEBUG: No entry found for /home/vagrant/test
2022/03/02 10:40:01 wazuh-syscheckd[16623] run_check.c:117 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"event","data":{"path":"/home/vagrant/test/a","version":2,"mode":"whodata","type":"deleted","timestamp":1646217424,"attributes":{"type":"file","size":22,"perm":"rw-r--r--","uid":"0","gid":"0","user_name":"root","group_name":"root","inode":271774,"mtime":1646217424,"hash_md5":"43f5b1b65499d0e6816532b4550377cd","hash_sha1":"d3929e2733ca5edd2a638293a23602bd8d71e936","hash_sha256":"1ca31deb6f04dfe7963e9b1622e91a831f95bb420e4ebcdeb5dbbdd5620c76ad","checksum":"1e63b2cfbb94070e121214447b4ad0de9872ba7f"},"audit":{"user_id":"0","user_name":"root","process_name":"/usr/bin/rm","process_id":17207,"cwd":"/home/vagrant","group_id":"0","group_name":"root","audit_uid":"1000","audit_name":"vagrant","effective_uid":"0","effective_name":"root","parent_name":"/usr/bin/bash","parent_cwd":"/home/vagrant","ppid":11466}}}
2022/03/02 10:40:12 wazuh-syscheckd[16623] audit_rule_handling.c:158 at fim_audit_reload_rules(): DEBUG: (6275): Reloading Audit rules.
2022/03/02 10:40:12 wazuh-syscheckd[16623] audit_op.c:264 at audit_manage_rules(): DEBUG: (6222): Stat() function failed on: '/home/vagrant/test' due to [(2)-(No such file or directory)]

```

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [x] Windows
  - [ ] MAC OS X
- [X] Source installation
- [X] Source upgrade
<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
