### PR TITLE
src/wazuh_modules/wm_ciscat.c: support both CIS-CAT Pro V3 and V4

### DIFF
--- a/src/config/wmodules-ciscat.c
+++ b/src/config/wmodules-ciscat.c
@@ -42,6 +42,13 @@ int wm_ciscat_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
     ciscat->flags.scan_on_start = 1;
     sched_scan_init(&(ciscat->scan_config));
     ciscat->scan_config.interval = WM_DEF_INTERVAL;
+    
+    // Set default ciscat binary
+    #ifdef WIN32
+        os_strdup(WM_CISCAT_V3_BINARY_WIN, ciscat->ciscat_binary);
+    #else
+        os_strdup(WM_CISCAT_V3_BINARY, ciscat->ciscat_binary);
+    #endif
     module->context = &WM_CISCAT_CONTEXT;
     module->tag = strdup(module->context->name);
     module->data = ciscat;
@@ -174,6 +181,8 @@ int wm_ciscat_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
         } else if (!strcmp(nodes[i]->element, XML_CISCAT_PATH)) {
             ciscat->ciscat_path = strdup(nodes[i]->content);
         } else if (!strcmp(nodes[i]->element, XML_CISCAT_BINARY)) {
+            // Free the old string (having the default value) before setting a new one.
+            os_free(ciscat->ciscat_binary);
             ciscat->ciscat_binary = strdup(nodes[i]->content);
             #ifdef WIN32
                 if (strcmp(ciscat->ciscat_binary, WM_CISCAT_V3_BINARY_WIN) && strcmp(ciscat->ciscat_binary, WM_CISCAT_V4_BINARY_WIN)) {

--- a/src/config/wmodules-ciscat.c
+++ b/src/config/wmodules-ciscat.c
@@ -21,6 +21,7 @@ static const char *XML_SCAN_ON_START = "scan-on-start";
 static const char *XML_PROFILE = "profile";
 static const char *XML_JAVA_PATH = "java_path";
 static const char *XML_CISCAT_PATH = "ciscat_path";
+static const char *XML_CISCAT_BINARY = "ciscat_binary";
 static const char *XML_DISABLED = "disabled";
 
 // Parse XML
@@ -172,6 +173,19 @@ int wm_ciscat_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
             ciscat->java_path = strdup(nodes[i]->content);
         } else if (!strcmp(nodes[i]->element, XML_CISCAT_PATH)) {
             ciscat->ciscat_path = strdup(nodes[i]->content);
+        } else if (!strcmp(nodes[i]->element, XML_CISCAT_BINARY)) {
+            ciscat->ciscat_binary = strdup(nodes[i]->content);
+            #ifdef WIN32
+                if (strcmp(ciscat->ciscat_binary, WM_CISCAT_V3_BINARY_WIN) && strcmp(ciscat->ciscat_binary, WM_CISCAT_V4_BINARY_WIN)) {
+                    mterror(WM_CISCAT_LOGTAG, "Unsupported CIS-CAT Binary '%s'.", ciscat->ciscat_binary);
+                    return OS_INVALID;
+                }
+            #else
+                if (strcmp(ciscat->ciscat_binary, WM_CISCAT_V3_BINARY) && strcmp(ciscat->ciscat_binary, WM_CISCAT_V4_BINARY)) {
+                    mterror(WM_CISCAT_LOGTAG, "Unsupported CIS-CAT Binary '%s'.", ciscat->ciscat_binary);
+                    return OS_INVALID;
+                }
+            #endif
         } else if (is_sched_tag(nodes[i]->element)) {
             // Do nothing
         } else {

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -27,7 +27,7 @@ static void wm_ciscat_destroy(wm_ciscat *ciscat);      // Destroy data
 #endif
 static void wm_ciscat_setup(wm_ciscat *_ciscat);       // Setup module
 static void wm_ciscat_check();                       // Check configuration, disable flag
-static void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char * java_path);      // Run a CIS-CAT policy
+static void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char *java_path, const char *ciscat_binary);      // Run a CIS-CAT policy
 static char * wm_ciscat_get_profile();               // Read evaluated profile from the report
 static void wm_ciscat_preparser();                   // Prepare report for the xml parser
 static wm_scan_data* wm_ciscat_txt_parser();        // Parse CIS-CAT csv reports
@@ -284,7 +284,7 @@ void wm_ciscat_cleanup() {
 
 #ifdef WIN32
 
-void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char * java_path) {
+void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char *java_path, const char *ciscat_binary) {
     char *command = NULL;
     char msg[OS_MAXSTR];
     char *ciscat_script;
@@ -1499,6 +1499,7 @@ cJSON *wm_ciscat_dump(const wm_ciscat * ciscat) {
 
     if (ciscat->java_path) cJSON_AddStringToObject(wm_cscat,"java_path",ciscat->java_path);
     if (ciscat->ciscat_path) cJSON_AddStringToObject(wm_cscat,"ciscat_path",ciscat->ciscat_path);
+    if (ciscat->ciscat_binary) cJSON_AddStringToObject(wm_cscat,"ciscat_binary",ciscat->ciscat_binary);
     cJSON_AddNumberToObject(wm_cscat,"timeout",ciscat->timeout);
     if (ciscat->evals) {
         cJSON *evals = cJSON_CreateArray();

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -904,7 +904,7 @@ wm_scan_data* wm_ciscat_txt_parser(){
 
         fclose(fp);
     } else {
-        mtdebug1(WM_CISCAT_LOGTAG, "Report result file '%s' missing: %s", file, strerror(errno));
+        mterror(WM_CISCAT_LOGTAG, "Report result file '%s' missing: %s", file, strerror(errno));
         ciscat->flags.error = 1;
     }
 

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -1583,6 +1583,9 @@ void wm_ciscat_destroy(wm_ciscat *ciscat) {
         free(cur_eval);
     }
 
+    free(ciscat->java_path);
+    free(ciscat->ciscat_path);
+    free(ciscat->ciscat_binary);
     free(ciscat);
     #ifdef WIN32
     return 0;

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -403,6 +403,9 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char * java_p
             } else {
                 scan_info->profile = wm_ciscat_get_profile();
             }
+            // send scan results if the txt file is right.
+            wm_ciscat_send_scan(scan_info, id);
+        } else {
             wm_ciscat_preparser();
             if (!ciscat->flags.error) {
                 wm_ciscat_xml_parser();
@@ -586,6 +589,9 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char * java_p
             } else {
                 scan_info->profile = wm_ciscat_get_profile();
             }
+            // send scan results if the txt file is right.
+            wm_ciscat_send_scan(scan_info, id);
+        } else {
             wm_ciscat_preparser();
             if (!ciscat->flags.error) {
                 wm_ciscat_xml_parser();

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -821,6 +821,10 @@ wm_scan_data* wm_ciscat_txt_parser(){
                 last_line = 1;
                 continue;
 
+            } else if ((readbuff[0] == '\0')) {
+                // Jump the empty line
+                continue;
+
             } else {
 
                 char ** parts = NULL;

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -221,7 +221,7 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
                     if (IsFile(eval->path) < 0) {
                         mterror(WM_CISCAT_LOGTAG, "Benchmark file '%s' not found.", eval->path);
                     } else {
-                        wm_ciscat_run(eval, cis_path, id, ciscat->java_path);
+                        wm_ciscat_run(eval, cis_path, id, ciscat->java_path, ciscat->ciscat_binary);
                         ciscat->flags.error = 0;
                     }
                 }
@@ -293,15 +293,11 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char *java_pa
 
     os_calloc(OS_MAXSTR, sizeof(char), ciscat_script);
 
-    snprintf(ciscat_script, OS_MAXSTR - 1, "\"%s\\CIS-CAT.BAT\"", path);
+    snprintf(ciscat_script, OS_MAXSTR - 1, "\"%s\\%s\"", path, ciscat_binary);
 
     // Create arguments
 
     wm_strcat(&command, ciscat_script, '\0');
-
-    // Accepting Terms of Use
-
-    wm_strcat(&command, "-a", ' ');
 
     switch (eval->type) {
     case WM_CISCAT_XCCDF:
@@ -331,31 +327,56 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char *java_pa
         pthread_exit(NULL);
     }
 
-    // Specify location for reports
+    // CIS-CAT Pro V3
+    if (!strcmp(ciscat_binary, WM_CISCAT_V3_BINARY_WIN)) {
+        // Accepting Terms of Use
+    
+        wm_strcat(&command, "-a", ' ');
 
-    wm_strcat(&command, "-r", ' ');
-    wm_strcat(&command, TMP_DIR, ' ');
+        // Specify location for reports
 
-    // Set reports file name
+        wm_strcat(&command, "-r", ' ');
+        wm_strcat(&command, TMP_DIR, ' ');
 
-    wm_strcat(&command, "-rn", ' ');
-    wm_strcat(&command, "ciscat-report", ' ');
+        // Set reports file name
 
-    // Get xml reports
+        wm_strcat(&command, "-rn", ' ');
+        wm_strcat(&command, "ciscat-report", ' ');
 
-    wm_strcat(&command, "-x", ' ');
+        // Get xml reports
 
-    // Get txt reports
+        wm_strcat(&command, "-x", ' ');
 
-    wm_strcat(&command, "-t", ' ');
+        // Get txt reports
 
-    // Do not create HTML report
+        wm_strcat(&command, "-t", ' ');
 
-    wm_strcat(&command, "-n", ' ');
+        // Do not create HTML report
 
-    // Add not selected checks
+        wm_strcat(&command, "-n", ' ');
 
-    wm_strcat(&command, "-y", ' ');
+        // Add not selected checks
+ 
+        wm_strcat(&command, "-y", ' ');
+    } else if (!strcmp(ciscat_binary, WM_CISCAT_V4_BINARY_WIN)) {
+        // CIS-CAT Pro V4
+
+        // Specify location for reports
+
+        wm_strcat(&command, "-rd", ' ');
+        wm_strcat(&command, TMP_DIR, ' ');
+
+        // Set reports file name
+
+        wm_strcat(&command, "-rp", ' ');
+        wm_strcat(&command, "ciscat-report", ' ');
+
+        // Do not include the auto-generated timestamp as part of the report name
+        wm_strcat(&command, "-nts", ' ');
+
+        // Get txt reports
+        wm_strcat(&command, "-txt", ' ');
+    }
 
     // Send rootcheck message
 
@@ -435,13 +456,12 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char *java_pa
 
 // Run a CIS-CAT policy for UNIX systems
 
-void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char * java_path) {
+void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char *java_path, const char *ciscat_binary) {
 
     char *command = NULL;
     int status, child_status;
     char *output = NULL;
     char msg[OS_MAXSTR];
-    char *ciscat_script = "./CIS-CAT.sh";
     wm_scan_data *scan_info = NULL;
     char pwd[PATH_MAX];
 
@@ -451,12 +471,8 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char * java_p
     }
 
     // Create arguments
-
-    wm_strcat(&command, ciscat_script, '\0');
-
-    // Accepting Terms of Use
-
-    wm_strcat(&command, "-a", ' ');
+    wm_strcat(&command, path, '/');    
+    wm_strcat(&command, ciscat_binary, '/');
 
     switch (eval->type) {
     case WM_CISCAT_XCCDF:
@@ -479,33 +495,59 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char * java_p
         pthread_exit(NULL);
     }
 
-    // Specify location for reports
-
-    wm_strcat(&command, "-r", ' ');
     char reports_path[PATH_MAX];
     os_snprintf(reports_path, sizeof(reports_path), "%s/%s", pwd, WM_CISCAT_REPORTS);
-    wm_strcat(&command, reports_path, ' ');
+    
+    // CIS-CAT Pro V3
+    if (!strcmp(ciscat_binary, WM_CISCAT_V3_BINARY)) {
+        // Accepting Terms of Use
 
-    // Set reports file name
+        wm_strcat(&command, "-a", ' ');
 
-    wm_strcat(&command, "-rn", ' ');
-    wm_strcat(&command, "ciscat-report", ' ');
+        // Specify location for reports
+        
+        wm_strcat(&command, "-r", ' ');
+        wm_strcat(&command, reports_path, ' ');
 
-    // Get xml reports
+        // Set reports file name
 
-    wm_strcat(&command, "-x", ' ');
+        wm_strcat(&command, "-rn", ' ');
+        wm_strcat(&command, "ciscat-report", ' ');
 
-    // Get txt reports
+        // Get xml reports
 
-    wm_strcat(&command, "-t", ' ');
+        wm_strcat(&command, "-x", ' ');
 
-    // Do not create HTML report
+        // Get txt reports
 
-    wm_strcat(&command, "-n", ' ');
+        wm_strcat(&command, "-t", ' ');
 
-    // Add not selected checks
+        // Do not create HTML report
 
-    wm_strcat(&command, "-y", ' ');
+        wm_strcat(&command, "-n", ' ');
+
+        // Add not selected checks
+
+        wm_strcat(&command, "-y", ' ');
+    } else if (!strcmp(ciscat_binary, WM_CISCAT_V4_BINARY)) {
+        // CIS-CAT Pro V4
+        
+        // Specify location for reports
+
+        wm_strcat(&command, "-rd", ' ');
+        wm_strcat(&command, reports_path, ' ');
+
+        // Set reports file name
+
+        wm_strcat(&command, "-rp", ' ');
+        wm_strcat(&command, "ciscat-report", ' ');
+
+        // Do not include the auto-generated timestamp as part of the report name
+        wm_strcat(&command, "-nts", ' ');
+
+        // Get txt reports
+        wm_strcat(&command, "-txt", ' ');
+    }
 
     // Send rootcheck message
 
@@ -523,11 +565,13 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char * java_p
             // Child process
             setsid();
 
-            if (chdir(path) < 0) {
-                ciscat->flags.error = 1;
-                mterror(WM_CISCAT_LOGTAG, "Unable to change working directory: %s", strerror(errno));
-                os_free(command);
-                _exit(EXIT_FAILURE);
+            if (!strcmp(ciscat_binary, WM_CISCAT_V3_BINARY)) {
+                if (chdir(path) < 0) {
+                    ciscat->flags.error = 1;
+                    mterror(WM_CISCAT_LOGTAG, "Unable to change working directory: %s", strerror(errno));
+                    os_free(command);
+                    _exit(EXIT_FAILURE);
+                }
             }
 
             mtdebug2(WM_CISCAT_LOGTAG, "Changing working directory to %s", path);

--- a/src/wazuh_modules/wm_ciscat.h
+++ b/src/wazuh_modules/wm_ciscat.h
@@ -18,6 +18,10 @@
 #define WM_CISCAT_LOGTAG ARGV0 ":ciscat"
 #define WM_CISCAT_DEFAULT_DIR     "wodles/ciscat"
 #define WM_CISCAT_DEFAULT_DIR_WIN "wodles\\ciscat"
+#define WM_CISCAT_V3_BINARY "CIS-CAT.sh"
+#define WM_CISCAT_V3_BINARY_WIN "CIS-CAT.BAT"
+#define WM_CISCAT_V4_BINARY "Assessor-CLI.sh"
+#define WM_CISCAT_V4_BINARY_WIN "Assessor-CLI.bat"
 #define WM_CISCAT_REPORTS "tmp"
 
 #define WM_CISCAT_PROFILE       "<Profile id="
@@ -71,6 +75,7 @@ typedef struct wm_ciscat {
     unsigned int timeout;           // Default execution time limit (seconds)
     char *java_path;                // Path to Java Runtime Environment
     char *ciscat_path;              // Path to CIS-CAT scanner tool
+    char *ciscat_binary;            // Binary Name of CIS-CAT scanner tool
     wm_ciscat_flags flags;          // Default flags
     wm_ciscat_state state;          // Running state
     wm_ciscat_eval *evals;          // Evaluations (linked list)


### PR DESCRIPTION
Support both CIS-CAT Pro V3 and V4

Signed-off-by: YiLin.Li <YiLin.Li@linux.alibaba.com>

|Related issue|
|---|
| #12581 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors