### PR TITLE
Clean FIM code after FIMDB changes

### DIFF
--- a/src/syscheckd/include/syscheck.h
+++ b/src/syscheckd/include/syscheck.h
@@ -124,13 +124,6 @@ typedef struct fim_txn_context_s {
 /** Function Prototypes **/
 
 /**
- * @brief Check the integrity of the files against the saved database
- *
- */
-void run_check(void);
-
-
-/**
  * @brief Start the file integrity monitoring daemon
  *
  */
@@ -350,13 +343,6 @@ cJSON *fim_json_event(const fim_entry *new_data,
 void free_file_data(fim_file_data *data);
 
 /**
- * @brief Deallocates fim_entry struct.
- *
- * @param entry Entry to be deallocated.
- */
-void free_entry(fim_entry * entry);
-
-/**
  * @brief Start real time monitoring
  *
  * @return 0 on success, -1 on error
@@ -414,13 +400,6 @@ void fim_realtime_print_watches();
  *
  */
 void realtime_process(void);
-
-/**
- * @brief Delete data form dir_tb hash table
- *
- * @param [out] data
- */
-void free_syscheck_dirtb_data(char *data);
 
 /**
  * @brief Deletes subdirectories watches when a folder changes its name
@@ -777,40 +756,6 @@ unsigned int get_realtime_watches();
 #endif
 
 /**
- * @brief Calculates the checksum of the FIM entry files and sends it to the database for integrity checking
- *
- * @param type Must be FIM_TYPE_FILE or FIM_TYPE_REGISTRY.
- * @param mutex A mutex associated with the DB tables to be synchronized.
- */
-void fim_sync_checksum(fim_type type, pthread_mutex_t *mutex);
-
-/**
- * @brief Calculates the checksum of the FIM entry files starting from `start` letter and finishing at `top` letter
- * It also sends it to the database for integrity checking
- *
- * @param start The letter to start checking from
- * @param top The letter to finish checking to
- * @param id
- */
-void fim_sync_checksum_split(const char *start, const char *top, long id);
-
-// TODO
-/**
- * @brief
- *
- * @param start
- * @param top
- */
-void fim_sync_send_list(const char *start, const char *top);
-
-/**
- * @brief Dispatches a message coming to the syscheck queue
- *
- * @param payload The message to dispatch
- */
-void fim_sync_dispatch(char *payload);
-
-/**
  * @brief Create file attribute set JSON from a FIM entry structure
  *
  * Format:
@@ -835,39 +780,6 @@ void fim_sync_dispatch(char *payload);
  * @return Pointer to cJSON structure.
  */
 cJSON * fim_attributes_json(const fim_file_data * data);
-
-/**
- * @brief Create file entry JSON from a FIM entry structure
- *
- * Format:
- * {
- *   path:              string
- *   timestamp:         number
- *   attributes: {
- *     type:            "file"|"registry"
- *     size:            number
- *     perm:            string
- *     user_name:       string
- *     group_name:      string
- *     uid:             string
- *     gid:             string
- *     inode:           number
- *     mtime:           number
- *     hash_md5:        string
- *     hash_sha1:       string
- *     hash_sha256:     string
- *     win_attributes:  string
- *     symlink_path:    string
- *     checksum:        string
- *   }
- * }
- *
- * @param key Pointer to the key used in the manager fim_entry DB.
- * @param entry Pointer to a FIM entry structure.
- * @pre entry is mutex-blocked.
- * @return Pointer to cJSON structure.
- */
-cJSON *fim_entry_json(const char *key, fim_entry *entry);
 
 /**
  * @brief Create file attribute comparison JSON object

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -1660,26 +1660,6 @@ void free_file_data(fim_file_data * data) {
     os_free(data);
 }
 
-
-void free_entry(fim_entry * entry) {
-    if (entry) {
-#ifndef WIN32
-        os_free(entry->file_entry.path);
-        free_file_data(entry->file_entry.data);
-        free(entry);
-#else
-        if (entry->type == FIM_TYPE_FILE) {
-            os_free(entry->file_entry.path);
-            free_file_data(entry->file_entry.data);
-            free(entry);
-        } else {
-            fim_registry_free_entry(entry);
-        }
-#endif
-    }
-}
-
-
 void fim_diff_folder_size() {
     char *diff_local;
 

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -794,14 +794,6 @@ STATIC void fim_link_delete_range(directory_t *configuration) {
     event_data_t evt_data = { .mode = FIM_SCHEDULED, .report_event = false, .w_evt = NULL, .type = FIM_DELETE };
     char pattern[PATH_MAX] = {0};
 
-    if((evt_data.mode == FIM_REALTIME && !(configuration->options & REALTIME_ACTIVE)) ||
-      (evt_data.mode == FIM_WHODATA && !(configuration->options & WHODATA_ACTIVE)))
-    {
-        /* Don't send alert if received mode and mode in configuration aren't the same.
-        Scheduled mode events must always be processed to preserve the state of the agent's DB.
-        */
-        return;
-    }
     get_data_ctx ctx = {
         .event = (event_data_t *)&evt_data,
         .config = configuration,

--- a/src/syscheckd/src/run_realtime.c
+++ b/src/syscheckd/src/run_realtime.c
@@ -351,10 +351,6 @@ int realtime_update_watch(const char *wd, const char *dir) {
     return 0;
 }
 
-void free_syscheck_dirtb_data(char *data) {
-    free(data);
-}
-
 void delete_subdirectories_watches(char *dir) {
     OSHashNode *hash_node;
     char *data;

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -4171,24 +4171,6 @@ void test_fim_db_process_missing_entry(void **state){
     fim_data->fentry->file_entry.path = NULL;
 }
 
-void test_free_entry(void **state){
-    fim_entry* fentry = (fim_entry*) malloc(sizeof(fim_entry));
-
-    char* path = (char*) malloc(11*sizeof(char));
-    fentry->file_entry.data = NULL;
-    fentry->file_entry.path = path;
-    fentry->type = FIM_TYPE_FILE;
-    free_entry(fentry);
-}
-
-void test_free_entry_registry(void **state){
-    fim_entry* fentry = (fim_entry*) malloc(sizeof(fim_entry));
-    fentry->type = FIM_TYPE_REGISTRY;
-    fentry->registry_entry.key = NULL;
-    fentry->registry_entry.value = NULL;
-    free_entry(fentry);
-}
-
 static void test_dbsync_attributes_json(void **state) {
     directory_t configuration = { .options = -1, .tag = "tag_name" };
     json_struct_t *data = *state;
@@ -4384,9 +4366,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_process_delete_event, setup_fim_entry, teardown_fim_entry),
         cmocka_unit_test_setup_teardown(test_fim_db_remove_entry, setup_fim_entry, teardown_fim_entry),
         cmocka_unit_test_setup_teardown(test_fim_db_process_missing_entry, setup_fim_entry, teardown_fim_entry),
-        cmocka_unit_test(test_free_entry),
-        cmocka_unit_test(test_free_entry_registry),
-    
+
         /* dbsync_attributes_json */
         cmocka_unit_test_setup_teardown(test_dbsync_attributes_json, setup_json_event_attributes, teardown_json_event_attributes),
     };

--- a/src/unit_tests/syscheckd/test_run_realtime.c
+++ b/src/unit_tests/syscheckd/test_run_realtime.c
@@ -579,29 +579,6 @@ void test_realtime_adddir_realtime_update_failure(void **state) {
     assert_int_equal(ret, -1);
 }
 
-
-void test_free_syscheck_dirtb_data(void **state)
-{
-    (void) state;
-    char *data = strdup("test");
-
-    free_syscheck_dirtb_data(data);
-
-    assert_non_null(data);
-}
-
-
-void test_free_syscheck_dirtb_data_null(void **state)
-{
-    (void) state;
-    char *data = NULL;
-
-    free_syscheck_dirtb_data(data);
-
-    assert_null(data);
-}
-
-
 void test_realtime_process(void **state) {
 
     syscheck.realtime->fd = 1;
@@ -1967,10 +1944,6 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_realtime_adddir_realtime_add_hash_failure, setup_OSHash, teardown_OSHash),
         cmocka_unit_test_setup_teardown(test_realtime_adddir_realtime_update, setup_OSHash, teardown_OSHash),
         cmocka_unit_test_setup_teardown(test_realtime_adddir_realtime_update_failure, setup_OSHash, teardown_OSHash),
-
-        /* free_syscheck_dirtb_data */
-        cmocka_unit_test(test_free_syscheck_dirtb_data),
-        cmocka_unit_test(test_free_syscheck_dirtb_data_null),
 
         /* realtime_process */
         cmocka_unit_test(test_realtime_process),

--- a/src/unit_tests/wrappers/wazuh/syscheckd/create_db_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/create_db_wrappers.c
@@ -24,12 +24,6 @@ directory_t *__wrap_fim_configuration_directory(const char *path) {
     return mock_type(directory_t *);
 }
 
-cJSON *__wrap_fim_entry_json(const char * path,
-                             __attribute__((unused)) fim_file_data * data) {
-    check_expected(path);
-    return mock_type(cJSON*);
-}
-
 cJSON *__wrap_fim_json_event() {
     return mock_type(cJSON *);
 }

--- a/src/unit_tests/wrappers/wazuh/syscheckd/create_db_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/create_db_wrappers.h
@@ -17,9 +17,6 @@ void __wrap_fim_checker(const char *path, event_data_t *evt_data, const director
 
 directory_t *__wrap_fim_configuration_directory(const char *path);
 
-cJSON *__wrap_fim_entry_json(const char * path,
-                             fim_file_data * data);
-
 cJSON *__wrap_fim_json_event();
 
 void __wrap_fim_realtime_event(char *file);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/10225|

## Description
this PR is in charge of removing all the FIM code that has been deprecated after the changes with dbsync and rsync, because a lot of code has been converted to c++, some functions may have become unused.
Also those unit tests or any references that depended on these functions should be removed.

Closes #10225