### PR TITLE
Prevent Analysisd from failing on missing rule dependencies - Backport to 4.3

### DIFF
--- a/src/analysisd/lists_list.c
+++ b/src/analysisd/lists_list.c
@@ -89,11 +89,16 @@ ListRule *OS_AddListRule(ListRule *first_rule_list, int lookup_type, int field,
     new_rulelist_pt->filename = strdup(listname);
     new_rulelist_pt->dfield = field == RULE_DYNAMIC ? strdup(dfield) : NULL;
     new_rulelist_pt->mutex = (pthread_mutex_t) PTHREAD_MUTEX_INITIALIZER;
+
     if ((new_rulelist_pt->db = OS_FindList(listname, l_node)) == NULL) {
-        new_rulelist_pt->loaded = 0;
-    } else {
-        new_rulelist_pt->loaded = 1;
+        os_free(new_rulelist_pt->filename);
+        os_free(new_rulelist_pt->dfield);
+        os_free(new_rulelist_pt);
+        return NULL;
     }
+    
+    new_rulelist_pt->loaded = 1;
+
     if (first_rule_list == NULL) {
         mdebug1("Adding First rulelist item: filename: %s field: %d lookup_type: %d",
                new_rulelist_pt->filename,

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -24,8 +24,6 @@
 #endif
 
 /* Global definition */
-// TODO removeme
-//RuleInfo *currently_rule;
 int default_timeframe;
 
 /* Used for statistics */
@@ -3201,6 +3199,10 @@ w_exp_type_t w_check_attr_type(xml_node * node, w_exp_type_t default_type, int r
 }
 
 STATIC INLINE void w_free_rules_tmp_params(rules_tmp_params_t * rule_tmp_params) {
+
+    if (rule_tmp_params == NULL) {
+        return;
+    }
 
     os_free(rule_tmp_params->regex);
     os_free(rule_tmp_params->match);

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -328,6 +328,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
         /* Get all rules for a global group */
         rule = OS_GetElementsbyNode(&xml, node[i]);
         if (rule == NULL) {
+            // TODO: Skip rule?
             smerror(log_msg, "Group '%s' without any rule.", node[i]->element);
             goto cleanup;
         }
@@ -629,7 +630,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
                         }
 
-                    } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element,xml_srcgeoip) == 0) {
+                    } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_srcgeoip) == 0) {
 
                         rule_tmp_params.srcgeoip = loadmemory(rule_tmp_params.srcgeoip, rule_tmp_params.rule_arr_opt[k]->content, log_msg);
                         negate_srcgeoip = w_check_attr_negate(rule_tmp_params.rule_arr_opt[k], config_ruleinfo->sigid, log_msg);
@@ -640,7 +641,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
                         }
 
-                    } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element,xml_dstgeoip) == 0) {
+                    } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_dstgeoip) == 0) {
 
                         rule_tmp_params.dstgeoip = loadmemory(rule_tmp_params.dstgeoip, rule_tmp_params.rule_arr_opt[k]->content, log_msg);
                         negate_dstgeoip = w_check_attr_negate(rule_tmp_params.rule_arr_opt[k], config_ruleinfo->sigid, log_msg);
@@ -735,14 +736,14 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         negate_action = w_check_attr_negate(rule_tmp_params.rule_arr_opt[k], config_ruleinfo->sigid, log_msg);
                         action_type = w_check_attr_type(rule_tmp_params.rule_arr_opt[k], EXP_TYPE_STRING, config_ruleinfo->sigid, log_msg);
 
-                    } else if(strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_system_name) == 0){
+                    } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_system_name) == 0){
 
                         rule_tmp_params.system_name = loadmemory(rule_tmp_params.system_name, rule_tmp_params.rule_arr_opt[k]->content, log_msg);
                         negate_system_name = w_check_attr_negate(rule_tmp_params.rule_arr_opt[k], config_ruleinfo->sigid, log_msg);
                         system_name_type = w_check_attr_type(rule_tmp_params.rule_arr_opt[k], EXP_TYPE_OSMATCH,
                                                              config_ruleinfo->sigid, log_msg);
 
-                    } else if(strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_protocol) == 0){
+                    } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_protocol) == 0){
 
                         rule_tmp_params.protocol = loadmemory(rule_tmp_params.protocol, rule_tmp_params.rule_arr_opt[k]->content, log_msg);
                         negate_protocol = w_check_attr_negate(rule_tmp_params.rule_arr_opt[k], config_ruleinfo->sigid, log_msg);
@@ -931,6 +932,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         } else if (strcmp(rule_tmp_params.rule_arr_opt[k]->content, "ossec") == 0) {
                             config_ruleinfo->category = OSSEC_RL;
                         } else {
+                            // TODO: Skip Rule?
                             merror(INVALID_CAT, rule_tmp_params.rule_arr_opt[k]->content);
                             goto cleanup;
                         }
@@ -938,7 +940,8 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                     } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_if_sid) == 0) {
                         config_ruleinfo->if_sid =
                             loadmemory(config_ruleinfo->if_sid,
-                                       rule_tmp_params.rule_arr_opt[k]->content, log_msg);
+                                       rule_tmp_params.rule_arr_opt[k]->content,
+                                       log_msg);
 
                     } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_if_level) == 0) {
                         if (!OS_StrIsNum(rule_tmp_params.rule_arr_opt[k]->content)) {
@@ -953,7 +956,8 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                     } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_if_group) == 0) {
                         config_ruleinfo->if_group =
                             loadmemory(config_ruleinfo->if_group,
-                                       rule_tmp_params.rule_arr_opt[k]->content, log_msg);
+                                       rule_tmp_params.rule_arr_opt[k]->content,
+                                       log_msg);
 
                     } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_if_matched_regex) == 0) {
                         config_ruleinfo->context = 1;
@@ -965,18 +969,18 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         config_ruleinfo->context = 1;
                         rule_tmp_params.if_matched_group =
                             loadmemory(rule_tmp_params.if_matched_group,
-                                       rule_tmp_params.rule_arr_opt[k]->content, log_msg);
+                                       rule_tmp_params.rule_arr_opt[k]->content,
+                                       log_msg);
 
 
-                    } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element,
-                                          xml_if_matched_sid) == 0) {
+                    } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_if_matched_sid) == 0) {
                         config_ruleinfo->context = 1;
                         if (!OS_StrIsNum(rule_tmp_params.rule_arr_opt[k]->content)) {
+                            // TODO: Skip rule?
                             smerror(log_msg, INVALID_CONFIG, "if_matched_sid", rule_tmp_params.rule_arr_opt[k]->content);
                             goto cleanup;
                         }
-                        config_ruleinfo->if_matched_sid =
-                            atoi(rule_tmp_params.rule_arr_opt[k]->content);
+                        config_ruleinfo->if_matched_sid = atoi(rule_tmp_params.rule_arr_opt[k]->content);
 
                     } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_same_source_ip) == 0 ||
                                strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_same_srcip) == 0) {
@@ -1107,9 +1111,10 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
                         }
 
-                    } else if (strcmp(rule_tmp_params.rule_arr_opt[k]->element, xml_different_srcip) == 0 ||
+                    } else if (strcmp(rule_tmp_params.rule_arr_opt[k]->element, 
+                                    xml_different_srcip) == 0 ||
                                strcmp(rule_tmp_params.rule_arr_opt[k]->element,
-                                      xml_notsame_source_ip) == 0) {
+                                    xml_notsame_source_ip) == 0) {
                         config_ruleinfo->different_field |= FIELD_SRCIP;
 
                         if(!(config_ruleinfo->alert_opts & SAME_EXTRAINFO)) {
@@ -1577,8 +1582,10 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         }
                         OS_ClearNode(mitre_opt);
                     } else {
-                        smerror(log_msg, "Invalid option '%s' for rule '%d'.", rule_tmp_params.rule_arr_opt[k]->element,
-                               config_ruleinfo->sigid);
+                        // TODO: Skip Rule?
+                        smerror(log_msg, "Invalid option '%s' for rule '%d'.",
+                                rule_tmp_params.rule_arr_opt[k]->element,
+                                config_ruleinfo->sigid);
                         goto cleanup;
                     }
                 }
@@ -1594,10 +1601,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                     && (config_ruleinfo->alert_opts & DO_OVERWRITE)) {
                     smwarn(log_msg, ANALYSISD_INV_OVERWRITE, config_ruleinfo->sigid);
                     goto cleanup;
-                    // w_free_rules_tmp_params(rule_tmp_params);
-                    // os_remove_ruleinfo(config_ruleinfo);
-                    // j++; // Next rule
-                    // continue;
                 }
 
                 /* Check for valid use of frequency */
@@ -1906,7 +1909,10 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 }
             } else {
                 if (OS_AddChild(config_ruleinfo, r_node, log_msg) == -1) {
-                    goto cleanup;
+                    // Skip rule's logic, without having to abort analysisd execution
+                    os_remove_ruleinfo(config_ruleinfo);
+                    config_ruleinfo = NULL;
+                    continue;
                 }
             }
 

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -49,13 +49,10 @@ EventList *os_analysisd_last_events;
 
 /* Prototypes */
 // TODO Docu
-STATIC int getattributes(char **attributes,
-                  char **values,
-                  int *id, int *level,
-                  int *maxsize, int *timeframe,
-                  int *frequency, int *accuracy,
-                  int *noalert, int *ignore_time, int *overwrite,
-                  OSList* log_msg);
+STATIC int getattributes(char **attributes, char **values, int *id, int *level,
+                         int *maxsize, int *timeframe, int *frequency,
+                         int *accuracy, int *noalert, int *ignore_time,
+                         int *overwrite, OSList* log_msg);
 STATIC int doesRuleExist(int sid, RuleNode *r_node);
 STATIC void Rule_AddAR(RuleInfo *config_rule);
 STATIC char *loadmemory(char *at, const char *str, OSList* log_msg);
@@ -338,6 +335,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
             /* Check if the rule element is correct */
             if (!rule[j]->element) {
+                smerror(log_msg, INVALID_RULE_ELEMENT);
                 goto cleanup;
             }
 
@@ -389,9 +387,9 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 }
 
                 /* Allocate memory and initialize structure */
-                config_ruleinfo = zerorulemember(id, level, maxsize,
-                                                 frequency, timeframe,
-                                                 noalert, ignore_time, overwrite, last_event_list);
+                config_ruleinfo = zerorulemember(id, level, maxsize, frequency,
+                                                 timeframe, noalert, ignore_time,
+                                                 overwrite, last_event_list);
 
                 /* If rule is 0, set it to level 99 to have high priority.
                  * Set it to 0 again later.
@@ -480,6 +478,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
                 rule_tmp_params.rule_arr_opt =  OS_GetElementsbyNode(&xml, rule[j]);
                 if (rule_tmp_params.rule_arr_opt == NULL) {
+                    // TODO: Skip rule?
                     smerror(log_msg, "Rule '%d' without any option. It may lead to false positives and some "
                            "other problems for the system. Exiting.", config_ruleinfo->sigid);
                     goto cleanup;
@@ -506,6 +505,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
                         config_ruleinfo->decoded_as = getDecoderfromlist(rule_tmp_params.rule_arr_opt[k]->content, decoder_list);
                         if (config_ruleinfo->decoded_as == 0) {
+                            // TODO: Skip rule?
                             smerror(log_msg, "Invalid decoder name: '%s'.", rule_tmp_params.rule_arr_opt[k]->content);
                             goto cleanup;
                         }
@@ -581,8 +581,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
                     } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_comment) == 0) {
 
-                        char *newline;
-                        newline = strchr(rule_tmp_params.rule_arr_opt[k]->content, '\n');
+                        char * newline = strchr(rule_tmp_params.rule_arr_opt[k]->content, '\n');
                         if (newline) {
                             *newline = ' ';
                         }
@@ -1651,8 +1650,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_regex, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.regex);
                 }
 
                 /* Add in match */
@@ -1664,8 +1661,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_match, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.match);
                 }
 
                 /* Add in id */
@@ -1677,8 +1672,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_id, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.id);
                 }
 
                 /* Add srcport */
@@ -1690,8 +1683,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_srcport, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.srcport);
                 }
 
                 /* Add dstport */
@@ -1704,8 +1695,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         goto cleanup;
                     }
 
-                    os_free(rule_tmp_params.dstport);
-
                 }
 
                 /* Add in status */
@@ -1717,8 +1706,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_status, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.status);
                 }
 
                 /* Add in hostname */
@@ -1730,8 +1717,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_hostname, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.hostname);
                 }
 
                 /* Add data */
@@ -1743,8 +1728,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_data, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.data);
                 }
 
                 /* Add extra data */
@@ -1756,8 +1739,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_extra_data, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.extra_data);
                 }
 
                 /* Add in program name */
@@ -1769,8 +1750,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_program_name, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.program_name);
                 }
 
                 /* Add in user */
@@ -1782,8 +1761,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_user, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.user);
                 }
 
                 /* Adding in srcgeoip */
@@ -1795,8 +1772,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_srcgeoip, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.srcgeoip);
                 }
 
                 /* Adding in dstgeoip */
@@ -1808,8 +1783,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_dstgeoip, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.dstgeoip);
                 }
 
                 /* Add in URL */
@@ -1821,8 +1794,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_url, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.url);
                 }
 
                 /* Add location */
@@ -1834,8 +1805,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_location, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.location);
                 }
 
                 /* Add location */
@@ -1847,8 +1816,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_action, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.action);
                 }
 
                 /* Add matched_group */
@@ -1858,8 +1825,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, REGEX_COMPILE, rule_tmp_params.if_matched_group, config_ruleinfo->if_matched_group->error);
                         goto cleanup;
                     }
-                    os_free(rule_tmp_params.if_matched_group);
-                    rule_tmp_params.if_matched_group = NULL;
                 }
 
                 /* Add matched_regex */
@@ -1869,8 +1834,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, REGEX_COMPILE, rule_tmp_params.if_matched_regex, config_ruleinfo->if_matched_regex->error);
                         goto cleanup;
                     }
-                    os_free(rule_tmp_params.if_matched_regex);
-                    rule_tmp_params.if_matched_regex = NULL;
                 }
 
                 /* Add protocol */
@@ -1882,8 +1845,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, rule_tmp_params.protocol, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.protocol);
                 }
 
                 /* Add system_name */
@@ -1895,8 +1856,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_system_name, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.system_name);
                 }
 
                 w_free_rules_tmp_params(&rule_tmp_params);
@@ -1917,14 +1876,19 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
             if (config_ruleinfo->sigid < 10) {
                 OS_AddRule(config_ruleinfo, r_node);
             } else if (config_ruleinfo->alert_opts & DO_OVERWRITE) {
+
                 if (!OS_AddRuleInfo(*r_node, config_ruleinfo, config_ruleinfo->sigid)) {
-                    /* TODO: It should never reach this point, but if it happens,
-                            should the rule be skiped? Add it anyway as on the
-                            following else? */
-                    smerror(log_msg, "Overwrite rule '%d' not found.", config_ruleinfo->sigid);
-                    goto cleanup;
+
+                    // If there is no rule to overwrite, then the rule is added as any other rule
+                    if (OS_AddChild(config_ruleinfo, r_node, log_msg) == -1) {
+                        // Skip rule, without having to abort analysisd execution
+                        os_remove_ruleinfo(config_ruleinfo);
+                        config_ruleinfo = NULL;
+                        continue;
+                    }
                 }
             } else {
+
                 if (OS_AddChild(config_ruleinfo, r_node, log_msg) == -1) {
                     // Skip rule, without having to abort analysisd execution
                     os_remove_ruleinfo(config_ruleinfo);
@@ -2230,12 +2194,10 @@ int get_info_attributes(char **attributes, char **values, OSList* log_msg)
 }
 
 /* Get the attributes */
-STATIC int getattributes(char **attributes, char **values,
-                  int *id, int *level,
-                  int *maxsize, int *timeframe,
-                  int *frequency, int *accuracy,
-                  int *noalert, int *ignore_time, int *overwrite,
-                  OSList* log_msg)
+STATIC int getattributes(char **attributes, char **values, int *id, int *level,
+                         int *maxsize, int *timeframe, int *frequency,
+                         int *accuracy, int *noalert, int *ignore_time,
+                         int *overwrite, OSList* log_msg)
 {
     int k = 0;
 

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -222,13 +222,38 @@ typedef struct _RuleInfo {
     bool internal_saving;      ///< Used to free RuleInfo structure in wazuh-logtest
 } RuleInfo;
 
+typedef struct _rules_tmp_params_t {
+
+    char * regex;
+    char * match;
+    char * url;
+    char * if_matched_regex;
+    char * if_matched_group;
+    char * user;
+    char * id;
+    char * srcport;
+    char * dstport;
+    char * srcgeoip;
+    char * dstgeoip;
+    char * protocol;
+    char * system_name;
+    char * status;
+    char * hostname;
+    char * data;
+    char * extra_data;
+    char * program_name;
+    char * location;
+    char * action;
+
+    XML_NODE rule_arr_opt;
+
+} rules_tmp_params_t;
 
 typedef struct _RuleNode {
     RuleInfo *ruleinfo;
     struct _RuleNode *next;
     struct _RuleNode *child;
 } RuleNode;
-
 
 /**
  * @brief Structure to save all rules read in starting.

--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -124,6 +124,7 @@ STATIC int _AddtoRule(int sid, int level, int none, const char *group,
 int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, OSList* log_msg)
 {
     if (!read_rule) {
+        // TODO: shouldn't it return -1? Leak?
         smerror(log_msg, "rules_list: Passing a NULL rule. Inconsistent state");
         return (1);
     }
@@ -131,46 +132,51 @@ int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, OSList* log_msg)
     /* Adding for if_sid */
     if (read_rule->if_sid) {
         int val = 0;
-        const char *sid;
-
-        sid  = read_rule->if_sid;
+        const char * sid_ptr = read_rule->if_sid;
 
         /* Loop to read all the rules (comma or space separated) */
         do {
-            int rule_id = 0;
-            if ((*sid == ',') || (*sid == ' ')) {
+            if ((*sid_ptr == ',') || (*sid_ptr == ' ')) {
                 val = 0;
                 continue;
-            } else if ((isdigit((int)*sid)) || (*sid == '\0')) {
+            } else if ((isdigit((int)*sid_ptr)) || (*sid_ptr == '\0')) {
                 if (val == 0) {
-                    rule_id = atoi(sid);
-                    if (!_AddtoRule(rule_id, 0, 0, NULL, *r_node, read_rule)) {
-                        smerror(log_msg, "rules_list: Signature ID '%d' not found. Invalid 'if_sid'.", rule_id);
+                    int if_sid_rule_id = atoi(sid_ptr);
+                    if (!_AddtoRule(if_sid_rule_id, 0, 0, NULL, *r_node, read_rule)) {
+                        smwarn(log_msg, ANALYSISD_SIG_ID_NOT_FOUND,
+                               if_sid_rule_id, read_rule->if_matched_sid != 0 ? 
+                                                    "if_matched_sid" : "if_sid",
+                               read_rule->sigid);
                         return -1;
                     }
                     val = 1;
                 }
             } else {
-                smerror(log_msg, "rules_list: Signature ID must be an integer. Exiting...");
+                smwarn(log_msg, ANALYSISD_INV_SIG_ID,
+                        read_rule->if_matched_sid != 0 ? "if_matched_sid" 
+                                                       : "if_sid",
+                        read_rule->sigid);
                 return -1;
             }
-        } while (*sid++ != '\0');
+        } while (*sid_ptr++ != '\0');
     }
 
     /* Adding for if_level */
     else if (read_rule->if_level) {
-        int ilevel = 0;
 
-        ilevel = atoi(read_rule->if_level);
+        int ilevel = atoi(read_rule->if_level);
+
         if (ilevel == 0) {
+            // TODO: shouldn't it return -1? Leak?
             smerror(log_msg, "Invalid level (atoi)");
             return (1);
         }
 
+        // TODO: why does it multiply the ilevel?
         ilevel *= 100;
 
         if (!_AddtoRule(0, ilevel, 0, NULL, *r_node, read_rule)) {
-            smerror(log_msg, "rules_list: Level ID '%d' not found. Invalid 'if_level'.", ilevel);
+            smwarn(log_msg, ANALYSISD_LEVEL_NOT_FOUND, ilevel, read_rule->sigid);
             return -1;
         }
     }
@@ -178,7 +184,7 @@ int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, OSList* log_msg)
     /* Adding for if_group */
     else if (read_rule->if_group) {
         if (!_AddtoRule(0, 0, 0, read_rule->if_group, *r_node, read_rule)) {
-            smerror(log_msg, "rules_list: Group '%s' not found. Invalid 'if_group'.", read_rule->if_group);
+            smwarn(log_msg, ANALYSISD_GROUP_NOT_FOUND, read_rule->if_group, read_rule->sigid);
             return -1;
         }
     }
@@ -186,7 +192,9 @@ int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, OSList* log_msg)
     /* Just add based on the category */
     else {
         if (!_AddtoRule(0, 0, 0, NULL, *r_node, read_rule)) {
-            smerror(log_msg, "rules_list: Category '%d' not found. Invalid 'category'.", read_rule->category);
+            // TODO: It should never reach this point as the CATEGORY is checked in rules.c (look for "xml_category" )
+            // TODO: Why is it asumed that if _AddtoRule fails is it because the category?
+            smwarn(log_msg, ANALYSISD_CATEGORY_NOT_FOUND, read_rule->category, read_rule->sigid);
             return -1;
         }
     }

--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -175,7 +175,6 @@ int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, OSList* log_msg)
             return -1;
         }
 
-        // TODO: why does it multiply the ilevel?
         ilevel *= 100;
 
         if (_AddtoRule(0, ilevel, 0, NULL, *r_node, read_rule) == 0) {

--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -194,7 +194,7 @@ int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, OSList* log_msg)
         if (!_AddtoRule(0, 0, 0, NULL, *r_node, read_rule)) {
             // TODO: It should never reach this point as the CATEGORY is checked in rules.c (look for "xml_category" )
             // TODO: Why is it asumed that if _AddtoRule fails is it because the category?
-            smwarn(log_msg, ANALYSISD_CATEGORY_NOT_FOUND, read_rule->category, read_rule->sigid);
+            smwarn(log_msg, ANALYSISD_CATEGORY_NOT_FOUND, read_rule->sigid);
             return -1;
         }
     }

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -139,6 +139,7 @@
 #define INVALID_GEOIP_DB        "(1276): Cannot open GeoIP database: '%s'."
 #define FIM_INVALID_MESSAGE     "(1277): Invalid syscheck message received."
 #define UNABLE_TO_RECONNECT     "(1278): Unable to reconnect to '%s': %s (%d)."
+#define INVALID_RULE_ELEMENT    "(1279): Invalid rule element."
 
 /* logcollector */
 #define SYSTEM_ERROR     "(1600): Internal error. Exiting.."

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -84,13 +84,13 @@
 
 
 /* Ruleset reading warnings */
-#define ANALYSISD_INV_VALUE_RULE                "(7600): Invalid value '%s' for attribute '%s' in rule %d"
+#define ANALYSISD_INV_VALUE_RULE                "(7600): Invalid value '%s' for attribute '%s' in rule %d."
 #define ANALYSISD_INV_VALUE_DEFAULT             "(7601): Invalid value for attribute '%s' in '%s' option " \
-                                                        "(decoder `%s`). Default value will be used"
+                                                        "(decoder `%s`). Default value will be used."
 #define ANALYSISD_INV_OPT_VALUE_DEFAULT         "(7602): Invalid value '%s' in '%s' option " \
-                                                        "(decoder `%s`). Default value will be used"
+                                                        "(decoder `%s`). Default value will be used."
 #define ANALYSISD_DEC_DEPRECATED_OPT_VALUE      "(7603): Deprecated value '%s' in '%s' option " \
-                                                        "(decoder `%s`). Default value will be used"
+                                                        "(decoder `%s`). Default value will be used."
 #define ANALYSISD_IGNORE_RULE                   "(7604): Rule '%d' will be ignored."
 #define ANALYSISD_INV_OVERWRITE                 "(7605): Invalid use of overwrite option. " \
                                                         "Could not overwrite parent rule at rule '%d'."
@@ -105,6 +105,10 @@
                                                         "Rule '%d' will be ignored."
 #define ANALYSISD_CATEGORY_NOT_FOUND            "(7611): Category was not found. Invalid 'category'. " \
                                                         "Rule '%d' will be ignored."
+#define ANALYSISD_DUPLICATED_SIG_ID             "(7612): Rule ID '%d' is duplicated. Only the first occurrence will be "\
+                                                        "considered."
+#define ANALYSISD_OVERWRITE_MISSING_RULE        "(7613): Rule ID '%d' does not exist but 'overwrite' is set to 'yes'. "\
+                                                        "Still, the rule will be loaded."
 
 
 /* Logcollector */

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -100,7 +100,7 @@
                                                         "Rule '%d' will be ignored."
 #define ANALYSISD_LEVEL_NOT_FOUND               "(7608): Level ID '%d' was not found. Invalid 'if_level'. " \
                                                         "Rule '%d' will be ignored."
-#define ANALYSISD_INV_LEVEL                     "(7609): Invalid 'if_level' value: '%s'. Rule '%d' will be ignored."
+#define ANALYSISD_INV_IF_LEVEL                  "(7609): Invalid 'if_level' value: '%s'. Rule '%d' will be ignored."
 #define ANALYSISD_GROUP_NOT_FOUND               "(7610): Group '%s' was not found. Invalid 'if_group'. " \
                                                         "Rule '%d' will be ignored."
 #define ANALYSISD_CATEGORY_NOT_FOUND            "(7611): Category was not found. Invalid 'category'. " \
@@ -109,7 +109,7 @@
                                                         "considered."
 #define ANALYSISD_OVERWRITE_MISSING_RULE        "(7613): Rule ID '%d' does not exist but 'overwrite' is set to 'yes'. "\
                                                         "Still, the rule will be loaded."
-
+#define ANALYSISD_NULL_RULE                     "(7614): Rule pointer is NULL. Skipping."
 
 /* Logcollector */
 #define LOGCOLLECTOR_INV_VALUE_DEFAULT          "(8000): Invalid value '%s' for attribute '%s' in '%s' option. " \

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -92,8 +92,8 @@
 #define ANALYSISD_DEC_DEPRECATED_OPT_VALUE      "(7603): Deprecated value '%s' in '%s' option " \
                                                         "(decoder `%s`). Default value will be used."
 #define ANALYSISD_IGNORE_RULE                   "(7604): Rule '%d' will be ignored."
-#define ANALYSISD_INV_OVERWRITE                 "(7605): Invalid use of overwrite option, 'overwrite' " \
-                                                        "is not compatible with 'if_sid', 'if_group' nor 'if_level'. " \
+#define ANALYSISD_INV_OVERWRITE                 "(7605): Invalid use of 'overwrite' option, it is not compatible " \
+                                                        "with 'if_sid', 'if_group' nor 'if_level' attributes. " \
                                                         "Could not overwrite rule '%d'."
 #define ANALYSISD_SIG_ID_NOT_FOUND              "(7606): Signature ID '%d' was not found. Invalid '%s'. " \
                                                         "Rule '%d' will be ignored."
@@ -112,6 +112,7 @@
                                                         "Still, the rule will be loaded."
 #define ANALYSISD_NULL_RULE                     "(7614): Rule pointer is NULL. Skipping."
 #define ANALYSISD_INV_IF_MATCHED_SID            "(7615): Invalid 'if_matched_sid' value: '%s'. Rule '%d' will be ignored."
+#define ANALYSISD_LIST_NOT_LOADED               "(7616): List '%s' could not be loaded. Rule '%d' will be ignored."
 
 /* Logcollector */
 #define LOGCOLLECTOR_INV_VALUE_DEFAULT          "(8000): Invalid value '%s' for attribute '%s' in '%s' option. " \

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -92,8 +92,9 @@
 #define ANALYSISD_DEC_DEPRECATED_OPT_VALUE      "(7603): Deprecated value '%s' in '%s' option " \
                                                         "(decoder `%s`). Default value will be used."
 #define ANALYSISD_IGNORE_RULE                   "(7604): Rule '%d' will be ignored."
-#define ANALYSISD_INV_OVERWRITE                 "(7605): Invalid use of overwrite option. " \
-                                                        "Could not overwrite parent rule at rule '%d'."
+#define ANALYSISD_INV_OVERWRITE                 "(7605): Invalid use of overwrite option, 'overwrite' " \
+                                                        "is not compatible with 'if_sid', 'if_group' nor 'if_level'. " \
+                                                        "Could not overwrite rule '%d'."
 #define ANALYSISD_SIG_ID_NOT_FOUND              "(7606): Signature ID '%d' was not found. Invalid '%s'. " \
                                                         "Rule '%d' will be ignored."
 #define ANALYSISD_INV_SIG_ID                    "(7607): Invalid '%s'. Signature ID must be an integer. " \
@@ -110,6 +111,7 @@
 #define ANALYSISD_OVERWRITE_MISSING_RULE        "(7613): Rule ID '%d' does not exist but 'overwrite' is set to 'yes'. "\
                                                         "Still, the rule will be loaded."
 #define ANALYSISD_NULL_RULE                     "(7614): Rule pointer is NULL. Skipping."
+#define ANALYSISD_INV_IF_MATCHED_SID            "(7615): Invalid 'if_matched_sid' value: '%s'. Rule '%d' will be ignored."
 
 /* Logcollector */
 #define LOGCOLLECTOR_INV_VALUE_DEFAULT          "(8000): Invalid value '%s' for attribute '%s' in '%s' option. " \

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -94,7 +94,17 @@
 #define ANALYSISD_IGNORE_RULE                   "(7604): Rule '%d' will be ignored."
 #define ANALYSISD_INV_OVERWRITE                 "(7605): Invalid use of overwrite option. " \
                                                         "Could not overwrite parent rule at rule '%d'."
-
+#define ANALYSISD_SIG_ID_NOT_FOUND              "(7606): Signature ID '%d' was not found. Invalid '%s'. " \
+                                                        "Rule '%d' will be ignored."
+#define ANALYSISD_INV_SIG_ID                    "(7607): Invalid '%s'. Signature ID must be an integer. " \
+                                                        "Rule '%d' will be ignored."
+#define ANALYSISD_LEVEL_NOT_FOUND               "(7608): Level ID '%d' was not found. Invalid 'if_level'. " \
+                                                        "Rule '%d' will be ignored."
+#define ANALYSISD_INV_LEVEL                     "(7609): Invalid 'if_level' value: '%s'. Rule '%d' will be ignored."
+#define ANALYSISD_GROUP_NOT_FOUND               "(7610): Group '%s' was not found. Invalid 'if_group'. " \
+                                                        "Rule '%d' will be ignored."
+#define ANALYSISD_CATEGORY_NOT_FOUND            "(7611): Category was not found. Invalid 'category'. " \
+                                                        "Rule '%d' will be ignored."
 
 
 /* Logcollector */

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -86,11 +86,16 @@
 /* Ruleset reading warnings */
 #define ANALYSISD_INV_VALUE_RULE                "(7600): Invalid value '%s' for attribute '%s' in rule %d"
 #define ANALYSISD_INV_VALUE_DEFAULT             "(7601): Invalid value for attribute '%s' in '%s' option " \
-                                                "(decoder `%s`). Default value will be used"
+                                                        "(decoder `%s`). Default value will be used"
 #define ANALYSISD_INV_OPT_VALUE_DEFAULT         "(7602): Invalid value '%s' in '%s' option " \
-                                                "(decoder `%s`). Default value will be used"
+                                                        "(decoder `%s`). Default value will be used"
 #define ANALYSISD_DEC_DEPRECATED_OPT_VALUE      "(7603): Deprecated value '%s' in '%s' option " \
-                                                "(decoder `%s`). Default value will be used"
+                                                        "(decoder `%s`). Default value will be used"
+#define ANALYSISD_IGNORE_RULE                   "(7604): Rule '%d' will be ignored."
+#define ANALYSISD_INV_OVERWRITE                 "(7605): Invalid use of overwrite option. " \
+                                                        "Could not overwrite parent rule at rule '%d'."
+
+
 
 /* Logcollector */
 #define LOGCOLLECTOR_INV_VALUE_DEFAULT          "(8000): Invalid value '%s' for attribute '%s' in '%s' option. " \

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -61,7 +61,8 @@ list(APPEND analysisd_names "test_mitre")
 list(APPEND analysisd_flags "-Wl,--wrap,wdbc_query_ex -Wl,--wrap,wdbc_query_parse_json ${HASH_OP_WRAPPERS} ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND analysisd_names "test_rules")
-LIST(APPEND analysisd_flags "-Wl,--wrap,_os_analysisd_add_logmsg ${DEBUG_OP_WRAPPERS}")
+LIST(APPEND analysisd_flags "-Wl,--wrap,_mwarn -Wl,--wrap,_merror -Wl,--wrap,_os_analysisd_add_logmsg \
+                             -Wl,--wrap,OS_ClearNode -Wl,--wrap,w_get_attr_val_by_name ${DEBUG_OP_WRAPPERS}")
 
 LIST(APPEND analysisd_names "test_same_different_loop")
 LIST(APPEND analysisd_flags "-W")

--- a/src/unit_tests/analysisd/test_logtest.c
+++ b/src/unit_tests/analysisd/test_logtest.c
@@ -1275,6 +1275,7 @@ void test_w_logtest_initialize_session_error_decoders(void ** state) {
     will_return(__wrap_pthread_mutex_init, 0);
 
     /* w_logtest_ruleset_load */
+    expect_function_call_any(__wrap_OS_ClearNode);
     will_return(__wrap_OS_ReadXML, 0);
     XML_NODE node;
     os_calloc(2, sizeof(xml_node *), node);
@@ -1299,6 +1300,7 @@ void test_w_logtest_initialize_session_error_decoders(void ** state) {
     will_return(__wrap_Read_Rules, 0);
 
     will_return(__wrap_ReadDecodeXML, 0);
+
 
     will_return(__wrap_pthread_mutex_destroy, 0);
 
@@ -1325,6 +1327,7 @@ void test_w_logtest_initialize_session_error_set_decoders(void ** state) {
     will_return(__wrap_pthread_mutex_init, 0);
 
     /* w_logtest_ruleset_load */
+    expect_function_call_any(__wrap_OS_ClearNode);
     will_return(__wrap_OS_ReadXML, 0);
     XML_NODE node;
     os_calloc(2, sizeof(xml_node *), node);
@@ -1379,6 +1382,7 @@ void test_w_logtest_initialize_session_error_cbd_list(void ** state) {
     will_return(__wrap_pthread_mutex_init, 0);
 
     /* w_logtest_ruleset_load */
+    expect_function_call_any(__wrap_OS_ClearNode);
     will_return(__wrap_OS_ReadXML, 0);
     XML_NODE node;
     os_calloc(2, sizeof(xml_node *), node);
@@ -1434,6 +1438,7 @@ void test_w_logtest_initialize_session_error_rules(void ** state) {
     will_return(__wrap_pthread_mutex_init, 0);
 
     /* w_logtest_ruleset_load */
+    expect_function_call_any(__wrap_OS_ClearNode);
     will_return(__wrap_OS_ReadXML, 0);
     XML_NODE node;
     os_calloc(2, sizeof(xml_node *), node);
@@ -1489,6 +1494,7 @@ void test_w_logtest_initialize_session_error_hash_rules(void ** state) {
     will_return(__wrap_pthread_mutex_init, 0);
 
     /* w_logtest_ruleset_load */
+    expect_function_call_any(__wrap_OS_ClearNode);
     will_return(__wrap_OS_ReadXML, 0);
     XML_NODE node;
     os_calloc(2, sizeof(xml_node *), node);
@@ -1547,6 +1553,7 @@ void test_w_logtest_initialize_session_error_fts_init(void ** state) {
     will_return(__wrap_pthread_mutex_init, 0);
 
     /* w_logtest_ruleset_load */
+    expect_function_call_any(__wrap_OS_ClearNode);
     will_return(__wrap_OS_ReadXML, 0);
     XML_NODE node;
     os_calloc(2, sizeof(xml_node *), node);
@@ -1614,6 +1621,7 @@ void test_w_logtest_initialize_session_error_accumulate_init(void ** state) {
     will_return(__wrap_pthread_mutex_init, 0);
 
     /* w_logtest_ruleset_load */
+    expect_function_call_any(__wrap_OS_ClearNode);
     will_return(__wrap_OS_ReadXML, 0);
     XML_NODE node;
     os_calloc(2, sizeof(xml_node *), node);
@@ -1696,6 +1704,7 @@ void test_w_logtest_initialize_session_success(void ** state) {
     will_return(__wrap_pthread_mutex_init, 0);
 
     /* w_logtest_ruleset_load */
+    expect_function_call_any(__wrap_OS_ClearNode);
     will_return(__wrap_OS_ReadXML, 0);
     XML_NODE node;
     os_calloc(2, sizeof(xml_node *), node);
@@ -1776,6 +1785,7 @@ void test_w_logtest_initialize_session_success_duplicate_key(void ** state) {
     will_return(__wrap_pthread_mutex_init, 0);
 
     /* w_logtest_ruleset_load */
+    expect_function_call_any(__wrap_OS_ClearNode);
     will_return(__wrap_OS_ReadXML, 0);
     XML_NODE node;
     os_calloc(2, sizeof(xml_node *), node);
@@ -3102,6 +3112,7 @@ void test_w_logtest_process_request_type_log_processing(void ** state) {
     will_return(__wrap_OSHash_Get_ex, NULL);
 
     /* Initialize session*/
+    expect_function_call_any(__wrap_OS_ClearNode);
     will_return(__wrap_time, 0);
     will_return(__wrap_pthread_mutex_init, 0);
 
@@ -4715,6 +4726,7 @@ void test_w_logtest_process_request_log_processing_fail_session(void ** state)
     will_return(__wrap_pthread_mutex_init, 0);
 
     /* w_logtest_ruleset_load */
+    expect_function_call_any(__wrap_OS_ClearNode);
     will_return(__wrap_OS_ReadXML, 0);
     XML_NODE node;
     os_calloc(2, sizeof(xml_node *), node);
@@ -5104,6 +5116,7 @@ void test_w_logtest_process_request_log_processing_ok_session_expired(void ** st
     will_return(__wrap_time, 1212);
 
     /* w_logtest_ruleset_load */
+    expect_function_call_any(__wrap_OS_ClearNode);
     will_return(__wrap_OS_ReadXML, 0);
     XML_NODE node;
     os_calloc(2, sizeof(xml_node *), node);
@@ -6219,6 +6232,7 @@ void test_w_logtest_ruleset_load_config_fail_read_rules(void ** state) {
     os_calloc(1, sizeof(xml_node), conf_section_nodes[0]);
 
     /* xml ruleset */
+    expect_function_call_any(__wrap_OS_ClearNode);
     os_strdup("ruleset", conf_section_nodes[0]->element);
 
     will_return(__wrap_OS_GetElementsbyNode, (xml_node **) calloc(1, sizeof(xml_node *)));
@@ -6246,6 +6260,7 @@ void test_w_logtest_ruleset_load_config_fail_read_alerts(void ** state) {
     os_calloc(1, sizeof(xml_node), conf_section_nodes[0]);
 
     /* xml ruleset */
+    expect_function_call_any(__wrap_OS_ClearNode);
     os_strdup("alerts", conf_section_nodes[0]->element);
 
     will_return(__wrap_OS_GetElementsbyNode, (xml_node **) calloc(1, sizeof(xml_node *)));
@@ -6277,6 +6292,7 @@ void test_w_logtest_ruleset_load_config_ok(void ** state) {
     os_calloc(1, sizeof(xml_node), conf_section_nodes[1]);
 
     /* xml ruleset */
+    expect_function_call_any(__wrap_OS_ClearNode);
     os_strdup("alerts", conf_section_nodes[0]->element);
     os_strdup("ruleset", conf_section_nodes[1]->element);
 
@@ -6357,6 +6373,7 @@ void test_w_logtest_ruleset_load_null_element(void ** state) {
     _Config ruleset_config = {0};
     OSList list_msg = {0};
 
+    expect_function_call_any(__wrap_OS_ClearNode);
     will_return(__wrap_OS_ReadXML, 0);
     XML_NODE node;
     os_calloc(2, sizeof(xml_node *), node);
@@ -6381,6 +6398,7 @@ void test_w_logtest_ruleset_load_empty_ossec_label(void ** state) {
     _Config ruleset_config = {0};
     OSList list_msg = {0};
 
+    expect_function_call_any(__wrap_OS_ClearNode);
     will_return(__wrap_OS_ReadXML, 0);
     XML_NODE node;
     os_calloc(2, sizeof(xml_node *), node);
@@ -6403,6 +6421,7 @@ void test_w_logtest_ruleset_load_fail_load_ruleset_config(void ** state) {
     _Config ruleset_config = {0};
     OSList list_msg = {0};
 
+    expect_function_call_any(__wrap_OS_ClearNode);
     will_return(__wrap_OS_ReadXML, 0);
     XML_NODE node;
     os_calloc(2, sizeof(xml_node *), node);
@@ -6438,6 +6457,7 @@ void test_w_logtest_ruleset_load_ok(void ** state) {
     _Config ruleset_config = {0};
     OSList list_msg = {0};
 
+    expect_function_call_any(__wrap_OS_ClearNode);
     will_return(__wrap_OS_ReadXML, 0);
     XML_NODE node;
     os_calloc(2, sizeof(xml_node *), node);

--- a/src/unit_tests/analysisd/test_rules.c
+++ b/src/unit_tests/analysisd/test_rules.c
@@ -18,6 +18,7 @@
 #include "../../analysisd/eventinfo.h"
 #include "../../analysisd/analysisd.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+#include "../wrappers/wazuh/os_xml/os_xml_wrappers.h"
 
 char *loadmemory(char *at, const char *str, OSList* log_msg);
 int get_info_attributes(char **attributes, char **values, OSList* log_msg);
@@ -476,7 +477,7 @@ void w_check_attr_negate_attr_unknow_val(void **state)
 
     OSList log_msg = {0};
     char expected_msg[OS_SIZE_2048];
-    snprintf(expected_msg, OS_SIZE_2048, "(7600): Invalid value 'hello' for attribute 'negate' in rule 1234");
+    snprintf(expected_msg, OS_SIZE_2048, "(7600): Invalid value 'hello' for attribute 'negate' in rule 1234.");
 
     expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_WARNING);
     expect_value(__wrap__os_analysisd_add_logmsg, list, &log_msg);
@@ -747,7 +748,7 @@ void w_check_attr_type_attr_unknow_val(void **state)
     os_strdup("hello", node.values[0]);
 
     OSList log_msg = {0};
-    char excpect_msg[70] = "(7600): Invalid value 'hello' for attribute 'type' in rule 1234";
+    char excpect_msg[70] = "(7600): Invalid value 'hello' for attribute 'type' in rule 1234.";
 
     expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_WARNING);
     expect_value(__wrap__os_analysisd_add_logmsg, list, &log_msg);
@@ -761,6 +762,98 @@ void w_check_attr_type_attr_unknow_val(void **state)
     os_free(node.values);
 
     assert_int_equal(ret_val, EXP_TYPE_OSMATCH);
+}
+
+// Test w_free_rules_tmp_params
+
+void w_free_rules_tmp_params_all(void ** state){
+
+    rules_tmp_params_t rule_tmp_params = {0};
+
+    rule_tmp_params.regex = strdup("test 123");
+    rule_tmp_params.match = strdup("test 123");
+    rule_tmp_params.url = strdup("test 123");
+    rule_tmp_params.if_matched_regex = strdup("test 123");
+    rule_tmp_params.if_matched_group = strdup("test 123");
+    rule_tmp_params.user = strdup("test 123");
+    rule_tmp_params.id = strdup("test 123");
+    rule_tmp_params.srcport = strdup("test 123");
+    rule_tmp_params.dstport = strdup("test 123");
+    rule_tmp_params.srcgeoip = strdup("test 123");
+    rule_tmp_params.dstgeoip = strdup("test 123");
+    rule_tmp_params.protocol = strdup("test 123");
+    rule_tmp_params.system_name = strdup("test 123");
+    rule_tmp_params.status = strdup("test 123");
+    rule_tmp_params.hostname = strdup("test 123");
+    rule_tmp_params.data = strdup("test 123");
+    rule_tmp_params.extra_data = strdup("test 123");
+    rule_tmp_params.program_name = strdup("test 123");
+    rule_tmp_params.location = strdup("test 123");
+    rule_tmp_params.action = strdup("test 123");
+
+    XML_NODE node;
+    os_calloc(2, sizeof(xml_node *), node);
+    /* <ossec_config></> */
+    os_calloc(1, sizeof(xml_node), node[0]);
+    os_strdup("ossec_config", node[0]->element);
+
+    rule_tmp_params.rule_arr_opt = node;
+
+    expect_function_call(__wrap_OS_ClearNode);
+
+    w_free_rules_tmp_params(&rule_tmp_params);
+}
+
+void w_free_rules_tmp_params_only_rule_arr(void ** state){
+
+    rules_tmp_params_t rule_tmp_params = {0};
+    XML_NODE node;
+    os_calloc(2, sizeof(xml_node *), node);
+    /* <ossec_config></> */
+    os_calloc(1, sizeof(xml_node), node[0]);
+    os_strdup("ossec_config", node[0]->element);
+
+    rule_tmp_params.rule_arr_opt = node;
+
+    expect_function_call(__wrap_OS_ClearNode);
+
+    w_free_rules_tmp_params(&rule_tmp_params);
+}
+
+void w_free_rules_tmp_params_only_params(void ** state){
+
+    rules_tmp_params_t rule_tmp_params = {0};
+
+    rule_tmp_params.regex = strdup("test 123");
+    rule_tmp_params.match = strdup("test 123");
+    rule_tmp_params.url = strdup("test 123");
+    rule_tmp_params.if_matched_regex = strdup("test 123");
+    rule_tmp_params.if_matched_group = strdup("test 123");
+    rule_tmp_params.user = strdup("test 123");
+    rule_tmp_params.id = strdup("test 123");
+    rule_tmp_params.srcport = strdup("test 123");
+    rule_tmp_params.dstport = strdup("test 123");
+    rule_tmp_params.srcgeoip = strdup("test 123");
+    rule_tmp_params.dstgeoip = strdup("test 123");
+    rule_tmp_params.protocol = strdup("test 123");
+    rule_tmp_params.system_name = strdup("test 123");
+    rule_tmp_params.status = strdup("test 123");
+    rule_tmp_params.hostname = strdup("test 123");
+    rule_tmp_params.data = strdup("test 123");
+    rule_tmp_params.extra_data = strdup("test 123");
+    rule_tmp_params.program_name = strdup("test 123");
+    rule_tmp_params.location = strdup("test 123");
+    rule_tmp_params.action = strdup("test 123");
+    rule_tmp_params.rule_arr_opt = NULL;
+
+
+    w_free_rules_tmp_params(&rule_tmp_params);
+}
+
+
+void w_free_rules_tmp_params_null(void ** state){
+
+    w_free_rules_tmp_params(NULL);
 }
 
 int main(void)
@@ -799,6 +892,11 @@ int main(void)
         cmocka_unit_test(w_check_attr_type_attr_to_osregex),
         cmocka_unit_test(w_check_attr_type_attr_to_pcre2),
         cmocka_unit_test(w_check_attr_type_attr_unknow_val),
+        // Test w_free_rules_tmp_params
+        cmocka_unit_test(w_free_rules_tmp_params_all),
+        cmocka_unit_test(w_free_rules_tmp_params_only_rule_arr),
+        cmocka_unit_test(w_free_rules_tmp_params_only_params),
+        cmocka_unit_test(w_free_rules_tmp_params_null),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wrappers/wazuh/os_xml/os_xml_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/os_xml/os_xml_wrappers.c
@@ -32,6 +32,8 @@ xml_node ** __wrap_OS_GetElementsbyNode(const OS_XML * _lxml, const xml_node * n
 }
 
 void __wrap_OS_ClearNode(xml_node ** node) {
+
+    function_called();
     if (node != NULL) {
         for (int i = 0; node[i]; i++) {
             if (node[i]->element) {


### PR DESCRIPTION
|Related issue|Related PR|
|---|---|
|#12641|#10720|

This PR applies #10720 into 4.3, keeping the same behavior.

## Sample rule

```xml
<group name="amazon,aws,">
  <rule id="80441" level="7" overwrite="yes">
    <if_sid>80440</if_sid>
    <field name="aws.action">ALLOW</field>
    <description>AWS WAF - Allowed request</description>
    <group>aws_waf,aws_waf_allow,</group>
    <options>no_full_log</options>
  </rule>
</group>
```

### Previous behavior

```
2022/03/09 17:54:16 wazuh-analysisd: ERROR: Invalid use of overwrite option. Could not overwrite parent rule at rule '80441'.
2022/03/09 17:54:16 wazuh-analysisd: CRITICAL: (1220): Error loading the rules: 'etc/rules/local_rules.xml'.
```

### New behavior

```
2022/03/09 17:47:49 wazuh-analysisd: WARNING: (7605): Invalid use of 'overwrite' option, it is not compatible with 'if_sid', 'if_group' nor 'if_level' attributes. Could not overwrite rule '80441'.
```

## Tests

- [ ] QA backport of https://github.com/wazuh/wazuh-qa/pull/2200 to branch 4.3.
- [x] Apply the rule above on 4.2 and upgrade to this branch.
- [x] Valgrind

### Known issues

- #12651