### PR TITLE
Fix domain contraint error at sys_programs table when upgrading DB

### DIFF
--- a/src/wazuh_db/schema_upgrade_v8.sql
+++ b/src/wazuh_db/schema_upgrade_v8.sql
@@ -32,7 +32,7 @@ CREATE TABLE IF NOT EXISTS _sys_programs (
     PRIMARY KEY (scan_id, name, version, architecture)
 );
 
-INSERT INTO _sys_programs SELECT * FROM sys_programs;
+INSERT INTO _sys_programs SELECT scan_id, scan_time, format, name, priority, section, size, vendor, install_time, version, architecture, multiarch, source, description, location, triaged, cpe, msu_name, CASE WHEN checksum <> '' THEN checksum ELSE 'legacy' END AS checksum, item_id FROM sys_programs;
 DROP TABLE IF EXISTS sys_programs;
 ALTER TABLE _sys_programs RENAME TO sys_programs;
 CREATE INDEX IF NOT EXISTS programs_id ON sys_programs (scan_id);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #12480|

This PR aims to fix a bug in the database upgrade that made Wazuh DB raise this log:


```
wazuh-db: WARNING: DB(000) wdb_sql_exec returned error: 'CHECK constraint failed: checksum <> '''
```

## Rationale

Until 4.2, the table `sys_programs` had no column `checksum`. In this version, that column was added (DB version 7):

```sql
ALTER TABLE sys_programs ADD COLUMN checksum TEXT DEFAULT '' NOT NULL CHECK(checksum <> '');
```

The column `checksum` is set to an empty string by default. At the same time, it gets restricted not to contain empty strings.

Then, in 4.3, the table is replaced and refilled, with the same constraints:

```sql
CREATE TABLE IF NOT EXISTS _sys_programs (...);
INSERT INTO _sys_programs SELECT * FROM sys_programs;
```

Thus, we're attempting to insert empty checksum values in the new table.

## Proposed fix

Change the `INSERT` operation to set `checksum` to `'legacy'` if the source row contains an empty checksum value, as we do with `sys_ports` in version 7.

## Test

- [x] Upgrade from 4.1 to 4.3 directly.
- [x] Check that `sys_programs` is filled and `checksum` is set to `'legacy'` just after upgrading.
- [x] Check that `sys_programs` contains no `'legacy'` values after a Syscollector scan.