### PR TITLE
Add "type" field to Vulnerability Detector alerts - Implementation

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -388,6 +388,7 @@ static int build_test_cve_report(vu_report* report, int add_condition, int add_i
     os_strdup("CVE-2016-6489 reports as vulnerable all the versions of this package", report->operation);
     os_strdup("4.3-2", report->operation_value);
     os_strdup("amd64", report->arch);
+    os_strdup("PACKAGE", report->type);
     // Agent data
     os_strdup("001", report->agent_id);
     os_strdup("Ubuntu_WAgent", report->agent_name);
@@ -6647,6 +6648,9 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors
 
     expect_string(__wrap_cJSON_AddStringToObject, name, "status");
     expect_string(__wrap_cJSON_AddStringToObject, string, VULN_CVES_STATUS_ACTIVE_LOWERCASE);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "type");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "PACKAGE");
     // Adding advisories data
     will_return(__wrap_cJSON_CreateArray, j_advisories);
     expect_string(__wrap_cJSON_CreateString, string, "RHSA-2020:0975");
@@ -7012,6 +7016,9 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors
 
     expect_string(__wrap_cJSON_AddStringToObject, name, "status");
     expect_string(__wrap_cJSON_AddStringToObject, string, VULN_CVES_STATUS_ACTIVE_LOWERCASE);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "type");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "PACKAGE");
     // Adding advisories data
     will_return(__wrap_cJSON_CreateArray, j_advisories);
     expect_string(__wrap_cJSON_CreateString, string, "RHSA-2020:0975");
@@ -7982,6 +7989,9 @@ void test_wm_vuldet_send_cve_report_error_j_advisories_create(void **state)
 
     expect_string(__wrap_cJSON_AddStringToObject, name, "status");
     expect_string(__wrap_cJSON_AddStringToObject, string, VULN_CVES_STATUS_ACTIVE_LOWERCASE);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "type");
+    expect_string(__wrap_cJSON_AddStringToObject, string, report->type);
     // Adding advisories data
     will_return(__wrap_cJSON_CreateArray, NULL);
     expect_function_call(__wrap_cJSON_Delete);
@@ -8134,6 +8144,9 @@ void test_wm_vuldet_send_cve_report_error_j_bug_references_create(void **state)
 
     expect_string(__wrap_cJSON_AddStringToObject, name, "status");
     expect_string(__wrap_cJSON_AddStringToObject, string, VULN_CVES_STATUS_ACTIVE_LOWERCASE);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "type");
+    expect_string(__wrap_cJSON_AddStringToObject, string,  report->type);
     // Adding advisories data
     will_return(__wrap_cJSON_CreateArray, j_advisories);
     expect_string(__wrap_cJSON_CreateString, string, "RHSA-2020:0975");
@@ -8294,6 +8307,9 @@ void test_wm_vuldet_send_cve_report_error_j_references_create(void **state)
 
     expect_string(__wrap_cJSON_AddStringToObject, name, "status");
     expect_string(__wrap_cJSON_AddStringToObject, string, VULN_CVES_STATUS_ACTIVE_LOWERCASE);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "type");
+    expect_string(__wrap_cJSON_AddStringToObject, string, report->type);
     // Adding advisories data
     will_return(__wrap_cJSON_CreateArray, j_advisories);
     expect_string(__wrap_cJSON_CreateString, string, "RHSA-2020:0975");
@@ -8465,6 +8481,9 @@ void test_wm_vuldet_send_cve_report_without_title(void **state)
 
     expect_string(__wrap_cJSON_AddStringToObject, name, "status");
     expect_string(__wrap_cJSON_AddStringToObject, string, VULN_CVES_STATUS_ACTIVE_LOWERCASE);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "type");
+    expect_string(__wrap_cJSON_AddStringToObject, string, report->type);
     // Adding advisories data
     will_return(__wrap_cJSON_CreateArray, j_advisories);
     expect_string(__wrap_cJSON_CreateString, string, "RHSA-2020:0975");
@@ -8655,6 +8674,9 @@ void test_wm_vuldet_send_cve_report_without_condition(void **state)
 
     expect_string(__wrap_cJSON_AddStringToObject, name, "status");
     expect_string(__wrap_cJSON_AddStringToObject, string, VULN_CVES_STATUS_ACTIVE_LOWERCASE);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "type");
+    expect_string(__wrap_cJSON_AddStringToObject, string, report->type);
     // Adding advisories data
     will_return(__wrap_cJSON_CreateArray, j_advisories);
     expect_string(__wrap_cJSON_CreateString, string, "RHSA-2020:0975");
@@ -8846,6 +8868,9 @@ void test_wm_vuldet_send_cve_report_without_ip(void **state)
 
     expect_string(__wrap_cJSON_AddStringToObject, name, "status");
     expect_string(__wrap_cJSON_AddStringToObject, string, VULN_CVES_STATUS_ACTIVE_LOWERCASE);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "type");
+    expect_string(__wrap_cJSON_AddStringToObject, string, report->type);
     // Adding advisories data
     will_return(__wrap_cJSON_CreateArray, j_advisories);
     expect_string(__wrap_cJSON_CreateString, string, "RHSA-2020:0975");
@@ -9036,6 +9061,9 @@ void test_wm_vuldet_send_cve_report_without_hotfix(void **state)
 
     expect_string(__wrap_cJSON_AddStringToObject, name, "status");
     expect_string(__wrap_cJSON_AddStringToObject, string, VULN_CVES_STATUS_ACTIVE_LOWERCASE);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "type");
+    expect_string(__wrap_cJSON_AddStringToObject, string, report->type);
     // Adding advisories data
     will_return(__wrap_cJSON_CreateArray, j_advisories);
     expect_string(__wrap_cJSON_CreateString, string, "RHSA-2020:0975");
@@ -9226,6 +9254,9 @@ void test_wm_vuldet_send_cve_report_sendmsg_error(void **state)
 
     expect_string(__wrap_cJSON_AddStringToObject, name, "status");
     expect_string(__wrap_cJSON_AddStringToObject, string, VULN_CVES_STATUS_ACTIVE_LOWERCASE);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "type");
+    expect_string(__wrap_cJSON_AddStringToObject, string, report->type);
     // Adding advisories data
     will_return(__wrap_cJSON_CreateArray, j_advisories);
     expect_string(__wrap_cJSON_CreateString, string, "RHSA-2020:0975");

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1485,7 +1485,7 @@ int wm_vuldet_process_agent_vulnerabilities(sqlite3 *db, OSHash *cve_table, scan
             }
 
             //Save the vulnerability in the agent database
-            bool check_pkg_existence = !strcmp(pkg->type, VULN_CVES_TYPE_PACKAGE);
+            bool check_pkg_existence = pkg->type && !strcmp(pkg->type, VULN_CVES_TYPE_PACKAGE);
             cJSON* j_result = wdb_insert_vuln_cves(scan_ctx->agent_id, report->software, report->version, report->arch, report->cve,
                                                    wm_vuldet_get_unified_severity(report->severity), report->cvss2 ? report->cvss2->base_score : 0,
                                                    report->cvss3 ? report->cvss3->base_score : 0, pkg->reference, pkg->type, VULN_CVES_STATUS_VALID,

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1449,10 +1449,7 @@ int wm_vuldet_process_agent_vulnerabilities(sqlite3 *db, OSHash *cve_table, scan
                 w_strdup(pkg->version, report->version);
             }
             w_strdup(pkg->arch, report->arch);
-            if(pkg->type) {
-                os_free(report->type);
-                w_strdup(pkg->type, report->type);
-            }
+            w_strdup(pkg->type, report->type);
 
             // Adding data from NVD
             if ((pkg->feed == VU_SRC_NVD) && pkg->nvd_cond) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1449,6 +1449,10 @@ int wm_vuldet_process_agent_vulnerabilities(sqlite3 *db, OSHash *cve_table, scan
                 w_strdup(pkg->version, report->version);
             }
             w_strdup(pkg->arch, report->arch);
+            if(pkg->type) {
+                os_free(report->type);
+                w_strdup(pkg->type, report->type);
+            }
 
             // Adding data from NVD
             if ((pkg->feed == VU_SRC_NVD) && pkg->nvd_cond) {
@@ -1645,6 +1649,8 @@ int wm_vuldet_send_cve_report(vu_report *report) {
         }
         if (report->cwe) cJSON_AddStringToObject(alert_cve, "cwe_reference", report->cwe);
         cJSON_AddStringToObject(alert_cve, "status", VULN_CVES_STATUS_ACTIVE_LOWERCASE);
+        cJSON_AddStringToObject(alert_cve, "type", report->type);
+
         if (report->advisories) {
             cJSON *j_advisories = NULL;
             if (j_advisories = cJSON_CreateArray(), !j_advisories) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2296,7 +2296,7 @@ int wm_vuldet_process_agent_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd
         w_strdup(agent->agent_ip, report->agent_ip);
 
         //Save the vulnerability in the agent database
-        bool check_pkg_existence = !strcmp(report->type, VULN_CVES_TYPE_PACKAGE);
+        bool check_pkg_existence = report->type && !strcmp(report->type, VULN_CVES_TYPE_PACKAGE);
         cJSON* j_result = wdb_insert_vuln_cves(atoi(agent->agent_id), report->software, report->version, report->arch, report->cve,
                                                wm_vuldet_get_unified_severity(report->severity), report->cvss2 ? report->cvss2->base_score : 0,
                                                report->cvss3 ? report->cvss3->base_score : 0, report->reference, report->type, VULN_CVES_STATUS_VALID,


### PR DESCRIPTION
|Related issue|
|---|
|#12600|

## Description

This PR adds the **type** (OS/PACKAGE) to the alerts generated by vulnerability detector.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report

- [x] Added unit tests (for new features)
