### PR TITLE
Fix error response on empty data

### DIFF
--- a/src/unit_tests/wazuh_db/test_wazuh_db-config.c
+++ b/src/unit_tests/wazuh_db/test_wazuh_db-config.c
@@ -82,7 +82,7 @@ void test_Read_WazuhDB_attribute_NULL(void **state)
     OS_ReadXMLString(test_config, &xml);
     nodes = OS_GetElementsbyNode(&xml, NULL);
 
-    expect_string(__wrap__merror, formatted_msg, "(1243): Invalid attribute '' in the configuration: 'backup'.");
+    expect_string(__wrap__merror, formatted_msg, "(1233): Invalid attribute '' in the configuration: 'backup'.");
 
     int ret = Read_WazuhDB(&xml, nodes);
     assert_int_equal(ret, OS_INVALID);
@@ -102,7 +102,7 @@ void test_Read_WazuhDB_attribute_invalid(void **state)
     OS_ReadXMLString(test_config, &xml);
     nodes = OS_GetElementsbyNode(&xml, NULL);
 
-    expect_string(__wrap__merror, formatted_msg, "(1243): Invalid attribute 'invalid' in the configuration: 'backup'.");
+    expect_string(__wrap__merror, formatted_msg, "(1233): Invalid attribute 'invalid' in the configuration: 'backup'.");
 
     int ret = Read_WazuhDB(&xml, nodes);
     assert_int_equal(ret, OS_INVALID);

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -1239,7 +1239,7 @@ void test_wdb_global_sync_agent_groups_get_exec_fail_get_hash_true_success(void 
     result = wdb_global_sync_agent_groups_get(data->wdb, condition, last_agent_id, set_synced, get_hash, agent_registration_delta, &j_output);
 
     char *output = cJSON_PrintUnformatted(j_output);
-    assert_string_equal(output, "[{\"data\":[],\"hash\":\"\"}]");
+    assert_string_equal(output, "[{\"data\":[],\"hash\":null}]");
     os_free(output);
     assert_int_equal(result, WDBC_OK);
     __real_cJSON_Delete(j_output);

--- a/src/unit_tests/wazuh_db/test_wdb_integrity.c
+++ b/src/unit_tests/wazuh_db/test_wdb_integrity.c
@@ -1658,7 +1658,7 @@ void wdb_get_global_group_hash_invalid_statement(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void wdb_get_global_group_hash_calculate_fail(void **state)
+void wdb_get_global_group_hash_calculate_success_no_group_hash_information(void **state)
 {
     wdb_t * data = *state;
     os_sha1 hexdigest;
@@ -1677,7 +1677,7 @@ void wdb_get_global_group_hash_calculate_fail(void **state)
 
     ret = wdb_get_global_group_hash(data, hexdigest);
 
-    assert_int_equal(ret, OS_INVALID);
+    assert_int_equal(ret, OS_SUCCESS);
 }
 
 void wdb_get_global_group_hash_calculate_success(void **state)
@@ -1813,7 +1813,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(wdb_get_global_group_hash_read_success, setup_wdb_t, teardown_wdb_t),
         cmocka_unit_test_setup_teardown(wdb_get_global_group_hash_invalid_db_structure, setup_wdb_t, teardown_wdb_t),
         cmocka_unit_test_setup_teardown(wdb_get_global_group_hash_invalid_statement, setup_wdb_t, teardown_wdb_t),
-        cmocka_unit_test_setup_teardown(wdb_get_global_group_hash_calculate_fail, setup_wdb_t, teardown_wdb_t),
+        cmocka_unit_test_setup_teardown(wdb_get_global_group_hash_calculate_success_no_group_hash_information, setup_wdb_t, teardown_wdb_t),
         cmocka_unit_test_setup_teardown(wdb_get_global_group_hash_calculate_success, setup_wdb_t, teardown_wdb_t),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1562,9 +1562,13 @@ wdbc_result wdb_global_sync_agent_groups_get(wdb_t *wdb, wdb_groups_sync_conditi
             if (get_hash) {
                 size_t hash_len = strlen("hash:\"\"")+sizeof(os_sha1);
                 if (response_size+hash_len+1 < WDB_MAX_RESPONSE_SIZE) {
-                    os_sha1 hash = "";
+                    os_sha1 hash = {0};
                     if (OS_SUCCESS == wdb_get_global_group_hash(wdb, hash)) {
-                        cJSON_AddStringToObject(j_response, "hash", hash);
+                        if (hash[0] == 0) {
+                            cJSON_AddItemToObject(j_response, "hash", cJSON_CreateNull());
+                        } else {
+                            cJSON_AddStringToObject(j_response, "hash", hash);
+                        }
                         status = WDBC_OK;
                     } else {
                         merror("Cannot obtain the global group hash");

--- a/src/wazuh_db/wdb_integrity.c
+++ b/src/wazuh_db/wdb_integrity.c
@@ -661,8 +661,9 @@ int wdb_get_global_group_hash(wdb_t * wdb, os_sha1 hexdigest) {
             mdebug2("New global group hash calculated and stored in cache.");
             return OS_SUCCESS;
         } else {
+            hexdigest[0] = 0;
             mdebug2("No group hash was found to calculate the global group hash.");
-            return OS_INVALID;
+            return OS_SUCCESS;
         }
     }
 }


### PR DESCRIPTION
|Related issue|
|---|
|#12490|

## Description

This PR fixes the error response to the query `sync-agent-groups-get` with `get_hash` enabled when there's no group hash information to calculate the global group hash. Now, it returns an `ok` message with hash = null.

## Scan-build report 

![2](https://user-images.githubusercontent.com/13010397/156424970-9f8b26ef-d582-4e64-be9b-6e74273e6730.png)

## DoD

- There's no group hash information.
  ![5](https://user-images.githubusercontent.com/13010397/156425780-b4b45a7b-8f65-4aef-9af1-6acdd8683d77.png)
- Returns hash = null.
  ![1](https://user-images.githubusercontent.com/13010397/156425768-fc7e41ca-6e01-40c8-8dfc-b14a314cc8a4.png)
- When information is found, it works as expected.
  ![4](https://user-images.githubusercontent.com/13010397/156425777-83edcfaf-42cb-4113-838d-814f6ccef495.png)
  ![3](https://user-images.githubusercontent.com/13010397/156425774-8e215a32-f943-4924-92ad-a3127de37e0a.png)
  ![6](https://user-images.githubusercontent.com/13010397/156426167-b2a8a392-5999-4837-bdfe-222af83c5fa3.png)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report