### PR TITLE
Fixed created_date field for LB and Umbrella

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2078,11 +2078,11 @@ class AWSCustomBucket(AWSBucket):
 
     def get_creation_date(self, log_file):
         # The Amazon S3 object name follows the pattern DeliveryStreamName-DeliveryStreamVersion-YYYY-MM-DD-HH-MM-SS-RandomString
-        name_regex = re.match(r"^[\w\-]+(\d\d\d\d-\d\d-\d\d)[\w\-.]+$", path.basename(log_file['Key']))
+        name_regex = re.match(r".+\/(\d\d\d\d[\/\-]\d\d[\/\-]\d\d)\/.+", log_file['Key'])
         if name_regex is None:
             return log_file['LastModified'].strftime('%Y%m%d')
         else:
-            return int(name_regex.group(1).replace('-', ''))
+            return int(name_regex.group(1).replace('/', '').replace('-',''))
 
     def get_full_prefix(self, account_id, account_region):
         return self.prefix

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2080,7 +2080,7 @@ class AWSCustomBucket(AWSBucket):
         # The Amazon S3 object name follows the pattern DeliveryStreamName-DeliveryStreamVersion-YYYY-MM-DD-HH-MM-SS-RandomString
         name_regex = re.match(r".*(\d\d\d\d[\/\-]\d\d[\/\-]\d\d).*", log_file['Key'])
         if name_regex is None:
-            return log_file['LastModified'].strftime('%Y%m%d')
+            return int(log_file['LastModified'].strftime('%Y%m%d'))
         else:
             return int(name_regex.group(1).replace('/', '').replace('-',''))
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2078,7 +2078,7 @@ class AWSCustomBucket(AWSBucket):
 
     def get_creation_date(self, log_file):
         # The Amazon S3 object name follows the pattern DeliveryStreamName-DeliveryStreamVersion-YYYY-MM-DD-HH-MM-SS-RandomString
-        name_regex = re.match(r".+\/(\d\d\d\d[\/\-]\d\d[\/\-]\d\d)\/.+", log_file['Key'])
+        name_regex = re.match(r".*(\d\d\d\d[\/\-]\d\d[\/\-]\d\d).*", log_file['Key'])
         if name_regex is None:
             return log_file['LastModified'].strftime('%Y%m%d')
         else:

--- a/wodles/aws/tests/conftest.py
+++ b/wodles/aws/tests/conftest.py
@@ -83,7 +83,7 @@ def aws_waf_bucket(request):
 def aws_config_bucket(request):
     """
     Return a AWSConfigBucket instance.
-    
+
     Parameters
     ----------
     request : pytest.fixtures.SubRequest

--- a/wodles/aws/tests/conftest.py
+++ b/wodles/aws/tests/conftest.py
@@ -83,7 +83,7 @@ def aws_waf_bucket(request):
 def aws_config_bucket(request):
     """
     Return a AWSConfigBucket instance.
-
+    
     Parameters
     ----------
     request : pytest.fixtures.SubRequest
@@ -94,3 +94,20 @@ def aws_config_bucket(request):
          patch('sqlite3.connect'), \
          patch('utils.get_wazuh_version'):
         return aws_s3.AWSConfigBucket(**{k: v for i in request.param for k, v in i.items()})
+
+
+@pytest.fixture(params=deepcopy(AWS_BUCKET_PARAMS))
+def aws_custom_bucket(request):
+    """
+    Return a AWSCustomBucket instance.
+
+    Parameters
+    ----------
+    request : pytest.fixtures.SubRequest
+        Object that contains information about the current test.
+    """
+    with patch('aws_s3.AWSCustomBucket.get_client'), \
+         patch('aws_s3.AWSCustomBucket.get_sts_client'), \
+         patch('sqlite3.connect'), \
+         patch('utils.get_wazuh_version'):
+        return aws_s3.AWSCustomBucket(**{k: v for i in request.param for k, v in i.items()})   

--- a/wodles/aws/tests/test_aws.py
+++ b/wodles/aws/tests/test_aws.py
@@ -308,7 +308,7 @@ def test_aws_waf_load_information_from_file_ko(
     ('2000/2/12', '20000212'),
     ('2022/02/1', '20220201')
 ])
-def test_config_format_created_date(date: str, expected_date: str, aws_config_bucket):
+def test_config_format_creation_date(date: str, expected_date: str, aws_config_bucket):
     """
     Test AWSConfigBucket's format_created_date method.
 
@@ -333,7 +333,7 @@ def test_config_format_created_date(date: str, expected_date: str, aws_config_bu
     ({'Key' : '2021/03/18/aws-waf-logs-delivery-stream-1-2021-03-18-10-32-48-77baca34f-efad-4f14-45bd7871'}, 20210318),
     ({'Key' : '2021-11-12-09-11-26-B9F9F891E8D0EB13'}, 20211112)
 ])
-def test_custom_get_created_date(log_file: dict, expected_date: str, aws_custom_bucket : aws_s3.AWSCustomBucket):
+def test_custom_get_creation_date(log_file: dict, expected_date: str, aws_custom_bucket : aws_s3.AWSCustomBucket):
     """
     Test AWSCustomBucket's get_creation_date method.
     Parameters

--- a/wodles/aws/tests/test_aws.py
+++ b/wodles/aws/tests/test_aws.py
@@ -10,6 +10,7 @@ import json
 from sqlite3 import connect
 from unittest.mock import patch, MagicMock
 import pytest
+from datetime import datetime
 
 # mock AWS libraries
 sys.modules['boto3'] = MagicMock()
@@ -330,17 +331,20 @@ def test_config_format_created_date(date: str, expected_date: str, aws_config_bu
     ({'Key' : '981837383623/iplogs/2020-09-20/2020-09-20-00-00-moyl.csv.gz'}, 20200920),
     ({'Key' : '836629801214/iplogs/2021-01-18/2021-01-18-00-00-zxsb.csv.gz'}, 20210118),
     ({'Key' : '2020/09/30/13/firehose_guardduty-1-2020-09-30-13-17-05-532e184c-1hfba.zip'}, 20200930),
+    ({'Key' : '2020/10/15/03/firehose_guardduty-1-2020-10-15-03-22-01-ea728dd1-763a4.zip'}, 20201015),
     ({'Key' : '2021/03/18/aws-waf-logs-delivery-stream-1-2021-03-18-10-32-48-77baca34f-efad-4f14-45bd7871'}, 20210318),
-    ({'Key' : '2021-11-12-09-11-26-B9F9F891E8D0EB13'}, 20211112)
+    ({'Key' : '2021/09/06/aws-waf-logs-delivery-stream-1-2021-09-06-21-02-18-8ba031bbd-babf-4c6a-83ba282c'}, 20210906),
+    ({'Key' : '2021-11-12-09-11-26-B9F9F891E8D0EB13'}, 20211112),
+    ({'Key' : '20-03-02-21-02-43-A8269E82CA8BDD21', 'LastModified' : datetime.strptime('2021/01/23', '%Y/%m/%d')}, 20210123)
 ])
-def test_custom_get_creation_date(log_file: dict, expected_date: str, aws_custom_bucket : aws_s3.AWSCustomBucket):
+def test_custom_get_creation_date(log_file: dict, expected_date: int, aws_custom_bucket : aws_s3.AWSCustomBucket):
     """
     Test AWSCustomBucket's get_creation_date method.
     Parameters
     ----------
     log_file : dict
         The log file introduced
-    expected_date : str
+    expected_date : int
         The date that the method should return.
     aws_custom_bucket : aws_s3.AWSCustomBucket
         Instance of the AWSCustomBucket class.  

--- a/wodles/aws/tests/test_aws.py
+++ b/wodles/aws/tests/test_aws.py
@@ -322,3 +322,27 @@ def test_config_format_created_date(date: str, expected_date: str, aws_config_bu
         Instance of the AWSConfigBucket class.
     """
     assert aws_config_bucket._format_created_date(date) == expected_date
+
+
+@pytest.mark.parametrize('log_file, expected_date', [
+    ({'Key' : 'AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/12/21/166157441623_elasticloadbalancing'}, 20211221),
+    ({'Key' : 'AWSLogs/875611522134/elasticloadbalancing/us-west-1/2020/01/03/166157441623_elasticloadbalancing'}, 20200103),
+    ({'Key' : '981837383623/iplogs/2020-09-20/2020-09-20-00-00-moyl.csv.gz'}, 20200920),
+    ({'Key' : '836629801214/iplogs/2021-01-18/2021-01-18-00-00-zxsb.csv.gz'}, 20210118),
+    ({'Key' : '2020/09/30/13/firehose_guardduty-1-2020-09-30-13-17-05-532e184c-1hfba.zip'}, 20200930),
+    ({'Key' : '2021/03/18/aws-waf-logs-delivery-stream-1-2021-03-18-10-32-48-77baca34f-efad-4f14-45bd7871'}, 20210318),
+    ({'Key' : '2021-11-12-09-11-26-B9F9F891E8D0EB13'}, 20211112)
+])
+def test_custom_get_created_date(log_file: dict, expected_date: str, aws_custom_bucket : aws_s3.AWSCustomBucket):
+    """
+    Test AWSCustomBucket's get_creation_date method.
+    Parameters
+    ----------
+    log_file : dict
+        The log file introduced
+    expected_date : str
+        The date that the method should return.
+    aws_custom_bucket : aws_s3.AWSCustomBucket
+        Instance of the AWSCustomBucket class.  
+    """
+    assert aws_custom_bucket.get_creation_date(log_file) == expected_date

--- a/wodles/aws/tests/test_aws.py
+++ b/wodles/aws/tests/test_aws.py
@@ -308,7 +308,7 @@ def test_aws_waf_load_information_from_file_ko(
     ('2000/2/12', '20000212'),
     ('2022/02/1', '20220201')
 ])
-def test_config_format_creation_date(date: str, expected_date: str, aws_config_bucket):
+def test_config_format_created_date(date: str, expected_date: str, aws_config_bucket):
     """
     Test AWSConfigBucket's format_created_date method.
 


### PR DESCRIPTION
| Related issue |
|---|
|Closes #11560 |

# Description

In this PR we have fixed a bug found in ALB, CLB, NLB buckets and Umbrella. The problem was that the `created_date` field was not seting correctly in the database. 

# Tests performed 

He are some examples of execution where we expect that the logs date will be the same as the date saved in the database. AWSGuardDutyBucket, AWSWAFBucket and AWSServerAccess have also been added  because they inherit from AWSCustomBucket and use the function `get_creation_date()`

## ALB

<details><summary> Command used and output </summary>

	root@wazuh-master:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-alb -t alb -p dev -d2 -s 2021-nov-01
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on 166157441623 - us-west-1
	DEBUG: +++ Marker: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/11/01
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/12/21/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20211221T0000Z_52.52.208.49_14pczeay.log.gz
	wazuh-aws-wodle-alb/ 20211221
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/12/22/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20211222T0000Z_52.52.208.49_14pczeay.log.gz
	wazuh-aws-wodle-alb/ 20211222
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/12/23/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20211223T0000Z_52.52.208.49_14pczeay.log.gz
	wazuh-aws-wodle-alb/ 20211223
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/12/23/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20211230T0000Z_52.52.208.49_14pczeay.log
	wazuh-aws-wodle-alb/ 20211223
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/12/23/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20211230T0000Z_52.52.208.49_14pczeay.log.gz
	wazuh-aws-wodle-alb/ 20211223
	DEBUG: +++ DB Maintenance

</details>

<details><summary> created_date field in database </summary>

	root@wazuh-master:/var/ossec/wodles/aws# sqlite3 s3_cloudtrail.db 'select log_key, created_date from alb'
	AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/12/21/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20211221T0000Z_52.52.208.49_14pczeay.log.gz|20211221
	AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/12/22/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20211222T0000Z_52.52.208.49_14pczeay.log.gz|20211222
	AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/12/23/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20211223T0000Z_52.52.208.49_14pczeay.log.gz|20211223
	AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/12/23/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20211230T0000Z_52.52.208.49_14pczeay.log|20211223
	AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/12/23/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20211230T0000Z_52.52.208.49_14pczeay.log.gz|20211223


</details>

## CLB 

<details><summary> Command used and output </summary>

	root@wazuh-master:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-clb -t clb -p dev -d2 -s 2021-nov-01
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on 166157441623 - us-west-1
	DEBUG: +++ Marker: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/11/01
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/11/09/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211109T1735Z_18.144.142.112_2helnha7.log
	wazuh-aws-wodle-clb/ 20211109
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/11/10/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211110T1735Z_18.144.142.112_2helnha7.log
	wazuh-aws-wodle-clb/ 20211110
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/11/11/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211111T1735Z_18.144.142.112_2helnha7.log
	wazuh-aws-wodle-clb/ 20211111
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/11/12/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211112T1735Z_18.144.142.112_2helnha7.log
	wazuh-aws-wodle-clb/ 20211112
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/12/23/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211223T1735Z_18.144.142.112_2helnha7.log
	wazuh-aws-wodle-clb/ 20211223
	DEBUG: +++ DB Maintenance

</details>

<details><summary> created_date field in database </summary>

	root@wazuh-master:/var/ossec/wodles/aws# sqlite3 s3_cloudtrail.db 'select log_key, created_date from clb'
	AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/11/09/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211109T1735Z_18.144.142.112_2helnha7.log|20211109
	AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/11/10/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211110T1735Z_18.144.142.112_2helnha7.log|20211110
	AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/11/11/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211111T1735Z_18.144.142.112_2helnha7.log|20211111
	AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/11/12/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211112T1735Z_18.144.142.112_2helnha7.log|20211112
	AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/12/23/166157441623_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211223T1735Z_18.144.142.112_2helnha7.log|20211223


</details>

## NLB
<details><summary> Command used and output </summary>

	root@wazuh-master:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-nlb -t nlb -p dev -d2 -s 2021-nov-01
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on 166157441623 - us-west-1
	DEBUG: +++ Marker: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/11/01
	DEBUG: ++ Found new log: AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/12/23/166157441623_elasticloadbalancing_us-west-1_net.fram-dev-N-Wazuh.9d0fcf192ea215c3_20201124T0305Z_beb2c861.log.gz
	wazuh-aws-wodle-nlb/ 20211223
	DEBUG: +++ DB Maintenance

</details>

<details><summary> created_date field in database </summary>

	root@wazuh-master:/var/ossec/wodles/aws# sqlite3 s3_cloudtrail.db 'select log_key, created_date from nlb'
	AWSLogs/166157441623/elasticloadbalancing/us-west-1/2021/12/23/166157441623_elasticloadbalancing_us-west-1_net.fram-dev-N-Wazuh.9d0fcf192ea215c3_20201124T0305Z_beb2c861.log.gz|20211223


</details>


## Umbrella

<details><summary> Command used and output </summary>

	root@wazuh-master:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -p dev -d2 -s 2021-Dec-01
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Marker: 166157441623/iplogs/2021-12-01
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-01/2021-12-01-00-00-xyzs.csv.gz
	wazuh-aws-wodle-umbrella/166157441623/iplogs/ 20211201
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-15/2021-12-15-00-00-asge.csv.gz
	wazuh-aws-wodle-umbrella/166157441623/iplogs/ 20211215
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-20/2021-12-20-00-00-xoal.csv.gz
	wazuh-aws-wodle-umbrella/166157441623/iplogs/ 20211220
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-24/2021-12-24-00-00-ixla.csv.gz
	wazuh-aws-wodle-umbrella/166157441623/iplogs/ 20211224
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-29/2021-12-29-00-00-ixla.csv.gz
	wazuh-aws-wodle-umbrella/166157441623/iplogs/ 20211229
	DEBUG: ++ Found new log: 166157441623/iplogs/2022-01-17/2022-01-17-00-00-ixla.csv.gz
	wazuh-aws-wodle-umbrella/166157441623/iplogs/ 20220117
	DEBUG: ++ Found new log: 166157441623/iplogs/2022-01-21/2022-01-21-00-00-ixla.csv.gz
	wazuh-aws-wodle-umbrella/166157441623/iplogs/ 20220121
	DEBUG: ++ Found new log: 166157441623/iplogs/2022-01-25/2022-02-11-00-00-abcd.csv.gz
	wazuh-aws-wodle-umbrella/166157441623/iplogs/ 20220125
	DEBUG: ++ Found new log: 166157441623/iplogs/2022-02-11/2022-01-25-00-00-xyzs.csv.gz
	wazuh-aws-wodle-umbrella/166157441623/iplogs/ 20220211
	DEBUG: +++ DB Maintenance

</details>

<details><summary> created_date field in database </summary>

	root@wazuh-master:/var/ossec/wodles/aws# sqlite3 s3_cloudtrail.db 'select log_key, created_date from cisco_umbrella'
	166157441623/iplogs/2021-12-01/2021-12-01-00-00-xyzs.csv.gz|20211201
	166157441623/iplogs/2021-12-15/2021-12-15-00-00-asge.csv.gz|20211215
	166157441623/iplogs/2021-12-20/2021-12-20-00-00-xoal.csv.gz|20211220
	166157441623/iplogs/2021-12-24/2021-12-24-00-00-ixla.csv.gz|20211224
	166157441623/iplogs/2021-12-29/2021-12-29-00-00-ixla.csv.gz|20211229
	166157441623/iplogs/2022-01-17/2022-01-17-00-00-ixla.csv.gz|20220117
	166157441623/iplogs/2022-01-21/2022-01-21-00-00-ixla.csv.gz|20220121
	166157441623/iplogs/2022-01-25/2022-02-11-00-00-abcd.csv.gz|20220125
	166157441623/iplogs/2022-02-11/2022-01-25-00-00-xyzs.csv.gz|20220211

</details>


## GuardDuty
<details><summary> Command used and output </summary>

	root@wazuh-master:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-guardduty -t custom -s 2021-Jun-22 -p dev -d2 | grep -v "Skipping file with another prefix"
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Marker: 2021/06/22
	DEBUG: ++ Found new log: 2021/06/22/16/firehose_guardduty-1-2021-06-22-16-15-05-872e154c-1fd8-4369-a151-947ec0438d8d.zip
	wazuh-aws-wodle-guardduty/ 20210622
	DEBUG: ++ Found new log: 2021/07/08/03/firehose_guardduty-1-2021-07-08-03-46-07-12788dc1-723b-4e2b-9d12-07885e967524.zip
	wazuh-aws-wodle-guardduty/ 20210708
	DEBUG: ++ Found new log: 2021/12/24/03/firehose_guardduty-1-2021-12-24-03-46-07-12788dc1-723b-4e2b-9d12-07885e967524.zip
	wazuh-aws-wodle-guardduty/ 20211224
	DEBUG: +++ DB Maintenance

</details>

<details><summary> created_date field in database </summary>

	root@wazuh-master:/var/ossec/wodles/aws# sqlite3 s3_cloudtrail.db 'select log_key, created_date from custom'
	2021/06/22/16/firehose_guardduty-1-2021-06-22-16-15-05-872e154c-1fd8-4369-a151-947ec0438d8d.zip|20210622
	2021/07/08/03/firehose_guardduty-1-2021-07-08-03-46-07-12788dc1-723b-4e2b-9d12-07885e967524.zip|20210708
	2021/12/24/03/firehose_guardduty-1-2021-12-24-03-46-07-12788dc1-723b-4e2b-9d12-07885e967524.zip|20211224

</details>

## WAF
<details><summary> Command used and output </summary>

	root@wazuh-master:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-waf -t custom -s 2021-Sep-17 -p dev -d2 | grep -v "Skipping file with another prefix"
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Marker: 2021/09/17
	DEBUG: ++ Found new log: 2021/12/21/aws-waf-logs-delivery-stream-1-2021-12-21-10-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718193
	wazuh-aws-wodle-waf/ 20211221
	DEBUG: ++ Found new log: 2021/12/22/aws-waf-logs-delivery-stream-1-2021-12-22-10-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718193
	wazuh-aws-wodle-waf/ 20211222
	DEBUG: ++ Found new log: 2021/12/23/aws-waf-logs-delivery-stream-1-2021-12-23-10-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718193
	wazuh-aws-wodle-waf/ 20211223
	DEBUG: ++ Found new log: 2021/12/24/aws-waf-logs-delivery-stream-1-2021-12-24-10-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718193
	wazuh-aws-wodle-waf/ 20211224
	DEBUG: +++ DB Maintenance

</details>

<details><summary> created_date field in database </summary>

	root@wazuh-master:/var/ossec/wodles/aws# sqlite3 s3_cloudtrail.db 'select log_key, created_date from custom'
	2021/12/21/aws-waf-logs-delivery-stream-1-2021-12-21-10-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718193|20211221
	2021/12/22/aws-waf-logs-delivery-stream-1-2021-12-22-10-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718193|20211222
	2021/12/23/aws-waf-logs-delivery-stream-1-2021-12-23-10-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718193|20211223
	2021/12/24/aws-waf-logs-delivery-stream-1-2021-12-24-10-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718193|20211224

</details>

## ServerAccess
<details><summary> Command used and output </summary>

	root@wazuh-master:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-access -t server_access -s 2021-NOV-12 -p dev -d2 | grep -v "Skipping file with another prefix"
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Marker: 2021-11-12
	DEBUG: ++ Found new log: 2021-11-12-09-11-26-B9F9F891E8D0EB13
	wazuh-aws-wodle-access/ 20211112
	DEBUG: ++ Found new log: 2021-11-12-13-11-26-B9F9F891E8D0EB13
	wazuh-aws-wodle-access/ 20211112
	DEBUG: ++ Found new log: 2021-11-15-09-12-25-F92E1554CC549BEE
	wazuh-aws-wodle-access/ 20211115
	DEBUG: ++ Found new log: 2021-12-27-09-12-23-F92E1554CC549BEA
	wazuh-aws-wodle-access/ 20211227
	DEBUG: ++ Found new log: 2022-01-25-09-12-23-F92E1554CC549BEX
	wazuh-aws-wodle-access/ 20220125
	DEBUG: ++ Found new log: 2022-02-11-09-12-25-H99KY554CC549BEE
	wazuh-aws-wodle-access/ 20220211
	DEBUG: +++ DB Maintenance

</details>

<details><summary> created_date field in database </summary>

	root@wazuh-master:/var/ossec/wodles/aws# sqlite3 s3_cloudtrail.db 'select log_key, created_date from s3_server_access'
	2021-11-12-09-11-26-B9F9F891E8D0EB13|20211112
	2021-11-12-13-11-26-B9F9F891E8D0EB13|20211112
	2021-11-15-09-12-25-F92E1554CC549BEE|20211115
	2021-12-27-09-12-23-F92E1554CC549BEA|20211227
	2022-01-25-09-12-23-F92E1554CC549BEX|20220125
	2022-02-11-09-12-25-H99KY554CC549BEE|20220211

</details>


# Conclusions

Everything worked as expected, all log dates were saved correctly in the database