### PR TITLE
Implemented shared_ptr for event pipeline

### DIFF
--- a/src/engine/source/builder/builder.hpp
+++ b/src/engine/source/builder/builder.hpp
@@ -157,7 +157,7 @@ public:
         Graph_t filters;
         json::Document asset = m_catalog.getAsset("environment", name);
 
-        this->assetBuilder(g, "decoder", asset.get(".decoders"),
+        this->assetBuilder(g, "decoder", asset.get("/decoders"),
                            std::get<internals::types::AssetBuilder>(internals::Registry::getBuilder("decoder")));
         this->connectGraph(g, internals::types::ConnectableT("DECODERS_INPUT"),
                            internals::types::ConnectableT("DECODERS_OUTPUT"));
@@ -165,7 +165,7 @@ public:
         g.addNode(internals::types::ConnectableT("RULES_INPUT"));
         g.addEdge(internals::types::ConnectableT("DECODERS_OUTPUT"), internals::types::ConnectableT("RULES_INPUT"));
 
-        this->assetBuilder(g, "rule", asset.get(".rules"),
+        this->assetBuilder(g, "rule", asset.get("/rules"),
                            std::get<internals::types::AssetBuilder>(internals::Registry::getBuilder("rule")));
         this->connectGraph(g, internals::types::ConnectableT("RULES_INPUT"),
                            internals::types::ConnectableT("RULES_OUTPUT"));
@@ -174,12 +174,12 @@ public:
         g.addEdge(internals::types::ConnectableT("DECODERS_OUTPUT"), internals::types::ConnectableT("OUTPUTS_INPUT"));
         g.addEdge(internals::types::ConnectableT("RULES_OUTPUT"), internals::types::ConnectableT("OUTPUTS_INPUT"));
 
-        this->assetBuilder(g, "output", asset.get(".outputs"),
+        this->assetBuilder(g, "output", asset.get("/outputs"),
                            std::get<internals::types::AssetBuilder>(internals::Registry::getBuilder("output")));
         this->connectGraph(g, internals::types::ConnectableT("OUTPUTS_INPUT"),
                            internals::types::ConnectableT("OUTPUTS_OUTPUT"));
 
-        this->assetBuilder(filters, "filter", asset.get(".filters"),
+        this->assetBuilder(filters, "filter", asset.get("/filters"),
                            std::get<internals::types::AssetBuilder>(internals::Registry::getBuilder("filter")));
         this->filterGraph(g, filters);
 

--- a/src/engine/source/builder/builder.hpp
+++ b/src/engine/source/builder/builder.hpp
@@ -156,7 +156,7 @@ public:
         Graph_t g;
         Graph_t filters;
         json::Document asset = m_catalog.getAsset("environment", name);
-
+        // TODO: Parametrize - define constextp string
         this->assetBuilder(g, "decoder", asset.get("/decoders"),
                            std::get<internals::types::AssetBuilder>(internals::Registry::getBuilder("decoder")));
         this->connectGraph(g, internals::types::ConnectableT("DECODERS_INPUT"),

--- a/src/engine/source/builder/builderTypes.hpp
+++ b/src/engine/source/builder/builderTypes.hpp
@@ -25,7 +25,7 @@
 namespace builder::internals::types
 {
 
-using Event = json::Document;
+using Event = std::shared_ptr<json::Document>;
 using Document = json::Document;
 using DocumentValue = json::Value;
 using Observable = rxcpp::observable<Event>;

--- a/src/engine/source/builder/builders/opBuilderConditionReference.cpp
+++ b/src/engine/source/builder/builders/opBuilderConditionReference.cpp
@@ -32,8 +32,8 @@ types::Lifter opBuilderConditionReference(const types::DocumentValue & def)
             [=](types::Event e)
             {
                 //TODO: implemente proper json check reference
-                auto v = e.get("/" + reference);
-                return e.check("/" + field, v);
+                auto v = e->get("/" + reference);
+                return e->check("/" + field, v);
             });
     };
 }

--- a/src/engine/source/builder/builders/opBuilderConditionReference.cpp
+++ b/src/engine/source/builder/builders/opBuilderConditionReference.cpp
@@ -20,9 +20,16 @@ namespace builder::internals::builders
 types::Lifter opBuilderConditionReference(const types::DocumentValue & def)
 {
     // Estract field and reference
-    std::string field = def.MemberBegin()->name.GetString();
-    std::string reference = def.MemberBegin()->value.GetString();
-    reference = reference.substr(1, std::string::npos);
+    // TODO Add test for this
+    std::string field {json::Document::preparePath(def.MemberBegin()->name.GetString())};
+
+    if (!def.MemberBegin()->value.IsString())
+    {
+        throw std::runtime_error("The value of the field '" + field + "' must be a string.");
+    }
+    std::string reference {def.MemberBegin()->value.GetString()};
+    // Delete the `$` at the beginning of the reference (Adds test, doc and handle the invalid reference)
+    reference = json::Document::preparePath(reference.substr(1, std::string::npos));
 
     // Return Lifter
     return [=](types::Observable o)
@@ -32,8 +39,8 @@ types::Lifter opBuilderConditionReference(const types::DocumentValue & def)
             [=](types::Event e)
             {
                 //TODO: implemente proper json check reference
-                auto v = e->get("/" + reference);
-                return e->check("/" + field, v);
+                auto v = e->get(reference);
+                return e->check(field, v);
             });
     };
 }

--- a/src/engine/source/builder/builders/opBuilderConditionReference.cpp
+++ b/src/engine/source/builder/builders/opBuilderConditionReference.cpp
@@ -28,7 +28,7 @@ types::Lifter opBuilderConditionReference(const types::DocumentValue & def)
         throw std::runtime_error("The value of the field '" + field + "' must be a string.");
     }
     std::string reference {def.MemberBegin()->value.GetString()};
-    // Delete the `$` at the beginning of the reference (Adds test, doc and handle the invalid reference)
+    // TODO: Delete the `$` at the beginning of the reference (Adds test, doc and handle the invalid reference)
     reference = json::Document::preparePath(reference.substr(1, std::string::npos));
 
     // Return Lifter
@@ -38,9 +38,17 @@ types::Lifter opBuilderConditionReference(const types::DocumentValue & def)
         return o.filter(
             [=](types::Event e)
             {
-                //TODO: implemente proper json check reference
-                auto v = e->get(reference);
-                return e->check(field, v);
+                // TODO: implemente proper json check reference
+                // TODO: remove try and catch
+                try
+                {
+                    auto v = e->get(reference);
+                    return v != nullptr && e->check(field, v);
+                }
+                catch (std::exception & ex)
+                {
+                    return false;
+                }
             });
     };
 }

--- a/src/engine/source/builder/builders/opBuilderConditionValue.cpp
+++ b/src/engine/source/builder/builders/opBuilderConditionValue.cpp
@@ -23,7 +23,7 @@ types::Lifter opBuilderConditionValue(const types::DocumentValue & def)
     return [=](types::Observable o)
     {
         // Append rxcpp operation
-        return o.filter([=](types::Event e) { return e.check(doc); });
+        return o.filter([=](types::Event e) { return e->check(doc); });
     };
 }
 

--- a/src/engine/source/builder/builders/opBuilderConditionValue.cpp
+++ b/src/engine/source/builder/builders/opBuilderConditionValue.cpp
@@ -17,6 +17,7 @@ namespace builder::internals::builders
 types::Lifter opBuilderConditionValue(const types::DocumentValue & def)
 {
     // Make deep copy of value
+    // TODO Should separete document to be checked, in order of build the path before check teh value
     types::Document doc{def};
 
     // Return Lifter

--- a/src/engine/source/builder/builders/opBuilderHelperFilter.cpp
+++ b/src/engine/source/builder/builders/opBuilderHelperFilter.cpp
@@ -37,7 +37,7 @@ using builder::internals::syntax::REFERENCE_ANCHOR;
 std::tuple<std::string, opString, opString> getCompOpParameter(const DocumentValue & def)
 {
     // Get destination path
-    std::string field {def.MemberBegin()->name.GetString()};
+    std::string field {json::Document::preparePath(def.MemberBegin()->name.GetString())};
     // Get function helper
     if (!def.MemberBegin()->value.IsString())
     {
@@ -57,7 +57,7 @@ std::tuple<std::string, opString, opString> getCompOpParameter(const DocumentVal
 
     if (parameters[1][0] == REFERENCE_ANCHOR)
     {
-        refValue = parameters[1].substr(1);
+        refValue = json::Document::preparePath(parameters[1].substr(1));
     }
     else
     {
@@ -128,7 +128,7 @@ bool opBuilderHelperStringComparison(const std::string key, char op, types::Even
     const rapidjson::Value * fieldToCompare {};
     try
     {
-        fieldToCompare = e->get("/" + key);
+        fieldToCompare = e->get(key);
     }
     catch (std::exception & ex)
     {
@@ -149,7 +149,7 @@ bool opBuilderHelperStringComparison(const std::string key, char op, types::Even
         const rapidjson::Value * refValueToCheck {};
         try
         {
-            refValueToCheck = e->get("/" + refValue.value());
+            refValueToCheck = e->get(refValue.value());
         }
         catch (std::exception & ex)
         {
@@ -296,7 +296,7 @@ bool opBuilderHelperIntComparison(const std::string field, char op, types::Event
     const rapidjson::Value * fieldValue {};
     try
     {
-        fieldValue = e->get("/" + field);
+        fieldValue = e->get(field);
     }
     catch (std::exception & ex)
     {
@@ -317,7 +317,7 @@ bool opBuilderHelperIntComparison(const std::string field, char op, types::Event
         const rapidjson::Value * refValueToCheck {};
         try
         {
-            refValueToCheck = e->get("/" + refValue.value());
+            refValueToCheck = e->get(refValue.value());
         }
         catch (std::exception & ex)
         {
@@ -503,10 +503,10 @@ types::Lifter opBuilderHelperIntGreaterThanEqual(const types::DocumentValue & de
 types::Lifter opBuilderHelperRegexMatch(const types::DocumentValue & def)
 {
     // Get field
-    std::string field = def.MemberBegin()->name.GetString();
-    std::string value = def.MemberBegin()->value.GetString();
+    std::string field {json::Document::preparePath(def.MemberBegin()->name.GetString())};
+    std::string value {def.MemberBegin()->value.GetString()};
 
-    std::vector<std::string> parameters = utils::string::split(value, '/');
+    std::vector<std::string> parameters {utils::string::split(value, '/')};
     if (parameters.size() != 2)
     {
         throw std::invalid_argument("Wrong number of arguments passed");
@@ -531,7 +531,7 @@ types::Lifter opBuilderHelperRegexMatch(const types::DocumentValue & def)
                 const rapidjson::Value * field_str {};
                 try
                 {
-                    field_str = e->get("/" + field);
+                    field_str = e->get(field);
                 }
                 catch (std::exception & ex)
                 {
@@ -551,7 +551,7 @@ types::Lifter opBuilderHelperRegexMatch(const types::DocumentValue & def)
 types::Lifter opBuilderHelperRegexNotMatch(const types::DocumentValue & def)
 {
     // Get field
-    std::string field = def.MemberBegin()->name.GetString();
+    std::string field {json::Document::preparePath(def.MemberBegin()->name.GetString())};
     std::string value = def.MemberBegin()->value.GetString();
 
     std::vector<std::string> parameters = utils::string::split(value, '/');
@@ -579,7 +579,7 @@ types::Lifter opBuilderHelperRegexNotMatch(const types::DocumentValue & def)
                 const rapidjson::Value * field_str {};
                 try
                 {
-                    field_str = e->get("/" + field);
+                    field_str = e->get(field);
                 }
                 catch (std::exception & ex)
                 {
@@ -606,7 +606,7 @@ types::Lifter opBuilderHelperRegexNotMatch(const types::DocumentValue & def)
 types::Lifter opBuilderHelperIPCIDR(const types::DocumentValue & def)
 {
     // Get Field path to check
-    std::string field = def.MemberBegin()->name.GetString();
+    std::string field {json::Document::preparePath(def.MemberBegin()->name.GetString())};
     // Get function helper
     std::string rawValue = def.MemberBegin()->value.GetString();
 
@@ -653,7 +653,7 @@ types::Lifter opBuilderHelperIPCIDR(const types::DocumentValue & def)
                 const rapidjson::Value * field_str{};
                 try
                 {
-                    field_str = e->get("/" + field);
+                    field_str = e->get(field);
                 }
                 catch (std::exception & ex)
                 {

--- a/src/engine/source/builder/builders/opBuilderHelperFilter.cpp
+++ b/src/engine/source/builder/builders/opBuilderHelperFilter.cpp
@@ -78,8 +78,8 @@ types::Lifter opBuilderHelperExists(const DocumentValue & def)
     std::string field {json::Document::preparePath(def.MemberBegin()->name.GetString())};
 
     //Check parameters
-    std::vector<std::string> parameters =
-        utils::string::split(def.MemberBegin()->value.GetString(), '/');
+    std::vector<std::string> parameters {
+        utils::string::split(def.MemberBegin()->value.GetString(), '/')};
     if (parameters.size() != 1)
     {
         throw std::runtime_error("Invalid number of parameters");

--- a/src/engine/source/builder/builders/opBuilderHelperFilter.cpp
+++ b/src/engine/source/builder/builders/opBuilderHelperFilter.cpp
@@ -89,7 +89,7 @@ types::Lifter opBuilderHelperExists(const DocumentValue & def)
     return [field](types::Observable o)
     {
         // Append rxcpp operation
-        return o.filter([=](types::Event e) { return e.exists("/" + field); });
+        return o.filter([=](types::Event e) { return e->exists("/" + field); });
     };
 }
 
@@ -110,7 +110,7 @@ types::Lifter opBuilderHelperNotExists(const DocumentValue & def)
     return [field](types::Observable o)
     {
         // Append rxcpp operation
-        return o.filter([=](types::Event e) { return !e.exists("/" + field); });
+        return o.filter([=](types::Event e) { return !e->exists("/" + field); });
     };
 }
 
@@ -128,7 +128,7 @@ bool opBuilderHelperStringComparison(const std::string key, char op, types::Even
     const rapidjson::Value * fieldToCompare {};
     try
     {
-        fieldToCompare = e.get("/" + key);
+        fieldToCompare = e->get("/" + key);
     }
     catch (std::exception & ex)
     {
@@ -149,7 +149,7 @@ bool opBuilderHelperStringComparison(const std::string key, char op, types::Even
         const rapidjson::Value * refValueToCheck {};
         try
         {
-            refValueToCheck = e.get("/" + refValue.value());
+            refValueToCheck = e->get("/" + refValue.value());
         }
         catch (std::exception & ex)
         {
@@ -296,7 +296,7 @@ bool opBuilderHelperIntComparison(const std::string field, char op, types::Event
     const rapidjson::Value * fieldValue {};
     try
     {
-        fieldValue = e.get("/" + field);
+        fieldValue = e->get("/" + field);
     }
     catch (std::exception & ex)
     {
@@ -317,7 +317,7 @@ bool opBuilderHelperIntComparison(const std::string field, char op, types::Event
         const rapidjson::Value * refValueToCheck {};
         try
         {
-            refValueToCheck = e.get("/" + refValue.value());
+            refValueToCheck = e->get("/" + refValue.value());
         }
         catch (std::exception & ex)
         {
@@ -531,7 +531,7 @@ types::Lifter opBuilderHelperRegexMatch(const types::DocumentValue & def)
                 const rapidjson::Value * field_str {};
                 try
                 {
-                    field_str = e.get("/" + field);
+                    field_str = e->get("/" + field);
                 }
                 catch (std::exception & ex)
                 {
@@ -579,7 +579,7 @@ types::Lifter opBuilderHelperRegexNotMatch(const types::DocumentValue & def)
                 const rapidjson::Value * field_str {};
                 try
                 {
-                    field_str = e.get("/" + field);
+                    field_str = e->get("/" + field);
                 }
                 catch (std::exception & ex)
                 {
@@ -653,7 +653,7 @@ types::Lifter opBuilderHelperIPCIDR(const types::DocumentValue & def)
                 const rapidjson::Value * field_str{};
                 try
                 {
-                    field_str = e.get("/" + field);
+                    field_str = e->get("/" + field);
                 }
                 catch (std::exception & ex)
                 {

--- a/src/engine/source/builder/builders/opBuilderHelperFilter.cpp
+++ b/src/engine/source/builder/builders/opBuilderHelperFilter.cpp
@@ -74,8 +74,8 @@ namespace builder::internals::builders
 // <field>: exists
 types::Lifter opBuilderHelperExists(const DocumentValue & def)
 {
-    // Get field
-    std::string field {def.MemberBegin()->name.GetString()};
+    // Get Field path to check
+    std::string field {json::Document::preparePath(def.MemberBegin()->name.GetString())};
 
     //Check parameters
     std::vector<std::string> parameters =
@@ -89,15 +89,15 @@ types::Lifter opBuilderHelperExists(const DocumentValue & def)
     return [field](types::Observable o)
     {
         // Append rxcpp operation
-        return o.filter([=](types::Event e) { return e->exists("/" + field); });
+        return o.filter([=](types::Event e) { return e->exists(field); });
     };
 }
 
 // <field>: not_exists
 types::Lifter opBuilderHelperNotExists(const DocumentValue & def)
 {
-    // Get field
-    std::string field {def.MemberBegin()->name.GetString()};
+    // Get Field path to check
+    std::string field {json::Document::preparePath(def.MemberBegin()->name.GetString())};
 
     std::vector<std::string> parameters =
         utils::string::split(def.MemberBegin()->value.GetString(), '/');
@@ -110,7 +110,7 @@ types::Lifter opBuilderHelperNotExists(const DocumentValue & def)
     return [field](types::Observable o)
     {
         // Append rxcpp operation
-        return o.filter([=](types::Event e) { return !e->exists("/" + field); });
+        return o.filter([=](types::Event e) { return !e->exists(field); });
     };
 }
 

--- a/src/engine/source/builder/builders/opBuilderHelperMap.cpp
+++ b/src/engine/source/builder/builders/opBuilderHelperMap.cpp
@@ -49,7 +49,7 @@ Event opBuilderHelperStringTransformation(const std::string field, char op, Even
         const rapidjson::Value * refValueToCheck{};
         try
         {
-            refValueToCheck = e.get("/" + refValue.value());
+            refValueToCheck = e->get("/" + refValue.value());
         }
         catch (std::exception & ex)
         {
@@ -87,8 +87,8 @@ Event opBuilderHelperStringTransformation(const std::string field, char op, Even
     // Create and add string to event
     try
     {
-        e.set("/" + field,
-              rapidjson::Value(value.value().c_str(), e.m_doc.GetAllocator()).Move());
+        e->set("/" + field,
+              rapidjson::Value(value.value().c_str(), e->m_doc.GetAllocator()).Move());
     }
     catch (std::exception & ex)
     {
@@ -124,7 +124,7 @@ Event opBuilderHelperIntTransformation(const std::string field, std::string op, 
     const rapidjson::Value * fieldValue{};
     try
     {
-        fieldValue = e.get("/" + field);
+        fieldValue = e->get("/" + field);
     }
     catch (std::exception & ex)
     {
@@ -144,7 +144,7 @@ Event opBuilderHelperIntTransformation(const std::string field, std::string op, 
         const rapidjson::Value * refValueToCheck {};
         try
         {
-            refValueToCheck = e.get("/" + refValue.value());
+            refValueToCheck = e->get("/" + refValue.value());
         }
         catch (std::exception & ex)
         {
@@ -188,7 +188,7 @@ Event opBuilderHelperIntTransformation(const std::string field, std::string op, 
     // Create and add string to event
     try
     {
-        e.set("/" + field, rapidjson::Value(value.value()));
+        e->set("/" + field, rapidjson::Value(value.value()));
     }
     catch (std::exception & ex)
     {
@@ -353,7 +353,7 @@ types::Lifter opBuilderHelperStringTrim(const types::DocumentValue & def)
                 const rapidjson::Value * fieldValue;
                 try
                 {
-                    fieldValue = e.get("/" + field);
+                    fieldValue = e->get("/" + field);
                 }
                 catch (std::exception & ex)
                 {
@@ -395,8 +395,8 @@ types::Lifter opBuilderHelperStringTrim(const types::DocumentValue & def)
                 // Update event
                 try
                 {
-                    e.set("/" + field,
-                          rapidjson::Value(strToTrim.c_str(), e.m_doc.GetAllocator())
+                    e->set("/" + field,
+                          rapidjson::Value(strToTrim.c_str(), e->m_doc.GetAllocator())
                               .Move());
                 }
                 catch (std::exception & ex)
@@ -503,7 +503,7 @@ types::Lifter opBuilderHelperRegexExtract(const types::DocumentValue & def)
                 const rapidjson::Value * field_str{};
                 try
                 {
-                    field_str = e.get("/" + field);
+                    field_str = e->get("/" + field);
                 }
                 catch (std::exception & ex)
                 {
@@ -518,8 +518,8 @@ types::Lifter opBuilderHelperRegexExtract(const types::DocumentValue & def)
                         // Create and add string to event
                         try
                         {
-                            e.set("/" + map_field,
-                                rapidjson::Value(match.c_str(), e.m_doc.GetAllocator()).Move());
+                            e->set("/" + map_field,
+                                rapidjson::Value(match.c_str(), e->m_doc.GetAllocator()).Move());
                         }
                         catch (std::exception & ex)
                         {

--- a/src/engine/source/builder/builders/opBuilderMapReference.cpp
+++ b/src/engine/source/builder/builders/opBuilderMapReference.cpp
@@ -30,8 +30,8 @@ types::Lifter opBuilderMapReference(const types::DocumentValue & def)
         return o.map(
             [=](types::Event e)
             {
-                auto v = e.get(reference);
-                e.set(field, *v);
+                auto v = e->get(reference);
+                e->set(field, *v);
                 return e;
             });
     };

--- a/src/engine/source/builder/builders/opBuilderMapReference.cpp
+++ b/src/engine/source/builder/builders/opBuilderMapReference.cpp
@@ -16,12 +16,18 @@ using namespace std;
 namespace builder::internals::builders
 {
 
+// TODO Add test for this
 types::Lifter opBuilderMapReference(const types::DocumentValue & def)
 {
     // Make deep copy of value
-    std::string field = "/" + string(def.MemberBegin()->name.GetString());
-    std::string reference = def.MemberBegin()->value.GetString();
-    reference = "/" + reference.substr(1, std::string::npos);
+    std::string field {json::Document::preparePath((def.MemberBegin()->name.GetString()))};
+    if (!def.MemberBegin()->value.IsString())
+    {
+        throw std::runtime_error("The value of the field '" + field + "' must be a string.");
+    }
+    std::string reference {def.MemberBegin()->value.GetString()};
+    // TODO Should start with a `$` to reference a field (Adds test, doc and handle the invalid reference)
+    reference = json::Document::preparePath(reference.substr(1, std::string::npos));
 
     // Return Lifter
     return [=](types::Observable o)

--- a/src/engine/source/builder/builders/opBuilderMapReference.cpp
+++ b/src/engine/source/builder/builders/opBuilderMapReference.cpp
@@ -36,8 +36,15 @@ types::Lifter opBuilderMapReference(const types::DocumentValue & def)
         return o.map(
             [=](types::Event e)
             {
-                auto v = e->get(reference);
-                e->set(field, *v);
+                // TODO TEst
+                try {
+                    auto v = e->get(reference);
+                    if (v != nullptr) {
+                        e->set(field, *v);
+                    }
+                } catch (std::exception & ex) {
+                    return e;
+                }
                 return e;
             });
     };

--- a/src/engine/source/builder/builders/opBuilderMapValue.cpp
+++ b/src/engine/source/builder/builders/opBuilderMapValue.cpp
@@ -26,7 +26,7 @@ types::Lifter opBuilderMapValue(const types::DocumentValue & def)
         return o.map(
             [=](types::Event e)
             {
-                e.set(doc);
+                e->set(doc);
                 return e;
             });
     };

--- a/src/engine/source/builder/builders/opBuilderMapValue.cpp
+++ b/src/engine/source/builder/builders/opBuilderMapValue.cpp
@@ -13,7 +13,7 @@ using namespace std;
 
 namespace builder::internals::builders
 {
-
+// TODOL DOC and test this
 types::Lifter opBuilderMapValue(const types::DocumentValue & def)
 {
     // Make deep copy of value

--- a/src/engine/source/builder/builders/opBuilderMapValue.cpp
+++ b/src/engine/source/builder/builders/opBuilderMapValue.cpp
@@ -18,6 +18,7 @@ types::Lifter opBuilderMapValue(const types::DocumentValue & def)
 {
     // Make deep copy of value
     types::Document doc{def};
+    auto field = json::Document::preparePath(def.MemberBegin()->name.GetString());
 
     // Return Lifter
     return [=](types::Observable o)
@@ -26,7 +27,7 @@ types::Lifter opBuilderMapValue(const types::DocumentValue & def)
         return o.map(
             [=](types::Event e)
             {
-                e->set(doc);
+                e->set(field, doc.m_doc.MemberBegin()->value);
                 return e;
             });
     };

--- a/src/engine/source/builder/outputs/file.hpp
+++ b/src/engine/source/builder/outputs/file.hpp
@@ -66,7 +66,7 @@ public:
      */
     void write(const types::Event & e)
     {
-        this->m_os << e.str() << std::endl;
+        this->m_os << e->str() << std::endl;
     }
 };
 

--- a/src/engine/source/json/json.hpp
+++ b/src/engine/source/json/json.hpp
@@ -222,7 +222,7 @@ public:
     bool exists(const std::string& path) const
     {
 
-        auto ptr = rapidjson::Pointer(preparePath(path).c_str());
+        auto ptr = rapidjson::Pointer(path.c_str());
         if (ptr.IsValid() && ptr.Get(this->m_doc))
         {
             return true;

--- a/src/engine/source/json/json.hpp
+++ b/src/engine/source/json/json.hpp
@@ -76,7 +76,6 @@ public:
      */
     void set(std::string path, const rapidjson::Value & v)
     {
-        //std::replace(std::begin(path), std::end(path), '.', '/');
         auto ptr = rapidjson::Pointer(path.c_str());
         if (ptr.IsValid())
         {
@@ -111,10 +110,7 @@ public:
         }
     }
 
-    /**
-     * @brief -----
-     * @param v 
-     */
+    // TODO: Doc this
     void setReference(const Document & v)
     {
         // TODO: Write a test and doc for this method and check if it works
@@ -198,7 +194,6 @@ public:
     bool contains(const std::string & field) const
     {
         // TODO DOC THIS
-        //auto ptr = rapidjson::Pointer(preparePath(field).c_str());
         auto ptr = rapidjson::Pointer(field.c_str());
         if (ptr.IsValid())
         {

--- a/src/engine/source/router/router.hpp
+++ b/src/engine/source/router/router.hpp
@@ -29,7 +29,7 @@ struct Route
 {
     std::string m_name;
     std::string m_to;
-    std::function<bool(json::Document)> m_from;
+    std::function<bool(std::shared_ptr<json::Document>)> m_from;
     rxcpp::composite_subscription m_subscription;
 
     Route() = default;
@@ -45,7 +45,7 @@ struct Route
      * @param subscription Subscription to handle status
      */
     Route(const std::string & name, const std::string & environment,
-          std::function<bool(json::Document)> filter_function, rxcpp::composite_subscription subscription) noexcept
+          std::function<bool(std::shared_ptr<json::Document>)> filter_function, rxcpp::composite_subscription subscription) noexcept
         : m_name(name), m_to(environment), m_from(filter_function), m_subscription(subscription)
     {
     }
@@ -91,11 +91,11 @@ struct Route
  */
 struct Environment
 {
-    using Obs_t = rxcpp::observable<json::Document>;
+    using Obs_t = rxcpp::observable<std::shared_ptr<json::Document>>;
     using Op_t = std::function<Obs_t(Obs_t)>;
 
     std::string m_name;
-    rxcpp::subjects::subject<json::Document> m_subject;
+    rxcpp::subjects::subject<std::shared_ptr<json::Document>> m_subject;
     Op_t m_build;
 
     Environment() = default;
@@ -131,7 +131,7 @@ struct Environment
  */
 template <class Builder> class Router
 {
-    using Obs_t = rxcpp::observable<json::Document>;
+    using Obs_t = rxcpp::observable<std::shared_ptr<json::Document>>;
     using Op_t = std::function<Obs_t(Obs_t)>;
 
     // Check Builder class is as expected
@@ -144,8 +144,8 @@ private:
 
     std::map<std::string, Environment> m_environments;
     std::map<std::string, Route> m_routes;
-    rxcpp::subjects::subject<json::Document> m_subj;
-    rxcpp::subscriber<json::Document> m_input;
+    rxcpp::subjects::subject<std::shared_ptr<json::Document>> m_subj;
+    rxcpp::subscriber<std::shared_ptr<json::Document>> m_input;
     Builder m_builder;
 
 public:
@@ -167,7 +167,7 @@ public:
      */
     void add(
         const std::string & route, const std::string & environment,
-        const std::function<bool(json::Document)> filterFunction = [](const auto) { return true; })
+        const std::function<bool(std::shared_ptr<json::Document>)> filterFunction = [](const auto) { return true; })
     {
         // Assert route with same name not exists
         if (this->m_routes.count(route) > 0)
@@ -225,7 +225,7 @@ public:
      *
      * @return const rxcpp::subscriber<json::Document>&
      */
-    const rxcpp::subscriber<json::Document> & input() const
+    const rxcpp::subscriber<std::shared_ptr<json::Document>> & input() const
     {
         return this->m_input;
     }

--- a/src/engine/source/server/protocolHandler.cpp
+++ b/src/engine/source/server/protocolHandler.cpp
@@ -33,17 +33,18 @@ bool ProtocolHandler::hasHeader()
     return false;
 }
 
-json::Document ProtocolHandler::parse(const string & event)
+std::shared_ptr<json::Document> ProtocolHandler::parse(const string & event)
 {
-    json::Document doc;
-    doc.m_doc.SetObject();
-    rapidjson::Document::AllocatorType & allocator = doc.getAllocator();
+
+    auto doc = std::make_shared<json::Document>();
+    doc->m_doc.SetObject();
+    rapidjson::Document::AllocatorType & allocator = doc->getAllocator();
 
     auto queuePos = event.find(":");
     try
     {
         int queue = std::stoi(event.substr(0, queuePos));
-        doc.m_doc.AddMember("queue", queue, allocator);
+        doc->m_doc.AddMember("queue", queue, allocator);
     }
     // std::out_of_range and std::invalid_argument
     catch (...)
@@ -57,7 +58,7 @@ json::Document ProtocolHandler::parse(const string & event)
         rapidjson::Value loc;
         string location = event.substr(queuePos, locPos);
         loc.SetString(location.c_str(), location.length(), allocator);
-        doc.m_doc.AddMember("location", loc, allocator);
+        doc->m_doc.AddMember("location", loc, allocator);
     }
     catch (std::out_of_range & e)
     {
@@ -69,7 +70,7 @@ json::Document ProtocolHandler::parse(const string & event)
         rapidjson::Value msg;
         string message = event.substr(locPos + 1, string::npos);
         msg.SetString(message.c_str(), message.length(), allocator);
-        doc.m_doc.AddMember("message", msg, allocator);
+        doc->m_doc.AddMember("message", msg, allocator);
     }
     catch (std::out_of_range & e)
     {

--- a/src/engine/source/server/protocolHandler.hpp
+++ b/src/engine/source/server/protocolHandler.hpp
@@ -47,7 +47,7 @@ public:
      *
      * @return json::Document
      */
-    static json::Document parse(const std::string & event);
+    static std::shared_ptr<json::Document> parse(const std::string & event);
 
     /**
      * @brief process the chunk of data and send messages to dst when. Return

--- a/src/engine/test/source/builder/builderTest.cpp
+++ b/src/engine/test/source/builder/builderTest.cpp
@@ -131,6 +131,6 @@ TEST(RXCPP, DecoderManualConnectExample)
     std::ifstream ifs(file);
     std::string gotContent((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
 
-   std::filesystem::remove(file);
-   ASSERT_EQ(expectedContents, gotContent);
+    std::filesystem::remove(file);
+    ASSERT_EQ(expectedContents, gotContent);
 }

--- a/src/engine/test/source/builder/builderTest.cpp
+++ b/src/engine/test/source/builder/builderTest.cpp
@@ -120,10 +120,6 @@ TEST(RXCPP, DecoderManualConnectExample)
     std::string expectedContents =
         R"({"type":"int","field":"odd","value":0,"new_dec_field0":"new_dec_value0","new_dec_field1":"new_dec_value1","new_dec_field3":"new_dec_value3"}
 {"type":"int","field":"odd","value":0,"new_dec_field0":"new_dec_value0","new_dec_field1":"new_dec_value1","new_dec_field3":"new_dec_value3","new_rule_field":"new_rule_value"}
-{"type":"int","field":"odd","value":0,"new_dec_field0":"new_dec_value0","new_dec_field2":"new_dec_value2","new_dec_field3":"new_dec_value3"}
-{"type":"int","field":"odd","value":0,"new_dec_field0":"new_dec_value0","new_dec_field2":"new_dec_value2","new_dec_field3":"new_dec_value3","new_rule_field":"new_rule_value"}
-{"type":"int","field":"even","value":1,"new_dec_field0":"new_dec_value0","new_dec_field1":"new_dec_value1","new_dec_field3":"new_dec_value3"}
-{"type":"int","field":"even","value":1,"new_dec_field0":"new_dec_value0","new_dec_field1":"new_dec_value1","new_dec_field3":"new_dec_value3","new_rule_field":"new_rule_value"}
 {"type":"int","field":"even","value":1,"new_dec_field0":"new_dec_value0","new_dec_field2":"new_dec_value2","new_dec_field3":"new_dec_value3"}
 {"type":"int","field":"even","value":1,"new_dec_field0":"new_dec_value0","new_dec_field2":"new_dec_value2","new_dec_field3":"new_dec_value3","new_rule_field":"new_rule_value"}
 )";
@@ -135,6 +131,6 @@ TEST(RXCPP, DecoderManualConnectExample)
     std::ifstream ifs(file);
     std::string gotContent((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
 
-    std::filesystem::remove(file);
-    ASSERT_EQ(expectedContents, gotContent);
+   std::filesystem::remove(file);
+   ASSERT_EQ(expectedContents, gotContent);
 }

--- a/src/engine/test/source/builder/builderTest.cpp
+++ b/src/engine/test/source/builder/builderTest.cpp
@@ -84,9 +84,9 @@ void visit(Obs_t<Value> source, Con_t<Value> root, std::map<Con_t<Value>, std::s
 
 TEST(RXCPP, DecoderManualConnectExample)
 {
-    using Event_t = json::Document;
-    using Obs_t = rxcpp::observable<json::Document>;
-    using Sub_t = rxcpp::subscriber<json::Document>;
+    using Event_t = std::shared_ptr<json::Document>;
+    using Obs_t = rxcpp::observable<std::shared_ptr<json::Document>>;
+    using Sub_t = rxcpp::subscriber<std::shared_ptr<json::Document>>;
     using Con_t = builder::internals::Connectable<Obs_t>;
 
     int expected = 2;
@@ -96,9 +96,9 @@ TEST(RXCPP, DecoderManualConnectExample)
                           for (int i = 0; i < expected; i++)
                           {
                               if (i % 2 == 0)
-                                  s.on_next(Event_t(R"({"type": "int", "field": "odd", "value": 0})"));
+                                  s.on_next(std::make_shared<json::Document>(R"({"type": "int", "field": "odd", "value": 0})"));
                               else
-                                  s.on_next(Event_t(R"({"type": "int", "field": "even", "value": 1})"));
+                                  s.on_next(std::make_shared<json::Document>(R"({"type": "int", "field": "even", "value": 1})"));
                           }
                           s.on_completed();
                       })
@@ -106,7 +106,7 @@ TEST(RXCPP, DecoderManualConnectExample)
 
     auto sub = rxcpp::subjects::subject<Event_t>();
 
-    auto subscriber = rxcpp::make_subscriber<Event_t>([](Event_t v) { GTEST_COUT << "Got " << v.str() << std::endl; },
+    auto subscriber = rxcpp::make_subscriber<Event_t>([](Event_t v) { GTEST_COUT << "Got " << v->str() << std::endl; },
                                                       []() { GTEST_COUT << "OnCompleted" << std::endl; });
 
     builder::Builder<FakeCatalog> b{FakeCatalog()};
@@ -136,5 +136,5 @@ TEST(RXCPP, DecoderManualConnectExample)
     std::string gotContent((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
 
     std::filesystem::remove(file);
-    ASSERT_TRUE(expectedContents == gotContent);
+    ASSERT_EQ(expectedContents, gotContent);
 }

--- a/src/engine/test/source/builder/builderTest.hpp
+++ b/src/engine/test/source/builder/builderTest.hpp
@@ -24,7 +24,7 @@ std::map<std::string, std::string> decoders = {{"decoder_0", R"(
                         "decoder_0"
                     ],
                     "check": [
-                        {"type": "int"}
+                        {"field": "odd"}
                     ],
                     "normalize": [
                         { "new_dec_field1": "new_dec_value1" }
@@ -38,7 +38,7 @@ std::map<std::string, std::string> decoders = {{"decoder_0", R"(
                         "decoder_0"
                     ],
                     "check": [
-                        {"type": "int"}
+                        {"field": "even"}
                     ],
                     "normalize": [
                         { "new_dec_field2": "new_dec_value2" }

--- a/src/engine/test/source/builder/builders/assetBuilderDecoderTest.cpp
+++ b/src/engine/test/source/builder/builders/assetBuilderDecoderTest.cpp
@@ -98,17 +98,17 @@ TEST(AssetBuilderDecoder, BuildsOperates)
         [=](auto s)
         {
             //TODO: fix json interface to not throw exception
-            s.on_next(Event{R"({
+            s.on_next(std::make_shared<json::Document>(R"({
                 "field1": "value",
                 "field2": 2,
                 "field3": "value",
                 "field4": true,
                 "field5": "+exists"
-            })"});
-            s.on_next(Event{R"(
+            })"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"value"}
-            )"});
-            s.on_next(Event{R"({
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"({
                 "field":"value",
                 "field1": "value",
                 "field2": 2,
@@ -116,10 +116,10 @@ TEST(AssetBuilderDecoder, BuildsOperates)
                 "field4": true,
                 "field5": "+exists",
                 "field6": "+exists"
-            })"});
-            s.on_next(Event{R"(
+            })"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":1}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -130,6 +130,6 @@ TEST(AssetBuilderDecoder, BuildsOperates)
     ASSERT_EQ(expected.size(), 2);
     for (auto e : expected)
     {
-        ASSERT_STREQ(e.get("/mapped/field")->GetString(), "value");
+        ASSERT_STREQ(e->get("/mapped/field")->GetString(), "value");
     }
 }

--- a/src/engine/test/source/builder/builders/assetBuilderFilterTest.cpp
+++ b/src/engine/test/source/builder/builders/assetBuilderFilterTest.cpp
@@ -77,17 +77,17 @@ TEST(AssetBuilderFilter, BuildsOperates)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"({
+            s.on_next(std::make_shared<json::Document>(R"({
                 "field1": "value",
                 "field2": 2,
                 "field3": "value",
                 "field4": true,
                 "field5": "+exists"
-            })"});
-            s.on_next(Event{R"(
+            })"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"value"}
-            )"});
-            s.on_next(Event{R"({
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"({
                 "field":"value",
                 "field1": "value",
                 "field2": 2,
@@ -95,10 +95,10 @@ TEST(AssetBuilderFilter, BuildsOperates)
                 "field4": true,
                 "field5": "+exists",
                 "field6": "+exists"
-            })"});
-            s.on_next(Event{R"(
+            })"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":1}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -109,6 +109,6 @@ TEST(AssetBuilderFilter, BuildsOperates)
     ASSERT_EQ(expected.size(), 2);
     for (auto e : expected)
     {
-        ASSERT_STREQ(e.get("/field")->GetString(), "value");
+        ASSERT_STREQ(e->get("/field")->GetString(), "value");
     }
 }

--- a/src/engine/test/source/builder/builders/assetBuilderOutputTest.cpp
+++ b/src/engine/test/source/builder/builders/assetBuilderOutputTest.cpp
@@ -109,24 +109,24 @@ TEST(AssetBuilderOutput, BuildsOperates)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field1":"value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"value1"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"value"}
-            )"});
+            )"));
             s.on_completed();
         });
     ConnectableT conn = assetBuilderOutput(doc);

--- a/src/engine/test/source/builder/builders/assetBuilderRuleTest.cpp
+++ b/src/engine/test/source/builder/builders/assetBuilderRuleTest.cpp
@@ -130,6 +130,6 @@ TEST(AssetBuilderRule, BuildsOperates)
     ASSERT_EQ(expected.size(), 2);
     for (auto e : expected)
     {
-        ASSERT_STREQ(e.get("/mapped/field")->GetString(), "value");
+        ASSERT_STREQ(e->get("/mapped/field")->GetString(), "value");
     }
 }

--- a/src/engine/test/source/builder/builders/assetBuilderRuleTest.cpp
+++ b/src/engine/test/source/builder/builders/assetBuilderRuleTest.cpp
@@ -98,17 +98,17 @@ TEST(AssetBuilderRule, BuildsOperates)
         [=](auto s)
         {
             // TODO: fix json interface to not throw exception
-            s.on_next(Event{R"({
+            s.on_next(std::make_shared<json::Document>(R"({
                 "field1": "value",
                 "field2": 2,
                 "field3": "value",
                 "field4": true,
                 "field5": "+exists"
-            })"});
-            s.on_next(Event{R"(
+            })"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"value"}
-            )"});
-            s.on_next(Event{R"({
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"({
                 "field":"value",
                 "field1": "value",
                 "field2": 2,
@@ -116,10 +116,10 @@ TEST(AssetBuilderRule, BuildsOperates)
                 "field4": true,
                 "field5": "+exists",
                 "field6": "+exists"
-            })"});
-            s.on_next(Event{R"(
+            })"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":1}
-            )"});
+            )"));
             s.on_completed();
         });
 

--- a/src/engine/test/source/builder/builders/opBuilderConditionReferenceTest.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderConditionReferenceTest.cpp
@@ -41,22 +41,22 @@ TEST(opBuilderConditionReference, BuildsOperatesString)
                     "otherfield":"value1"
                 }
             )"));
-            // s.on_next(std::make_shared<json::Document>(R"(
-            //     {
-            //         "field":"value1",
-            //         "otherfield":"value2"
-            //     }
-            // )"));
-            // s.on_next(std::make_shared<json::Document>(R"(
-            //     {
-            //         "otherfield":"value1"
-            //     }
-            // )"));
-            // s.on_next(std::make_shared<json::Document>(R"(
-            //     {
-            //         "field":"value1"
-            //     }
-            // )"));
+            s.on_next(std::make_shared<json::Document>(R"(
+                {
+                    "field":"value1",
+                    "otherfield":"value2"
+                }
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
+                {
+                    "otherfield":"value1"
+                }
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
+                {
+                    "field":"value1"
+                }
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderConditionReference(*doc.get("/check"));

--- a/src/engine/test/source/builder/builders/opBuilderConditionReferenceTest.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderConditionReferenceTest.cpp
@@ -64,8 +64,8 @@ TEST(opBuilderConditionReference, BuildsOperatesString)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_STREQ(expected[0].get("/field")->GetString(), "value1");
-    ASSERT_STREQ(expected[0].get("/otherfield")->GetString(), "value1");
+    ASSERT_STREQ(expected[0]->get("/field")->GetString(), "value1");
+    ASSERT_STREQ(expected[0]->get("/otherfield")->GetString(), "value1");
 }
 
 // TODO: Add rest of use cases (int, bool, null)

--- a/src/engine/test/source/builder/builders/opBuilderConditionReferenceTest.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderConditionReferenceTest.cpp
@@ -35,28 +35,28 @@ TEST(opBuilderConditionReference, BuildsOperatesString)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field":"value1",
                     "otherfield":"value1"
                 }
-            )"});
-            // s.on_next(Event{R"(
+            )"));
+            // s.on_next(std::make_shared<json::Document>(R"(
             //     {
             //         "field":"value1",
             //         "otherfield":"value2"
             //     }
-            // )"});
-            // s.on_next(Event{R"(
+            // )"));
+            // s.on_next(std::make_shared<json::Document>(R"(
             //     {
             //         "otherfield":"value1"
             //     }
-            // )"});
-            // s.on_next(Event{R"(
+            // )"));
+            // s.on_next(std::make_shared<json::Document>(R"(
             //     {
             //         "field":"value1"
             //     }
-            // )"});
+            // )"));
             s.on_completed();
         });
     Lifter lift = opBuilderConditionReference(*doc.get("/check"));

--- a/src/engine/test/source/builder/builders/opBuilderConditionValueTest.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderConditionValueTest.cpp
@@ -42,18 +42,18 @@ TEST(opBuilderConditionValue, BuildsOperatesString)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"values"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":"value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":1}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderConditionValue(*doc.get("/check"));

--- a/src/engine/test/source/builder/builders/opBuilderConditionValueTest.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderConditionValueTest.cpp
@@ -61,7 +61,7 @@ TEST(opBuilderConditionValue, BuildsOperatesString)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_STREQ(expected[0].get("/field")->GetString(), doc.get("/check")->MemberBegin()->value.GetString());
+    ASSERT_STREQ(expected[0]->get("/field")->GetString(), doc.get("/check")->MemberBegin()->value.GetString());
 }
 
 //TODO: Add rest of use cases (int, bool, null)

--- a/src/engine/test/source/builder/builders/opBuilderFileOutputTest.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderFileOutputTest.cpp
@@ -39,18 +39,18 @@ TEST(opBuilderFileOutput, BuildsOperates)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"value"}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderFileOutput(*doc.get("/file"));

--- a/src/engine/test/source/builder/builders/opBuilderHelperExists_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperExists_test.cpp
@@ -73,9 +73,9 @@ TEST(opBuilderHelperExists, Exec_exists_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_TRUE(expected[0].exists("/field2check"));
-    ASSERT_TRUE(expected[1].exists("/field2check"));
-    ASSERT_TRUE(expected[2].exists("/field2check"));
+    ASSERT_TRUE(expected[0]->exists("/field2check"));
+    ASSERT_TRUE(expected[1]->exists("/field2check"));
+    ASSERT_TRUE(expected[2]->exists("/field2check"));
 }
 
 TEST(opBuilderHelperExists, Exec_multilevel_ok)
@@ -150,7 +150,7 @@ TEST(opBuilderHelperExists, Exec_multilevel_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_TRUE(expected[0].get("/parentObjt_1/field2check"));
-    ASSERT_TRUE(expected[1].get("/parentObjt_1/field2check"));
-    ASSERT_TRUE(expected[2].get("/parentObjt_1/field2check"));
+    ASSERT_TRUE(expected[0]->get("/parentObjt_1/field2check"));
+    ASSERT_TRUE(expected[1]->get("/parentObjt_1/field2check"));
+    ASSERT_TRUE(expected[2]->get("/parentObjt_1/field2check"));
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperExists_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperExists_test.cpp
@@ -45,24 +45,24 @@ TEST(opBuilderHelperExists, Exec_exists_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":11,
                     "ref_key":10
                 }
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":10,
                     "ref_key":10
                 }
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":10,
                     "ref_key":11
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -88,7 +88,7 @@ TEST(opBuilderHelperExists, Exec_multilevel_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -99,9 +99,9 @@ TEST(opBuilderHelperExists, Exec_multilevel_ok)
                         "ref_key": 11
                     }
                 }
-            )"});
+            )"));
 
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -112,10 +112,10 @@ TEST(opBuilderHelperExists, Exec_multilevel_ok)
                         "ref_key": 11
                     }
                 }
-            )"});
+            )"));
 
             // false
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -126,9 +126,9 @@ TEST(opBuilderHelperExists, Exec_multilevel_ok)
                         "ref_key":11
                     }
                 }
-            )"});
+            )"));
 
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -139,7 +139,7 @@ TEST(opBuilderHelperExists, Exec_multilevel_ok)
                         "ref_key":11
                     }
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperIPCIDRCheck_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIPCIDRCheck_test.cpp
@@ -105,8 +105,8 @@ TEST(opBuilderHelperIPCIDR, chack_ip_range)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 4);
-    ASSERT_STREQ(expected[0].get("/field2check")->GetString(), "192.168.0.0");
-    ASSERT_STREQ(expected[1].get("/field2check")->GetString(), "192.168.0.1");
-    ASSERT_STREQ(expected[2].get("/field2check")->GetString(), "192.168.255.254");
-    ASSERT_STREQ(expected[3].get("/field2check")->GetString(), "192.168.255.255");
+    ASSERT_STREQ(expected[0]->get("/field2check")->GetString(), "192.168.0.0");
+    ASSERT_STREQ(expected[1]->get("/field2check")->GetString(), "192.168.0.1");
+    ASSERT_STREQ(expected[2]->get("/field2check")->GetString(), "192.168.255.254");
+    ASSERT_STREQ(expected[3]->get("/field2check")->GetString(), "192.168.255.255");
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperIPCIDRCheck_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIPCIDRCheck_test.cpp
@@ -74,28 +74,28 @@ TEST(opBuilderHelperIPCIDR, chack_ip_range)
         [=](auto s)
         {
             // Network address
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"192.168.0.0"}
-            )"});
+            )"));
             // First address
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"192.168.0.1"}
-            )"});
+            )"));
             // Last address
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"192.168.255.254"}
-            )"});
+            )"));
             // Broadcast address
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"192.168.255.255"}
-            )"});
+            )"));
             // Address out of cidr range
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"10.0.0.1"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"127.0.0.1"}
-            )"});
+            )"));
             s.on_completed();
         });
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
@@ -86,18 +86,18 @@ TEST(opBuilderHelperIntCalc, Exec_equal_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
@@ -124,24 +124,24 @@ TEST(opBuilderHelperIntCalc, Exec_sum_int)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":0}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":100}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":-100}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
@@ -170,24 +170,24 @@ TEST(opBuilderHelperIntCalc, Exec_sub_int)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":0}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":100}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":-100}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
@@ -216,24 +216,24 @@ TEST(opBuilderHelperIntCalc, Exec_mult_int)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":0}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":100}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":-100}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
@@ -262,24 +262,24 @@ TEST(opBuilderHelperIntCalc, Exec_div_int)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":0}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":100}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":-100}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
@@ -308,30 +308,30 @@ TEST(opBuilderHelperIntCalc, Exec_sum_ref)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 0,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 10,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 0,"field_src":-10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src":-10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 10,"field_src":-10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src":-10}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
@@ -362,30 +362,30 @@ TEST(opBuilderHelperIntCalc, Exec_sub_ref)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 0,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 10,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 0,"field_src":-10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src":-10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 10,"field_src":-10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src":-10}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
@@ -416,30 +416,30 @@ TEST(opBuilderHelperIntCalc, Exec_mult_ref)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 0,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 10,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 0,"field_src":-10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src":-10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 10,"field_src":-10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src":-10}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
@@ -470,30 +470,30 @@ TEST(opBuilderHelperIntCalc, Exec_div_ref)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 0,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 10,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 0,"field_src":-10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src":-10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 10,"field_src":-10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src":-10}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
@@ -524,30 +524,30 @@ TEST(opBuilderHelperIntCalc, Exec_div_ref_zero)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 0,"field_src":0}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src":0}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 10,"field_src":0}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src":0}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 0,"field_src":0}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src":0}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 10,"field_src":0}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src":0}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntCalc(*doc.get("/normalice"));
@@ -579,7 +579,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sum)
         [=](auto s)
         {
             // sorted
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_1": {
                         "field2check": 10,
@@ -590,9 +590,9 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sum)
                         "ref_key": 11
                     }
                 }
-            )"});
+            )"));
             // not sorted
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -603,7 +603,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sum)
                         "ref_key": 11
                     }
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -629,7 +629,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sub)
         [=](auto s)
         {
             // sorted
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_1": {
                         "field2check": 10,
@@ -640,9 +640,9 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sub)
                         "ref_key": 11
                     }
                 }
-            )"});
+            )"));
             // not sorted
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -653,7 +653,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sub)
                         "ref_key": 11
                     }
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -679,7 +679,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_mul)
         [=](auto s)
         {
             // sorted
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_1": {
                         "field2check": 10,
@@ -690,9 +690,9 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_mul)
                         "ref_key": 11
                     }
                 }
-            )"});
+            )"));
             // not sorted
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -703,7 +703,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_mul)
                         "ref_key": 11
                     }
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -729,7 +729,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_div)
         [=](auto s)
         {
             // sorted
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_1": {
                         "field2check": 10,
@@ -740,9 +740,9 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_div)
                         "ref_key": 11
                     }
                 }
-            )"});
+            )"));
             // not sorted
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -753,7 +753,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_div)
                         "ref_key": 11
                     }
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
@@ -107,10 +107,10 @@ TEST(opBuilderHelperIntCalc, Exec_equal_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 4);
-    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),19);
-    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),20);
-    ASSERT_EQ(expected[2].get("/field_test")->GetInt(),20);
-    ASSERT_EQ(expected[3].get("/field_test")->GetInt(),21);
+    ASSERT_EQ(expected[0]->get("/field_test")->GetInt(),19);
+    ASSERT_EQ(expected[1]->get("/field_test")->GetInt(),20);
+    ASSERT_EQ(expected[2]->get("/field_test")->GetInt(),20);
+    ASSERT_EQ(expected[3]->get("/field_test")->GetInt(),21);
 
 }
 
@@ -151,12 +151,12 @@ TEST(opBuilderHelperIntCalc, Exec_sum_int)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 6);
-    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),10);
-    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),19);
-    ASSERT_EQ(expected[2].get("/field_test")->GetInt(),20);
-    ASSERT_EQ(expected[3].get("/field_test")->GetInt(),21);
-    ASSERT_EQ(expected[4].get("/field_test")->GetInt(),110);
-    ASSERT_EQ(expected[5].get("/field_test")->GetInt(),-90);
+    ASSERT_EQ(expected[0]->get("/field_test")->GetInt(),10);
+    ASSERT_EQ(expected[1]->get("/field_test")->GetInt(),19);
+    ASSERT_EQ(expected[2]->get("/field_test")->GetInt(),20);
+    ASSERT_EQ(expected[3]->get("/field_test")->GetInt(),21);
+    ASSERT_EQ(expected[4]->get("/field_test")->GetInt(),110);
+    ASSERT_EQ(expected[5]->get("/field_test")->GetInt(),-90);
 
 }
 
@@ -197,12 +197,12 @@ TEST(opBuilderHelperIntCalc, Exec_sub_int)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 6);
-    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),-10);
-    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),-1);
-    ASSERT_EQ(expected[2].get("/field_test")->GetInt(),0);
-    ASSERT_EQ(expected[3].get("/field_test")->GetInt(),1);
-    ASSERT_EQ(expected[4].get("/field_test")->GetInt(),90);
-    ASSERT_EQ(expected[5].get("/field_test")->GetInt(),-110);
+    ASSERT_EQ(expected[0]->get("/field_test")->GetInt(),-10);
+    ASSERT_EQ(expected[1]->get("/field_test")->GetInt(),-1);
+    ASSERT_EQ(expected[2]->get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[3]->get("/field_test")->GetInt(),1);
+    ASSERT_EQ(expected[4]->get("/field_test")->GetInt(),90);
+    ASSERT_EQ(expected[5]->get("/field_test")->GetInt(),-110);
 
 }
 
@@ -243,12 +243,12 @@ TEST(opBuilderHelperIntCalc, Exec_mult_int)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 6);
-    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),0);
-    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),90);
-    ASSERT_EQ(expected[2].get("/field_test")->GetInt(),100);
-    ASSERT_EQ(expected[3].get("/field_test")->GetInt(),110);
-    ASSERT_EQ(expected[4].get("/field_test")->GetInt(),1000);
-    ASSERT_EQ(expected[5].get("/field_test")->GetInt(),-1000);
+    ASSERT_EQ(expected[0]->get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[1]->get("/field_test")->GetInt(),90);
+    ASSERT_EQ(expected[2]->get("/field_test")->GetInt(),100);
+    ASSERT_EQ(expected[3]->get("/field_test")->GetInt(),110);
+    ASSERT_EQ(expected[4]->get("/field_test")->GetInt(),1000);
+    ASSERT_EQ(expected[5]->get("/field_test")->GetInt(),-1000);
 
 }
 
@@ -289,12 +289,12 @@ TEST(opBuilderHelperIntCalc, Exec_div_int)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 6);
-    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),0);
-    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),0);
-    ASSERT_EQ(expected[2].get("/field_test")->GetInt(),1);
-    ASSERT_EQ(expected[3].get("/field_test")->GetInt(),1);
-    ASSERT_EQ(expected[4].get("/field_test")->GetInt(),10);
-    ASSERT_EQ(expected[5].get("/field_test")->GetInt(),-10);
+    ASSERT_EQ(expected[0]->get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[1]->get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[2]->get("/field_test")->GetInt(),1);
+    ASSERT_EQ(expected[3]->get("/field_test")->GetInt(),1);
+    ASSERT_EQ(expected[4]->get("/field_test")->GetInt(),10);
+    ASSERT_EQ(expected[5]->get("/field_test")->GetInt(),-10);
 
 }
 
@@ -341,14 +341,14 @@ TEST(opBuilderHelperIntCalc, Exec_sum_ref)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 8);
-    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),10);
-    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),19);
-    ASSERT_EQ(expected[2].get("/field_test")->GetInt(),20);
-    ASSERT_EQ(expected[3].get("/field_test")->GetInt(),21);
-    ASSERT_EQ(expected[4].get("/field_test")->GetInt(),-10);
-    ASSERT_EQ(expected[5].get("/field_test")->GetInt(),-1);
-    ASSERT_EQ(expected[6].get("/field_test")->GetInt(),0);
-    ASSERT_EQ(expected[7].get("/field_test")->GetInt(),1);
+    ASSERT_EQ(expected[0]->get("/field_test")->GetInt(),10);
+    ASSERT_EQ(expected[1]->get("/field_test")->GetInt(),19);
+    ASSERT_EQ(expected[2]->get("/field_test")->GetInt(),20);
+    ASSERT_EQ(expected[3]->get("/field_test")->GetInt(),21);
+    ASSERT_EQ(expected[4]->get("/field_test")->GetInt(),-10);
+    ASSERT_EQ(expected[5]->get("/field_test")->GetInt(),-1);
+    ASSERT_EQ(expected[6]->get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[7]->get("/field_test")->GetInt(),1);
 
 }
 
@@ -395,14 +395,14 @@ TEST(opBuilderHelperIntCalc, Exec_sub_ref)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 8);
-    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),-10);
-    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),-1);
-    ASSERT_EQ(expected[2].get("/field_test")->GetInt(),0);
-    ASSERT_EQ(expected[3].get("/field_test")->GetInt(),1);
-    ASSERT_EQ(expected[4].get("/field_test")->GetInt(),10);
-    ASSERT_EQ(expected[5].get("/field_test")->GetInt(),19);
-    ASSERT_EQ(expected[6].get("/field_test")->GetInt(),20);
-    ASSERT_EQ(expected[7].get("/field_test")->GetInt(),21);
+    ASSERT_EQ(expected[0]->get("/field_test")->GetInt(),-10);
+    ASSERT_EQ(expected[1]->get("/field_test")->GetInt(),-1);
+    ASSERT_EQ(expected[2]->get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[3]->get("/field_test")->GetInt(),1);
+    ASSERT_EQ(expected[4]->get("/field_test")->GetInt(),10);
+    ASSERT_EQ(expected[5]->get("/field_test")->GetInt(),19);
+    ASSERT_EQ(expected[6]->get("/field_test")->GetInt(),20);
+    ASSERT_EQ(expected[7]->get("/field_test")->GetInt(),21);
 
 }
 
@@ -449,14 +449,14 @@ TEST(opBuilderHelperIntCalc, Exec_mult_ref)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 8);
-    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),0);
-    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),90);
-    ASSERT_EQ(expected[2].get("/field_test")->GetInt(),100);
-    ASSERT_EQ(expected[3].get("/field_test")->GetInt(),110);
-    ASSERT_EQ(expected[4].get("/field_test")->GetInt(),0);
-    ASSERT_EQ(expected[5].get("/field_test")->GetInt(),-90);
-    ASSERT_EQ(expected[6].get("/field_test")->GetInt(),-100);
-    ASSERT_EQ(expected[7].get("/field_test")->GetInt(),-110);
+    ASSERT_EQ(expected[0]->get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[1]->get("/field_test")->GetInt(),90);
+    ASSERT_EQ(expected[2]->get("/field_test")->GetInt(),100);
+    ASSERT_EQ(expected[3]->get("/field_test")->GetInt(),110);
+    ASSERT_EQ(expected[4]->get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[5]->get("/field_test")->GetInt(),-90);
+    ASSERT_EQ(expected[6]->get("/field_test")->GetInt(),-100);
+    ASSERT_EQ(expected[7]->get("/field_test")->GetInt(),-110);
 
 }
 
@@ -503,14 +503,14 @@ TEST(opBuilderHelperIntCalc, Exec_div_ref)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 8);
-    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),0);
-    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),0);
-    ASSERT_EQ(expected[2].get("/field_test")->GetInt(),1);
-    ASSERT_EQ(expected[3].get("/field_test")->GetInt(),1);
-    ASSERT_EQ(expected[4].get("/field_test")->GetInt(),0);
-    ASSERT_EQ(expected[5].get("/field_test")->GetInt(),0);
-    ASSERT_EQ(expected[6].get("/field_test")->GetInt(),-1);
-    ASSERT_EQ(expected[7].get("/field_test")->GetInt(),-1);
+    ASSERT_EQ(expected[0]->get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[1]->get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[2]->get("/field_test")->GetInt(),1);
+    ASSERT_EQ(expected[3]->get("/field_test")->GetInt(),1);
+    ASSERT_EQ(expected[4]->get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[5]->get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[6]->get("/field_test")->GetInt(),-1);
+    ASSERT_EQ(expected[7]->get("/field_test")->GetInt(),-1);
 
 }
 
@@ -557,14 +557,14 @@ TEST(opBuilderHelperIntCalc, Exec_div_ref_zero)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 8);
-    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),0);
-    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),9);
-    ASSERT_EQ(expected[2].get("/field_test")->GetInt(),10);
-    ASSERT_EQ(expected[3].get("/field_test")->GetInt(),11);
-    ASSERT_EQ(expected[4].get("/field_test")->GetInt(),0);
-    ASSERT_EQ(expected[5].get("/field_test")->GetInt(),9);
-    ASSERT_EQ(expected[6].get("/field_test")->GetInt(),10);
-    ASSERT_EQ(expected[7].get("/field_test")->GetInt(),11);
+    ASSERT_EQ(expected[0]->get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[1]->get("/field_test")->GetInt(),9);
+    ASSERT_EQ(expected[2]->get("/field_test")->GetInt(),10);
+    ASSERT_EQ(expected[3]->get("/field_test")->GetInt(),11);
+    ASSERT_EQ(expected[4]->get("/field_test")->GetInt(),0);
+    ASSERT_EQ(expected[5]->get("/field_test")->GetInt(),9);
+    ASSERT_EQ(expected[6]->get("/field_test")->GetInt(),10);
+    ASSERT_EQ(expected[7]->get("/field_test")->GetInt(),11);
 
 }
 
@@ -614,8 +614,8 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sum)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_EQ(expected[0].get("/parentObjt_1/field2check")->GetInt(), 21);
-    ASSERT_EQ(expected[1].get("/parentObjt_1/field2check")->GetInt(), 20);
+    ASSERT_EQ(expected[0]->get("/parentObjt_1/field2check")->GetInt(), 21);
+    ASSERT_EQ(expected[1]->get("/parentObjt_1/field2check")->GetInt(), 20);
 }
 
 TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sub)
@@ -664,8 +664,8 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sub)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_EQ(expected[0].get("/parentObjt_1/field2check")->GetInt(), -1);
-    ASSERT_EQ(expected[1].get("/parentObjt_1/field2check")->GetInt(), 0);
+    ASSERT_EQ(expected[0]->get("/parentObjt_1/field2check")->GetInt(), -1);
+    ASSERT_EQ(expected[1]->get("/parentObjt_1/field2check")->GetInt(), 0);
 }
 
 TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_mul)
@@ -714,8 +714,8 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_mul)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_EQ(expected[0].get("/parentObjt_1/field2check")->GetInt(), 110);
-    ASSERT_EQ(expected[1].get("/parentObjt_1/field2check")->GetInt(), 100);
+    ASSERT_EQ(expected[0]->get("/parentObjt_1/field2check")->GetInt(), 110);
+    ASSERT_EQ(expected[1]->get("/parentObjt_1/field2check")->GetInt(), 100);
 }
 
 TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_div)
@@ -764,6 +764,6 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_div)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_EQ(expected[0].get("/parentObjt_1/field2check")->GetInt(), 0);
-    ASSERT_EQ(expected[1].get("/parentObjt_1/field2check")->GetInt(), 1);
+    ASSERT_EQ(expected[0]->get("/parentObjt_1/field2check")->GetInt(), 0);
+    ASSERT_EQ(expected[1]->get("/parentObjt_1/field2check")->GetInt(), 1);
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntEqual_test.cpp
@@ -76,8 +76,8 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_EQ(expected[0].get("/field_test")->GetInt(), 10);
-    ASSERT_EQ(expected[1].get("/field_test")->GetInt(), 10);
+    ASSERT_EQ(expected[0]->get("/field_test")->GetInt(), 10);
+    ASSERT_EQ(expected[1]->get("/field_test")->GetInt(), 10);
 }
 
 TEST(opBuilderHelperIntEqual, Exec_equal_true)
@@ -111,8 +111,8 @@ TEST(opBuilderHelperIntEqual, Exec_equal_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_EQ(expected[0].get("/field_test")->GetInt(), 10);
-    ASSERT_EQ(expected[1].get("/field_test")->GetInt(), 10);
+    ASSERT_EQ(expected[0]->get("/field_test")->GetInt(), 10);
+    ASSERT_EQ(expected[1]->get("/field_test")->GetInt(), 10);
 }
 
 TEST(opBuilderHelperIntEqual, Exec_equal_false)
@@ -190,10 +190,10 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ref_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_EQ(expected[0].get("/field_test")->GetInt(),
-              expected[0].get("/field_src")->GetInt());
-    ASSERT_EQ(expected[1].get("/field_test")->GetInt(),
-              expected[0].get("/field_src")->GetInt());
+    ASSERT_EQ(expected[0]->get("/field_test")->GetInt(),
+              expected[0]->get("/field_src")->GetInt());
+    ASSERT_EQ(expected[1]->get("/field_test")->GetInt(),
+              expected[0]->get("/field_src")->GetInt());
 }
 
 TEST(opBuilderHelperIntEqual, Exec_equal_ref_false)
@@ -281,8 +281,8 @@ TEST(opBuilderHelperIntEqual, Exec_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_EQ(expected[0].get("/field2check")->GetInt(),
-              expected[0].get("/ref_key")->GetInt());
+    ASSERT_EQ(expected[0]->get("/field2check")->GetInt(),
+              expected[0]->get("/ref_key")->GetInt());
 }
 
 TEST(opBuilderHelperIntEqual, Exec_multilevel_dynamics_int_ok)
@@ -356,6 +356,6 @@ TEST(opBuilderHelperIntEqual, Exec_multilevel_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_EQ(expected[0].get("/parentObjt_1/field2check")->GetInt(),
-              expected[0].get("/parentObjt_2/ref_key")->GetInt());
+    ASSERT_EQ(expected[0]->get("/parentObjt_1/field2check")->GetInt(),
+              expected[0]->get("/parentObjt_2/ref_key")->GetInt());
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntEqual_test.cpp
@@ -55,18 +55,18 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntEqual(*doc.get("/check"));
@@ -90,18 +90,18 @@ TEST(opBuilderHelperIntEqual, Exec_equal_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntEqual(*doc.get("/check"));
@@ -125,18 +125,18 @@ TEST(opBuilderHelperIntEqual, Exec_equal_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test2":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test3":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntEqual(*doc.get("/check"));
@@ -158,30 +158,30 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ref_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 9,"field_src": 10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10,"field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":"10","field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":"10","field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10,"field_src":"test"}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntEqual(*doc.get("/check"));
@@ -206,30 +206,30 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ref_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test2":9,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10,"field_src3":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10,"field_src4":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test5":10,"field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test6":"10","field_src2":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_":"10","field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src2":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test2":10,"field_src2":"test"}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntEqual(*doc.get("/check"));
@@ -251,26 +251,26 @@ TEST(opBuilderHelperIntEqual, Exec_dynamics_int_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":11,
                     "ref_key":10
                 }
-            )"});
+            )"));
             // Equal
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":10,
                     "ref_key":10
                 }
-            )"});
+            )"));
             // Less
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":10,
                     "ref_key":11
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -295,7 +295,7 @@ TEST(opBuilderHelperIntEqual, Exec_multilevel_dynamics_int_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -306,9 +306,9 @@ TEST(opBuilderHelperIntEqual, Exec_multilevel_dynamics_int_ok)
                         "ref_key": 11
                     }
                 }
-            )"});
+            )"));
 
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -319,9 +319,9 @@ TEST(opBuilderHelperIntEqual, Exec_multilevel_dynamics_int_ok)
                         "ref_key": 11
                     }
                 }
-            )"});
+            )"));
 
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -332,9 +332,9 @@ TEST(opBuilderHelperIntEqual, Exec_multilevel_dynamics_int_ok)
                         "ref_key":11
                     }
                 }
-            )"});
+            )"));
 
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -345,7 +345,7 @@ TEST(opBuilderHelperIntEqual, Exec_multilevel_dynamics_int_ok)
                         "ref_key":11
                     }
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThanEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThanEqual_test.cpp
@@ -57,18 +57,18 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntGreaterThanEqual(*doc.get("/check"));
@@ -93,18 +93,18 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntGreaterThanEqual(*doc.get("/check"));
@@ -129,18 +129,18 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test2":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test3":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":8}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntGreaterThanEqual(*doc.get("/check"));
@@ -162,30 +162,30 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ref_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 10,"field_src": 10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":"11","field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":"11","field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src":"test"}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntGreaterThanEqual(*doc.get("/check"));
@@ -211,30 +211,30 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ref_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test2":11,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src3":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src4":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test5":11,"field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test6":"11","field_src2":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_":"11","field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src2":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test2":11,"field_src2":"test"}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntGreaterThanEqual(*doc.get("/check"));
@@ -257,26 +257,26 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_dynamics_int_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":11,
                     "ref_key":10
                 }
-            )"});
+            )"));
             // Equal
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":10,
                     "ref_key":10
                 }
-            )"});
+            )"));
             // Less
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":10,
                     "ref_key":11
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -303,7 +303,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_multilevel_dynamics_int_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -314,9 +314,9 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_multilevel_dynamics_int_ok)
                         "ref_key": 11
                     }
                 }
-            )"});
+            )"));
 
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -327,9 +327,9 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_multilevel_dynamics_int_ok)
                         "ref_key": 11
                     }
                 }
-            )"});
+            )"));
 
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -340,9 +340,9 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_multilevel_dynamics_int_ok)
                         "ref_key":11
                     }
                 }
-            )"});
+            )"));
 
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -353,7 +353,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_multilevel_dynamics_int_ok)
                         "ref_key":11
                     }
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThanEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThanEqual_test.cpp
@@ -78,9 +78,9 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_GE(expected[0].get("/field_test")->GetInt(), 10);
-    ASSERT_GE(expected[1].get("/field_test")->GetInt(), 10);
-    ASSERT_GE(expected[2].get("/field_test")->GetInt(), 10);
+    ASSERT_GE(expected[0]->get("/field_test")->GetInt(), 10);
+    ASSERT_GE(expected[1]->get("/field_test")->GetInt(), 10);
+    ASSERT_GE(expected[2]->get("/field_test")->GetInt(), 10);
 }
 
 TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_true)
@@ -114,9 +114,9 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_GE(expected[0].get("/field_test")->GetInt(), 10);
-    ASSERT_GE(expected[1].get("/field_test")->GetInt(), 10);
-    ASSERT_GE(expected[2].get("/field_test")->GetInt(), 11);
+    ASSERT_GE(expected[0]->get("/field_test")->GetInt(), 10);
+    ASSERT_GE(expected[1]->get("/field_test")->GetInt(), 10);
+    ASSERT_GE(expected[2]->get("/field_test")->GetInt(), 11);
 }
 
 TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_false)
@@ -195,10 +195,10 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ref_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_GE(expected[0].get("/field_test")->GetInt(),
-              expected[0].get("/field_src")->GetInt());
-    ASSERT_GE(expected[1].get("/field_test")->GetInt(),
-              expected[1].get("/field_src")->GetInt());
+    ASSERT_GE(expected[0]->get("/field_test")->GetInt(),
+              expected[0]->get("/field_src")->GetInt());
+    ASSERT_GE(expected[1]->get("/field_test")->GetInt(),
+              expected[1]->get("/field_src")->GetInt());
 }
 
 TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ref_false)
@@ -287,10 +287,10 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_GE(expected[0].get("/field2check")->GetInt(),
-              expected[0].get("/ref_key")->GetInt());
-    ASSERT_GE(expected[1].get("/field2check")->GetInt(),
-              expected[1].get("/ref_key")->GetInt());
+    ASSERT_GE(expected[0]->get("/field2check")->GetInt(),
+              expected[0]->get("/ref_key")->GetInt());
+    ASSERT_GE(expected[1]->get("/field2check")->GetInt(),
+              expected[1]->get("/ref_key")->GetInt());
 }
 
 TEST(opBuilderHelperIntGreaterThanEqual, Exec_multilevel_dynamics_int_ok)
@@ -364,8 +364,8 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_multilevel_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_GE(expected[0].get("/parentObjt_1/field2check")->GetInt(),
-              expected[0].get("/parentObjt_2/ref_key")->GetInt());
-    ASSERT_GE(expected[1].get("/parentObjt_1/field2check")->GetInt(),
-              expected[1].get("/parentObjt_2/ref_key")->GetInt());
+    ASSERT_GE(expected[0]->get("/parentObjt_1/field2check")->GetInt(),
+              expected[0]->get("/parentObjt_2/ref_key")->GetInt());
+    ASSERT_GE(expected[1]->get("/parentObjt_1/field2check")->GetInt(),
+              expected[1]->get("/parentObjt_2/ref_key")->GetInt());
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThan_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThan_test.cpp
@@ -77,7 +77,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_GT(expected[0].get("/field_test")->GetInt(), 10);
+    ASSERT_GT(expected[0]->get("/field_test")->GetInt(), 10);
 }
 
 TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_true)
@@ -111,7 +111,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_GT(expected[0].get("/field_test")->GetInt(), 10);
+    ASSERT_GT(expected[0]->get("/field_test")->GetInt(), 10);
 }
 
 TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_false)
@@ -190,10 +190,10 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ref_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_GT(expected[0].get("/field_test")->GetInt(),
-              expected[0].get("/field_src")->GetInt());
-    ASSERT_GT(expected[1].get("/field_test")->GetInt(),
-              expected[1].get("/field_src")->GetInt());
+    ASSERT_GT(expected[0]->get("/field_test")->GetInt(),
+              expected[0]->get("/field_src")->GetInt());
+    ASSERT_GT(expected[1]->get("/field_test")->GetInt(),
+              expected[1]->get("/field_src")->GetInt());
 }
 
 TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ref_false)
@@ -282,8 +282,8 @@ TEST(opBuilderHelperIntGreaterThan, Exec_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_GT(expected[0].get("/field2check")->GetInt(),
-              expected[0].get("/ref_key")->GetInt());
+    ASSERT_GT(expected[0]->get("/field2check")->GetInt(),
+              expected[0]->get("/ref_key")->GetInt());
 }
 
 TEST(opBuilderHelperIntGreaterThan, Exec_multilevel_dynamics_int_ok)
@@ -357,6 +357,6 @@ TEST(opBuilderHelperIntGreaterThan, Exec_multilevel_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_GT(expected[0].get("/parentObjt_1/field2check")->GetInt(),
-              expected[0].get("/parentObjt_2/ref_key")->GetInt());
+    ASSERT_GT(expected[0]->get("/parentObjt_1/field2check")->GetInt(),
+              expected[0]->get("/parentObjt_2/ref_key")->GetInt());
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThan_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThan_test.cpp
@@ -56,18 +56,18 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntGreaterThan(*doc.get("/check"));
@@ -90,18 +90,18 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntGreaterThan(*doc.get("/check"));
@@ -124,18 +124,18 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test2":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test3":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":8}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntGreaterThan(*doc.get("/check"));
@@ -157,30 +157,30 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ref_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 10,"field_src": 10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":"11","field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":"11","field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src":"test"}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntGreaterThan(*doc.get("/check"));
@@ -206,30 +206,30 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ref_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test2":11,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10,"field_src3":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10,"field_src4":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test5":10,"field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test6":"10","field_src2":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_":"10","field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src2":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test2":10,"field_src2":"test"}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntGreaterThan(*doc.get("/check"));
@@ -252,26 +252,26 @@ TEST(opBuilderHelperIntGreaterThan, Exec_dynamics_int_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":11,
                     "ref_key":10
                 }
-            )"});
+            )"));
             // Equal
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":10,
                     "ref_key":10
                 }
-            )"});
+            )"));
             // Less
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":10,
                     "ref_key":11
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -296,7 +296,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_multilevel_dynamics_int_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -307,9 +307,9 @@ TEST(opBuilderHelperIntGreaterThan, Exec_multilevel_dynamics_int_ok)
                         "ref_key": 11
                     }
                 }
-            )"});
+            )"));
 
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -320,9 +320,9 @@ TEST(opBuilderHelperIntGreaterThan, Exec_multilevel_dynamics_int_ok)
                         "ref_key": 11
                     }
                 }
-            )"});
+            )"));
 
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -333,9 +333,9 @@ TEST(opBuilderHelperIntGreaterThan, Exec_multilevel_dynamics_int_ok)
                         "ref_key":11
                     }
                 }
-            )"});
+            )"));
 
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -346,7 +346,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_multilevel_dynamics_int_ok)
                         "ref_key":11
                     }
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntLessThanEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntLessThanEqual_test.cpp
@@ -56,18 +56,18 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntLessThanEqual(*doc.get("/check"));
@@ -92,18 +92,18 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntLessThanEqual(*doc.get("/check"));
@@ -128,18 +128,18 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":20}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test2":100}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test3":100}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntLessThanEqual(*doc.get("/check"));
@@ -161,30 +161,30 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ref_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 10,"field_src": 10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":"9","field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":"9","field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src":"test"}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntLessThanEqual(*doc.get("/check"));
@@ -212,30 +212,30 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ref_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test2":9,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src3":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src4":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test5":9,"field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test6":"9","field_src2":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_":"9","field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src2":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test2":9,"field_src2":"test"}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntLessThanEqual(*doc.get("/check"));
@@ -258,26 +258,26 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_dynamics_int_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":11,
                     "ref_key":10
                 }
-            )"});
+            )"));
             // Equal
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":10,
                     "ref_key":10
                 }
-            )"});
+            )"));
             // Less
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":10,
                     "ref_key":11
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -304,7 +304,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_multilevel_dynamics_int_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -315,9 +315,9 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_multilevel_dynamics_int_ok)
                         "ref_key": 9
                     }
                 }
-            )"});
+            )"));
 
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 9,
@@ -328,9 +328,9 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_multilevel_dynamics_int_ok)
                         "ref_key": 9
                     }
                 }
-            )"});
+            )"));
 
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -341,9 +341,9 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_multilevel_dynamics_int_ok)
                         "ref_key":9
                     }
                 }
-            )"});
+            )"));
 
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -354,7 +354,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_multilevel_dynamics_int_ok)
                         "ref_key":9
                     }
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntLessThanEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntLessThanEqual_test.cpp
@@ -77,9 +77,9 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_LE(expected[0].get("/field_test")->GetInt(), 10);
-    ASSERT_LE(expected[1].get("/field_test")->GetInt(), 10);
-    ASSERT_LE(expected[2].get("/field_test")->GetInt(), 10);
+    ASSERT_LE(expected[0]->get("/field_test")->GetInt(), 10);
+    ASSERT_LE(expected[1]->get("/field_test")->GetInt(), 10);
+    ASSERT_LE(expected[2]->get("/field_test")->GetInt(), 10);
 }
 
 TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_true)
@@ -113,9 +113,9 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_LE(expected[0].get("/field_test")->GetInt(), 10);
-    ASSERT_LE(expected[1].get("/field_test")->GetInt(), 10);
-    ASSERT_LE(expected[2].get("/field_test")->GetInt(), 10);
+    ASSERT_LE(expected[0]->get("/field_test")->GetInt(), 10);
+    ASSERT_LE(expected[1]->get("/field_test")->GetInt(), 10);
+    ASSERT_LE(expected[2]->get("/field_test")->GetInt(), 10);
 }
 
 TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_false)
@@ -194,12 +194,12 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ref_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_LE(expected[0].get("/field_test")->GetInt(),
-              expected[0].get("/field_src")->GetInt());
-    ASSERT_LE(expected[1].get("/field_test")->GetInt(),
-              expected[1].get("/field_src")->GetInt());
-    ASSERT_LE(expected[2].get("/field_test")->GetInt(),
-              expected[2].get("/field_src")->GetInt());
+    ASSERT_LE(expected[0]->get("/field_test")->GetInt(),
+              expected[0]->get("/field_src")->GetInt());
+    ASSERT_LE(expected[1]->get("/field_test")->GetInt(),
+              expected[1]->get("/field_src")->GetInt());
+    ASSERT_LE(expected[2]->get("/field_test")->GetInt(),
+              expected[2]->get("/field_src")->GetInt());
 }
 
 TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ref_false)
@@ -288,10 +288,10 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_LE(expected[0].get("/field2check")->GetInt(),
-              expected[0].get("/ref_key")->GetInt());
-    ASSERT_LE(expected[1].get("/field2check")->GetInt(),
-              expected[1].get("/ref_key")->GetInt());
+    ASSERT_LE(expected[0]->get("/field2check")->GetInt(),
+              expected[0]->get("/ref_key")->GetInt());
+    ASSERT_LE(expected[1]->get("/field2check")->GetInt(),
+              expected[1]->get("/ref_key")->GetInt());
 }
 
 TEST(opBuilderHelperIntLessThanEqual, Exec_multilevel_dynamics_int_ok)
@@ -365,8 +365,8 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_multilevel_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_LE(expected[0].get("/parentObjt_1/field2check")->GetInt(),
-              expected[0].get("/parentObjt_2/ref_key")->GetInt());
-    ASSERT_LE(expected[1].get("/parentObjt_1/field2check")->GetInt(),
-              expected[1].get("/parentObjt_2/ref_key")->GetInt());
+    ASSERT_LE(expected[0]->get("/parentObjt_1/field2check")->GetInt(),
+              expected[0]->get("/parentObjt_2/ref_key")->GetInt());
+    ASSERT_LE(expected[1]->get("/parentObjt_1/field2check")->GetInt(),
+              expected[1]->get("/parentObjt_2/ref_key")->GetInt());
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntLessThan_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntLessThan_test.cpp
@@ -76,7 +76,7 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_LT(expected[0].get("/field_test")->GetInt(), 10);
+    ASSERT_LT(expected[0]->get("/field_test")->GetInt(), 10);
 }
 
 TEST(opBuilderHelperIntLessThan, Exec_less_than_true)
@@ -110,7 +110,7 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_LT(expected[0].get("/field_test")->GetInt(), 10);
+    ASSERT_LT(expected[0]->get("/field_test")->GetInt(), 10);
 }
 
 TEST(opBuilderHelperIntLessThan, Exec_less_than_false)
@@ -189,10 +189,10 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_ref_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_LT(expected[0].get("/field_test")->GetInt(),
-              expected[0].get("/field_src")->GetInt());
-    ASSERT_LT(expected[1].get("/field_test")->GetInt(),
-              expected[1].get("/field_src")->GetInt());
+    ASSERT_LT(expected[0]->get("/field_test")->GetInt(),
+              expected[0]->get("/field_src")->GetInt());
+    ASSERT_LT(expected[1]->get("/field_test")->GetInt(),
+              expected[1]->get("/field_src")->GetInt());
 }
 
 TEST(opBuilderHelperIntLessThan, Exec_less_than_ref_false)
@@ -281,8 +281,8 @@ TEST(opBuilderHelperIntLessThan, Exec_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_LT(expected[0].get("/field2check")->GetInt(),
-              expected[0].get("/ref_key")->GetInt());
+    ASSERT_LT(expected[0]->get("/field2check")->GetInt(),
+              expected[0]->get("/ref_key")->GetInt());
 }
 
 TEST(opBuilderHelperIntLessThan, Exec_multilevel_dynamics_int_ok)
@@ -356,6 +356,6 @@ TEST(opBuilderHelperIntLessThan, Exec_multilevel_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_LT(expected[0].get("/parentObjt_1/field2check")->GetInt(),
-              expected[0].get("/parentObjt_2/ref_key")->GetInt());
+    ASSERT_LT(expected[0]->get("/parentObjt_1/field2check")->GetInt(),
+              expected[0]->get("/parentObjt_2/ref_key")->GetInt());
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntLessThan_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntLessThan_test.cpp
@@ -55,18 +55,18 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntLessThan(*doc.get("/check"));
@@ -89,18 +89,18 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntLessThan(*doc.get("/check"));
@@ -123,18 +123,18 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":20}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test2":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test3":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntLessThan(*doc.get("/check"));
@@ -156,30 +156,30 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_ref_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 10,"field_src": 10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":"9","field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":"9","field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src":"test"}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntLessThan(*doc.get("/check"));
@@ -205,30 +205,30 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_ref_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test2":9,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src3":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src4":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test5":9,"field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test6":"9","field_src2":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_":"9","field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9,"field_src2":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test2":9,"field_src2":"test"}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntLessThan(*doc.get("/check"));
@@ -251,26 +251,26 @@ TEST(opBuilderHelperIntLessThan, Exec_dynamics_int_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":11,
                     "ref_key":10
                 }
-            )"});
+            )"));
             // Equal
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":10,
                     "ref_key":10
                 }
-            )"});
+            )"));
             // Less
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":10,
                     "ref_key":11
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -295,7 +295,7 @@ TEST(opBuilderHelperIntLessThan, Exec_multilevel_dynamics_int_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -306,9 +306,9 @@ TEST(opBuilderHelperIntLessThan, Exec_multilevel_dynamics_int_ok)
                         "ref_key": 9
                     }
                 }
-            )"});
+            )"));
 
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 9,
@@ -319,9 +319,9 @@ TEST(opBuilderHelperIntLessThan, Exec_multilevel_dynamics_int_ok)
                         "ref_key": 9
                     }
                 }
-            )"});
+            )"));
 
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -332,9 +332,9 @@ TEST(opBuilderHelperIntLessThan, Exec_multilevel_dynamics_int_ok)
                         "ref_key":9
                     }
                 }
-            )"});
+            )"));
 
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -345,7 +345,7 @@ TEST(opBuilderHelperIntLessThan, Exec_multilevel_dynamics_int_ok)
                         "ref_key":9
                     }
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntNotEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntNotEqual_test.cpp
@@ -55,18 +55,18 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntNotEqual(*doc.get("/check"));
@@ -90,18 +90,18 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":9}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntNotEqual(*doc.get("/check"));
@@ -125,18 +125,18 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test2":9}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test3":11}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntNotEqual(*doc.get("/check"));
@@ -158,30 +158,30 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ref_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test": 9,"field_src": 10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10,"field_src":11}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10,"field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":"10","field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":"10","field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10,"field_src":"test"}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntNotEqual(*doc.get("/check"));
@@ -207,30 +207,30 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ref_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test2":9,"field_src":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10,"field_src3":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":10,"field_src4":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test5":10,"field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test6":"10","field_src2":10}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_":"10","field_src":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test":11,"field_src2":"10"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field_test2":10,"field_src2":"test"}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = opBuilderHelperIntNotEqual(*doc.get("/check"));
@@ -253,26 +253,26 @@ TEST(opBuilderHelperIntNotEqual, Exec_dynamics_int_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":11,
                     "ref_key":10
                 }
-            )"});
+            )"));
             // Equal
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":10,
                     "ref_key":10
                 }
-            )"});
+            )"));
             // Less
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":10,
                     "ref_key":11
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -299,7 +299,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_multilevel_dynamics_int_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -310,9 +310,9 @@ TEST(opBuilderHelperIntNotEqual, Exec_multilevel_dynamics_int_ok)
                         "ref_key": 11
                     }
                 }
-            )"});
+            )"));
 
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -323,9 +323,9 @@ TEST(opBuilderHelperIntNotEqual, Exec_multilevel_dynamics_int_ok)
                         "ref_key": 11
                     }
                 }
-            )"});
+            )"));
 
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -336,9 +336,9 @@ TEST(opBuilderHelperIntNotEqual, Exec_multilevel_dynamics_int_ok)
                         "ref_key":11
                     }
                 }
-            )"});
+            )"));
 
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -349,7 +349,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_multilevel_dynamics_int_ok)
                         "ref_key":11
                     }
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntNotEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntNotEqual_test.cpp
@@ -76,8 +76,8 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_EQ(expected[0].get("/field_test")->GetInt(), 9);
-    ASSERT_EQ(expected[1].get("/field_test")->GetInt(), 11);
+    ASSERT_EQ(expected[0]->get("/field_test")->GetInt(), 9);
+    ASSERT_EQ(expected[1]->get("/field_test")->GetInt(), 11);
 }
 
 TEST(opBuilderHelperIntNotEqual, Exec_not_equal_true)
@@ -111,8 +111,8 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_EQ(expected[0].get("/field_test")->GetInt(), 9);
-    ASSERT_EQ(expected[1].get("/field_test")->GetInt(), 11);
+    ASSERT_EQ(expected[0]->get("/field_test")->GetInt(), 9);
+    ASSERT_EQ(expected[1]->get("/field_test")->GetInt(), 11);
 }
 
 TEST(opBuilderHelperIntNotEqual, Exec_not_equal_false)
@@ -191,10 +191,10 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ref_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_NE(expected[0].get("/field_test")->GetInt(),
-              expected[0].get("/field_src")->GetInt());
-    ASSERT_NE(expected[1].get("/field_test")->GetInt(),
-              expected[1].get("/field_src")->GetInt());
+    ASSERT_NE(expected[0]->get("/field_test")->GetInt(),
+              expected[0]->get("/field_src")->GetInt());
+    ASSERT_NE(expected[1]->get("/field_test")->GetInt(),
+              expected[1]->get("/field_src")->GetInt());
 }
 
 TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ref_false)
@@ -283,10 +283,10 @@ TEST(opBuilderHelperIntNotEqual, Exec_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_NE(expected[0].get("/field2check")->GetInt(),
-              expected[0].get("/ref_key")->GetInt());
-    ASSERT_NE(expected[1].get("/field2check")->GetInt(),
-              expected[1].get("/ref_key")->GetInt());
+    ASSERT_NE(expected[0]->get("/field2check")->GetInt(),
+              expected[0]->get("/ref_key")->GetInt());
+    ASSERT_NE(expected[1]->get("/field2check")->GetInt(),
+              expected[1]->get("/ref_key")->GetInt());
 }
 
 TEST(opBuilderHelperIntNotEqual, Exec_multilevel_dynamics_int_ok)
@@ -360,6 +360,6 @@ TEST(opBuilderHelperIntNotEqual, Exec_multilevel_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_NE(expected[0].get("/parentObjt_1/field2check")->GetInt(),
-              expected[0].get("/parentObjt_2/ref_key")->GetInt());
+    ASSERT_NE(expected[0]->get("/parentObjt_1/field2check")->GetInt(),
+              expected[0]->get("/parentObjt_2/ref_key")->GetInt());
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperNotExists_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperNotExists_test.cpp
@@ -153,8 +153,8 @@ TEST(opBuilderHelperNotExists, Exec_multilevel_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_FALSE(expected[0].get("/parentObjt_1/field2check"));
-    ASSERT_FALSE(expected[1].get("/parentObjt_1/field2check"));
-    ASSERT_FALSE(expected[2].get("/parentObjt_1/field2check"));
+    ASSERT_FALSE(expected[0]->get("/parentObjt_1/field2check"));
+    ASSERT_FALSE(expected[1]->get("/parentObjt_1/field2check"));
+    ASSERT_FALSE(expected[2]->get("/parentObjt_1/field2check"));
 }
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperNotExists_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperNotExists_test.cpp
@@ -46,26 +46,26 @@ TEST(opBuilderHelperNotExists, Exec_not_exists_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check2":11,
                     "ref_key":10
                 }
-            )"});
+            )"));
             // Equal
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field":10,
                     "ref_key":10
                 }
-            )"});
+            )"));
             // Less
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "fieldcheck":10,
                     "ref_key":11
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -76,9 +76,9 @@ TEST(opBuilderHelperNotExists, Exec_not_exists_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_FALSE(expected[0].exists("/field2check"));
-    ASSERT_FALSE(expected[1].exists("/field2check"));
-    ASSERT_FALSE(expected[2].exists("/field2check"));
+    ASSERT_FALSE(expected[0]->exists("/field2check"));
+    ASSERT_FALSE(expected[1]->exists("/field2check"));
+    ASSERT_FALSE(expected[2]->exists("/field2check"));
 }
 
 TEST(opBuilderHelperNotExists, Exec_multilevel_ok)
@@ -91,7 +91,7 @@ TEST(opBuilderHelperNotExists, Exec_multilevel_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -102,9 +102,9 @@ TEST(opBuilderHelperNotExists, Exec_multilevel_ok)
                         "ref_key": 11
                     }
                 }
-            )"});
+            )"));
 
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -115,9 +115,9 @@ TEST(opBuilderHelperNotExists, Exec_multilevel_ok)
                         "ref_key": 11
                     }
                 }
-            )"});
+            )"));
 
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -128,10 +128,10 @@ TEST(opBuilderHelperNotExists, Exec_multilevel_ok)
                         "ref_key":11
                     }
                 }
-            )"});
+            )"));
 
             // true
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -142,7 +142,7 @@ TEST(opBuilderHelperNotExists, Exec_multilevel_ok)
                         "ref_key":11
                     }
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperRegexExtract_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperRegexExtract_test.cpp
@@ -74,9 +74,9 @@ TEST(opBuilderHelperRegexExtract, String_regex_extract)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_TRUE(RE2::PartialMatch(expected[0].get("/_field")->GetString(), "exp"));
-    ASSERT_TRUE(RE2::PartialMatch(expected[1].get("/_field")->GetString(), "exp"));
-    ASSERT_TRUE(RE2::PartialMatch(expected[2].get("/_field")->GetString(), "exp"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[0]->get("/_field")->GetString(), "exp"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[1]->get("/_field")->GetString(), "exp"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[2]->get("/_field")->GetString(), "exp"));
 }
 
 TEST(opBuilderHelperRegexExtract, Numeric_regex_extract)
@@ -107,9 +107,9 @@ TEST(opBuilderHelperRegexExtract, Numeric_regex_extract)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_TRUE(RE2::PartialMatch(expected[0].get("/_field")->GetString(), "123"));
-    ASSERT_TRUE(RE2::PartialMatch(expected[1].get("/_field")->GetString(), "123"));
-    ASSERT_TRUE(RE2::PartialMatch(expected[2].get("/_field")->GetString(), "123"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[0]->get("/_field")->GetString(), "123"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[1]->get("/_field")->GetString(), "123"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[2]->get("/_field")->GetString(), "123"));
 }
 
 TEST(opBuilderHelperRegexExtract, Advanced_regex_extract)
@@ -138,9 +138,9 @@ TEST(opBuilderHelperRegexExtract, Advanced_regex_extract)
 
     ASSERT_EQ(expected.size(), 2);
     ASSERT_TRUE(
-        RE2::PartialMatch(expected[0].get("/_field")->GetString(), "client@wazuh.com"));
+        RE2::PartialMatch(expected[0]->get("/_field")->GetString(), "client@wazuh.com"));
     ASSERT_TRUE(
-        RE2::PartialMatch(expected[1].get("/_field")->GetString(), "engine@wazuh.com"));
+        RE2::PartialMatch(expected[1]->get("/_field")->GetString(), "engine@wazuh.com"));
 }
 
 TEST(opBuilderHelperRegexExtract, Nested_field_regex_extract)
@@ -170,8 +170,8 @@ TEST(opBuilderHelperRegexExtract, Nested_field_regex_extract)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_TRUE(RE2::PartialMatch(expected[0].get("/_field")->GetString(), "exp"));
-    ASSERT_TRUE(RE2::PartialMatch(expected[1].get("/_field")->GetString(), "exp"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[0]->get("/_field")->GetString(), "exp"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[1]->get("/_field")->GetString(), "exp"));
 }
 
 TEST(opBuilderHelperRegexExtract, Field_not_exists_regex_extract)
@@ -234,8 +234,8 @@ TEST(opBuilderHelperRegexExtract, Multilevel_field_regex_extract)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_TRUE(RE2::PartialMatch(expected[0].get("/_field")->GetString(), "exp"));
-    ASSERT_TRUE(RE2::PartialMatch(expected[1].get("/_field")->GetString(), "exp"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[0]->get("/_field")->GetString(), "exp"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[1]->get("/_field")->GetString(), "exp"));
 }
 
 TEST(opBuilderHelperRegexExtract, Multilevel_field_dst_regex_extract)
@@ -265,6 +265,6 @@ TEST(opBuilderHelperRegexExtract, Multilevel_field_dst_regex_extract)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_TRUE(RE2::PartialMatch(expected[0].get("/parent/_field")->GetString(), "exp"));
-    ASSERT_TRUE(RE2::PartialMatch(expected[1].get("/parent/_field")->GetString(), "exp"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[0]->get("/parent/_field")->GetString(), "exp"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[1]->get("/parent/_field")->GetString(), "exp"));
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperRegexExtract_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperRegexExtract_test.cpp
@@ -56,15 +56,15 @@ TEST(opBuilderHelperRegexExtract, String_regex_extract)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"exp"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"expregex"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"this is a test exp"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -89,15 +89,15 @@ TEST(opBuilderHelperRegexExtract, Numeric_regex_extract)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"123"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"123"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"123"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -122,12 +122,12 @@ TEST(opBuilderHelperRegexExtract, Advanced_regex_extract)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"client@wazuh.com"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"engine@wazuh.com"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -153,14 +153,14 @@ TEST(opBuilderHelperRegexExtract, Nested_field_regex_extract)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"~~({
+            s.on_next(std::make_shared<json::Document>(R"~~({
             "test":
                 {"field": "exp"}
-            })~~"});
-            s.on_next(Event{R"~~({
+            })~~"));
+            s.on_next(std::make_shared<json::Document>(R"~~({
             "test":
                 {"field": "this is a test exp"}
-            })~~"});
+            })~~"));
             s.on_completed();
         });
 
@@ -184,15 +184,15 @@ TEST(opBuilderHelperRegexExtract, Field_not_exists_regex_extract)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"exp"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"expregex"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"this is a test exp"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -202,9 +202,9 @@ TEST(opBuilderHelperRegexExtract, Field_not_exists_regex_extract)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_FALSE(expected[0].exists("/_field"));
-    ASSERT_FALSE(expected[1].exists("/_field"));
-    ASSERT_FALSE(expected[2].exists("/_field"));
+    ASSERT_FALSE(expected[0]->exists("/_field"));
+    ASSERT_FALSE(expected[1]->exists("/_field"));
+    ASSERT_FALSE(expected[2]->exists("/_field"));
 }
 
 TEST(opBuilderHelperRegexExtract, Multilevel_field_regex_extract)
@@ -217,14 +217,14 @@ TEST(opBuilderHelperRegexExtract, Multilevel_field_regex_extract)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"~~({
+            s.on_next(std::make_shared<json::Document>(R"~~({
             "test":
                 {"field": "exp"}
-            })~~"});
-            s.on_next(Event{R"~~({
+            })~~"));
+            s.on_next(std::make_shared<json::Document>(R"~~({
             "test":
                 {"field": "this is a test exp"}
-            })~~"});
+            })~~"));
             s.on_completed();
         });
 
@@ -248,14 +248,14 @@ TEST(opBuilderHelperRegexExtract, Multilevel_field_dst_regex_extract)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"~~({
+            s.on_next(std::make_shared<json::Document>(R"~~({
             "test":
                 {"field": "exp"}
-            })~~"});
-            s.on_next(Event{R"~~({
+            })~~"));
+            s.on_next(std::make_shared<json::Document>(R"~~({
             "test":
                 {"field": "this is a test exp"}
-            })~~"});
+            })~~"));
             s.on_completed();
         });
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperRegexMatch_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperRegexMatch_test.cpp
@@ -121,9 +121,9 @@ TEST(opBuilderHelperRegexMatch, String_regex_match)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_TRUE(RE2::PartialMatch(expected[0].get("/field")->GetString(), "exp"));
-    ASSERT_TRUE(RE2::PartialMatch(expected[1].get("/field")->GetString(), "exp"));
-    ASSERT_TRUE(RE2::PartialMatch(expected[2].get("/field")->GetString(), "exp"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[0]->get("/field")->GetString(), "exp"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[1]->get("/field")->GetString(), "exp"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[2]->get("/field")->GetString(), "exp"));
 }
 
 TEST(opBuilderHelperRegexMatch, Numeric_regex_match)
@@ -157,9 +157,9 @@ TEST(opBuilderHelperRegexMatch, Numeric_regex_match)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_TRUE(RE2::PartialMatch(expected[0].get("/field")->GetString(), "123"));
-    ASSERT_TRUE(RE2::PartialMatch(expected[1].get("/field")->GetString(), "123"));
-    ASSERT_TRUE(RE2::PartialMatch(expected[2].get("/field")->GetString(), "123"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[0]->get("/field")->GetString(), "123"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[1]->get("/field")->GetString(), "123"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[2]->get("/field")->GetString(), "123"));
 }
 
 TEST(opBuilderHelperRegexMatch, Advanced_regex_match)
@@ -190,9 +190,9 @@ TEST(opBuilderHelperRegexMatch, Advanced_regex_match)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_TRUE(RE2::PartialMatch(expected[0].get("/field")->GetString(),
+    ASSERT_TRUE(RE2::PartialMatch(expected[0]->get("/field")->GetString(),
                                   "([^ @]+)@([^ @]+)"));
-    ASSERT_TRUE(RE2::PartialMatch(expected[1].get("/field")->GetString(),
+    ASSERT_TRUE(RE2::PartialMatch(expected[1]->get("/field")->GetString(),
                                   "([^ @]+)@([^ @]+)"));
 }
 
@@ -223,8 +223,8 @@ TEST(opBuilderHelperRegexMatch, Nested_field_regex_match)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_TRUE(RE2::PartialMatch(expected[0].get("/test/field")->GetString(), "exp"));
-    ASSERT_TRUE(RE2::PartialMatch(expected[1].get("/test/field")->GetString(), "exp"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[0]->get("/test/field")->GetString(), "exp"));
+    ASSERT_TRUE(RE2::PartialMatch(expected[1]->get("/test/field")->GetString(), "exp"));
 }
 
 TEST(opBuilderHelperRegexMatch, Field_not_exists_regex_match)

--- a/src/engine/test/source/builder/builders/opBuilderHelperRegexMatch_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperRegexMatch_test.cpp
@@ -64,21 +64,21 @@ TEST(opBuilderHelperRegexMatch, Invalid_src_type)
         [=](auto s)
         {
             // Object
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldSrc": { "fieldSrc" : "child value"} }
-            )"});
+            )"));
             // Number
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldSrc":55}
-            )"});
+            )"));
             // Array
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldSrc":[123]}
-            )"});
+            )"));
             // Not existing field
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"fieldSrc not exist"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -100,18 +100,18 @@ TEST(opBuilderHelperRegexMatch, String_regex_match)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"exp"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"expregex"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"this is a test exp"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"value"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -136,18 +136,18 @@ TEST(opBuilderHelperRegexMatch, Numeric_regex_match)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"123"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"123.02"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"10123"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"234"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -172,15 +172,15 @@ TEST(opBuilderHelperRegexMatch, Advanced_regex_match)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"client@wazuh.com"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"engine@wazuh.com"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"wazuh.com"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -206,14 +206,14 @@ TEST(opBuilderHelperRegexMatch, Nested_field_regex_match)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"~~({
+            s.on_next(std::make_shared<json::Document>(R"~~({
             "test":
                 {"field": "exp"}
-            })~~"});
-            s.on_next(Event{R"~~({
+            })~~"));
+            s.on_next(std::make_shared<json::Document>(R"~~({
             "test":
                 {"field": "this is a test exp"}
-            })~~"});
+            })~~"));
             s.on_completed();
         });
 
@@ -237,12 +237,12 @@ TEST(opBuilderHelperRegexMatch, Field_not_exists_regex_match)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2":"exp"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"exp"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -252,5 +252,5 @@ TEST(opBuilderHelperRegexMatch, Field_not_exists_regex_match)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_TRUE(expected[0].exists("/field2"));
+    ASSERT_TRUE(expected[0]->exists("/field2"));
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperRegexNotMatch_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperRegexNotMatch_test.cpp
@@ -125,8 +125,8 @@ TEST(opBuilderHelperRegexNotMatch, StringRegexMatch)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_FALSE(RE2::PartialMatch(expected[0].get("/field")->GetString(), "exp"));
-    ASSERT_FALSE(RE2::PartialMatch(expected[1].get("/field")->GetString(), "exp"));
+    ASSERT_FALSE(RE2::PartialMatch(expected[0]->get("/field")->GetString(), "exp"));
+    ASSERT_FALSE(RE2::PartialMatch(expected[1]->get("/field")->GetString(), "exp"));
 }
 
 TEST(opBuilderHelperRegexNotMatch, NumericRegexMatch)
@@ -157,8 +157,8 @@ TEST(opBuilderHelperRegexNotMatch, NumericRegexMatch)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_FALSE(RE2::PartialMatch(expected[0].get("/field")->GetString(), "123"));
-    ASSERT_FALSE(RE2::PartialMatch(expected[1].get("/field")->GetString(), "123"));
+    ASSERT_FALSE(RE2::PartialMatch(expected[0]->get("/field")->GetString(), "123"));
+    ASSERT_FALSE(RE2::PartialMatch(expected[1]->get("/field")->GetString(), "123"));
 }
 
 TEST(opBuilderHelperRegexNotMatch, AdvancedRegexMatch)
@@ -186,7 +186,7 @@ TEST(opBuilderHelperRegexNotMatch, AdvancedRegexMatch)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_FALSE(RE2::PartialMatch(expected[0].get("/field")->GetString(),
+    ASSERT_FALSE(RE2::PartialMatch(expected[0]->get("/field")->GetString(),
                                    "([^ @]+)@([^ @]+)")
     );
 }
@@ -218,8 +218,8 @@ TEST(opBuilderHelperRegexNotMatch, NestedFieldRegexMatch)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_FALSE(RE2::PartialMatch(expected[0].get("/test/field")->GetString(), "exp"));
-    ASSERT_FALSE(RE2::PartialMatch(expected[1].get("/test/field")->GetString(), "exp"));
+    ASSERT_FALSE(RE2::PartialMatch(expected[0]->get("/test/field")->GetString(), "exp"));
+    ASSERT_FALSE(RE2::PartialMatch(expected[1]->get("/test/field")->GetString(), "exp"));
 }
 
 TEST(opBuilderHelperRegexNotMatch, FieldNotExistsRegexNotMatch)

--- a/src/engine/test/source/builder/builders/opBuilderHelperRegexNotMatch_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperRegexNotMatch_test.cpp
@@ -68,21 +68,21 @@ TEST(opBuilderHelperRegexNotMatch, InvalidSrcType)
         [=](auto s)
         {
             // Object
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldSrc": { "fieldSrc" : "child value"} }
-            )"});
+            )"));
             // Number
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldSrc":55}
-            )"});
+            )"));
             // Array
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldSrc":[123]}
-            )"});
+            )"));
             // Not existing field
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"fieldSrc not exist"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -104,18 +104,18 @@ TEST(opBuilderHelperRegexNotMatch, StringRegexMatch)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"ex-president"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"this is a test exp"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"exp"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -139,15 +139,15 @@ TEST(opBuilderHelperRegexNotMatch, NumericRegexMatch)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"1023"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"19"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"0.123"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -171,12 +171,12 @@ TEST(opBuilderHelperRegexNotMatch, AdvancedRegexMatch)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"wazuh.com"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"client@wazuh.com"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -201,14 +201,14 @@ TEST(opBuilderHelperRegexNotMatch, NestedFieldRegexMatch)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"~~({
+            s.on_next(std::make_shared<json::Document>(R"~~({
             "test":
                 {"field": "value"}
-            })~~"});
-            s.on_next(Event{R"~~({
+            })~~"));
+            s.on_next(std::make_shared<json::Document>(R"~~({
             "test":
                 {"field": "ex-president"}
-            })~~"});
+            })~~"));
             s.on_completed();
         });
 
@@ -232,12 +232,12 @@ TEST(opBuilderHelperRegexNotMatch, FieldNotExistsRegexNotMatch)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2":"value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"value"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -247,5 +247,5 @@ TEST(opBuilderHelperRegexNotMatch, FieldNotExistsRegexNotMatch)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_TRUE(expected[0].exists("/field2"));
+    ASSERT_TRUE(expected[0]->exists("/field2"));
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringEq_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringEq_test.cpp
@@ -69,8 +69,8 @@ TEST(opBuilderHelperStringEQ, Static_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_STREQ(expected[0].get("/field2check")->GetString(), "test_value");
-    ASSERT_STREQ(expected[1].get("/field2check")->GetString(), "test_value");
+    ASSERT_STREQ(expected[0]->get("/field2check")->GetString(), "test_value");
+    ASSERT_STREQ(expected[1]->get("/field2check")->GetString(), "test_value");
 }
 
 // Test ok: static values (numbers, compare as string)
@@ -107,8 +107,8 @@ TEST(opBuilderHelperStringEQ, Static_number_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_STREQ(expected[0].get("/field2check")->GetString(), "11");
-    ASSERT_STREQ(expected[1].get("/field2check")->GetString(), "11");
+    ASSERT_STREQ(expected[0]->get("/field2check")->GetString(), "11");
+    ASSERT_STREQ(expected[1]->get("/field2check")->GetString(), "11");
 }
 
 // Test ok: dynamic values (string)
@@ -160,8 +160,8 @@ TEST(opBuilderHelperStringEQ, Dynamics_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_STREQ(expected[0].get("/field2check")->GetString(), "test_value");
-    ASSERT_STREQ(expected[1].get("/field2check")->GetString(), "test_value");
+    ASSERT_STREQ(expected[0]->get("/field2check")->GetString(), "test_value");
+    ASSERT_STREQ(expected[1]->get("/field2check")->GetString(), "test_value");
 }
 
 // Test ok: multilevel dynamic values (string)
@@ -223,11 +223,11 @@ TEST(opBuilderHelperStringEQ, MultiLevel_dynamics_string_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
 
-    ASSERT_STREQ(expected[0].get("/parentObjt_1/field2check")->GetString(),
-                 expected[0].get("/parentObjt_2/ref_key")->GetString());
+    ASSERT_STREQ(expected[0]->get("/parentObjt_1/field2check")->GetString(),
+                 expected[0]->get("/parentObjt_2/ref_key")->GetString());
 
-    ASSERT_STRNE(expected[0].get("/parentObjt_2/field2check")->GetString(), "test_value");
-    ASSERT_STRNE(expected[0].get("/parentObjt_1/ref_key")->GetString(), "test_value");
+    ASSERT_STRNE(expected[0]->get("/parentObjt_2/field2check")->GetString(), "test_value");
+    ASSERT_STRNE(expected[0]->get("/parentObjt_1/ref_key")->GetString(), "test_value");
 }
 
 // Test ok: dynamic values (number)

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringEq_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringEq_test.cpp
@@ -46,21 +46,21 @@ TEST(opBuilderHelperStringEQ, Static_string_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"not_test_value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"test_value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":"value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":"test_value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"test_value"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -84,21 +84,21 @@ TEST(opBuilderHelperStringEQ, Static_number_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"not_11"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"11"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":"11"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":11}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"11"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -122,36 +122,36 @@ TEST(opBuilderHelperStringEQ, Dynamics_string_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":"not_test_value",
                     "ref_key":"test_value"
                 }
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":"test_value",
                     "ref_key":"test_value"
                 }
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "otherfield":"value",
                     "ref_key":"test_value"
                 }
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "otherfield":"test_value",
                     "ref_key":"test_value"
                 }
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":"test_value",
                     "ref_key":"test_value"
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -176,7 +176,7 @@ TEST(opBuilderHelperStringEQ, MultiLevel_dynamics_string_ok)
         [=](auto s)
         {
             // no
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": "test_value",
@@ -187,9 +187,9 @@ TEST(opBuilderHelperStringEQ, MultiLevel_dynamics_string_ok)
                         "ref_key": "123_not_test_value"
                     }
                 }
-            )"});
+            )"));
             // yes
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": "not_test_value",
@@ -200,9 +200,9 @@ TEST(opBuilderHelperStringEQ, MultiLevel_dynamics_string_ok)
                         "ref_key": "not_test_value"
                     }
                 }
-            )"});
+            )"));
             // no
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check":"test_value",
@@ -213,7 +213,7 @@ TEST(opBuilderHelperStringEQ, MultiLevel_dynamics_string_ok)
                         "ref_key":"not_test_value"
                     }
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -241,42 +241,42 @@ TEST(opBuilderHelperStringEQ, Dynamics_number_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":11,
                     "ref_key":11
                 }
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":"11",
                     "ref_key":11
                 }
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "otherfield":11,
                     "ref_key":11
                 }
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "otherfield":11,
                     "ref_key":11
                 }
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":11,
                     "ref_key":"11"
                 }
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":"11",
                     "not_ref_key":"11"
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringGe_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringGe_test.cpp
@@ -91,12 +91,12 @@ TEST(opBuilderHelperStringGE, Static_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 6);
-    ASSERT_STREQ(expected[0].get("/field2check")->GetString(), "ABCD");
-    ASSERT_STREQ(expected[1].get("/field2check")->GetString(), "ABCDE");
-    ASSERT_STREQ(expected[2].get("/field2check")->GetString(), "BBBB");
-    ASSERT_STREQ(expected[3].get("/field2check")->GetString(), "abc");
-    ASSERT_STREQ(expected[4].get("/field2check")->GetString(), "abcd");
-    ASSERT_STREQ(expected[5].get("/field2check")->GetString(), "abcde");
+    ASSERT_STREQ(expected[0]->get("/field2check")->GetString(), "ABCD");
+    ASSERT_STREQ(expected[1]->get("/field2check")->GetString(), "ABCDE");
+    ASSERT_STREQ(expected[2]->get("/field2check")->GetString(), "BBBB");
+    ASSERT_STREQ(expected[3]->get("/field2check")->GetString(), "abc");
+    ASSERT_STREQ(expected[4]->get("/field2check")->GetString(), "abcd");
+    ASSERT_STREQ(expected[5]->get("/field2check")->GetString(), "abcde");
 }
 
 // Test ok: static values (numbers, compare as string)
@@ -132,8 +132,8 @@ TEST(opBuilderHelperStringGE, Static_number_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_STREQ(expected[0].get("/field2check")->GetString(), "AA");
-    ASSERT_STREQ(expected[1].get("/field2check")->GetString(), "BB");
+    ASSERT_STREQ(expected[0]->get("/field2check")->GetString(), "AA");
+    ASSERT_STREQ(expected[1]->get("/field2check")->GetString(), "BB");
 }
 
 // Test ok: dynamic values (string)
@@ -176,6 +176,6 @@ TEST(opBuilderHelperStringGE, Dynamics_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_STREQ(expected[0].get("/field2check")->GetString(), "abcd");
-    ASSERT_STREQ(expected[1].get("/field2check")->GetString(), "ABCD");
+    ASSERT_STREQ(expected[0]->get("/field2check")->GetString(), "abcd");
+    ASSERT_STREQ(expected[1]->get("/field2check")->GetString(), "ABCD");
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringGe_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringGe_test.cpp
@@ -47,42 +47,42 @@ TEST(opBuilderHelperStringGE, Static_string_ok)
         [=](auto s)
         {
             // less
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"ABC"}
-            )"});
+            )"));
             // Equal
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"ABCD"}
-            )"});
+            )"));
             // Greater
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"ABCDE"}
-            )"});
+            )"));
             // Greater with different case
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"BBBB"}
-            )"});
+            )"));
             // Less with different case
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"AABCD"}
-            )"});
+            )"));
             // lower case are greater
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"abc"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"abcd"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"abcde"}
-            )"});
+            )"));
             // Other fields will be ignored
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":"abcd"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":"abcd"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -111,19 +111,19 @@ TEST(opBuilderHelperStringGE, Static_number_ok)
         [=](auto s)
         {
             // Equal
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"AA"}
-            )"});
+            )"));
             // Greater
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"BB"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":"aa"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield": "bb"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -148,26 +148,26 @@ TEST(opBuilderHelperStringGE, Dynamics_string_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":"abcd",
                     "ref_key":"ABCD"
                 }
-            )"});
+            )"));
             // Equal
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":"ABCD",
                     "ref_key":"ABCD"
                 }
-            )"});
+            )"));
             // Less
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "otherfield":"AABCD",
                     "ref_key":"ABCD"
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringGt_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringGt_test.cpp
@@ -91,11 +91,11 @@ TEST(opBuilderHelperStringGT, Static_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 5);
-    ASSERT_STREQ(expected[0].get("/field2check")->GetString(), "ABCDE");
-    ASSERT_STREQ(expected[1].get("/field2check")->GetString(), "BBBB");
-    ASSERT_STREQ(expected[2].get("/field2check")->GetString(), "abc");
-    ASSERT_STREQ(expected[3].get("/field2check")->GetString(), "abcd");
-    ASSERT_STREQ(expected[4].get("/field2check")->GetString(), "abcde");
+    ASSERT_STREQ(expected[0]->get("/field2check")->GetString(), "ABCDE");
+    ASSERT_STREQ(expected[1]->get("/field2check")->GetString(), "BBBB");
+    ASSERT_STREQ(expected[2]->get("/field2check")->GetString(), "abc");
+    ASSERT_STREQ(expected[3]->get("/field2check")->GetString(), "abcd");
+    ASSERT_STREQ(expected[4]->get("/field2check")->GetString(), "abcde");
 }
 
 // Test ok: static values (numbers, compare as string)
@@ -131,7 +131,7 @@ TEST(opBuilderHelperStringGT, Static_number_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_STREQ(expected[0].get("/field2check")->GetString(), "BB");
+    ASSERT_STREQ(expected[0]->get("/field2check")->GetString(), "BB");
 }
 
 // Test ok: dynamic values (string)
@@ -174,5 +174,5 @@ TEST(opBuilderHelperStringGT, Dynamics_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_STREQ(expected[0].get("/field2check")->GetString(), "abcd");
+    ASSERT_STREQ(expected[0]->get("/field2check")->GetString(), "abcd");
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringGt_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringGt_test.cpp
@@ -47,42 +47,42 @@ TEST(opBuilderHelperStringGT, Static_string_ok)
         [=](auto s)
         {
             // less
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"ABC"}
-            )"});
+            )"));
             // Equal
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"ABCD"}
-            )"});
+            )"));
             // Greater
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"ABCDE"}
-            )"});
+            )"));
             // Greater with different case
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"BBBB"}
-            )"});
+            )"));
             // Less with different case
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"AABCD"}
-            )"});
+            )"));
             // lower case are greater
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"abc"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"abcd"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"abcde"}
-            )"});
+            )"));
             // Other fields will be ignored
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":"abcd"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":"abcd"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -110,19 +110,19 @@ TEST(opBuilderHelperStringGT, Static_number_ok)
         [=](auto s)
         {
             // Equal
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"AA"}
-            )"});
+            )"));
             // Greater
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"BB"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":"aa"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield": "bb"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -146,26 +146,26 @@ TEST(opBuilderHelperStringGT, Dynamics_string_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":"abcd",
                     "ref_key":"ABCD"
                 }
-            )"});
+            )"));
             // Equal
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":"ABCD",
                     "ref_key":"ABCD"
                 }
-            )"});
+            )"));
             // Less
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "otherfield":"AABCD",
                     "ref_key":"ABCD"
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringLO_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringLO_test.cpp
@@ -46,15 +46,15 @@ TEST(opBuilderHelperStringLO, Static_string_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"not_fieltToCreate": "qwe"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"not_fieltToCreate": "ASD123asd"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"not_fieltToCreate": "ASD"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -79,15 +79,15 @@ TEST(opBuilderHelperStringLO, Dynamics_string_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"srcField": "qwe"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"srcField": "ASD123asd"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"srcField": "ASD"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -111,15 +111,15 @@ TEST(opBuilderHelperStringLO, Multilevel_dst)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"a": {"b": {"c": {"srcField": "qwe"}}}}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"a": {"b": {"c": {"srcField": "ASD123asd"}}}}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"a": {"b": {"c": {"srcField": "ASD"}}}}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -143,15 +143,15 @@ TEST(opBuilderHelperStringLO, Exist_dst)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"a": {"b": {"c": {"srcField": "qwe"}}}}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"a": {"b": {"c": {"srcField": "ASD123asd"}}}}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"a": {"b": {"c": {"srcField": "ASD"}}}}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -175,12 +175,12 @@ TEST(opBuilderHelperStringLO, Not_exist_src)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"a": {"b": "QWE"}}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"c": {"d": "QWE123"}}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -190,7 +190,7 @@ TEST(opBuilderHelperStringLO, Not_exist_src)
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
     ASSERT_STREQ(expected[0]->get("/a/b")->GetString(), "QWE");
-    ASSERT_FALSE(expected[1].exists("/a/b"));
+    ASSERT_FALSE(expected[1]->exists("/a/b"));
 }
 
 TEST(opBuilderHelperStringLO, Src_not_string)
@@ -203,15 +203,15 @@ TEST(opBuilderHelperStringLO, Src_not_string)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"srcField": "qwe"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"srcField": "ASD123asd"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"srcField": "ASD"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -220,9 +220,9 @@ TEST(opBuilderHelperStringLO, Src_not_string)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_FALSE(expected[0].exists("/fieltToCreate"));
-    ASSERT_FALSE(expected[1].exists("/fieltToCreate"));
-    ASSERT_FALSE(expected[2].exists("/fieltToCreate"));
+    ASSERT_FALSE(expected[0]->exists("/fieltToCreate"));
+    ASSERT_FALSE(expected[1]->exists("/fieltToCreate"));
+    ASSERT_FALSE(expected[2]->exists("/fieltToCreate"));
 }
 
 TEST(opBuilderHelperStringLO, Multilevel_src)
@@ -235,15 +235,15 @@ TEST(opBuilderHelperStringLO, Multilevel_src)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"a": {"b": {"c": {"srcField": "qwe"}}}}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"a": {"b": {"c": {"srcField": "ASD123asd"}}}}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"a": {"b": {"c": {"srcField": "ASD"}}}}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -267,15 +267,15 @@ TEST(opBuilderHelperStringLO, MultiLevel_dst)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"a": {"b": {"c": {"srcField": "qwe"}}}}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"a": {"b": {"c": {"srcField": "ASD123asd"}}}}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"a": {"b": {"c": {"srcField": "ASD"}}}}
-            )"});
+            )"));
             s.on_completed();
         });
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringLO_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringLO_test.cpp
@@ -63,9 +63,9 @@ TEST(opBuilderHelperStringLO, Static_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0].get("/fieltToCreate")->GetString(), "asd123asd");
-    ASSERT_STREQ(expected[1].get("/fieltToCreate")->GetString(), "asd123asd");
-    ASSERT_STREQ(expected[2].get("/fieltToCreate")->GetString(), "asd123asd");
+    ASSERT_STREQ(expected[0]->get("/fieltToCreate")->GetString(), "asd123asd");
+    ASSERT_STREQ(expected[1]->get("/fieltToCreate")->GetString(), "asd123asd");
+    ASSERT_STREQ(expected[2]->get("/fieltToCreate")->GetString(), "asd123asd");
 }
 
 // Test ok: dynamic values (string)
@@ -96,9 +96,9 @@ TEST(opBuilderHelperStringLO, Dynamics_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0].get("/fieltToCreate")->GetString(), "qwe");
-    ASSERT_STREQ(expected[1].get("/fieltToCreate")->GetString(), "asd123asd");
-    ASSERT_STREQ(expected[2].get("/fieltToCreate")->GetString(), "asd");
+    ASSERT_STREQ(expected[0]->get("/fieltToCreate")->GetString(), "qwe");
+    ASSERT_STREQ(expected[1]->get("/fieltToCreate")->GetString(), "asd123asd");
+    ASSERT_STREQ(expected[2]->get("/fieltToCreate")->GetString(), "asd");
 }
 
 TEST(opBuilderHelperStringLO, Multilevel_dst)
@@ -128,9 +128,9 @@ TEST(opBuilderHelperStringLO, Multilevel_dst)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0].get("/a/b/fieltToCreate/2")->GetString(), "qwe");
-    ASSERT_STREQ(expected[1].get("/a/b/fieltToCreate/2")->GetString(), "asd123asd");
-    ASSERT_STREQ(expected[2].get("/a/b/fieltToCreate/2")->GetString(), "asd");
+    ASSERT_STREQ(expected[0]->get("/a/b/fieltToCreate/2")->GetString(), "qwe");
+    ASSERT_STREQ(expected[1]->get("/a/b/fieltToCreate/2")->GetString(), "asd123asd");
+    ASSERT_STREQ(expected[2]->get("/a/b/fieltToCreate/2")->GetString(), "asd");
 }
 
 TEST(opBuilderHelperStringLO, Exist_dst)
@@ -160,9 +160,9 @@ TEST(opBuilderHelperStringLO, Exist_dst)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0].get("/a/b")->GetString(), "qwe");
-    ASSERT_STREQ(expected[1].get("/a/b")->GetString(), "asd123asd");
-    ASSERT_STREQ(expected[2].get("/a/b")->GetString(), "asd");
+    ASSERT_STREQ(expected[0]->get("/a/b")->GetString(), "qwe");
+    ASSERT_STREQ(expected[1]->get("/a/b")->GetString(), "asd123asd");
+    ASSERT_STREQ(expected[2]->get("/a/b")->GetString(), "asd");
 }
 
 TEST(opBuilderHelperStringLO, Not_exist_src)
@@ -189,7 +189,7 @@ TEST(opBuilderHelperStringLO, Not_exist_src)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_STREQ(expected[0].get("/a/b")->GetString(), "QWE");
+    ASSERT_STREQ(expected[0]->get("/a/b")->GetString(), "QWE");
     ASSERT_FALSE(expected[1].exists("/a/b"));
 }
 
@@ -252,9 +252,9 @@ TEST(opBuilderHelperStringLO, Multilevel_src)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0].get("/fieltToCreate")->GetString(), "qwe");
-    ASSERT_STREQ(expected[1].get("/fieltToCreate")->GetString(), "asd123asd");
-    ASSERT_STREQ(expected[2].get("/fieltToCreate")->GetString(), "asd");
+    ASSERT_STREQ(expected[0]->get("/fieltToCreate")->GetString(), "qwe");
+    ASSERT_STREQ(expected[1]->get("/fieltToCreate")->GetString(), "asd123asd");
+    ASSERT_STREQ(expected[2]->get("/fieltToCreate")->GetString(), "asd");
 }
 
 TEST(opBuilderHelperStringLO, MultiLevel_dst)
@@ -284,7 +284,7 @@ TEST(opBuilderHelperStringLO, MultiLevel_dst)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0].get("/a/b")->GetString(), "qwe");
-    ASSERT_STREQ(expected[1].get("/a/b")->GetString(), "asd123asd");
-    ASSERT_STREQ(expected[2].get("/a/b")->GetString(), "asd");
+    ASSERT_STREQ(expected[0]->get("/a/b")->GetString(), "qwe");
+    ASSERT_STREQ(expected[1]->get("/a/b")->GetString(), "asd123asd");
+    ASSERT_STREQ(expected[2]->get("/a/b")->GetString(), "asd");
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringLe_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringLe_test.cpp
@@ -47,42 +47,42 @@ TEST(opBuilderHelperStringLE, Static_string_ok)
         [=](auto s)
         {
             // less
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"ABC"}
-            )"});
+            )"));
             // Equal
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"ABCD"}
-            )"});
+            )"));
             // Greater
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"ABCDE"}
-            )"});
+            )"));
             // Greater with different case
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"BBBB"}
-            )"});
+            )"));
             // Less with different case
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"AABCD"}
-            )"});
+            )"));
             // lower case are greater
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"abc"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"abcd"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"abcde"}
-            )"});
+            )"));
             // Other fields will be ignored
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":"abcd"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":"abcd"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -108,17 +108,17 @@ TEST(opBuilderHelperStringLE, Static_number_ok)
         [=](auto s)
         {
             // Less
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"499"}
-            )"});
+            )"));
             // Equal
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"50"}
-            )"});
+            )"));
             // Greater
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":"51"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -143,26 +143,26 @@ TEST(opBuilderHelperStringLE, Dynamics_string_ok)
         [=](auto s)
         {
             // Less
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":"ABCD",
                     "ref_key":"abcd"
                 }
-            )"});
+            )"));
             // Equal
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":"ABCD",
                     "ref_key":"ABCD"
                 }
-            )"});
+            )"));
             // GREATER
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "otherfield":"abcd",
                     "ref_key":"ABCD"
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringLe_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringLe_test.cpp
@@ -91,9 +91,9 @@ TEST(opBuilderHelperStringLE, Static_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0].get("/field2check")->GetString(), "ABC");
-    ASSERT_STREQ(expected[1].get("/field2check")->GetString(), "ABCD");
-    ASSERT_STREQ(expected[2].get("/field2check")->GetString(), "AABCD");
+    ASSERT_STREQ(expected[0]->get("/field2check")->GetString(), "ABC");
+    ASSERT_STREQ(expected[1]->get("/field2check")->GetString(), "ABCD");
+    ASSERT_STREQ(expected[2]->get("/field2check")->GetString(), "AABCD");
 }
 
 // Test ok: static values (numbers, compare as string)
@@ -127,8 +127,8 @@ TEST(opBuilderHelperStringLE, Static_number_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_STREQ(expected[0].get("/field2check")->GetString(), "499");
-    ASSERT_STREQ(expected[1].get("/field2check")->GetString(), "50");
+    ASSERT_STREQ(expected[0]->get("/field2check")->GetString(), "499");
+    ASSERT_STREQ(expected[1]->get("/field2check")->GetString(), "50");
 }
 
 // Test ok: dynamic values (string)
@@ -171,6 +171,6 @@ TEST(opBuilderHelperStringLE, Dynamics_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_STREQ(expected[0].get("/field2check")->GetString(), "ABCD");
-    ASSERT_STREQ(expected[1].get("/field2check")->GetString(), "ABCD");
+    ASSERT_STREQ(expected[0]->get("/field2check")->GetString(), "ABCD");
+    ASSERT_STREQ(expected[1]->get("/field2check")->GetString(), "ABCD");
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringLt_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringLt_test.cpp
@@ -91,8 +91,8 @@ TEST(opBuilderHelperStringLT, Static_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_STREQ(expected[0].get("/field2check")->GetString(), "ABC");
-    ASSERT_STREQ(expected[1].get("/field2check")->GetString(), "AABCD");
+    ASSERT_STREQ(expected[0]->get("/field2check")->GetString(), "ABC");
+    ASSERT_STREQ(expected[1]->get("/field2check")->GetString(), "AABCD");
 }
 
 // Test ok: static values (numbers, compare as string)
@@ -126,7 +126,7 @@ TEST(opBuilderHelperStringLT, Static_number_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_STREQ(expected[0].get("/field2check")->GetString(), "499");
+    ASSERT_STREQ(expected[0]->get("/field2check")->GetString(), "499");
 }
 
 // Test ok: dynamic values (string)
@@ -169,5 +169,5 @@ TEST(opBuilderHelperStringLT, Dynamics_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_STREQ(expected[0].get("/field2check")->GetString(), "ABCD");
+    ASSERT_STREQ(expected[0]->get("/field2check")->GetString(), "ABCD");
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringLt_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringLt_test.cpp
@@ -47,42 +47,42 @@ TEST(opBuilderHelperStringLT, Static_string_ok)
         [=](auto s)
         {
             // less
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"ABC"}
-            )"});
+            )"));
             // Equal
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"ABCD"}
-            )"});
+            )"));
             // Greater
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"ABCDE"}
-            )"});
+            )"));
             // Greater with different case
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"BBBB"}
-            )"});
+            )"));
             // Less with different case
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"AABCD"}
-            )"});
+            )"));
             // lower case are greater
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"abc"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"abcd"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"abcde"}
-            )"});
+            )"));
             // Other fields will be ignored
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":"abcd"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":"abcd"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -107,17 +107,17 @@ TEST(opBuilderHelperStringLT, Static_number_ok)
         [=](auto s)
         {
             // Less
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"499"}
-            )"});
+            )"));
             // Equal
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"50"}
-            )"});
+            )"));
             // Greater
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":"51"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -141,26 +141,26 @@ TEST(opBuilderHelperStringLT, Dynamics_string_ok)
         [=](auto s)
         {
             // Less
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":"ABCD",
                     "ref_key":"abcd"
                 }
-            )"});
+            )"));
             // Equal
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":"ABCD",
                     "ref_key":"ABCD"
                 }
-            )"});
+            )"));
             // GREATER
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "otherfield":"abcd",
                     "ref_key":"ABCD"
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringNe_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringNe_test.cpp
@@ -46,21 +46,21 @@ TEST(opBuilderHelperStringNE, Static_string_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"not_test_value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"test_value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":"value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":"test_value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"test_value_2"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -85,25 +85,25 @@ TEST(opBuilderHelperStringNE, Static_number_ok)
         [=](auto s)
         {
             // yes
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"not_11"}
-            )"});
+            )"));
             // no
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"11"}
-            )"});
+            )"));
             // yes
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":"11"}
-            )"});
+            )"));
             // yes
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":11}
-            )"});
+            )"));
             // no
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field2check":"11"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -126,36 +126,36 @@ TEST(opBuilderHelperStringNE, Dynamics_string_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":"not_test_value",
                     "ref_key":"test_value"
                 }
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":"test_value",
                     "ref_key":"test_value"
                 }
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "otherfield":"value",
                     "ref_key":"test_value"
                 }
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "otherfield":"test_value",
                     "ref_key":"test_value"
                 }
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":"test_value",
                     "ref_key":"test_value"
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -180,7 +180,7 @@ TEST(opBuilderHelperStringNE, Multilevel_dynamics_string_ok)
         [=](auto s)
         {
             // yes
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": "test_value",
@@ -191,9 +191,9 @@ TEST(opBuilderHelperStringNE, Multilevel_dynamics_string_ok)
                         "ref_key": "123_not_test_value"
                     }
                 }
-            )"});
+            )"));
             // no
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check": "not_test_value",
@@ -204,9 +204,9 @@ TEST(opBuilderHelperStringNE, Multilevel_dynamics_string_ok)
                         "ref_key": "not_test_value"
                     }
                 }
-            )"});
+            )"));
             // yes
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check":"test_value",
@@ -217,9 +217,9 @@ TEST(opBuilderHelperStringNE, Multilevel_dynamics_string_ok)
                         "ref_key":"not_test_value"
                     }
                 }
-            )"});
+            )"));
             // yes
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "parentObjt_2": {
                         "field2check":"test_value",
@@ -230,7 +230,7 @@ TEST(opBuilderHelperStringNE, Multilevel_dynamics_string_ok)
                         "ref_key":"not_test_value"
                     }
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -254,36 +254,36 @@ TEST(opBuilderHelperStringNE, Dynamics_number_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":11,
                     "ref_key":11
                 }
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":"11",
                     "ref_key":11
                 }
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "otherfield":11,
                     "ref_key":11
                 }
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":11,
                     "ref_key":"11"
                 }
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {
                     "field2check":"11",
                     "not_ref_key":"11"
                 }
-            )"});
+            )"));
             s.on_completed();
         });
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringNe_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringNe_test.cpp
@@ -69,8 +69,8 @@ TEST(opBuilderHelperStringNE, Static_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    EXPECT_STRNE(expected[0].get("/field2check")->GetString(), "test_value");
-    EXPECT_STRNE(expected[1].get("/field2check")->GetString(), "test_value");
+    EXPECT_STRNE(expected[0]->get("/field2check")->GetString(), "test_value");
+    EXPECT_STRNE(expected[1]->get("/field2check")->GetString(), "test_value");
 }
 
 // Test ok: static values (numbers, compare as string)
@@ -112,7 +112,7 @@ TEST(opBuilderHelperStringNE, Static_number_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    EXPECT_STRNE(expected[0].get("/field2check")->GetString(), "11");
+    EXPECT_STRNE(expected[0]->get("/field2check")->GetString(), "11");
 }
 
 // Test ok: dynamic values (string)
@@ -164,8 +164,8 @@ TEST(opBuilderHelperStringNE, Dynamics_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_STRNE(expected[0].get("/field2check")->GetString(),
-                 expected[0].get("/ref_key")->GetString());
+    ASSERT_STRNE(expected[0]->get("/field2check")->GetString(),
+                 expected[0]->get("/ref_key")->GetString());
 }
 
 // Test ok: multilevel dynamic values (string)
@@ -239,8 +239,8 @@ TEST(opBuilderHelperStringNE, Multilevel_dynamics_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_STRNE(expected[0].get("/parentObjt_1/field2check")->GetString(),
-                 expected[0].get("/parentObjt_2/ref_key")->GetString());
+    ASSERT_STRNE(expected[0]->get("/parentObjt_1/field2check")->GetString(),
+                 expected[0]->get("/parentObjt_2/ref_key")->GetString());
 }
 
 // Test ok: dynamic values (number)

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringTrim_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringTrim_test.cpp
@@ -46,18 +46,18 @@ TEST(opBuilderHelperStringTrim, BothOk)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldToTranf": "---hi---"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldToTranf": "hi---"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldToTranf": "---hi"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldToTranf": "hi"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -81,18 +81,18 @@ TEST(opBuilderHelperStringTrim, Start_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldToTranf": "---hi---"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldToTranf": "hi---"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldToTranf": "---hi"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldToTranf": "hi"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -118,18 +118,18 @@ TEST(opBuilderHelperStringTrim, End_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldToTranf": "---hi---"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldToTranf": "hi---"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldToTranf": "---hi"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldToTranf": "hi"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -154,18 +154,18 @@ TEST(opBuilderHelperStringTrim, Multilevel_src)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldToTranf": {"a": {"b": "---hi---"}}}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldToTranf": {"a": {"b": "hi---"}}}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldToTranf": {"a": {"b": "---hi"}}}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldToTranf": {"a": {"b": "hi"}}}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -190,9 +190,9 @@ TEST(opBuilderHelperStringTrim, Not_exist_src)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"not_ext": "---hi---"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -201,7 +201,7 @@ TEST(opBuilderHelperStringTrim, Not_exist_src)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_FALSE(expected[0].exists("/fieldToTranf"));
+    ASSERT_FALSE(expected[0]->exists("/fieldToTranf"));
 }
 
 TEST(opBuilderHelperStringTrim, Src_not_string)
@@ -214,9 +214,9 @@ TEST(opBuilderHelperStringTrim, Src_not_string)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldToTranf": 15}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -225,7 +225,7 @@ TEST(opBuilderHelperStringTrim, Src_not_string)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_TRUE(expected[0].exists("/fieldToTranf"));
+    ASSERT_TRUE(expected[0]->exists("/fieldToTranf"));
     ASSERT_EQ(expected[0]->get("/fieldToTranf")->GetInt(), 15);
 }
 
@@ -239,18 +239,18 @@ TEST(opBuilderHelperStringTrim, Multilevel)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldToTranf": {"a": {"b": "---hi---"}}}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldToTranf": {"a": {"b": "hi---"}}}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldToTranf": {"a": {"b": "---hi"}}}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"fieldToTranf": {"a": {"b": "hi"}}}
-            )"});
+            )"));
             s.on_completed();
         });
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringTrim_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringTrim_test.cpp
@@ -66,9 +66,9 @@ TEST(opBuilderHelperStringTrim, BothOk)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 4);
-    ASSERT_STREQ(expected[0].get("/fieldToTranf")->GetString(), "hi");
-    ASSERT_STREQ(expected[1].get("/fieldToTranf")->GetString(), "hi");
-    ASSERT_STREQ(expected[2].get("/fieldToTranf")->GetString(), "hi");
+    ASSERT_STREQ(expected[0]->get("/fieldToTranf")->GetString(), "hi");
+    ASSERT_STREQ(expected[1]->get("/fieldToTranf")->GetString(), "hi");
+    ASSERT_STREQ(expected[2]->get("/fieldToTranf")->GetString(), "hi");
 }
 
 TEST(opBuilderHelperStringTrim, Start_ok)
@@ -101,10 +101,10 @@ TEST(opBuilderHelperStringTrim, Start_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 4);
-    ASSERT_STREQ(expected[0].get("/fieldToTranf")->GetString(), "hi---");
-    ASSERT_STREQ(expected[1].get("/fieldToTranf")->GetString(), "hi---");
-    ASSERT_STREQ(expected[2].get("/fieldToTranf")->GetString(), "hi");
-    ASSERT_STREQ(expected[3].get("/fieldToTranf")->GetString(), "hi");
+    ASSERT_STREQ(expected[0]->get("/fieldToTranf")->GetString(), "hi---");
+    ASSERT_STREQ(expected[1]->get("/fieldToTranf")->GetString(), "hi---");
+    ASSERT_STREQ(expected[2]->get("/fieldToTranf")->GetString(), "hi");
+    ASSERT_STREQ(expected[3]->get("/fieldToTranf")->GetString(), "hi");
 }
 
 // Test ok: dynamic values (string)
@@ -138,10 +138,10 @@ TEST(opBuilderHelperStringTrim, End_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 4);
-    ASSERT_STREQ(expected[0].get("/fieldToTranf")->GetString(), "---hi");
-    ASSERT_STREQ(expected[1].get("/fieldToTranf")->GetString(), "hi");
-    ASSERT_STREQ(expected[2].get("/fieldToTranf")->GetString(), "---hi");
-    ASSERT_STREQ(expected[3].get("/fieldToTranf")->GetString(), "hi");
+    ASSERT_STREQ(expected[0]->get("/fieldToTranf")->GetString(), "---hi");
+    ASSERT_STREQ(expected[1]->get("/fieldToTranf")->GetString(), "hi");
+    ASSERT_STREQ(expected[2]->get("/fieldToTranf")->GetString(), "---hi");
+    ASSERT_STREQ(expected[3]->get("/fieldToTranf")->GetString(), "hi");
 }
 
 TEST(opBuilderHelperStringTrim, Multilevel_src)
@@ -174,10 +174,10 @@ TEST(opBuilderHelperStringTrim, Multilevel_src)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 4);
-    ASSERT_STREQ(expected[0].get("/fieldToTranf/a/b")->GetString(), "---hi");
-    ASSERT_STREQ(expected[1].get("/fieldToTranf/a/b")->GetString(), "hi");
-    ASSERT_STREQ(expected[2].get("/fieldToTranf/a/b")->GetString(), "---hi");
-    ASSERT_STREQ(expected[3].get("/fieldToTranf/a/b")->GetString(), "hi");
+    ASSERT_STREQ(expected[0]->get("/fieldToTranf/a/b")->GetString(), "---hi");
+    ASSERT_STREQ(expected[1]->get("/fieldToTranf/a/b")->GetString(), "hi");
+    ASSERT_STREQ(expected[2]->get("/fieldToTranf/a/b")->GetString(), "---hi");
+    ASSERT_STREQ(expected[3]->get("/fieldToTranf/a/b")->GetString(), "hi");
 }
 
 TEST(opBuilderHelperStringTrim, Not_exist_src)
@@ -226,7 +226,7 @@ TEST(opBuilderHelperStringTrim, Src_not_string)
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
     ASSERT_TRUE(expected[0].exists("/fieldToTranf"));
-    ASSERT_EQ(expected[0].get("/fieldToTranf")->GetInt(), 15);
+    ASSERT_EQ(expected[0]->get("/fieldToTranf")->GetInt(), 15);
 }
 
 TEST(opBuilderHelperStringTrim, Multilevel)
@@ -259,8 +259,8 @@ TEST(opBuilderHelperStringTrim, Multilevel)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 4);
-    ASSERT_STREQ(expected[0].get("/fieldToTranf/a/b")->GetString(), "---hi");
-    ASSERT_STREQ(expected[1].get("/fieldToTranf/a/b")->GetString(), "hi");
-    ASSERT_STREQ(expected[2].get("/fieldToTranf/a/b")->GetString(), "---hi");
-    ASSERT_STREQ(expected[3].get("/fieldToTranf/a/b")->GetString(), "hi");
+    ASSERT_STREQ(expected[0]->get("/fieldToTranf/a/b")->GetString(), "---hi");
+    ASSERT_STREQ(expected[1]->get("/fieldToTranf/a/b")->GetString(), "hi");
+    ASSERT_STREQ(expected[2]->get("/fieldToTranf/a/b")->GetString(), "---hi");
+    ASSERT_STREQ(expected[3]->get("/fieldToTranf/a/b")->GetString(), "hi");
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringUP_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringUP_test.cpp
@@ -46,15 +46,15 @@ TEST(opBuilderHelperStringUP, Static_string_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"not_fieltToCreate": "qwe"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"not_fieltToCreate": "ASD123asd"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"not_fieltToCreate": "ASD"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -80,15 +80,15 @@ TEST(opBuilderHelperStringUP, Dynamics_string_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"srcField": "qwe"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"srcField": "ASD123asd"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"srcField": "ASD"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -112,15 +112,15 @@ TEST(opBuilderHelperStringUP, Multilevel_src)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"a": {"b": {"c": {"srcField": "qwe"}}}}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"a": {"b": {"c": {"srcField": "ASD123asd"}}}}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"a": {"b": {"c": {"srcField": "ASD"}}}}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -144,15 +144,15 @@ TEST(opBuilderHelperStringUP, Multilevel_dst)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"a": {"b": {"c": {"srcField": "qwe"}}}}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"a": {"b": {"c": {"srcField": "ASD123asd"}}}}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"a": {"b": {"c": {"srcField": "ASD"}}}}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -176,15 +176,15 @@ TEST(opBuilderHelperStringUP, Exist_dst)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"a": {"b": {"c": {"srcField": "qwe"}}}}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"a": {"b": {"c": {"srcField": "ASD123asd"}}}}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"a": {"b": {"c": {"srcField": "ASD"}}}}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -208,12 +208,12 @@ TEST(opBuilderHelperStringUP, Not_exist_src)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"a": {"b": "QWE"}}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"c": {"d": "QWE123"}}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -223,7 +223,7 @@ TEST(opBuilderHelperStringUP, Not_exist_src)
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
     ASSERT_STREQ(expected[0]->get("/a/b")->GetString(), "QWE");
-    ASSERT_FALSE(expected[1].exists("/a/b"));
+    ASSERT_FALSE(expected[1]->exists("/a/b"));
 }
 
 TEST(opBuilderHelperStringUP, Src_not_string)
@@ -236,15 +236,15 @@ TEST(opBuilderHelperStringUP, Src_not_string)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"srcField": "qwe"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"srcField": "ASD123asd"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"srcField": "ASD"}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -253,7 +253,7 @@ TEST(opBuilderHelperStringUP, Src_not_string)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_FALSE(expected[0].exists("/fieltToCreate"));
-    ASSERT_FALSE(expected[1].exists("/fieltToCreate"));
-    ASSERT_FALSE(expected[2].exists("/fieltToCreate"));
+    ASSERT_FALSE(expected[0]->exists("/fieltToCreate"));
+    ASSERT_FALSE(expected[1]->exists("/fieltToCreate"));
+    ASSERT_FALSE(expected[2]->exists("/fieltToCreate"));
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringUP_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringUP_test.cpp
@@ -63,9 +63,9 @@ TEST(opBuilderHelperStringUP, Static_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0].get("/fieltToCreate")->GetString(), "ASD123ASD");
-    ASSERT_STREQ(expected[1].get("/fieltToCreate")->GetString(), "ASD123ASD");
-    ASSERT_STREQ(expected[2].get("/fieltToCreate")->GetString(), "ASD123ASD");
+    ASSERT_STREQ(expected[0]->get("/fieltToCreate")->GetString(), "ASD123ASD");
+    ASSERT_STREQ(expected[1]->get("/fieltToCreate")->GetString(), "ASD123ASD");
+    ASSERT_STREQ(expected[2]->get("/fieltToCreate")->GetString(), "ASD123ASD");
 }
 
 // Test ok: dynamic values (string)
@@ -97,9 +97,9 @@ TEST(opBuilderHelperStringUP, Dynamics_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0].get("/fieltToCreate")->GetString(), "QWE");
-    ASSERT_STREQ(expected[1].get("/fieltToCreate")->GetString(), "ASD123ASD");
-    ASSERT_STREQ(expected[2].get("/fieltToCreate")->GetString(), "ASD");
+    ASSERT_STREQ(expected[0]->get("/fieltToCreate")->GetString(), "QWE");
+    ASSERT_STREQ(expected[1]->get("/fieltToCreate")->GetString(), "ASD123ASD");
+    ASSERT_STREQ(expected[2]->get("/fieltToCreate")->GetString(), "ASD");
 }
 
 TEST(opBuilderHelperStringUP, Multilevel_src)
@@ -129,9 +129,9 @@ TEST(opBuilderHelperStringUP, Multilevel_src)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0].get("/fieltToCreate")->GetString(), "qwe");
-    ASSERT_STREQ(expected[1].get("/fieltToCreate")->GetString(), "asd123asd");
-    ASSERT_STREQ(expected[2].get("/fieltToCreate")->GetString(), "asd");
+    ASSERT_STREQ(expected[0]->get("/fieltToCreate")->GetString(), "qwe");
+    ASSERT_STREQ(expected[1]->get("/fieltToCreate")->GetString(), "asd123asd");
+    ASSERT_STREQ(expected[2]->get("/fieltToCreate")->GetString(), "asd");
 }
 
 TEST(opBuilderHelperStringUP, Multilevel_dst)
@@ -161,9 +161,9 @@ TEST(opBuilderHelperStringUP, Multilevel_dst)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0].get("/a/b/fieltToCreate/2")->GetString(), "QWE");
-    ASSERT_STREQ(expected[1].get("/a/b/fieltToCreate/2")->GetString(), "ASD123ASD");
-    ASSERT_STREQ(expected[2].get("/a/b/fieltToCreate/2")->GetString(), "ASD");
+    ASSERT_STREQ(expected[0]->get("/a/b/fieltToCreate/2")->GetString(), "QWE");
+    ASSERT_STREQ(expected[1]->get("/a/b/fieltToCreate/2")->GetString(), "ASD123ASD");
+    ASSERT_STREQ(expected[2]->get("/a/b/fieltToCreate/2")->GetString(), "ASD");
 }
 
 TEST(opBuilderHelperStringUP, Exist_dst)
@@ -193,9 +193,9 @@ TEST(opBuilderHelperStringUP, Exist_dst)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0].get("/a/b")->GetString(), "QWE");
-    ASSERT_STREQ(expected[1].get("/a/b")->GetString(), "ASD123ASD");
-    ASSERT_STREQ(expected[2].get("/a/b")->GetString(), "ASD");
+    ASSERT_STREQ(expected[0]->get("/a/b")->GetString(), "QWE");
+    ASSERT_STREQ(expected[1]->get("/a/b")->GetString(), "ASD123ASD");
+    ASSERT_STREQ(expected[2]->get("/a/b")->GetString(), "ASD");
 }
 
 TEST(opBuilderHelperStringUP, Not_exist_src)
@@ -222,7 +222,7 @@ TEST(opBuilderHelperStringUP, Not_exist_src)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_STREQ(expected[0].get("/a/b")->GetString(), "QWE");
+    ASSERT_STREQ(expected[0]->get("/a/b")->GetString(), "QWE");
     ASSERT_FALSE(expected[1].exists("/a/b"));
 }
 

--- a/src/engine/test/source/builder/builders/opBuilderMapReferenceTest.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderMapReferenceTest.cpp
@@ -36,15 +36,15 @@ TEST(opBuilderMapReference, BuildsOperates)
         [=](auto s)
         {
             // TODO: Fix json to return false instead of throw
-            // s.on_next(Event{R"(
+            // s.on_next(std::make_shared<json::Document>(R"(
             //     {"field":"value"}
-            // )"});
-            // s.on_next(Event{R"(
+            // )"));
+            // s.on_next(std::make_shared<json::Document>(R"(
             //     {"field":"values"}
-            // )"});
-            s.on_next(Event{R"(
+            // )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"other_field":"referenced"}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift1 = opBuilderMapReference(*doc.get("/normalize"));

--- a/src/engine/test/source/builder/builders/opBuilderMapReferenceTest.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderMapReferenceTest.cpp
@@ -53,5 +53,5 @@ TEST(opBuilderMapReference, BuildsOperates)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_STREQ(expected[0].get("/field")->GetString(), "referenced");
+    ASSERT_STREQ(expected[0]->get("/field")->GetString(), "referenced");
 }

--- a/src/engine/test/source/builder/builders/opBuilderMapReferenceTest.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderMapReferenceTest.cpp
@@ -36,14 +36,14 @@ TEST(opBuilderMapReference, BuildsOperates)
         [=](auto s)
         {
             // TODO: Fix json to return false instead of throw
-            // s.on_next(std::make_shared<json::Document>(R"(
-            //     {"field":"value"}
-            // )"));
-            // s.on_next(std::make_shared<json::Document>(R"(
-            //     {"field":"values"}
-            // )"));
             s.on_next(std::make_shared<json::Document>(R"(
                 {"other_field":"referenced"}
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
+                {"field":"value"}
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
+                {"field":"values"}
             )"));
             s.on_completed();
         });
@@ -52,6 +52,6 @@ TEST(opBuilderMapReference, BuildsOperates)
     Observable output = lift1(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
-    ASSERT_EQ(expected.size(), 1);
+    ASSERT_EQ(expected.size(), 3);
     ASSERT_STREQ(expected[0]->get("/field")->GetString(), "referenced");
 }

--- a/src/engine/test/source/builder/builders/opBuilderMapValueTest.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderMapValueTest.cpp
@@ -45,18 +45,18 @@ TEST(opBuilderMapValue, BuildsOperates)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"values"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":"value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":1}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift1 = opBuilderMapValue(*doc.get("/normalize/0"));

--- a/src/engine/test/source/builder/builders/opBuilderMapValueTest.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderMapValueTest.cpp
@@ -69,9 +69,9 @@ TEST(opBuilderMapValue, BuildsOperates)
     ASSERT_EQ(expected.size(), 4);
     for (auto got : expected)
     {
-        ASSERT_STREQ(got.get("/mapped/string")->GetString(), "value");
-        ASSERT_EQ(got.get("/mapped/int")->GetInt(), 1);
-        ASSERT_TRUE(got.get("/mapped/bool")->GetBool());
+        ASSERT_STREQ(got->get("/mapped/string")->GetString(), "value");
+        ASSERT_EQ(got->get("/mapped/int")->GetInt(), 1);
+        ASSERT_TRUE(got->get("/mapped/bool")->GetBool());
     }
 }
 

--- a/src/engine/test/source/builder/builders/stageBuilderCheckTest.cpp
+++ b/src/engine/test/source/builder/builders/stageBuilderCheckTest.cpp
@@ -82,27 +82,27 @@ TEST(StageBuilderCheck, BuildsOperates)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"({
+            s.on_next(std::make_shared<json::Document>(R"({
                 "field1": "value",
                 "field2": 2,
                 "field3": "value",
                 "field4": true,
                 "field5": "+exists"
-            })"});
-            s.on_next(Event{R"(
+            })"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"values"}
-            )"});
-            s.on_next(Event{R"({
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"({
                 "field1": "value",
                 "field2": 2,
                 "field3": "value",
                 "field4": true,
                 "field5": "+exists",
                 "field6": "+exists"
-            })"});
-            s.on_next(Event{R"(
+            })"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":1}
-            )"});
+            )"));
             s.on_completed();
         });
 
@@ -111,10 +111,10 @@ TEST(StageBuilderCheck, BuildsOperates)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_STREQ(expected[0].get("/field1")->GetString(), "value");
-    ASSERT_EQ(expected[0].get("/field2")->GetInt(), 2);
-    ASSERT_STREQ(expected[0].get("/field3")->GetString(), "value");
-    ASSERT_TRUE(expected[0].get("/field4")->GetBool());
-    ASSERT_NO_THROW(expected[0].get("/field5"));
-    ASSERT_EQ(expected[0].get("/field6"), nullptr);
+    ASSERT_STREQ(expected[0]->get("/field1")->GetString(), "value");
+    ASSERT_EQ(expected[0]->get("/field2")->GetInt(), 2);
+    ASSERT_STREQ(expected[0]->get("/field3")->GetString(), "value");
+    ASSERT_TRUE(expected[0]->get("/field4")->GetBool());
+    ASSERT_NO_THROW(expected[0]->get("/field5"));
+    ASSERT_EQ(expected[0]->get("/field6"), nullptr);
 }

--- a/src/engine/test/source/builder/builders/stageBuilderNormalizeTest.cpp
+++ b/src/engine/test/source/builder/builders/stageBuilderNormalizeTest.cpp
@@ -71,28 +71,28 @@ TEST(StageBuilderNormalize, BuildsOperates)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"({
+            s.on_next(std::make_shared<json::Document>(R"({
                 "field1": "value",
                 "field2": 2,
                 "field3": "value",
                 "field4": true,
                 "field5": "+exists"
-            })"});
+            })"));
             // TODO: fix json interfaces to dont throw
-            // s.on_next(Event{R"(
+            // s.on_next(std::make_shared<json::Document>(R"(
             //     {"field":"values"}
-            // )"});
-            s.on_next(Event{R"({
+            // )"));
+            s.on_next(std::make_shared<json::Document>(R"({
                 "field1": "value",
                 "field2": 2,
                 "field3": "value",
                 "field4": true,
                 "field5": "+exists",
                 "field6": "+exists"
-            })"});
-            // s.on_next(Event{R"(
+            })"));
+            // s.on_next(std::make_shared<json::Document>(R"(
             //     {"otherfield":1}
-            // )"});
+            // )"));
             s.on_completed();
         });
 

--- a/src/engine/test/source/builder/builders/stageBuilderNormalizeTest.cpp
+++ b/src/engine/test/source/builder/builders/stageBuilderNormalizeTest.cpp
@@ -103,9 +103,9 @@ TEST(StageBuilderNormalize, BuildsOperates)
     ASSERT_EQ(expected.size(), 2);
     for (auto e : expected)
     {
-        ASSERT_STREQ(e.get("/mapped/field1")->GetString(), "value");
-        ASSERT_EQ(e.get("/mapped/field2")->GetInt(), 2);
-        ASSERT_STREQ(e.get("/mapped/field3")->GetString(), "value");
-        ASSERT_TRUE(e.get("/mapped/field4")->GetBool());
+        ASSERT_STREQ(e->get("/mapped/field1")->GetString(), "value");
+        ASSERT_EQ(e->get("/mapped/field2")->GetInt(), 2);
+        ASSERT_STREQ(e->get("/mapped/field3")->GetString(), "value");
+        ASSERT_TRUE(e->get("/mapped/field4")->GetBool());
     }
 }

--- a/src/engine/test/source/builder/builders/stageBuilderOutputsTest.cpp
+++ b/src/engine/test/source/builder/builders/stageBuilderOutputsTest.cpp
@@ -74,18 +74,18 @@ TEST(StageBuilderOutputs, BuildsOperates)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(Event{R"(
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"value"}
-            )"});
-            s.on_next(Event{R"(
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
                 {"field":"value"}
-            )"});
+            )"));
             s.on_completed();
         });
     Lifter lift = builders::stageBuilderOutputs(*doc.get("/outputs"));

--- a/src/engine/test/source/builder/outputs/fileOutputTest.cpp
+++ b/src/engine/test/source/builder/outputs/fileOutputTest.cpp
@@ -17,7 +17,7 @@
 
 using namespace builder::internals;
 
-auto message = R"({
+auto messageStr = R"({
     "event": {
         "original": "::1 - - [26/Dec/2016:16:16:29 +0200] \"GET /favicon.ico HTTP/1.1\" 404 209\n"
     },
@@ -69,11 +69,10 @@ TEST(FileOutput, Unknown_path)
 
 TEST(FileOutput, Write)
 {
-    using event_t = json::Document;
     auto filepath = "/tmp/file";
-
+    auto msg = std::make_shared<json::Document>(messageStr);
     auto output = outputs::FileOutput(filepath);
-    output.write(event_t(message));
+    output.write(msg);
 
     std::ifstream ifs(filepath);
     std::stringstream buffer;

--- a/src/engine/test/source/json/json_test.cpp
+++ b/src/engine/test/source/json/json_test.cpp
@@ -73,10 +73,10 @@ TEST(JsonTest, Operates)
     json::Document e(message);
 
     // Testing set and get
-    e.set(".module.name", Value("changed"));
+    e.set("/module/name", Value("changed"));
 
-    ASSERT_EQ(*(e.get(".module.name")), Value("changed"));
+    ASSERT_EQ(*(e.get("/module/name")), Value("changed"));
 
     auto expected = Value("changed");
-    ASSERT_TRUE(e.check(".module.name", &expected));
+    ASSERT_TRUE(e.check("/module/name", &expected));
 }

--- a/src/engine/test/source/router/routerTest.cpp
+++ b/src/engine/test/source/router/routerTest.cpp
@@ -19,7 +19,7 @@
 using namespace std;
 using namespace rxcpp;
 using namespace router;
-using document_t = json::Document;
+using document_t = std::shared_ptr<json::Document>;
 using documents_t = vector<document_t>;
 
 struct FakeServer
@@ -32,7 +32,7 @@ struct FakeServer
                   {
                       if (verbose)
                       {
-                          GTEST_COUT << "FakeServer emits " << document.str() << endl;
+                          GTEST_COUT << "FakeServer emits " << document->str() << endl;
                       }
                       s.on_next(document);
                   }
@@ -57,7 +57,7 @@ struct FakeBuilder
         if (verbose)
         {
             this->m_subj.get_observable().subscribe([](auto j)
-                                                    { GTEST_COUT << "FakeBuilder got " << j.str() << endl; });
+                                                    { GTEST_COUT << "FakeBuilder got " << j->str() << endl; });
         }
     }
 
@@ -114,13 +114,13 @@ TEST(RouterTest, RemoveNonExistentRoute)
 TEST(RouterTest, PassThroughSingleRoute)
 {
     documents_t input{
-        document_t(R"({
+        std::make_shared<json::Document>(R"({
         "event": 1
     })"),
-        document_t(R"({
+        std::make_shared<json::Document>(R"({
         "event": 2
     })"),
-        document_t(R"({
+        std::make_shared<json::Document>(R"({
         "event": 3
     })"),
     };
@@ -137,6 +137,6 @@ TEST(RouterTest, PassThroughSingleRoute)
     ASSERT_EQ(expected.size(), 3);
     for (auto i = 0; i < 3; ++i)
     {
-        ASSERT_EQ(input[i].str(), expected[i].str());
+        ASSERT_EQ(input[i]->str(), expected[i]->str());
     }
 }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/12612|

In this PR, we change of the observable's JSON event by a shared pointer, so that it is not copied during its life cycle.