### PR TITLE
Let FIM DB disable registry sync

### DIFF
--- a/src/syscheckd/cppcheckSuppress.txt
+++ b/src/syscheckd/cppcheckSuppress.txt
@@ -1,5 +1,5 @@
 *:*src/syscheckd/src/db/src/file.cpp:78
 *:*src/syscheckd/src/db/src/file.cpp:392
 *:*src/db/testtool/action.h:378
-*:*src/syscheckd/src/db/src/db.cpp:97
+*:*src/syscheckd/src/db/src/db.cpp:99
 *:*src/syscheckd/src/create_db.c:846

--- a/src/syscheckd/src/db/include/db.h
+++ b/src/syscheckd/src/db/include/db.h
@@ -37,13 +37,15 @@ extern "C" {
  * @param log_callback Callback to perform logging operations.
  * @param file_limit Maximum number of files to be monitored
  * @param value_limit Maximum number of registry values to be monitored.
+ * @param sync_registry_enable Flag to enable the registry synchronization.
  */
 void fim_db_init(int storage,
                  int sync_interval,
                  fim_sync_callback_t sync_callback,
                  logging_callback_t log_callback,
                  int file_limit,
-                 int value_limit);
+                 int value_limit,
+                 bool sync_registry_enabled);
 
 /**
  * @brief Get entry data using path.

--- a/src/syscheckd/src/db/include/db.hpp
+++ b/src/syscheckd/src/db/include/db.hpp
@@ -80,6 +80,7 @@ class EXPORTED DB final
         * @param callbackLogWrapper Callback to log lines.
         * @param fileLimit File limit.
         * @param valueLimit Registry value limit.
+        * @param syncRegistryEnabled Flag to enable/disable the registry sync mechanism.
         */
         void init(const int storage,
                   const int syncInterval,
@@ -87,7 +88,8 @@ class EXPORTED DB final
                   std::function<void(const std::string&)> callbackSyncRegistryWrapper,
                   std::function<void(modules_log_level_t, const std::string&)> callbackLogWrapper,
                   int fileLimit,
-                  int valueLimit);
+                  int valueLimit,
+                  bool syncRegistryEnabled);
 
         /**
         * @brief runIntegrity Execute the integrity mechanism.

--- a/src/syscheckd/src/db/smokeTests/config.json
+++ b/src/syscheckd/src/db/smokeTests/config.json
@@ -2,5 +2,6 @@
     "storage_type": 1,
     "sync_interval": 60,
     "file_limit": 20,
-    "registry_limit": 1
+    "registry_limit": 1,
+    "registry_sync": true
 }

--- a/src/syscheckd/src/db/src/db.cpp
+++ b/src/syscheckd/src/db/src/db.cpp
@@ -40,7 +40,8 @@ void DB::init(const int storage,
               std::function<void(const std::string&)> callbackSyncRegistryWrapper,
               std::function<void(modules_log_level_t, const std::string&)> callbackLogWrapper,
               const int fileLimit,
-              const int valueLimit)
+              const int valueLimit,
+              bool syncRegistryEnabled)
 {
     auto path { storage == FIM_DB_MEMORY ? FIM_DB_MEMORY_PATH : FIM_DB_DISK_PATH };
     auto dbsyncHandler
@@ -58,7 +59,8 @@ void DB::init(const int storage,
                            dbsyncHandler,
                            rsyncHandler,
                            fileLimit,
-                           valueLimit);
+                           valueLimit,
+                           syncRegistryEnabled);
 }
 
 void DB::runIntegrity()
@@ -126,7 +128,8 @@ void fim_db_init(int storage,
                  fim_sync_callback_t sync_callback,
                  logging_callback_t log_callback,
                  int file_limit,
-                 int value_limit)
+                 int value_limit,
+                 bool sync_registry_enabled)
 {
     try
     {
@@ -170,7 +173,8 @@ void fim_db_init(int storage,
                             callbackSyncRegistryWrapper,
                             callbackLogWrapper,
                             file_limit,
-                            value_limit);
+                            value_limit,
+                            sync_registry_enabled);
 
     }
     // LCOV_EXCL_START

--- a/src/syscheckd/src/db/src/fimDB.cpp
+++ b/src/syscheckd/src/db/src/fimDB.cpp
@@ -23,7 +23,8 @@ void FIMDB::registerRSync()
         FIMDBCreator<OS_TYPE>::registerRsync(m_rsyncHandler,
                                              m_dbsyncHandler->handle(),
                                              m_syncFileMessageFunction,
-                                             m_syncRegistryMessageFunction);
+                                             m_syncRegistryMessageFunction,
+                                             m_syncRegistryEnabled);
     }
 }
 
@@ -37,7 +38,8 @@ void FIMDB::sync()
         FIMDBCreator<OS_TYPE>::sync(m_rsyncHandler,
                                     m_dbsyncHandler->handle(),
                                     m_syncFileMessageFunction,
-                                    m_syncRegistryMessageFunction);
+                                    m_syncRegistryMessageFunction,
+                                    m_syncRegistryEnabled);
         m_loggingFunction(LOG_INFO, "Finished FIM sync.");
     }
 }
@@ -49,7 +51,8 @@ void FIMDB::init(unsigned int syncInterval,
                  std::shared_ptr<DBSync> dbsyncHandler,
                  std::shared_ptr<RemoteSync> rsyncHandler,
                  unsigned int fileLimit,
-                 unsigned int registryLimit)
+                 unsigned int registryLimit,
+                 bool syncRegistryEnabled)
 {
     m_syncInterval = syncInterval;
     m_dbsyncHandler = dbsyncHandler;
@@ -61,6 +64,7 @@ void FIMDB::init(unsigned int syncInterval,
     m_runIntegrity = false;
     std::shared_lock<std::shared_timed_mutex> lock(m_handlersMutex);
     FIMDBCreator<OS_TYPE>::setLimits(m_dbsyncHandler, fileLimit, registryLimit);
+    m_syncRegistryEnabled = syncRegistryEnabled;
 }
 
 void FIMDB::removeItem(const nlohmann::json& item)

--- a/src/syscheckd/src/db/src/fimDB.hpp
+++ b/src/syscheckd/src/db/src/fimDB.hpp
@@ -131,7 +131,8 @@ class FIMDB
                   std::shared_ptr<DBSync> dbsyncHandler,
                   std::shared_ptr<RemoteSync> rsyncHandler,
                   unsigned int fileLimit,
-                  unsigned int registryLimit = 0);
+                  unsigned int registryLimit = 0,
+                  bool syncRegistryEnabled = true);
 
         /**
          * @brief Remove a given item from the database
@@ -255,6 +256,7 @@ class FIMDB
         bool                                                                    m_runIntegrity;
         std::thread                                                             m_integrityThread;
         std::shared_timed_mutex                                                 m_handlersMutex;
+        bool                                                                    m_syncRegistryEnabled;
 
         /**
         * @brief Function that executes the synchronization of the databases with the manager

--- a/src/syscheckd/src/db/src/fimDBSpecialization.h
+++ b/src/syscheckd/src/db/src/fimDBSpecialization.h
@@ -187,7 +187,8 @@ class FIMDBCreator final
         static void registerRsync(std::shared_ptr<RemoteSync> RSyncHandler,
                                   const RSYNC_HANDLE& handle,
                                   std::function<void(const std::string&)> syncFileMessageFunction,
-                                  __attribute__((unused)) std::function<void(const std::string&)> syncRegistryMessageFunction)
+                                  __attribute__((unused)) std::function<void(const std::string&)> syncRegistryMessageFunction,
+                                  const bool syncRegistryEnabled)
         {
             throw std::runtime_error
             {
@@ -241,29 +242,41 @@ class FIMDBCreator<OSType::WINDOWS> final
         static void registerRsync(std::shared_ptr<RemoteSync> RSyncHandler,
                                   const RSYNC_HANDLE& handle,
                                   std::function<void(const std::string&)> syncFileMessageFunction,
-                                  __attribute__((unused)) std::function<void(const std::string&)> syncRegistryMessageFunction)
+                                  __attribute__((unused)) std::function<void(const std::string&)> syncRegistryMessageFunction,
+                                  const bool syncRegistryEnabled)
         {
             RSyncHandler->registerSyncID(FIM_COMPONENT_FILE,
-                                         handle,
-                                         nlohmann::json::parse(FIM_FILE_SYNC_CONFIG_STATEMENT),
-                                         syncFileMessageFunction);
-            RSyncHandler->registerSyncID(FIM_COMPONENT_REGISTRY,
-                                         handle,
-                                         nlohmann::json::parse(FIM_REGISTRY_SYNC_CONFIG_STATEMENT),
-                                         syncRegistryMessageFunction);
+                                        handle,
+                                        nlohmann::json::parse(FIM_FILE_SYNC_CONFIG_STATEMENT),
+                                        syncFileMessageFunction);
+
+            if (syncRegistryEnabled)
+            {
+
+                RSyncHandler->registerSyncID(FIM_COMPONENT_REGISTRY,
+                                            handle,
+                                            nlohmann::json::parse(FIM_REGISTRY_SYNC_CONFIG_STATEMENT),
+                                            syncRegistryMessageFunction);
+            }
+
         }
 
         static void sync(std::shared_ptr<RemoteSync> RSyncHandler,
                          const DBSYNC_HANDLE& handle,
                          std::function<void(const std::string&)> syncFileMessageFunction,
-                         __attribute__((unused)) std::function<void(const std::string&)> syncRegistryMessageFunction)
+                         __attribute__((unused)) std::function<void(const std::string&)> syncRegistryMessageFunction,
+                         const bool syncRegistryEnabled)
         {
             RSyncHandler->startSync(handle,
                                     nlohmann::json::parse(FIM_FILE_START_CONFIG_STATEMENT),
                                     syncFileMessageFunction);
-            RSyncHandler->startSync(handle,
-                                    nlohmann::json::parse(FIM_REGISTRY_START_CONFIG_STATEMENT),
-                                    syncRegistryMessageFunction);
+
+            if (syncRegistryEnabled)
+            {
+                RSyncHandler->startSync(handle,
+                                        nlohmann::json::parse(FIM_REGISTRY_START_CONFIG_STATEMENT),
+                                        syncRegistryMessageFunction);
+            }
         }
 
         static void encodeString(__attribute__((unused)) std::string& stringToEncode)
@@ -293,18 +306,20 @@ class FIMDBCreator<OSType::OTHERS> final
         static void registerRsync(std::shared_ptr<RemoteSync> RSyncHandler,
                                   const RSYNC_HANDLE& handle,
                                   std::function<void(const std::string&)> syncFileMessageFunction,
-                                  __attribute__((unused)) std::function<void(const std::string&)> syncRegistryMessageFunction)
+                                  __attribute__((unused)) std::function<void(const std::string&)> syncRegistryMessageFunction,
+                                  __attribute__((unused)) const bool syncRegistryEnabled)
         {
             RSyncHandler->registerSyncID(FIM_COMPONENT_FILE,
-                                         handle,
-                                         nlohmann::json::parse(FIM_FILE_SYNC_CONFIG_STATEMENT),
-                                         syncFileMessageFunction);
+                                        handle,
+                                        nlohmann::json::parse(FIM_FILE_SYNC_CONFIG_STATEMENT),
+                                        syncFileMessageFunction);
         }
 
         static void sync(std::shared_ptr<RemoteSync> RSyncHandler,
                          const DBSYNC_HANDLE& handle,
                          std::function<void(const std::string&)> syncFileMessageFunction,
-                         __attribute__((unused)) std::function<void(const std::string&)> syncRegistryMessageFunction)
+                         __attribute__((unused)) std::function<void(const std::string&)> syncRegistryMessageFunction,
+                         __attribute__((unused)) const bool syncRegistryEnabled)
         {
             RSyncHandler->startSync(handle,
                                     nlohmann::json::parse(FIM_FILE_START_CONFIG_STATEMENT),

--- a/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.h
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.h
@@ -85,7 +85,8 @@ class DBTestFixture : public testing::Test {
                         mockSyncMessage,
                         mockLoggingFunction,
                         MAX_FILE_LIMIT,
-                        100000);
+                        100000,
+                        true);
 
             evt_data = {};
             evt_data.report_event = true;

--- a/src/syscheckd/src/db/testtool/main.cpp
+++ b/src/syscheckd/src/db/testtool/main.cpp
@@ -49,6 +49,7 @@ int main(int argc, const char* argv[])
             const auto syncInterval{ jsonConfigFile.at("sync_interval").get<const uint32_t>() };
             const auto fileLimit{ jsonConfigFile.at("file_limit").get<const uint32_t>() };
             const auto registryLimit{ jsonConfigFile.at("registry_limit").get<const uint32_t>() };
+            const bool syncRegistryEnabled { jsonConfigFile.at("registry_sync") };
 
             std::function<void(const std::string&)> callbackSyncFileWrapper
             {
@@ -82,7 +83,8 @@ int main(int argc, const char* argv[])
                                     callbackSyncRegistryWrapper,
                                     callbackLogWrapper,
                                     fileLimit,
-                                    registryLimit);
+                                    registryLimit,
+                                    syncRegistryEnabled);
 
                 std::unique_ptr<TestContext> testContext { std::make_unique<TestContext>()};
                 testContext->outputPath = cmdLineArgs.outputFolder();

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -83,14 +83,16 @@ void fim_initialize() {
                 fim_send_sync_state,
                 loggingFunction,
                 syscheck.db_entry_file_limit,
-                0);
+                0,
+                false);
 #else
     fim_db_init(syscheck.database_store,
                 syscheck.sync_interval,
                 fim_send_sync_state,
                 loggingFunction,
                 syscheck.db_entry_file_limit,
-                syscheck.db_entry_registry_limit);
+                syscheck.db_entry_registry_limit,
+                syscheck.enable_registry_synchronization);
 #endif
 
     w_rwlock_init(&syscheck.directories_lock, NULL);

--- a/src/unit_tests/syscheckd/test_syscheck.c
+++ b/src/unit_tests/syscheckd/test_syscheck.c
@@ -98,17 +98,19 @@ void test_fim_initialize(void **state)
 {
     syscheck_config *syscheck_conf = *state;
 
-    #ifdef WIN32
+#ifdef TEST_WINAGENT
     expect_wrapper_fim_db_init(syscheck_conf->database_store,
                                syscheck_conf->sync_interval,
                                syscheck_conf->db_entry_file_limit,
-                               syscheck_conf->db_entry_registry_limit);
-    #else
+                               syscheck_conf->db_entry_registry_limit,
+                               1);
+#else
     expect_wrapper_fim_db_init(syscheck_conf->database_store,
                                syscheck_conf->sync_interval,
                                syscheck_conf->db_entry_file_limit,
+                               0,
                                0);
-    #endif
+#endif
     fim_initialize();
 }
 
@@ -192,7 +194,7 @@ void test_Start_win32_Syscheck_corrupted_config_file(void **state) {
 
     will_return(__wrap_rootcheck_init, 1);
 
-    expect_wrapper_fim_db_init(0, 300, 100000, 100000);
+    expect_wrapper_fim_db_init(0, 300, 100000, 100000, 1);
 
     expect_function_call(__wrap_os_wait);
     expect_function_call(__wrap_start_daemon);
@@ -219,7 +221,7 @@ void test_Start_win32_Syscheck_syscheck_disabled_1(void **state) {
 
     will_return(__wrap_rootcheck_init, 0);
 
-    expect_wrapper_fim_db_init(0, 300, 100000, 100000);
+    expect_wrapper_fim_db_init(0, 300, 100000, 100000, 1);
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FILE_SIZE_LIMIT_DISABLED);
 
@@ -250,7 +252,7 @@ void test_Start_win32_Syscheck_syscheck_disabled_2(void **state) {
 
     will_return(__wrap_rootcheck_init, 0);
 
-    expect_wrapper_fim_db_init(0, 300, 100000, 100000);
+    expect_wrapper_fim_db_init(0, 300, 100000, 100000, 1);
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FILE_SIZE_LIMIT_DISABLED);
 
@@ -321,7 +323,7 @@ void test_Start_win32_Syscheck_dirs_and_registry(void **state) {
 
     expect_string(__wrap__minfo, formatted_msg, "(6004): No diff for file: 'Diff'");
 
-    expect_wrapper_fim_db_init(0, 300, 100000, 100000);
+    expect_wrapper_fim_db_init(0, 300, 100000, 100000, 1);
 
     snprintf(info_msg, OS_MAXSTR, "Started (pid: %d).", getpid());
     expect_string(__wrap__minfo, formatted_msg, info_msg);
@@ -370,7 +372,7 @@ void test_Start_win32_Syscheck_whodata_active(void **state) {
 
     expect_string(__wrap__minfo, formatted_msg, "(6003): Monitoring path: 'c:\\dir1', with options 'whodata'.");
 
-    expect_wrapper_fim_db_init(0, 300, 100000, 100000);
+    expect_wrapper_fim_db_init(0, 300, 100000, 100000, 1);
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FILE_SIZE_LIMIT_DISABLED);
 

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
@@ -42,22 +42,26 @@ void __wrap_fim_db_init(int storage,
                         __attribute__((unused)) fim_sync_callback_t sync_callback,
                         __attribute__((unused)) logging_callback_t log_callback,
                         int file_limit,
-                        int value_limit
+                        int value_limit,
+                        int sync_registry_enable
                         ) {
     check_expected(storage);
     check_expected(sync_interval);
     check_expected(file_limit);
     check_expected(value_limit);
+    check_expected(sync_registry_enable);
 }
 
 void expect_wrapper_fim_db_init(int storage,
                                 int sync_interval,
                                 int file_limit,
-                                int value_limit) {
+                                int value_limit,
+                                int sync_registry_enable) {
     expect_value(__wrap_fim_db_init, storage, storage);
     expect_value(__wrap_fim_db_init, sync_interval, sync_interval);
     expect_value(__wrap_fim_db_init, file_limit, file_limit);
     expect_value(__wrap_fim_db_init, value_limit, value_limit);
+    expect_value(__wrap_fim_db_init, sync_registry_enable, sync_registry_enable);
 }
 
 int __wrap_fim_db_remove_path(const char *path) {

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
@@ -44,12 +44,14 @@ void __wrap_fim_db_init(int storage,
                         fim_sync_callback_t sync_callback,
                         logging_callback_t log_callback,
                         int file_limit,
-                        int value_limit);
+                        int value_limit,
+                        int sync_registry_enable);
 
 void expect_wrapper_fim_db_init(int storage,
                                 int sync_interval,
                                 int file_limit,
-                                int value_limit);
+                                int value_limit,
+                                int sync_registry_enable);
 
 int __wrap_fim_db_remove_path(const char *path);
 


### PR DESCRIPTION
|Related issue|
|---|
|#12499|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team!!

This PR aims to add the functionality of disabling the registry synchronization mechanism. When it's disable, FIM DB won't execute the `registerSyncID` neither `startSync`.


Closes #12499
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->


<!--
Paste here related logs and alerts
-->
```xml
<syscheck>
........  
  <synchronization>
      <enabled>yes</enabled>
      <registry_enabled>no</registry_enabled>
      <interval>5m</interval>
      <max_interval>1h</max_interval>
      <max_eps>10</max_eps>
    </synchronization>
</syscheck>
```
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows

- [X] Source installation
- [X] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer