### PR TITLE
Add python-json-logger to framework's requirements.txt 

### DIFF
--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -65,6 +65,7 @@ pycparser==2.20
 pyparsing==2.4.7
 python-dateutil==2.8.1
 python-jose==3.1.0
+python-json-logger==2.0.2
 pytz==2020.1
 PyYAML==5.4.1
 requests==2.25.1


### PR DESCRIPTION
|Related issue|
|---|
|Closes #11153|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
In this PR we add the `python-json-logger` dependency to the framework's `requirements.txt` file after the changes made for #11153.

Installing the framework and trying to use with the different installation methods and supported architectures shows the following results:

## Tests

### amd64
The installation for amd64 processors is working as expected

```
root@f99dcc72066b:/var/ossec# uname -m
x86_64
root@f99dcc72066b:/var/ossec/framework/python/bin# ./python3
Python 3.9.9 (main, Mar  3 2022, 16:05:35) 
[GCC 5.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from wazuh import *
>>> from pythonjsonlogger import *
>>> 
root@f99dcc72066b:/var/ossec/framework/python/bin# ./pip3 freeze | grep python-json
python-json-logger==2.0.2
root@f99dcc72066b:/var/ossec/logs# cat api.json
{"timestamp": "2022/03/04 08:48:40", "levelname": "INFO", "data": {"type": "informative", "payload": "Listening on 0.0.0.0:55000.."}}
```

### aarch64
The installation for arm64 processors is working as expected. 
```
root@50dbeab70e32:/var/ossec# uname -m
aarch64
root@50dbeab70e32:/var/ossec/framework/python/bin# /var/ossec/framework/python/bin/python3
Python 3.9.9 (main, Mar  3 2022, 12:33:11) 
[GCC 5.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from wazuh import *
>>> from pythonjsonlogger import jsonlogger
>>> 
root@50dbeab70e32:/var/ossec/framework/python/bin# /var/ossec/framework/python/bin/python3 -m pip freeze | grep json-logger
python-json-logger==2.0.2
root@50dbeab70e32:/var/ossec/logs# cat api.json 
{"timestamp": "2022/03/04 08:58:45", "levelname": "INFO", "data": {"type": "informative", "payload": "Listening on 0.0.0.0:55000.."}}
```

### sources
The installation from sources is working as expected.

```
root@336796223f1a:/var/ossec# uname -m
x86_64
root@336796223f1a:/var/ossec/framework/python/bin# ./python3
Python 3.9.9 (main, Mar  3 2022, 16:09:58) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from pythonjsonlogger import *
>>> from wazuh import *
>>> 
root@336796223f1a:/var/ossec/framework/python/bin# ./pip3 freeze | grep python-json
python-json-logger==2.0.2
root@336796223f1a:/var/ossec/logs# cat api.json
{"timestamp": "2022/03/04 09:00:30", "levelname": "INFO", "data": {"type": "informative", "payload": "Listening on 0.0.0.0:55000.."}}
```

### [Dependencies scanner](https://github.com/wazuh/wazuh-qa/tree/master/tests/scans/dependencies)
The dependency scanner is passing without new vulnerabilities with the updated `requirements.txt` file.

```
(venv) ➜  dependencies git:(master) ✗ pytest --branch feature/11153-add-python-json-logger
==================================== test session starts ====================================
platform linux -- Python 3.10.2, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/gonzz/git/wazuh-qa/tests/scans/dependencies
collected 1 item                                                                            

test_dependencies.py .                                                                [100%]

===================================== 1 passed in 0.62s =====================================
(venv) ➜  dependencies git:(master) ✗ cat report_file.json                                
{
    "report_date": "2022-03-04T10:49:24.313230",
    "vulnerabilities_found": 0,
    "packages": []
}
```
