### PR TITLE
Update default `disabled` tag value

### DIFF
--- a/framework/wazuh/core/cluster/tests/test_cluster.py
+++ b/framework/wazuh/core/cluster/tests/test_cluster.py
@@ -90,8 +90,8 @@ def test_read_configuration(read_config):
             assert configuration[k] == read_config['cluster'][k]
 
         # values not present in the read user configuration will be filled with default values
-        if 'disabled' not in read_config and read_config != {}:
-            default_cluster_configuration['disabled'] = 'no'
+        if read_config != {} and 'disabled' not in read_config.get('cluster', {}):
+            default_cluster_configuration['disabled'] = 'yes'
         for k in default_cluster_configuration.keys() - read_config.keys():
             assert configuration[k] == default_cluster_configuration[k]
 

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -48,7 +48,7 @@ def read_cluster_config(config_file=common.ossec_conf, from_import=False) -> typ
         Dictionary with cluster configuration.
     """
     cluster_default_configuration = {
-        'disabled': False,
+        'disabled': True,
         'node_type': 'master',
         'name': 'wazuh',
         'node_name': 'node01',


### PR DESCRIPTION
|Related issue|
|---|
| Closes #12387 |


## Description

This PR updates the default `default` tag value so that it behaves as indicated in the [documentation](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/cluster.html#disabled). Now, these two blocks would have the same effect:
```
  <cluster>
    <name>wazuh</name>
        <node_name>master-node</node_name>
        <node_type>master</node_type>
        <key>9d273b53510fef702b54a92e9cffc82e</key>
        <port>1516</port>
        <bind_addr>0.0.0.0</bind_addr>
        <nodes>
            <node>wazuh-master</node>
        </nodes>
        <hidden>no</hidden>
        <disabled>yes</disabled>
     </cluster>
```

```
  <cluster>
    <name>wazuh</name>
        <node_name>master-node</node_name>
        <node_type>master</node_type>
        <key>9d273b53510fef702b54a92e9cffc82e</key>
        <port>1516</port>
        <bind_addr>0.0.0.0</bind_addr>
        <nodes>
            <node>wazuh-master</node>
        </nodes>
        <hidden>no</hidden>
     </cluster>
```

The cluster process will not start in either case, even when the `disabled` tag does not exist in `ossec.conf`.