### PR TITLE
Fixing warnings in exec.c file

### DIFF
--- a/src/os_execd/exec.c
+++ b/src/os_execd/exec.c
@@ -122,8 +122,7 @@ int ReadExecConfig()
         for (j = 0; j < exec_size; j++) {
             if (strcmp(exec_names[j], exec_names[exec_size]) == 0) {
                 if (exec_cmd[j][0] == '\0') {
-                    strncpy(exec_cmd[j], exec_cmd[exec_size], OS_FLSIZE);
-                    exec_cmd[j][OS_FLSIZE] = '\0';
+                    snprintf(exec_cmd[j], sizeof(exec_cmd[j]), "%s", exec_cmd[exec_size]);
                     dup_entry = 1;
                     break;
                 } else if (exec_cmd[exec_size][0] == '\0') {


### PR DESCRIPTION
|Related issue|
|---|
|#12099|


## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh windows agent project in exec.c, there is a warning on the file that it was yet fixed in another PR. The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Windows Agent</summary>

```
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_mysql_log.o
    CC logcollector/read_ucs2_be.o
    CC logcollector/read_multiline.o
    CC logcollector/macos_log.o
    CC logcollector/read_fullcommand.o
logcollector/read_multiline.c: In function ‘read_multiline’:
logcollector/read_multiline.c:96:9: warning: ‘strncpy’ output may be truncated copying between 0 and 65534 bytes from a string of length 65536 [-Wstringop-truncation]
   96 |         strncpy(buffer + buffer_size, str, OS_MAXSTR - buffer_size - 2);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_snortfull.o
    CC os_execd/exec.o
logcollector/read_snortfull.c: In function ‘read_snortfull’:
logcollector/read_snortfull.c:54:17: warning: ‘strncpy’ output may be truncated copying 65536 bytes from a string of length 65536 [-Wstringop-truncation]
   54 |                 strncpy(f_msg, str, OS_MAXSTR);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC os_execd/config.o
os_execd/exec.c: In function ‘ReadExecConfig’:
os_execd/exec.c:72:9: warning: ‘strncpy’ output may be truncated copying 256 bytes from a string of length 65536 [-Wstringop-truncation]
   72 |         strncpy(exec_names[exec_size], str_pt, OS_FLSIZE);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC os_execd/wcom.o
    CC os_execd/execd.o
    CC os_execd/win_execd.o
    CC active-response/active_responses.o
    CC monitord/rotate_log.o
    CC monitord/compress_log.o
    CC config/wmodules-aws.o
    CC config/localfile-config.o
    CC config/rootcheck-config.o
    CC config/remote-config.o
    CC config/active-response.o

```

</details>


## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Windows Agent</summary>

```
    CC logcollector/read_ucs2_le.o
logcollector/read_snortfull.c: In function ‘read_snortfull’:
logcollector/read_snortfull.c:54:17: warning: ‘strncpy’ output may be truncated copying 65536 bytes from a string of length 65536 [-Wstringop-truncation]
   54 |                 strncpy(f_msg, str, OS_MAXSTR);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_win_el.o
    CC logcollector/read_win_event_channel.o
    CC logcollector/state.o
    CC os_execd/config.o
    CC os_execd/exec.o
    CC os_execd/execd.o
    CC os_execd/wcom.o
    CC os_execd/win_execd.o
    CC active-response/active_responses.o
os_execd/exec.c: In function ‘ReadExecConfig’:
os_execd/exec.c:72:9: warning: ‘strncpy’ output may be truncated copying 256 bytes from a string of length 65536 [-Wstringop-truncation]
   72 |         strncpy(exec_names[exec_size], str_pt, OS_FLSIZE);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC monitord/rotate_log.o
    CC monitord/compress_log.o
    CC config/active-response.o
    CC config/agentlessd-config.o
    CC config/alerts-config.o
    CC config/authd-config.o
    CC config/buffer-config.o
    CC config/client-config.o
    CC config/cluster-config.o
    CC config/config.o
    CC config/csyslogd-config.o
    CC config/dbd-config.o
    CC config/email-alerts-config.o
    CC config/global-config.o
    CC config/integrator-config.o
    CC config/labels-config.o

```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors