### PR TITLE
HLP - Adding basic user agent parser

### DIFF
--- a/src/engine/source/hlp/src/LogQLParser.cpp
+++ b/src/engine/source/hlp/src/LogQLParser.cpp
@@ -1,10 +1,11 @@
+#include "LogQLParser.hpp"
+#include "hlpDetails.hpp"
+
 #include <stdio.h>
 #include <string>
 #include <string_view>
 #include <unordered_map>
 #include <vector>
-#include "LogQLParser.hpp"
-#include "hlpDetails.hpp"
 
 static const std::unordered_map<std::string_view, ParserType> kECSParserMapper {
     { "source.ip", ParserType::IP },
@@ -16,7 +17,8 @@ static const std::unordered_map<std::string_view, ParserType> kECSParserMapper {
     { "file.created", ParserType::Ts},
     { "url", ParserType::URL},
     { "http.request.method", ParserType::Any },
-    { "client", ParserType::Domain}
+    { "client", ParserType::Domain},
+    { "userAgent", ParserType::UserAgent },
 };
 
 static const std::unordered_map<std::string_view, ParserType> kTempTypeMapper {

--- a/src/engine/source/hlp/src/LogQLParser.cpp
+++ b/src/engine/source/hlp/src/LogQLParser.cpp
@@ -27,6 +27,7 @@ static const std::unordered_map<std::string_view, ParserType> kTempTypeMapper {
     { "timestamp", ParserType::Ts},
     { "domain", ParserType::Domain},
     { "FilePath", ParserType::FilePath},
+    { "userAgent", ParserType::UserAgent},
 };
 
 struct Tokenizer {

--- a/src/engine/source/hlp/src/SpecificParsers.cpp
+++ b/src/engine/source/hlp/src/SpecificParsers.cpp
@@ -84,14 +84,14 @@ void parseFilePath(const char **it,
 
     std::string_view file_path {start, (size_t)((*it) - start)};
     std::string folder_separator = "/\\";
-    bool search_drive_letter     = true;
+    bool search_drive_letter = true;
     if(!captureOpts.empty() && captureOpts[0] == "UNIX")
     {
         search_drive_letter = false;
-        folder_separator    = "/";
+        folder_separator = "/";
     }
 
-    result.path     = file_path;
+    result.path = file_path;
     auto folder_end = file_path.find_last_of(folder_separator);
 
     result.folder = (folder_end == std::string::npos)
@@ -103,9 +103,9 @@ void parseFilePath(const char **it,
                       : file_path.substr(folder_end + 1);
 
     auto extension_start = result.name.find_last_of('.');
-    result.extension     = (extension_start == std::string::npos)
-                               ? ""
-                               : result.name.substr(extension_start + 1);
+    result.extension = (extension_start == std::string::npos)
+                           ? ""
+                           : result.name.substr(extension_start + 1);
 
     if(search_drive_letter && file_path[1] == ':' &&
        (file_path[2] == '\\' || file_path[2] == '/'))
@@ -143,17 +143,17 @@ std::string parseMap(const char **it,
     size_t opts_size = captureOpts.size();
     if(opts_size < 2)
     {
-        //TODO report error
+        // TODO report error
         return {};
     }
 
-    char tuples_separator  = captureOpts[0][0];
-    char values_separator  = captureOpts[1][0];
-    char map_finalizer     = endToken;
+    char tuples_separator = captureOpts[0][0];
+    char values_separator = captureOpts[1][0];
+    char map_finalizer = endToken;
     bool has_map_finalizer = false;
     if(opts_size > 2)
     {
-        map_finalizer     = captureOpts[2][0];
+        map_finalizer = captureOpts[2][0];
         has_map_finalizer = true;
     }
 
@@ -174,7 +174,7 @@ std::string parseMap(const char **it,
     auto &allocator = output_doc.GetAllocator();
 
     size_t tuple_start_pos = 0;
-    bool done              = false;
+    bool done = false;
     while(!done)
     {
         size_t separator_pos = map_str.find(values_separator, tuple_start_pos);
@@ -272,7 +272,7 @@ static bool parseFormattedTime(const char *fmt,
 
         if(fds.has_tod && fds.tod.in_conventional_range())
         {
-            ret.hour    = std::to_string(fds.tod.hours().count());
+            ret.hour = std::to_string(fds.tod.hours().count());
             ret.minutes = std::to_string(fds.tod.minutes().count());
             ret.seconds = std::to_string(fds.tod.seconds().count());
             auto subsec = fds.tod.subseconds().count();
@@ -323,7 +323,7 @@ bool parseTimeStamp(const char **it,
     if(!opts.empty())
     {
         bool ret = false;
-        auto it  = kTimeStampFormatMapper.find(opts[0]);
+        auto it = kTimeStampFormatMapper.find(opts[0]);
         if(it != kTimeStampFormatMapper.end())
         {
             ret = parseFormattedTime(it->second, tsStr, tsr);
@@ -492,7 +492,7 @@ bool parseDomain(const char **it,
                  DomainResult &result)
 {
     constexpr int DOMAIN_MAX_SIZE = 253;
-    constexpr int LABEL_MAX_SIZE  = 63;
+    constexpr int LABEL_MAX_SIZE = 63;
     const bool validate_FQDN =
         (!captureOpts.empty() && captureOpts[0] == "FQDN");
 
@@ -509,7 +509,7 @@ bool parseDomain(const char **it,
     if(std::string::npos != protocol_end)
     {
         result.protocol = str.substr(0, protocol_end);
-        domain_start    = protocol_end + 3;
+        domain_start = protocol_end + 3;
     }
     size_t domain_end = str.find("/", protocol_end + 3);
     // Domain
@@ -539,7 +539,7 @@ bool parseDomain(const char **it,
     // require to change the logic to avoid deleting the used labels.
     std::vector<std::string> labels;
     size_t start_label = 0;
-    size_t end_label   = 0;
+    size_t end_label = 0;
     while(end_label != std::string::npos)
     {
         end_label = result.domain.find('.', start_label);
@@ -639,10 +639,11 @@ bool parseUserAgent(const char **it, char endToken, UserAgentResult &ret)
 
     // NOTE: This will try to validate 'some' part of the user-agent standard as
     // is defined in https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.3
-    // it will accept as valid only user agents with the form of - token/token
+    // it will accept as valid only User agents with the form of - token/token
     // (comment) token/token - or - token/token token/token - Other ~valid~
-    // formats of user agents like:
-    //     - Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko
+    // formats of User agents like:
+    //     - Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like
+    //     Gecko
     //     - product1/version1 product2/version2 product3
     //     - product/version (comment, (nested comment))
     // are not considered valid because it would be impossible to differentiate
@@ -650,7 +651,7 @@ bool parseUserAgent(const char **it, char endToken, UserAgentResult &ret)
 
     bool done = false;
     UAState state = UAState::Product;
-    const char* lastValid = ev;
+    const char *lastValid = ev;
     while(!done)
     {
         switch(state)

--- a/src/engine/source/hlp/src/SpecificParsers.cpp
+++ b/src/engine/source/hlp/src/SpecificParsers.cpp
@@ -639,7 +639,7 @@ bool parseUserAgent(const char **it, char endToken, UserAgentResult &ret)
 
     // NOTE: This will try to validate 'some' part of the user-agent standard as
     // is defined in https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.3
-    // it will accept as valid only User agents with the form of - token/token
+    // It will accept as valid only User agents with the form of - token/token
     // (comment) token/token - or - token/token token/token - Other ~valid~
     // formats of User agents like:
     //     - Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like

--- a/src/engine/source/hlp/src/SpecificParsers.hpp
+++ b/src/engine/source/hlp/src/SpecificParsers.hpp
@@ -49,8 +49,6 @@ struct UserAgentResult
     std::string original;
 };
 
-bool parseFilePath(const char **it, char endToken);
-
 std::string parseAny(const char **it, char endToken);
 
 bool matchLiteral(const char **it, std::string const& literal);

--- a/src/engine/source/hlp/src/SpecificParsers.hpp
+++ b/src/engine/source/hlp/src/SpecificParsers.hpp
@@ -44,6 +44,13 @@ struct FilePathResult{
     std::string extension;      //"file.extension": "keyword",
 };
 
+struct UserAgentResult
+{
+    std::string original;
+};
+
+bool parseFilePath(const char **it, char endToken);
+
 std::string parseAny(const char **it, char endToken);
 
 bool matchLiteral(const char **it, std::string const& literal);
@@ -61,5 +68,7 @@ bool parseTimeStamp(const char **it, std::vector<std::string> const& opts, char 
 bool parseURL(const char **it, char endToken, URLResult &result);
 
 bool parseDomain(const char **it, char endToken, std::vector<std::string> const& captureOpts, DomainResult &result);
+
+bool parseUserAgent(const char** it, char endToken, UserAgentResult& ret);
 
 #endif //_FILE_PATH_PARSER_H

--- a/src/engine/source/hlp/src/hlp.cpp
+++ b/src/engine/source/hlp/src/hlp.cpp
@@ -137,6 +137,18 @@ static void executeParserList(std::string const &event, ParserList const &parser
                 result[parser.name + ".extension"] = std::move(filePathResult.extension);
                 break;
             }
+            case ParserType::UserAgent:
+            {
+                UserAgentResult userAgent;
+                if(parseUserAgent(&eventIt,
+                                  parser.endToken,
+                                  userAgent))
+                {
+                    result[parser.name + ".original"] =
+                        std::move(userAgent.original);
+                }
+                break;
+            }
             default: {
                 fprintf(stderr,
                         "Missing implementation for parser type: [%i]\n",

--- a/src/engine/source/hlp/src/hlpDetails.hpp
+++ b/src/engine/source/hlp/src/hlpDetails.hpp
@@ -19,6 +19,7 @@ enum class ParserType {
     Map,
     Domain,
     FilePath,
+    UserAgent,
     Invalid,
 };
 

--- a/src/engine/test/source/hlp/hlp_test.cpp
+++ b/src/engine/test/source/hlp/hlp_test.cpp
@@ -646,7 +646,7 @@ TEST(filepathParserTests, force_unix_format)
     ASSERT_EQ("txt", result["_file.extension"]);
 }
 
-TEST(userAgentTests, user_agent_firefox)
+TEST(hlpTests_UserAgent, user_agent_firefox)
 {
     const char *logQl     = "[<userAgent>] <_>";
     const char *userAgent = "[Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; "
@@ -660,7 +660,7 @@ TEST(userAgentTests, user_agent_firefox)
               "rv:42.0) Gecko/20100101 Firefox/42.0");
 }
 
-TEST(userAgentTests, user_agent_chrome)
+TEST(hlpTests_UserAgent, user_agent_chrome)
 {
     const char *logQl = "[<userAgent>] <_>";
     const char *userAgent =
@@ -675,7 +675,7 @@ TEST(userAgentTests, user_agent_chrome)
               "Gecko) Chrome/51.0.2704.103 Safari/537.36");
 }
 
-TEST(userAgentTests, user_agent_edge)
+TEST(hlpTests_UserAgent, user_agent_edge)
 {
     const char *logQl = "[<userAgent>] <_>";
     const char *userAgent =
@@ -692,7 +692,7 @@ TEST(userAgentTests, user_agent_edge)
         "like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.59");
 }
 
-TEST(userAgentTests, user_agent_opera)
+TEST(hlpTests_UserAgent, user_agent_opera)
 {
     const char *logQl = "[<userAgent>] <_>";
     const char *userAgent =
@@ -708,7 +708,7 @@ TEST(userAgentTests, user_agent_opera)
               "Gecko) Chrome/51.0.2704.106 Safari/537.36 OPR/38.0.2220.41");
 }
 
-TEST(userAgentTests, user_agent_safari)
+TEST(hlpTests_UserAgent, user_agent_safari)
 {
     const char *logQl = "[<userAgent>] <_>";
     const char *userAgent =

--- a/src/engine/test/source/hlp/hlp_test.cpp
+++ b/src/engine/test/source/hlp/hlp_test.cpp
@@ -3,83 +3,74 @@
 #include <hlp/hlp.hpp>
 
 static const char *logQl =
-    "<source.address> - <json> - [<timestamp/APACHE>] \"<http.request.method> <url> HTTP/<http.version>\" "
-    "<http.response.status_code> <http.response.body.bytes> \"-\" \"<user_agent.original>\"";
+    "<source.address> - <json> - [<timestamp/APACHE>] \"<http.request.method> "
+    "<url> HTTP/<http.version>\" "
+    "<http.response.status_code> <http.response.body.bytes> \"-\" "
+    "\"<user_agent.original>\"";
 static const char *event =
-    "monitoring-server - {\"data\":\"this is a json\"} - [29/May/2017:19:02:48 +0000] \"GET "
-    "https://user:password@wazuh.com:8080/status?query=%22a%20query%20with%20a%20space%22#fragment "
-    "HTTP/1.1\" 200 612 \"-\" \"Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 "
+    "monitoring-server - {\"data\":\"this is a json\"} - [29/May/2017:19:02:48 "
+    "+0000] \"GET "
+    "https://user:password@wazuh.com:8080/"
+    "status?query=%22a%20query%20with%20a%20space%22#fragment "
+    "HTTP/1.1\" 200 612 \"-\" \"Mozilla/5.0 (Windows NT 6.1; rv:15.0) "
+    "Gecko/20120716 "
     "Firefox/15.0a2\"";
 
-static const char *logQl2 = "<source.ip> - - [<timestamp/APACHE>] \"-\" "
-                            "<http.response.status_code> <http.response.body.bytes> \"-\" \"-\"";
-static const char *event2 = "127.0.0.1 - - [02/Feb/2019:05:38:45 +0100] \"-\" 408 152 \"-\" \"-\"";
+static const char *logQl2 =
+    "<source.ip> - - [<timestamp/APACHE>] \"-\" "
+    "<http.response.status_code> <http.response.body.bytes> \"-\" \"-\"";
+static const char *event2 =
+    "127.0.0.1 - - [02/Feb/2019:05:38:45 +0100] \"-\" 408 152 \"-\" \"-\"";
 
-// Test: An asset that fails the check against the schema
 TEST(hlpTests, general)
 {
     fprintf(stderr, "\n\n---HLP Test---\n");
 
     auto parseOp = getParserOp(logQl);
-    auto result = parseOp(event);
+    auto result  = parseOp(event);
     fprintf(stderr, "\n%30s | %s\n", "Key", "Val");
     fprintf(stderr, "-------------------------------|------------\n");
-    for (auto const &r : result) { fprintf(stderr, "%30s | %s\n", r.first.c_str(), r.second.c_str()); }
+    for(auto const &r : result)
+    {
+        fprintf(stderr, "%30s | %s\n", r.first.c_str(), r.second.c_str());
+    }
 
     auto parseOp2 = getParserOp(logQl2);
-    auto result2 = parseOp2(event2);
+    auto result2  = parseOp2(event2);
     fprintf(stderr, "\n%30s | %s\n", "Key", "Val");
     fprintf(stderr, "-------------------------------|------------\n");
-    for (auto const &r : result2) { fprintf(stderr, "%30s | %s\n", r.first.c_str(), r.second.c_str()); }
+    for(auto const &r : result2)
+    {
+        fprintf(stderr, "%30s | %s\n", r.first.c_str(), r.second.c_str());
+    }
 
     fprintf(stderr, "\n--------------\n\n");
-}
-
-// Test: parsing succesfully three different IP addresses
-TEST(hlpTests, IP_Parser)
-{
-    const char *logQl = "<source.ip> - <server.ip> -- <source.nat.ip> \"-\" \"-\"";
-    const char *event = "127.0.0.1 - 2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF -- 0:db8:0:4:CCCC:0:EEEE:FFFF \"-\" \"-\"";
-
-    fprintf(stderr, "\n\n---HLP IP parser Test---\n");
-
-    auto parseOp = getParserOp(logQl);
-    auto result = parseOp(event);
-    fprintf(stderr, "\n%30s | %s\n", "Key", "Val");
-    fprintf(stderr, "-------------------------------|------------\n");
-    for (auto const &r : result) { fprintf(stderr, "%30s | %s\n", r.first.c_str(), r.second.c_str()); }
-
-    fprintf(stderr, "\n--------------\n\n");
-
-    ASSERT_EQ("127.0.0.1", result["source.ip"]);
-    ASSERT_EQ("2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF", result["server.ip"]);
-    ASSERT_EQ("0:db8:0:4:CCCC:0:EEEE:FFFF", result["source.nat.ip"]);
 }
 
 TEST(hlpTests, invalid_logql)
 {
     const char *logQl = "<source.ip><invalid>";
-    auto invalidFunc = getParserOp(logQl);
+    auto invalidFunc  = getParserOp(logQl);
     ASSERT_EQ(false, static_cast<bool>(invalidFunc));
 
     const char *logQl2 = "invalid capture <source.ip><invalid> between strings";
-    auto invalidFunc2 = getParserOp(logQl2);
+    auto invalidFunc2  = getParserOp(logQl2);
     ASSERT_EQ(false, static_cast<bool>(invalidFunc2));
 
     const char *logQl3 = "invalid capture <source.ip between strings";
-    auto invalidFunc3 = getParserOp(logQl3);
+    auto invalidFunc3  = getParserOp(logQl3);
     ASSERT_EQ(false, static_cast<bool>(invalidFunc3));
 }
 
 TEST(hlpTests, optional_Or)
 {
-    static const char *logQl = "this won't match an url <url>?<source.ip> but will match ip";
-    static const char *event = "this won't match an url 127.0.0.1 but will match ip";
+    static const char *logQl =
+        "this won't match an url <url>?<source.ip> but will match ip";
+    static const char *event =
+        "this won't match an url 127.0.0.1 but will match ip";
 
     auto parseOp = getParserOp(logQl);
-    auto result = parseOp(event);
-
-    fprintf(stderr, "Matched: [%s]\n", result["source.ip"].c_str());
+    auto result  = parseOp(event);
 
     ASSERT_EQ("127.0.0.1", result["source.ip"]);
 }
@@ -90,22 +81,39 @@ TEST(hlpTests, options_parsing)
     static const char *event = "one temp temp1 temp2";
 
     auto parseOp = getParserOp(logQl);
-    auto result = parseOp(event);
+    auto result  = parseOp(event);
 
     ASSERT_EQ("temp", result["_temp"]);
     ASSERT_EQ("temp1", result["_temp1"]);
     ASSERT_EQ("temp2", result["_temp2"]);
 }
 
-TEST(hlpTests, url_parsing)
+// Test: parsing succesfully three different IP addresses
+TEST(ipParsingTests, IP_Parser)
 {
-    static const char *logQl = "this is an url <url> in text";
-    static const char *event = "this is an url "
-                               "https://user:password@wazuh.com:8080/"
-                               "path?query=%22a%20query%20with%20a%20space%22#fragment in text";
+    const char *logQl =
+        "<source.ip> - <server.ip> -- <source.nat.ip> \"-\" \"-\"";
+    const char *event = "127.0.0.1 - 2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF -- "
+                        "0:db8:0:4:CCCC:0:EEEE:FFFF \"-\" \"-\"";
 
     auto parseOp = getParserOp(logQl);
-    auto result = parseOp(event);
+    auto result  = parseOp(event);
+
+    ASSERT_EQ("127.0.0.1", result["source.ip"]);
+    ASSERT_EQ("2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF", result["server.ip"]);
+    ASSERT_EQ("0:db8:0:4:CCCC:0:EEEE:FFFF", result["source.nat.ip"]);
+}
+
+TEST(urlParsingTests, url_parsing)
+{
+    static const char *logQl = "this is an url <url> in text";
+    static const char *event =
+        "this is an url "
+        "https://user:password@wazuh.com:8080/"
+        "path?query=%22a%20query%20with%20a%20space%22#fragment in text";
+
+    auto parseOp = getParserOp(logQl);
+    auto result  = parseOp(event);
 
     std::string url = "https://user:password@wazuh.com:8080/"
                       "path?query=%22a%20query%20with%20a%20space%22#fragment";
@@ -120,61 +128,61 @@ TEST(hlpTests, url_parsing)
     ASSERT_EQ("user", result["url.username"]);
 }
 
-TEST(json_test, dummy_test)
+TEST(jsonParsingTests, dummy_test)
 {
     const char *logQl = "<_json1/JSON> - <_json2/JSON>";
-    const char *event = "{\"String\":\"This is a string\"} - {\"String\":\"This is another string\"}";
+    const char *event = "{\"String\":\"This is a string\"} - "
+                        "{\"String\":\"This is another string\"}";
 
     auto parseOp = getParserOp(logQl);
-    auto result = parseOp(event);
+    auto result  = parseOp(event);
 
     ASSERT_EQ("{\"String\":\"This is a string\"}", result["_json1"]);
     ASSERT_EQ("{\"String\":\"This is another string\"}", result["_json2"]);
 }
 
-TEST(map_test, success_test)
+TEST(mapParsingTests, success_test)
 {
-    const char *logQl ="<_map/MAP/ /=>-<_dummy>";
-    const char *event ="key1=Value1 Key2=Value2-dummy";
+    const char *logQl = "<_map/MAP/ /=>-<_dummy>";
+    const char *event = "key1=Value1 Key2=Value2-dummy";
 
     ParserFn parseOp = getParserOp(logQl);
-    auto result = parseOp(event);
-
+    auto result      = parseOp(event);
 
     ASSERT_EQ("{\"key1\":\"Value1\",\"Key2\":\"Value2\"}", result["_map"]);
     ASSERT_EQ("dummy", result["_dummy"]);
 }
 
-TEST(map_test, end_mark_test)
+TEST(mapParsingTests, end_mark_test)
 {
-    const char *logQl ="<_map/MAP/ /=/.> <_dummy>";
-    const char *event ="key1=Value1 Key2=Value2. dummy";
+    const char *logQl = "<_map/MAP/ /=/.> <_dummy>";
+    const char *event = "key1=Value1 Key2=Value2. dummy";
 
     ParserFn parseOp = getParserOp(logQl);
-    auto result = parseOp(event);
+    auto result      = parseOp(event);
 
     ASSERT_EQ("{\"key1\":\"Value1\",\"Key2\":\"Value2\"}", result["_map"]);
     ASSERT_EQ("dummy", result["_dummy"]);
 }
 
-TEST(map_test, incomplete_map_test)
+TEST(mapParsingTests, incomplete_map_test)
 {
-    const char *logQl ="<_map/MAP/ /=>";
-    const char *event1 ="key1=Value1 Key2=";
-    const char *event2 ="key1=Value1 Key2";
-    const char *event3 ="key1=Value1 =Value2";
+    const char *logQl  = "<_map/MAP/ /=>";
+    const char *event1 = "key1=Value1 Key2=";
+    const char *event2 = "key1=Value1 Key2";
+    const char *event3 = "key1=Value1 =Value2";
 
     ParserFn parseOp = getParserOp(logQl);
-    auto result1 = parseOp(event1);
-    auto result2 = parseOp(event2);
-    auto result3 = parseOp(event3);
+    auto result1     = parseOp(event1);
+    auto result2     = parseOp(event2);
+    auto result3     = parseOp(event3);
 
     ASSERT_TRUE(result1.empty());
     ASSERT_TRUE(result2.empty());
     ASSERT_TRUE(result3.empty());
 }
 
-TEST(hlpTimestampTests, ansic)
+TEST(timestampParsingTests, ansic)
 {
     static const char *logQl   = "[<timestamp/ANSIC>]";
     static const char *ansicTs = "[Mon Jan 2 15:04:05 2006]";
@@ -198,21 +206,23 @@ TEST(hlpTimestampTests, ansic)
     ASSERT_EQ("5.123456", resultMillis["timestamp.seconds"]);
 }
 
-TEST(hlpTimestampTests, kitchen)
+TEST(timestampParsingTests, kitchen)
 {
 
     static const char *logQl     = "[<timestamp/Kitchen>]";
     static const char *kitchenTs = "[3:04a.m.]";
-    auto parseOp                 = getParserOp(logQl);
-    auto result                  = parseOp(kitchenTs);
+
+    auto parseOp = getParserOp(logQl);
+    auto result  = parseOp(kitchenTs);
+
     ASSERT_EQ("3", result["timestamp.hour"]);
     ASSERT_EQ("4", result["timestamp.minutes"]);
 }
 
-TEST(hlpTimestampTests, rfc1123)
+TEST(timestampParsingTests, rfc1123)
 {
     static const char *logQl      = "[<timestamp/RFC1123>]";
-    static const char *logQlz      = "[<timestamp/RFC1123Z>]";
+    static const char *logQlz     = "[<timestamp/RFC1123Z>]";
     static const char *rfc1123Ts  = "[Mon, 02 Jan 2006 15:04:05 MST]";
     static const char *rfc1123zTs = "[Mon, 02 Jan 2006 15:04:05 -0700]";
 
@@ -226,7 +236,7 @@ TEST(hlpTimestampTests, rfc1123)
     ASSERT_EQ("5", result["timestamp.seconds"]);
 
     auto parseOpz = getParserOp(logQlz);
-    auto resultz = parseOpz(rfc1123zTs);
+    auto resultz  = parseOpz(rfc1123zTs);
     ASSERT_EQ("2006", resultz["timestamp.year"]);
     ASSERT_EQ("1", resultz["timestamp.month"]);
     ASSERT_EQ("2", resultz["timestamp.day"]);
@@ -235,7 +245,7 @@ TEST(hlpTimestampTests, rfc1123)
     ASSERT_EQ("5", resultz["timestamp.seconds"]);
 }
 
-TEST(hlpTimestampTests, rfc3339)
+TEST(timestampParsingTests, rfc3339)
 {
     static const char *logQl         = "[<timestamp/RFC3339>]";
     static const char *rfc3339Ts     = "[2006-01-02T15:04:05Z07:00]";
@@ -259,10 +269,10 @@ TEST(hlpTimestampTests, rfc3339)
     ASSERT_EQ("5.999999999", resultNano["timestamp.seconds"]);
 }
 
-TEST(hlpTimestampTests, rfc822)
+TEST(timestampParsingTests, rfc822)
 {
     static const char *logQl     = "[<timestamp/RFC822>]";
-    static const char *logQlz     = "[<timestamp/RFC822Z>]";
+    static const char *logQlz    = "[<timestamp/RFC822Z>]";
     static const char *rfc822Ts  = "[02 Jan 06 15:04 MST]";
     static const char *rfc822zTs = "[02 Jan 06 15:04 -0700]";
 
@@ -277,7 +287,7 @@ TEST(hlpTimestampTests, rfc822)
     ASSERT_EQ("MST", result["timestamp.timezone"]);
 
     auto parseOpz = getParserOp(logQlz);
-    auto resultz = parseOpz(rfc822zTs);
+    auto resultz  = parseOpz(rfc822zTs);
     ASSERT_EQ("2006", resultz["timestamp.year"]);
     ASSERT_EQ("1", resultz["timestamp.month"]);
     ASSERT_EQ("2", resultz["timestamp.day"]);
@@ -287,7 +297,7 @@ TEST(hlpTimestampTests, rfc822)
     ASSERT_EQ("-0700", resultz["timestamp.timezone"]);
 }
 
-TEST(hlpTimestampTests, rfc850)
+TEST(timestampParsingTests, rfc850)
 {
     static const char *logQl    = "[<timestamp/RFC850>]";
     static const char *rfc850Ts = "[Monday, 02-Jan-06 15:04:05 MST]";
@@ -303,7 +313,7 @@ TEST(hlpTimestampTests, rfc850)
     ASSERT_EQ("MST", result["timestamp.timezone"]);
 }
 
-TEST(hlpTimestampTests, ruby)
+TEST(timestampParsingTests, ruby)
 {
     static const char *logQl  = "[<timestamp/RubyDate>]";
     static const char *rubyTs = "[Mon Jan 02 15:04:05 -0700 2006]";
@@ -319,7 +329,7 @@ TEST(hlpTimestampTests, ruby)
     ASSERT_EQ("-0700", result["timestamp.timezone"]);
 }
 
-TEST(hlpTimestampTests, stamp)
+TEST(timestampParsingTests, stamp)
 {
     static const char *logQl        = "[<timestamp/Stamp>]";
     static const char *stampTs      = "[Jan 2 15:04:05]";
@@ -357,7 +367,7 @@ TEST(hlpTimestampTests, stamp)
     ASSERT_EQ("5", resultNanos["timestamp.seconds"]);
 }
 
-TEST(hlpTimestampTests, Unix)
+TEST(timestampParsingTests, Unix)
 {
     static const char *logQl  = "[<timestamp/UnixDate>]";
     static const char *unixTs = "[Mon Jan 2 15:04:05 MST 2006]";
@@ -372,18 +382,16 @@ TEST(hlpTimestampTests, Unix)
     ASSERT_EQ("5", result["timestamp.seconds"]);
 }
 
-TEST(hlpTimestampTests, specific_format)
+TEST(timestampParsingTests, specific_format)
 {
-    static const char *logQl =
-        "[<timestamp>] - "
-        "[<_ansicTs/timestamp>] - "
-        "[<_unixTs/timestamp>] - "
-        "[<_stampTs/timestamp>]";
-    static const char *event =
-        "[Mon Jan 02 15:04:05 -0700 2006] - "
-        "[Mon Jan 2 15:04:05 2006] - "
-        "[Mon Jan 2 15:04:05 MST 2006] - "
-        "[Jan 2 15:04:05]";
+    static const char *logQl = "[<timestamp>] - "
+                               "[<_ansicTs/timestamp>] - "
+                               "[<_unixTs/timestamp>] - "
+                               "[<_stampTs/timestamp>]";
+    static const char *event = "[Mon Jan 02 15:04:05 -0700 2006] - "
+                               "[Mon Jan 2 15:04:05 2006] - "
+                               "[Mon Jan 2 15:04:05 MST 2006] - "
+                               "[Jan 2 15:04:05]";
 
     auto parseOp = getParserOp(logQl);
     auto result  = parseOp(event);
@@ -417,101 +425,102 @@ TEST(hlpTimestampTests, specific_format)
     ASSERT_EQ("5", result["_stampTs.seconds"]);
 }
 
-TEST(domain_test, success)
+TEST(domainParserTests, success)
 {
-    const char *logQl ="<_my_domain/domain>";
-    ParserFn parseOp = getParserOp(logQl);
+    const char *logQl = "<_my_domain/domain>";
+    ParserFn parseOp  = getParserOp(logQl);
     ParseResult result;
 
     // Single TLD
-    const char *event1 ="www.wazuh.com";
-    result = parseOp(event1);
+    const char *event1 = "www.wazuh.com";
+    result             = parseOp(event1);
     ASSERT_EQ("www", result["_my_domain.subdomain"]);
     ASSERT_EQ("wazuh.com", result["_my_domain.registered_domain"]);
     ASSERT_EQ("com", result["_my_domain.top_level_domain"]);
 
     // Dual TLD
-    const char *event2 ="www.wazuh.com.ar";
-    result = parseOp(event2);
+    const char *event2 = "www.wazuh.com.ar";
+    result             = parseOp(event2);
     ASSERT_EQ("www", result["_my_domain.subdomain"]);
     ASSERT_EQ("wazuh.com.ar", result["_my_domain.registered_domain"]);
     ASSERT_EQ("com.ar", result["_my_domain.top_level_domain"]);
 
     // Multiple subdomains
-    const char *event3 ="www.subdomain1.wazuh.com.ar";
-    result = parseOp(event3);
+    const char *event3 = "www.subdomain1.wazuh.com.ar";
+    result             = parseOp(event3);
     ASSERT_EQ("www.subdomain1", result["_my_domain.subdomain"]);
     ASSERT_EQ("wazuh.com.ar", result["_my_domain.registered_domain"]);
     ASSERT_EQ("com.ar", result["_my_domain.top_level_domain"]);
 
     // No subdomains
-    const char *event4 ="wazuh.com.ar";
-    result = parseOp(event4);
+    const char *event4 = "wazuh.com.ar";
+    result             = parseOp(event4);
     ASSERT_EQ("", result["_my_domain.subdomain"]);
     ASSERT_EQ("wazuh.com.ar", result["_my_domain.registered_domain"]);
     ASSERT_EQ("com.ar", result["_my_domain.top_level_domain"]);
 
     // No TLD
-    const char *event5 ="www.wazuh";
-    result = parseOp(event5);
+    const char *event5 = "www.wazuh";
+    result             = parseOp(event5);
     ASSERT_EQ("www", result["_my_domain.subdomain"]);
     ASSERT_EQ("wazuh", result["_my_domain.registered_domain"]);
     ASSERT_EQ("", result["_my_domain.top_level_domain"]);
 
     // Only Host
-    const char *event6 ="wazuh";
-    result = parseOp(event6);
+    const char *event6 = "wazuh";
+    result             = parseOp(event6);
     ASSERT_EQ("", result["_my_domain.subdomain"]);
     ASSERT_EQ("wazuh", result["_my_domain.registered_domain"]);
     ASSERT_EQ("", result["_my_domain.top_level_domain"]);
 }
 
-TEST(domain_test, FQDN_validation)
+TEST(domainParserTests, FQDN_validation)
 {
-    const char *logQl ="<_my_domain/domain/FQDN>";
-    ParserFn parseOp = getParserOp(logQl);
+    const char *logQl = "<_my_domain/domain/FQDN>";
+    ParserFn parseOp  = getParserOp(logQl);
     ParseResult result;
 
     // Single TLD
-    const char *event1 ="www.wazuh.com";
-    result = parseOp(event1);
+    const char *event1 = "www.wazuh.com";
+    result             = parseOp(event1);
     ASSERT_EQ("www", result["_my_domain.subdomain"]);
     ASSERT_EQ("wazuh.com", result["_my_domain.registered_domain"]);
     ASSERT_EQ("com", result["_my_domain.top_level_domain"]);
 
     // No subdomains
-    const char *event2 ="wazuh.com";
-    result = parseOp(event2);
+    const char *event2 = "wazuh.com";
+    result             = parseOp(event2);
     ASSERT_TRUE(result.empty());
 
     // No TLD
-    const char *event3 ="www.wazuh";
-    result = parseOp(event3);
+    const char *event3 = "www.wazuh";
+    result             = parseOp(event3);
     ASSERT_TRUE(result.empty());
 
     // Only Host
-    const char *event4 ="wazuh";
-    result = parseOp(event4);
+    const char *event4 = "wazuh";
+    result             = parseOp(event4);
     ASSERT_TRUE(result.empty());
 }
 
-TEST(domain_test, host_route)
+TEST(domainParserTests, host_route)
 {
-    const char *logQl ="<_my_domain/domain>";
-    ParserFn parseOp = getParserOp(logQl);
+    const char *logQl = "<_my_domain/domain>";
+    ParserFn parseOp  = getParserOp(logQl);
 
-    const char *event1 ="ftp://www.wazuh.com/route.txt";
-    auto result = parseOp(event1);
-    // TODO protocol and route aren´t part of the result. We only extract it from the event
+    const char *event1 = "ftp://www.wazuh.com/route.txt";
+    auto result        = parseOp(event1);
+    // TODO protocol and route aren´t part of the result. We only extract it
+    // from the event
     ASSERT_EQ("www", result["_my_domain.subdomain"]);
     ASSERT_EQ("wazuh.com", result["_my_domain.registered_domain"]);
     ASSERT_EQ("com", result["_my_domain.top_level_domain"]);
 }
 
-TEST(domain_test, valid_content)
+TEST(domainParserTests, valid_content)
 {
-    const char *logQl ="<_my_domain/domain>";
-    ParserFn parseOp = getParserOp(logQl);
+    const char *logQl = "<_my_domain/domain>";
+    ParserFn parseOp  = getParserOp(logQl);
     ParseResult result;
 
     std::string big_domain(254, 'w');
@@ -519,23 +528,23 @@ TEST(domain_test, valid_content)
     ASSERT_TRUE(result.empty());
 
     const char *invalid_character_domain = "www.wazuh?.com";
-    result = parseOp(invalid_character_domain);
+    result                               = parseOp(invalid_character_domain);
     ASSERT_TRUE(result.empty());
 
     std::string invalid_label(64, 'w');
     std::string invalid_label_domain = "www." + invalid_label + ".com";
-    result = parseOp(invalid_label_domain);
+    result                           = parseOp(invalid_label_domain);
     ASSERT_TRUE(result.empty());
 }
 
-TEST(filepath_test, windows_path)
+TEST(filepathParserTests, windows_path)
 {
-    const char *logQl ="<_file/FilePath>";
-    ParserFn parseOp = getParserOp(logQl);
+    const char *logQl = "<_file/FilePath>";
+    ParserFn parseOp  = getParserOp(logQl);
     ParseResult result;
 
     const char *full_path = "C:\\Users\\Name\\Desktop\\test.txt";
-    result = parseOp(full_path);
+    result                = parseOp(full_path);
     ASSERT_EQ("C:\\Users\\Name\\Desktop\\test.txt", result["_file.path"]);
     ASSERT_EQ("C", result["_file.drive_letter"]);
     ASSERT_EQ("C:\\Users\\Name\\Desktop", result["_file.folder"]);
@@ -543,7 +552,7 @@ TEST(filepath_test, windows_path)
     ASSERT_EQ("txt", result["_file.extension"]);
 
     const char *relative_path = "Desktop\\test.txt";
-    result = parseOp(relative_path);
+    result                    = parseOp(relative_path);
     ASSERT_EQ("Desktop\\test.txt", result["_file.path"]);
     ASSERT_EQ("", result["_file.drive_letter"]);
     ASSERT_EQ("Desktop", result["_file.folder"]);
@@ -551,7 +560,7 @@ TEST(filepath_test, windows_path)
     ASSERT_EQ("txt", result["_file.extension"]);
 
     const char *file_without_ext = "Desktop\\test";
-    result = parseOp(file_without_ext);
+    result                       = parseOp(file_without_ext);
     ASSERT_EQ("Desktop\\test", result["_file.path"]);
     ASSERT_EQ("", result["_file.drive_letter"]);
     ASSERT_EQ("Desktop", result["_file.folder"]);
@@ -559,7 +568,7 @@ TEST(filepath_test, windows_path)
     ASSERT_EQ("", result["_file.extension"]);
 
     const char *only_file = "test.txt";
-    result = parseOp(only_file);
+    result                = parseOp(only_file);
     ASSERT_EQ("test.txt", result["_file.path"]);
     ASSERT_EQ("", result["_file.drive_letter"]);
     ASSERT_EQ("", result["_file.folder"]);
@@ -567,7 +576,7 @@ TEST(filepath_test, windows_path)
     ASSERT_EQ("txt", result["_file.extension"]);
 
     const char *folder_path = "C:\\Users\\Name\\Desktop\\";
-    result = parseOp(folder_path);
+    result                  = parseOp(folder_path);
     ASSERT_EQ("C:\\Users\\Name\\Desktop\\", result["_file.path"]);
     ASSERT_EQ("C", result["_file.drive_letter"]);
     ASSERT_EQ("C:\\Users\\Name\\Desktop", result["_file.folder"]);
@@ -575,7 +584,7 @@ TEST(filepath_test, windows_path)
     ASSERT_EQ("", result["_file.extension"]);
 
     const char *lower_case_drive = "c:\\test.txt";
-    result = parseOp(lower_case_drive);
+    result                       = parseOp(lower_case_drive);
     ASSERT_EQ("c:\\test.txt", result["_file.path"]);
     ASSERT_EQ("C", result["_file.drive_letter"]);
     ASSERT_EQ("c:", result["_file.folder"]);
@@ -583,14 +592,14 @@ TEST(filepath_test, windows_path)
     ASSERT_EQ("txt", result["_file.extension"]);
 }
 
-TEST(filepath_test, unix_path)
+TEST(filepathParserTests, unix_path)
 {
-    const char *logQl ="<_file/FilePath>";
-    ParserFn parseOp = getParserOp(logQl);
+    const char *logQl = "<_file/FilePath>";
+    ParserFn parseOp  = getParserOp(logQl);
     ParseResult result;
 
     const char *full_path = "/Desktop/test.txt";
-    result = parseOp(full_path);
+    result                = parseOp(full_path);
     ASSERT_EQ("/Desktop/test.txt", result["_file.path"]);
     ASSERT_EQ("", result["_file.drive_letter"]);
     ASSERT_EQ("/Desktop", result["_file.folder"]);
@@ -598,7 +607,7 @@ TEST(filepath_test, unix_path)
     ASSERT_EQ("txt", result["_file.extension"]);
 
     const char *relative_path = "Desktop/test.txt";
-    result = parseOp(relative_path);
+    result                    = parseOp(relative_path);
     ASSERT_EQ("Desktop/test.txt", result["_file.path"]);
     ASSERT_EQ("", result["_file.drive_letter"]);
     ASSERT_EQ("Desktop", result["_file.folder"]);
@@ -606,7 +615,7 @@ TEST(filepath_test, unix_path)
     ASSERT_EQ("txt", result["_file.extension"]);
 
     const char *folder_path = "/Desktop/";
-    result = parseOp(folder_path);
+    result                  = parseOp(folder_path);
     ASSERT_EQ("/Desktop/", result["_file.path"]);
     ASSERT_EQ("", result["_file.drive_letter"]);
     ASSERT_EQ("/Desktop", result["_file.folder"]);
@@ -614,10 +623,10 @@ TEST(filepath_test, unix_path)
     ASSERT_EQ("", result["_file.extension"]);
 }
 
-TEST(filepath_test, force_unix_format)
+TEST(filepathParserTests, force_unix_format)
 {
-    const char *logQl ="<_file/FilePath/UNIX>";
-    ParserFn parseOp = getParserOp(logQl);
+    const char *logQl = "<_file/FilePath/UNIX>";
+    ParserFn parseOp  = getParserOp(logQl);
     ParseResult result;
 
     const char *drive_like_file = "C:\\_test.txt";
@@ -635,4 +644,83 @@ TEST(filepath_test, force_unix_format)
     ASSERT_EQ("/Desktop", result["_file.folder"]);
     ASSERT_EQ("test\\1:2.txt", result["_file.name"]);
     ASSERT_EQ("txt", result["_file.extension"]);
+}
+
+TEST(userAgentTests, user_agent_firefox)
+{
+    const char *logQl     = "[<userAgent>] <_>";
+    const char *userAgent = "[Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; "
+                            "rv:42.0) Gecko/20100101 Firefox/42.0] the rest of the log";
+
+    ParserFn parseOp = getParserOp(logQl);
+    auto result      = parseOp(userAgent);
+
+    ASSERT_EQ(result["userAgent.original"],
+              "Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; "
+              "rv:42.0) Gecko/20100101 Firefox/42.0");
+}
+
+TEST(userAgentTests, user_agent_chrome)
+{
+    const char *logQl = "[<userAgent>] <_>";
+    const char *userAgent =
+        "[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like "
+        "Gecko) Chrome/51.0.2704.103 Safari/537.36] the rest of the log";
+
+    ParserFn parseOp     = getParserOp(logQl);
+    auto result          = parseOp(userAgent);
+
+    ASSERT_EQ(result["userAgent.original"],
+              "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like "
+              "Gecko) Chrome/51.0.2704.103 Safari/537.36");
+}
+
+TEST(userAgentTests, user_agent_edge)
+{
+    const char *logQl = "[<userAgent>] <_>";
+    const char *userAgent =
+        "[Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, "
+        "like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.59] the "
+        "rest of the log";
+
+    ParserFn parseOp = getParserOp(logQl);
+    auto result      = parseOp(userAgent);
+
+    ASSERT_EQ(
+        result["userAgent.original"],
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, "
+        "like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.59");
+}
+
+TEST(userAgentTests, user_agent_opera)
+{
+    const char *logQl = "[<userAgent>] <_>";
+    const char *userAgent =
+        "[Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like "
+        "Gecko) Chrome/51.0.2704.106 Safari/537.36 OPR/38.0.2220.41] the rest "
+        "of the log";
+
+    ParserFn parseOp     = getParserOp(logQl);
+    auto result          = parseOp(userAgent);
+
+    ASSERT_EQ(result["userAgent.original"],
+              "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like "
+              "Gecko) Chrome/51.0.2704.106 Safari/537.36 OPR/38.0.2220.41");
+}
+
+TEST(userAgentTests, user_agent_safari)
+{
+    const char *logQl = "[<userAgent>] <_>";
+    const char *userAgent =
+        "[Mozilla/5.0 (iPhone; CPU iPhone OS 13_5_1 like Mac OS X) "
+        "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Mobile/15E148 "
+        "Safari/604.1] the rest of the log";
+
+    ParserFn parseOp     = getParserOp(logQl);
+    auto result          = parseOp(userAgent);
+
+    ASSERT_EQ(result["userAgent.original"],
+              "Mozilla/5.0 (iPhone; CPU iPhone OS 13_5_1 like Mac OS X) "
+              "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 "
+              "Mobile/15E148 Safari/604.1");
 }


### PR DESCRIPTION
|Related issue|
|---|
|#12176|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Adding basic validation and identification of the User Agent string. This not includes the extraction of any information of the string but only recognizes the whole User agent string.

We tried using the library https://github.com/ua-parser/uap-cpp based on https://github.com/ua-parser/uap-core (which is the most widely used 'library' for parsing User Agent strings on all languages) and we could not make it work as there were two main issues:
- First, the library does not compile out of the box currently, and it hasn't had any commits in over a year (this is because all this 'libraries' are mostly intended to be a reference implementation of how to use the uap-core)
- The library does not work well with our package manager as it relies on the dependencies having 'good' make files (you can see that in the '[limitations](https://github.com/cpm-cmake/CPM.cmake#limitations)' section of the docs) and this uap library have some colliding targets with other libraries (rxcpp for example) that cannot be configured out, so the build breaks.

Also, this implementation follows the existing POC python implementation of the engine and  has the same limitations on what it considers to be a valid User agent string, and does not cover the entire RFC, because for example. the product without a version referenced there does not differ from a string literal so it would be impossible to separate that correctly from the rest of the log. Same limitations come from the 'endToken' identification and others not mentioned here. Some of this limitations are reflected in a comment on the code itself