### PR TITLE
Fixing warnings in win_utils.c file

### DIFF
--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -51,7 +51,11 @@ void *EventForward(void);
 int receive_msg(void);
 
 /* Receiver messages for Windows */
+#ifdef WIN32
+DWORD WINAPI receiver_thread(LPVOID none);
+#else
 void *receiver_thread(void *none);
+#endif
 
 /* Initialize agent buffer */
 void buffer_init();
@@ -60,8 +64,11 @@ void buffer_init();
 int buffer_append(const char *msg);
 
 /* Thread to dispatch messages from the buffer */
+#ifdef WIN32
+DWORD WINAPI dispatch_buffer(LPVOID arg);
+#else
 void *dispatch_buffer(void * arg);
-
+#endif
 /**
  * @brief get the number of events in buffer
  *
@@ -105,7 +112,11 @@ void run_notify(void);
 int format_labels(char *str, size_t size);
 
 // Thread to rotate internal log
+#ifdef WIN32
+DWORD WINAPI w_rotate_log_thread(LPVOID arg);
+#else
 void * w_rotate_log_thread(void * arg);
+#endif
 
 // Initialize request module
 void req_init();
@@ -114,7 +125,11 @@ void req_init();
 int req_push(char * buffer, size_t length);
 
 // Request receiver thread start
+#ifdef WIN32
+DWORD WINAPI req_receiver(LPVOID arg);
+#else
 void * req_receiver(void * arg);
+#endif
 
 // Restart agent
 void * restartAgent();

--- a/src/client-agent/buffer.c
+++ b/src/client-agent/buffer.c
@@ -136,8 +136,11 @@ int buffer_append(const char *msg){
 }
 
 /* Send messages from buffer to the server */
+#ifdef WIN32
+DWORD WINAPI dispatch_buffer(__attribute__((unused)) LPVOID arg) {
+#else
 void *dispatch_buffer(__attribute__((unused)) void * arg){
-
+#endif
     char flood_msg[OS_MAXSTR];
     char full_msg[OS_MAXSTR];
     char warn_msg[OS_MAXSTR];

--- a/src/client-agent/receiver-win.c
+++ b/src/client-agent/receiver-win.c
@@ -23,7 +23,11 @@ static const char * IGNORE_LIST[] = { SHAREDCFG_FILENAME, NULL };
 w_queue_t * winexec_queue;
 
 /* Receive events from the server */
+#ifdef WIN32
+DWORD WINAPI receiver_thread(__attribute__((unused)) LPVOID none)
+#else
 void *receiver_thread(__attribute__((unused)) void *none)
+#endif
 {
     ssize_t recv_b;
     size_t msg_length;
@@ -334,7 +338,11 @@ void *receiver_thread(__attribute__((unused)) void *none)
         }
     }
 
+#ifdef WIN32
+    return 0;
+#else
     return (NULL);
+#endif
 }
 
 #endif /* WIN32 */

--- a/src/client-agent/request.c
+++ b/src/client-agent/request.c
@@ -227,7 +227,11 @@ int req_push(char * buffer, size_t length) {
 }
 
 // Request receiver thread start
+#ifdef WIN32
+DWORD WINAPI req_receiver(__attribute__((unused)) LPVOID arg) {
+#else
 void * req_receiver(__attribute__((unused)) void * arg) {
+#endif
     int attempts;
     long nsec;
     ssize_t length = 0;
@@ -379,6 +383,9 @@ void * req_receiver(__attribute__((unused)) void * arg) {
         req_free(node);
     }
 
-
+#ifdef WIN32
+    return 0;
+#else
     return NULL;
+#endif
 }

--- a/src/client-agent/rotate_log.c
+++ b/src/client-agent/rotate_log.c
@@ -22,7 +22,11 @@ int daily_rotations;
 int size_rotate_read;
 
 // Thread to rotate internal log
+#ifdef WIN32
+DWORD WINAPI w_rotate_log_thread(__attribute__((unused)) LPVOID arg) {
+#else
 void * w_rotate_log_thread(__attribute__((unused)) void * arg) {
+#endif
     char path[PATH_MAX];
     char path_json[PATH_MAX];
     struct stat buf;

--- a/src/client-agent/state.c
+++ b/src/client-agent/state.c
@@ -33,11 +33,18 @@ void w_agentd_state_init() {
     interval = getDefine_Int("agent", "state_interval", 0, 86400);
 }
 
+#ifdef WIN32
+DWORD WINAPI state_main(__attribute__((unused)) LPVOID arg) {
+#else
 void * state_main(__attribute__((unused)) void * args) {
-
+#endif
     if (!interval) {
         minfo("State file is disabled.");
+#ifdef WIN32
+        return 0;
+#else
         return NULL;
+#endif
     }
 
     mdebug1("State file updating thread started.");
@@ -47,7 +54,11 @@ void * state_main(__attribute__((unused)) void * args) {
         sleep(interval);
     }
 
-    return NULL;
+#ifdef WIN32
+        return 0;
+#else
+        return NULL;
+#endif
 }
 
 int write_state() {

--- a/src/client-agent/state.h
+++ b/src/client-agent/state.h
@@ -59,8 +59,11 @@ void w_agentd_state_init();
 /**
  * @brief Main thread, write the statistics in the file
  */
+#ifdef WIN32
+DWORD WINAPI state_main(__attribute__((unused)) LPVOID arg);
+#else
 void * state_main(__attribute__((unused)) void * args);
-
+#endif
 /**
  * @brief Update agent statistics
  * @param type Action

--- a/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.c
+++ b/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.c
@@ -67,25 +67,20 @@ STATIC void *wm_agent_upgrade_main(wm_agent_upgrade* upgrade_config) {
 }
 
 #ifdef WIN32
-STATIC DWORD WINAPI wm_agent_upgrade_destroy(void* upgrade_config) {
-    wm_agent_upgrade *ptr = (wm_agent_upgrade *)upgrade_config;
-
-    mtinfo(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_MODULE_FINISHED);
-    #ifndef CLIENT
-    os_free(ptr->manager_config.wpk_repository);
-    #endif
-    os_free(ptr);
-    return 0;
-}
+STATIC DWORD WINAPI wm_agent_upgrade_destroy(void* upgrade_config_ptr) {
+    wm_agent_upgrade *upgrade_config = (wm_agent_upgrade *)upgrade_config_ptr;
 #else
 STATIC void wm_agent_upgrade_destroy(wm_agent_upgrade* upgrade_config) {
+#endif
     mtinfo(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_MODULE_FINISHED);
     #ifndef CLIENT
     os_free(upgrade_config->manager_config.wpk_repository);
     #endif
     os_free(upgrade_config);
+    #ifdef WIN32
+    return 0;
+    #endif
 }
- #endif
 
 STATIC cJSON *wm_agent_upgrade_dump(const wm_agent_upgrade* upgrade_config){
     cJSON *root = cJSON_CreateObject();

--- a/src/wazuh_modules/task_manager/wm_task_manager.c
+++ b/src/wazuh_modules/task_manager/wm_task_manager.c
@@ -221,16 +221,15 @@ STATIC void* wm_task_manager_main(wm_task_manager* task_config) {
 
 #ifdef WIN32
 STATIC DWORD WINAPI wm_task_manager_destroy(void* task_config) {
-    mtinfo(WM_TASK_MANAGER_LOGTAG, MOD_TASK_FINISH);
-    os_free(task_config);
-    return 0;
-}
 #else
 STATIC void wm_task_manager_destroy(wm_task_manager* task_config) {
+#endif
     mtinfo(WM_TASK_MANAGER_LOGTAG, MOD_TASK_FINISH);
     os_free(task_config);
+    #ifdef WIN32
+    return 0;
+    #endif
 }
-#endif
 
 STATIC cJSON* wm_task_manager_dump(const wm_task_manager* task_config){
     cJSON *root = cJSON_CreateObject();

--- a/src/wazuh_modules/task_manager/wm_task_manager.c
+++ b/src/wazuh_modules/task_manager/wm_task_manager.c
@@ -31,8 +31,13 @@ extern void mock_assert(const int result, const char* const expression,
 
 
 STATIC int wm_task_manager_init(wm_task_manager *task_config) __attribute__((nonnull));
+#ifdef WIN32
+STATIC DWORD WINAPI wm_task_manager_main(void *arg);
+STATIC DWORD WINAPI wm_task_manager_destroy(void* task_config);
+#else
 STATIC void* wm_task_manager_main(wm_task_manager* task_config);    // Module main function. It won't return
 STATIC void wm_task_manager_destroy(wm_task_manager* task_config);
+#endif
 STATIC cJSON* wm_task_manager_dump(const wm_task_manager* task_config);
 
 /* Context definition */
@@ -122,7 +127,12 @@ STATIC int wm_task_manager_init(wm_task_manager *task_config) {
     return sock;
 }
 
+#ifdef WIN32
+STATIC DWORD WINAPI wm_task_manager_main(void *arg) {
+    wm_task_manager* task_config = (wm_task_manager *)arg;
+#else
 STATIC void* wm_task_manager_main(wm_task_manager* task_config) {
+#endif
     int sock;
     int peer;
     char *buffer = NULL;
@@ -132,7 +142,11 @@ STATIC void* wm_task_manager_main(wm_task_manager* task_config) {
 
     if (w_is_worker()) {
         mtinfo(WM_TASK_MANAGER_LOGTAG, MOD_TASK_DISABLED_WORKER);
+#ifdef WIN32
+        return 0;
+#else
         return NULL;
+#endif
     }
 
     // Initial configuration
@@ -198,13 +212,25 @@ STATIC void* wm_task_manager_main(wm_task_manager* task_config) {
     }
 
     close(sock);
+#ifdef WIN32
+    return 0;
+#else
     return NULL;
+#endif
 }
 
+#ifdef WIN32
+STATIC DWORD WINAPI wm_task_manager_destroy(void* task_config) {
+    mtinfo(WM_TASK_MANAGER_LOGTAG, MOD_TASK_FINISH);
+    os_free(task_config);
+    return 0;
+}
+#else
 STATIC void wm_task_manager_destroy(wm_task_manager* task_config) {
     mtinfo(WM_TASK_MANAGER_LOGTAG, MOD_TASK_FINISH);
     os_free(task_config);
 }
+#endif
 
 STATIC cJSON* wm_task_manager_dump(const wm_task_manager* task_config){
     cJSON *root = cJSON_CreateObject();

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -264,14 +264,14 @@ cJSON *wm_aws_dump(const wm_aws *aws_config) {
 // Destroy data
 #ifdef WIN32
 DWORD WINAPI wm_aws_destroy(void *aws_config) {         // Destroy data
-    free(aws_config);
-    return 0;
-}
 #else
 void wm_aws_destroy(wm_aws *aws_config) {
-    free(aws_config);
-}
 #endif
+    free(aws_config);
+    #ifdef WIN32
+    return 0;
+    #endif
+}
 
 // Setup module
 

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -19,13 +19,17 @@
 #endif
 
 static wm_aws *aws_config;                              // Pointer to aws_configuration
-
+#ifdef WIN32
+static DWORD WINAPI wm_aws_main(void *arg);             // Module main function. It won't return
+static DWORD WINAPI wm_aws_destroy(void *aws_config);   // Destroy data
+#else
 static void* wm_aws_main(wm_aws *aws_config);           // Module main function. It won't return
+static void wm_aws_destroy(wm_aws *aws_config);         // Destroy data
+#endif
 static void wm_aws_setup(wm_aws *_aws_config);          // Setup module
 static void wm_aws_check();                             // Check configuration, disable flag
 static void wm_aws_run_s3(wm_aws *aws_config, wm_aws_bucket *bucket);       // Run a s3 bucket
 static void wm_aws_run_service(wm_aws *aws_config, wm_aws_service *service);// Run a AWS service such as Inspector
-static void wm_aws_destroy(wm_aws *aws_config);         // Destroy data
 cJSON *wm_aws_dump(const wm_aws *aws_config);
 
 // Command module context definition
@@ -40,8 +44,12 @@ const wm_context WM_AWS_CONTEXT = {
 };
 
 // Module module main function. It won't return.
-
+#ifdef WIN32
+DWORD WINAPI wm_aws_main(void *arg) {
+    wm_aws *aws_config = (wm_aws *)arg;
+#else
 void* wm_aws_main(wm_aws *aws_config) {
+#endif
     wm_aws_bucket *cur_bucket;
     wm_aws_service *cur_service;
     char *log_info;
@@ -167,7 +175,11 @@ void* wm_aws_main(wm_aws *aws_config) {
 
     } while (FOREVER());
 
+#ifdef WIN32
+    return 0;
+#else
     return NULL;
+#endif
 }
 
 
@@ -250,10 +262,16 @@ cJSON *wm_aws_dump(const wm_aws *aws_config) {
 
 
 // Destroy data
-
+#ifdef WIN32
+DWORD WINAPI wm_aws_destroy(void *aws_config) {         // Destroy data
+    free(aws_config);
+    return 0;
+}
+#else
 void wm_aws_destroy(wm_aws *aws_config) {
     free(aws_config);
 }
+#endif
 
 // Setup module
 

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -18,7 +18,13 @@ static wm_rule_data *head;                            // Pointer to head of rule
 static int queue_fd;                                // Output queue file descriptor
 #endif
 
+#ifdef WIN32
+static DWORD WINAPI wm_ciscat_main(void *arg);                  // Module main function. It won't return
+static DWORD WINAPI wm_ciscat_destroy(void *ciscat);            // Destroy data
+#else
 static void* wm_ciscat_main(wm_ciscat *ciscat);        // Module main function. It won't return
+static void wm_ciscat_destroy(wm_ciscat *ciscat);      // Destroy data
+#endif
 static void wm_ciscat_setup(wm_ciscat *_ciscat);       // Setup module
 static void wm_ciscat_check();                       // Check configuration, disable flag
 static void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char * java_path);      // Run a CIS-CAT policy
@@ -34,7 +40,6 @@ static void wm_ciscat_info();                        // Show module info
 #ifndef WIN32
 static void wm_ciscat_cleanup();                     // Cleanup function, doesn't overwrite wm_cleanup
 #endif
-static void wm_ciscat_destroy(wm_ciscat *ciscat);      // Destroy data
 cJSON *wm_ciscat_dump(const wm_ciscat *ciscat);
 
 const char *WM_CISCAT_LOCATION = "wodle_cis-cat";  // Location field for event sending
@@ -51,8 +56,12 @@ const wm_context WM_CISCAT_CONTEXT = {
 };
 
 // CIS-CAT module main function. It won't return.
-
+#ifdef WIN32
+DWORD WINAPI wm_ciscat_main(void *arg) {
+    wm_ciscat *ciscat = (wm_ciscat *)arg;
+#else
 void* wm_ciscat_main(wm_ciscat *ciscat) {
+#endif
     wm_ciscat_eval *eval;
     int skip_java = 0;
     char *cis_path = NULL;
@@ -223,9 +232,10 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
     free(cis_path);
 #ifdef WIN32
     free(current);
-#endif
-
+    return 0;
+#else
     return NULL;
+#endif
 }
 
 // Setup module
@@ -1499,7 +1509,27 @@ cJSON *wm_ciscat_dump(const wm_ciscat * ciscat) {
 
 
 // Destroy data
+#ifdef WIN32
+DWORD WINAPI wm_ciscat_destroy(void *ciscat) {
 
+    wm_ciscat_eval *cur_eval;
+    wm_ciscat_eval *next_eval;
+    wm_ciscat *ptr_ciscat = (wm_ciscat *)ciscat;
+
+    // Delete evals
+
+    for (cur_eval = ptr_ciscat->evals; cur_eval; cur_eval = next_eval) {
+
+        next_eval = cur_eval->next;
+        free(cur_eval->path);
+        free(cur_eval->profile);
+        free(cur_eval);
+    }
+
+    free(ptr_ciscat);
+    return 0;
+}
+#else
 void wm_ciscat_destroy(wm_ciscat *ciscat) {
 
     wm_ciscat_eval *cur_eval;
@@ -1517,4 +1547,6 @@ void wm_ciscat_destroy(wm_ciscat *ciscat) {
 
     free(ciscat);
 }
+#endif
+
 #endif

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -1507,34 +1507,15 @@ cJSON *wm_ciscat_dump(const wm_ciscat * ciscat) {
     return root;
 }
 
-
 // Destroy data
 #ifdef WIN32
-DWORD WINAPI wm_ciscat_destroy(void *ciscat) {
-
-    wm_ciscat_eval *cur_eval;
-    wm_ciscat_eval *next_eval;
-    wm_ciscat *ptr_ciscat = (wm_ciscat *)ciscat;
-
-    // Delete evals
-
-    for (cur_eval = ptr_ciscat->evals; cur_eval; cur_eval = next_eval) {
-
-        next_eval = cur_eval->next;
-        free(cur_eval->path);
-        free(cur_eval->profile);
-        free(cur_eval);
-    }
-
-    free(ptr_ciscat);
-    return 0;
-}
+DWORD WINAPI wm_ciscat_destroy(void *ptr_ciscat) {
+    wm_ciscat *ciscat = (wm_ciscat *)ptr_ciscat;
 #else
 void wm_ciscat_destroy(wm_ciscat *ciscat) {
-
+#endif
     wm_ciscat_eval *cur_eval;
     wm_ciscat_eval *next_eval;
-
     // Delete evals
 
     for (cur_eval = ciscat->evals; cur_eval; cur_eval = next_eval) {
@@ -1546,7 +1527,9 @@ void wm_ciscat_destroy(wm_ciscat *ciscat) {
     }
 
     free(ciscat);
+    #ifdef WIN32
+    return 0;
+    #endif
 }
 #endif
 
-#endif

--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -266,20 +266,16 @@ cJSON *wm_command_dump(const wm_command_t * command) {
 
 // Destroy data
 #ifdef WIN32
-DWORD WINAPI wm_command_destroy(void *command) {
-    wm_command_t * ptr_command = (wm_command_t *)command;
-
-    free(ptr_command->tag);
-    free(ptr_command->command);
-    free(ptr_command->full_command);
-    free(ptr_command);
-    return 0;
-}
+DWORD WINAPI wm_command_destroy(void *ptr_command) {
+    wm_command_t * command = (wm_command_t *)ptr_command;
 #else
 void wm_command_destroy(wm_command_t * command) {
+#endif
     free(command->tag);
     free(command->command);
     free(command->full_command);
     free(command);
+    #ifdef WIN32
+    return 0;
+    #endif
 }
-#endif

--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -11,8 +11,13 @@
 
 #include "wmodules.h"
 
+#ifdef WIN32
+static DWORD WINAPI wm_command_main(void *arg);             // Module main function. It won't return
+static DWORD WINAPI wm_command_destroy(void *command);      // Destroy data
+#else
 static void * wm_command_main(wm_command_t * command);    // Module main function. It won't return
 static void wm_command_destroy(wm_command_t * command);   // Destroy data
+#endif
 cJSON *wm_command_dump(const wm_command_t * command);
 
 // Command module context definition
@@ -28,7 +33,12 @@ const wm_context WM_COMMAND_CONTEXT = {
 
 // Module module main function. It won't return.
 
+#ifdef WIN32
+DWORD WINAPI wm_command_main(void *arg) {
+    wm_command_t * command = (wm_command_t *)arg;
+#else
 void * wm_command_main(wm_command_t * command) {
+#endif
     size_t extag_len;
     char * extag;
     int usec = 1000000 / wm_max_eps;
@@ -221,7 +231,11 @@ void * wm_command_main(wm_command_t * command) {
     } while (FOREVER());
 
     free(extag);
+#ifdef WIN32
+    return 0;
+#else
     return NULL;
+#endif
 }
 
 
@@ -251,10 +265,21 @@ cJSON *wm_command_dump(const wm_command_t * command) {
 
 
 // Destroy data
+#ifdef WIN32
+DWORD WINAPI wm_command_destroy(void *command) {
+    wm_command_t * ptr_command = (wm_command_t *)command;
 
+    free(ptr_command->tag);
+    free(ptr_command->command);
+    free(ptr_command->full_command);
+    free(ptr_command);
+    return 0;
+}
+#else
 void wm_command_destroy(wm_command_t * command) {
     free(command->tag);
     free(command->command);
     free(command->full_command);
     free(command);
 }
+#endif

--- a/src/wazuh_modules/wm_gcp.c
+++ b/src/wazuh_modules/wm_gcp.c
@@ -21,22 +21,10 @@
 #endif
 
 /**
- * @brief Main function for Google Cloud Pub/Sub
- * @param gcp_config Module configuration structure
- */
-static void* wm_gcp_pubsub_main(wm_gcp_pubsub *gcp_config);          // Module main function. It won't return
-
-/**
  * @brief Run module function for Google Cloud Pub/Sub
  * @param data Module configuration structure
  */
 static void wm_gcp_pubsub_run(const wm_gcp_pubsub *data);            // Running python script
-
-/**
- * @brief Free configuration structure for Google Cloud Pub/Sub
- * @param gcp_config Module configuration structure
- */
-static void wm_gcp_pubsub_destroy(wm_gcp_pubsub *gcp_config);        // Destroy data
 
 /**
  * @brief Dump configuration structure in JSON for Google Cloud Pub/Sub
@@ -44,6 +32,36 @@ static void wm_gcp_pubsub_destroy(wm_gcp_pubsub *gcp_config);        // Destroy 
  * @return JSON structure with module configuration
  */
 cJSON *wm_gcp_pubsub_dump(const wm_gcp_pubsub *gcp_config);          // Read config
+#ifdef WIN32
+/**
+ * @brief Main function for Google Cloud Pub/Sub
+ * @param gcp_config Module configuration structure
+ */
+static DWORD WINAPI wm_gcp_pubsub_main(void *arg);                     // Module main function. It won't return
+
+/**
+ * @brief Main function for Google Cloud bucket
+ * @param gcp_config Module configuration structure
+ */
+static DWORD WINAPI wm_gcp_bucket_main(void *arg);                     // Module main function. It won't return
+
+/**
+ * @brief Free configuration structure for Google Cloud Pub/Sub
+ * @param gcp_config Module configuration structure
+ */
+static DWORD WINAPI wm_gcp_pubsub_destroy(void *gcp_config);           // Destroy data
+
+/**
+ * @brief Free configuration structure for Google Cloud bucket
+ * @param gcp_config Module configuration structure
+ */
+static DWORD WINAPI wm_gcp_bucket_destroy(void *gcp_config);           // Destroy data
+#else
+/**
+ * @brief Main function for Google Cloud Pub/Sub
+ * @param gcp_config Module configuration structure
+ */
+static void* wm_gcp_pubsub_main(wm_gcp_pubsub *gcp_config);          // Module main function. It won't return
 
 /**
  * @brief Main function for Google Cloud bucket
@@ -52,17 +70,23 @@ cJSON *wm_gcp_pubsub_dump(const wm_gcp_pubsub *gcp_config);          // Read con
 static void* wm_gcp_bucket_main(wm_gcp_bucket_base *gcp_config);          // Module main function. It won't return
 
 /**
- * @brief Run module function for Google Cloud bucket
- * @param data Module configuration structure
- * @param exec_bucket Bucket configuration structure
+ * @brief Free configuration structure for Google Cloud Pub/Sub
+ * @param gcp_config Module configuration structure
  */
-static void wm_gcp_bucket_run(const wm_gcp_bucket_base *data, wm_gcp_bucket *exec_bucket);            // Running python script
+static void wm_gcp_pubsub_destroy(wm_gcp_pubsub *gcp_config);        // Destroy data
 
 /**
  * @brief Free configuration structure for Google Cloud bucket
  * @param gcp_config Module configuration structure
  */
 static void wm_gcp_bucket_destroy(wm_gcp_bucket_base *gcp_config);        // Destroy data
+#endif
+/**
+ * @brief Run module function for Google Cloud bucket
+ * @param data Module configuration structure
+ * @param exec_bucket Bucket configuration structure
+ */
+static void wm_gcp_bucket_run(const wm_gcp_bucket_base *data, wm_gcp_bucket *exec_bucket);            // Running python script
 
 /**
  * @brief Dump configuration structure in JSON for Google Cloud bucket
@@ -96,7 +120,12 @@ const wm_context WM_GCP_BUCKET_CONTEXT = {
 #define pthread_exit(a) return a
 #endif
 // Module main function. It won't return
+#ifdef WIN32
+DWORD WINAPI wm_gcp_pubsub_main(void *arg) {
+    wm_gcp_pubsub *data = (wm_gcp_pubsub *)arg;
+#else
 void* wm_gcp_pubsub_main(wm_gcp_pubsub *data) {
+#endif
     char * timestamp = NULL;
     // If module is disabled, exit
     if (data->enabled) {
@@ -123,10 +152,19 @@ void* wm_gcp_pubsub_main(wm_gcp_pubsub *data) {
         mtdebug1(WM_GCP_PUBSUB_LOGTAG, "Fetching logs finished.");
     } while (FOREVER());
 
+#ifdef WIN32
+    return 0;
+#else
     return NULL;
+#endif
 }
 
+#ifdef WIN32
+DWORD WINAPI wm_gcp_bucket_main(void *arg) {
+    wm_gcp_bucket_base *data = (wm_gcp_bucket_base *)arg;
+#else
 void* wm_gcp_bucket_main(wm_gcp_bucket_base *data) {
+#endif
     char * timestamp = NULL;
     // If module is disabled, exit
     if (data->enabled) {
@@ -188,7 +226,11 @@ void* wm_gcp_bucket_main(wm_gcp_bucket_base *data) {
         mtdebug1(WM_GCP_BUCKET_LOGTAG, "Fetching logs finished.");
     } while (FOREVER());
 
+#ifdef WIN32
+    return 0;
+#else
     return NULL;
+#endif
 }
 
 #ifdef WAZUH_UNIT_TESTING
@@ -477,7 +519,36 @@ void wm_gcp_bucket_run(const wm_gcp_bucket_base *data, wm_gcp_bucket *exec_bucke
 
     os_free(output);
 }
+#ifdef WIN32
+DWORD WINAPI wm_gcp_pubsub_destroy(void *gcp_config) {
+    wm_gcp_pubsub *data = (wm_gcp_pubsub *)gcp_config;
 
+    if (data->project_id) os_free(data->project_id);
+    if (data->subscription_name) os_free(data->subscription_name);
+    if (data->credentials_file) os_free(data->credentials_file);
+    os_free(data);
+    return 0;
+}
+
+DWORD WINAPI wm_gcp_bucket_destroy(void *gcp_config) {
+    wm_gcp_bucket *cur_bucket;
+    wm_gcp_bucket_base * data = (wm_gcp_bucket_base *)gcp_config;
+    wm_gcp_bucket *next_bucket = data->buckets;
+
+    while(next_bucket){
+        cur_bucket = next_bucket;
+        next_bucket = next_bucket->next;
+        if (cur_bucket->bucket) os_free(cur_bucket->bucket);
+        if (cur_bucket->type) os_free(cur_bucket->type);
+        if (cur_bucket->credentials_file) os_free(cur_bucket->credentials_file);
+        if (cur_bucket->prefix) os_free(cur_bucket->prefix);
+        if (cur_bucket->only_logs_after) os_free(cur_bucket->only_logs_after);
+        os_free(cur_bucket);
+    }
+    os_free(data);
+    return 0;
+}
+#else
 void wm_gcp_pubsub_destroy(wm_gcp_pubsub * data) {
     if (data->project_id) os_free(data->project_id);
     if (data->subscription_name) os_free(data->subscription_name);
@@ -500,6 +571,7 @@ void wm_gcp_bucket_destroy(wm_gcp_bucket_base * data) {
     }
     os_free(data);
 }
+#endif
 
 cJSON *wm_gcp_pubsub_dump(const wm_gcp_pubsub *data) {
     cJSON *root = cJSON_CreateObject();

--- a/src/wazuh_modules/wm_gcp.c
+++ b/src/wazuh_modules/wm_gcp.c
@@ -519,44 +519,28 @@ void wm_gcp_bucket_run(const wm_gcp_bucket_base *data, wm_gcp_bucket *exec_bucke
 
     os_free(output);
 }
+
 #ifdef WIN32
 DWORD WINAPI wm_gcp_pubsub_destroy(void *gcp_config) {
     wm_gcp_pubsub *data = (wm_gcp_pubsub *)gcp_config;
-
-    if (data->project_id) os_free(data->project_id);
-    if (data->subscription_name) os_free(data->subscription_name);
-    if (data->credentials_file) os_free(data->credentials_file);
-    os_free(data);
-    return 0;
-}
-
-DWORD WINAPI wm_gcp_bucket_destroy(void *gcp_config) {
-    wm_gcp_bucket *cur_bucket;
-    wm_gcp_bucket_base * data = (wm_gcp_bucket_base *)gcp_config;
-    wm_gcp_bucket *next_bucket = data->buckets;
-
-    while(next_bucket){
-        cur_bucket = next_bucket;
-        next_bucket = next_bucket->next;
-        if (cur_bucket->bucket) os_free(cur_bucket->bucket);
-        if (cur_bucket->type) os_free(cur_bucket->type);
-        if (cur_bucket->credentials_file) os_free(cur_bucket->credentials_file);
-        if (cur_bucket->prefix) os_free(cur_bucket->prefix);
-        if (cur_bucket->only_logs_after) os_free(cur_bucket->only_logs_after);
-        os_free(cur_bucket);
-    }
-    os_free(data);
-    return 0;
-}
 #else
 void wm_gcp_pubsub_destroy(wm_gcp_pubsub * data) {
+#endif
     if (data->project_id) os_free(data->project_id);
     if (data->subscription_name) os_free(data->subscription_name);
     if (data->credentials_file) os_free(data->credentials_file);
     os_free(data);
+    #ifdef WIN32
+    return 0;
+    #endif
 }
 
+#ifdef WIN32
+DWORD WINAPI wm_gcp_bucket_destroy(void *gcp_config) {
+    wm_gcp_bucket_base * data = (wm_gcp_bucket_base *)gcp_config;
+#else
 void wm_gcp_bucket_destroy(wm_gcp_bucket_base * data) {
+#endif
     wm_gcp_bucket *cur_bucket;
     wm_gcp_bucket *next_bucket = data->buckets;
     while(next_bucket){
@@ -570,8 +554,10 @@ void wm_gcp_bucket_destroy(wm_gcp_bucket_base * data) {
         os_free(cur_bucket);
     }
     os_free(data);
+    #ifdef WIN32
+    return 0;
+    #endif
 }
-#endif
 
 cJSON *wm_gcp_pubsub_dump(const wm_gcp_pubsub *data) {
     cJSON *root = cJSON_CreateObject();

--- a/src/wazuh_modules/wm_github.c
+++ b/src/wazuh_modules/wm_github.c
@@ -117,25 +117,22 @@ void * wm_github_main(wm_github* github_config) {
     return NULL;
 #endif
 }
+
 #ifdef WIN32
-STATIC DWORD WINAPI wm_github_destroy(void* github_config) {
-    wm_github *ptr = (wm_github *)github_config;
-    mtinfo(WM_GITHUB_LOGTAG, "Module GitHub finished.");
-    wm_github_auth_destroy(ptr->auth);
-    wm_github_fail_destroy(ptr->fails);
-    os_free(ptr->event_type);
-    os_free(github_config);
-    return 0;
-}
+STATIC DWORD WINAPI wm_github_destroy(void* ptr_github_config) {
+    wm_github *github_config = (wm_github *)ptr_github_config;
 #else
 void wm_github_destroy(wm_github* github_config) {
+#endif
     mtinfo(WM_GITHUB_LOGTAG, "Module GitHub finished.");
     wm_github_auth_destroy(github_config->auth);
     wm_github_fail_destroy(github_config->fails);
     os_free(github_config->event_type);
     os_free(github_config);
+    #ifdef WIN32
+    return 0;
+    #endif
 }
-#endif
 
 void wm_github_auth_destroy(wm_github_auth* github_auth)
 {

--- a/src/wazuh_modules/wm_github.c
+++ b/src/wazuh_modules/wm_github.c
@@ -30,8 +30,13 @@
 #endif
 #endif
 
+#ifdef WIN32
+STATIC DWORD WINAPI wm_github_main(void* arg);              // Module main function. It won't return
+STATIC DWORD WINAPI wm_github_destroy(void* github_config);
+#else
 STATIC void* wm_github_main(wm_github* github_config);    // Module main function. It won't return
 STATIC void wm_github_destroy(wm_github* github_config);
+#endif
 STATIC void wm_github_auth_destroy(wm_github_auth* github_auth);
 STATIC void wm_github_fail_destroy(wm_github_fail* github_fails);
 cJSON *wm_github_dump(const wm_github* github_config);
@@ -70,8 +75,12 @@ const wm_context WM_GITHUB_CONTEXT = {
     NULL
 };
 
+#ifdef WIN32
+DWORD WINAPI wm_github_main(void* arg) {
+    wm_github* github_config = (wm_github *)arg;
+#else
 void * wm_github_main(wm_github* github_config) {
-
+#endif
     if (github_config->enabled) {
         mtinfo(WM_GITHUB_LOGTAG, "Module GitHub started.");
 
@@ -80,7 +89,11 @@ void * wm_github_main(wm_github* github_config) {
         github_config->queue_fd = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS);
         if (github_config->queue_fd < 0) {
             mterror(WM_GITHUB_LOGTAG, "Can't connect to queue. Closing module.");
+#ifdef WIN32
+            return 0;
+#else
             return NULL;
+#endif
         }
 #endif
 
@@ -98,9 +111,23 @@ void * wm_github_main(wm_github* github_config) {
         mtinfo(WM_GITHUB_LOGTAG, "Module GitHub disabled.");
     }
 
+#ifdef WIN32
+    return 0;
+#else
     return NULL;
+#endif
 }
-
+#ifdef WIN32
+STATIC DWORD WINAPI wm_github_destroy(void* github_config) {
+    wm_github *ptr = (wm_github *)github_config;
+    mtinfo(WM_GITHUB_LOGTAG, "Module GitHub finished.");
+    wm_github_auth_destroy(ptr->auth);
+    wm_github_fail_destroy(ptr->fails);
+    os_free(ptr->event_type);
+    os_free(github_config);
+    return 0;
+}
+#else
 void wm_github_destroy(wm_github* github_config) {
     mtinfo(WM_GITHUB_LOGTAG, "Module GitHub finished.");
     wm_github_auth_destroy(github_config->auth);
@@ -108,6 +135,7 @@ void wm_github_destroy(wm_github* github_config) {
     os_free(github_config->event_type);
     os_free(github_config);
 }
+#endif
 
 void wm_github_auth_destroy(wm_github_auth* github_auth)
 {

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -157,25 +157,20 @@ void * wm_office365_main(wm_office365* office365_config) {
 }
 
 #ifdef WIN32
-STATIC DWORD WINAPI wm_office365_destroy(void *office365_config) {
-    wm_office365 *office365_config_ptr = (wm_office365 *)office365_config;
-
-    mtinfo(WM_OFFICE365_LOGTAG, "Module Office365 finished.");
-    wm_office365_auth_destroy(office365_config_ptr->auth);
-    wm_office365_subscription_destroy(office365_config_ptr->subscription);
-    wm_office365_fail_destroy(office365_config_ptr->fails);
-    os_free(office365_config_ptr);
-    return 0;
-}
+STATIC DWORD WINAPI wm_office365_destroy(void *office365_config_ptr) {
+    wm_office365 *office365_config = (wm_office365 *)office365_config_ptr;
 #else
 void wm_office365_destroy(wm_office365* office365_config) {
+#endif
     mtinfo(WM_OFFICE365_LOGTAG, "Module Office365 finished.");
     wm_office365_auth_destroy(office365_config->auth);
     wm_office365_subscription_destroy(office365_config->subscription);
     wm_office365_fail_destroy(office365_config->fails);
     os_free(office365_config);
+    #ifdef WIN32
+    return 0;
+    #endif
 }
-#endif
 
 void wm_office365_auth_destroy(wm_office365_auth* office365_auth) {
     wm_office365_auth* current = office365_auth;

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -30,8 +30,13 @@
 #endif
 #endif
 
+#ifdef WIN32
+STATIC DWORD WINAPI wm_office365_main(void *arg);                   // Module main function. It won't return
+STATIC DWORD WINAPI wm_office365_destroy(void *office365_config);
+#else
 STATIC void* wm_office365_main(wm_office365* office365_config);    // Module main function. It won't return
 STATIC void wm_office365_destroy(wm_office365* office365_config);
+#endif
 STATIC void wm_office365_auth_destroy(wm_office365_auth* office365_auth);
 STATIC void wm_office365_subscription_destroy(wm_office365_subscription* office365_subscription);
 STATIC void wm_office365_fail_destroy(wm_office365_fail* office365_fails);
@@ -112,8 +117,12 @@ const wm_context WM_OFFICE365_CONTEXT = {
     NULL
 };
 
+#ifdef WIN32
+STATIC DWORD WINAPI wm_office365_main(void *arg) {
+    wm_office365* office365_config = (wm_office365 *)arg;
+#else
 void * wm_office365_main(wm_office365* office365_config) {
-
+#endif
     if (office365_config->enabled) {
         mtinfo(WM_OFFICE365_LOGTAG, "Module Office365 started.");
 
@@ -140,9 +149,25 @@ void * wm_office365_main(wm_office365* office365_config) {
         mtinfo(WM_OFFICE365_LOGTAG, "Module Office365 disabled.");
     }
 
+#ifdef WIN32
+    return 0;
+#else
     return NULL;
+#endif
 }
 
+#ifdef WIN32
+STATIC DWORD WINAPI wm_office365_destroy(void *office365_config) {
+    wm_office365 *office365_config_ptr = (wm_office365 *)office365_config;
+
+    mtinfo(WM_OFFICE365_LOGTAG, "Module Office365 finished.");
+    wm_office365_auth_destroy(office365_config_ptr->auth);
+    wm_office365_subscription_destroy(office365_config_ptr->subscription);
+    wm_office365_fail_destroy(office365_config_ptr->fails);
+    os_free(office365_config_ptr);
+    return 0;
+}
+#else
 void wm_office365_destroy(wm_office365* office365_config) {
     mtinfo(WM_OFFICE365_LOGTAG, "Module Office365 finished.");
     wm_office365_auth_destroy(office365_config->auth);
@@ -150,6 +175,7 @@ void wm_office365_destroy(wm_office365* office365_config) {
     wm_office365_fail_destroy(office365_config->fails);
     os_free(office365_config);
 }
+#endif
 
 void wm_office365_auth_destroy(wm_office365_auth* office365_auth) {
     wm_office365_auth* current = office365_auth;

--- a/src/wazuh_modules/wm_oscap.c
+++ b/src/wazuh_modules/wm_oscap.c
@@ -343,43 +343,13 @@ cJSON *wm_oscap_dump(const wm_oscap *oscap) {
     return root;
 }
 
-
 // Destroy data
-
 #ifdef WIN32
-DWORD WINAPI wm_oscap_destroy(void *oscap) {
-    wm_oscap *oscap_ptr = (wm_oscap *)oscap;
-    wm_oscap_eval *cur_eval;
-    wm_oscap_eval *next_eval;
-    wm_oscap_profile *cur_profile;
-    wm_oscap_profile *next_profile;
-
-    // Delete evals
-
-    for (cur_eval = oscap_ptr->evals; cur_eval; cur_eval = next_eval) {
-
-        // Delete profiles
-
-        for (cur_profile = cur_eval->profiles; cur_profile; cur_profile = next_profile) {
-            next_profile = cur_profile->next;
-            free(cur_profile->name);
-            free(cur_profile);
-        }
-
-        next_eval = cur_eval->next;
-        free(cur_eval->path);
-        free(cur_eval->xccdf_id);
-        free(cur_eval->oval_id);
-        free(cur_eval->ds_id);
-        free(cur_eval->cpe);
-        free(cur_eval);
-    }
-
-    free(oscap_ptr);
-    return 0;
-}
+DWORD WINAPI wm_oscap_destroy(void *oscap_ptr) {
+    wm_oscap *oscap = (wm_oscap *)oscap_ptr;
 #else
 void wm_oscap_destroy(wm_oscap *oscap) {
+#endif
     wm_oscap_eval *cur_eval;
     wm_oscap_eval *next_eval;
     wm_oscap_profile *cur_profile;
@@ -407,5 +377,8 @@ void wm_oscap_destroy(wm_oscap *oscap) {
     }
 
     free(oscap);
+    #ifdef WIN32
+    return 0;
+    #endif
 }
-#endif
+

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -668,32 +668,11 @@ void *wm_osquery_monitor_main(wm_osquery_monitor_t *osquery) {
 }
 
 #ifdef WIN32
-DWORD WINAPI wm_osquery_monitor_destroy(void *osquery_monitor)
-{
-    int i;
-    wm_osquery_monitor_t *osquery_monitor_ptr = (wm_osquery_monitor_t *)osquery_monitor;
-
-    if (osquery_monitor_ptr)
-    {
-        free(osquery_monitor_ptr->bin_path);
-        free(osquery_monitor_ptr->log_path);
-        free(osquery_monitor_ptr->config_path);
-
-        for (i = 0; osquery_monitor_ptr->packs[i]; ++i) {
-            free(osquery_monitor_ptr->packs[i]->name);
-            free(osquery_monitor_ptr->packs[i]->path);
-            free(osquery_monitor_ptr->packs[i]);
-        }
-
-        free(osquery_monitor_ptr->packs);
-        free(osquery_monitor_ptr);
-    }
-
-    return 0;
-}
+DWORD WINAPI wm_osquery_monitor_destroy(void *osquery_monitor_ptr) {
+    wm_osquery_monitor_t *osquery_monitor = (wm_osquery_monitor_t *)osquery_monitor_ptr;
 #else
-void wm_osquery_monitor_destroy(wm_osquery_monitor_t *osquery_monitor)
-{
+void wm_osquery_monitor_destroy(wm_osquery_monitor_t *osquery_monitor) {
+#endif
     int i;
 
     if (osquery_monitor)
@@ -711,9 +690,10 @@ void wm_osquery_monitor_destroy(wm_osquery_monitor_t *osquery_monitor)
         free(osquery_monitor->packs);
         free(osquery_monitor);
     }
+    #ifdef WIN32
+    return 0;
+    #endif
 }
-#endif
-
 
 // Get read data
 cJSON *wm_osquery_dump(const wm_osquery_monitor_t *osquery_monitor) {

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -37,8 +37,13 @@
 #define mdebug1(msg, ...) _mtdebug1(WM_OSQUERYMONITOR_LOGTAG, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
 #define mdebug2(msg, ...) _mtdebug2(WM_OSQUERYMONITOR_LOGTAG, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
 
+#ifdef WIN32
+static DWORD WINAPI wm_osquery_monitor_main(void *arg);
+static DWORD WINAPI wm_osquery_monitor_destroy(void *osquery_monitor);
+#else
 static void *wm_osquery_monitor_main(wm_osquery_monitor_t *osquery_monitor);
 static void wm_osquery_monitor_destroy(wm_osquery_monitor_t *osquery_monitor);
+#endif
 static int wm_osquery_check_logfile(const char * path, FILE * fp);
 static int wm_osquery_packs(wm_osquery_monitor_t *osquery);
 static char * wm_osquery_already_running(char * text);
@@ -587,14 +592,22 @@ int wm_osquery_packs(wm_osquery_monitor_t *osquery)
     return retval;
 }
 
-void *wm_osquery_monitor_main(wm_osquery_monitor_t *osquery)
-{
+#ifdef WIN32
+DWORD WINAPI wm_osquery_monitor_main(void *arg) {
+    wm_osquery_monitor_t *osquery = (wm_osquery_monitor_t *)arg;
+#else
+void *wm_osquery_monitor_main(wm_osquery_monitor_t *osquery) {
+#endif
     pthread_t tlauncher = 0;
     pthread_t treader = 0;
 
     if (osquery->disable) {
         minfo("Module disabled. Exiting...");
+#ifdef WIN32
+        return 0;
+#else
         return NULL;
+#endif
     }
 
     minfo("Module started.");
@@ -613,19 +626,31 @@ void *wm_osquery_monitor_main(wm_osquery_monitor_t *osquery)
 
     if( pthread_create(&treader, NULL, (void *)&Read_Log, osquery) != 0){
         merror("Error while creating Read_Log thread.");
+#ifdef WIN32
+        return 0;
+#else
         return NULL;
+#endif
     }
 
     if (osquery->run_daemon) {
         // Handle configuration
 
         if (wm_osquery_packs(osquery) < 0 || wm_osquery_decorators(osquery) < 0) {
+#ifdef WIN32
+            return 0;
+#else
             return NULL;
+#endif
         }
 
         if( pthread_create(&tlauncher, NULL, (void *)&Execute_Osquery, osquery) != 0){
             merror("Error while creating Execute_Osquery thread.");
+#ifdef WIN32
+            return 0;
+#else
             return NULL;
+#endif
         }
         pthread_join(tlauncher, NULL);
     } else {
@@ -635,10 +660,36 @@ void *wm_osquery_monitor_main(wm_osquery_monitor_t *osquery)
     pthread_join(treader, NULL);
 
     minfo("Closing module.");
+#ifdef WIN32
+    return 0;
+#else
     return NULL;
+#endif
 }
 
+#ifdef WIN32
+DWORD WINAPI wm_osquery_monitor_destroy(void *osquery_monitor)
+{
+    int i;
+    wm_osquery_monitor_t *osquery_monitor_ptr = (wm_osquery_monitor_t *)osquery_monitor;
 
+    if (osquery_monitor_ptr)
+    {
+        free(osquery_monitor_ptr->bin_path);
+        free(osquery_monitor_ptr->log_path);
+        free(osquery_monitor_ptr->config_path);
+
+        for (i = 0; osquery_monitor_ptr->packs[i]; ++i) {
+            free(osquery_monitor_ptr->packs[i]->name);
+            free(osquery_monitor_ptr->packs[i]->path);
+        }
+
+        free(osquery_monitor_ptr);
+    }
+
+    return 0;
+}
+#else
 void wm_osquery_monitor_destroy(wm_osquery_monitor_t *osquery_monitor)
 {
     int i;
@@ -652,11 +703,14 @@ void wm_osquery_monitor_destroy(wm_osquery_monitor_t *osquery_monitor)
         for (i = 0; osquery_monitor->packs[i]; ++i) {
             free(osquery_monitor->packs[i]->name);
             free(osquery_monitor->packs[i]->path);
+            free(osquery_monitor->packs[i]);
         }
 
+        free(osquery_monitor->packs);
         free(osquery_monitor);
     }
 }
+#endif
 
 
 // Get read data

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -682,8 +682,10 @@ DWORD WINAPI wm_osquery_monitor_destroy(void *osquery_monitor)
         for (i = 0; osquery_monitor_ptr->packs[i]; ++i) {
             free(osquery_monitor_ptr->packs[i]->name);
             free(osquery_monitor_ptr->packs[i]->path);
+            free(osquery_monitor_ptr->packs[i]);
         }
 
+        free(osquery_monitor_ptr->packs);
         free(osquery_monitor_ptr);
     }
 

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -2067,17 +2067,15 @@ static int wm_sca_check_process_is_running(OSList *p_list, char *value, char **r
 
 // Destroy data
 #ifdef WIN32
-DWORD WINAPI wm_sca_destroy(void *data)
-{
-    os_free(data);
-    return 0;
-}
+DWORD WINAPI wm_sca_destroy(void *data) {
 #else
-void wm_sca_destroy(wm_sca_t * data)
-{
-    os_free(data);
-}
+void wm_sca_destroy(wm_sca_t * data) {
 #endif
+    os_free(data);
+    #ifdef WIN32
+    return 0;
+    #endif
+}
 
 #ifdef WIN32
 

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -45,8 +45,13 @@ static const int RETURN_NOT_FOUND = 0;
 static const int RETURN_FOUND = 1;
 static const int RETURN_INVALID = 2;
 
+#ifdef WIN32
+static DWORD WINAPI wm_sca_main(void *arg);         // Module main function. It won't return
+static DWORD WINAPI wm_sca_destroy(void *data);     // Destroy data
+#else
 static void * wm_sca_main(wm_sca_t * data);   // Module main function. It won't return
 static void wm_sca_destroy(wm_sca_t * data);  // Destroy data
+#endif
 static int wm_sca_start(wm_sca_t * data);  // Start
 static cJSON *wm_sca_build_event(const cJSON * const check, const cJSON * const policy, char **p_alert_msg, int id, const char * const result, const char * const reason);
 static int wm_sca_send_event_check(wm_sca_t * data,cJSON *event);  // Send check event
@@ -135,7 +140,12 @@ cJSON **last_summary_json = NULL;
 static pthread_rwlock_t dump_rwlock;
 
 // Module main function. It won't return
+#ifdef WIN32
+DWORD WINAPI wm_sca_main(void *arg) {
+    wm_sca_t *data = (wm_sca_t *)arg;
+#else
 void * wm_sca_main(wm_sca_t * data) {
+#endif
     // If module is disabled, exit
     if (data->enabled) {
         minfo("Module started.");
@@ -240,7 +250,11 @@ void * wm_sca_main(wm_sca_t * data) {
 
     wm_sca_start(data);
 
+#ifdef WIN32
+    return 0;
+#else
     return NULL;
+#endif
 }
 
 static int wm_sca_send_alert(wm_sca_t * data,cJSON *json_alert)
@@ -2052,10 +2066,18 @@ static int wm_sca_check_process_is_running(OSList *p_list, char *value, char **r
 }
 
 // Destroy data
+#ifdef WIN32
+DWORD WINAPI wm_sca_destroy(void *data)
+{
+    os_free(data);
+    return 0;
+}
+#else
 void wm_sca_destroy(wm_sca_t * data)
 {
     os_free(data);
 }
+#endif
 
 #ifdef WIN32
 

--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -17,8 +17,13 @@
 #include "defs.h"
 #include "mq_op.h"
 
+#ifdef WIN32
+static DWORD WINAPI wm_sys_main(void *arg);         // Module main function. It won't return
+static DWORD WINAPI wm_sys_destroy(void *data);      // Destroy data
+#else
 static void* wm_sys_main(wm_sys_t *sys);        // Module main function. It won't return
-static void wm_sys_destroy(wm_sys_t *sys);      // Destroy data
+static void wm_sys_destroy(wm_sys_t *data);      // Destroy data
+#endif
 static void wm_sys_stop(wm_sys_t *sys);         // Module stopper
 const char *WM_SYS_LOCATION = "syscollector";   // Location field for event sending
 cJSON *wm_sys_dump(const wm_sys_t *sys);
@@ -118,7 +123,12 @@ static void wm_sys_log_config(wm_sys_t *sys)
     }
 }
 
+#ifdef WIN32
+DWORD WINAPI wm_sys_main(void *arg) {
+    wm_sys_t *sys = (wm_sys_t *)arg;
+#else
 void* wm_sys_main(wm_sys_t *sys) {
+#endif
     w_cond_init(&sys_stop_condition, NULL);
     w_mutex_init(&sys_stop_mutex, NULL);
     w_mutex_init(&sys_reconnect_mutex, NULL);
@@ -199,9 +209,16 @@ void* wm_sys_main(wm_sys_t *sys) {
     return 0;
 }
 
+#ifdef WIN32
+DWORD WINAPI wm_sys_destroy(void *data) {
+    free(data);
+    return 0;
+}
+#else
 void wm_sys_destroy(wm_sys_t *data) {
     free(data);
 }
+#endif
 
 void wm_sys_stop(__attribute__((unused))wm_sys_t *data) {
     mtinfo(WM_SYS_LOGTAG, "Stop received for Syscollector.");

--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -211,14 +211,14 @@ void* wm_sys_main(wm_sys_t *sys) {
 
 #ifdef WIN32
 DWORD WINAPI wm_sys_destroy(void *data) {
-    free(data);
-    return 0;
-}
 #else
 void wm_sys_destroy(wm_sys_t *data) {
-    free(data);
-}
 #endif
+    free(data);
+#ifdef WIN32
+    return 0;
+#endif
+}
 
 void wm_sys_stop(__attribute__((unused))wm_sys_t *data) {
     mtinfo(WM_SYS_LOGTAG, "Stop received for Syscollector.");

--- a/src/wazuh_modules/wmodules_def.h
+++ b/src/wazuh_modules/wmodules_def.h
@@ -15,11 +15,20 @@
 #include <pthread.h>
 #include "cJSON.h"
 
+#ifdef WIN32
+#include <winsock2.h>
+#include <windows.h>
+#endif
+
 #ifndef ARGV0
 #define ARGV0 "wazuh-modulesd"
 #endif // ARGV0
 
-typedef void* (*wm_routine)(void*);     // Standard routine pointer
+#ifdef WIN32
+typedef DWORD WINAPI (*wm_routine)(void*);  // Standard routine pointer
+#else
+typedef void* (*wm_routine)(void*);         // Standard routine pointer
+#endif
 
 // Module context: this should be defined for every module
 

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -29,12 +29,19 @@ sysinfo_free_result_func sysinfo_free_result_ptr = NULL;
 int Start_win32_Syscheck();
 
 /* syscheck main thread */
+#ifdef WIN32
+DWORD WINAPI skthread(__attribute__((unused)) LPVOID arg)
+#else
 void *skthread()
+#endif
 {
 
     Start_win32_Syscheck();
-
+#ifdef WIN32
+    return 0;
+#else
     return (NULL);
+#endif
 }
 
 void stop_wmodules()
@@ -195,7 +202,7 @@ int local_start()
         buffer_init();
         w_create_thread(NULL,
                          0,
-                         (LPTHREAD_START_ROUTINE)dispatch_buffer,
+                         dispatch_buffer,
                          NULL,
                          0,
                          (LPDWORD)&threadID);
@@ -207,7 +214,7 @@ int local_start()
     w_agentd_state_init();
     w_create_thread(NULL,
                      0,
-                     (LPTHREAD_START_ROUTINE)state_main,
+                     state_main,
                      NULL,
                      0,
                      (LPDWORD)&threadID);
@@ -224,7 +231,7 @@ int local_start()
     /* Start syscheck thread */
     w_create_thread(NULL,
                      0,
-                     (LPTHREAD_START_ROUTINE)skthread,
+                     skthread,
                      NULL,
                      0,
                      (LPDWORD)&threadID);
@@ -234,7 +241,7 @@ int local_start()
     if (rotate_log) {
         w_create_thread(NULL,
                         0,
-                        (LPTHREAD_START_ROUTINE)w_rotate_log_thread,
+                        w_rotate_log_thread,
                         NULL,
                         0,
                         (LPDWORD)&threadID);
@@ -251,7 +258,7 @@ int local_start()
     /* Start receiver thread */
     w_create_thread(NULL,
                      0,
-                     (LPTHREAD_START_ROUTINE)receiver_thread,
+                     receiver_thread,
                      NULL,
                      0,
                      (LPDWORD)&threadID2);
@@ -259,7 +266,7 @@ int local_start()
     /* Start request receiver thread */
     w_create_thread(NULL,
                      0,
-                     (LPTHREAD_START_ROUTINE)req_receiver,
+                     req_receiver,
                      NULL,
                      0,
                      (LPDWORD)&threadID2);
@@ -272,7 +279,7 @@ int local_start()
         for (cur_module = wmodules; cur_module; cur_module = cur_module->next) {
             w_create_thread(NULL,
                             0,
-                            (LPTHREAD_START_ROUTINE)cur_module->context->start,
+                            cur_module->context->start,
                             cur_module->data,
                             0,
                             (LPDWORD)&threadID2);


### PR DESCRIPTION
|Related issue|
|---|
|#12099|


## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh windows agent project in win_utils.c. . The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Windows Agent</summary>

```
grep: /etc/redhat-release: No such file or directory
    CC win32/icon.o
    CC win32/win_agent.o
    CC win32/win_service.o
    CC win32/win_utils.o
    CC syscheckd/db/schema_fim_db.o
    CC syscheckd/run_realtime.o
    CC syscheckd/config.o
    CC syscheckd/create_db.o
    CC syscheckd/run_check.o
syscheckd/create_db.c: In function ‘fim_directory’:
syscheckd/create_db.c:397:9: warning: ‘strncpy’ output may be truncated copying between 0 and 258 bytes from a string of length 259 [-Wstringop-truncation]
  397 |         strncpy(s_name, entry->d_name, PATH_MAX - path_size - 2);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC syscheckd/syscheck.o
    CC syscheckd/fim_diff_changes.o
    CC syscheckd/fim_sync.o
    CC syscheckd/syscom.o
    CC syscheckd/main.o
    CC syscheckd/db/fim_db.o
    CC syscheckd/db/fim_db_files.o
    CC syscheckd/db/fim_db_registries.o
    CC syscheckd/whodata/audit_healthcheck.o
    CC syscheckd/whodata/audit_rule_handling.o
    CC syscheckd/whodata/syscheck_audit.o
    CC syscheckd/whodata/audit_parse.o
    CC syscheckd/whodata/win_whodata.o
    CC syscheckd/registry/registry.o
    CC syscheckd/registry/events.o
    CC rootcheck/common_rcl.o
    CC rootcheck/rootcheck-config.o
    CC rootcheck/config.o
    CC rootcheck/check_rc_files.o
    CC rootcheck/check_rc_ports.o
    CC rootcheck/win-process.o
    CC rootcheck/unix-process.o
    CC rootcheck/common.o
    CC rootcheck/rootcheck.o
In file included from ./headers/shared.h:220,
                 from rootcheck/common.c:11:
In function ‘is_file’,
    inlined from ‘is_file’ at rootcheck/common.c:446:5:
./headers/debug_op.h:46:32: warning: argument 6 null where non-null expected [-Wnonnull]
   46 | #define mterror(tag, msg, ...) _mterror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./headers/debug_op.h:46:32: note: in definition of macro ‘mterror’
   46 | #define mterror(tag, msg, ...) _mterror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
      |                                ^~~~~~~~
In file included from ./headers/shared.h:220,
                 from rootcheck/common.c:11:
rootcheck/common.c: In function ‘is_file’:
./headers/debug_op.h:61:6: note: in a call to function ‘_mterror’ declared here
   61 | void _mterror(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull));
      |      ^~~~~~~~
    CC rootcheck/check_rc_if.o
    CC rootcheck/check_open_ports.o
    CC rootcheck/os_string.o
    CC rootcheck/win-common.o
    CC rootcheck/check_rc_readproc.o
    CC rootcheck/check_rc_dev.o
    CC rootcheck/check_rc_sys.o
rootcheck/win-common.c: In function ‘__os_winreg_querykey’:
rootcheck/win-common.c:265:29: warning: ‘strncat’ output may be truncated copying between 3 and 16381 bytes from a string of length 16383 [-Wstringop-truncation]
  265 |                             strncat(var_storage, mt_data, size_available);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC rootcheck/run_rk_check.o
    CC rootcheck/check_rc_policy.o
    CC rootcheck/check_rc_pids.o
    CC rootcheck/check_rc_trojans.o
    CC client-agent/state.o
    CC client-agent/sendmsg.o
    CC client-agent/request.o
    CC client-agent/config.o
    CC client-agent/rotate_log.o
    CC client-agent/receiver-win.o
    CC client-agent/restart_agent.o
    CC client-agent/receiver.o
    CC client-agent/buffer.o
    CC client-agent/start_agent.o
    CC client-agent/agcom.o
    CC client-agent/notify.o
    CC logcollector/read_ossecalert.o
    CC logcollector/state.o
    CC logcollector/config.o
    CC logcollector/logcollector.o
    CC logcollector/read_djb_multilog.o
    CC logcollector/read_postgresql_log.o
    CC logcollector/read_ucs2_le.o
logcollector/read_postgresql_log.c: In function ‘read_postgresql_log’:
logcollector/read_postgresql_log.c:114:17: warning: ‘strncpy’ output may be truncated copying between 35 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  114 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_postgresql_log.c:106:17: warning: ‘strncpy’ output may be truncated copying between 35 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_mssql_log.o
    CC logcollector/read_win_el.o
logcollector/read_mssql_log.c: In function ‘read_mssql_log’:
logcollector/read_mssql_log.c:117:17: warning: ‘strncpy’ output may be truncated copying between 22 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  117 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_mssql_log.c:108:17: warning: ‘strncpy’ output may be truncated copying between 22 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  108 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/lccom.o
    CC logcollector/read_macos.o
    CC logcollector/read_json.o
    CC logcollector/read_win_event_channel.o
    CC logcollector/read_syslog.o
    CC logcollector/read_audit.o
    CC logcollector/read_multiline_regex.o
logcollector/read_audit.c: In function ‘audit_send_msg’:
logcollector/read_audit.c:31:13: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
   31 |             strncpy(message + n, cache[i], z);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_audit.c:25:13: note: length computed here
   25 |         z = strlen(cache[i]);
      |             ^~~~~~~~~~~~~~~~
    CC logcollector/read_nmapg.o
    CC logcollector/read_command.o
logcollector/read_nmapg.c: In function ‘read_nmapg’:
logcollector/read_nmapg.c:246:13: warning: ‘strncat’ output may be truncated copying between 27 and 65533 bytes from a string of length 65536 [-Wstringop-truncation]
  246 |             strncat(final_msg, buffer, final_msg_s);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_mysql_log.o
    CC logcollector/read_ucs2_be.o
    CC logcollector/read_multiline.o
    CC logcollector/macos_log.o
    CC logcollector/read_fullcommand.o
    CC logcollector/read_snortfull.o
logcollector/read_multiline.c: In function ‘read_multiline’:
logcollector/read_multiline.c:96:9: warning: ‘strncpy’ output may be truncated copying between 0 and 65534 bytes from a string of length 65536 [-Wstringop-truncation]
   96 |         strncpy(buffer + buffer_size, str, OS_MAXSTR - buffer_size - 2);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC os_execd/exec.o
logcollector/read_snortfull.c: In function ‘read_snortfull’:
logcollector/read_snortfull.c:54:17: warning: ‘strncpy’ output may be truncated copying 65536 bytes from a string of length 65536 [-Wstringop-truncation]
   54 |                 strncpy(f_msg, str, OS_MAXSTR);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC os_execd/config.o
os_execd/exec.c: In function ‘ReadExecConfig’:
os_execd/exec.c:72:9: warning: ‘strncpy’ output may be truncated copying 256 bytes from a string of length 65536 [-Wstringop-truncation]
   72 |         strncpy(exec_names[exec_size], str_pt, OS_FLSIZE);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
os_execd/exec.c:125:21: warning: ‘strncpy’ accessing 256 bytes at offsets [0, 16705] and [0, 16705] may overlap up to 256 bytes at offset 255 [-Wrestrict]
  125 |                     strncpy(exec_cmd[j], exec_cmd[exec_size], OS_FLSIZE);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC os_execd/wcom.o
    CC os_execd/execd.o
    CC os_execd/win_execd.o
    CC active-response/active_responses.o
    CC monitord/rotate_log.o
    CC monitord/compress_log.o
    CC config/wmodules-aws.o
    CC config/localfile-config.o
    CC config/rootcheck-config.o
    CC config/remote-config.o
    CC config/active-response.o
    CC config/wmodules-osquery-monitor.o
    CC config/integrator-config.o
    CC config/wmodules-agent-upgrade.o
    CC config/socket-config.o
    CC config/reports-config.o
    CC config/alerts-config.o
    CC config/agentlessd-config.o
    CC config/wmodules_syscollector.o
    CC config/wmodules-oscap.o
    CC config/config.o
    CC config/wmodules-github.o
    CC config/wmodules-docker.o
    CC config/syscheck-config.o
    CC config/global-config.o
config/syscheck-config.c: In function ‘read_data_unit’:
config/syscheck-config.c:1261:13: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
 1261 |             strncpy(value_str, content, len_value_str - 2);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
config/syscheck-config.c:1251:28: note: length computed here
 1251 |     size_t len_value_str = strlen(content);
      |                            ^~~~~~~~~~~~~~~
    CC config/client-config.o
    CC config/labels-config.o
    CC config/email-alerts-config.o
    CC config/wmodules-sca.o
    CC config/wmodules-fluent.o
    CC config/wmodules-office365.o
    CC config/cluster-config.o
    CC config/rules-config.o
    CC config/dbd-config.o
    CC config/wmodules-key-request.o
    CC config/wmodules-vuln-detector.o
    CC config/wmodules-azure.o
    CC config/authd-config.o
    CC config/wmodules-task-manager.o
    CC config/buffer-config.o
    CC config/wmodules-command.o
    CC config/csyslogd-config.o
    CC config/wmodules-ciscat.o
    CC config/wmodules-gcp.o
    CC config/logtest-config.o
    CC config/wmodules-config.o
    CC wazuh_modules/wm_control.o
    CC wazuh_modules/wmcom.o
    CC wazuh_modules/wm_oscap.o
    CC wazuh_modules/wm_gcp.o
    CC wazuh_modules/wmodules.o
    CC wazuh_modules/wm_azure.o
    CC wazuh_modules/wm_office365.o
    CC wazuh_modules/wm_exec.o
wazuh_modules/wm_office365.c: In function ‘wm_office365_execute_scan’:
wazuh_modules/wm_office365.c:458:33: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  458 |                                 strncpy(url, next_page, strlen(next_page));
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_modules/wm_osquery_monitor.o
    CC wazuh_modules/wm_task_general.o
    CC wazuh_modules/wm_aws.o
    CC wazuh_modules/wm_syscollector.o
    CC wazuh_modules/wm_keyrequest.o
    CC wazuh_modules/wm_github.o
    CC wazuh_modules/wm_database.o
wazuh_modules/wm_github.c: In function ‘wm_github_execute_scan’:
wazuh_modules/wm_github.c:336:33: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  336 |                                 strncpy(url, next_page, strlen(next_page));
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_modules/wm_download.o
    CC wazuh_modules/wm_docker.o
    CC wazuh_modules/wm_sca.o
    CC wazuh_modules/wm_fluent.o
    CC wazuh_modules/wm_command.o
    CC wazuh_modules/wm_ciscat.o
wazuh_modules/wm_sca.c: In function ‘wm_sca_winreg_querykey’:
wazuh_modules/wm_sca.c:2347:29: warning: ‘strncat’ output may be truncated copying between 3 and 16381 bytes from a string of length 16383 [-Wstringop-truncation]
 2347 |                             strncat(var_storage, mt_data, size_available);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
wazuh_modules/wm_ciscat.c: In function ‘wm_ciscat_main’:
wazuh_modules/wm_ciscat.c:128:14: warning: unused variable ‘pwd’ [-Wunused-variable]
  128 |         char pwd[PATH_MAX];
      |              ^~~
    CC wazuh_modules/agent_upgrade/wm_agent_upgrade.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.o
    CC wazuh_db/wdb_metadata.o
wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c: In function ‘wm_agent_upgrade_com_open’:
wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c:233:9: warning: ‘strncpy’ output may be truncated copying 260 bytes from a string of length 260 [-Wstringop-truncation]
  233 |         strncpy(file.path, final_path, PATH_MAX);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_db/wdb_agents.o
    CC wazuh_db/wdb_integrity.o
    CC wazuh_db/wdb_global.o
    CC wazuh_db/wdb_syscollector.o
    CC wazuh_db/wdb_upgrade.o
    CC wazuh_db/wdb_task.o
    CC wazuh_db/wdb_delta_event.o
    CC wazuh_db/wdb_scan_info.o
    CC wazuh_db/wdb.o
    CC wazuh_db/wdb_parser.o
    CC wazuh_db/wdb_fim.o
wazuh_db/wdb_parser.c: In function ‘wdb_parse_syscheck’:
wazuh_db/wdb_parser.c:1278:13: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
 1278 |             strncpy(unsc_checksum + unsc_size, mark, mark_size);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
wazuh_db/wdb_parser.c:1276:32: note: length computed here
 1276 |             size_t mark_size = strlen(mark);
      |                                ^~~~~~~~~~~~
    CC wazuh_db/wdb_sca.o
    CC wazuh_db/wdb_rootcheck.o
    CC wazuh_db/wdb_ciscat.o
    CC wazuh_db/helpers/wdb_global_helpers.o
    CC wazuh_db/helpers/wdb_agents_helpers.o
    CC wazuh_db/schema_global_upgrade_v2.o
    CC wazuh_db/schema_upgrade_v3.o
    CC wazuh_db/schema_upgrade_v1.o
    CC wazuh_db/schema_upgrade_v8.o
    CC wazuh_db/schema_agents.o
    CC wazuh_db/schema_upgrade_v6.o
    CC wazuh_db/schema_global_upgrade_v1.o
    CC wazuh_db/schema_task_manager.o
    CC wazuh_db/schema_upgrade_v4.o
    CC wazuh_db/schema_global.o
    CC wazuh_db/schema_upgrade_v2.o
    CC wazuh_db/schema_upgrade_v5.o
    CC wazuh_db/schema_global_upgrade_v3.o
    CC wazuh_db/schema_vuln_detector.o
    CC os_crypto/blowfish/bf_op.o
    CC wazuh_db/schema_upgrade_v7.o
    CC os_crypto/md5/md5_op.o
    CC os_crypto/sha1/sha1_op.o
    CC os_crypto/shared/keys.o
    CC os_crypto/shared/msgs.o
os_crypto/shared/keys.c: In function ‘OS_ReadKeys’:
os_crypto/shared/keys.c:251:13: warning: ‘strncpy’ output may be truncated copying 127 bytes from a string of length 2048 [-Wstringop-truncation]
  251 |             strncpy(id, valid_str, KEYSIZE - 1);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC os_crypto/md5_sha1/md5_sha1_op.o
    CC os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.o
    CC os_crypto/sha256/sha256_op.o
    CC os_crypto/sha512/sha512_op.o
    CC os_crypto/aes/aes_op.o
    CC os_crypto/hmac/hmac.o
    CC os_crypto/signature/signature.o
    CC shared/json-queue.o
    CC shared/read-alert.o
    CC shared/rootcheck_op.o
    CC shared/notify_op.o
    CC shared/regex_op.o
    CC shared/store_op.o
    CC shared/bzip2_op.o
    CC shared/exec_op.o
    CC shared/mem_op.o
    CC shared/request_op.o
shared/mem_op.c: In function ‘os_LoadString’:
shared/mem_op.c:112:9: warning: ‘strncat’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  112 |         strncat(at, str, strsize);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~
shared/mem_op.c:101:26: note: length computed here
  101 |         size_t strsize = strlen(str);
      |                          ^~~~~~~~~~~
    CC shared/log_builder.o
    CC shared/time_op.o
    CC shared/file_op.o
    CC shared/pthreads_op.o
    CC shared/integrity_op.o
shared/file_op.c: In function ‘getuname’:
shared/file_op.c:1910:81: warning: format ‘%d’ expects argument of type ‘int’, but argument 7 has type ‘DWORD’ {aka ‘long unsigned int’} [-Wformat=]
 1910 |                                 snprintf(__wp,  sizeof(__wp), " [Ver: %d.%d.%s.%d]", (unsigned int)winMajor, (unsigned int)winMinor, wincomp, buildRevision);
      |                                                                                ~^                                                             ~~~~~~~~~~~~~
      |                                                                                 |                                                             |
      |                                                                                 int                                                           DWORD {aka long unsigned int}
      |                                                                                %ld
shared/file_op.c:1946:77: warning: format ‘%d’ expects argument of type ‘int’, but argument 6 has type ‘DWORD’ {aka ‘long unsigned int’} [-Wformat=]
 1946 |                                 snprintf(__wp, sizeof(__wp), " [Ver: %s.%s.%d]", winver, wincomp, buildRevision);
      |                                                                            ~^                     ~~~~~~~~~~~~~
      |                                                                             |                     |
      |                                                                             int                   DWORD {aka long unsigned int}
      |                                                                            %ld
    CC shared/queue_linked_op.o
    CC shared/os_utils.o
    CC shared/rbtree_op.o
    CC shared/fs_op.o
    CC shared/cluster_utils.o
    CC shared/read-agents.o
    CC shared/audit_op.o
    CC shared/syscheck_op.o
    CC shared/yaml2json.o
shared/syscheck_op.c: In function ‘get_registry_permissions’:
shared/syscheck_op.c:1116:11: warning: unused variable ‘dwErrorCode’ [-Wunused-variable]
 1116 |     DWORD dwErrorCode = 0;
      |           ^~~~~~~~~~~
    CC shared/buffer_op.o
    CC shared/report_op.o
    CC shared/sig_op.o
    CC shared/sym_load.o
    CC shared/wait_op.o
    CC shared/help.o
    CC shared/labels_op.o
    CC shared/auth_client.o
    CC shared/list_op.o
    CC shared/privsep_op.o
    CC shared/hash_op.o
    CC shared/b64.o
    CC shared/file-queue.o
    CC shared/math_op.o
    CC shared/atomic.o
    CC shared/rules_op.o
    CC shared/string_op.o
shared/string_op.c: In function ‘wstr_split’:
shared/string_op.c:612:17: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  612 |                 strncpy(new_term_it, acc_strs[count], strlen(acc_strs[count]));
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
shared/string_op.c:609:21: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  609 |                     strncpy(new_term_it, new_delim, new_delim_size);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
shared/string_op.c:569:29: note: length computed here
  569 |     size_t new_delim_size = strlen(replace_delim ? replace_delim : delim);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC shared/url.o
    CC shared/version_op.o
    CC shared/enrollment_op.o
    CC shared/vector_op.o
shared/enrollment_op.c: In function ‘w_enrollment_concat_src_ip’:
shared/enrollment_op.c:547:13: warning: ‘strncat’ output may be truncated copying 254 bytes from a string of length 255 [-Wstringop-truncation]
  547 |             strncat(buff,opt_buf,254);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~
    CC shared/mq_op.o
    CC shared/sysinfo_utils.o
    CC shared/custom_output_search_replace.o
    CC shared/validate_op.o
shared/custom_output_search_replace.c: In function ‘searchAndReplace’:
shared/custom_output_search_replace.c:51:9: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
   51 |         strncpy(tmp + tmp_offset, value, value_len);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
shared/custom_output_search_replace.c:19:30: note: length computed here
   19 |     const size_t value_len = strlen(value);
      |                              ^~~~~~~~~~~~~
    CC shared/json_op.o
    CC shared/schedule_scan.o
    CC shared/expression.o
    CC shared/debug_op.o
    CC shared/remoted_op.o
    CC shared/bqueue_op.o
    CC shared/queue_op.o
    CC shared/utf8_op.o
    CC shared/randombytes.o
    CC shared/agent_op.o
    CC shared/wazuhdb_op.o
    CC os_net/os_net.o
    CC os_regex/os_regex_match.o
    CC os_regex/os_regex.o
    CC os_regex/os_regex_str.o
    CC os_regex/os_match.o
    CC os_regex/os_regex_compile.o
    CC os_regex/os_regex_startswith.o
    CC os_regex/os_regex_free_pattern.o
    CC os_regex/os_match_compile.o
    CC os_regex/os_regex_strbreak.o
    CC os_regex/os_match_free_pattern.o
    CC os_regex/os_regex_maps.o
    CC os_regex/os_regex_execute.o
    CC os_regex/os_match_execute.o
    CC os_xml/os_xml_variables.o
    CC os_xml/os_xml.o
    CC os_xml/os_xml_access.o
    CC os_xml/os_xml_node_access.o
    CC os_xml/os_xml_writer.o
    CC os_zlib/os_zlib.o
    CC os_auth/ssl.o
    CC os_auth/check_cert.o
    CC addagent/validate.o
    CC analysisd/logmsg.o
    CC libwazuhext.dll
    CC syscheckd/run_realtime-event.o
    CC syscheckd/config-event.o
    CC syscheckd/create_db-event.o
    CC syscheckd/run_check-event.o
    CC syscheckd/syscheck-event.o
syscheckd/create_db.c: In function ‘fim_directory’:
syscheckd/create_db.c:397:9: warning: ‘strncpy’ output may be truncated copying between 0 and 258 bytes from a string of length 259 [-Wstringop-truncation]
  397 |         strncpy(s_name, entry->d_name, PATH_MAX - path_size - 2);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC syscheckd/fim_diff_changes-event.o
    CC syscheckd/fim_sync-event.o
    CC syscheckd/syscom-event.o
    CC syscheckd/db/fim_db-event.o
    CC syscheckd/db/fim_db_files-event.o
    CC syscheckd/db/fim_db_registries-event.o
    CC syscheckd/whodata/audit_healthcheck-event.o
    CC syscheckd/whodata/audit_rule_handling-event.o
    CC syscheckd/whodata/syscheck_audit-event.o
    CC syscheckd/whodata/audit_parse-event.o
    CC syscheckd/whodata/win_whodata-event.o
    CC syscheckd/registry/registry-event.o
    CC syscheckd/registry/events-event.o
    CC logcollector/read_ossecalert-event.o
    CC logcollector/state-event.o
    CC logcollector/config-event.o
    CC logcollector/logcollector-event.o
    CC logcollector/read_djb_multilog-event.o
    CC logcollector/read_postgresql_log-event.o
    CC logcollector/read_ucs2_le-event.o
logcollector/read_postgresql_log.c: In function ‘read_postgresql_log’:
logcollector/read_postgresql_log.c:114:17: warning: ‘strncpy’ output may be truncated copying between 35 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  114 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_postgresql_log.c:106:17: warning: ‘strncpy’ output may be truncated copying between 35 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_mssql_log-event.o
    CC logcollector/read_win_el-event.o
logcollector/read_mssql_log.c: In function ‘read_mssql_log’:
logcollector/read_mssql_log.c:117:17: warning: ‘strncpy’ output may be truncated copying between 22 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  117 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_mssql_log.c:108:17: warning: ‘strncpy’ output may be truncated copying between 22 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  108 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/lccom-event.o
    CC logcollector/read_macos-event.o
    CC logcollector/read_json-event.o
    CC logcollector/read_win_event_channel-event.o
    CC logcollector/read_syslog-event.o
    CC logcollector/read_audit-event.o
    CC logcollector/read_multiline_regex-event.o
logcollector/read_audit.c: In function ‘audit_send_msg’:
logcollector/read_audit.c:31:13: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
   31 |             strncpy(message + n, cache[i], z);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_audit.c:25:13: note: length computed here
   25 |         z = strlen(cache[i]);
      |             ^~~~~~~~~~~~~~~~
    CC logcollector/read_nmapg-event.o
    CC logcollector/read_command-event.o
logcollector/read_nmapg.c: In function ‘read_nmapg’:
logcollector/read_nmapg.c:246:13: warning: ‘strncat’ output may be truncated copying between 27 and 65533 bytes from a string of length 65536 [-Wstringop-truncation]
  246 |             strncat(final_msg, buffer, final_msg_s);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_mysql_log-event.o
    CC logcollector/read_ucs2_be-event.o
    CC logcollector/read_multiline-event.o
    CC logcollector/macos_log-event.o
    CC logcollector/read_fullcommand-event.o
logcollector/read_multiline.c: In function ‘read_multiline’:
logcollector/read_multiline.c:96:9: warning: ‘strncpy’ output may be truncated copying between 0 and 65534 bytes from a string of length 65536 [-Wstringop-truncation]
   96 |         strncpy(buffer + buffer_size, str, OS_MAXSTR - buffer_size - 2);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_snortfull-event.o
    CC win32/win_service_rk.o
logcollector/read_snortfull.c: In function ‘read_snortfull’:
logcollector/read_snortfull.c:54:17: warning: ‘strncpy’ output may be truncated copying 65536 bytes from a string of length 65536 [-Wstringop-truncation]
   54 |                 strncpy(f_msg, str, OS_MAXSTR);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC addagent/read_from_user.o
    CC addagent/main.o
    CC addagent/manage_keys.o
    CC addagent/manage_agents.o
    CC win32/setup-win.o
    CC win32/setup-shared.o
In file included from ./headers/file_op.h:23,
                 from win32/setup-shared.h:20,
                 from win32/setup-win.c:11:
/usr/share/mingw-w64/include/winsock2.h:15:2: warning: #warning Please include winsock2.h before windows.h [-Wcpp]
   15 | #warning Please include winsock2.h before windows.h
      |  ^~~~~~~
    CC win32/setup-syscheck.o
    CC win32/setup-iis.o
In file included from ./headers/file_op.h:23,
                 from win32/setup-shared.h:20,
                 from win32/setup-syscheck.c:11:
/usr/share/mingw-w64/include/winsock2.h:15:2: warning: #warning Please include winsock2.h before windows.h [-Wcpp]
   15 | #warning Please include winsock2.h before windows.h
      |  ^~~~~~~
    CC win32/ui/common.o
    CC win32/ui/os_win32ui.o
    CC os_auth/main-client.o
cd shared_modules/dbsync/ && mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix   .. && make
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
cd data_provider/ && mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix    .. && make
-- Detecting CXX compiler ABI info - done
-- The C compiler identification is GNU 9.3.0
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/shared_modules/dbsync/build
make[2]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[3]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 10%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync.cpp.obj
-- The CXX compiler identification is GNU 9.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/data_provider/build
make[2]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
make[3]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
Scanning dependencies of target sysinfo
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
[ 14%] Building CXX object CMakeFiles/sysinfo.dir/src/network/networkInterfaceWindows.cpp.obj
[ 28%] Building CXX object CMakeFiles/sysinfo.dir/src/osinfo/sysOsInfoWin.cpp.obj
[ 20%] Building CXX object CMakeFiles/dbsync.dir/src/dbsyncPipelineFactory.cpp.obj
[ 42%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfoWin.cpp.obj
/home/hanes/wazuh/src/data_provider/src/sysInfoWin.cpp:463:56: warning: multi-character character constant [-Wmultichar]
  463 |             const auto size {pfnGetSystemFirmwareTable('RSMB', 0, nullptr, 0)};
      |                                                        ^~~~~~
/home/hanes/wazuh/src/data_provider/src/sysInfoWin.cpp:472:51: warning: multi-character character constant [-Wmultichar]
  472 |                     if (pfnGetSystemFirmwareTable('RSMB', 0, spBuff.get(), size) == size)
      |                                                   ^~~~~~
[ 30%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync_implementation.cpp.obj
[ 40%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_dbengine.cpp.obj
[ 57%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfo.cpp.obj
[ 50%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_wrapper.cpp.obj
[ 60%] Linking CXX shared library bin/dbsync.dll
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 60%] Built target dbsync
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync_example
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 70%] Building CXX object example/CMakeFiles/dbsync_example.dir/main.cpp.obj
[ 71%] Linking CXX shared library bin/sysinfo.dll
[ 80%] Linking CXX executable ../bin/dbsync_example.exe
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 80%] Built target dbsync_example
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
[ 71%] Built target sysinfo
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 90%] Building CXX object testtool/CMakeFiles/dbsync_test_tool.dir/main.cpp.obj
Scanning dependencies of target sysinfo_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
[ 85%] Building CXX object testtool/CMakeFiles/sysinfo_test_tool.dir/main.cpp.obj
[100%] Linking CXX executable ../bin/sysinfo_test_tool.exe
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
[100%] Built target sysinfo_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
    LINK libwazuh.a
i686-w64-mingw32-ar: `u' modifier ignored since `D' is the default (see `U')
    RANLIB libwazuh.a
    CC win32/wazuh-agent.exe
    CC win32/wazuh-agent-eventchannel.exe
    CC win32/manage_agents.exe
    CC win32/setup-windows.exe
    CC win32/setup-syscheck.exe
    CC win32/setup-iis.exe
    CC win32/os_win32ui.exe
    CC win32/agent-auth.exe
[100%] Linking CXX executable ../bin/dbsync_test_tool.exe
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[100%] Built target dbsync_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
cd shared_modules/rsync/ &&  mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix   .. && make
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/shared_modules/rsync/build
make[2]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[3]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
Scanning dependencies of target rsync
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[ 12%] Building CXX object CMakeFiles/rsync.dir/src/rsync.cpp.obj
[ 25%] Building CXX object CMakeFiles/rsync.dir/src/rsyncImplementation.cpp.obj
[ 37%] Linking CXX shared library bin/rsync.dll
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[ 37%] Built target rsync
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
Scanning dependencies of target rsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[ 50%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/agentEmulator.cpp.obj
[ 62%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/main.cpp.obj
[ 75%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/oneTimeSync.cpp.obj
[ 87%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/managerEmulator.cpp.obj
[100%] Linking CXX executable ../bin/rsync_test_tool.exe
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[100%] Built target rsync_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
cd wazuh_modules/syscollector/ && mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix   .. && make
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/wazuh_modules/syscollector/build
make[2]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[3]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
Scanning dependencies of target syscollector
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[ 33%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorImp.cpp.obj
[ 33%] Building CXX object CMakeFiles/syscollector.dir/src/syscollector.cpp.obj
[ 50%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorNormalizer.cpp.obj
[ 66%] Linking CXX shared library bin/syscollector.dll
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[ 66%] Built target syscollector
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
Scanning dependencies of target syscollector_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[ 83%] Building CXX object testtool/CMakeFiles/syscollector_test_tool.dir/main.cpp.obj
[100%] Linking CXX executable ../bin/syscollector_test_tool.exe
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[100%] Built target syscollector_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[1]: Leaving directory '/home/hanes/wazuh/src'
make win32/restart-wazuh.exe win32/route-null.exe win32/netsh.exe CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
make[1]: Entering directory '/home/hanes/wazuh/src'
grep: /etc/redhat-release: No such file or directory
    CC shared/file_op_proc.o
    CC shared/debug_op_proc.o
shared/file_op.c: In function ‘getuname’:
shared/file_op.c:1910:81: warning: format ‘%d’ expects argument of type ‘int’, but argument 7 has type ‘DWORD’ {aka ‘long unsigned int’} [-Wformat=]
 1910 |                                 snprintf(__wp,  sizeof(__wp), " [Ver: %d.%d.%s.%d]", (unsigned int)winMajor, (unsigned int)winMinor, wincomp, buildRevision);
      |                                                                                ~^                                                             ~~~~~~~~~~~~~
      |                                                                                 |                                                             |
      |                                                                                 int                                                           DWORD {aka long unsigned int}
      |                                                                                %ld
shared/file_op.c:1946:77: warning: format ‘%d’ expects argument of type ‘int’, but argument 6 has type ‘DWORD’ {aka ‘long unsigned int’} [-Wformat=]
 1946 |                                 snprintf(__wp, sizeof(__wp), " [Ver: %s.%s.%d]", winver, wincomp, buildRevision);
      |                                                                            ~^                     ~~~~~~~~~~~~~
      |                                                                             |                     |
      |                                                                             int                   DWORD {aka long unsigned int}
      |                                                                            %ld
    CC active-response/restart-wazuh.o
    CC active-response/route-null.o
    CC active-response/netsh.o
active-response/route-null.c: In function ‘main’:
active-response/route-null.c:130:21: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
  130 |                     strncpy(gateway, ptr+2, strlen(ptr+2)-1);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
active-response/route-null.c:130:45: note: length computed here
  130 |                     strncpy(gateway, ptr+2, strlen(ptr+2)-1);
      |                                             ^~~~~~~~~~~~~
    CC libwazuhshared.dll
    CC win32/restart-wazuh.exe
    CC win32/route-null.exe
    CC win32/netsh.exe
make[1]: Leaving directory '/home/hanes/wazuh/src'
cd win32/ && ./unix2dos.pl ossec.conf > default-ossec.conf
cd win32/ && ./unix2dos.pl help.txt > help_win.txt
cd win32/ && ./unix2dos.pl ../../etc/internal_options.conf > internal_options.conf
cd win32/ && ./unix2dos.pl ../../etc/local_internal_options-win.conf > default-local_internal_options.conf
cd win32/ && ./unix2dos.pl ../../LICENSE > LICENSE.txt
cd win32/ && ./unix2dos.pl ../VERSION > VERSION
cd win32/ && ./unix2dos.pl ../REVISION > REVISION
cd win32/ && makensis wazuh-installer.nsi
Processing config: /etc/nsisconf.nsh
Processing script file: "wazuh-installer.nsi" (UTF8)

Processed 1 file, writing output (x86-ansi):
warning 7998: ANSI targets are deprecated

Output: "wazuh-agent-4.4.0.exe"
Install: 6 pages (384 bytes), 3 sections (12360 bytes), 1152 instructions (32256 bytes), 402 strings (33233 bytes), 1 language table (346 bytes).
Uninstall: 4 pages (320 bytes), 1 section (4120 bytes), 401 instructions (11228 bytes), 207 strings (3694 bytes), 1 language table (290 bytes).

Using zlib compression.

EXE header size:              112128 / 78336 bytes
Install code:                  16769 / 69827 bytes
Install data:                8104477 / 22839688 bytes
Uninstall code+data:           48188 / 70343 bytes
CRC (0xC3DA9267):                  4 / 4 bytes

Total size:                  8281566 / 23058198 bytes (35.9%)

1 warning:
  7998: ANSI targets are deprecated
make settings
make[1]: Entering directory '/home/hanes/wazuh/src'
grep: /etc/redhat-release: No such file or directory

General settings:
    TARGET:             winagent
    V:                  
    DEBUG:              
    DEBUGAD             
    INSTALLDIR:         
    DATABASE:           
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/16
    EXTERNAL_SRC_ONLY:  
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_ZEROMQ:         no
    USE_GEOIP:          no
    USE_PRELUDE:        no
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          no
    DISABLE_SYSC:       no
    DISABLE_CISCAT:     no
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DENABLE_SYSC -DENABLE_CISCAT
Compiler:
    CFLAGS            -pthread -DNDEBUG -O2 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DENABLE_SYSC -DENABLE_CISCAT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Ishared_modules/common -Ishared_modules/dbsync/include -Ishared_modules/rsync/include -Iwazuh_modules/syscollector/include  -Idata_provider/include  -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include 
    LDFLAGS           -pthread -O2 -Lshared_modules/dbsync/build/bin -Lshared_modules/rsync/build/bin  -Lwazuh_modules/syscollector/build/bin -Ldata_provider/build/bin
    LIBS              
    CC                gcc
    MAKE              make
make[1]: Leaving directory '/home/hanes/wazuh/src'

Done building winagent

```

</details>

## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Windows Agent</summary>

```
grep: /etc/redhat-release: No such file or directory
    CC win32/icon.o
    CC win32/win_agent.o
    CC win32/win_service.o
    CC win32/win_utils.o
    CC syscheckd/db/schema_fim_db.o
    CC syscheckd/config.o
    CC syscheckd/create_db.o
    CC syscheckd/fim_diff_changes.o
    CC syscheckd/fim_sync.o
    CC syscheckd/main.o
    CC syscheckd/run_check.o
    CC syscheckd/run_realtime.o
syscheckd/create_db.c: In function ‘fim_directory’:
syscheckd/create_db.c:397:9: warning: ‘strncpy’ output may be truncated copying between 0 and 258 bytes from a string of length 259 [-Wstringop-truncation]
  397 |         strncpy(s_name, entry->d_name, PATH_MAX - path_size - 2);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC syscheckd/syscheck.o
    CC syscheckd/syscom.o
    CC syscheckd/db/fim_db.o
    CC syscheckd/db/fim_db_files.o
    CC syscheckd/db/fim_db_registries.o
    CC syscheckd/whodata/audit_healthcheck.o
    CC syscheckd/whodata/audit_parse.o
    CC syscheckd/whodata/audit_rule_handling.o
    CC syscheckd/whodata/syscheck_audit.o
    CC syscheckd/whodata/win_whodata.o
    CC syscheckd/registry/events.o
    CC syscheckd/registry/registry.o
    CC rootcheck/check_open_ports.o
    CC rootcheck/check_rc_dev.o
    CC rootcheck/check_rc_files.o
    CC rootcheck/check_rc_if.o
    CC rootcheck/check_rc_pids.o
    CC rootcheck/check_rc_policy.o
    CC rootcheck/check_rc_ports.o
    CC rootcheck/check_rc_readproc.o
    CC rootcheck/check_rc_sys.o
    CC rootcheck/check_rc_trojans.o
    CC rootcheck/common.o
    CC rootcheck/common_rcl.o
    CC rootcheck/config.o
    CC rootcheck/os_string.o
In file included from ./headers/shared.h:220,
                 from rootcheck/common.c:11:
rootcheck/common.c: In function ‘is_file’:
./headers/debug_op.h:46:32: warning: argument 6 null where non-null expected [-Wnonnull]
   46 | #define mterror(tag, msg, ...) _mterror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./headers/debug_op.h:46:32: note: in definition of macro ‘mterror’
   46 | #define mterror(tag, msg, ...) _mterror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
      |                                ^~~~~~~~
In file included from ./headers/shared.h:220,
                 from rootcheck/common.c:11:
./headers/debug_op.h:61:6: note: in a call to function ‘_mterror’ declared here
   61 | void _mterror(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull));
      |      ^~~~~~~~
    CC rootcheck/rootcheck.o
    CC rootcheck/rootcheck-config.o
    CC rootcheck/run_rk_check.o
In function ‘_rkcl_getrootdir’,
    inlined from ‘rkcl_get_entry’ at rootcheck/common_rcl.c:286:5:
rootcheck/common_rcl.c:47:9: warning: ‘strncpy’ output may be truncated copying 1025 bytes from a string of length 2048 [-Wstringop-truncation]
   47 |         strncpy(root_dir, final_file, dir_size);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC rootcheck/unix-process.o
    CC rootcheck/win-common.o
    CC rootcheck/win-process.o
    CC client-agent/agcom.o
    CC client-agent/buffer.o
rootcheck/win-common.c: In function ‘__os_winreg_querykey’:
rootcheck/win-common.c:265:29: warning: ‘strncat’ output may be truncated copying between 3 and 16381 bytes from a string of length 16383 [-Wstringop-truncation]
  265 |                             strncat(var_storage, mt_data, size_available);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC client-agent/config.o
    CC client-agent/notify.o
    CC client-agent/receiver.o
    CC client-agent/receiver-win.o
    CC client-agent/request.o
    CC client-agent/restart_agent.o
    CC client-agent/rotate_log.o
    CC client-agent/sendmsg.o
    CC client-agent/start_agent.o
    CC client-agent/state.o
    CC logcollector/config.o
    CC logcollector/lccom.o
    CC logcollector/logcollector.o
    CC logcollector/macos_log.o
    CC logcollector/read_audit.o
    CC logcollector/read_command.o
    CC logcollector/read_djb_multilog.o
    CC logcollector/read_fullcommand.o
    CC logcollector/read_json.o
    CC logcollector/read_macos.o
    CC logcollector/read_mssql_log.o
    CC logcollector/read_multiline.o
    CC logcollector/read_multiline_regex.o
    CC logcollector/read_mysql_log.o
logcollector/read_multiline.c: In function ‘read_multiline’:
logcollector/read_multiline.c:96:9: warning: ‘strncpy’ output may be truncated copying between 0 and 65534 bytes from a string of length 65536 [-Wstringop-truncation]
   96 |         strncpy(buffer + buffer_size, str, OS_MAXSTR - buffer_size - 2);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_nmapg.o
logcollector/read_mssql_log.c: In function ‘read_mssql_log’:
logcollector/read_mssql_log.c:117:17: warning: ‘strncpy’ output may be truncated copying between 22 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  117 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_mssql_log.c:108:17: warning: ‘strncpy’ output may be truncated copying between 22 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  108 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_ossecalert.o
    CC logcollector/read_postgresql_log.o
    CC logcollector/read_snortfull.o
logcollector/read_nmapg.c: In function ‘read_nmapg’:
logcollector/read_nmapg.c:246:13: warning: ‘strncat’ output may be truncated copying between 27 and 65533 bytes from a string of length 65536 [-Wstringop-truncation]
  246 |             strncat(final_msg, buffer, final_msg_s);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_syslog.o
    CC logcollector/read_ucs2_be.o
logcollector/read_postgresql_log.c: In function ‘read_postgresql_log’:
logcollector/read_postgresql_log.c:114:17: warning: ‘strncpy’ output may be truncated copying between 35 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  114 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_postgresql_log.c:106:17: warning: ‘strncpy’ output may be truncated copying between 35 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_ucs2_le.o
logcollector/read_snortfull.c: In function ‘read_snortfull’:
logcollector/read_snortfull.c:54:17: warning: ‘strncpy’ output may be truncated copying 65536 bytes from a string of length 65536 [-Wstringop-truncation]
   54 |                 strncpy(f_msg, str, OS_MAXSTR);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_win_el.o
    CC logcollector/read_win_event_channel.o
    CC logcollector/state.o
    CC os_execd/config.o
    CC os_execd/exec.o
    CC os_execd/execd.o
    CC os_execd/wcom.o
    CC os_execd/win_execd.o
    CC active-response/active_responses.o
os_execd/exec.c: In function ‘ReadExecConfig’:
os_execd/exec.c:72:9: warning: ‘strncpy’ output may be truncated copying 256 bytes from a string of length 65536 [-Wstringop-truncation]
   72 |         strncpy(exec_names[exec_size], str_pt, OS_FLSIZE);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
os_execd/exec.c:125:21: warning: ‘strncpy’ accessing 256 bytes at offsets [0, 16705] and [0, 16705] may overlap up to 256 bytes at offset [0, 255] [-Wrestrict]
  125 |                     strncpy(exec_cmd[j], exec_cmd[exec_size], OS_FLSIZE);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC monitord/rotate_log.o
    CC monitord/compress_log.o
    CC config/active-response.o
    CC config/agentlessd-config.o
    CC config/alerts-config.o
    CC config/authd-config.o
    CC config/buffer-config.o
    CC config/client-config.o
    CC config/cluster-config.o
    CC config/config.o
    CC config/csyslogd-config.o
    CC config/dbd-config.o
    CC config/email-alerts-config.o
    CC config/global-config.o
    CC config/integrator-config.o
    CC config/labels-config.o
    CC config/localfile-config.o
    CC config/logtest-config.o
    CC config/remote-config.o
    CC config/reports-config.o
    CC config/rootcheck-config.o
    CC config/rules-config.o
    CC config/socket-config.o
    CC config/syscheck-config.o
    CC config/wmodules-agent-upgrade.o
    CC config/wmodules-aws.o
    CC config/wmodules-azure.o
    CC config/wmodules-ciscat.o
config/syscheck-config.c: In function ‘read_data_unit’:
config/syscheck-config.c:1261:13: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
 1261 |             strncpy(value_str, content, len_value_str - 2);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
config/syscheck-config.c:1251:28: note: length computed here
 1251 |     size_t len_value_str = strlen(content);
      |                            ^~~~~~~~~~~~~~~
    CC config/wmodules-command.o
    CC config/wmodules-config.o
    CC config/wmodules-docker.o
    CC config/wmodules-fluent.o
    CC config/wmodules-gcp.o
    CC config/wmodules-github.o
    CC config/wmodules-key-request.o
    CC config/wmodules-office365.o
    CC config/wmodules-oscap.o
    CC config/wmodules-osquery-monitor.o
    CC config/wmodules-sca.o
    CC config/wmodules_syscollector.o
    CC config/wmodules-task-manager.o
    CC config/wmodules-vuln-detector.o
    CC wazuh_modules/wm_aws.o
    CC wazuh_modules/wm_azure.o
    CC wazuh_modules/wm_ciscat.o
    CC wazuh_modules/wmcom.o
    CC wazuh_modules/wm_command.o
    CC wazuh_modules/wm_control.o
wazuh_modules/wm_ciscat.c: In function ‘wm_ciscat_main’:
wazuh_modules/wm_ciscat.c:128:14: warning: unused variable ‘pwd’ [-Wunused-variable]
  128 |         char pwd[PATH_MAX];
      |              ^~~
    CC wazuh_modules/wm_database.o
    CC wazuh_modules/wm_docker.o
    CC wazuh_modules/wm_download.o
    CC wazuh_modules/wm_exec.o
    CC wazuh_modules/wm_fluent.o
    CC wazuh_modules/wm_gcp.o
    CC wazuh_modules/wm_github.o
    CC wazuh_modules/wm_keyrequest.o
    CC wazuh_modules/wmodules.o
    CC wazuh_modules/wm_office365.o
wazuh_modules/wm_github.c: In function ‘wm_github_execute_scan’:
wazuh_modules/wm_github.c:336:33: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  336 |                                 strncpy(url, next_page, strlen(next_page));
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_modules/wm_oscap.o
    CC wazuh_modules/wm_osquery_monitor.o
    CC wazuh_modules/wm_sca.o
wazuh_modules/wm_office365.c: In function ‘wm_office365_execute_scan’:
wazuh_modules/wm_office365.c:458:33: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  458 |                                 strncpy(url, next_page, strlen(next_page));
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_modules/wm_syscollector.o
    CC wazuh_modules/wm_task_general.o
    CC wazuh_modules/agent_upgrade/wm_agent_upgrade.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.o
    CC wazuh_db/wdb_agents.o
wazuh_modules/wm_sca.c: In function ‘wm_sca_winreg_querykey’:
wazuh_modules/wm_sca.c:2347:29: warning: ‘strncat’ output may be truncated copying between 3 and 16381 bytes from a string of length 16383 [-Wstringop-truncation]
 2347 |                             strncat(var_storage, mt_data, size_available);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_db/wdb.o
wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c: In function ‘wm_agent_upgrade_com_open’:
wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c:233:9: warning: ‘strncpy’ output may be truncated copying 260 bytes from a string of length 260 [-Wstringop-truncation]
  233 |         strncpy(file.path, final_path, PATH_MAX);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_db/wdb_ciscat.o
    CC wazuh_db/wdb_delta_event.o
    CC wazuh_db/wdb_fim.o
    CC wazuh_db/wdb_global.o
    CC wazuh_db/wdb_integrity.o
    CC wazuh_db/wdb_metadata.o
    CC wazuh_db/wdb_parser.o
    CC wazuh_db/wdb_rootcheck.o
    CC wazuh_db/wdb_sca.o
    CC wazuh_db/wdb_scan_info.o
    CC wazuh_db/wdb_syscollector.o
    CC wazuh_db/wdb_task.o
    CC wazuh_db/wdb_upgrade.o
    CC wazuh_db/helpers/wdb_agents_helpers.o
    CC wazuh_db/helpers/wdb_global_helpers.o
    CC wazuh_db/schema_agents.o
    CC wazuh_db/schema_global.o
    CC wazuh_db/schema_global_upgrade_v1.o
    CC wazuh_db/schema_global_upgrade_v2.o
    CC wazuh_db/schema_global_upgrade_v3.o
    CC wazuh_db/schema_task_manager.o
    CC wazuh_db/schema_upgrade_v1.o
    CC wazuh_db/schema_upgrade_v2.o
    CC wazuh_db/schema_upgrade_v3.o
    CC wazuh_db/schema_upgrade_v4.o
    CC wazuh_db/schema_upgrade_v5.o
    CC wazuh_db/schema_upgrade_v6.o
    CC wazuh_db/schema_upgrade_v7.o
    CC wazuh_db/schema_upgrade_v8.o
    CC os_crypto/blowfish/bf_op.o
    CC wazuh_db/schema_vuln_detector.o
    CC os_crypto/md5/md5_op.o
    CC os_crypto/sha1/sha1_op.o
    CC os_crypto/shared/keys.o
    CC os_crypto/shared/msgs.o
    CC os_crypto/md5_sha1/md5_sha1_op.o
    CC os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.o
    CC os_crypto/sha256/sha256_op.o
    CC os_crypto/sha512/sha512_op.o
    CC os_crypto/aes/aes_op.o
    CC os_crypto/hmac/hmac.o
    CC os_crypto/signature/signature.o
    CC shared/agent_op.o
os_crypto/shared/keys.c: In function ‘OS_ReadKeys’:
os_crypto/shared/keys.c:251:13: warning: ‘strncpy’ output may be truncated copying 127 bytes from a string of length 2048 [-Wstringop-truncation]
  251 |             strncpy(id, valid_str, KEYSIZE - 1);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC shared/atomic.o
    CC shared/audit_op.o
    CC shared/auth_client.o
    CC shared/b64.o
    CC shared/bqueue_op.o
    CC shared/buffer_op.o
    CC shared/bzip2_op.o
    CC shared/cluster_utils.o
    CC shared/custom_output_search_replace.o
    CC shared/debug_op.o
    CC shared/enrollment_op.o
    CC shared/exec_op.o
shared/custom_output_search_replace.c: In function ‘searchAndReplace’:
shared/custom_output_search_replace.c:51:9: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
   51 |         strncpy(tmp + tmp_offset, value, value_len);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
shared/custom_output_search_replace.c:19:30: note: length computed here
   19 |     const size_t value_len = strlen(value);
      |                              ^~~~~~~~~~~~~
    CC shared/expression.o
    CC shared/file_op.o
shared/enrollment_op.c: In function ‘w_enrollment_concat_src_ip’:
shared/enrollment_op.c:547:13: warning: ‘strncat’ output may be truncated copying 254 bytes from a string of length 255 [-Wstringop-truncation]
  547 |             strncat(buff,opt_buf,254);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~
    CC shared/file-queue.o
    CC shared/fs_op.o
    CC shared/hash_op.o
shared/file_op.c: In function ‘getuname’:
shared/file_op.c:1910:81: warning: format ‘%d’ expects argument of type ‘int’, but argument 7 has type ‘DWORD’ {aka ‘long unsigned int’} [-Wformat=]
 1910 |                                 snprintf(__wp,  sizeof(__wp), " [Ver: %d.%d.%s.%d]", (unsigned int)winMajor, (unsigned int)winMinor, wincomp, buildRevision);
      |                                                                                ~^                                                             ~~~~~~~~~~~~~
      |                                                                                 |                                                             |
      |                                                                                 int                                                           DWORD {aka long unsigned int}
      |                                                                                %ld
shared/file_op.c:1946:77: warning: format ‘%d’ expects argument of type ‘int’, but argument 6 has type ‘DWORD’ {aka ‘long unsigned int’} [-Wformat=]
 1946 |                                 snprintf(__wp, sizeof(__wp), " [Ver: %s.%s.%d]", winver, wincomp, buildRevision);
      |                                                                            ~^                     ~~~~~~~~~~~~~
      |                                                                             |                     |
      |                                                                             int                   DWORD {aka long unsigned int}
      |                                                                            %ld
    CC shared/help.o
    CC shared/integrity_op.o
    CC shared/json_op.o
    CC shared/json-queue.o
    CC shared/labels_op.o
    CC shared/list_op.o
    CC shared/log_builder.o
    CC shared/math_op.o
    CC shared/mem_op.o
    CC shared/mq_op.o
    CC shared/notify_op.o
    CC shared/os_utils.o
    CC shared/privsep_op.o
    CC shared/pthreads_op.o
    CC shared/queue_linked_op.o
    CC shared/queue_op.o
    CC shared/randombytes.o
    CC shared/rbtree_op.o
    CC shared/read-agents.o
    CC shared/read-alert.o
    CC shared/regex_op.o
    CC shared/remoted_op.o
    CC shared/report_op.o
    CC shared/request_op.o
    CC shared/rootcheck_op.o
    CC shared/rules_op.o
    CC shared/schedule_scan.o
    CC shared/sig_op.o
    CC shared/store_op.o
    CC shared/string_op.o
    CC shared/sym_load.o
shared/string_op.c: In function ‘wstr_split’:
shared/string_op.c:612:17: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
  612 |                 strncpy(new_term_it, acc_strs[count], strlen(acc_strs[count]));
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
shared/string_op.c:609:21: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  609 |                     strncpy(new_term_it, new_delim, new_delim_size);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
shared/string_op.c:569:29: note: length computed here
  569 |     size_t new_delim_size = strlen(replace_delim ? replace_delim : delim);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC shared/syscheck_op.o
    CC shared/sysinfo_utils.o
    CC shared/time_op.o
    CC shared/url.o
shared/syscheck_op.c: In function ‘get_registry_permissions’:
shared/syscheck_op.c:1116:11: warning: unused variable ‘dwErrorCode’ [-Wunused-variable]
 1116 |     DWORD dwErrorCode = 0;
      |           ^~~~~~~~~~~
    CC shared/utf8_op.o
    CC shared/validate_op.o
    CC shared/vector_op.o
    CC shared/version_op.o
    CC shared/wait_op.o
    CC shared/wazuhdb_op.o
    CC shared/yaml2json.o
    CC os_net/os_net.o
    CC os_regex/os_match.o
    CC os_regex/os_match_compile.o
    CC os_regex/os_match_execute.o
    CC os_regex/os_match_free_pattern.o
    CC os_regex/os_regex.o
    CC os_regex/os_regex_compile.o
    CC os_regex/os_regex_execute.o
    CC os_regex/os_regex_free_pattern.o
    CC os_regex/os_regex_maps.o
    CC os_regex/os_regex_match.o
    CC os_regex/os_regex_startswith.o
    CC os_regex/os_regex_strbreak.o
    CC os_regex/os_regex_str.o
    CC os_xml/os_xml_access.o
    CC os_xml/os_xml.o
    CC os_xml/os_xml_node_access.o
    CC os_xml/os_xml_variables.o
    CC os_xml/os_xml_writer.o
    CC os_zlib/os_zlib.o
    CC os_auth/ssl.o
    CC os_auth/check_cert.o
    CC addagent/validate.o
In function ‘_writecontent’,
    inlined from ‘_ReadElem’ at os_xml/os_xml.c:361:17:
os_xml/os_xml.c:510:5: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
  510 |     strncpy(_lxml->ct[parent], str, size - 1);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
os_xml/os_xml.c: In function ‘_ReadElem’:
os_xml/os_xml.c:361:37: note: length computed here
  361 |             if (_writecontent(cont, strlen(cont) + 1, _currentlycont, _lxml) < 0) {
      |                                     ^~~~~~~~~~~~
    CC analysisd/logmsg.o
    CC libwazuhext.dll
    CC syscheckd/config-event.o
    CC syscheckd/create_db-event.o
    CC syscheckd/fim_diff_changes-event.o
    CC syscheckd/fim_sync-event.o
syscheckd/create_db.c: In function ‘fim_directory’:
syscheckd/create_db.c:397:9: warning: ‘strncpy’ output may be truncated copying between 0 and 258 bytes from a string of length 259 [-Wstringop-truncation]
  397 |         strncpy(s_name, entry->d_name, PATH_MAX - path_size - 2);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC syscheckd/run_check-event.o
    CC syscheckd/run_realtime-event.o
    CC syscheckd/syscheck-event.o
    CC syscheckd/syscom-event.o
    CC syscheckd/db/fim_db-event.o
    CC syscheckd/db/fim_db_files-event.o
    CC syscheckd/db/fim_db_registries-event.o
    CC syscheckd/whodata/audit_healthcheck-event.o
    CC syscheckd/whodata/audit_parse-event.o
    CC syscheckd/whodata/audit_rule_handling-event.o
    CC syscheckd/whodata/syscheck_audit-event.o
    CC syscheckd/whodata/win_whodata-event.o
    CC syscheckd/registry/events-event.o
    CC syscheckd/registry/registry-event.o
    CC logcollector/config-event.o
    CC logcollector/lccom-event.o
    CC logcollector/logcollector-event.o
    CC logcollector/macos_log-event.o
    CC logcollector/read_audit-event.o
    CC logcollector/read_command-event.o
    CC logcollector/read_djb_multilog-event.o
    CC logcollector/read_fullcommand-event.o
    CC logcollector/read_json-event.o
    CC logcollector/read_macos-event.o
    CC logcollector/read_mssql_log-event.o
    CC logcollector/read_multiline-event.o
    CC logcollector/read_multiline_regex-event.o
    CC logcollector/read_mysql_log-event.o
logcollector/read_mssql_log.c: In function ‘read_mssql_log’:
logcollector/read_mssql_log.c:117:17: warning: ‘strncpy’ output may be truncated copying between 22 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  117 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_mssql_log.c:108:17: warning: ‘strncpy’ output may be truncated copying between 22 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  108 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_nmapg-event.o
logcollector/read_multiline.c: In function ‘read_multiline’:
logcollector/read_multiline.c:96:9: warning: ‘strncpy’ output may be truncated copying between 0 and 65534 bytes from a string of length 65536 [-Wstringop-truncation]
   96 |         strncpy(buffer + buffer_size, str, OS_MAXSTR - buffer_size - 2);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_ossecalert-event.o
    CC logcollector/read_postgresql_log-event.o
    CC logcollector/read_snortfull-event.o
logcollector/read_nmapg.c: In function ‘read_nmapg’:
logcollector/read_nmapg.c:246:13: warning: ‘strncat’ output may be truncated copying between 27 and 65533 bytes from a string of length 65536 [-Wstringop-truncation]
  246 |             strncat(final_msg, buffer, final_msg_s);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_syslog-event.o
    CC logcollector/read_ucs2_be-event.o
logcollector/read_postgresql_log.c: In function ‘read_postgresql_log’:
logcollector/read_postgresql_log.c:114:17: warning: ‘strncpy’ output may be truncated copying between 35 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  114 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_postgresql_log.c:106:17: warning: ‘strncpy’ output may be truncated copying between 35 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_ucs2_le-event.o
logcollector/read_snortfull.c: In function ‘read_snortfull’:
logcollector/read_snortfull.c:54:17: warning: ‘strncpy’ output may be truncated copying 65536 bytes from a string of length 65536 [-Wstringop-truncation]
   54 |                 strncpy(f_msg, str, OS_MAXSTR);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_win_el-event.o
    CC logcollector/read_win_event_channel-event.o
    CC logcollector/state-event.o
    CC win32/win_service_rk.o
    CC addagent/main.o
    CC addagent/manage_agents.o
    CC addagent/manage_keys.o
    CC addagent/read_from_user.o
    CC win32/setup-win.o
    CC win32/setup-shared.o
    CC win32/setup-syscheck.o
    CC win32/setup-iis.o
In file included from ./headers/file_op.h:23,
                 from win32/setup-shared.h:20,
                 from win32/setup-win.c:11:
/usr/share/mingw-w64/include/winsock2.h:15:2: warning: #warning Please include winsock2.h before windows.h [-Wcpp]
   15 | #warning Please include winsock2.h before windows.h
      |  ^~~~~~~
    CC win32/ui/common.o
    CC win32/ui/os_win32ui.o
In file included from ./headers/file_op.h:23,
                 from win32/setup-shared.h:20,
                 from win32/setup-syscheck.c:11:
/usr/share/mingw-w64/include/winsock2.h:15:2: warning: #warning Please include winsock2.h before windows.h [-Wcpp]
   15 | #warning Please include winsock2.h before windows.h
      |  ^~~~~~~
    CC os_auth/main-client.o
cd shared_modules/dbsync/ && mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix   .. && make
-- The C compiler identification is GNU 10.0.0
-- The CXX compiler identification is GNU 10.0.0
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix
cd data_provider/ && mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix    .. && make
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - works
-- Detecting CXX compiler ABI info
-- The C compiler identification is GNU 10.0.0
    LINK libwazuh.a
i686-w64-mingw32-ar: `u' modifier ignored since `D' is the default (see `U')
    RANLIB libwazuh.a
-- Detecting CXX compiler ABI info - done
-- The CXX compiler identification is GNU 10.0.0
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
    CC win32/wazuh-agent.exe
    CC win32/wazuh-agent-eventchannel.exe
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build
make[2]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[3]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 10%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync.cpp.obj
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - works
-- Detecting C compiler ABI info
    CC win32/manage_agents.exe
    CC win32/setup-windows.exe
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
    CC win32/setup-syscheck.exe
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix
    CC win32/setup-iis.exe
    CC win32/os_win32ui.exe
    CC win32/agent-auth.exe
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - works
-- Detecting CXX compiler ABI info
[ 20%] Building CXX object CMakeFiles/dbsync.dir/src/dbsyncPipelineFactory.cpp.obj
[ 30%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync_implementation.cpp.obj
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/wazuh/src/data_provider/build
make[2]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[3]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
Scanning dependencies of target sysinfo
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
[ 14%] Building CXX object CMakeFiles/sysinfo.dir/src/network/networkInterfaceWindows.cpp.obj
[ 40%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_dbengine.cpp.obj
[ 50%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_wrapper.cpp.obj
[ 28%] Building CXX object CMakeFiles/sysinfo.dir/src/osinfo/sysOsInfoWin.cpp.obj
[ 42%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfoWin.cpp.obj
/home/hanes/wazuh/wazuh/src/data_provider/src/sysInfoWin.cpp:463:56: warning: multi-character character constant [-Wmultichar]
  463 |             const auto size {pfnGetSystemFirmwareTable('RSMB', 0, nullptr, 0)};
      |                                                        ^~~~~~
/home/hanes/wazuh/wazuh/src/data_provider/src/sysInfoWin.cpp:472:51: warning: multi-character character constant [-Wmultichar]
  472 |                     if (pfnGetSystemFirmwareTable('RSMB', 0, spBuff.get(), size) == size)
      |                                                   ^~~~~~
[ 57%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfo.cpp.obj
[ 60%] Linking CXX shared library bin/dbsync.dll
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 60%] Built target dbsync
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync_example
Scanning dependencies of target dbsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 70%] Building CXX object testtool/CMakeFiles/dbsync_test_tool.dir/main.cpp.obj
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 80%] Building CXX object example/CMakeFiles/dbsync_example.dir/main.cpp.obj
[ 90%] Linking CXX executable ../bin/dbsync_example.exe
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 90%] Built target dbsync_example
In file included from /home/hanes/wazuh/wazuh/src/data_provider/include/sysInfoInterface.h:15,
                 from /home/hanes/wazuh/wazuh/src/data_provider/include/sysInfo.hpp:28,
                 from /home/hanes/wazuh/wazuh/src/data_provider/src/sysInfoWin.cpp:26:
/home/hanes/wazuh/wazuh/src/external/nlohmann/json.hpp: In function ‘nlohmann::json getProcessInfo(const PROCESSENTRY32&)’:
/home/hanes/wazuh/wazuh/src/external/nlohmann/json.hpp:3676:62: warning: ‘process.SysInfoProcess::m_virtualSize’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 3676 |     external_constructor<value_t::number_unsigned>::construct(j, static_cast<typename BasicJsonType::number_unsigned_t>(val));
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/hanes/wazuh/wazuh/src/data_provider/src/sysInfoWin.cpp:353:24: note: ‘process.SysInfoProcess::m_virtualSize’ was declared here
  353 |         SysInfoProcess process(pId, processHandle);
      |                        ^~~~~~~
In file included from /home/hanes/wazuh/wazuh/src/data_provider/include/sysInfoInterface.h:15,
                 from /home/hanes/wazuh/wazuh/src/data_provider/include/sysInfo.hpp:28,
                 from /home/hanes/wazuh/wazuh/src/data_provider/src/sysInfoWin.cpp:26:
/home/hanes/wazuh/wazuh/src/external/nlohmann/json.hpp:3676:62: warning: ‘process.SysInfoProcess::m_pageFileUsage’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 3676 |     external_constructor<value_t::number_unsigned>::construct(j, static_cast<typename BasicJsonType::number_unsigned_t>(val));
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/hanes/wazuh/wazuh/src/data_provider/src/sysInfoWin.cpp:353:24: note: ‘process.SysInfoProcess::m_pageFileUsage’ was declared here
  353 |         SysInfoProcess process(pId, processHandle);
      |                        ^~~~~~~
[ 71%] Linking CXX shared library bin/sysinfo.dll
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
[ 71%] Built target sysinfo
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
Scanning dependencies of target sysinfo_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
[ 85%] Building CXX object testtool/CMakeFiles/sysinfo_test_tool.dir/main.cpp.obj
[100%] Linking CXX executable ../bin/sysinfo_test_tool.exe
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
[100%] Built target sysinfo_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[2]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
[100%] Linking CXX executable ../bin/dbsync_test_tool.exe
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[100%] Built target dbsync_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[2]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
cd shared_modules/rsync/ &&  mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix   .. && make
-- The C compiler identification is GNU 10.0.0
-- The CXX compiler identification is GNU 10.0.0
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/wazuh/src/shared_modules/rsync/build
make[2]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[3]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
Scanning dependencies of target rsync
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
[ 25%] Building CXX object CMakeFiles/rsync.dir/src/rsync.cpp.obj
[ 25%] Building CXX object CMakeFiles/rsync.dir/src/rsyncImplementation.cpp.obj
[ 37%] Linking CXX shared library bin/rsync.dll
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
[ 37%] Built target rsync
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
Scanning dependencies of target rsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
[ 50%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/main.cpp.obj
[ 62%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/agentEmulator.cpp.obj
[ 75%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/oneTimeSync.cpp.obj
[ 87%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/managerEmulator.cpp.obj
[100%] Linking CXX executable ../bin/rsync_test_tool.exe
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
[100%] Built target rsync_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[2]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
cd wazuh_modules/syscollector/ && mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix   .. && make
-- The C compiler identification is GNU 10.0.0
-- The CXX compiler identification is GNU 10.0.0
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build
make[2]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[3]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
Scanning dependencies of target syscollector
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
[ 16%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorNormalizer.cpp.obj
[ 33%] Building CXX object CMakeFiles/syscollector.dir/src/syscollector.cpp.obj
[ 50%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorImp.cpp.obj
[ 66%] Linking CXX shared library bin/syscollector.dll
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
[ 66%] Built target syscollector
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
Scanning dependencies of target syscollector_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
[ 83%] Building CXX object testtool/CMakeFiles/syscollector_test_tool.dir/main.cpp.obj
[100%] Linking CXX executable ../bin/syscollector_test_tool.exe
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
[100%] Built target syscollector_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[2]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[1]: Leaving directory '/home/hanes/wazuh/wazuh/src'
make win32/restart-wazuh.exe win32/route-null.exe win32/netsh.exe CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
make[1]: Entering directory '/home/hanes/wazuh/wazuh/src'
grep: /etc/redhat-release: No such file or directory
    CC shared/file_op_proc.o
    CC shared/debug_op_proc.o
    CC active-response/restart-wazuh.o
    CC active-response/route-null.o
shared/file_op.c: In function ‘getuname’:
shared/file_op.c:1910:81: warning: format ‘%d’ expects argument of type ‘int’, but argument 7 has type ‘DWORD’ {aka ‘long unsigned int’} [-Wformat=]
 1910 |                                 snprintf(__wp,  sizeof(__wp), " [Ver: %d.%d.%s.%d]", (unsigned int)winMajor, (unsigned int)winMinor, wincomp, buildRevision);
      |                                                                                ~^                                                             ~~~~~~~~~~~~~
      |                                                                                 |                                                             |
      |                                                                                 int                                                           DWORD {aka long unsigned int}
      |                                                                                %ld
shared/file_op.c:1946:77: warning: format ‘%d’ expects argument of type ‘int’, but argument 6 has type ‘DWORD’ {aka ‘long unsigned int’} [-Wformat=]
 1946 |                                 snprintf(__wp, sizeof(__wp), " [Ver: %s.%s.%d]", winver, wincomp, buildRevision);
      |                                                                            ~^                     ~~~~~~~~~~~~~
      |                                                                             |                     |
      |                                                                             int                   DWORD {aka long unsigned int}
      |                                                                            %ld
    CC active-response/netsh.o
active-response/route-null.c: In function ‘main’:
active-response/route-null.c:130:21: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
  130 |                     strncpy(gateway, ptr+2, strlen(ptr+2)-1);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
active-response/route-null.c:130:45: note: length computed here
  130 |                     strncpy(gateway, ptr+2, strlen(ptr+2)-1);
      |                                             ^~~~~~~~~~~~~
    CC libwazuhshared.dll
    CC win32/restart-wazuh.exe
    CC win32/route-null.exe
    CC win32/netsh.exe
make[1]: Leaving directory '/home/hanes/wazuh/wazuh/src'
cd win32/ && ./unix2dos.pl ossec.conf > default-ossec.conf
cd win32/ && ./unix2dos.pl help.txt > help_win.txt
cd win32/ && ./unix2dos.pl ../../etc/internal_options.conf > internal_options.conf
cd win32/ && ./unix2dos.pl ../../etc/local_internal_options-win.conf > default-local_internal_options.conf
cd win32/ && ./unix2dos.pl ../../LICENSE > LICENSE.txt
cd win32/ && ./unix2dos.pl ../VERSION > VERSION
cd win32/ && ./unix2dos.pl ../REVISION > REVISION
cd win32/ && makensis wazuh-installer.nsi
Processing config: /etc/nsisconf.nsh
Processing script file: "wazuh-installer.nsi" (UTF8)

Processed 1 file, writing output (x86-ansi):
warning 7998: ANSI targets are deprecated

Output: "wazuh-agent-4.4.0.exe"
Install: 6 pages (384 bytes), 3 sections (12360 bytes), 1152 instructions (32256 bytes), 402 strings (33233 bytes), 1 language table (346 bytes).
Uninstall: 4 pages (320 bytes), 1 section (4120 bytes), 401 instructions (11228 bytes), 207 strings (3694 bytes), 1 language table (290 bytes).

Using zlib compression.

EXE header size:              112640 / 78848 bytes
Install code:                  16773 / 69827 bytes
Install data:                7511708 / 20474313 bytes
Uninstall code+data:           48169 / 70324 bytes
CRC (0x7B7B6D3E):                  4 / 4 bytes

Total size:                  7689294 / 20693316 bytes (37.1%)

1 warning:
  7998: ANSI targets are deprecated
make settings
make[1]: Entering directory '/home/hanes/wazuh/wazuh/src'
grep: /etc/redhat-release: No such file or directory

General settings:
    TARGET:             winagent
    V:                  
    DEBUG:              
    DEBUGAD             
    INSTALLDIR:         
    DATABASE:           
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/16
    EXTERNAL_SRC_ONLY:  
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_ZEROMQ:         no
    USE_GEOIP:          no
    USE_PRELUDE:        no
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          no
    DISABLE_SYSC:       no
    DISABLE_CISCAT:     no
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DENABLE_SYSC -DENABLE_CISCAT
Compiler:
    CFLAGS            -pthread -DNDEBUG -O2 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DENABLE_SYSC -DENABLE_CISCAT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Ishared_modules/common -Ishared_modules/dbsync/include -Ishared_modules/rsync/include -Iwazuh_modules/syscollector/include  -Idata_provider/include  -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include 
    LDFLAGS           -pthread -O2 -Lshared_modules/dbsync/build/bin -Lshared_modules/rsync/build/bin  -Lwazuh_modules/syscollector/build/bin -Ldata_provider/build/bin
    LIBS              
    CC                gcc
    MAKE              make
make[1]: Leaving directory '/home/hanes/wazuh/wazuh/src'

Done building winagent
```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors