### PR TITLE
Adding checks for alternative parameters in `sync-agent-groups-get` wazuh-db command

### DIFF
--- a/src/unit_tests/wazuh_db/test_wazuh_db-config.c
+++ b/src/unit_tests/wazuh_db/test_wazuh_db-config.c
@@ -82,7 +82,7 @@ void test_Read_WazuhDB_attribute_NULL(void **state)
     OS_ReadXMLString(test_config, &xml);
     nodes = OS_GetElementsbyNode(&xml, NULL);
 
-    expect_string(__wrap__merror, formatted_msg, "(1243): Invalid attribute '' in the configuration: 'backup'.");
+    expect_string(__wrap__merror, formatted_msg, "(1233): Invalid attribute '' in the configuration: 'backup'.");
 
     int ret = Read_WazuhDB(&xml, nodes);
     assert_int_equal(ret, OS_INVALID);
@@ -102,7 +102,7 @@ void test_Read_WazuhDB_attribute_invalid(void **state)
     OS_ReadXMLString(test_config, &xml);
     nodes = OS_GetElementsbyNode(&xml, NULL);
 
-    expect_string(__wrap__merror, formatted_msg, "(1243): Invalid attribute 'invalid' in the configuration: 'backup'.");
+    expect_string(__wrap__merror, formatted_msg, "(1233): Invalid attribute 'invalid' in the configuration: 'backup'.");
 
     int ret = Read_WazuhDB(&xml, nodes);
     assert_int_equal(ret, OS_INVALID);

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -2051,19 +2051,83 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_json(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_parse_global_sync_agent_groups_get_missing_field(void **state)
+void test_wdb_parse_global_sync_agent_groups_get_missing_condition_field(void **state)
 {
     int ret = 0;
     test_struct_t *data = (test_struct_t *)*state;
-    char query[OS_BUFFER_SIZE] = "global sync-agent-groups-get {\"last_id\":3,\"set_synced\":true,\"get_global_hash\":true}";
+    char query[OS_BUFFER_SIZE] = "global sync-agent-groups-get {\"last_id\":1,\"set_synced\":true,\"get_global_hash\":true,\"agent_registration_delta\":0}";
 
     will_return(__wrap_wdb_open_global, data->wdb);
-    expect_string(__wrap__mdebug2, formatted_msg, "Global query: sync-agent-groups-get {\"last_id\":3,\"set_synced\":true,\"get_global_hash\":true}");
-    expect_string(__wrap__mdebug1, formatted_msg, "Missing mandatory fields in sync-agent-groups-get command.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: sync-agent-groups-get {\"last_id\":1,\"set_synced\":true,\"get_global_hash\":true,\"agent_registration_delta\":0}");
+    expect_string(__wrap__mdebug1, formatted_msg, "Missing mandatory 'condition' field in sync-agent-groups-get command.");
 
     ret = wdb_parse(query, data->output, 0);
 
-    assert_string_equal(data->output, "err Invalid JSON data, missing required fields");
+    assert_string_equal(data->output, "err Invalid JSON data, missing required 'condition' field");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_sync_agent_groups_get_invalid_last_id_data_type(void **state)
+{
+    int ret = 0;
+    test_struct_t *data = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global sync-agent-groups-get {\"condition\":\"sync_status\",\"last_id\":\"1_string\"}";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: sync-agent-groups-get {\"condition\":\"sync_status\",\"last_id\":\"1_string\"}");
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid alternative fields data type in sync-agent-groups-get command.");
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Invalid JSON data, invalid alternative fields data type");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_sync_agent_groups_get_invalid_set_synced_data_type(void **state)
+{
+    int ret = 0;
+    test_struct_t *data = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global sync-agent-groups-get {\"condition\":\"sync_status\",\"set_synced\":\"true_string\"}";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: sync-agent-groups-get {\"condition\":\"sync_status\",\"set_synced\":\"true_string\"}");
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid alternative fields data type in sync-agent-groups-get command.");
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Invalid JSON data, invalid alternative fields data type");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_sync_agent_groups_get_invalid_get_hash_data_type(void **state)
+{
+    int ret = 0;
+    test_struct_t *data = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global sync-agent-groups-get {\"condition\":\"sync_status\",\"get_global_hash\":\"true_string\"}";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: sync-agent-groups-get {\"condition\":\"sync_status\",\"get_global_hash\":\"true_string\"}");
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid alternative fields data type in sync-agent-groups-get command.");
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Invalid JSON data, invalid alternative fields data type");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_sync_agent_groups_get_invalid_agent_registration_delta_data_type(void **state)
+{
+    int ret = 0;
+    test_struct_t *data = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global sync-agent-groups-get {\"condition\":\"sync_status\",\"agent_registration_delta\":\"0_string\"}";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: sync-agent-groups-get {\"condition\":\"sync_status\",\"agent_registration_delta\":\"0_string\"}");
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid alternative fields data type in sync-agent-groups-get command.");
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Invalid JSON data, invalid alternative fields data type");
     assert_int_equal(ret, OS_INVALID);
 }
 
@@ -2892,7 +2956,11 @@ int main()
         /* Tests wdb_parse_global_sync_agent_groups_get */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_invalid_json, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_missing_field, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_missing_condition_field, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_invalid_last_id_data_type, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_invalid_set_synced_data_type, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_invalid_get_hash_data_type, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_invalid_agent_registration_delta_data_type, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_null_response, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_invalid_response, test_setup, test_teardown),

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5382,7 +5382,7 @@ int wdb_parse_global_sync_agent_groups_get(wdb_t* wdb, char* input, char* output
             } else if (0 == strcmp(j_sync_condition->valuestring, "all")) {
                 condition = WDB_GROUP_ALL;
             }
-            if (cJSON_IsNumber(j_last_id)){
+            if (j_last_id && cJSON_IsNumber(j_last_id)){
                 last_id = j_last_id->valueint;
             }
             if (cJSON_IsTrue(j_set_synced)) {
@@ -5391,7 +5391,7 @@ int wdb_parse_global_sync_agent_groups_get(wdb_t* wdb, char* input, char* output
             if (cJSON_IsTrue(j_get_hash)) {
                 get_hash = true;
             }
-            if (cJSON_IsNumber(j_agent_registration_delta)){
+            if (j_agent_registration_delta && cJSON_IsNumber(j_agent_registration_delta)){
                 agent_registration_delta = j_agent_registration_delta->valueint;
             }
 

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5356,8 +5356,21 @@ int wdb_parse_global_sync_agent_groups_get(wdb_t* wdb, char* input, char* output
         cJSON *j_set_synced = cJSON_GetObjectItem(args, "set_synced");
         cJSON *j_get_hash = cJSON_GetObjectItem(args, "get_global_hash");
         cJSON *j_agent_registration_delta = cJSON_GetObjectItem(args, "agent_registration_delta");
-        // Mandatory fields
-        if (cJSON_IsString(j_sync_condition)) {
+        // Checking the existence of mandatory parameters
+        if (!cJSON_IsString(j_sync_condition)) {
+            mdebug1("Missing mandatory 'condition' field in sync-agent-groups-get command.");
+            snprintf(output, OS_MAXSTR + 1, "err Invalid JSON data, missing required 'condition' field");
+            ret = OS_INVALID;
+        }
+        // Checking data types of alternative parameters in case they would have been sent in the input JSON.
+        else if ((j_last_id && !cJSON_IsNumber(j_last_id)) ||
+            (j_set_synced && !cJSON_IsBool(j_set_synced)) ||
+            (j_get_hash && !cJSON_IsBool(j_get_hash)) ||
+            (j_agent_registration_delta && !cJSON_IsNumber(j_agent_registration_delta))) {
+            mdebug1("Invalid alternative fields data type in sync-agent-groups-get command.");
+            snprintf(output, OS_MAXSTR + 1, "err Invalid JSON data, invalid alternative fields data type");
+            ret = OS_INVALID;
+        } else {
             wdb_groups_sync_condition_t condition = WDB_GROUP_INVALID_CONDITION;
             int last_id = 0;
             bool set_synced = false;
@@ -5398,10 +5411,6 @@ int wdb_parse_global_sync_agent_groups_get(wdb_t* wdb, char* input, char* output
                 snprintf(output, OS_MAXSTR + 1, "err %s", "Could not obtain a response from wdb_global_sync_agent_groups_get");
                 ret = OS_INVALID;
             }
-        } else {
-            mdebug1("Missing mandatory fields in sync-agent-groups-get command.");
-            snprintf(output, OS_MAXSTR + 1, "err Invalid JSON data, missing required fields");
-            ret = OS_INVALID;
         }
         cJSON_Delete(args);
     } else {

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5382,7 +5382,7 @@ int wdb_parse_global_sync_agent_groups_get(wdb_t* wdb, char* input, char* output
             } else if (0 == strcmp(j_sync_condition->valuestring, "all")) {
                 condition = WDB_GROUP_ALL;
             }
-            if (j_last_id && cJSON_IsNumber(j_last_id)){
+            if (j_last_id) {
                 last_id = j_last_id->valueint;
             }
             if (cJSON_IsTrue(j_set_synced)) {
@@ -5391,7 +5391,7 @@ int wdb_parse_global_sync_agent_groups_get(wdb_t* wdb, char* input, char* output
             if (cJSON_IsTrue(j_get_hash)) {
                 get_hash = true;
             }
-            if (j_agent_registration_delta && cJSON_IsNumber(j_agent_registration_delta)){
+            if (j_agent_registration_delta) {
                 agent_registration_delta = j_agent_registration_delta->valueint;
             }
 


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/12495 |

## Description

This pull request adds checks for the data types of the alternative parameters that can be used in the `sync-agent-groups-get` wazuh-db command. Now, the parsing of the command behaves in this way:

- It first verifies the existence of the `condition` parameter. If the parameter is not present or the data type is invalid, the command returns `err`.
- For the case of the parameters `last_id`, `set_synced`, `get_global_hash`, and `agent_registration_delta`, if any of them was sent, its data type is verified. In case of not being the right data type, it returns `err`.
- For the case of the parameters `last_id`, `set_synced`, `get_global_hash`, and `agent_registration_delta`, if they are not sent, they will take a default value:
  - `last_id` = 0
  - `set_synced` = false
  - `get_global_hash` = false
  - `agent_registration_delta` = 0

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade


- Memory tests for Linux
  - [x] Scan-build report
  <img width="661" alt="image" src="https://user-images.githubusercontent.com/5703274/156555823-99b56324-a9b6-45f9-8316-88cbba802ef5.png">

- [x] Added unit tests (for new features)