### PR TITLE
Avoid compile warning for unused parameter `scan_ctx`

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2379,7 +2379,7 @@ int wm_vuldet_find_agent_vulnerabilities(sqlite3 *db, scan_agent *agent, wm_vuld
 
     // Windows vulnerabilities
     if (agent->dist == FEED_WIN) {
-        if (wm_vuldet_win_nvd_vulnerabilities(db, agent, flags, scan_ctx)) {
+        if (wm_vuldet_win_nvd_vulnerabilities(db, agent, flags)) {
             goto end;
         }
         retval = 0;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -967,7 +967,7 @@ int wm_vuldet_linux_nvd_vulnerabilities(sqlite3 *db, scan_agent *agent, OSHash *
  * @param flags Configuration options.
  * @return 0 on success, -1 otherwise.
  */
-int wm_vuldet_win_nvd_vulnerabilities(sqlite3 *db, scan_agent *agent, wm_vuldet_flags *flags, scan_ctx_t *scan_ctx);
+int wm_vuldet_win_nvd_vulnerabilities(sqlite3 *db, scan_agent *agent, wm_vuldet_flags *flags);
 
 /**
  * @brief Check if the package is vulnerable or not to a certain CVE.

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -48,7 +48,7 @@ STATIC int wm_vuldet_get_vuln_nvd_cpe(sqlite3 *db,
                                       char *raw_type,
                                       vu_nvd_report **nvd_report_list);
 STATIC vu_nvd_report *wm_vuldet_check_nvd_vulnerability(sqlite3 *db, scan_agent *agent, wm_vuldet_flags *flags, cpe *agent_cpe, int cve_id, int conf_id, int vulnerable, char *operator, int parent, char *uri_version, char *v_start_inc, char *v_start_exc, char *v_end_inc, char *v_end_exc);
-STATIC int wm_vuldet_process_agent_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd_report, scan_agent *agent, scan_ctx_t *scan_ctx);
+STATIC int wm_vuldet_process_agent_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd_report, scan_agent *agent);
 
 /**
  * @brief Clean a package's version by removing the epoch and revision (if available).
@@ -1813,7 +1813,7 @@ end:
     return OS_INVALID;
 }
 
-int wm_vuldet_win_nvd_vulnerabilities(sqlite3 *db, scan_agent *agent, wm_vuldet_flags *flags, scan_ctx_t *scan_ctx) {
+int wm_vuldet_win_nvd_vulnerabilities(sqlite3 *db, scan_agent *agent, wm_vuldet_flags *flags) {
     vu_nvd_report *nvd_report_list = NULL;
     time_t start_time;
     time_t find_vul_time;
@@ -1836,7 +1836,7 @@ int wm_vuldet_win_nvd_vulnerabilities(sqlite3 *db, scan_agent *agent, wm_vuldet_
     mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_START_VUL_AG_SEND, atoi(agent->agent_id));
 
     // Process the vulnerabilities
-    if (wm_vuldet_process_agent_nvd_vulnerabilities(db, &nvd_report_list, agent, scan_ctx)) {
+    if (wm_vuldet_process_agent_nvd_vulnerabilities(db, &nvd_report_list, agent)) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_REPORT_NVD_ERROR, atoi(agent->agent_id));
         wm_vuldet_free_nvd_report_list(nvd_report_list);
         return OS_INVALID;
@@ -2131,7 +2131,7 @@ end:
     return nvd_report_node;
 }
 
-int wm_vuldet_process_agent_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd_report, scan_agent *agent, scan_ctx_t *scan_ctx) {
+int wm_vuldet_process_agent_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd_report, scan_agent *agent) {
     sqlite3_stmt *stmt = NULL;
     vu_nvd_report *report_node;
     vu_nvd_report *f_report_node;


### PR DESCRIPTION
|Related issue|
|---|
|#12588|

## Description

After eliminating the condition that made use of `scan_ctx` to obtain the type of scan (https://github.com/wazuh/wazuh/pull/12618), the `scan_ctx` variable was unused, so the compiler showed the following error:

```
    CC wazuh_modules/vulnerability_detector/wm_vuln_detector.o
    CC wazuh_modules/vulnerability_detector/wm_vuln_detector_evr.o
    CC wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.o
    CC wazuh_modules/task_manager/wm_task_manager.o
    CC wazuh_modules/task_manager/wm_task_manager_parsing.o
    CC wazuh_modules/task_manager/wm_task_manager_commands.o
    CC wazuh_modules/task_manager/wm_task_manager_tasks.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_manager.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_upgrades.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_parsing.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_commands.o
wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c: In function 'wm_vuldet_process_agent_nvd_vulnerabilities':
wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c:2134:121: warning: unused parameter 'scan_ctx' [-Wunused-parameter]
 2134 | int wm_vuldet_process_agent_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd_report, scan_agent *agent, scan_ctx_t *scan_ctx) {
      |                                                                                                             ~~~~~~~~~~~~^~~~~~~~
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks_callbacks.o
```

With this PR, the parameters that are not used have been eliminated so that the Warning does not appear.

## Logs/Alerts example
With the fix:
```
    CC wazuh_modules/vulnerability_detector/wm_vuln_detector.o
    CC wazuh_modules/vulnerability_detector/wm_vuln_detector_evr.o
    CC wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.o
    CC wazuh_modules/task_manager/wm_task_manager.o
    CC wazuh_modules/task_manager/wm_task_manager_parsing.o
    CC wazuh_modules/task_manager/wm_task_manager_commands.o
    CC wazuh_modules/task_manager/wm_task_manager_tasks.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_manager.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_upgrades.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_parsing.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_commands.o
    CC wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks_callbacks.o
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
