### PR TITLE
Fixing warnings in wm_sca.c file

### DIFF
--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -2309,17 +2309,15 @@ static int wm_sca_winreg_querykey(HKEY hKey, const char *full_key_name, char *re
 
             /* Write value into a string */
             switch (data_type) {
-                    int size_available;
+                int size_available;
+                size_t size_data = 0;
 
                 case REG_SZ:
-                case REG_EXPAND_SZ: {
+                case REG_EXPAND_SZ:
                     snprintf(var_storage, MAX_VALUE_NAME, "%s", data_buffer);
-                }
-                break;
-
-                case REG_MULTI_SZ: {
+                    break;
+                case REG_MULTI_SZ:
                     /* Printing multiple strings */
-                    char size_data = 0;
                     size_available = MAX_VALUE_NAME;
                     mt_data = data_buffer;
 
@@ -2334,16 +2332,11 @@ static int wm_sca_winreg_querykey(HKEY hKey, const char *full_key_name, char *re
                         }
                         mt_data += strlen(mt_data) + 1;
                     }
-
-                }
-                break;
-
-                case REG_DWORD: {
+                    break;
+                case REG_DWORD:
                     snprintf(var_storage, MAX_VALUE_NAME, "%u", *((uint32_t*)data_buffer));
-                }
-                break;
-
-                default: {
+                    break;
+                default:
                     size_available = MAX_VALUE_NAME - 2;
                     for (j = 0; j < data_size; j++) {
                         char tmp_c[12];
@@ -2357,8 +2350,7 @@ static int wm_sca_winreg_querykey(HKEY hKey, const char *full_key_name, char *re
                                              (strlen(var_storage) + 2);
                         }
                     }
-                }
-                break;
+                    break;
             }
 
             mdebug2("Checking value data '%s' with rule '%s'", var_storage, reg_value);

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -2312,29 +2312,38 @@ static int wm_sca_winreg_querykey(HKEY hKey, const char *full_key_name, char *re
                     int size_available;
 
                 case REG_SZ:
-                case REG_EXPAND_SZ:
+                case REG_EXPAND_SZ: {
                     snprintf(var_storage, MAX_VALUE_NAME, "%s", data_buffer);
-                    break;
-                case REG_MULTI_SZ:
+                }
+                break;
+
+                case REG_MULTI_SZ: {
                     /* Printing multiple strings */
-                    size_available = MAX_VALUE_NAME - 3;
+                    char size_data = 0;
+                    size_available = MAX_VALUE_NAME;
                     mt_data = data_buffer;
 
                     while (*mt_data) {
-                        if (size_available > 2) {
+                        size_data = strlen(mt_data) + strlen(" ");
+
+                        if (size_available >= size_data) {
                             strncat(var_storage, mt_data, size_available);
-                            strncat(var_storage, " ", 2);
-                            size_available = MAX_VALUE_NAME -
-                                             (strlen(var_storage) + 2);
+                            size_available -= strlen(mt_data);
+                            strncat(var_storage, " ", size_available);
+                            size_available -= strlen(" ");
                         }
                         mt_data += strlen(mt_data) + 1;
                     }
 
-                    break;
-                case REG_DWORD:
+                }
+                break;
+
+                case REG_DWORD: {
                     snprintf(var_storage, MAX_VALUE_NAME, "%u", *((uint32_t*)data_buffer));
-                    break;
-                default:
+                }
+                break;
+
+                default: {
                     size_available = MAX_VALUE_NAME - 2;
                     for (j = 0; j < data_size; j++) {
                         char tmp_c[12];
@@ -2348,7 +2357,8 @@ static int wm_sca_winreg_querykey(HKEY hKey, const char *full_key_name, char *re
                                              (strlen(var_storage) + 2);
                         }
                     }
-                    break;
+                }
+                break;
             }
 
             mdebug2("Checking value data '%s' with rule '%s'", var_storage, reg_value);


### PR DESCRIPTION
|Related issue|
|---|
|#12099|


## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh windows agent project in wm_sca.c. The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Windows Agent</summary>

```
    CC wazuh_modules/wm_github.o
    CC wazuh_modules/wm_database.o
wazuh_modules/wm_github.c: In function ‘wm_github_execute_scan’:
wazuh_modules/wm_github.c:308:33: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  308 |                                 strncpy(url, next_page, strlen(next_page));
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_modules/wm_download.o
    CC wazuh_modules/wm_docker.o
    CC wazuh_modules/wm_sca.o
    CC wazuh_modules/wm_fluent.o
    CC wazuh_modules/wm_command.o
    CC wazuh_modules/wm_ciscat.o
wazuh_modules/wm_ciscat.c: In function ‘wm_ciscat_main’:
wazuh_modules/wm_ciscat.c:119:14: warning: unused variable ‘pwd’ [-Wunused-variable]
  119 |         char pwd[PATH_MAX];
      |              ^~~
    CC wazuh_modules/agent_upgrade/wm_agent_upgrade.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.o
    CC wazuh_db/wdb_metadata.o
wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c: In function ‘wm_agent_upgrade_com_open’:
wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c:233:9: warning: ‘strncpy’ output may be truncated copying 260 bytes from a string of length 260 [-Wstringop-truncation]
  233 |         strncpy(file.path, final_path, PATH_MAX);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```

</details>

## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Windows Agent</summary>

```
    CC config/wmodules-azure.o
    CC config/wmodules-ciscat.o
config/syscheck-config.c: In function ‘read_data_unit’:
config/syscheck-config.c:1261:13: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
 1261 |             strncpy(value_str, content, len_value_str - 2);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
config/syscheck-config.c:1251:28: note: length computed here
 1251 |     size_t len_value_str = strlen(content);
      |                            ^~~~~~~~~~~~~~~
    CC config/wmodules-command.o
    CC config/wmodules-config.o
    CC config/wmodules-docker.o
    CC config/wmodules-fluent.o
    CC config/wmodules-gcp.o
    CC config/wmodules-github.o
    CC config/wmodules-key-request.o
    CC config/wmodules-office365.o
    CC config/wmodules-oscap.o
    CC config/wmodules-osquery-monitor.o
    CC config/wmodules-sca.o
    CC config/wmodules_syscollector.o
    CC config/wmodules-task-manager.o
    CC config/wmodules-vuln-detector.o
    CC wazuh_modules/wm_aws.o
    CC wazuh_modules/wm_azure.o
    CC wazuh_modules/wm_ciscat.o
    CC wazuh_modules/wmcom.o
    CC wazuh_modules/wm_command.o
wazuh_modules/wm_ciscat.c: In function ‘wm_ciscat_main’:
wazuh_modules/wm_ciscat.c:119:14: warning: unused variable ‘pwd’ [-Wunused-variable]
  119 |         char pwd[PATH_MAX];
      |              ^~~
    CC wazuh_modules/wm_control.o
    CC wazuh_modules/wm_database.o
    CC wazuh_modules/wm_docker.o
    CC wazuh_modules/wm_download.o
    CC wazuh_modules/wm_exec.o
    CC wazuh_modules/wm_fluent.o
    CC wazuh_modules/wm_gcp.o

```

</details>


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors