### PR TITLE
Generate Vulnerability Detector alerts on first scan of agent

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1517,7 +1517,7 @@ int wm_vuldet_process_agent_vulnerabilities(sqlite3 *db, OSHash *cve_table, scan
                     "exists");
             }
 
-            if (scan_ctx->scan_type != VU_BASELINE_SCAN && !update) {
+            if (!update) {
                 // Sending CVE report
                 if (wm_vuldet_send_cve_report(report)) {
                     mterror(WM_VULNDETECTOR_LOGTAG, VU_SEND_AGENT_REPORT_ERROR, report->cve, report->software, scan_ctx->agent_id);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2333,7 +2333,7 @@ int wm_vuldet_process_agent_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd
         }
 
         if (!update) {
-            // No report should be generated for baseline scans or already reported vulnerabilities
+            // No report should be generated for vulnerabilities already reported
             // Sending CVE report
             wm_vuldet_send_cve_report(report);
         }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2332,7 +2332,7 @@ int wm_vuldet_process_agent_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd
                 "exists");
         }
 
-        if (scan_ctx->scan_type != VU_BASELINE_SCAN && !update) {
+        if (!update) {
             // No report should be generated for baseline scans or already reported vulnerabilities
             // Sending CVE report
             wm_vuldet_send_cve_report(report);


### PR DESCRIPTION
|Related issue|
|---|
|#12588|

## Description

In order to generate vulnerability alerts when you scan an agent for the first time, it has been necessary to eliminate the conditions of being a scan different from the baseline in the functions where the vulnerabilities of the agents are processed.

## Steps to test the change

1. Activate vulnerability-detector next to the corresponding feed to scan the agent.
2. Connect the new agent
3. Wait for the manager to scan for the first time the agent
4. View the alerts (or check the _DEBUG_ log: `A total of '322' vulnerabilities have been reported for agent '000'`)

## Logs/Alerts example

Logs:
```
2022/03/08 12:20:04 wazuh-modulesd:vulnerability-detector[32440] wm_vuln_detector.c:2519 at wm_vuldet_check_agent_vulnerabilities(): DEBUG: (5491): A baseline scan will be run on agent '000'
...
2022/03/08 12:20:30 wazuh-modulesd:vulnerability-detector[32440] wm_vuln_detector.c:1545 at wm_vuldet_process_agent_vulnerabilities(): DEBUG: (5482): A total of '252' vulnerabilities have been reported for agent '000' thanks to the 'NVD' feed.
2022/03/08 12:20:30 wazuh-modulesd:vulnerability-detector[32440] wm_vuln_detector.c:1546 at wm_vuldet_process_agent_vulnerabilities(): DEBUG: (5482): A total of '322' vulnerabilities have been reported for agent '000' thanks to the 'vendor' feed.
2022/03/08 12:20:30 wazuh-modulesd:vulnerability-detector[32440] wm_vuln_detector.c:1548 at wm_vuldet_process_agent_vulnerabilities(): DEBUG: (5469): A total of '322' vulnerabilities have been reported for agent '000'
2022/03/08 12:20:30 wazuh-modulesd:vulnerability-detector[32440] wm_vuln_detector.c:1549 at wm_vuldet_process_agent_vulnerabilities(): DEBUG: (5470): It took '13' seconds to 'report' vulnerabilities in agent '000'
```

Alerts:
```json
{"timestamp":"2022-03-08T12:20:17.773+0000","rule":{"level":10,"description":"CVE-2022-0554 affects vim","id":"23505","firedtimes":1,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"000","name":"6f790cc7af58","ip":"127.0.0.1"},"manager":{"name":"6f790cc7af58"},"id":"1646742017.1016037","decoder":{"name":"json"},"data":{"vulnerability":{"package":{"name":"vim","version":"2:8.1.2269-1ubuntu5.7","architecture":"amd64","condition":"Package unfixed"},"cvss":{"cvss2":{"vector":{"attack_vector":"network","access_complexity":"medium","authentication":"none","confidentiality_impact":"partial","integrity_impact":"partial","availability":"partial"},"base_score":"6.800000"},"cvss3":{"vector":{"attack_vector":"local","access_complexity":"low","privileges_required":"none","user_interaction":"required","scope":"unchanged","confidentiality_impact":"high","integrity_impact":"high","availability":"high"},"base_score":"7.800000"}},"cve":"CVE-2022-0554","title":"CVE-2022-0554 affects vim","rationale":"Use of Out-of-range Pointer Offset in GitHub repository vim/vim prior to 8.2.","severity":"High","published":"2022-02-10","updated":"2022-03-04","cwe_reference":"CWE-119","references":["https://github.com/vim/vim/commit/e3537aec2f8d6470010547af28dcbd83d41461b8","https://huntr.dev/bounties/7e8f6cd0-b5ee-48a2-8255-6a86f4c46c71","https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/7ZLEHVP4LNAGER4ZDGUDS5V5YVQD6INF/","https://nvd.nist.gov/vuln/detail/CVE-2022-0554","http://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-0554.html","https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-0554"],"assigner":"security@huntr.dev","cve_version":"4.0"}},"location":"vulnerability-detector"}
...
{"timestamp":"2022-03-08T12:20:30.917+0000","rule":{"level":10,"description":"CVE-2018-6952 affects patch","id":"23505","firedtimes":164,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"000","name":"6f790cc7af58","ip":"127.0.0.1"},"manager":{"name":"6f790cc7af58"},"id":"1646742030.2287525","decoder":{"name":"json"},"data":{"vulnerability":{"package":{"name":"patch","version":"2.7.6-6","architecture":"amd64","condition":"Package unfixed"},"cvss":{"cvss2":{"vector":{"attack_vector":"network","access_complexity":"low","authentication":"none","confidentiality_impact":"none","integrity_impact":"none","availability":"partial"},"base_score":"5"},"cvss3":{"vector":{"attack_vector":"network","access_complexity":"low","privileges_required":"none","user_interaction":"none","scope":"unchanged","confidentiality_impact":"none","integrity_impact":"none","availability":"high"},"base_score":"7.500000"}},"cve":"CVE-2018-6952","title":"CVE-2018-6952 affects patch","rationale":"A double free exists in the another_hunk function in pch.c in GNU patch through 2.7.6.","severity":"High","published":"2018-02-13","updated":"2019-04-17","cwe_reference":"CWE-415","bugzilla_references":["https://savannah.gnu.org/bugs/index.php?53133","https://savannah.gnu.org/bugs/index.php?56683 (regression)"],"references":["https://savannah.gnu.org/bugs/index.php?53133","http://www.securityfocus.com/bid/103047","https://security.gentoo.org/glsa/201904-17","https://access.redhat.com/errata/RHSA-2019:2033","https://nvd.nist.gov/vuln/detail/CVE-2018-6952","http://people.canonical.com/~ubuntu-security/cve/2018/CVE-2018-6952.html","https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-6952"],"assigner":"cve@mitre.org","cve_version":"4.0"}},"location":"vulnerability-detector"}
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Working on cluster environments (with the mentioned problem in the issue description)
- [x] The data flow works as expected (agent-manager-api-app)
