### PR TITLE
FIMDB: Avoid error when setting file or registry limit to 0

### DIFF
--- a/src/syscheckd/src/db/src/fimDBSpecialization.h
+++ b/src/syscheckd/src/db/src/fimDBSpecialization.h
@@ -224,9 +224,17 @@ class FIMDBCreator<OSType::WINDOWS> final
                               const unsigned int& fileLimit,
                               const unsigned int& registryLimit)
         {
-            DBSyncHandler->setTableMaxRow("file_entry", fileLimit);
-            DBSyncHandler->setTableMaxRow("registry_key", registryLimit);
-            DBSyncHandler->setTableMaxRow("registry_data", registryLimit);
+            if (fileLimit > 0)
+            {
+                DBSyncHandler->setTableMaxRow("file_entry", fileLimit);
+
+            }
+            if (registryLimit > 0)
+            {
+                DBSyncHandler->setTableMaxRow("registry_key", registryLimit);
+                DBSyncHandler->setTableMaxRow("registry_data", registryLimit);
+            }
+
         }
 
         static std::string CreateStatement()
@@ -295,7 +303,10 @@ class FIMDBCreator<OSType::OTHERS> final
                               const unsigned int& fileLimit,
                               __attribute__((unused)) const unsigned int& registryLimit)
         {
-            DBSyncHandler->setTableMaxRow("file_entry", fileLimit);
+            if (fileLimit > 0)
+            {
+                DBSyncHandler->setTableMaxRow("file_entry", fileLimit);
+            }
         }
 
         static std::string CreateStatement()


### PR DESCRIPTION
|Related issue|
|---|
|#12528|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR aims to add the needed logic to make FIMDB able to disable the registry synchronization mechanism.

Closes #12528

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer