### PR TITLE
[Agent-groups] Fix issues with a high volume of agents

### DIFF
--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -1504,7 +1504,7 @@ def send_data_to_wdb(data, timeout, info_type='agent-info'):
                         wdb_conn.send(f"{data['set_data_command']} {chunk}", raw=True)
                     elif info_type == 'agent-groups':
                         data['payload']['data'] = json.loads(chunk)[0]['data']
-                        wdb_conn.send(f"{data['set_data_command']} {json.dumps(data['payload'])}", raw=True)
+                        wdb_conn.send(f"{data['set_data_command']} {json.dumps(data['payload'], separators=(',', ':'))}", raw=True)
                     result['updated_chunks'] += 1
                 except TimeoutError as e:
                     raise e

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -710,8 +710,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             info = self.server.get_agent_groups_info(self.name)
             if info != {}:
                 try:
-                    self.send_agent_groups_status['date_start'] = perf_counter()
                     logger.info("Starting.")
+                    self.send_agent_groups_status['date_start'] = perf_counter()
                     await sync_object.sync(start_time=self.send_agent_groups_status['date_start'], chunks=info)
                 except Exception as e:
                     logger.error(f'Error sending agent-groups information to {self.name}: {e}')

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -679,7 +679,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                                            data_retriever=WazuhDBConnection().run_wdb_command,
                                            get_data_command='global sync-agent-groups-get ',
                                            get_payload={"condition": "all", "set_synced": False,
-                                                        "get_global_hash": True})
+                                                        "get_global_hash": True, "last_id": 0}, pivot_key='last_id')
         local_agent_groups_information = await sync_object.retrieve_information()
 
         sync_object = c_common.SyncWazuhdb(manager=self, logger=logger, cmd=b'syn_g_m_w',
@@ -714,7 +714,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                     logger.info("Starting.")
                     await sync_object.sync(start_time=self.send_agent_groups_status['date_start'], chunks=info)
                 except Exception as e:
-                    logger.error(f'Error sending agent-groups information to {self.cluster_name}: {e}')
+                    logger.error(f'Error sending agent-groups information to {self.name}: {e}')
 
             await asyncio.sleep(1)
 
@@ -1107,7 +1107,7 @@ class Master(server.AbstractServer):
             Updated data on agent-groups.
         """
         result = {}
-        if client not in self.agent_groups_control_workers:
+        if client in self.clients.keys() and client not in self.agent_groups_control_workers:
             result = self.agent_groups_control
             self.agent_groups_control_workers.add(client)
 

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -943,7 +943,7 @@ async def test_manager_handler_send_entire_agent_groups_information(WazuhDBConne
         """Auxiliary class."""
 
         def __init__(self, manager, logger, data_retriever, get_data_command='',
-                     get_payload='', set_data_command='', set_payload='', cmd=''):
+                     get_payload='', set_data_command='', set_payload='', cmd='', pivot_key=''):
             self.counter = 0
             self.logger = logger
 
@@ -1028,6 +1028,7 @@ async def test_manager_handler_send_agent_groups_information(WazuhDBConnection_m
         return 'testing'
 
     master_handler = get_master_handler()
+    master_handler.name = 'worker_test'
     master_handler.server.agent_groups_control = 'testing'
     master_handler.task_loggers["Agent-groups send"] = LoggerMock()
     master_handler.server.get_agent_groups_info = get_agent_groups_info.__get__(master_handler.server)
@@ -1039,7 +1040,7 @@ async def test_manager_handler_send_agent_groups_information(WazuhDBConnection_m
 
     assert master_handler.task_loggers["Agent-groups send"]._info == ['Starting.', 'Starting.']
     assert master_handler.task_loggers["Agent-groups send"]._error == [f'Error sending agent-groups information to '
-                                                                       f'{master_handler.cluster_name}: Stop while True']
+                                                                       f'{master_handler.name}: Stop while True']
 
 
 @pytest.mark.asyncio

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -532,8 +532,8 @@ def test_worker_handler_sync_integrity_ok_from_master(logger_mock):
 
 @pytest.mark.asyncio
 @patch("wazuh.core.wdb.socket.socket")
-async def test_worker_compare_agent_groups_checksum(socket_mock):
-    """Check all the possible cases in the checksum comparison."""
+async def test_worker_compare_agent_groups_checksums(socket_mock):
+    """Check all the possible cases in the checksums comparison."""
 
     class LoggerMock:
         """Auxiliary class."""

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -405,6 +405,9 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                                            get_payload={"condition": "sync_status", "get_global_hash": True})
 
         local_agent_groups = await sync_object.retrieve_information()
+        if not local_agent_groups:
+            return False
+
         local_agent_groups = json.loads(local_agent_groups[0])
         if not local_agent_groups[0]['data']:
             logger.debug2('There is no data requiring synchronization in the local database.')


### PR DESCRIPTION
|Related issue|
|---|
|#12487|

This issue closes #12487. In this PR we have fixed several errors related to environments where there are a large number of agents (>2000). Here we can see the plots of an environment with 10000 agents and 10 worker nodes:

#### Master node
![image](https://user-images.githubusercontent.com/15522808/156590271-950dd494-5e98-408d-bd48-a6fdf043699a.png)

#### Worker node
![image](https://user-images.githubusercontent.com/15522808/156590325-e996b17a-6a67-447d-bf12-74c04615f0ae.png)
![image](https://user-images.githubusercontent.com/15522808/156590374-b817780d-08a2-4501-bd7b-a85d9f9fc3de.png)