### PR TITLE
Refactor `_format_data_into_dictionary` method of `WazuhDBQuerySyscheck` class

### DIFF
--- a/framework/wazuh/core/syscheck.py
+++ b/framework/wazuh/core/syscheck.py
@@ -11,21 +11,20 @@ from wazuh.core.wdb import WazuhDBConnection
 
 class WazuhDBQuerySyscheck(WazuhDBQuery):
     nested_fields = ['value']
+    date_fields = {'start', 'end', 'mtime', 'date'}
 
     def __init__(self, agent_id, nested=False, default_sort_field='mtime', min_select_fields=None, *args,
                  **kwargs):
         if min_select_fields is None:
             min_select_fields = set()
         super().__init__(backend=WazuhDBBackend(agent_id), default_sort_field=default_sort_field,
-                         min_select_fields=min_select_fields, count=True, get_data=True, date_fields={'mtime', 'date'},
+                         min_select_fields=min_select_fields, count=True, get_data=True, date_fields=self.date_fields,
                          *args, **kwargs)
         self.nested = nested
 
     def _format_data_into_dictionary(self):
         def format_fields(field_name, value):
-            if field_name == 'mtime' or field_name == 'date':
-                return get_date_from_timestamp(value)
-            elif field_name == 'end' or field_name == 'start':
+            if field_name in self.date_fields:
                 return None if not value else get_date_from_timestamp(value)
             elif field_name == 'perm':
                 try:

--- a/framework/wazuh/core/tests/test_syscheck.py
+++ b/framework/wazuh/core/tests/test_syscheck.py
@@ -27,7 +27,7 @@ def test_wazuh_db_query_syscheck__init__(mock_wdbquery, mock_backend, agent):
     syscheck.WazuhDBQuerySyscheck(agent)
     mock_backend.assert_called_with(agent)
     mock_wdbquery.assert_called_with(backend=ANY, default_sort_field='mtime', min_select_fields=set(), count=True,
-                                     get_data=True, date_fields={'mtime', 'date'})
+                                     get_data=True, date_fields={'start', 'end', 'mtime', 'date'})
 
 
 @pytest.mark.parametrize('data, is_json', [


### PR DESCRIPTION
|Related issue|
|---|
|closes #12135 |

## Description

As the former implementation was not clear enough, a refactor was needed to group all the date parameters and increase readability throughout the method.

## Tests performed

### Unit tests

```
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.9, pytest-7.0.0, pluggy-1.0.0
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.18.1, cov-3.0.0
asyncio: mode=legacy
collected 32 items                                                                                                                                                                                                

wazuh/core/tests/test_syscheck.py .......                                                                                                                                                                   [ 21%]
wazuh/tests/test_syscheck.py .........................                                                                                                                                                      [100%]

========================================================================================= 32 passed, 3 warnings in 0.24s ==========================================================================================

```

### API integration tests

```
test_syscheck_endpoints_cluster - Cluster environment
	 35 passed, 38 warnings

test_rbac_black_syscheck_endpoints
	 4 passed, 5 warnings

test_rbac_white_syscheck_endpoints
	 4 passed, 5 warnings
```

Regards,
Víctor