### PR TITLE
Fixing warnings in wm_ciscat.c file

### DIFF
--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -117,11 +117,13 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
 
     if (ciscat->ciscat_path) {
         switch (wm_relative_path(ciscat->ciscat_path)) {
-            case 0:
+            case 0: {
                 // Full path
                 snprintf(cis_path, OS_MAXSTR - 1, "%s", ciscat->ciscat_path);
-                break;
-            case 1:
+            }
+            break;
+
+            case 1: {
                 // Relative path
             #ifdef WIN32
                 if (*current) {
@@ -137,10 +139,13 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
                     os_snprintf(cis_path, OS_MAXSTR - 1, "%s/%s", pwd, ciscat->ciscat_path);
                 }
             #endif
-                break;
-            default:
+            }
+            break;
+
+            default: {
                 mterror(WM_CISCAT_LOGTAG, "Defined CIS-CAT path is not valid.");
                 ciscat->flags.error = 1;
+            }
         }
     } else {
     #ifdef WIN32

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -116,8 +116,6 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
     // Define path where CIS-CAT is installed
 
     if (ciscat->ciscat_path) {
-        char pwd[PATH_MAX];
-
         switch (wm_relative_path(ciscat->ciscat_path)) {
             case 0:
                 // Full path
@@ -130,6 +128,8 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
                     snprintf(cis_path, OS_MAXSTR - 1, "%s\\%s", current, ciscat->ciscat_path);
                 }
             #else
+                char pwd[PATH_MAX];
+
                 if (getcwd(pwd, sizeof(pwd)) == NULL) {
                     mterror(WM_CISCAT_LOGTAG, "Could not get the current working directory: %s (%d)", strerror(errno), errno);
                     ciscat->flags.error = 1;

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -117,21 +117,20 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
 
     if (ciscat->ciscat_path) {
         switch (wm_relative_path(ciscat->ciscat_path)) {
-            case 0: {
+        #ifndef WIN32
+            char pwd[PATH_MAX];
+        #endif
+            case 0:
                 // Full path
                 snprintf(cis_path, OS_MAXSTR - 1, "%s", ciscat->ciscat_path);
-            }
-            break;
-
-            case 1: {
+                break;
+            case 1:
                 // Relative path
             #ifdef WIN32
                 if (*current) {
                     snprintf(cis_path, OS_MAXSTR - 1, "%s\\%s", current, ciscat->ciscat_path);
                 }
             #else
-                char pwd[PATH_MAX];
-
                 if (getcwd(pwd, sizeof(pwd)) == NULL) {
                     mterror(WM_CISCAT_LOGTAG, "Could not get the current working directory: %s (%d)", strerror(errno), errno);
                     ciscat->flags.error = 1;
@@ -139,13 +138,10 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
                     os_snprintf(cis_path, OS_MAXSTR - 1, "%s/%s", pwd, ciscat->ciscat_path);
                 }
             #endif
-            }
-            break;
-
-            default: {
+                break;
+            default:
                 mterror(WM_CISCAT_LOGTAG, "Defined CIS-CAT path is not valid.");
                 ciscat->flags.error = 1;
-            }
         }
     } else {
     #ifdef WIN32

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -2317,18 +2317,15 @@ static int wm_sca_winreg_querykey(HKEY hKey, const char *full_key_name, char *re
                     break;
                 case REG_MULTI_SZ:
                     /* Printing multiple strings */
-                    size_available = MAX_VALUE_NAME;
+                    size_available = MAX_VALUE_NAME - 3;
                     mt_data = data_buffer;
-                    int size_data = 0;
 
                     while (*mt_data) {
-                        size_data = strlen(mt_data) + strlen(" ");
-
-                        if (size_available > size_data) {
+                        if (size_available > 2) {
                             strncat(var_storage, mt_data, size_available);
-                            size_available -= strlen(mt_data);
                             strncat(var_storage, " ", 2);
-                            size_available -= 1;
+                            size_available = MAX_VALUE_NAME -
+                                             (strlen(var_storage) + 2);
                         }
                         mt_data += strlen(mt_data) + 1;
                     }

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -2317,15 +2317,18 @@ static int wm_sca_winreg_querykey(HKEY hKey, const char *full_key_name, char *re
                     break;
                 case REG_MULTI_SZ:
                     /* Printing multiple strings */
-                    size_available = MAX_VALUE_NAME - 3;
+                    size_available = MAX_VALUE_NAME;
                     mt_data = data_buffer;
+                    int size_data = 0;
 
                     while (*mt_data) {
-                        if (size_available > 2) {
+                        size_data = strlen(mt_data) + strlen(" ");
+
+                        if (size_available > size_data) {
                             strncat(var_storage, mt_data, size_available);
+                            size_available -= strlen(mt_data);
                             strncat(var_storage, " ", 2);
-                            size_available = MAX_VALUE_NAME -
-                                             (strlen(var_storage) + 2);
+                            size_available -= 1;
                         }
                         mt_data += strlen(mt_data) + 1;
                     }


### PR DESCRIPTION
|Related issue|
|---|
|#12099|


## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh windows agent project in wm_ciscat.c. The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Windows Agent</summary>

```
   CC config/syscheck-config.o
    CC config/global-config.o
config/syscheck-config.c: In function ‘read_data_unit’:
config/syscheck-config.c:1261:13: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
 1261 |             strncpy(value_str, content, len_value_str - 2);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
config/syscheck-config.c:1251:28: note: length computed here
 1251 |     size_t len_value_str = strlen(content);
      |                            ^~~~~~~~~~~~~~~
    CC config/client-config.o
    CC config/labels-config.o
    CC config/email-alerts-config.o
    CC config/wmodules-sca.o
    CC config/wmodules-fluent.o
    CC config/wmodules-office365.o
    CC config/cluster-config.o
    CC config/rules-config.o
    CC config/dbd-config.o
    CC config/wmodules-key-request.o
    CC config/wmodules-vuln-detector.o
    CC config/wmodules-azure.o
    CC config/authd-config.o
    CC config/wmodules-task-manager.o
    CC config/buffer-config.o
    CC config/wmodules-command.o
    CC config/csyslogd-config.o
    CC config/wmodules-ciscat.o
    CC config/wmodules-gcp.o
    CC config/logtest-config.o
    CC config/wmodules-config.o
    CC wazuh_modules/wm_control.o
    CC wazuh_modules/wmcom.o
    CC wazuh_modules/wm_oscap.o
    CC wazuh_modules/wm_gcp.o
    CC wazuh_modules/wmodules.o
    CC wazuh_modules/wm_azure.o
    CC wazuh_modules/wm_office365.o
    CC wazuh_modules/wm_exec.o
wazuh_modules/wm_office365.c: In function ‘wm_office365_execute_scan’:
wazuh_modules/wm_office365.c:432:33: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  432 |                                 strncpy(url, next_page, strlen(next_page));
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_modules/wm_osquery_monitor.o
    CC wazuh_modules/wm_task_general.o
    CC wazuh_modules/wm_aws.o
```

</details>

## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Windows Agent</summary>

```
config/syscheck-config.c: In function ‘read_data_unit’:
config/syscheck-config.c:1261:13: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
 1261 |             strncpy(value_str, content, len_value_str - 2);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
config/syscheck-config.c:1251:28: note: length computed here
 1251 |     size_t len_value_str = strlen(content);
      |                            ^~~~~~~~~~~~~~~
    CC config/wmodules-command.o
    CC config/wmodules-config.o
    CC config/wmodules-docker.o
    CC config/wmodules-fluent.o
    CC config/wmodules-gcp.o
    CC config/wmodules-github.o
    CC config/wmodules-key-request.o
    CC config/wmodules-office365.o
    CC config/wmodules-oscap.o
    CC config/wmodules-osquery-monitor.o
    CC config/wmodules-sca.o
    CC config/wmodules_syscollector.o
    CC config/wmodules-task-manager.o
    CC config/wmodules-vuln-detector.o
    CC wazuh_modules/wm_aws.o
    CC wazuh_modules/wm_azure.o
    CC wazuh_modules/wm_ciscat.o
    CC wazuh_modules/wmcom.o
    CC wazuh_modules/wm_command.o
    CC wazuh_modules/wm_control.o
    CC wazuh_modules/wm_database.o
    CC wazuh_modules/wm_docker.o
    CC wazuh_modules/wm_download.o
    CC wazuh_modules/wm_exec.o
    CC wazuh_modules/wm_fluent.o
    CC wazuh_modules/wm_gcp.o
    CC wazuh_modules/wm_github.o
    CC wazuh_modules/wm_keyrequest.o
    CC wazuh_modules/wmodules.o
    CC wazuh_modules/wm_office365.o
    CC wazuh_modules/wm_oscap.o
wazuh_modules/wm_github.c: In function ‘wm_github_execute_scan’:
wazuh_modules/wm_github.c:308:33: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  308 |                                 strncpy(url, next_page, strlen(next_page));
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors