### PR TITLE
Remove `never_connected` limitation when assigning agents to groups

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -6475,14 +6475,8 @@ paths:
                         remediation: Please, use `GET /agents?select=id,name` to find all available agents
                       id:
                         - '999'
-                    - error:
-                        code: 1753
-                        message: Could not assign group. Agent status is never_connected
-                        remediation: Please select another agent or connect your agent before assigning groups
-                      id:
-                        - '011'
                   total_affected_items: 2
-                  total_failed_items: 2
+                  total_failed_items: 1
                   message: Some agents were not assigned to group2 and removed from the other groups
                   error: 2
         '400':

--- a/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
@@ -184,7 +184,9 @@ stages:
             - "004"
             - "007"
             - "009"
-          total_affected_items: 5
+            - "011"
+            - "012"
+          total_affected_items: 7
 
     # PUT /agents/group?group_id=group2&force_single_group=true
   - name: Assign all agents to group2 with force_single_group
@@ -218,7 +220,9 @@ stages:
             - "008"
             - "009"
             - "010"
-          total_affected_items: 10
+            - "011"
+            - "012"
+          total_affected_items: 12
 
 ---
 test_name: PUT /groups/{group_id}/configuration

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -302,8 +302,6 @@ class WazuhException(Exception):
         1751: {'message': 'Could not assign agent to group',
                'remediation': 'Agent already belongs to specified group, please select another agent'},
         1752: {'message': 'Could not force single group for the agent'},
-        1753: {'message': 'Could not assign group. Agent status is never_connected',
-               'remediation': 'Please select another agent or connect your agent before assigning groups'},
         1757: {'message': 'Error deleting an agent',
                'remediation': 'Please check all data fields and try again'
                },

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -728,8 +728,7 @@ def test_agent_delete_groups_other_exceptions(mock_get_groups, group_list, expec
 
 @pytest.mark.parametrize('group_list, agent_list, num_failed', [
     (['group-1'], ['001'], 0),
-    (['group-1'], ['001', '002', '003'], 1),
-    (['group-1'], ['001', '002', '003', '100'], 2)
+    (['group-1'], ['001', '002', '003', '100'], 1)
 ])
 @patch('wazuh.agent.Agent.add_group_to_agent')
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)


### PR DESCRIPTION
|Related issue|
|---|
|closes #12334 |

## Description

This PR allows the framework and API to assign never connected agents to groups.

## Tests performed
### Manual tests

Register a new agent.

```json
{
  "data": {
    "affected_items": [
      {
        "id": "10002",
        "status": "never_connected"
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information was returned",
  "error": 0
}
```

Assign this agent to an existent group.

```json
{
  "data": {
    "affected_items": [
      "10002"
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents were assigned to test",
  "error": 0
}
```

Check its groups.

```json
{
  "data": {
    "affected_items": [
      {
        "group": [
          "test"
        ],
        "id": "10002",
        "status": "never_connected"
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information was returned",
  "error": 0
}
```

Remove it from the group.

```json
{
  "data": {
    "affected_items": [
      "10002"
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents were removed from group test",
  "error": 0
}
```

Check its groups again.

```json
{
  "data": {
    "affected_items": [
      {
        "group": [
          "default"
        ],
        "id": "10002",
        "status": "never_connected"
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information was returned",
  "error": 0
}
```

### Unit tests

```
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.9, pytest-7.0.0, pluggy-1.0.0
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.18.1, cov-3.0.0
asyncio: mode=legacy
collected 259 items                                                                                                                                                                                               

wazuh/core/tests/test_agent.py ...............................................................................................................................................                              [ 55%]
wazuh/tests/test_agent.py ....................................................................................................................                                                              [100%]

======================================================================================== 259 passed, 10 warnings in 3.98s =========================================================================================

```

Regards,
Víctor