### PR TITLE
Improve Google Cloud integration's error handling

### DIFF
--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1095,6 +1095,7 @@ InstallServer()
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/gcloud.py ${INSTALLDIR}/wodles/gcloud/gcloud.py
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/integration.py ${INSTALLDIR}/wodles/gcloud/integration.py
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/tools.py ${INSTALLDIR}/wodles/gcloud/tools.py
+    ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/exceptions.py ${INSTALLDIR}/wodles/gcloud/exceptions.py
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/buckets/bucket.py ${INSTALLDIR}/wodles/gcloud/buckets/bucket.py
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/buckets/access_logs.py ${INSTALLDIR}/wodles/gcloud/buckets/access_logs.py
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/pubsub/subscriber.py ${INSTALLDIR}/wodles/gcloud/pubsub/subscriber.py
@@ -1147,6 +1148,7 @@ InstallAgent()
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/gcloud.py ${INSTALLDIR}/wodles/gcloud/gcloud
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/integration.py ${INSTALLDIR}/wodles/gcloud/integration.py
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/tools.py ${INSTALLDIR}/wodles/gcloud/tools.py
+    ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/exceptions.py ${INSTALLDIR}/wodles/gcloud/exceptions.py
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/buckets/bucket.py ${INSTALLDIR}/wodles/gcloud/buckets/bucket.py
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/buckets/access_logs.py ${INSTALLDIR}/wodles/gcloud/buckets/access_logs.py
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/pubsub/subscriber.py ${INSTALLDIR}/wodles/gcloud/pubsub/subscriber.py

--- a/wodles/gcloud/buckets/bucket.py
+++ b/wodles/gcloud/buckets/bucket.py
@@ -24,7 +24,7 @@ try:
     from google.api_core import exceptions as google_exceptions
     import pytz
 except ImportError as e:
-    raise exceptions.GCloudException(errcode=4, package=e.name)
+    raise exceptions.WazuhIntegrationException(errcode=1003, package=e.name)
 
 
 class WazuhGCloudBucket(WazuhGCloudIntegration):
@@ -53,7 +53,7 @@ class WazuhGCloudBucket(WazuhGCloudIntegration):
 
         Raises
         ------
-        GCloudError
+        exceptions.GCloudError
             If the credentials file doesn't exist or doesn't have the required
             structure.
         """
@@ -63,9 +63,9 @@ class WazuhGCloudBucket(WazuhGCloudIntegration):
         try:
             self.client = storage.client.Client.from_service_account_json(credentials_file)
         except JSONDecodeError as error:
-            raise exceptions.GCloudError(1, credentials_file=credentials_file) from error
+            raise exceptions.GCloudError(1000, credentials_file=credentials_file) from error
         except FileNotFoundError as error:
-            raise exceptions.GCloudError(2, credentials_file=credentials_file) from error
+            raise exceptions.GCloudError(1001, credentials_file=credentials_file) from error
         self.project_id = self.client.project
         self.prefix = prefix if not prefix or prefix[-1] == '/' else f'{prefix}/'
         self.delete_file = delete_file
@@ -201,16 +201,16 @@ class WazuhGCloudBucket(WazuhGCloudIntegration):
 
         Raises
         ------
-        GCloudError
+        exceptions.GCloudError
             If the specified bucket doesn't exist or the client doesn't
             have permissions to access it.
         """
         try:
             self.bucket = self.client.get_bucket(self.bucket_name)
         except google_exceptions.NotFound:
-            raise exceptions.GCloudError(100, bucket_name=self.bucket_name)
+            raise exceptions.GCloudError(1100, bucket_name=self.bucket_name)
         except google_exceptions.Forbidden:
-            raise exceptions.GCloudError(101, permissions='storage.buckets.get',
+            raise exceptions.GCloudError(1101, permissions='storage.buckets.get',
                                          resource_name=self.bucket_name)
 
     def init_db(self):

--- a/wodles/gcloud/exceptions.py
+++ b/wodles/gcloud/exceptions.py
@@ -10,11 +10,11 @@
 import tools
 
 
-UNKNOWN_ERROR_ERRCODE = 901
+UNKNOWN_ERROR_ERRCODE = 999
 
 
-class GCloudException(Exception):
-    """Class that represents an exception of the GCloud package.
+class WazuhIntegrationException(Exception):
+    """Class that represents an exception for the Wazuh external integrations.
 
     Parameters
     ----------
@@ -44,74 +44,78 @@ class GCloudException(Exception):
         return self._message
 
 
-class GCloudError(GCloudException):
+class WazuhIntegrationInternalError(WazuhIntegrationException):
+    """Class that represents a critical exception for the Wazuh external integrations."""
+    ERRORS = {
+        # 1-99 -> Internal errors
+        1: {
+            'key': 'GCloudWazuhNotRunning',
+            'message': 'Wazuh must be running'
+        },
+        2: {
+            'key': 'GCloudSocketError',
+            'message': 'Error initializing {socket_path} socket'
+        },
+        3: {
+            'key': 'GCloudSocketSendError',
+            'message': 'Error sending event to Wazuh'
+        },
+    }
+
+class GCloudError(WazuhIntegrationException):
     """Class that represents an error of the GCloud package."""
     ERRORS = {
-        # 1-99 General errors
-        1: {
+        # 1000-1099 General errors
+        1000: {
             'key': 'GCloudCredentialsStructureError',
             'message': "The '{credentials_file}' credentials file doesn't have the required structure"},
-        2: {
+        1001: {
             'key': 'GCloudCredentialsNotFoundError',
             'message': "The '{credentials_file}' file doesn't exist"},
-        3: {
+        1002: {
             'key': 'GCloudIntegrationTypeError',
             'message': 'Unsupported gcloud integration type: "{integration_type}".' f'The supported types are {*tools.valid_types,}'},
-        4: {
+        1003: {
             'key': 'GCloudImportError',
             'message': "The '{package}' module is required"},
-        # 100-199 -> GCP Bucket errors
-        100: {
+
+        # 1100-1199 -> GCP Bucket errors
+        1100: {
             'key': 'GCloudBucketNotFound',
             'message': "The bucket '{bucket_name}' does not exist"},
-        101: {
+        1101: {
             'key': 'GCloudBucketForbidden',
             'message': "The Service Account provided does not have {permissions} permissions to access the '{resource_name}' bucket or it does not exist in the account"},
-        102: {
+        1102: {
             'key': 'GCloudBucketNumThreadsError',
             'message': 'The parameter -t/--num_threads only works with the Pub/Sub module.'},
-        103: {
+        1103: {
             'key': 'GCloudBucketNameError',
             'message': 'The name of the bucket is required. Use -b <BUCKET_NAME> to specify it.'},
-        # 200-299 -> Pub/Sub errors
-        200: {
+
+        # 1200-1299 -> Pub/Sub errors
+        1200: {
             'key': 'GCloudPubSubNoSubscriptionID',
             'message': 'A subscription ID is required. Use -s <SUBSCRIPTION ID> to specify it.'},
-        201: {
+        1201: {
             'key': 'GCloudPubSubNoProjectID',
             'message': 'A project ID is required. Use -p <PROJECT ID> to specify it.'},
-        202: {
+        1202: {
             'key': 'GCloudPubSubNumThreadsError',
             'message': f'The minimum number of threads is {tools.min_num_threads}. Please check your configuration.'},
-        203: {
+        1203: {
             'key':
             'GCloudPubSubNumMessagesError', 'message': f'The minimum number of messages is {tools.min_num_messages}. Please check your configuration.'},
-        204: {
+        1204: {
             'key': 'GCloudPubSubSubscriptionError',
             'message': "The '{subscription}' subscription is incorrect or the user credentials are not valid"},
-        205: {
+        1205: {
             'key': 'GCloudPubSubProjectError',
             'message': "The '{project}' project ID is incorrect or the user does not have permissions to access to it"},
-        206: {
+        1206: {
             'key': 'GCloudPubSubForbidden',
             'message': "The client does not have the {permissions} required permissions}"}
     }
 
 
-class GCloudInternalError(GCloudException):
-    """Class that represents a critical exception of the GCloud package."""
-    ERRORS = {
-        # 800-899 -> Internal errors
-        800: {
-            'key': 'GCloudWazuhNotRunning',
-            'message': 'Wazuh must be running'
-        },
-        801: {
-            'key': 'GCloudSocketError',
-            'message': 'Error initializing {socket_path} socket'
-        },
-        802: {
-            'key': 'GCloudSocketSendError',
-            'message': 'Error sending event to Wazuh'
-        },
-    }
+

--- a/wodles/gcloud/exceptions.py
+++ b/wodles/gcloud/exceptions.py
@@ -1,0 +1,250 @@
+# Copyright (C) 2015, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute
+# it and/or modify it under the terms of GPLv2
+
+"""This module contains the different exceptions that could be raised
+   by the Gcloud package.
+"""
+
+import tools
+
+
+class GCloudException(Exception):
+    """Class that represents a exception of the GCloud package."""
+    pass
+
+
+class GCloudCriticalError(GCloudException):
+    """Class that represents a critical exception."""
+    pass
+
+
+class GCloudWazuhNotRunning(GCloudCriticalError):
+    """
+    Exception that indicates that Wazuh is not running.
+    """
+    def __init__(self):
+        super().__init__('Wazuh must be running')
+
+
+class GCloudSocketError(GCloudCriticalError):
+    """
+    Exception that indicates that there was an error occurred
+    when initializing the analysid socket.
+
+    Parameters
+    ----------
+    socket_path : str
+        Path of the analysisd socket.
+    """
+    def __init__(self, socket_path: str):
+        super().__init__(f'Error initializing {socket_path} socket')
+
+
+class GCloudSocketSendError(GCloudCriticalError):
+    """
+    Exception that indicates that there was an error occurred
+    when trying to send a log to the analysid socket.
+    """
+    def __init__(self, socket_path: str):
+        super().__init__('Error sending event to Wazuh')
+
+
+class GCloudCredentialsStructureError(GCloudException):
+    """
+    Exception that indicates that the credentials file used doesn't have
+    the required structure.
+
+    Parameters
+    ----------
+    credentials_file : str
+        Path of the credentials file.
+    """
+    def __init__(self, credentials_file: str = ''):
+        message = f"The '{credentials_file}' credentials file doesn't have"\
+                   "the required structure"
+        super().__init__(message)
+
+
+class GCloudCredentialsNotFoundError(GCloudException):
+    """
+    Exception that indicates that the credentials file passed doesn't exist.
+
+    Parameters
+    ----------
+    credentials_file : str
+        Path of the credentials file.
+    """
+    def __init__(self, credentials_file: str = ''):
+        message = f"The '{credentials_file}' file doesn't exist"
+        super().__init__(message)
+
+
+class GCloudIntegrationTypeError(GCloudException):
+    """
+    Exception that indicates that the module was called
+    specifying an unsupported integration_type.
+
+    Parameters
+    ----------
+    integration_type : str
+        Integration type specified by the user.
+    """
+    def __init__(self, integration_type: str):
+        message = ('Unsupported gcloud integration type: '
+                   f'"{integration_type}". The supported types are'
+                   f' {*tools.valid_types,}')
+        super().__init__(message)
+
+
+class GCloudBucketNotFound(GCloudException):
+    """
+    Exception that indicates that the required bucket doesn't exist.
+
+    Parameters
+    ----------
+    bucket_name : str
+        Bucket that wasn't found.
+    """
+    def __init__(self, bucket_name: str = ''):
+        message = f"The bucket '{bucket_name}' does not exist"
+        super().__init__(message)
+
+
+class GCloudBucketForbidden(GCloudException):
+    """
+    Exception that indicates that the client doesn't have permissions
+    to access the designated resource.
+
+    Parameters
+    ----------
+    resource_name : str
+        Resource that was being accessed.
+    permissions : str
+        Permissions that the client must have.
+    """
+    def __init__(self, resource_name: str, permissions: str = ''):
+        message = 'The Service Account provided does not have '\
+                  f"""{"'" + permissions + "' " if permissions else ""}""" \
+                  f"permissions to access the '{resource_name}' bucket " \
+                  "or it does not exist in the account"
+        super().__init__(message)
+
+
+class GCloudBucketNumThreadsError(GCloudException):
+    """
+    Exception that indicates that the Access Logs module was executed
+    specifying a number of threads different than 1.
+    """
+    def __init__(self):
+        message = 'The parameter -t/--num_threads only works with the '\
+                  'Pub/Sub module.'
+        super().__init__(message)
+
+
+class GCloudBucketNameError(GCloudException):
+    """
+    Exception that indicates that the Access Logs module was executed
+    specifying a number of threads different than 1.
+    """
+    def __init__(self):
+        message = 'The name of the bucket is required. Use -b <BUCKET_NAME> '\
+                  'to specify it.'
+        super().__init__(message)
+
+
+class GCloudPubSubNoSubscriptionID(GCloudException):
+    """
+    Exception that indicates that the Pub/Sub module was executed
+    without specifying a subscription ID.
+    """
+    def __init__(self):
+        message = 'A subscription ID is required. Use -s '\
+            '<SUBSCRIPTION ID> to specify it.'
+        super().__init__(message)
+
+
+class GCloudPubSubNoProjectID(GCloudException):
+    """
+    Exception that indicates that the Pub/Sub module was executed
+    without specifying a project ID.
+    """
+    def __init__(self):
+        message = 'A project ID is required. Use -p <PROJECT ID> to '\
+            'specify it.'
+        super().__init__(message)
+
+
+class GCloudPubSubNumThreadsError(GCloudException):
+    """
+    Exception that indicates that the Pub/Sub module was executed
+    scecifying a wrong number of threads.
+    """
+    def __init__(self):
+        message = f'The minimum number of threads is {tools.min_num_threads}.'\
+            ' Please check your configuration.'
+        super().__init__(message)
+
+
+class GCloudPubSubNumMessagesError(GCloudException):
+    """
+    Exception that indicates that the Pub/Sub module was executed
+    scecifying a wrong number of threads.
+    """
+    def __init__(self):
+        message = 'The minimum number of messages is '\
+                  f'{tools.min_num_messages}. Please check your configuration.'
+        super().__init__(message)
+
+
+class GCloudPubSubForbidden(GCloudException):
+    """
+    Exception that indicates that the client doesn't have the
+    permissions required to consume PubSub logs.
+
+    Parameters
+    ----------
+    permissions : str
+        The permissions that the client should have.
+    """
+    def __init__(self, permissions: str = ''):
+        if permissions:
+            message = f"The client does not have the '{permissions}' "\
+                "required permissions"
+        else:
+            message = 'No permissions for executing the wodle from this '\
+                'subscription'
+        super().__init__(message)
+
+
+class GCloudPubSubSubscriptionError(GCloudException):
+    """
+    Exception that indicates that the subscription ID passed
+    to the Pub/Sub module might have an error.
+
+    Parameters
+    ----------
+    subscription : str
+        The subscription specified.
+    """
+    def __init__(self, subscription: str):
+        message = f"The '{subscription}' subscription is incorrect or the "\
+            "user credentials are not valid"
+        super().__init__(message)
+
+
+class GCloudPubSubProjectError(GCloudException):
+    """
+    Exception that indicates that the project ID passed
+    to the Pub/Sub module might have an error.
+
+    Parameters
+    ----------
+    project_id : str
+        The project specified.
+    """
+    def __init__(self, project: str):
+        message = f"The '{project}' project ID is incorrect or the "\
+            "user does not have permissions to access to it"
+        super().__init__(message)

--- a/wodles/gcloud/gcloud.py
+++ b/wodles/gcloud/gcloud.py
@@ -36,9 +36,9 @@ def main():
 
         if arguments.integration_type == "pubsub":
             if arguments.subscription_id is None:
-                raise exceptions.GCloudError(200)
+                raise exceptions.GCloudError(1200)
             if arguments.project is None:
-                raise exceptions.GCloudError(201)
+                raise exceptions.GCloudError(1201)
 
             project = arguments.project
             subscription_id = arguments.subscription_id
@@ -49,9 +49,9 @@ def main():
                 n_threads = max_threads
                 logger.warning(f'Reached maximum number of threads. Truncating to {max_threads}.')
             if n_threads < tools.min_num_threads:
-                raise exceptions.GCloudError(202)
+                raise exceptions.GCloudError(1202)
             if max_messages < tools.min_num_messages:
-                raise exceptions.GCloudError(203)
+                raise exceptions.GCloudError(1203)
 
             logger.debug(f"Setting {n_threads} thread{'s' if n_threads > 1 else ''} to pull {max_messages}"
                          f" message{'s' if max_messages > 1 else ''} in total")
@@ -76,9 +76,9 @@ def main():
 
         elif arguments.integration_type == "access_logs":
             if arguments.n_threads != tools.min_num_threads:
-                raise exceptions.GCloudError(102)
+                raise exceptions.GCloudError(1102)
             if not arguments.bucket_name:
-                raise exceptions.GCloudError(103)
+                raise exceptions.GCloudError(1103)
 
             f_kwargs = {"bucket_name": arguments.bucket_name,
                         "prefix": arguments.prefix,
@@ -90,11 +90,11 @@ def main():
             num_processed_messages = integration.process_data()
 
         else:
-            raise exceptions.GCloudError(3, integration_type=arguments.integration_type)
+            raise exceptions.GCloudError(1002, integration_type=arguments.integration_type)
 
-    except exceptions.GCloudException as gcloud_exception:
+    except exceptions.WazuhIntegrationException as gcloud_exception:
         logging_func = logger.critical if \
-            isinstance(gcloud_exception, exceptions.GCloudInternalError) else \
+            isinstance(gcloud_exception, exceptions.WazuhIntegrationInternalError) else \
             logger.error
 
         logging_func('An exception happened while running the wodle: '

--- a/wodles/gcloud/gcloud.py
+++ b/wodles/gcloud/gcloud.py
@@ -31,9 +31,11 @@ try:
 
     if arguments.integration_type == "pubsub":
         if arguments.subscription_id is None:
-            raise Exception(f'A subscription ID is required. Use -s <SUBSCRIPTION ID> to specify it.')
+            logger.error('A subscription ID is required. Use -s <SUBSCRIPTION ID> to specify it.')
+            exit(1)
         if arguments.project is None:
-            raise Exception(f'A project ID is required. Use -p <PROJECT ID> to specify it.')
+            logger.error('A project ID is required. Use -p <PROJECT ID> to specify it.')
+            exit(1)
 
         project = arguments.project
         subscription_id = arguments.subscription_id
@@ -73,10 +75,11 @@ try:
 
     elif arguments.integration_type == "access_logs":
         if arguments.n_threads != tools.min_num_threads:
-            logger.error(f'The parameter -t/--num_threads only works with the Pub/Sub module.')
+            logger.error('The parameter -t/--num_threads only works with the Pub/Sub module.')
             exit(1)
         if arguments.bucket_name is None:
-            raise Exception(f'The name of the bucket is required. Use -b <BUCKET_NAME> to specify it.')
+            logger.error('The name of the bucket is required. Use -b <BUCKET_NAME> to specify it.')
+            exit(1)
 
         f_kwargs = {"bucket_name": arguments.bucket_name,
                     "prefix": arguments.prefix,
@@ -88,11 +91,15 @@ try:
         num_processed_messages = integration.process_data()
 
     else:
-        raise Exception(f'Unsupported gcloud integration type: {arguments.integration_type}')
+        logger.error('Unsupported gcloud integration type: '
+                     f'"{arguments.integration_type}". The supported types are'
+                     f' {*tools.valid_types,}')
+        exit(1)
 
 
-except Exception as e:
-    logger.critical(f'An exception happened while running the wodle: {e}')
+except Exception:
+    logger.critical('An exception happened while running the wodle',
+                    exc_info=True)
     exit(1)
 
 else:

--- a/wodles/gcloud/integration.py
+++ b/wodles/gcloud/integration.py
@@ -63,7 +63,7 @@ class WazuhGCloudIntegration:
 
         Raises
         ------
-        exception.GCloudInternalError
+        exceptions.WazuhIntegrationInternalError
             If the socket is unable to establish a connection or send a message
              to analysisd.
         """
@@ -72,9 +72,9 @@ class WazuhGCloudIntegration:
             self.socket.connect(ANALYSISD)
             return self.socket
         except ConnectionRefusedError:
-            raise exceptions.GCloudInternalError(800)
+            raise exceptions.WazuhIntegrationInternalError(1)
         except OSError:
-            raise exceptions.GCloudInternalError(801, socket_path=ANALYSISD)
+            raise exceptions.WazuhIntegrationInternalError(2, socket_path=ANALYSISD)
 
     def process_data(self):
         raise NotImplementedError
@@ -89,7 +89,7 @@ class WazuhGCloudIntegration:
 
         Raises
         ------
-        GCloudCriticalError
+        exceptions.WazuhIntegrationInternalError
             If the socket is unable to send the message to analysisd.
         """
         event_json = f'{self.header}{msg}'.encode(errors='replace')
@@ -97,4 +97,4 @@ class WazuhGCloudIntegration:
         try:
             self.socket.send(event_json)
         except OSError:
-            raise exceptions.GCloudCriticalError(802)
+            raise exceptions.WazuhIntegrationInternalError(3)

--- a/wodles/gcloud/integration.py
+++ b/wodles/gcloud/integration.py
@@ -63,17 +63,18 @@ class WazuhGCloudIntegration:
 
         Raises
         ------
-        OSError
-            If the socket is unable to establish a connection or send a message to analysisd.
+        exception.GCloudInternalError
+            If the socket is unable to establish a connection or send a message
+             to analysisd.
         """
         try:
             self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
             self.socket.connect(ANALYSISD)
             return self.socket
         except ConnectionRefusedError:
-            raise exceptions.GCloudWazuhNotRunning
+            raise exceptions.GCloudInternalError(800)
         except OSError:
-            raise exceptions.GCloudSocketError(ANALYSISD)
+            raise exceptions.GCloudInternalError(801, socket_path=ANALYSISD)
 
     def process_data(self):
         raise NotImplementedError
@@ -88,12 +89,12 @@ class WazuhGCloudIntegration:
 
         Raises
         ------
-        OSError
+        GCloudCriticalError
             If the socket is unable to send the message to analysisd.
         """
-        event_json = f'{self.header}{msg}'.encode(errors='replace')  # noqa: E501
+        event_json = f'{self.header}{msg}'.encode(errors='replace')
         self.logger.debug(f'Sending msg to analysisd: "{event_json}"')
         try:
             self.socket.send(event_json)
         except OSError:
-            raise exceptions.GCloudSocketSendError
+            raise exceptions.GCloudCriticalError(802)

--- a/wodles/gcloud/pubsub/subscriber.py
+++ b/wodles/gcloud/pubsub/subscriber.py
@@ -19,7 +19,7 @@ try:
     from google.cloud import pubsub_v1 as pubsub
     import google.api_core.exceptions
 except ImportError as e:
-    raise exceptions.GCloudException(errcode=4, package=e.name)
+    raise exceptions.GCloudError(errcode=1003, package=e.name)
 
 
 class WazuhGCloudSubscriber(WazuhGCloudIntegration):
@@ -41,7 +41,7 @@ class WazuhGCloudSubscriber(WazuhGCloudIntegration):
 
         Raises
         ------
-        GCloudError
+        exceptions.GCloudError
             If the credentials file doesn't exist or have a wrong structure.
         """
         super().__init__(logger)
@@ -51,9 +51,9 @@ class WazuhGCloudSubscriber(WazuhGCloudIntegration):
             self.subscriber = self.get_subscriber_client(credentials_file)
             self.subscription_path = self.get_subscription_path(project, subscription_id)
         except JSONDecodeError as error:
-            raise exceptions.GCloudError(1, credentials_file=credentials_file) from error
+            raise exceptions.GCloudError(1000, credentials_file=credentials_file) from error
         except FileNotFoundError as error:
-            raise exceptions.GCloudError(2, credentials_file=credentials_file) from error
+            raise exceptions.GCloudError(1001, credentials_file=credentials_file) from error
 
     @staticmethod
     def get_subscriber_client(credentials_file: str) -> pubsub.subscriber.Client:
@@ -94,7 +94,7 @@ class WazuhGCloudSubscriber(WazuhGCloudIntegration):
 
         Raises
         ------
-        GCloudError
+        exceptions.GCloudError
             If the parameters or credentials are invalid.
         """
         required_permissions = {'pubsub.subscriptions.consume'}
@@ -105,12 +105,12 @@ class WazuhGCloudSubscriber(WazuhGCloudIntegration):
 
         except google.api_core.exceptions.NotFound as e:
             if 'project not found or user does not have access' in e.message:
-                raise exceptions.GCloudError(204, subscription=self.subscription_path.split('/')[1])
+                raise exceptions.GCloudError(1204, subscription=self.subscription_path.split('/')[1])
             else:
-                raise exceptions.GCloudError(205, project=self.subscription_path.split('/')[-1])
+                raise exceptions.GCloudError(1205, project=self.subscription_path.split('/')[-1])
 
         if required_permissions.difference(response.permissions) != set():
-            raise exceptions.GCloudError(206)
+            raise exceptions.GCloudError(1206)
 
     def pull_request(self, max_messages: int) -> int:
         """Make request for pulling messages from the subscription and acknowledge them.

--- a/wodles/gcloud/tests/conftest.py
+++ b/wodles/gcloud/tests/conftest.py
@@ -1,0 +1,94 @@
+import os
+from sys import path
+import pytest
+from unittest.mock import patch
+from copy import deepcopy
+
+path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))
+from buckets.bucket import WazuhGCloudBucket
+from pubsub.subscriber import WazuhGCloudSubscriber
+
+
+COMMON_PARAMETERS = [
+    {'credentials_file': 'credentials.json'},
+    {'logger': None},
+]
+
+GCLOUD_BUCKET_PARAMETERS = [
+    COMMON_PARAMETERS + [
+        {'bucket_name': 'test-bucket'},
+        {'prefix': ''},
+        {'delete_file': False},
+        {'only_logs_after': None},
+    ]
+]
+
+GCLOUD_PUBSUB_PARAMETERS = [
+    COMMON_PARAMETERS + [
+        {'project': 'wazuh-dev'},
+        {'subscription_id': 'testing'},
+    ]
+]
+
+
+data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                         'data/')
+
+
+@pytest.fixture()
+def test_data_path() -> str:
+    """
+    Fixture that returns the path where the tests data is at.
+
+    Returns
+    -------
+    str
+        Full path of the tests' data folder.
+    """
+    return deepcopy(data_path)
+
+
+@pytest.fixture(params=deepcopy(GCLOUD_BUCKET_PARAMETERS))
+@patch('buckets.bucket.storage.client.Client.from_service_account_json')
+def gcloud_bucket(mock_client, request):
+    """
+    Return a WazuhGCloudBucket client.
+
+    Parameters
+    ----------
+    mock_client : MagicMock
+        Mocked GCP client.
+    request : pytest.fixtures.SubRequest
+        Object that contains information about the current test.
+
+    Returns
+    -------
+    WazuhGCloudBucket
+        Initialized client.
+    """
+    client = WazuhGCloudBucket(**{k: v for i in request.param for k, v in
+                                  i.items()})
+    return client
+
+
+@pytest.fixture(params=deepcopy(GCLOUD_PUBSUB_PARAMETERS))
+@patch('pubsub.subscriber.pubsub.subscriber.Client.from_service_account_file')
+def gcloud_subscriber(mock_client, request):
+    """
+    Return a WazuhGCloudSubscriber client.
+
+    Parameters
+    ----------
+    mock_client : MagicMock
+        Mocked GCP client.
+    request : pytest.fixtures.SubRequest
+        Object that contains information about the current test.
+
+    Returns
+    -------
+    WazuhGCloudSubscriber
+        Initialized subscriber.
+    """
+    client = WazuhGCloudSubscriber(**{k: v for i in request.param for k, v in
+                                   i.items()})
+    return client

--- a/wodles/gcloud/tests/data/invalid_credentials_file.json
+++ b/wodles/gcloud/tests/data/invalid_credentials_file.json
@@ -1,0 +1,5 @@
+{
+  "type",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509"
+}

--- a/wodles/gcloud/tests/test_bucket.py
+++ b/wodles/gcloud/tests/test_bucket.py
@@ -41,7 +41,7 @@ def test_get_bucket(gcloud_bucket: WazuhGCloudBucket):
      exceptions.GCloudError, 1)
 ])
 def test_bucket_ko(credentials_file: str, logger: Logger,
-                   bucket_name: str, exception: exceptions.GCloudException,
+                   bucket_name: str, exception: exceptions.WazuhIntegrationException,
                    test_data_path: str, errcode: int):
     """
     Check that the appropriate exceptions are raised
@@ -56,7 +56,7 @@ def test_bucket_ko(credentials_file: str, logger: Logger,
         Logger used to capture the output of the module.
     bucket_name : str
         Name of the bucket.
-    exception : exceptions.GCloudException
+    exception : exceptions.WazuhIntegrationException
         Exception that should be raised by the module.
     test_data_path : str
         Path where the data folder is.

--- a/wodles/gcloud/tests/test_bucket.py
+++ b/wodles/gcloud/tests/test_bucket.py
@@ -10,36 +10,58 @@
 
 import os
 import sys
+import pytest
 from unittest.mock import patch
+from logging import Logger
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))  # noqa: E501
+import exceptions
 from buckets.bucket import WazuhGCloudBucket
 
-test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
-credentials_file = 'credentials.json'
-logger = None
-bucket_name = 'test-bucket'
-prefix = ""
-delete_file = False
-only_logs_after = None
-
-
-@patch('buckets.bucket.storage.client.Client.from_service_account_json')
-def get_WazuhGCloudBucket(mock_client):
-    """Return a WazuhGCloudSubscriber client."""
-    client = WazuhGCloudBucket(credentials_file, logger, bucket_name, prefix, delete_file, only_logs_after)
-    return client
-
-
-def test_get_bucket():
+def test_get_bucket(gcloud_bucket: WazuhGCloudBucket):
     """Check if an instance of WazuhGCloudBucket is created properly."""
-    expected_attributes = ['bucket_name', 'bucket', 'client', 'project_id', 'prefix', 'delete_file', 'only_logs_after',
+    expected_attributes = ['bucket_name', 'bucket', 'client', 'project_id',
+                           'prefix', 'delete_file', 'only_logs_after',
                            'db_connector', 'datetime_format']
 
-    client = get_WazuhGCloudBucket()
-
-    assert isinstance(client, WazuhGCloudBucket)
+    assert isinstance(gcloud_bucket, WazuhGCloudBucket)
 
     for attribute in expected_attributes:
-        assert hasattr(client, attribute)
+        assert hasattr(gcloud_bucket, attribute)
+
+
+@pytest.mark.parametrize('credentials_file,logger,bucket_name,exception', [
+    ('unexistent_file',
+     None,
+     'test_bucket',
+     exceptions.GCloudCredentialsNotFoundError),
+    ('invalid_credentials_file.json',
+     None,
+     'test_bucket',
+     exceptions.GCloudCredentialsStructureError)
+])
+def test_bucket_ko(credentials_file: str, logger: Logger,
+                   bucket_name: str, exception: exceptions.GCloudException,
+                   test_data_path: str):
+    """
+    Check that the appropriate exceptions are raised
+    when the WazuhGCloudBucket constructor is called with
+    wrong parameters.
+
+    Parameters
+    ----------
+    credentials_file : str
+        File with the GCP credentials.
+    logger : Logger
+        Logger used to capture the output of the module.
+    bucket_name : str
+        Name of the bucket.
+    exception : exceptions.GCloudException
+        Exception that should be raised by the module.
+    test_data_path : str
+        Path where the data folder is.
+    """
+    with pytest.raises(exception):
+        WazuhGCloudBucket(credentials_file=test_data_path + credentials_file,
+                          logger=logger, bucket_name=bucket_name)

--- a/wodles/gcloud/tests/test_bucket.py
+++ b/wodles/gcloud/tests/test_bucket.py
@@ -34,11 +34,11 @@ def test_get_bucket(gcloud_bucket: WazuhGCloudBucket):
 @pytest.mark.parametrize('credentials_file,logger,bucket_name,exception,errcode', [
     ('unexistent_file',
      None,
-     'test_bucket', exceptions.GCloudError, 2),
+     'test_bucket', exceptions.GCloudError, 1001),
     ('invalid_credentials_file.json',
      None,
      'test_bucket',
-     exceptions.GCloudError, 1)
+     exceptions.GCloudError, 1000)
 ])
 def test_bucket_ko(credentials_file: str, logger: Logger,
                    bucket_name: str, exception: exceptions.WazuhIntegrationException,
@@ -66,4 +66,4 @@ def test_bucket_ko(credentials_file: str, logger: Logger,
     with pytest.raises(exception) as e:
         WazuhGCloudBucket(credentials_file=test_data_path + credentials_file,
                           logger=logger, bucket_name=bucket_name)
-        assert e.errcode == errcode
+    assert e.value.errcode == errcode

--- a/wodles/gcloud/tests/test_bucket.py
+++ b/wodles/gcloud/tests/test_bucket.py
@@ -31,19 +31,18 @@ def test_get_bucket(gcloud_bucket: WazuhGCloudBucket):
         assert hasattr(gcloud_bucket, attribute)
 
 
-@pytest.mark.parametrize('credentials_file,logger,bucket_name,exception', [
+@pytest.mark.parametrize('credentials_file,logger,bucket_name,exception,errcode', [
     ('unexistent_file',
      None,
-     'test_bucket',
-     exceptions.GCloudCredentialsNotFoundError),
+     'test_bucket', exceptions.GCloudError, 2),
     ('invalid_credentials_file.json',
      None,
      'test_bucket',
-     exceptions.GCloudCredentialsStructureError)
+     exceptions.GCloudError, 1)
 ])
 def test_bucket_ko(credentials_file: str, logger: Logger,
                    bucket_name: str, exception: exceptions.GCloudException,
-                   test_data_path: str):
+                   test_data_path: str, errcode: int):
     """
     Check that the appropriate exceptions are raised
     when the WazuhGCloudBucket constructor is called with
@@ -61,7 +60,10 @@ def test_bucket_ko(credentials_file: str, logger: Logger,
         Exception that should be raised by the module.
     test_data_path : str
         Path where the data folder is.
+    errcode : int
+        Error code of the exception raised.
     """
-    with pytest.raises(exception):
+    with pytest.raises(exception) as e:
         WazuhGCloudBucket(credentials_file=test_data_path + credentials_file,
                           logger=logger, bucket_name=bucket_name)
+        assert e.errcode == errcode

--- a/wodles/gcloud/tests/test_gcloud.py
+++ b/wodles/gcloud/tests/test_gcloud.py
@@ -21,31 +21,31 @@ import gcloud
     ({'integration_type': 'type', 'credentials_file': None, 'max_messages': 1,
       'log_level': 1, 'prefix': '', 'store_true': False, 'delete_file': False,
       'only_logs_after': None, 'n_threads': 1},
-     exceptions.GCloudError, 3),
+     exceptions.GCloudError, 1002),
 
     ({'integration_type': 'pubsub', 'subscription_id': 'subscription_id',
       'project': 'project', 'credentials_file': None, 'max_messages': 1,
       'log_level': 1, 'prefix': '', 'store_true': False, 'delete_file': False,
       'only_logs_after': None, 'n_threads': 0},
-     exceptions.GCloudError, 202),
+     exceptions.GCloudError, 1202),
 
     ({'integration_type': 'pubsub', 'subscription_id': 'subscription_id',
       'project': 'project', 'credentials_file': None, 'max_messages': 0,
       'log_level': 1, 'prefix': '', 'store_true': False, 'delete_file': False,
       'only_logs_after': None, 'n_threads': 1},
-     exceptions.GCloudError, 203),
+     exceptions.GCloudError, 1203),
 
     ({'integration_type': 'access_logs', 'credentials_file': None,
       'max_messages': 1, 'bucket_name': '', 'log_level': 1,
       'prefix': '', 'store_true': False, 'only_logs_after': None,
       'delete_file': False, 'n_threads': 1},
-     exceptions.GCloudError, 103),
+     exceptions.GCloudError, 1103),
 
     ({'integration_type': 'access_logs', 'credentials_file': None,
       'max_messages': 1, 'bucket_name': 'bucket', 'log_level': 1,
       'prefix': '', 'store_true': False, 'only_logs_after': None,
       'delete_file': False, 'n_threads': 2},
-     exceptions.GCloudError, 102),
+     exceptions.GCloudError, 1102),
 
 ])
 def test_gcloud_ko(parameters, exception, errcode, caplog):
@@ -75,4 +75,4 @@ def test_gcloud_ko(parameters, exception, errcode, caplog):
          pytest.raises(SystemExit):
         gcloud.main()
 
-        assert exception.ERRORS[errcode]['key'] in caplog.text
+    assert exception.ERRORS[errcode]['key'] in caplog.text

--- a/wodles/gcloud/tests/test_gcloud.py
+++ b/wodles/gcloud/tests/test_gcloud.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2015, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute
+# it and/or modify it under the terms of GPLv2
+
+"""Unit tests for gcloud module."""
+
+import sys
+import os
+import pytest
+import runpy
+from unittest.mock import patch
+from argparse import Namespace
+
+sys.path.append(os.path.join(os.path.dirname(
+    os.path.realpath(__file__)), '..'))
+import exceptions
+
+
+@pytest.mark.parametrize('parameters, exception', [
+    ({'integration_type': 'type', 'credentials_file': None, 'max_messages': 1,
+      'log_level': 1, 'prefix': '', 'store_true': False, 'delete_file': False,
+      'only_logs_after': None, 'n_threads': 1},
+     exceptions.GCloudIntegrationTypeError),
+
+    ({'integration_type': 'pubsub', 'subscription_id': 'subscription_id',
+      'project': 'project', 'credentials_file': None, 'max_messages': 1,
+      'log_level': 1, 'prefix': '', 'store_true': False, 'delete_file': False,
+      'only_logs_after': None, 'n_threads': 0},
+     exceptions.GCloudPubSubNumThreadsError),
+
+    ({'integration_type': 'pubsub', 'subscription_id': 'subscription_id',
+      'project': 'project', 'credentials_file': None, 'max_messages': 0,
+      'log_level': 1, 'prefix': '', 'store_true': False, 'delete_file': False,
+      'only_logs_after': None, 'n_threads': 1},
+     exceptions.GCloudPubSubNumMessagesError),
+
+    ({'integration_type': 'pubsub', 'subscription_id': 'subscription_id',
+      'project': 'project', 'credentials_file': None, 'max_messages': 1,
+      'log_level': 1, 'prefix': '', 'store_true': False, 'delete_file': False,
+      'only_logs_after': None, 'n_threads': 1},
+     SystemExit),
+
+    ({'integration_type': 'access_logs', 'credentials_file': None,
+      'max_messages': 1, 'bucket_name': '', 'log_level': 1,
+      'prefix': '', 'store_true': False, 'only_logs_after': None,
+      'delete_file': False, 'n_threads': 1},
+     exceptions.GCloudBucketNameError),
+
+    ({'integration_type': 'access_logs', 'credentials_file': None,
+      'max_messages': 1, 'bucket_name': 'bucket', 'log_level': 1,
+      'prefix': '', 'store_true': False, 'only_logs_after': None,
+      'delete_file': False, 'n_threads': 2},
+     exceptions.GCloudBucketNumThreadsError),
+
+    ({'integration_type': 'access_logs', 'credentials_file': None,
+      'max_messages': 1, 'bucket_name': 'bucket', 'log_level': 1,
+      'prefix': '', 'store_true': False,
+      'only_logs_after': None, 'delete_file': False,
+      'n_threads': 1},
+     SystemExit),
+])
+def test_gcloud_ko(parameters, exception):
+    """
+    Test that the module will abort its execution when called
+    with invalid parameters.
+
+    Parameters
+    ----------
+    parameters : dict
+        Dictionary that simulates the values that could have
+        been introduced by the user.
+    exception : Exception
+        Exception that should be raised by the module.
+    """
+    with pytest.raises(exception), \
+         patch('tools.get_script_arguments',
+               return_value=Namespace(**parameters)), \
+         patch('pubsub.subscriber.pubsub.subscriber.Client.from_service_account_file'), \
+         patch('pubsub.subscriber.WazuhGCloudSubscriber.check_permissions'), \
+         patch('pubsub.subscriber.WazuhGCloudSubscriber.process_messages'), \
+         patch('buckets.bucket.storage.client.Client.from_service_account_json'), \
+         patch('buckets.access_logs.GCSAccessLogs.process_data',
+               return_value=0):
+        runpy.run_module('gcloud.py')

--- a/wodles/gcloud/tests/test_integration.py
+++ b/wodles/gcloud/tests/test_integration.py
@@ -86,4 +86,4 @@ def test_initialize_socket_ko(
     with patch('socket.socket', side_effect=raised_exception),\
          pytest.raises(expected_exception) as e:
         gcloud_subscriber.initialize_socket()
-        assert errcode == e.errcode
+    assert errcode == e.value.errcode

--- a/wodles/gcloud/tests/test_integration.py
+++ b/wodles/gcloud/tests/test_integration.py
@@ -59,12 +59,12 @@ def test_format_msg():
 
 
 @pytest.mark.parametrize('raised_exception, expected_exception, errcode', [
-    (ConnectionRefusedError, exceptions.GCloudInternalError, 800),
-    (OSError, exceptions.GCloudInternalError, 801)
+    (ConnectionRefusedError, exceptions.WazuhIntegrationInternalError, 1),
+    (OSError, exceptions.WazuhIntegrationInternalError, 2)
 ])
 def test_initialize_socket_ko(
         raised_exception: Exception,
-        expected_exception: exceptions.GCloudException,
+        expected_exception: exceptions.WazuhIntegrationException,
         gcloud_subscriber: WazuhGCloudSubscriber,
         errcode: int):
     """
@@ -75,7 +75,7 @@ def test_initialize_socket_ko(
     ----------
     raised_exception : Exception
         Exception raised that will be captured.
-    expected_exception : exceptions.GCloudException
+    expected_exception : exceptions.WazuhIntegrationException
         Exception that should be raised by the module after capturing
         raised_exception.
     gcloud_subscriber : WazuhGCloudSubscriber

--- a/wodles/gcloud/tests/test_integration.py
+++ b/wodles/gcloud/tests/test_integration.py
@@ -16,6 +16,8 @@ from os.path import join, dirname, realpath
 sys.path.append(join(dirname(realpath(__file__)), '..'))  # noqa: E501
 from pubsub.subscriber import WazuhGCloudSubscriber
 from logging import getLogger
+import exceptions
+
 test_data_path = join(dirname(realpath(__file__)), 'data')
 
 credentials_file = 'credentials.json'
@@ -54,3 +56,30 @@ def test_format_msg():
     formatted_message = client.format_msg(test_message)
 
     assert type(formatted_message) is str
+
+
+@pytest.mark.parametrize('raised_exception, expected_exception', [
+    (ConnectionRefusedError, exceptions.GCloudWazuhNotRunning),
+    (OSError, exceptions.GCloudSocketError)
+])
+def test_initialize_socket_ko(
+        raised_exception: Exception,
+        expected_exception: exceptions.GCloudException,
+        gcloud_subscriber: WazuhGCloudSubscriber):
+    """
+    Test that the WazuhGCloudIntegration's initialize_socket properly handles
+    exceptions.
+
+    Parameters
+    ----------
+    raised_exception : Exception
+        Exception raised that will be captured.
+    expected_exception : exceptions.GCloudException
+        Exception that should be raised by the module after capturing
+        raised_exception.
+    gcloud_subscriber : WazuhGCloudSubscriber
+        GCP client.
+    """
+    with patch('socket.socket', side_effect=raised_exception),\
+         pytest.raises(expected_exception):
+        gcloud_subscriber.initialize_socket()

--- a/wodles/gcloud/tests/test_subscriber.py
+++ b/wodles/gcloud/tests/test_subscriber.py
@@ -10,34 +10,59 @@
 
 import os
 import sys
-from unittest.mock import patch
+import pytest
+from logging import Logger
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))  # noqa: E501
 from pubsub.subscriber import WazuhGCloudSubscriber
-
-test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
-
-credentials_file = 'credentials.json'
-logger = None
-project = 'wazuh-dev'
-subscription_id = 'testing'
-test_message = 'test-message'.encode()
+import exceptions
 
 
-@patch('pubsub.subscriber.pubsub.subscriber.Client.from_service_account_file')
-def get_wazuhgcloud_subscriber(mock_client):
-    """Return a WazuhGCloudSubscriber client."""
-    client = WazuhGCloudSubscriber(credentials_file, logger, project, subscription_id)
-    return client
-
-
-def test_get_subscriber():
+def test_get_subscriber(gcloud_subscriber):
     """Check if an instance of WazuhGCloudSubscriber is created properly."""
     expected_attributes = ['logger', 'subscriber', 'subscription_path']
 
-    client = get_wazuhgcloud_subscriber()
-
-    assert isinstance(client, WazuhGCloudSubscriber)
+    assert isinstance(gcloud_subscriber, WazuhGCloudSubscriber)
 
     for attribute in expected_attributes:
-        assert hasattr(client, attribute)
+        assert hasattr(gcloud_subscriber, attribute)
+
+
+@pytest.mark.parametrize(
+    'credentials_file,logger,project,subscription_id, exception', [
+        ('unexistent_file',
+         None, 'test_project', 'test_subscription',
+         exceptions.GCloudCredentialsNotFoundError),
+
+        ('invalid_credentials_file.json',
+         None, 'test_project', 'test_subscription',
+         exceptions.GCloudCredentialsStructureError)
+    ])
+def test_subscription_ko(credentials_file: str, logger: Logger,
+                         project: str, subscription_id: str,
+                         exception: exceptions.GCloudException,
+                         test_data_path: str):
+    """
+    Check that the appropriate exceptions are raised
+    when the WazuhGCloudSubscriber constructor is called with
+    wrong parameters.
+
+    Parameters
+    ----------
+    credentials_file : str
+        File with the GCP credentials.
+    logger : Logger
+        Logger used to capture the output of the module.
+    project : str
+        Name of the project.
+    subscription_id : str
+        ID of the subscription.
+    exception : exceptions.GCloudException
+        Exception that should be raised by the module.
+    test_data_path : str
+        Path where the data folder is.
+    """
+    with pytest.raises(exception):
+        WazuhGCloudSubscriber(
+            credentials_file=test_data_path + credentials_file,
+            logger=logger, project=project, subscription_id=subscription_id)

--- a/wodles/gcloud/tests/test_subscriber.py
+++ b/wodles/gcloud/tests/test_subscriber.py
@@ -41,7 +41,7 @@ def test_get_subscriber(gcloud_subscriber):
     ])
 def test_subscription_ko(credentials_file: str, logger: Logger,
                          project: str, subscription_id: str,
-                         exception: exceptions.GCloudException,
+                         exception: exceptions.WazuhIntegrationException,
                          exception_name: str,
                          test_data_path: str):
     """
@@ -59,7 +59,7 @@ def test_subscription_ko(credentials_file: str, logger: Logger,
         Name of the project.
     subscription_id : str
         ID of the subscription.
-    exception : exceptions.GCloudException
+    exception : exceptions.WazuhIntegrationException
         Exception that should be raised by the module.
     exception_name : str
         Key of the exception in the exceptions.py file.

--- a/wodles/gcloud/tests/test_subscriber.py
+++ b/wodles/gcloud/tests/test_subscriber.py
@@ -29,18 +29,20 @@ def test_get_subscriber(gcloud_subscriber):
 
 
 @pytest.mark.parametrize(
-    'credentials_file,logger,project,subscription_id, exception', [
+    'credentials_file,logger,project,subscription_id, exception, '
+    'exception_name', [
         ('unexistent_file',
          None, 'test_project', 'test_subscription',
-         exceptions.GCloudCredentialsNotFoundError),
+         exceptions.GCloudError, 'GCloudCredentialsNotFoundError'),
 
         ('invalid_credentials_file.json',
          None, 'test_project', 'test_subscription',
-         exceptions.GCloudCredentialsStructureError)
+         exceptions.GCloudError, 'GCloudCredentialsStructureError')
     ])
 def test_subscription_ko(credentials_file: str, logger: Logger,
                          project: str, subscription_id: str,
                          exception: exceptions.GCloudException,
+                         exception_name: str,
                          test_data_path: str):
     """
     Check that the appropriate exceptions are raised
@@ -59,10 +61,13 @@ def test_subscription_ko(credentials_file: str, logger: Logger,
         ID of the subscription.
     exception : exceptions.GCloudException
         Exception that should be raised by the module.
+    exception_name : str
+        Key of the exception in the exceptions.py file.
     test_data_path : str
         Path where the data folder is.
     """
-    with pytest.raises(exception):
+    with pytest.raises(exception) as e:
         WazuhGCloudSubscriber(
             credentials_file=test_data_path + credentials_file,
             logger=logger, project=project, subscription_id=subscription_id)
+    assert e.value.key == exception_name

--- a/wodles/gcloud/tools.py
+++ b/wodles/gcloud/tools.py
@@ -61,7 +61,7 @@ def get_script_arguments():
     parser.add_argument('-l', '--log_level', dest='log_level', type=int,
                         help='Log level', required=False, default=3)
 
-    parser.add_argument('-b', '--bucket_name', dest='bucket_name',
+    parser.add_argument('-b', '--bucket_name', dest='bucket_name', type=str,
                         help='The name of the bucket to read the logs from')
 
     parser.add_argument('-P', '--prefix', dest='prefix', help='The relative path to the logs', default='')
@@ -161,3 +161,16 @@ def arg_valid_date(arg_string: str) -> datetime:
         return datetime.strptime(arg_string, "%Y-%b-%d").replace(tzinfo=UTC)
     except ValueError:
         raise argparse.ArgumentTypeError(f"Argument not a valid date in format YYYY-MMM-DD: '{arg_string}'.")
+
+
+def import_error(package: str):
+    """
+    Function to use when a required package could not be found.
+
+    Parameters
+    ----------
+    package : str
+        Package that could not be imported.
+    """
+    get_stdout_logger(logger_name).error(f"The '{package}' module is required")
+    exit(1)

--- a/wodles/gcloud/tools.py
+++ b/wodles/gcloud/tools.py
@@ -161,16 +161,3 @@ def arg_valid_date(arg_string: str) -> datetime:
         return datetime.strptime(arg_string, "%Y-%b-%d").replace(tzinfo=UTC)
     except ValueError:
         raise argparse.ArgumentTypeError(f"Argument not a valid date in format YYYY-MMM-DD: '{arg_string}'.")
-
-
-def import_error(package: str):
-    """
-    Function to use when a required package could not be found.
-
-    Parameters
-    ----------
-    package : str
-        Package that could not be imported.
-    """
-    get_stdout_logger(logger_name).error(f"The '{package}' module is required")
-    exit(1)

--- a/wodles/gcloud/tools.py
+++ b/wodles/gcloud/tools.py
@@ -28,6 +28,7 @@ log_levels = {0: logging.NOTSET,
 logging_format = logging.Formatter('%(name)s - %(levelname)s - %(message)s')
 min_num_threads = 1
 min_num_messages = 1
+valid_types = ['pubsub', 'access_logs']
 
 
 def get_script_arguments():
@@ -43,7 +44,7 @@ def get_script_arguments():
                                      formatter_class=argparse.RawTextHelpFormatter)
 
     parser.add_argument('-T', '--integration_type', dest='integration_type',
-                        help='Supported integration types: pubsub, access_logs', required=True)
+                        help=f'Supported integration types: {*valid_types,}', required=True)
 
     parser.add_argument('-p', '--project', dest='project',
                         help='Project ID')


### PR DESCRIPTION
|Related issue|
|---|
|Closes #12140|

## Description
In this PR we rework the way the GCP module handles errors and exceptions. We add the `wodles/gcloud/exceptions.py` file, which enclose the information about all the errors the module might raise. All the exceptions are now being explicitely captured by the logger that is configured to set a different logging level depending on the severity of the error. Exceptions that are unhandled will be registered with the full exception trace to help debugging them. 

Along with this error handling system, we start handling errors that could be raised when specifying invalid credentials, bucket names and subscription and project names to make it easier for the user to use the module.

Because of the tests, we found out that the Access Logs integrations could be executed specifying '' as the bucket name, which made the module perform an incorrect API call to the GCP platform. We fixed that problem for this issue too by ensuring that the bucket name is of str type and that it evaluates to True, which means is not an empty string.

## Tests performed
All the tests passed without any further problems.

### Unit tests
We added unit tests to check that the changes that doesn't depend on the GCP API work as expected. All of them passed.

```
(wazuh-unit) ➜  gcloud git:(feature/12140-improve-gcp-error-handling) ✗ pytest
==================================== test session starts ====================================
platform linux -- Python 3.10.2, pytest-6.2.5, py-1.11.0, pluggy-0.13.1
rootdir: /home/gonzz/git/wazuh/wodles/gcloud
plugins: asyncio-0.15.1
collected 17 items                                                                          

tests/test_access_logs.py .                                                           [  5%]
tests/test_bucket.py ...                                                              [ 23%]
tests/test_gcloud.py .....                                                            [ 52%]
tests/test_integration.py .....                                                       [ 82%]
tests/test_subscriber.py ...                                                          [100%]

===================================== warnings summary ======================================
../../../../venv/wazuh-unit/lib/python3.10/site-packages/google/pubsub_v1/services/publisher/client.py:17
  /home/gonzz/venv/wazuh-unit/lib/python3.10/site-packages/google/pubsub_v1/services/publisher/client.py:17: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
    from distutils import util

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=============================== 17 passed, 1 warning in 0.04s ===============================
```

### Test Access Logs

<details><summary>Tests output</summary>

```
root@97cff1b2dfb7:/# /var/ossec/wodles/gcloud/gcloud -b framework-test-bucket  -c /var/ossec/wodles/gcloud/credentials.json -l 1 -o 2021-jan-01 -T access_logs
gcloud_wodle - INFO - Processing test_1_new.txt
gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 1", "source": "gcp_bucket"}}'"
gcloud_wodle - INFO - Processing test_22.txt
gcloud_wodle - INFO - Processing test_2_new.txt
gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 2", "source": "gcp_bucket"}}'"
gcloud_wodle - INFO - Processing test_3.txt
gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 3", "source": "gcp_bucket"}}'"
gcloud_wodle - INFO - Processing test_3_new.txt
gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 3", "source": "gcp_bucket"}}'"
gcloud_wodle - INFO - Processing test_4.txt
gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 4", "source": "gcp_bucket"}}'"
gcloud_wodle - INFO - Processing test_5.txt
gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 5", "source": "gcp_bucket"}}'"
gcloud_wodle - INFO - Processing test_6.txt
gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 6", "source": "gcp_bucket"}}'"
gcloud_wodle - INFO - Updating previously processed files.
gcloud_wodle - INFO - Received 7 messages
root@d3599e41fbc1:/# /var/ossec/wodles/gcloud/gcloud -b framework-test-bucket  -c /var/ossec/wodles/gcloud/credentials.json -l 1 -o 2021-jan-01 -T access_log 
gcloud_wodle - ERROR - An exception happened while running the wodle: Unsupported gcloud integration type: "access_log". The supported types are ('pubsub', 'access_logs')
Traceback (most recent call last):
  File "/var/ossec/wodles/gcloud/gcloud.py", line 89, in <module>
    raise exceptions.GCloudIntegrationTypeError(arguments.integration_type)
exceptions.GCloudIntegrationTypeError: Unsupported gcloud integration type: "access_log". The supported types are ('pubsub', 'access_logs')
root@d3599e41fbc1:/# /var/ossec/wodles/gcloud/gcloud -b framework-test-bucket  -c /var/ossec/wodles/gcloud/credentials.json -l 2 -o 2021-jan-01 -T access_log
gcloud_wodle - ERROR - An exception happened while running the wodle: Unsupported gcloud integration type: "access_log". The supported types are ('pubsub', 'access_logs')
root@d3599e41fbc1:/# /var/ossec/wodles/gcloud/gcloud -b framework-test-bucket  -c /var/ossec/wodles/gcloud/credentials.json -l 2 -o 2021-9jan-01 -T access_logs
usage: usage: gcloud.py [options]
gcloud.py: error: argument -o/--only_logs_after: Argument not a valid date in format YYYY-MMM-DD: '2021-9jan-01'.
root@d3599e41fbc1:/# /var/ossec/wodles/gcloud/gcloud -b framework-test-bucketo  -c /var/ossec/wodles/gcloud/credentials.json -l 2 -o 2021-jan-01 -T access_logs
gcloud_wodle - ERROR - An exception happened while running the wodle: The bucket 'framework-test-bucketo' does not exist
```

</details>



### Test Pub/Sub
<details><summary>Test output</summary>

```
root@97cff1b2dfb7:/# /var/ossec/wodles/gcloud/gcloud -T pubsub -l 1 -s test_gcloud_blog -p wazuh-dev-123456 -c /var/ossec/wodles/gcloud/credentials.json  
gcloud_wodle - DEBUG - Setting 1 thread to pull 100 messages in total
gcloud_wodle - INFO - Received and acknowledged 0 messages
root@d3599e41fbc1:/# /var/ossec/wodles/gcloud/gcloud -T pubsub -l 2 -s wazuh-audit-log -p wazuh-dev-123456 -c /var/ossec/wodles/gcloud/credentials.json -m 10
gcloud_wodle - ERROR - An exception happened while running the wodle: The 'wazuh-audit-log' project ID is incorrect or the user does not have permissions to access to it
root@d3599e41fbc1:/# /var/ossec/wodles/gcloud/gcloud -T pubsub -l 2 -s wazuh-audit-logs -p wazuh-dev-123456 -c /var/ossec/wodles/gcloud/credentials.json -m 10
gcloud_wodle - INFO - Received and acknowledged 10 messages
root@d3599e41fbc1:/# /var/ossec/wodles/gcloud/gcloud -T pubsub -l 2 -s wazuh-audit-logs -p wazuh-dev-123456 -c /var/ossec/wodles/gcloud/credentials.json -m 10 -t 99999
gcloud_wodle - WARNING - Reached maximum number of threads. Truncating to 80.
gcloud_wodle - INFO - Received and acknowledged 10 messages
root@d3599e41fbc1:/# /var/ossec/wodles/gcloud/gcloud -T pubsub -l 2 -s wazuh-audit-logs -p wazuh-dev-123456 -c /var/ossec/wodles/gcloud/credentials.json -m 10 -t -99999
gcloud_wodle - ERROR - An exception happened while running the wodle: The minimum number of threads is 1. Please check your configuration.
root@d3599e41fbc1:/# /var/ossec/wodles/gcloud/gcloud -T pubsub -l 2 -s wazuh-audit-logs -p wazuh-dev-1234568 -c /var/ossec/wodles/gcloud/credentials.json -m 10     
gcloud_wodle - ERROR - An exception happened while running the wodle: The 'wazuh-dev-1234568' subscription is incorrect or the user credentials are not valid
root@d3599e41fbc1:/# /var/ossec/wodles/gcloud/gcloud -T pubsub -l 1 -s wazuh-audit-logs -p wazuh-dev-1234568 -c /var/ossec/wodles/gcloud/credentials.json -m 10 
gcloud_wodle - DEBUG - Setting 1 thread to pull 10 messages in total
gcloud_wodle - ERROR - An exception happened while running the wodle: The 'wazuh-dev-1234568' subscription is incorrect or the user credentials are not valid
Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.9/site-packages/google/api_core/grpc_helpers.py", line 67, in error_remapped_callable
    return callable_(*args, **kwargs)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/grpc/_channel.py", line 946, in __call__
    return _end_unary_response_blocking(state, call, False, None)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/grpc/_channel.py", line 849, in _end_unary_response_blocking
    raise _InactiveRpcError(state)
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.NOT_FOUND
	details = "Requested project not found or user does not have access to it (project=wazuh-dev-1234568). Make sure to specify the unique project identifier and not the Google Cloud Console display name."
	debug_error_string = "{"created":"@1646826490.039509764","description":"Error received from peer ipv4:142.250.184.10:443","file":"src/core/lib/surface/call.cc","file_line":1067,"grpc_message":"Requested project not found or user does not have access to it (project=wazuh-dev-1234568). Make sure to specify the unique project identifier and not the Google Cloud Console display name.","grpc_status":5}"
>

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/var/ossec/wodles/gcloud/pubsub/subscriber.py", line 91, in check_permissions
    response = self.subscriber.test_iam_permissions(
  File "/var/ossec/framework/python/lib/python3.9/site-packages/google/cloud/pubsub_v1/_gapic.py", line 40, in <lambda>
    fx = lambda self, *a, **kw: wrapped_fx(self.api, *a, **kw)  # noqa
  File "/var/ossec/framework/python/lib/python3.9/site-packages/google/pubsub_v1/services/subscriber/client.py", line 2029, in test_iam_permissions
    response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/google/api_core/gapic_v1/method.py", line 145, in __call__
    return wrapped_func(*args, **kwargs)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/google/api_core/grpc_helpers.py", line 69, in error_remapped_callable
    six.raise_from(exceptions.from_grpc_error(exc), exc)
  File "<string>", line 3, in raise_from
google.api_core.exceptions.NotFound: 404 Requested project not found or user does not have access to it (project=wazuh-dev-1234568). Make sure to specify the unique project identifier and not the Google Cloud Console display name.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/ossec/wodles/gcloud/gcloud.py", line 62, in <module>
    subscriber_client.check_permissions()
  File "/var/ossec/wodles/gcloud/pubsub/subscriber.py", line 97, in check_permissions
    raise exceptions.GCloudPubSubSubscriptionError(
exceptions.GCloudPubSubSubscriptionError: The 'wazuh-dev-1234568' subscription is incorrect or the user credentials are not valid
```

</details>
