### PR TITLE
Add reparse option to CloudWatchLogs and GCP

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2617,7 +2617,7 @@ class AWSService(WazuhIntegration):
         # reparse
         self.reparse = reparse
 
-        WazuhIntegration.__init__(self, reparse=reparse, access_key=access_key, secret_key=secret_key,
+        WazuhIntegration.__init__(self, access_key=access_key, secret_key=secret_key,
                                   aws_profile=aws_profile, iam_role_arn=iam_role_arn,
                                   service_name=service_name, region=region, discard_field=discard_field,
                                   discard_regex=discard_regex, sts_endpoint=sts_endpoint,

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2617,7 +2617,7 @@ class AWSService(WazuhIntegration):
         # reparse
         self.reparse = reparse
 
-        WazuhIntegration.__init__(self, access_key=access_key, secret_key=secret_key,
+        WazuhIntegration.__init__(self, reparse=reparse, access_key=access_key, secret_key=secret_key,
                                   aws_profile=aws_profile, iam_role_arn=iam_role_arn,
                                   service_name=service_name, region=region, discard_field=discard_field,
                                   discard_regex=discard_regex, sts_endpoint=sts_endpoint,
@@ -2737,7 +2737,7 @@ class AWSInspector(AWSService):
         self.service_name = 'inspector'
         self.inspector_region = region
 
-        AWSService.__init__(self, access_key=access_key, secret_key=secret_key,
+        AWSService.__init__(self, reparse=reparse, access_key=access_key, secret_key=secret_key,
                             aws_profile=aws_profile, iam_role_arn=iam_role_arn, only_logs_after=only_logs_after,
                             service_name=self.service_name, region=region, aws_log_groups=aws_log_groups,
                             remove_log_streams=remove_log_streams, discard_field=discard_field,
@@ -2949,7 +2949,7 @@ class AWSCloudWatchLogs(AWSService):
                                 aws_log_group='{aws_log_group}' AND
                                 aws_log_stream='{aws_log_stream}';"""
 
-        AWSService.__init__(self, reparse, access_key=access_key, secret_key=secret_key,
+        AWSService.__init__(self, reparse=reparse, access_key=access_key, secret_key=secret_key,
                             aws_profile=aws_profile, iam_role_arn=iam_role_arn, only_logs_after=only_logs_after,
                             region=region, aws_log_groups=aws_log_groups, remove_log_streams=remove_log_streams,
                             service_name='cloudwatchlogs', discard_field=discard_field, discard_regex=discard_regex,

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2614,7 +2614,6 @@ class AWSService(WazuhIntegration):
         self.db_name = 'aws_services'
         # table name
         self.db_table_name = 'aws_services'
-        # reparse
         self.reparse = reparse
 
         WazuhIntegration.__init__(self, access_key=access_key, secret_key=secret_key,
@@ -2980,6 +2979,9 @@ class AWSCloudWatchLogs(AWSService):
         """
         self.init_db(self.sql_cloudwatch_create_table.format(table_name=self.db_table_name))
 
+        if self.reparse:
+            debug('Reparse mode ON', 1)
+
         try:
             for log_group in self.log_group_list:
                 for log_stream in self.get_log_streams(log_group=log_group):
@@ -2996,7 +2998,6 @@ class AWSCloudWatchLogs(AWSService):
 
                     if db_values:
                         if self.reparse: 
-                            debug('Reparse mode ON', 1)
                             result_before = self.get_alerts_within_range(log_group=log_group, log_stream=log_stream,
                                                                          token=None, start_time=start_time, 
                                                                          end_time=None)

--- a/wodles/gcloud/buckets/access_logs.py
+++ b/wodles/gcloud/buckets/access_logs.py
@@ -17,11 +17,13 @@ from bucket import WazuhGCloudBucket
 
 class GCSAccessLogs(WazuhGCloudBucket):
     """Class for getting Google Cloud Storage Access Logs logs"""
-    def __init__(self, credentials_file: str, logger: logging.Logger, **kwargs):
+    def __init__(self, reparse, credentials_file: str, logger: logging.Logger, **kwargs):
         """Class constructor.
 
         Parameters
         ----------
+        reparse : bool
+            Whether to parse already parsed logs or not.
         credentials_file : str
             Path to credentials file.
         logger : logging.Logger
@@ -30,7 +32,7 @@ class GCSAccessLogs(WazuhGCloudBucket):
             Additional named arguments for WazuhGCloudBucket.
         """
         self.db_table_name = "access_logs"
-        super().__init__(credentials_file, logger, **kwargs)
+        super().__init__(reparse, credentials_file, logger, **kwargs)
 
     def load_information_from_file(self, msg: str):
         """Load the contents of an Access Logs blob and process them.

--- a/wodles/gcloud/buckets/access_logs.py
+++ b/wodles/gcloud/buckets/access_logs.py
@@ -17,13 +17,11 @@ from bucket import WazuhGCloudBucket
 
 class GCSAccessLogs(WazuhGCloudBucket):
     """Class for getting Google Cloud Storage Access Logs logs"""
-    def __init__(self, reparse, credentials_file: str, logger: logging.Logger, **kwargs):
+    def __init__(self, credentials_file: str, logger: logging.Logger, **kwargs):
         """Class constructor.
 
         Parameters
         ----------
-        reparse : bool
-            Whether to parse already parsed logs or not.
         credentials_file : str
             Path to credentials file.
         logger : logging.Logger
@@ -32,7 +30,7 @@ class GCSAccessLogs(WazuhGCloudBucket):
             Additional named arguments for WazuhGCloudBucket.
         """
         self.db_table_name = "access_logs"
-        super().__init__(reparse, credentials_file, logger, **kwargs)
+        super().__init__(credentials_file, logger, **kwargs)
 
     def load_information_from_file(self, msg: str):
         """Load the contents of an Access Logs blob and process them.

--- a/wodles/gcloud/buckets/bucket.py
+++ b/wodles/gcloud/buckets/bucket.py
@@ -29,14 +29,12 @@ from integration import WazuhGCloudIntegration
 class WazuhGCloudBucket(WazuhGCloudIntegration):
     """Class for getting Google Cloud Storage Bucket logs"""
 
-    def __init__(self, reparse, credentials_file: str, logger: logging.Logger, bucket_name: str, prefix: str = None,
-                 delete_file: bool = False, only_logs_after: datetime = None):
+    def __init__(self, credentials_file: str, logger: logging.Logger, bucket_name: str, prefix: str = None,
+            delete_file: bool = False, only_logs_after: datetime = None, reparse : bool = False):
         """Class constructor.
 
         Parameters
         ----------
-        reparse : bool 
-            Whether to parse already parsed logs or not.
         credentials_file : str
             Path to credentials file.
         logger : logging.Logger
@@ -49,11 +47,12 @@ class WazuhGCloudBucket(WazuhGCloudIntegration):
             Indicate whether blobs should be deleted after being processed.
         only_logs_after : datetime
             Date after which obtain logs.
+        reparse : bool
+            Whether to parse already parsed logs or not
         """
         super().__init__(logger)
         self.bucket_name = bucket_name
         self.bucket = None
-        self.reparse = reparse
         self.client = storage.client.Client.from_service_account_json(credentials_file)
         self.project_id = self.client.project
         self.prefix = prefix if not prefix or prefix[-1] == '/' else f'{prefix}/'
@@ -63,6 +62,7 @@ class WazuhGCloudBucket(WazuhGCloudIntegration):
         self.db_path = join(utils.find_wazuh_path(), "wodles/gcloud/gcloud.db")
         self.db_connector = None
         self.datetime_format = "%Y-%m-%d %H:%M:%S.%f%z"
+        self.reparse = reparse
 
         self.sql_create_table = """
                             CREATE TABLE

--- a/wodles/gcloud/buckets/bucket.py
+++ b/wodles/gcloud/buckets/bucket.py
@@ -253,9 +253,11 @@ class WazuhGCloudBucket(WazuhGCloudIntegration):
                         processed_files.append(blob)
 
                     elif self.reparse:
-                        self.logger.info(f'File previously processed, but reparse flag set: {blob.name}')
                         processed_messages += self.process_blob(blob)
                         processed_files.append(blob)
+
+                    else: 
+                        self.logger.info(f'Skipping previously processed file: {blob.name}')
 
                 else:
                     self.logger.info(f'The creation time of {blob.name} is older than {comparison_date}. '

--- a/wodles/gcloud/buckets/bucket.py
+++ b/wodles/gcloud/buckets/bucket.py
@@ -229,6 +229,9 @@ class WazuhGCloudBucket(WazuhGCloudIntegration):
             last_creation_time = self._get_last_creation_time()
             previous_processed_files = self._get_last_processed_files()
 
+            if self.reparse:
+                self.logger.info('Reparse Mode ON')
+
             for blob in bucket_contents:
                 # Skip folders
                 if blob.name.endswith('/'):
@@ -254,8 +257,6 @@ class WazuhGCloudBucket(WazuhGCloudIntegration):
                         processed_messages += self.process_blob(blob)
                         processed_files.append(blob)
 
-                    else:
-                        self.logger.info(f'Skipping previously processed file: {blob.name}')
                 else:
                     self.logger.info(f'The creation time of {blob.name} is older than {comparison_date}. '
                                      f'Skipping it...')

--- a/wodles/gcloud/gcloud.py
+++ b/wodles/gcloud/gcloud.py
@@ -82,7 +82,7 @@ try:
                     "prefix": arguments.prefix,
                     "delete_file": arguments.delete_file,
                     "only_logs_after": arguments.only_logs_after}
-        integration = GCSAccessLogs(arguments.credentials_file, logger, **f_kwargs)
+        integration = GCSAccessLogs(arguments.reparse, arguments.credentials_file, logger, **f_kwargs)
         integration.check_permissions()
         num_processed_messages = integration.process_data()
 

--- a/wodles/gcloud/gcloud.py
+++ b/wodles/gcloud/gcloud.py
@@ -81,8 +81,9 @@ try:
         f_kwargs = {"bucket_name": arguments.bucket_name,
                     "prefix": arguments.prefix,
                     "delete_file": arguments.delete_file,
-                    "only_logs_after": arguments.only_logs_after}
-        integration = GCSAccessLogs(arguments.reparse, arguments.credentials_file, logger, **f_kwargs)
+                    "only_logs_after": arguments.only_logs_after,
+                    "reparse": arguments.reparse}
+        integration = GCSAccessLogs(arguments.credentials_file, logger, **f_kwargs)
         integration.check_permissions()
         num_processed_messages = integration.process_data()
 

--- a/wodles/gcloud/tools.py
+++ b/wodles/gcloud/tools.py
@@ -74,6 +74,9 @@ def get_script_arguments():
 
     parser.add_argument('-t', '--num_threads', dest='n_threads', type=int,
                         help='Number of threads', required=False, default=min_num_threads)
+    
+    parser.add_argument('--reparse', action='store_true', dest='reparse', 
+                        help='Parse the log, even if its been parsed before', default=False)
 
     return parser.parse_args()
 


### PR DESCRIPTION
| Related issue |
|---|
|Closes #10663 |

# Description

In this PR we have added the option of reparsing the logs to Azure Storage, Google Cloud Storage, and CloudWatch Logs integrations.  This allows these services to parse older logs.

# Tests performed 

Here are some examples where we can check that including the `--reparse` option the logs are processed again

## Azure
### Graphs API
<details><summary> Command used and output </summary>

	./azure-logs --graph --graph_query 'auditLogs/directoryAudits' --graph_auth_path credentials_graph.txt --graph_tenant_domain wazuh.onmicrosoft.com --graph_time_offset 3d -v
	02/25/2022 10:53:01 AM INFO: AZURE Getting the data from /var/ossec/wodles/azure/last_dates.json.
	02/25/2022 10:53:01 AM INFO: AZURE Azure Graph starting.
	02/25/2022 10:53:01 AM INFO: AZURE Graph: Getting authentication token.
	02/25/2022 10:53:01 AM DEBUG: AZURE Starting new HTTPS connection (1): login.microsoftonline.com:443
	02/25/2022 10:53:02 AM DEBUG: AZURE https://login.microsoftonline.com:443 "POST /wazuh.onmicrosoft.com/oauth2/v2.0/token HTTP/1.1" 200 1901
	02/25/2022 10:53:02 AM INFO: AZURE Graph: Building the url.
	02/25/2022 10:53:02 AM INFO: AZURE 5956825a2e7b02dbebce74ec3c2ac5a5 was not found in /var/ossec/wodles/azure/last_dates.json for graph
	02/25/2022 10:53:02 AM INFO: AZURE Graph: The search starts for query: 'auditLogs/directoryAudits' using activityDateTime+ge+2022-02-26T20:53:02.102134Z
	02/25/2022 10:53:02 AM INFO: AZURE Graph: The URL is 'https://graph.microsoft.com/v1.0/auditLogs/directoryAudits?&$filter=activityDateTime+ge+2022-02-26T20:53:02.102134Z'
	02/25/2022 10:53:02 AM INFO: AZURE Graph: Pagination starts
	02/25/2022 10:53:02 AM DEBUG: AZURE Starting new HTTPS connection (1): graph.microsoft.com:443
	02/25/2022 10:53:02 AM DEBUG: AZURE https://graph.microsoft.com:443 "GET /v1.0/auditLogs/directoryAudits?&$filter=activityDateTime+ge+2022-02-26T20:53:02.102134Z HTTP/1.1" 200 None
	02/25/2022 10:53:02 AM INFO: AZURE Graph: Sending event by socket.
	02/25/2022 10:53:02 AM INFO: AZURE Graph: Sending event by socket.
	02/25/2022 10:53:02 AM INFO: AZURE Graph: Sending event by socket.
	02/25/2022 10:53:02 AM INFO: AZURE Graph: Sending event by socket.
	02/25/2022 10:53:02 AM INFO: AZURE Graph: Sending event by socket.
	02/25/2022 10:53:02 AM INFO: AZURE Graph: Sending event by socket.
	02/25/2022 10:53:02 AM INFO: AZURE Updating /var/ossec/wodles/azure/last_dates.json file.
	02/25/2022 10:53:02 AM INFO: AZURE Graph: End

</details>

<details><summary> Using reparse option </summary>

	./azure-logs --graph --graph_query 'auditLogs/directoryAudits' --graph_auth_path credentials_graph.txt --graph_tenant_domain wazuh.onmicrosoft.com --graph_time_offset 3d -v --reparse
	02/25/2022 10:55:47 AM INFO: AZURE Getting the data from /var/ossec/wodles/azure/last_dates.json.
	02/25/2022 10:55:47 AM INFO: AZURE Azure Graph starting.
	02/25/2022 10:55:47 AM INFO: AZURE Graph: Getting authentication token.
	02/25/2022 10:55:47 AM DEBUG: AZURE Starting new HTTPS connection (1): login.microsoftonline.com:443
	02/25/2022 10:55:48 AM DEBUG: AZURE https://login.microsoftonline.com:443 "POST /wazuh.onmicrosoft.com/oauth2/v2.0/token HTTP/1.1" 200 1901
	02/25/2022 10:55:48 AM INFO: AZURE Graph: Building the url.
	02/25/2022 10:55:48 AM INFO: AZURE Graph: The search starts for query: 'auditLogs/directoryAudits' using activityDateTime+ge+2022-02-26T20:55:48.233418Z
	02/25/2022 10:55:48 AM INFO: AZURE Graph: The URL is 'https://graph.microsoft.com/v1.0/auditLogs/directoryAudits?&$filter=activityDateTime+ge+2022-02-26T20:55:48.233418Z'
	02/25/2022 10:55:48 AM INFO: AZURE Graph: Pagination starts
	02/25/2022 10:55:48 AM DEBUG: AZURE Starting new HTTPS connection (1): graph.microsoft.com:443
	02/25/2022 10:55:48 AM DEBUG: AZURE https://graph.microsoft.com:443 "GET /v1.0/auditLogs/directoryAudits?&$filter=activityDateTime+ge+2022-02-26T20:55:48.233418Z HTTP/1.1" 200 None
	02/25/2022 10:55:48 AM INFO: AZURE Graph: Sending event by socket.
	02/25/2022 10:55:48 AM INFO: AZURE Graph: Sending event by socket.
	02/25/2022 10:55:48 AM INFO: AZURE Graph: Sending event by socket.
	02/25/2022 10:55:48 AM INFO: AZURE Graph: Sending event by socket.
	02/25/2022 10:55:48 AM INFO: AZURE Graph: Sending event by socket.
	02/25/2022 10:55:48 AM INFO: AZURE Graph: Sending event by socket.
	02/25/2022 10:55:48 AM INFO: AZURE Updating /var/ossec/wodles/azure/last_dates.json file.
	02/25/2022 10:55:48 AM INFO: AZURE Graph: End

</details>

### Log analytics API
<details><summary> Command used and output</summary>

	./azure-logs --log_analytics --la_auth_path credentials_log.txt --la_tenant_domain wazuh.onmicrosoft.com --la_tag azure-activity --la_query "AzureActivity" --workspace bc8d21bd-b966-4a4f-8eed-9e0328720cbe --la_time_offset 50d -v
	02/25/2022 11:11:27 AM INFO: AZURE Getting the data from /var/ossec/wodles/azure/last_dates.json.
	02/25/2022 11:11:27 AM INFO: AZURE Azure Log Analytics starting.
	02/25/2022 11:11:27 AM INFO: AZURE Log Analytics: Getting authentication token.
	02/25/2022 11:11:27 AM DEBUG: AZURE Starting new HTTPS connection (1): login.microsoftonline.com:443
	02/25/2022 11:11:27 AM DEBUG: AZURE https://login.microsoftonline.com:443 "POST /wazuh.onmicrosoft.com/oauth2/v2.0/token HTTP/1.1" 200 1348
	02/25/2022 11:11:27 AM INFO: AZURE f90c15b0327962c9e661142547368572 was not found in /var/ossec/wodles/azure/last_dates.json for log_analytics
	02/25/2022 11:11:27 AM INFO: AZURE Log Analytics: The search starts for query: 'AzureActivity | order by TimeGenerated asc | where TimeGenerated >= datetime(2022-01-10T21:11:27.760978Z) '
	02/25/2022 11:11:27 AM INFO: AZURE Log Analytics: Sending a request to the Log Analytics API.
	02/25/2022 11:11:27 AM DEBUG: AZURE Starting new HTTPS connection (1): api.loganalytics.io:443
	02/25/2022 11:11:29 AM DEBUG: AZURE https://api.loganalytics.io:443 "GET /v1/workspaces/bc8d21bd-b966-4a4f-8eed-9e0328720cbe/query?query=AzureActivity+%7C+order+by+TimeGenerated+asc+%7C+where+TimeGenerated+%3E%3D+datetime%282022-01-10T21%3A09%3A27.760978Z%29+ HTTP/1.1" 200 None
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:29 AM INFO: AZURE Updating /var/ossec/wodles/azure/last_dates.json file.
	02/25/2022 11:11:29 AM INFO: AZURE Azure Log Analytics ending.

</details>

<details><summary> Using reparse option </summary>

	./azure-logs --log_analytics --la_auth_path credentials_log.txt --la_tenant_domain wazuh.onmicrosoft.com --la_tag azure-activity --la_query "AzureActivity" --workspace bc8d21bd-b966-4a4f-8eed-9e0328720cbe --la_time_offset 50d -v --reparse
	02/25/2022 11:11:33 AM INFO: AZURE Getting the data from /var/ossec/wodles/azure/last_dates.json.
	02/25/2022 11:11:33 AM INFO: AZURE Azure Log Analytics starting.
	02/25/2022 11:11:33 AM INFO: AZURE Log Analytics: Getting authentication token.
	02/25/2022 11:11:33 AM DEBUG: AZURE Starting new HTTPS connection (1): login.microsoftonline.com:443
	02/25/2022 11:11:34 AM DEBUG: AZURE https://login.microsoftonline.com:443 "POST /wazuh.onmicrosoft.com/oauth2/v2.0/token HTTP/1.1" 200 1348
	02/25/2022 11:11:34 AM INFO: AZURE Log Analytics: The search starts for query: 'AzureActivity | order by TimeGenerated asc | where TimeGenerated >= datetime(2022-01-10T21:11:34.206360Z) '
	02/25/2022 11:11:34 AM INFO: AZURE Log Analytics: Sending a request to the Log Analytics API.
	02/25/2022 11:11:34 AM DEBUG: AZURE Starting new HTTPS connection (1): api.loganalytics.io:443
	02/25/2022 11:11:35 AM DEBUG: AZURE https://api.loganalytics.io:443 "GET /v1/workspaces/bc8d21bd-b966-4a4f-8eed-9e0328720cbe/query?query=AzureActivity+%7C+order+by+TimeGenerated+asc+%7C+where+TimeGenerated+%3E%3D+datetime%282022-01-10T21%3A11%3A34.206360Z%29+ HTTP/1.1" 200 None
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Log Analytics: Sending event by socket.
	02/25/2022 11:11:35 AM INFO: AZURE Updating /var/ossec/wodles/azure/last_dates.json file.
	02/25/2022 11:11:35 AM INFO: AZURE Azure Log Analytics ending.


</details>


### Storage API

The content has been included in [this gist](https://gist.github.com/robertogp21/05232559b1f32ad022a688b0f9d57cc4), because it was very long.


## Google Cloud Storage

<details><summary> Command used and output </summary>

	./gcloud -T access_logs -b framework-test-bucket -c credentials.json -l 1 -o 2021-nov-01
	gcloud_wodle - INFO - Skipping previously processed file: test_1_new.txt
	gcloud_wodle - INFO - Skipping previously processed file: test_22.txt
	gcloud_wodle - INFO - Skipping previously processed file: test_2_new.txt
	gcloud_wodle - INFO - Skipping previously processed file: test_3.txt
	gcloud_wodle - INFO - Skipping previously processed file: test_3_new.txt
	gcloud_wodle - INFO - Skipping previously processed file: test_4.txt
	gcloud_wodle - INFO - Skipping previously processed file: test_5.txt
	gcloud_wodle - INFO - Skipping previously processed file: test_6.txt
	gcloud_wodle - INFO - Received 0 messages

</details>

<details><summary> Using reparse option </summary>

	./gcloud -T access_logs -b framework-test-bucket -c credentials.json -l 1 -o 2021-nov-01 --reparse
	gcloud_wodle - INFO - File previously processed, but reparse flag set: test_1_new.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 1", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - File previously processed, but reparse flag set: test_22.txt
	gcloud_wodle - INFO - File previously processed, but reparse flag set: test_2_new.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 2", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - File previously processed, but reparse flag set: test_3.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 3", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - File previously processed, but reparse flag set: test_3_new.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 3", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - File previously processed, but reparse flag set: test_4.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 4", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - File previously processed, but reparse flag set: test_5.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 5", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - File previously processed, but reparse flag set: test_6.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 6", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - Updating previously processed files.
	gcloud_wodle - INFO - Received 7 messages

</details>

## AWS CloudWatchLogs

<details><summary> Command used and output </summary>

	./aws-s3 -sr cloudwatchlogs -g 4_3_test -d 2 -s 2020-feb-11 -p dev -r us-east-1 
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Getting alerts from "us-east-1" region.
	DEBUG: only logs: 1581379200000
	DEBUG: +++ Table does not exist; create
	DEBUG: Getting log streams for "4_3_test" log group
	DEBUG: Found "test_stream" log stream in 4_3_test
	DEBUG: Getting data from DB for log stream "test_stream" in log group "4_3_test"
	DEBUG: Token: "None", start_time: "None", end_time: "None"
	DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "4_3_test" using token "None", start_time "1581379200000" and end_time "None"
	DEBUG: +++ Sending events to Analysisd...
	DEBUG: The message is "Test log 0 - 2022-1-14 - 1642158889249"
	DEBUG: +++ Sending events to Analysisd...
	DEBUG: The message is "Test log 1 - 2022-1-14 - 1642158889250"
	DEBUG: +++ Sending events to Analysisd...
	DEBUG: The message is "Test log 2 - 2022-1-14 - 1642158889251"
	DEBUG: +++ Sending events to Analysisd...
	DEBUG: The message is "Test log 3 - 2022-1-14 - 1642158889252"
	DEBUG: +++ Sending events to Analysisd...
	DEBUG: The message is "Test log 4 - 2022-1-14 - 1642158889253"
	DEBUG: +++ Sending events to Analysisd...
	DEBUG: The message is "Test log 5 - 2022-1-17 - 1642419404426"
	DEBUG: +++ Sending events to Analysisd...
	DEBUG: The message is "Test log 6 - 2022-1-17 - 1642419404427"
	DEBUG: +++ Sending events to Analysisd...
	DEBUG: The message is "Test log 7 - 2022-1-21 - 1642765328448"
	DEBUG: +++ Sending events to Analysisd...
	DEBUG: The message is "Test log 8 - 2022-1-21 - 1642765328449"
	DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "4_3_test" using token "f/36634891010743919584474076488460266823645439445062647808/s", start_time "1581379200000" and end_time "None"
	DEBUG: Saving data for log group "4_3_test" and log stream "test_stream".
	DEBUG: The saved values are "{'token': 'f/36634891010777370700285891000285551355225419957179219967/s', 'start_time': 1581379200000, 'end_time': 1642765328450}"
	DEBUG: Purging the BD
	DEBUG: Getting log streams for "4_3_test" log group
	DEBUG: Found "test_stream" log stream in 4_3_test
	DEBUG: committing changes and closing the DB

</details>

<details><summary> Using reparse option </summary>

	./aws-s3 -sr cloudwatchlogs -g 4_3_test -d 2 -s 2020-feb-11 -p dev -r us-east-1 -o
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Getting alerts from "us-east-1" region.
	DEBUG: only logs: 1581379200000
	DEBUG: Getting log streams for "4_3_test" log group
	DEBUG: Found "test_stream" log stream in 4_3_test
	DEBUG: Getting data from DB for log stream "test_stream" in log group "4_3_test"
	DEBUG: Token: "f/36634891010777370700285891000285551355225419957179219967/s", start_time: "1581379200000", end_time: "1642765328450"
	DEBUG: Reparse mode ON
	DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "4_3_test" using token "None", start_time "1581379200000" and end_time "None"
	DEBUG: +++ Sending events to Analysisd...
	DEBUG: The message is "Test log 0 - 2022-1-14 - 1642158889249"
	DEBUG: +++ Sending events to Analysisd...
	DEBUG: The message is "Test log 1 - 2022-1-14 - 1642158889250"
	DEBUG: +++ Sending events to Analysisd...
	DEBUG: The message is "Test log 2 - 2022-1-14 - 1642158889251"
	DEBUG: +++ Sending events to Analysisd...
	DEBUG: The message is "Test log 3 - 2022-1-14 - 1642158889252"
	DEBUG: +++ Sending events to Analysisd...
	DEBUG: The message is "Test log 4 - 2022-1-14 - 1642158889253"
	DEBUG: +++ Sending events to Analysisd...
	DEBUG: The message is "Test log 5 - 2022-1-17 - 1642419404426"
	DEBUG: +++ Sending events to Analysisd...
	DEBUG: The message is "Test log 6 - 2022-1-17 - 1642419404427"
	DEBUG: +++ Sending events to Analysisd...
	DEBUG: The message is "Test log 7 - 2022-1-21 - 1642765328448"
	DEBUG: +++ Sending events to Analysisd...
	DEBUG: The message is "Test log 8 - 2022-1-21 - 1642765328449"
	DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "4_3_test" using token "f/36634891010743919584474076488460266823645439445062647808/s", start_time "1581379200000" and end_time "None"
	DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "4_3_test" using token "f/36634891010777370700285891000285551355225419957179219967/s", start_time "1642765328451" and end_time "None"
	DEBUG: Saving data for log group "4_3_test" and log stream "test_stream".
	DEBUG: The saved values are "{'token': 'f/36634891010777370700285891000285551355225419957179219967/s', 'start_time': 1581379200000, 'end_time': 1642765328451}"
	DEBUG: Some data already exists on DB for that key. Updating their values...
	DEBUG: Purging the BD
	DEBUG: Getting log streams for "4_3_test" log group
	DEBUG: Found "test_stream" log stream in 4_3_test
	DEBUG: committing changes and closing the DB

</details>

# Conclusions

Everything worked as expected, all the executions were correct and all the logs were processed again properly.

# Documentation

We have opened [this issue](https://github.com/wazuh/wazuh-documentation/issues/4902) to include it in wazuh-documentation repository.