### PR TITLE
Remove references to queue/agent-groups in cluster tests

### DIFF
--- a/framework/wazuh/core/cluster/tests/test_cluster.py
+++ b/framework/wazuh/core/cluster/tests/test_cluster.py
@@ -456,20 +456,20 @@ def test_merge_info(stat_mock, listdir_mock):
     stat_mock.return_value.st_size = len(agent_groups)
 
     with patch('builtins.open', mock_open(read_data=agent_groups)) as open_mock:
-        files_to_send, output_file = cluster.merge_info('agent-groups', 'worker1', file_type='-shared')
-        open_mock.assert_any_call(common.wazuh_path + '/queue/cluster/worker1/agent-groups-shared.merged', 'wb')
-        open_mock.assert_any_call(common.wazuh_path + '/queue/agent-groups/005', 'rb')
-        open_mock.assert_any_call(common.wazuh_path + '/queue/agent-groups/006', 'rb')
+        files_to_send, output_file = cluster.merge_info('testing', 'worker1', file_type='-shared')
+        open_mock.assert_any_call(common.wazuh_path + '/queue/cluster/worker1/testing-shared.merged', 'wb')
+        open_mock.assert_any_call(common.wazuh_path + '/queue/testing/005', 'rb')
+        open_mock.assert_any_call(common.wazuh_path + '/queue/testing/006', 'rb')
 
         assert files_to_send == 2
-        assert output_file == "queue/cluster/worker1/agent-groups-shared.merged"
+        assert output_file == "queue/cluster/worker1/testing-shared.merged"
 
         handle = open_mock()
         expected = f'{len(agent_groups)} 005 ' \
                    f'{datetime.utcfromtimestamp(stat_mock.return_value.st_mtime)}\n'.encode() + agent_groups
         handle.write.assert_any_call(expected)
 
-        files_to_send, output_file = cluster.merge_info('agent-groups', 'worker1', files=["one", "two"],
+        files_to_send, output_file = cluster.merge_info('testing', 'worker1', files=["one", "two"],
                                                         file_type='-shared')
 
         assert files_to_send == 0

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -1060,7 +1060,7 @@ async def test_worker_handler_process_files_from_master_ko(send_request_mock, js
 @patch("os.path.exists", return_value=False)
 @patch("wazuh.core.cluster.worker.safe_move")
 @patch("wazuh.core.cluster.worker.utils.mkdir_with_mode")
-@patch("os.path.join", return_value="queue/agent-groups/")
+@patch("os.path.join", return_value="queue/testing/")
 @patch("wazuh.core.common.wazuh_uid", return_value="wazuh_uid")
 @patch("wazuh.core.common.wazuh_gid", return_value="wazuh_gid")
 def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, wazuh_uid_mock, path_join_mock,
@@ -1107,7 +1107,7 @@ def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, wazuh_u
                                 "extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, zip_path="/zip/path",
                             cluster_items=cluster_items, logger=LoggerMock())
 
-                        os_remove_mock.assert_any_call("queue/agent-groups/")
+                        os_remove_mock.assert_any_call("queue/testing/")
                         logger_error_mock.assert_not_called()
                         logger_debug_mock.assert_has_calls(
                             [call("Received 1 shared files to update from master."),
@@ -1123,7 +1123,7 @@ def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, wazuh_u
                                                          call(core_common.wazuh_path, 'filename3')])
                         wazuh_uid_mock.assert_called_with()
                         wazuh_gid_mock.assert_called_with()
-                        mkdir_with_mode_mock.assert_any_call("queue/agent-groups")
+                        mkdir_with_mode_mock.assert_any_call("queue/testing")
                         assert safe_move_mock.call_count == 2
                         open_mock.assert_called_once()
                         path_exists_mock.assert_called_once()
@@ -1171,7 +1171,7 @@ def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, wazuh_u
 
                 # Test the first for: for -> if -> for -> except AND for -> elif -> for -> try -> except -> else AND
                 # for -> elif -> for -> except
-                path_join_mock.return_value = "queue/agent-groups_mock/"
+                path_join_mock.return_value = "queue/testing_mock/"
                 worker_handler.update_master_files_in_worker(
                     {"shared": {"filename1": "data1"}, "missing": {"filename2": "data2"},
                      "extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
@@ -1183,7 +1183,7 @@ def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, wazuh_u
                      call("Found errors: 1 overwriting, 1 creating and 0 removing"),
                      call("Error processing shared file 'filename1': string indices must be integers"),
                      call("Error processing missing file 'filename2': string indices must be integers"),
-                     call("Found errors: 1 overwriting, 1 creating and 1 removing")])
+                     call("Found errors: 1 overwriting, 1 creating and 0 removing")])
                 logger_debug_mock.assert_has_calls(
                     [call("Received 1 shared files to update from master."),
                      call("Received 1 missing files to update from master."),
@@ -1202,8 +1202,7 @@ def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, wazuh_u
                      call("Processing file filename1"),
                      call("Processing file filename2"),
                      call("Remove file: 'filename3'"),
-                     call("Error removing file 'filename3': [Errno 2] No such file or directory: "
-                          "'queue/agent-groups_mock/'")])
+                     call("File filename3 doesn't exist.")])
                 path_join_mock.assert_has_calls([call(core_common.wazuh_path, "filename1"),
                                                  call(core_common.wazuh_path, "filename2"),
                                                  call(core_common.wazuh_path, "filename3")])
@@ -1238,8 +1237,7 @@ def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, wazuh_u
                              call("Found errors: 1 overwriting, 1 creating and 0 removing"),
                              call("Error processing shared file 'filename1': string indices must be integers"),
                              call("Error processing missing file 'filename2': string indices must be integers"),
-                             call("Found errors: 1 overwriting, 1 creating and 1 removing"),
-                             call("Found errors: 0 overwriting, 0 creating and 1 removing")])
+                             call("Found errors: 1 overwriting, 1 creating and 0 removing")])
                         logger_debug_mock.assert_has_calls(
                             [call("Received 1 shared files to update from master."),
                              call("Received 1 missing files to update from master."),
@@ -1258,11 +1256,9 @@ def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, wazuh_u
                              call("Processing file filename1"),
                              call("Processing file filename2"),
                              call("Remove file: 'filename3'"),
-                             call("Error removing file 'filename3': [Errno 2] No such file or directory: "
-                                  "'queue/agent-groups_mock/'"),
+                             call("File filename3 doesn't exist."),
                              call("Remove file: 'filename3'"),
-                             call("Error removing file 'filename3': [Errno 2] No such file or directory: "
-                                  "'queue/agent-groups_mock/'")])
+                             call("File filename3 doesn't exist.")])
                         path_join_mock.assert_has_calls([call(core_common.wazuh_path, "filename3"),
                                                          call(core_common.wazuh_path, "")])
                         wazuh_uid_mock.assert_not_called()
@@ -1287,9 +1283,8 @@ def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, wazuh_u
                      call("Found errors: 1 overwriting, 1 creating and 0 removing"),
                      call("Error processing shared file 'filename1': string indices must be integers"),
                      call("Error processing missing file 'filename2': string indices must be integers"),
-                     call("Found errors: 1 overwriting, 1 creating and 1 removing"),
-                     call("Found errors: 0 overwriting, 0 creating and 1 removing"),
-                     call("Found errors: 0 overwriting, 0 creating and 2 removing")])
+                     call("Found errors: 1 overwriting, 1 creating and 0 removing"),
+                     call("Found errors: 0 overwriting, 0 creating and 1 removing")])
                 logger_debug_mock.assert_has_calls(
                     [call("Received 1 shared files to update from master."),
                      call("Received 1 missing files to update from master."),
@@ -1308,16 +1303,12 @@ def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, wazuh_u
                      call("Processing file filename1"),
                      call("Processing file filename2"),
                      call("Remove file: 'filename3'"),
-                     call("Error removing file 'filename3': [Errno 2] No such file or directory: "
-                          "'queue/agent-groups_mock/'"),
+                     call("File filename3 doesn't exist."),
                      call("Remove file: 'filename3'"),
-                     call("Error removing file 'filename3': [Errno 2] No such file or directory: "
-                          "'queue/agent-groups_mock/'"),
+                     call("File filename3 doesn't exist."),
                      call("Remove file: 'filename3'"),
-                     call("Error removing file 'filename3': [Errno 2] No such file or directory: "
-                          "'queue/agent-groups_mock/'"),
-                     call("Error removing directory '': [Errno 2] No such file or directory: "
-                          "'queue/agent-groups_mock/'")])
+                     call("File filename3 doesn't exist."),
+                     call("Error removing directory '': [Errno 2] No such file or directory: 'queue/testing_mock/'")])
                 path_join_mock.assert_has_calls([call(core_common.wazuh_path, "filename3"),
                                                  call(core_common.wazuh_path, "")])
                 wazuh_uid_mock.assert_not_called()

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -807,7 +807,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                         try:
                             os.remove(file_path)
                         except OSError as e:
-                            if e.errno == errno.ENOENT and 'queue/agent-groups/' in file_path:
+                            if e.errno == errno.ENOENT:
                                 logger.debug2(f"File {file_to_remove} doesn't exist.")
                                 continue
                             else:

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -71,7 +71,6 @@ local_internal_options = os.path.join(wazuh_path, 'etc', 'local_internal_options
 ossec_log = os.path.join(wazuh_path, 'logs', 'ossec.log')
 client_keys = os.path.join(wazuh_path, 'etc', 'client.keys')
 stats_path = os.path.join(wazuh_path, 'stats')
-groups_path = os.path.join(wazuh_path, 'queue', 'agent-groups')
 multi_groups_path = os.path.join(wazuh_path, 'var', 'multigroups')
 shared_path = os.path.join(wazuh_path, 'etc', 'shared')
 backup_path = os.path.join(wazuh_path, 'backup')


### PR DESCRIPTION
|Related issue|
|---|
|#10771|

In this PR we have removed all references to `queue/agent-groups` from the Python code.

Test results after changes:

```
============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.5, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
rootdir: /mnt/c/Users/adr_i/git/wazuh/framework
plugins: asyncio-0.15.1, trio-0.7.0, cov-2.12.0, metadata-1.11.0, tavern-1.19.0, testinfra-6.4.0, html-3.1.1, aiohttp-0.3.0
collected 269 items

framework/wazuh/core/cluster/tests/test_client.py ................                                                                                                                                         [  5%]
framework/wazuh/core/cluster/tests/test_cluster.py .............................                                                                                                                           [ 16%]
framework/wazuh/core/cluster/tests/test_common.py ...........................................................................                                                                              [ 44%]
framework/wazuh/core/cluster/tests/test_control.py .....                                                                                                                                                   [ 46%]
framework/wazuh/core/cluster/tests/test_local_client.py .............                                                                                                                                      [ 51%]
framework/wazuh/core/cluster/tests/test_local_server.py .......................                                                                                                                            [ 59%]
framework/wazuh/core/cluster/tests/test_master.py .................................................                                                                                                        [ 78%]
framework/wazuh/core/cluster/tests/test_server.py ...................                                                                                                                                      [ 85%]
framework/wazuh/core/cluster/tests/test_utils.py ........                                                                                                                                                  [ 88%]
framework/wazuh/core/cluster/tests/test_worker.py ................................                                                                                                                         [100%]

======================================================================================= 269 passed, 21 warnings in 45.54s ========================================================================================
```