### PR TITLE
Improve cluster integrity sync reliability

### DIFF
--- a/framework/wazuh/core/cluster/cluster.json
+++ b/framework/wazuh/core/cluster/cluster.json
@@ -116,6 +116,7 @@
             "timeout_receiving_file": 120,
             "max_zip_size": 1073741824,
             "min_zip_size": 31457280,
+            "compress_level": 1,
             "zip_limit_tolerance": 0.2
         }
     },

--- a/framework/wazuh/core/cluster/cluster.json
+++ b/framework/wazuh/core/cluster/cluster.json
@@ -113,7 +113,10 @@
         "communication":{
             "timeout_cluster_request": 20,
             "timeout_dapi_request": 200,
-            "timeout_receiving_file": 120
+            "timeout_receiving_file": 120,
+            "max_zip_size": 1073741824,
+            "min_zip_size": 31457280,
+            "zip_limit_tolerance": 0.2
         }
     },
 

--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -1,12 +1,13 @@
 # Copyright (C) 2015, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+import errno
 import itertools
 import json
 import logging
 import os.path
 import shutil
-import zipfile
+import zlib
 from asyncio import wait_for
 from datetime import datetime
 from functools import partial
@@ -24,6 +25,9 @@ from wazuh.core.utils import md5, mkdir_with_mode
 logger = logging.getLogger('wazuh')
 agent_groups_path = os.path.relpath(common.GROUPS_PATH, common.WAZUH_PATH)
 
+# Separators used in compression/decompression functions to delimit files.
+FILE_SEP = '|@!@|'
+PATH_SEP = '|!@!|'
 
 #
 # Cluster
@@ -227,74 +231,107 @@ def get_files_status(previous_status=None, get_md5=True):
     return final_items
 
 
-def update_cluster_control_with_failed(failed_files, ko_files):
-    """Check if file paths inside 'shared' and 'missing' do really exist.
+def update_cluster_control(failed_file, ko_files, exists=True):
+    """Move or remove files listed inside 'ko_files'.
 
-    Sometimes, files that no longer exist are still listed in cluster_control.json. Two situations can occur:
+    Sometimes, files that could not be compressed or that no longer exist, are still listed in cluster_control.json.
+    Two situations can occur:
         - A missing file on a worker no longer exists on the master. It is removed from the list of missing files.
+        - A missing file on a worker could not be compressed (too big or not space left). It is also removed from
+        the list of missing files.
         - A shared file no longer exists on the master. It is deleted from 'shared' and added to 'extra'.
+        - A shared file could not be compressed (too big or not space left). It is removed from the 'shared' list.
 
     Parameters
     ----------
-    failed_files : list
-        List of files to update
+    failed_file : str
+        File path (used as a dict key) to be searched and updated/deleted in the ko_files dict.
     ko_files : dict
         KO files dict with 'missing', 'shared' and 'extra' keys.
+    exists : bool
+        Whether the file to be removed exists in the master. If it does not exist, but it is in the 'shared' list,
+        it should be moved to the 'extra' files list.
     """
-    for f in failed_files:
-        if 'missing' in ko_files.keys() and f in ko_files['missing'].keys():
-            ko_files['missing'].pop(f, None)
-        elif 'shared' in ko_files.keys() and 'extra' in ko_files.keys() and f in ko_files['shared'].keys():
-            ko_files['extra'][f] = ko_files['shared'][f]
-            ko_files['shared'].pop(f, None)
+    try:
+        if failed_file in ko_files['missing']:
+            ko_files['missing'].pop(failed_file, None)
+        elif failed_file in ko_files['shared']:
+            if not exists:
+                ko_files['extra'][failed_file] = ko_files['shared'][failed_file]
+            ko_files['shared'].pop(failed_file, None)
+    except (KeyError, AttributeError, TypeError):
+        pass
 
 
 def compress_files(name, list_path, cluster_control_json=None, max_zip_size=None):
     """Create a zip with cluster_control.json and the files listed in list_path.
 
-    Iterate the list of files and groups them in the zip. If a file does not
+    Iterate the list of files and groups them in a compressed file. If a file does not
     exist, the cluster_control_json dictionary is updated.
 
     Parameters
     ----------
     name : str
-        Name of the node to which the zip will be sent.
+        Name of the node to which the compress file will be sent.
     list_path : list
         File paths to be zipped.
     cluster_control_json : dict
-        KO files (path-metadata) to be zipped as a json.
+        KO files (path-metadata) to be compressed as a json.
     max_zip_size : int
         Maximum size from which no new files should be added to the zip.
 
     Returns
     -------
-    zip_file_path : str
-        Path where the zip file has been saved.
+    compress_file_path : str
+        Path where the compress file has been saved.
     """
+    zip_size = 0
+    exceeded_size = False
+    compress_level = get_cluster_items()['intervals']['communication']['compress_level']
     if max_zip_size is None:
         max_zip_size = get_cluster_items()['intervals']['communication']['max_zip_size']
-    failed_files = list()
     zip_file_path = path.join(common.WAZUH_PATH, 'queue', 'cluster', name,
                               f'{name}-{datetime.utcnow().timestamp()}-{uuid4().hex}.zip')
 
     if not path.exists(path.dirname(zip_file_path)):
         mkdir_with_mode(path.dirname(zip_file_path))
 
-    with zipfile.ZipFile(zip_file_path, 'x') as zf:
-        # write files
-        if list_path:
-            for f in list_path:
-                try:
-                    zf.write(filename=path.join(common.WAZUH_PATH, f), arcname=f)
-                except zipfile.LargeZipFile as e:
-                    raise WazuhError(3001, str(e))
-                except Exception as e:
-                    logger.debug(f"[Cluster] {str(WazuhException(3001, str(e)))}")
-                    failed_files.append(f)
+    with open(zip_file_path, 'ab') as wf:
+        for file in list_path:
+            if exceeded_size:
+                update_cluster_control(file, cluster_control_json)
+                continue
+
+            try:
+                with open(path.join(common.WAZUH_PATH, file), 'rb') as rf:
+                    new_file = rf.read()
+                    if len(new_file) > max_zip_size:
+                        logger.warning(f'File too large to be synced: {path.join(common.WAZUH_PATH, file)}')
+                        update_cluster_control(file, cluster_control_json)
+                        continue
+                    # Compress the content of each file and surrounds it with separators.
+                    new_file = f'{file}{PATH_SEP}'.encode() + zlib.compress(new_file, level=compress_level) + \
+                               FILE_SEP.encode()
+
+                if (len(new_file) + zip_size) <= max_zip_size:
+                    # Append the new compressed file to previous ones only if total size is under max allowed.
+                    zip_size += len(new_file)
+                    wf.write(new_file)
+                else:
+                    # Otherwise, remove it from cluster_control_json.
+                    logger.warning('Maximum zip size exceeded. Not all files will be compressed during this sync.')
+                    exceeded_size = True
+                    update_cluster_control(file, cluster_control_json)
+            except zlib.error as e:
+                raise WazuhError(3001, str(e))
+            except Exception as e:
+                logger.debug(str(WazuhException(3001, str(e))))
+                update_cluster_control(file, cluster_control_json, exists=False)
+
         try:
-            if cluster_control_json and failed_files:
-                update_cluster_control_with_failed(failed_files, cluster_control_json)
-            zf.writestr("files_metadata.json", json.dumps(cluster_control_json))
+            # Compress and save cluster_control data as a JSON.
+            wf.write(f'files_metadata.json{PATH_SEP}'.encode() +
+                     zlib.compress(json.dumps(cluster_control_json).encode(), level=compress_level))
         except Exception as e:
             raise WazuhError(3001, str(e))
 
@@ -321,42 +358,71 @@ async def async_decompress_files(zip_path, ko_files_name="files_metadata.json"):
     return decompress_files(zip_path, ko_files_name)
 
 
-def decompress_files(zip_path, ko_files_name="files_metadata.json"):
-    """Unzip files in a directory and load the files_metadata.json as a dict.
+def decompress_files(compress_path, ko_files_name="files_metadata.json"):
+    """Decompress files in a directory and load the files_metadata.json as a dict.
+
+    To avoid consuming too many memory resources, the compressed file is read in chunks
+    of 'windows_size' and split based on a file separator.
 
     Parameters
     ----------
-    zip_path : str
-        Full path to the zip file.
+    compress_path : str
+        Full path to the compress file.
     ko_files_name : str
-        Name of the metadata json inside zip file.
+        Name of the metadata json inside the compress file.
 
     Returns
     -------
     ko_files : dict
         Paths (keys) and metadata (values) of the files listed in cluster.json.
     zip_dir : str
-        Full path to unzipped directory.
+        Full path to decompressed directory.
     """
-    try:
-        ko_files = ""
-        # Create a directory like {wazuh_path}/{cluster_path}/123456-123456.zipdir/
-        zip_dir = zip_path + 'dir'
-        mkdir_with_mode(zip_dir)
-        with zipfile.ZipFile(zip_path) as zipf:
-            zipf.extractall(path=zip_dir)
+    ko_files = ''
+    compressed_data = b''
+    window_size = 1024*1024*10   # 10 MiB
+    decompress_dir = compress_path + 'dir'
 
-        if path.exists(path.join(zip_dir, ko_files_name)):
-            with open(path.join(zip_dir, ko_files_name)) as ko:
+    try:
+        mkdir_with_mode(decompress_dir)
+
+        with open(compress_path, 'rb') as rf:
+            while True:
+                new_data = rf.read(window_size)
+                compressed_data += new_data
+                files = compressed_data.split(FILE_SEP.encode())
+                if new_data:
+                    # If 'files' list contains only 1 item, it is probably incomplete, so it is not used.
+                    compressed_data = files.pop(-1)
+
+                for file in files:
+                    filepath, content = file.split(PATH_SEP.encode(), 1)
+                    content = zlib.decompress(content)
+                    full_path = os.path.join(decompress_dir, filepath.decode())
+                    if not os.path.exists(os.path.dirname(full_path)):
+                        try:
+                            os.makedirs(os.path.dirname(full_path))
+                        except OSError as exc:  # Guard against race condition
+                            if exc.errno != errno.EEXIST:
+                                raise
+                    with open(full_path, 'wb') as f:
+                        f.write(content)
+
+                if not new_data:
+                    break
+
+        if path.exists(path.join(decompress_dir, ko_files_name)):
+            with open(path.join(decompress_dir, ko_files_name)) as ko:
                 ko_files = json.loads(ko.read())
     except Exception as e:
-        if path.exists(zip_dir):
-            shutil.rmtree(zip_dir)
+        if path.exists(decompress_dir):
+            shutil.rmtree(decompress_dir)
         raise e
     finally:
-        # Once read all files, remove the zipfile.
-        remove(zip_path)
-    return ko_files, zip_dir
+        # Once read all files, remove the compress file.
+        remove(compress_path)
+
+    return ko_files, decompress_dir
 
 
 def compare_files(good_files, check_files, node_name):

--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -293,6 +293,8 @@ class Handler(asyncio.Protocol):
         self.cluster_items = cluster_items
         # Transports in asyncio are an abstraction of sockets.
         self.transport = None
+        # Tasks to be interrupted.
+        self.interrupted_tasks = set()
 
     def push(self, message: bytes):
         """Send a message to peer.
@@ -475,13 +477,15 @@ class Handler(asyncio.Protocol):
             return b'Error sending request: timeout expired.'
         return response_data
 
-    async def send_file(self, filename: str) -> bytes:
+    async def send_file(self, filename: str, task_id: bytes = None) -> bytes:
         """Send a file to peer, slicing it into chunks.
 
         Parameters
         ----------
         filename : str
             Full path of the file to send.
+        task_id : bytes
+            Task identifier to stop sending file if needed.
 
         Returns
         -------
@@ -502,6 +506,8 @@ class Handler(asyncio.Protocol):
             for chunk in iter(lambda: f.read(self.request_chunk - len(relative_path) - 1), b''):
                 await self.send_request(command=b'file_upd', data=relative_path + b' ' + chunk)
                 file_hash.update(chunk)
+                if task_id in self.interrupted_tasks:
+                    break
 
         # Close the destination file descriptor so the file in memory is dumped to disk.
         await self.send_request(command=b'file_end', data=relative_path + b' ' + file_hash.digest())
@@ -696,8 +702,10 @@ class Handler(asyncio.Protocol):
             return self.str_upd(data)
         elif command == b'err_str':
             return self.process_error_str(data)
-        elif command == b"file_end":
+        elif command == b'file_end':
             return self.end_file(data)
+        elif command == b'cancel_task':
+            return self.cancel_task(data)
         else:
             return self.process_unknown_cmd(command)
 
@@ -801,6 +809,31 @@ class Handler(asyncio.Protocol):
         else:
             del self.in_file[name]
             return b"err", b"File wasn't correctly received. Checksums aren't equal."
+
+    def cancel_task(self, data: bytes) -> Tuple[bytes, bytes]:
+        """Add task_id to interrupted_tasks and log the error message.
+
+        Parameters
+        ----------
+        data : bytes
+            String containing task_id and WazuhJSONEncoded object with the exception details.
+
+        Returns
+        -------
+        bytes
+            Result.
+        bytes
+            Response message.
+        """
+        task_id, error_details = data.split(b' ', 1)
+        error_json = json.loads(error_details, object_hook=as_wazuh_object)
+        if task_id != b'None':
+            self.interrupted_tasks.add(task_id)
+            self.logger.error(f'The task was canceled due to the following error on the remote node: {error_json}')
+        else:
+            self.logger.error(f'The task was requested to be canceled but no task_id was received: {error_json}')
+
+        return b'ok', b'Request received correctly'
 
     def receive_str(self, data: bytes) -> Tuple[bytes, bytes]:
         """Create a bytearray with the string size.

--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -477,7 +477,7 @@ class Handler(asyncio.Protocol):
             return b'Error sending request: timeout expired.'
         return response_data
 
-    async def send_file(self, filename: str, task_id: bytes = None) -> bytes:
+    async def send_file(self, filename: str, task_id: bytes = None) -> int:
         """Send a file to peer, slicing it into chunks.
 
         Parameters
@@ -489,14 +489,16 @@ class Handler(asyncio.Protocol):
 
         Returns
         -------
-        bytes
-            Response message.
+        sent_size : int
+            Number of bytes that were successfully sent.
         """
         if not os.path.exists(filename):
             raise exception.WazuhClusterError(3034, extra_message=filename)
 
+        sent_size = 0
         filename = filename.encode()
         relative_path = filename.replace(common.WAZUH_PATH.encode(), b'')
+
         # Tell to the destination node where (inside wazuh_path) the file has to be written.
         await self.send_request(command=b'new_file', data=relative_path)
 
@@ -506,13 +508,14 @@ class Handler(asyncio.Protocol):
             for chunk in iter(lambda: f.read(self.request_chunk - len(relative_path) - 1), b''):
                 await self.send_request(command=b'file_upd', data=relative_path + b' ' + chunk)
                 file_hash.update(chunk)
+                sent_size += len(chunk)
                 if task_id in self.interrupted_tasks:
                     break
 
         # Close the destination file descriptor so the file in memory is dumped to disk.
         await self.send_request(command=b'file_end', data=relative_path + b' ' + file_hash.digest())
 
-        return b'File sent'
+        return sent_size
 
     async def send_string(self, my_str: bytes) -> bytes:
         """Send a large string to peer, slicing it into chunks.

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -654,8 +654,16 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         logger.info(f"Starting.")
 
         logger.debug("Waiting to receive zip file from worker.")
-        await asyncio.wait_for(received_file.wait(),
-                               timeout=self.cluster_items['intervals']['communication']['timeout_receiving_file'])
+        try:
+            await asyncio.wait_for(received_file.wait(),
+                                   timeout=self.cluster_items['intervals']['communication']['timeout_receiving_file'])
+        except Exception:
+            # Notify the sending node to stop its task.
+            await self.send_request(
+                command=b'cancel_task',
+                data=task_id.encode() + b' ' + json.dumps(timeout_exc := exception.WazuhClusterError(3039),
+                                                          cls=c_common.WazuhJSONEncoder).encode())
+            raise timeout_exc
 
         # Full path where the zip sent by the worker is located.
         received_filename = self.sync_tasks[task_id].filename
@@ -715,13 +723,13 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                     raise exc_info
 
                 # Send zip file to the worker into chunks.
-                await self.send_file(compressed_data)
+                await self.send_file(compressed_data, task_id)
                 logger.debug("Zip with files to be synced sent to worker.")
 
-                # Finish the synchronization process and notify where the file corresponding to the taskID is located.
-                result = await self.send_request(command=b'syn_m_c_e',
-                                                 data=task_id + b' ' + os.path.relpath(
+                # Notify what is the zip path for the current taskID.
+                result = await self.send_request(command=b'syn_m_c_e', data=task_id + b' ' + os.path.relpath(
                                                      compressed_data, common.WAZUH_PATH).encode())
+
                 if isinstance(result, Exception):
                     raise result
                 elif result.startswith(b'Error'):
@@ -729,17 +737,19 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             except exception.WazuhException as e:
                 # Notify error to worker and delete its received file.
                 self.logger.error(f"Error sending files information: {e}")
-                result = await self.send_request(
+                await self.send_request(
                     command=b'syn_m_c_r', data=task_id + b' ' + json.dumps(e, cls=c_common.WazuhJSONEncoder).encode())
             except Exception as e:
                 # Notify error to worker and delete its received file.
                 self.logger.error(f"Error sending files information: {e}")
                 exc_info = json.dumps(exception.WazuhClusterError(1000, extra_message=str(e)),
                                       cls=c_common.WazuhJSONEncoder).encode()
-                result = await self.send_request(command=b'syn_m_c_r', data=task_id + b' ' + exc_info)
+                await self.send_request(command=b'syn_m_c_r', data=task_id + b' ' + exc_info)
             finally:
                 # Remove local file.
                 os.unlink(compressed_data)
+                # In case task was interrupted, remove its ID from the interrupted set.
+                self.interrupted_tasks.discard(task_id)
                 logger.debug("Finished sending files to worker.")
                 # Log 'Finished in' message only if there are no extra_valid files to sync.
                 if not self.extra_valid_requested:
@@ -752,7 +762,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                     self.integrity_sync_status['date_end_master'] = \
                         self.integrity_sync_status['date_end_master'].strftime(DECIMALS_DATE_FORMAT)
 
-        return result
+        return b'ok'
 
     async def sync_extra_valid(self, task_id: str, received_file: asyncio.Event):
         """Run extra valid sync process and set up necessary parameters.
@@ -790,8 +800,16 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             Logger to use (can't use self since one of the task loggers will be used).
         """
         logger.debug("Waiting to receive zip file from worker.")
-        await asyncio.wait_for(received_file.wait(),
-                               timeout=self.cluster_items['intervals']['communication']['timeout_receiving_file'])
+        try:
+            await asyncio.wait_for(received_file.wait(),
+                                   timeout=self.cluster_items['intervals']['communication']['timeout_receiving_file'])
+        except Exception:
+            # Notify the sending node to stop its task.
+            await self.send_request(
+                command=b'cancel_task',
+                data=task_id.encode() + b' ' + json.dumps(timeout_exc := exception.WazuhClusterError(3039),
+                                                          cls=c_common.WazuhJSONEncoder).encode())
+            raise timeout_exc
 
         # Full path where the zip sent by the worker is located.
         received_filename = self.sync_tasks[task_id].filename

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -641,13 +641,6 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             ID of the asyncio task in charge of doing the sync process.
         received_file : asyncio.Event
             Asyncio event that is holding a lock while the files are not received.
-
-        Returns
-        -------
-        bytes
-            Result.
-        bytes
-            Response message.
         """
         logger = self.task_loggers['Integrity check']
         date_start_master = datetime.utcnow()
@@ -761,8 +754,6 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                         'tmp_date_start_master'].strftime(DECIMALS_DATE_FORMAT)
                     self.integrity_sync_status['date_end_master'] = \
                         self.integrity_sync_status['date_end_master'].strftime(DECIMALS_DATE_FORMAT)
-
-        return b'ok'
 
     async def sync_extra_valid(self, task_id: str, received_file: asyncio.Event):
         """Run extra valid sync process and set up necessary parameters.

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -7,12 +7,11 @@ import json
 import operator
 import os
 import shutil
+import time
 from calendar import timegm
 from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime
-from functools import partial
-from time import time
 from typing import Tuple, Dict, Callable
 from uuid import uuid4
 
@@ -174,6 +173,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         # Dictionary to save loggers for each sync task.
         self.task_loggers = {}
         context_tag.set(self.tag)
+        self.current_zip_limit = self.cluster_items['intervals']['communication']['max_zip_size']
 
     def to_dict(self):
         """Get worker healthcheck information.
@@ -704,7 +704,10 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             master_files_paths = worker_files_ko['shared'].keys() | worker_files_ko['missing'].keys()
             compressed_data = await cluster.run_in_pool(self.loop, self.server.task_pool,
                                                         wazuh.core.cluster.cluster.compress_files, self.name,
-                                                        master_files_paths, worker_files_ko)
+                                                        master_files_paths, worker_files_ko, self.current_zip_limit)
+
+            time_to_send = 0
+            sent_size = 0
 
             try:
                 # Start the synchronization process with the worker and get a taskID.
@@ -716,7 +719,9 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                     raise exc_info
 
                 # Send zip file to the worker into chunks.
-                await self.send_file(compressed_data, task_id)
+                time_to_send = time.perf_counter()
+                sent_size = await self.send_file(compressed_data, task_id)
+                time_to_send = time.perf_counter() - time_to_send
                 logger.debug("Zip with files to be synced sent to worker.")
 
                 # Notify what is the zip path for the current taskID.
@@ -739,10 +744,30 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                                       cls=c_common.WazuhJSONEncoder).encode()
                 await self.send_request(command=b'syn_m_c_r', data=task_id + b' ' + exc_info)
             finally:
+                try:
+                    # Decrease max zip size if task was interrupted (otherwise, KeyError exception raised).
+                    self.interrupted_tasks.remove(task_id)
+                    self.current_zip_limit = max(
+                        self.cluster_items['intervals']['communication']['min_zip_size'],
+                        sent_size * (1 - self.cluster_items['intervals']['communication']['zip_limit_tolerance'])
+                    )
+                    self.logger.debug(f"Decreasing sync size limit to {self.current_zip_limit / (1024**2):.2f} MB.")
+                except KeyError:
+                    # Increase max zip size if two conditions are met:
+                    #   1. Current zip limit is lower than default.
+                    #   2. Time to send zip was far under timeout_receiving_file.
+                    if (self.current_zip_limit < self.cluster_items['intervals']['communication']['max_zip_size'] and
+                            time_to_send < self.cluster_items['intervals']['communication']['timeout_receiving_file'] *
+                            (1 - self.cluster_items['intervals']['communication']['zip_limit_tolerance'])):
+                        self.current_zip_limit = min(
+                            self.cluster_items['intervals']['communication']['max_zip_size'],
+                            self.current_zip_limit * (
+                                    1 / (1 - self.cluster_items['intervals']['communication']['zip_limit_tolerance'])
+                            ))
+                        self.logger.debug(f"Increasing sync size limit to {self.current_zip_limit / (1024**2):.2f} MB.")
+
                 # Remove local file.
                 os.unlink(compressed_data)
-                # In case task was interrupted, remove its ID from the interrupted set.
-                self.interrupted_tasks.discard(task_id)
                 logger.debug("Finished sending files to worker.")
                 # Log 'Finished in' message only if there are no extra_valid files to sync.
                 if not self.extra_valid_requested:

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -987,7 +987,6 @@ class Master(server.AbstractServer):
 
     def __init__(self, **kwargs):
         """Class constructor.
-
         Parameters
         ----------
         kwargs

--- a/framework/wazuh/core/cluster/tests/test_client.py
+++ b/framework/wazuh/core/cluster/tests/test_client.py
@@ -76,10 +76,10 @@ def test_acm_init():
     assert abstract_client_manager.configuration == configuration
     assert abstract_client_manager.cluster_items == cluster_items
     assert abstract_client_manager.ssl is True
-    assert abstract_client_manager.performance_test is 10
-    assert abstract_client_manager.concurrency_test is 10
-    assert abstract_client_manager.file is "/file/path"
-    assert abstract_client_manager.string is 1000
+    assert abstract_client_manager.performance_test == 10
+    assert abstract_client_manager.concurrency_test == 10
+    assert abstract_client_manager.file == "/file/path"
+    assert abstract_client_manager.string == 1000
     assert abstract_client_manager.logger == logging.getLogger("wazuh")
     assert abstract_client_manager.tag == "Client Manager"
     assert abstract_client_manager.tasks == []

--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -528,7 +528,7 @@ async def test_handler_send_file_ok(send_request_mock, os_path_exists_mock):
     handler.interrupted_tasks.add(b'abcd')
 
     with patch('hashlib.sha256', return_value=MockHash()):
-        assert (await handler.send_file('some_file.txt', task_id=b'abcd') == b'File sent')
+        assert (await handler.send_file('some_file.txt', task_id=b'abcd') == 3)
         send_request_mock.assert_has_calls([call(command=b'file_upd', data=b'some_file.txt chu'),
                                             call(command=b'file_end', data=b'some_file.txt ')])
         assert send_request_mock.call_count == 3

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -156,8 +156,9 @@ def test_get_cluster_items():
                                               'max_allowed_time_without_keepalive': 120, 'process_pool_size': 2,
                                               'timeout_agent_info': 40, 'max_locked_integrity_time': 1000},
                                    'communication': {'timeout_cluster_request': 20, 'timeout_dapi_request': 200,
-                                                     'timeout_receiving_file': 120, 'max_zip_size': 1073741824,
-                                                     'min_zip_size': 31457280, 'zip_limit_tolerance': 0.2}},
+                                                     'timeout_receiving_file': 120, 'min_zip_size': 31457280,
+                                                     'max_zip_size': 1073741824, 'compress_level': 1,
+                                                     'zip_limit_tolerance': 0.2}},
                      'distributed_api': {'enabled': True}}
 
 

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -156,7 +156,8 @@ def test_get_cluster_items():
                                               'max_allowed_time_without_keepalive': 120, 'process_pool_size': 2,
                                               'timeout_agent_info': 40, 'max_locked_integrity_time': 1000},
                                    'communication': {'timeout_cluster_request': 20, 'timeout_dapi_request': 200,
-                                                     'timeout_receiving_file': 120}},
+                                                     'timeout_receiving_file': 120, 'max_zip_size': 1073741824,
+                                                     'min_zip_size': 31457280, 'zip_limit_tolerance': 0.2}},
                      'distributed_api': {'enabled': True}}
 
 

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -251,6 +251,8 @@ async def test_sync_files_sync_ok(compress_files_mock, unlink_mock, relpath_mock
 
             assert worker_mock.interrupted_tasks == {b'abcd'}
 
+            assert worker_mock.interrupted_tasks == {b'abcd'}
+
 
 @pytest.mark.asyncio
 @patch("wazuh.core.cluster.worker.WorkerHandler.send_request", return_value=Exception())

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -5,7 +5,7 @@ import asyncio
 import json
 import logging
 import sys
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock, call, ANY
 
 import pytest
 import uvloop
@@ -159,6 +159,7 @@ async def test_sync_files_sync_ok(compress_files_mock, unlink_mock, relpath_mock
         def __init__(self):
             self.name = "Testing"
             self.count = 1
+            self.interrupted_tasks = {b'OK', b'abcd'}
 
         async def send_request(self, command, data):
             """Decide with will be the right output depending on the scenario."""
@@ -198,13 +199,13 @@ async def test_sync_files_sync_ok(compress_files_mock, unlink_mock, relpath_mock
         with patch.object(logging.getLogger("wazuh"), "debug") as logger_debug_mock:
             with patch.object(logging.getLogger("wazuh"), "error") as logger_error_mock:
                 await sync_files.sync(files_to_sync, files_metadata)
-                send_file_mock.assert_called_once_with(filename='files/path/')
+                send_file_mock.assert_called_once_with(filename='files/path/', task_id=b'OK')
                 logger_debug_mock.assert_has_calls([call(
                     f"Compressing {'files and ' if files_to_sync else ''}'files_metadata.json' of {len(files_metadata)}"
                     f" files."), call("Sending zip file to master."), call("Zip file sent to master.")])
                 logger_error_mock.assert_called_once_with("Error sending zip file: ")
-                compress_files_mock.assert_called_once_with(name="Testing", list_path=files_to_sync,
-                                                            cluster_control_json=files_metadata)
+                compress_files_mock.assert_has_calls([call(name="Testing", list_path=files_to_sync,
+                                                           cluster_control_json=files_metadata)]*2)
                 unlink_mock.assert_called_once_with("files/path/")
                 relpath_mock.assert_called_once_with('files/path/', core_common.WAZUH_PATH)
                 assert json_dumps_mock.call_count == 2
@@ -218,7 +219,7 @@ async def test_sync_files_sync_ok(compress_files_mock, unlink_mock, relpath_mock
                 # Test elif present in try and first exception
                 worker_mock.count = 3
                 await sync_files.sync(files_to_sync, files_metadata)
-                send_file_mock.assert_called_once_with(filename='files/path/')
+                send_file_mock.assert_called_once_with(filename='files/path/', task_id=b'OK')
                 logger_debug_mock.assert_has_calls([call(
                     f"Compressing {'files and ' if files_to_sync else ''}'files_metadata.json' of {len(files_metadata)}"
                     f" files."), call("Sending zip file to master."), call("Zip file sent to master.")])
@@ -239,7 +240,7 @@ async def test_sync_files_sync_ok(compress_files_mock, unlink_mock, relpath_mock
             # Test return
             worker_mock.count = 4
             assert await sync_files.sync(files_to_sync, files_metadata) is True
-            send_file_mock.assert_called_once_with(filename='files/path/')
+            send_file_mock.assert_called_once_with(filename='files/path/', task_id=b'OK')
             logger_debug_mock.assert_has_calls([call(
                 f"Compressing {'files and ' if files_to_sync else ''}'files_metadata.json' of {len(files_metadata)}"
                 f" files."), call("Sending zip file to master."), call("Zip file sent to master.")])
@@ -247,6 +248,8 @@ async def test_sync_files_sync_ok(compress_files_mock, unlink_mock, relpath_mock
                                                         cluster_control_json=files_metadata)
             unlink_mock.assert_called_once_with("files/path/")
             relpath_mock.assert_called_once_with('files/path/', core_common.WAZUH_PATH)
+
+            assert worker_mock.interrupted_tasks == {b'abcd'}
 
 
 @pytest.mark.asyncio
@@ -875,18 +878,16 @@ async def test_worker_handler_process_files_from_master_ko(send_request_mock, js
     with pytest.raises(Exception):
         worker_handler.sync_tasks["task_id"] = TaskMock()
         await worker_handler.process_files_from_master(name="task_id", file_received=event_mock)
-
-        json_dumps_mock.assert_called_once_with(exception.WazuhClusterError(code=1000, extra_message=str(Exception())),
-                                                cls=core_common.WazuhJSONEncoder)
-        send_request_mock.assert_called_once_with(command=b'syn_i_w_m_r', data=b'None ' + "".encode())
-        wait_mock.assert_called_once_with(event_mock.wait(),
-                                          timeout=cluster_items['intervals']['communication']['timeout_receiving_file'])
+    json_dumps_mock.assert_called_with(exception.WazuhClusterError(code=1000, extra_message=str(Exception())),
+                                       cls=common.WazuhJSONEncoder)
+    send_request_mock.assert_called_with(command=b'syn_i_w_m_r', data=b'None ')
+    wait_mock.assert_called_once_with(event_mock.wait(),
+                                      timeout=cluster_items['intervals']['communication']['timeout_receiving_file'])
 
     wait_mock.side_effect = Exception
     with pytest.raises(exception.WazuhClusterError, match=r".* 3039 .*"):
         await worker_handler.process_files_from_master(name="task_id", file_received=event_mock)
-
-        send_request_mock.assert_called_once_with(command=b'syn_i_w_m_r', data=b'None ' + "".encode())
+    send_request_mock.assert_called_with(command=b'cancel_task', data=b'task_id ')
 
 
 @patch("builtins.open")

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -655,11 +655,11 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                     f"Finished in {datetime.utcnow().timestamp() - self.integrity_sync_status['date_start']:.3f}s.")
 
         except exception.WazuhException as e:
-            logger.error(f"Error synchronizing extra valid files: {e}")
+            logger.error(f"Error synchronizing files: {e}")
             await self.send_request(command=b'syn_i_w_m_r',
                                     data=b'None ' + json.dumps(e, cls=c_common.WazuhJSONEncoder).encode())
         except Exception as e:
-            logger.error(f"Error synchronizing extra valid files: {e}")
+            logger.error(f"Error synchronizing files: {e}")
             exc_info = json.dumps(exception.WazuhClusterError(1000, extra_message=str(e)),
                                   cls=c_common.WazuhJSONEncoder)
             await self.send_request(command=b'syn_i_w_m_r', data=b'None ' + exc_info.encode())

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -121,6 +121,12 @@ class SyncFiles(SyncTask):
         bool
             True if files were correctly sent to the master node, None otherwise.
         """
+        self.logger.debug(
+            f"Compressing {'files and ' if files_to_sync else ''}'files_metadata.json' of {len(files_metadata)} files."
+        )
+        compressed_data_path = cluster.compress_files(name=self.worker.name, list_path=files_to_sync,
+                                                      cluster_control_json=files_metadata)
+
         # Start the synchronization process with the master and get a taskID.
         task_id = await self.worker.send_request(command=self.cmd, data=b'')
         if isinstance(task_id, Exception):
@@ -132,16 +138,10 @@ class SyncFiles(SyncTask):
             await self.worker.send_request(command=self.cmd + b'_r', data=b'None ' + exc_info)
             return
 
-        self.logger.debug(
-            f"Compressing {'files and ' if files_to_sync else ''}'files_metadata.json' of {len(files_metadata)} files."
-        )
-        compressed_data_path = cluster.compress_files(name=self.worker.name, list_path=files_to_sync,
-                                                      cluster_control_json=files_metadata)
-
         try:
             # Send zip file to the master into chunks.
             self.logger.debug("Sending zip file to master.")
-            await self.worker.send_file(filename=compressed_data_path)
+            await self.worker.send_file(filename=compressed_data_path, task_id=task_id)
             self.logger.debug("Zip file sent to master.")
 
             # Finish the synchronization process and notify where the file corresponding to the taskID is located.
@@ -165,6 +165,8 @@ class SyncFiles(SyncTask):
             await self.worker.send_request(command=self.cmd + b'_r', data=task_id + b' ' + exc_info)
         finally:
             os.unlink(compressed_data_path)
+            # In case task was interrupted, remove its ID from the interrupted set.
+            self.worker.interrupted_tasks.discard(task_id)
 
 
 class SyncWazuhdb(SyncTask):
@@ -603,10 +605,11 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             await asyncio.wait_for(file_received.wait(),
                                    timeout=self.cluster_items['intervals']['communication']['timeout_receiving_file'])
         except Exception:
+            # Notify the sending node to stop its task.
             await self.send_request(
-                command=b'syn_i_w_m_r',
-                data=b'None ' + json.dumps(timeout_exc := WazuhClusterError(
-                    3039, extra_message=f'Integrity sync at {self.name}'), cls=c_common.WazuhJSONEncoder).encode())
+                command=b'cancel_task',
+                data=name.encode() + b' ' + json.dumps(timeout_exc := WazuhClusterError(3039),
+                                                       cls=c_common.WazuhJSONEncoder).encode())
             raise timeout_exc
 
         if isinstance(self.sync_tasks[name].filename, Exception):


### PR DESCRIPTION
|Related issue|
|---|
| Closes #11945 |

## Description

This PR improves the reliability of file synchronization (Integrity sync) in the cluster, especially in cases where the zip with all the files was too large to be sent in less than 120 seconds. With the changes of this PR, the cluster has these features:
- Now, files are not only grouped (zipped) but also compressed.
- After a timeout while receiving a file, the sending node stops sending.
- A maximum size for the zip is set. When exceeded, no new files are added.
- The maximum zip size is dynamic, it adapts based on the number of bytes that could be sent in a timeouted sync, before being cancelled.
- A new system test has been added to check the correct operation of these features.

## Configuration options

These parameters are not intended to be modified by users. They affect the behavior of the new features mentioned above:

- Time receiving a file. After it, a command will be sent to interrupt the task if the reception has not yet been completed. https://github.com/wazuh/wazuh/blob/7b91170d49ac3cbf178ea11ad7fca4ec15f5eecc/framework/wazuh/core/cluster/cluster.json#L116
- Maximum size in bytes of the zips. No new files will be added to the zip after exceeding this value. https://github.com/wazuh/wazuh/blob/7b91170d49ac3cbf178ea11ad7fca4ec15f5eecc/framework/wazuh/core/cluster/cluster.json#L117
- Minimum zip limit size in bytes. The zip size limit will never be less than this value. https://github.com/wazuh/wazuh/blob/7b91170d49ac3cbf178ea11ad7fca4ec15f5eecc/framework/wazuh/core/cluster/cluster.json#L118
- Compression level, from 0 (no compression) to 9 (maximum compression). The higher compression, the lower speed. https://github.com/wazuh/wazuh/blob/7b91170d49ac3cbf178ea11ad7fca4ec15f5eecc/framework/wazuh/core/cluster/cluster.json#L119
- Time and size tolerance. The zip size will be adjusted based on this value. https://github.com/wazuh/wazuh/blob/7b91170d49ac3cbf178ea11ad7fca4ec15f5eecc/framework/wazuh/core/cluster/cluster.json#L120


## Logs/Alerts example

```
2022/03/03 14:44:03 INFO: [Worker wazuh-worker1] [Integrity sync] Starting.
2022/03/03 14:44:03 INFO: [Worker wazuh-worker1] [Integrity sync] Files to create in worker: 6 | Files to update in worker: 0 | Files to delete in worker: 0 | Files to receive: 0
2022/03/03 14:44:03 DEBUG: [Worker wazuh-worker1] [Integrity sync] Compressing files to be synced in worker.
2022/03/03 14:44:04 WARNING: [Local Server] [Main] Maximum zip size exceeded. Not all files will be compressed during this sync.
2022/03/03 14:44:05 DEBUG: [Worker wazuh-worker1] [Main] Command received: b'cancel_task'
2022/03/03 14:44:05 ERROR: [Worker wazuh-worker1] [Main] The task was canceled due to the following error on the remote node: Error 3039 - Timeout while waiting to receive a file
2022/03/03 14:44:05 DEBUG: [Worker wazuh-worker1] [Integrity sync] Zip with files to be synced sent to worker.
2022/03/03 14:44:05 ERROR: [Worker wazuh-worker1] [Main] Error sending files information: Error 3027 - Unknown received task name: 40c0e4ff-4789-441b-8e1a-ad7d8cf6bd27
2022/03/03 14:44:05 DEBUG: [Worker wazuh-worker1] [Main] Decreasing sync size limit to 28.00 MB.
2022/03/03 14:44:05 DEBUG: [Worker wazuh-worker1] [Integrity sync] Finished sending files to worker.
2022/03/03 14:44:05 INFO: [Worker wazuh-worker1] [Integrity sync] Finished in 1.506s.
2022/03/03 14:44:13 INFO: [Worker wazuh-worker1] [Integrity check] Finished in 0.014s. Received metadata of 38 files. Sync required.
2022/03/03 14:44:13 INFO: [Worker wazuh-worker1] [Integrity sync] Starting.
2022/03/03 14:44:13 INFO: [Worker wazuh-worker1] [Integrity sync] Files to create in worker: 6 | Files to update in worker: 0 | Files to delete in worker: 0 | Files to receive: 0
2022/03/03 14:44:13 DEBUG: [Worker wazuh-worker1] [Integrity sync] Compressing files to be synced in worker.
2022/03/03 14:44:13 WARNING: [Local Server] [Main] Maximum zip size exceeded. Not all files will be compressed during this sync.
2022/03/03 14:44:13 DEBUG: [Worker wazuh-worker1] [Integrity sync] Zip with files to be synced sent to worker.
2022/03/03 14:44:13 DEBUG: [Worker wazuh-worker1] [Main] Increasing sync size limit to 35.00 MB.
2022/03/03 14:44:13 DEBUG: [Worker wazuh-worker1] [Integrity sync] Finished sending files to worker.
2022/03/03 14:44:13 INFO: [Worker wazuh-worker1] [Integrity sync] Finished in 0.672s.
```

## Tests

```
$ python3 -m pytest test_integrity_sync.py -vv
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.8.10, pytest-5.0.0, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.10', 'Platform': 'Linux-5.4.0-99-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.0.0', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'html': '3.1.1', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'pep8': '1.0.6', 'cov': '2.10.0', 'asyncio': '0.14.0'}}
rootdir: /home/selu/Git/wazuh-qa/tests/system/test_cluster/test_integrity_sync
plugins: metadata-1.10.0, html-3.1.1, testinfra-5.0.0, tavern-1.2.2, pep8-1.0.6, cov-2.10.0, asyncio-0.14.0
collected 5 items                                                                                                                                                                                           

test_integrity_sync.py::test_missing_file PASSED                                                                                                                                                      [ 20%]
test_integrity_sync.py::test_shared_files PASSED                                                                                                                                                      [ 40%]
test_integrity_sync.py::test_extra_files PASSED                                                                                                                                                       [ 60%]
test_integrity_sync.py::test_extra_valid_files PASSED                                                                                                                                                 [ 80%]
test_integrity_sync.py::test_zip_size_limit[5] PASSED                                                                                                                                                 [100%]

======================================================================================== 5 passed in 825.69 seconds =========================================================================================
```