### PR TITLE
Fix AWS integration's unit test

### DIFF
--- a/wodles/aws/tests/conftest.py
+++ b/wodles/aws/tests/conftest.py
@@ -77,3 +77,20 @@ def aws_waf_bucket(request):
          patch('sqlite3.connect'), \
          patch('utils.get_wazuh_version'):
         return aws_s3.AWSWAFBucket(**{k: v for i in request.param for k, v in i.items()})
+
+
+@pytest.fixture(params=deepcopy(AWS_BUCKET_PARAMS))
+def aws_config_bucket(request):
+    """
+    Return a AWSConfigBucket instance.
+
+    Parameters
+    ----------
+    request : pytest.fixtures.SubRequest
+        Object that contains information about the current test.
+    """
+    with patch('aws_s3.AWSConfigBucket.get_client'), \
+         patch('aws_s3.AWSConfigBucket.get_sts_client'), \
+         patch('sqlite3.connect'), \
+         patch('utils.get_wazuh_version'):
+        return aws_s3.AWSConfigBucket(**{k: v for i in request.param for k, v in i.items()})

--- a/wodles/aws/tests/test_aws.py
+++ b/wodles/aws/tests/test_aws.py
@@ -302,13 +302,13 @@ def test_aws_waf_load_information_from_file_ko(
 
 
 @pytest.mark.parametrize('date, expected_date', [
-    ('2021/1/19','20210119'),
+    ('2021/1/19', '20210119'),
     ('2021/1/1', '20210101'),
     ('2021/01/01', '20210101'),
     ('2000/2/12', '20000212'),
     ('2022/02/1', '20220201')
 ])
-def test_config_format_created_date(date: str, expected_date: str):
+def test_config_format_created_date(date: str, expected_date: str, aws_config_bucket):
     """
     Test AWSConfigBucket's format_created_date method.
 
@@ -318,15 +318,7 @@ def test_config_format_created_date(date: str, expected_date: str):
         The date introduced.
     expected_date : str
         The date that the method should return.
+    aws_config_bucket : aws_s3.AWSConfigBucket
+        Instance of the AWSConfigBucket class.
     """
-    with patch('aws_s3.AWSConfigBucket.get_client'), \
-        patch('aws_s3.AWSConfigBucket.get_sts_client'), \
-        patch('sqlite3.connect'):
-        bucket = aws_s3.AWSConfigBucket(**{'reparse': False, 'access_key': None, 'secret_key': None,
-                        'profile': None, 'iam_role_arn': None, 'bucket': 'test',
-                        'only_logs_after': '19700101', 'skip_on_error': True,
-                        'account_alias': None, 'prefix': 'test',
-                        'delete_file': False, 'aws_organization_id': None,
-                        'region': None, 'suffix': '', 'discard_field': None,
-                        'discard_regex': None, 'sts_endpoint': None, 'service_endpoint': None})
-    assert bucket._format_created_date(date) == expected_date
+    assert aws_config_bucket._format_created_date(date) == expected_date


### PR DESCRIPTION
|Related issue|
|---|
|Closes #12637 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
In this PR we fix the `test_config_format_created_date` test, which was failing in the master branch due to a call to `wazuh-control` that was not mocked. In `4.3` the test passed because the exception was not being handled, but we changed that for #10155.

To fix the test we declared a fixture that returns the required object with all the calls to external resources mocked.
<!--
Add a clear description of how the problem has been solved.
-->

## Tests
All the unit tests pass without any further problems.
```
(wazuh-unit) ➜  wazuh git:(fix/12637-aws-config-test) ✗ pytest wodles
==================================== test session starts ====================================
platform linux -- Python 3.10.2, pytest-6.2.5, py-1.11.0, pluggy-0.13.1
rootdir: /home/gonzz/git/wazuh
plugins: asyncio-0.15.1
collected 32 items                                                                          

wodles/aws/tests/test_aws.py ..........................                               [ 81%]
wodles/gcloud/tests/test_access_logs.py .                                             [ 84%]
wodles/gcloud/tests/test_bucket.py .                                                  [ 87%]
wodles/gcloud/tests/test_integration.py ...                                           [ 96%]
wodles/gcloud/tests/test_subscriber.py .                                              [100%]

===================================== warnings summary ======================================
../../venv/wazuh-unit/lib/python3.10/site-packages/google/pubsub_v1/services/publisher/client.py:17
  /home/gonzz/venv/wazuh-unit/lib/python3.10/site-packages/google/pubsub_v1/services/publisher/client.py:17: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
    from distutils import util

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=============================== 32 passed, 1 warning in 0.49s ===============================
```