### PR TITLE
Change modulesd group to root

### DIFF
--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -105,6 +105,10 @@ https://www.gnu.org/licenses/gpl.html\n"
 #define GROUPGLOBAL     "wazuh"
 #endif
 
+#ifndef ROOTGROUP
+#define ROOTGROUP     "root"
+#endif
+
 // Wazuh home environment variable
 #define WAZUH_HOME_ENV  "WAZUH_HOME"
 

--- a/src/wazuh_modules/main.c
+++ b/src/wazuh_modules/main.c
@@ -128,6 +128,7 @@ void wm_setup()
 {
     gid_t gid;
     struct sigaction action = { .sa_handler = wm_handler };
+    const char *group = ROOTGROUP;
 
     // Read XML settings and internal options
 
@@ -144,12 +145,13 @@ void wm_setup()
 
     // Set group
 
-    if (gid = Privsep_GetGroup(GROUPGLOBAL), gid == (gid_t) -1) {
-        merror_exit(USER_ERROR, "", GROUPGLOBAL, strerror(errno), errno);
+
+    if (gid = Privsep_GetGroup(group), gid == (gid_t) -1) {
+        merror_exit(USER_ERROR, "", group, strerror(errno), errno);
     }
 
     if (Privsep_SetGroup(gid) < 0) {
-        merror_exit(SETGID_ERROR, GROUPGLOBAL, errno, strerror(errno));
+        merror_exit(SETGID_ERROR, group, errno, strerror(errno));
     }
 
     if (wm_check() < 0) {


### PR DESCRIPTION
|Related issue|
|---|
|Closes [#10828](https://github.com/wazuh/wazuh/issues/10828) |

## Description
This PR makes wazuh-modules run as root:root instead of root:wazuh, to fix an issue where it would accidentally change permission of some system files (see https://github.com/wazuh/wazuh/issues/10828)


<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors