### PR TITLE
Change `Agent-groups get` tag to `Local agent-group`

### DIFF
--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -1126,7 +1126,7 @@ class Master(server.AbstractServer):
         This information will only be sent to the worker nodes when it contains data.
         It looks like this: ['[{"data":[{"id":1,"group":["default","group1"]}]}]'].
         """
-        logger = self.setup_task_logger('Agent-groups get')
+        logger = self.setup_task_logger('Local agent-groups')
         wdb_conn = WazuhDBConnection()
         sync_object = c_common.SyncWazuhdb(manager=self, logger=logger, cmd=b'syn_g_m_w',
                                            data_retriever=wdb_conn.run_wdb_command,

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -1864,7 +1864,7 @@ async def test_agent_groups_update(sleep_mock):
                 assert "Finished in 0.000s." in logger_mock._info
                 assert "Error getting agent-groups from WDB: Stop while true" in logger_mock._error
                 assert master_class.agent_groups_control_workers == set()
-                setup_task_logger_mock.assert_called_once_with('Agent-groups get')
+                setup_task_logger_mock.assert_called_once_with('Local agent-groups')
 
                 with pytest.raises(Exception, match='Stop while true'):
                     logger_mock.counter = 0


### PR DESCRIPTION
|Related issue|
|---|
|#12639|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR closes #12639. In this PR we have changed the name of the task in charge of getting the agent-groups that need synchronization.

In this case, we have renamed `Agent-groups get` to `Local agent-groups` to be more consistent with the existing `Local integrity` task.