### PR TITLE
Changes to agent groups API validation

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -6677,9 +6677,10 @@ paths:
               type: object
               properties:
                 group_id:
-                  description: "Group name"
+                  description: "Group name. It can contain any of the characters between a-z, A-Z, 0-9, '_', '-' and '.'. Names '.' and '..' are restricted."
                   type: string
                   format: group_names
+                  maxLength: 128
               required:
                 - group_id
             example:

--- a/api/api/test/test_validator.py
+++ b/api/api/test/test_validator.py
@@ -33,7 +33,11 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
     ('file%1-test_name1', _names),
     ('[(Random_symbols-string123)],<>!.+:"\'|=~#', _symbols_alphanumeric_param),
     ('Group_name-2', _group_names),
+    ('.group-2', _group_names),
+    ('...', _group_names),
     ('Group_name-2', _group_names_or_all),
+    ('.Group_name-2', _group_names_or_all),
+    ('...', _group_names_or_all),
     ('all', _group_names_or_all),
     # IPs
     ('192.168.122.255', _ips),
@@ -97,6 +101,10 @@ def test_validation_check_exp_ok(exp, regex_name):
     ('file-$', _array_names),
     ('file_1$,file_2#,file-3', _array_names),
     ('all', _group_names),
+    ('.', _group_names),
+    ('..', _group_names),
+    ('.', _group_names_or_all),
+    ('..', _group_names_or_all),
     # IPs
     ('192.168.122.256', _ips),
     ('192.266.1.1', _ips),

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -19,8 +19,8 @@ _base64 = re.compile(r'^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]
 _boolean = re.compile(r'^true$|^false$')
 _dates = re.compile(r'^\d{8}$')
 _empty_boolean = re.compile(r'^$|(^true$|^false$)')
-_group_names = re.compile(r'^[\w.\-]+\b(?<!\ball)$')
-_group_names_or_all = re.compile(r'^[\w.\-]+$')
+_group_names = re.compile(r'^(?!^(\.{1,2}|all)$)[\w.\-]+$')
+_group_names_or_all = re.compile(r'^(?!^\.{1,2}$)[\w.\-]+$')
 _hashes = re.compile(r'^(?:[\da-fA-F]{32})?$|(?:[\da-fA-F]{40})?$|(?:[\da-fA-F]{56})?$|(?:[\da-fA-F]{64})?$|(?:['
                      r'\da-fA-F]{96})?$|(?:[\da-fA-F]{128})?$')
 _ips = re.compile(

--- a/framework/wazuh/core/InputValidator.py
+++ b/framework/wazuh/core/InputValidator.py
@@ -1,12 +1,13 @@
 
-
 # Copyright (C) 2015, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-import re
 import operator
+import re
 from functools import reduce
+
+from api.validator import _group_names
 
 
 class InputValidator:
@@ -28,7 +29,6 @@ class InputValidator:
         else:
             return False
 
-
     def check_length(self, name, length=255, func=operator.le):
         """
         Function to compare the length of a string.
@@ -39,7 +39,6 @@ class InputValidator:
         """
         return func(len(name), length)
 
-
     def group(self, group_name):
         """
         function to validate the name of a group. Returns True if the
@@ -48,7 +47,7 @@ class InputValidator:
         group_name: name of the group to be validated
         """
         def check_single_group_name(group_name):
-            return self.check_length(group_name) and self.check_name(group_name, regex_str=r'[A-Za-z0-9.\-_]+')
+            return self.check_length(group_name) and self.check_name(group_name, regex_str=_group_names)
 
         if isinstance(group_name, list):
             return reduce(operator.mul, map(lambda x: check_single_group_name(x), group_name))

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -173,7 +173,7 @@ def wazuh_gid():
 
 
 # Multigroup variables
-max_groups_per_multigroup = 256
+max_groups_per_multigroup = 128
 
 # Context variables
 rbac: ContextVar[Dict] = ContextVar('rbac', default={'rbac_mode': 'black'})

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -977,6 +977,8 @@ def test_agent_add_group_to_agent(set_agent_group_mock, agent_groups_mock, agent
 @patch('wazuh.core.agent.Agent.get_agent_groups', return_value=['default'])
 def test_agent_add_group_to_agent_ko(agent_groups_mock):
     """Test if add_group_to_agent() raises expected exceptions"""
+    max_groups_number = 128
+
     # Error getting agent groups
     with patch('wazuh.core.agent.Agent.get_agent_groups', side_effect=WazuhError(2003)):
         with pytest.raises(WazuhInternalError, match='.* 2007 .*'):
@@ -990,7 +992,8 @@ def test_agent_add_group_to_agent_ko(agent_groups_mock):
     with pytest.raises(WazuhError, match='.* 1751 .*'):
         Agent.add_group_to_agent('default', '002')
 
-    with patch('wazuh.core.common.max_groups_per_multigroup', new=0):
+    with patch('wazuh.core.agent.Agent.get_agent_groups',
+               return_value=[f'group_{i}' for i in range(max_groups_number)]):
         # Multigroup limit exceeded.
         with pytest.raises(WazuhError, match='.* 1737 .*'):
             Agent.add_group_to_agent('test_group', '002')

--- a/framework/wazuh/core/tests/test_input_validator.py
+++ b/framework/wazuh/core/tests/test_input_validator.py
@@ -37,8 +37,14 @@ class TestInputValidator(TestCase):
         result = InputValidator().group(['test1', 'test2'])
         self.assertEqual(result, True)
 
-        result = InputValidator().group('test')
+        result = InputValidator().group('TesT')
         self.assertEqual(result, True)
 
-        result = InputValidator().group(['test1', 'test2'])
+        result = InputValidator().group(['teSt1', '.test2', '..Test3', '.....'])
         self.assertEqual(result, True)
+
+        result = InputValidator().group(['.'])
+        self.assertEqual(result, False)
+
+        result = InputValidator().group(['..'])
+        self.assertEqual(result, False)


### PR DESCRIPTION
|Related issue|
|---|
|closes #12396 |

## Description

This PR reduces the maximum number of multigroups per agent to 128 and updates and unifies the regexes used to validate the agent groups names, excluding names like `.` and `..`. In addition, it updates the API reference to show the supported format:

![image](https://user-images.githubusercontent.com/37274979/157240756-68bd98d6-2d82-4318-8cf5-6f25db70890b.png)


## Tests performed
### API unit tests
```
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.9, pytest-7.0.0, pluggy-1.0.0
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: asyncio-0.18.1, cov-3.0.0
asyncio: mode=legacy
collected 507 items                                                                                                                                                                                               

api/controllers/test/test_active_response_controller.py .                                                                                                                                                   [  0%]
api/controllers/test/test_agent_controller.py ..........................................                                                                                                                    [  8%]
api/controllers/test/test_cdb_list_controller.py ......                                                                                                                                                     [  9%]
api/controllers/test/test_ciscat_controller.py .                                                                                                                                                            [  9%]
api/controllers/test/test_cluster_controller.py ......................                                                                                                                                      [ 14%]
api/controllers/test/test_decoder_controller.py .......                                                                                                                                                     [ 15%]
api/controllers/test/test_default_controller.py .                                                                                                                                                           [ 15%]
api/controllers/test/test_experimental_controller.py ...............                                                                                                                                        [ 18%]
api/controllers/test/test_manager_controller.py .................                                                                                                                                           [ 22%]
api/controllers/test/test_mitre_controller.py .......                                                                                                                                                       [ 23%]
api/controllers/test/test_overview_controller.py .                                                                                                                                                          [ 23%]
api/controllers/test/test_rootcheck_controller.py ....                                                                                                                                                      [ 24%]
api/controllers/test/test_rule_controller.py ........                                                                                                                                                       [ 26%]
api/controllers/test/test_sca_controller.py ..                                                                                                                                                              [ 26%]
api/controllers/test/test_security_controller.py ...................................................                                                                                                        [ 36%]
api/controllers/test/test_syscheck_controller.py ....                                                                                                                                                       [ 37%]
api/controllers/test/test_syscollector_controller.py .........                                                                                                                                              [ 39%]
api/controllers/test/test_task_controller.py .                                                                                                                                                              [ 39%]
api/controllers/test/test_vulnerability_controller.py ..                                                                                                                                                    [ 39%]
api/models/test/test_model.py ...........................                                                                                                                                                   [ 44%]
api/test/test_alogging.py ..........                                                                                                                                                                        [ 46%]
api/test/test_authentication.py ..........                                                                                                                                                                  [ 48%]
api/test/test_configuration.py .........................................                                                                                                                                    [ 57%]
api/test/test_encoder.py ...                                                                                                                                                                                [ 57%]
api/test/test_middlewares.py ............                                                                                                                                                                   [ 59%]
api/test/test_uri_parser.py ...                                                                                                                                                                             [ 60%]
api/test/test_util.py ......................................                                                                                                                                                [ 68%]
api/test/test_validator.py ..................................................................................................................................................................               [100%]

======================================================================================== 507 passed, 14 warnings in 2.81s =========================================================================================

```

### Framework unit tests
```
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.9, pytest-7.0.0, pluggy-1.0.0
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.18.1, cov-3.0.0
asyncio: mode=legacy
collected 260 items                                                                                                                                                                                               

wazuh/core/tests/test_agent.py ...............................................................................................................................................                              [ 55%]
wazuh/tests/test_agent.py .....................................................................................................................                                                             [100%]

======================================================================================== 260 passed, 10 warnings in 3.89s =========================================================================================

```

Regards,
Víctor