### PR TITLE
Avoid memory leak when discarding kernel packages in VD

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5032,6 +5032,9 @@ int wm_vuldet_collect_agent_software(scan_agent *agent, sqlite3 *db, scan_ctx_t*
 
                 if (agent->dist != FEED_WIN && agent->dist != FEED_MAC) {
                     if (wm_vuldet_discard_kernel_package(agent, name, version, architecture)) {
+                        if (s_cpe) {
+                            wm_vuldet_free_cpe(&s_cpe);
+                        }
                         continue;
                     }
                 }


### PR DESCRIPTION
|Related issue|
|---|
| Closes #12640 |

## Description

As described at #12640, this pull request includes the freeing of the `s_cpe` struct in a condition detected by Coverity as a potential resource leak.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Coverity scan confirms the bug is solved