### PR TITLE
Remove `board_serial` from syscollector API integration tests expected responses

### DIFF
--- a/api/test/integration/test_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_experimental_endpoints.tavern.yaml
@@ -134,9 +134,6 @@ stages:
 ---
 test_name: GET /experimental/syscollector/hardware
 
-marks:
-  - xfail # https://github.com/wazuh/wazuh-jenkins/issues/2415
-
 stages:
 
   - name: Request
@@ -154,7 +151,6 @@ stages:
           affected_items:
             - &hardware_response
               agent_id: !anystr
-              board_serial: !anystr
               cpu:
                 cores: !anyint
                 mhz: !anything


### PR DESCRIPTION
|Related issue|
|---|
| #12474 |

This PR closes #12474.

In this pull request, the board_serial field is no longer expected in API integration tests validating syscollector endpoints responses.

Only test_experimental_endpoints.tavern.yaml was affected since it is the only test checking this field.

### Test results

```
test_experimental_endpoints.tavern.yaml - Cluster environment 
	 12 passed, 13 warnings
```
