### PR TITLE
Change Ubuntu OVAL repository

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -41,7 +41,7 @@
 #define VU_CPE_HELPER_FILE "queue/vulnerabilities/dictionaries/cpe_helper.json"
 #define VU_MSU_FILE "queue/vulnerabilities/dictionaries/msu.json"
 #define VU_CPEHELPER_FORMAT_VERSION 1
-#define CANONICAL_REPO "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.%s.cve.oval.xml.bz2"
+#define CANONICAL_REPO "https://security-metadata.canonical.com/oval/com.ubuntu.%s.cve.oval.xml.bz2"
 #define DEBIAN_REPO "https://www.debian.org/security/oval/oval-definitions-%s.xml"
 #define DEBIAN_REPO_STATUS "https://security-tracker.debian.org/tracker/data/json"
 #define ALAS_REPO "https://feed.wazuh.com/vulnerability-detector/ALAS/1/alas.json.gz"


### PR DESCRIPTION
|Related issue|
|---|
|#12469|

## Description

As of 16 November 2021, the repository at the following URL is no longer supported:
`https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.$(lsb_release -cs).cve.oval.xml.bz2`

And it seems that because they have changed the URL where the repository is located, so that it has been modified by the following link:
`https://security-metadata.canonical.com/oval/com.ubuntu.$(lsb_release -cs).cve.oval.xml.bz2`

In this PR, all the old links have been replaced to modify them by the new one.

## Configuration options

With the new change, the default configuration already uses the new URLs, so you only need to use the default configuration:
```
    <!-- Ubuntu OS vulnerabilities -->
    <provider name="canonical">
      <enabled>no</enabled>
      <os>trusty</os>
      <os>xenial</os>
      <os>bionic</os>
      <os>focal</os>
      <update_interval>1h</update_interval>
    </provider>
```
However, if the Wazuh version does not yet contain the fix, a workaround is the one commented in the issue: 
https://github.com/wazuh/wazuh/issues/12469#issuecomment-1056866115

## Logs/Alerts example

`sqlite3 /var/ossec/queue/vulnerabilities/cve.db "select target,timestamp from metadata;"`
```
TRUSTY|2022-03-02T12:04:41
XENIAL|2022-03-02T12:04:42
BIONIC|2022-03-02T12:04:43
FOCAL|2022-03-02T12:04:44
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer


<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Added unit tests (for new features)
- [x] Stress test for affected components
