### PR TITLE
Removed generated_cpe and reference from vulnerability alerts

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -383,7 +383,6 @@ static int build_test_cve_report(vu_report* report, int add_condition, int add_i
     // Reported software
     os_strdup("libhogweed4", report->software);
     os_strdup("nettle", report->source);
-    os_strdup("o:microsoft:windows_server_2008:r2:sp1::::::", report->generated_cpe);
     os_strdup("3.4-1", report->version);
     os_strdup("CVE-2016-6489 reports as vulnerable all the versions of this package", report->operation);
     os_strdup("4.3-2", report->operation_value);
@@ -7786,8 +7785,6 @@ void test_wm_vuldet_send_cve_report_error_j_cvss_create(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->source);
     expect_string(__wrap_cJSON_AddStringToObject, name, "version");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->version);
-    expect_string(__wrap_cJSON_AddStringToObject, name, "generated_cpe");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->generated_cpe);
     expect_string(__wrap_cJSON_AddStringToObject, name, "architecture");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->arch);
     expect_string(__wrap_cJSON_AddStringToObject, name, "condition");
@@ -7829,8 +7826,6 @@ void test_wm_vuldet_send_cve_report_error_j_cvss_node_create(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->source);
     expect_string(__wrap_cJSON_AddStringToObject, name, "version");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->version);
-    expect_string(__wrap_cJSON_AddStringToObject, name, "generated_cpe");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->generated_cpe);
     expect_string(__wrap_cJSON_AddStringToObject, name, "architecture");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->arch);
     expect_string(__wrap_cJSON_AddStringToObject, name, "condition");
@@ -7877,8 +7872,6 @@ void test_wm_vuldet_send_cve_report_error_j_advisories_create(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->source);
     expect_string(__wrap_cJSON_AddStringToObject, name, "version");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->version);
-    expect_string(__wrap_cJSON_AddStringToObject, name, "generated_cpe");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->generated_cpe);
     expect_string(__wrap_cJSON_AddStringToObject, name, "architecture");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->arch);
     expect_string(__wrap_cJSON_AddStringToObject, name, "condition");
@@ -8032,8 +8025,6 @@ void test_wm_vuldet_send_cve_report_error_j_bug_references_create(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->source);
     expect_string(__wrap_cJSON_AddStringToObject, name, "version");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->version);
-    expect_string(__wrap_cJSON_AddStringToObject, name, "generated_cpe");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->generated_cpe);
     expect_string(__wrap_cJSON_AddStringToObject, name, "architecture");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->arch);
     expect_string(__wrap_cJSON_AddStringToObject, name, "condition");
@@ -8195,8 +8186,6 @@ void test_wm_vuldet_send_cve_report_error_j_references_create(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->source);
     expect_string(__wrap_cJSON_AddStringToObject, name, "version");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->version);
-    expect_string(__wrap_cJSON_AddStringToObject, name, "generated_cpe");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->generated_cpe);
     expect_string(__wrap_cJSON_AddStringToObject, name, "architecture");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->arch);
     expect_string(__wrap_cJSON_AddStringToObject, name, "condition");
@@ -8369,8 +8358,6 @@ void test_wm_vuldet_send_cve_report_without_title(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->source);
     expect_string(__wrap_cJSON_AddStringToObject, name, "version");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->version);
-    expect_string(__wrap_cJSON_AddStringToObject, name, "generated_cpe");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->generated_cpe);
     expect_string(__wrap_cJSON_AddStringToObject, name, "architecture");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->arch);
     expect_string(__wrap_cJSON_AddStringToObject, name, "condition");
@@ -8562,8 +8549,6 @@ void test_wm_vuldet_send_cve_report_without_condition(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->source);
     expect_string(__wrap_cJSON_AddStringToObject, name, "version");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->version);
-    expect_string(__wrap_cJSON_AddStringToObject, name, "generated_cpe");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->generated_cpe);
     expect_string(__wrap_cJSON_AddStringToObject, name, "architecture");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->arch);
     expect_string(__wrap_cJSON_AddStringToObject, name, "condition");
@@ -8756,8 +8741,6 @@ void test_wm_vuldet_send_cve_report_without_ip(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->source);
     expect_string(__wrap_cJSON_AddStringToObject, name, "version");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->version);
-    expect_string(__wrap_cJSON_AddStringToObject, name, "generated_cpe");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->generated_cpe);
     expect_string(__wrap_cJSON_AddStringToObject, name, "architecture");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->arch);
     expect_string(__wrap_cJSON_AddStringToObject, name, "condition");
@@ -8949,8 +8932,6 @@ void test_wm_vuldet_send_cve_report_without_hotfix(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->source);
     expect_string(__wrap_cJSON_AddStringToObject, name, "version");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->version);
-    expect_string(__wrap_cJSON_AddStringToObject, name, "generated_cpe");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->generated_cpe);
     expect_string(__wrap_cJSON_AddStringToObject, name, "architecture");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->arch);
     expect_string(__wrap_cJSON_AddStringToObject, name, "condition");
@@ -9142,8 +9123,6 @@ void test_wm_vuldet_send_cve_report_sendmsg_error(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->source);
     expect_string(__wrap_cJSON_AddStringToObject, name, "version");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->version);
-    expect_string(__wrap_cJSON_AddStringToObject, name, "generated_cpe");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->generated_cpe);
     expect_string(__wrap_cJSON_AddStringToObject, name, "architecture");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->arch);
     expect_string(__wrap_cJSON_AddStringToObject, name, "condition");

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -20126,7 +20126,7 @@ void test_wm_vuldet_find_obsolete_vulnerabilities_report_fail() {
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5490): The vulnerability 'CVE' affecting 'PACKAGE' was solved");
     // wm_vuldet_send_removed_cve_report
-    will_return_count(__wrap_cJSON_GetStringValue, NULL, 6);
+    will_return_count(__wrap_cJSON_GetStringValue, NULL, 5);
 
     // Vulnerability removed log (nvd)
     will_return(__wrap_cJSON_GetStringValue, "PACKAGE_nvd");
@@ -20134,7 +20134,7 @@ void test_wm_vuldet_find_obsolete_vulnerabilities_report_fail() {
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5490): The vulnerability 'CVE_nvd' affecting 'PACKAGE_nvd' was solved");
     // wm_vuldet_send_removed_cve_report (nvd)
-    will_return_count(__wrap_cJSON_GetStringValue, NULL, 6);
+    will_return_count(__wrap_cJSON_GetStringValue, NULL, 5);
 
     // wm_vuldet_send_removed_cve_report
     will_return_count(__wrap_cJSON_GetObjectItem, NULL, -1);
@@ -20189,8 +20189,7 @@ void test_wm_vuldet_send_removed_cve_report_ip_assigned_success() {
     wm_max_eps = 1;
 
     char* alert = "{\"vulnerability\":{\"package\":{\"name\":\"ncurses\",\"version\":\"5.9-14.20130511.el7_4\","
-                  "\"architecture\":\"x86_64\"},\"cve\":\"CVE-2019-17594\", \"status\":\"Solved\", \"reference\":"
-                  "\"fb783b1c771a643f81259a93248e7f61e9a4a597\"}}";
+                  "\"architecture\":\"x86_64\"},\"cve\":\"CVE-2019-17594\", \"status\":\"Solved\"}}";
     char* alert_cpy = NULL;
     char alert_message[OS_MAXSTR + 1];
 
@@ -20206,7 +20205,6 @@ void test_wm_vuldet_send_removed_cve_report_ip_assigned_success() {
     will_return(__wrap_cJSON_GetStringValue, "5.9-14.20130511.el7_4");
     will_return(__wrap_cJSON_GetStringValue, "x86_64");
     will_return(__wrap_cJSON_GetStringValue, "CVE-2019-17594");
-    will_return(__wrap_cJSON_GetStringValue, "fb783b1c771a643f81259a93248e7f61e9a4a597");
     will_return(__wrap_cJSON_GetStringValue, "PACKAGE");
 
     will_return_count(__wrap_cJSON_CreateObject, (cJSON*)1, -1);
@@ -20224,8 +20222,6 @@ void test_wm_vuldet_send_removed_cve_report_ip_assigned_success() {
     expect_string(__wrap_cJSON_AddStringToObject, string, "CVE-2019-17594");
     expect_string(__wrap_cJSON_AddStringToObject, name, "status");
     expect_string(__wrap_cJSON_AddStringToObject, string, "Solved");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "reference");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "fb783b1c771a643f81259a93248e7f61e9a4a597");
     expect_string(__wrap_cJSON_AddStringToObject, name, "type");
     expect_string(__wrap_cJSON_AddStringToObject, string, "PACKAGE");
     expect_string(__wrap_cJSON_AddStringToObject, name, "title");
@@ -20266,8 +20262,7 @@ void test_wm_vuldet_send_removed_cve_report_no_ip_success() {
     wm_max_eps = 1;
 
     char* alert = "{\"vulnerability\":{\"package\":{\"name\":\"ncurses\",\"version\":\"5.9-14.20130511.el7_4\","
-                  "\"architecture\":\"x86_64\"},\"cve\":\"CVE-2019-17594\", \"status\":\"Solved\", \"reference\":"
-                  "\"fb783b1c771a643f81259a93248e7f61e9a4a597\"}}";
+                  "\"architecture\":\"x86_64\"},\"cve\":\"CVE-2019-17594\", \"status\":\"Solved\"}}";
     char* alert_cpy = NULL;
 
     os_strdup(alert, alert_cpy);
@@ -20278,7 +20273,6 @@ void test_wm_vuldet_send_removed_cve_report_no_ip_success() {
     will_return(__wrap_cJSON_GetStringValue, "5.9-14.20130511.el7_4");
     will_return(__wrap_cJSON_GetStringValue, "x86_64");
     will_return(__wrap_cJSON_GetStringValue, "CVE-2019-17594");
-    will_return(__wrap_cJSON_GetStringValue, "fb783b1c771a643f81259a93248e7f61e9a4a597");
     will_return(__wrap_cJSON_GetStringValue, "PACKAGE");
 
     will_return_count(__wrap_cJSON_CreateObject, (cJSON*)1, -1);
@@ -20296,8 +20290,6 @@ void test_wm_vuldet_send_removed_cve_report_no_ip_success() {
     expect_string(__wrap_cJSON_AddStringToObject, string, "CVE-2019-17594");
     expect_string(__wrap_cJSON_AddStringToObject, name, "status");
     expect_string(__wrap_cJSON_AddStringToObject, string, "Solved");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "reference");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "fb783b1c771a643f81259a93248e7f61e9a4a597");
     expect_string(__wrap_cJSON_AddStringToObject, name, "type");
     expect_string(__wrap_cJSON_AddStringToObject, string, "PACKAGE");
     expect_string(__wrap_cJSON_AddStringToObject, name, "title");

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -999,8 +999,6 @@ void wm_vuldet_free_cve_node(void *data){
             os_free(pkg->version);
             os_free(pkg->type);
             os_free(pkg->reference);
-            os_free(pkg->type);
-            os_free(pkg->reference);
 
             if (pkg->nvd_cond) {
                 os_free(pkg->nvd_cond->operator);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1729,7 +1729,6 @@ int wm_vuldet_send_removed_cve_report (cJSON* j_vuln, scan_ctx_t* scan_ctx) {
     char* package_version = cJSON_GetStringValue(cJSON_GetObjectItem(j_vuln, "version"));
     char* package_architecture = cJSON_GetStringValue(cJSON_GetObjectItem(j_vuln, "architecture"));
     char* cve_id = cJSON_GetStringValue(cJSON_GetObjectItem(j_vuln, "cve"));
-    char* cve_reference = cJSON_GetStringValue(cJSON_GetObjectItem(j_vuln, "reference"));
     char* cve_type = cJSON_GetStringValue(cJSON_GetObjectItem(j_vuln, "type"));
     // Define time to sleep between messages sent
     int usec = 1000000 / wm_max_eps;
@@ -1750,7 +1749,6 @@ int wm_vuldet_send_removed_cve_report (cJSON* j_vuln, scan_ctx_t* scan_ctx) {
         cJSON_AddStringToObject(j_alert_cve, "cve", cve_id);
         // To trigger the alert, the status is defined here
         cJSON_AddStringToObject(j_alert_cve, "status", VULN_CVES_STATUS_SOLVED_LOWERCASE);
-        cJSON_AddStringToObject(j_alert_cve, "reference", cve_reference);
         cJSON_AddStringToObject(j_alert_cve, "type", cve_type);
         cJSON_AddStringToObject(j_alert_cve, "title", alert_title);
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1051,7 +1051,6 @@ void wm_vuldet_free_report(vu_report *report) {
     // Reported software
     os_free(report->software);
     os_free(report->source);
-    os_free(report->generated_cpe);
     os_free(report->version);
     os_free(report->operation);
     os_free(report->operation_value);
@@ -1591,7 +1590,6 @@ int wm_vuldet_send_cve_report(vu_report *report) {
         cJSON_AddStringToObject(j_package, "name", report->software);
         if (report->source) cJSON_AddStringToObject(j_package, "source", report->source);
         if (report->version && *report->version) cJSON_AddStringToObject(j_package, "version", report->version);
-        if (report->generated_cpe) cJSON_AddStringToObject(j_package, "generated_cpe", report->generated_cpe);
         if (report->arch && *report->arch) cJSON_AddStringToObject(j_package, "architecture", report->arch);
 
         if (report->condition && *report->condition != '\0') {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -515,7 +515,6 @@ struct vu_report {
     // Reported software
     char *software;
     char *source;
-    char *generated_cpe;
     char *version;
     char *operation;
     char *operation_value;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2261,7 +2261,6 @@ int wm_vuldet_process_agent_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd
         }
 
         if (NULL != report_node->generated_cpe) {
-            os_strdup(report_node->generated_cpe, report->generated_cpe);
             cpe_data = wm_vuldet_decode_cpe(report_node->generated_cpe);
         }
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #12601 |

## Description

As the title states, this pull request removes the following fields:
- `generated_cpe` (c91d30482b46b700f0f0768b3ba3a0bec787b86f)
- `reference` (f0bddeba02dfe99242bf880e9453f1d0443190d0)

## Logs/Alerts example

Once applied the changes, the undesired fields don't appear when triggering vulnerability alerts:

```
** Alert 1646836253.1711291: - vulnerability-detector,gdpr_IV_35.7.d,pci_dss_11.2.1,pci_dss_11.2.3,tsc_CC7.1,tsc_CC7.2,
2022 Mar 09 15:30:53 (wazuh) 127.0.0.1->vulnerability-detector
Rule: 23502 (level 3) -> 'The CVE-2022-0529 that affected unzip was solved due to a package removal/update or a system upgrade'
{"vulnerability":{"package":{"name":"unzip","version":"6.0-25ubuntu1","architecture":"amd64"},"cve":"CVE-2022-0529","status":"Solved","type":"PACKAGE","title":"CVE-2022-0529 affecting unzip was solved"}}
vulnerability.package.name: unzip
vulnerability.package.version: 6.0-25ubuntu1
vulnerability.package.architecture: amd64
vulnerability.cve: CVE-2022-0529
vulnerability.status: Solved
vulnerability.type: PACKAGE
vulnerability.title: CVE-2022-0529 affecting unzip was solved
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
- [x] Added unit tests (for new features)