### PR TITLE
Update copyright for FIM files

### DIFF
--- a/architecture/FIM/db/001-class-testtool.puml
+++ b/architecture/FIM/db/001-class-testtool.puml
@@ -1,4 +1,4 @@
-' Copyright (C) 2015-2021, Wazuh Inc.
+' Copyright (C) 2015, Wazuh Inc.
 ' Created by Wazuh, Inc. <info@wazuh.com>.
 ' This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 

--- a/architecture/FIM/db/002-sequence-testtool.puml
+++ b/architecture/FIM/db/002-sequence-testtool.puml
@@ -1,4 +1,4 @@
-' Copyright (C) 2015-2021, Wazuh Inc.
+' Copyright (C) 2015, Wazuh Inc.
 ' Created by Wazuh, Inc. <info@wazuh.com>.
 ' This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 

--- a/architecture/FIM/db/sequence_diagram.puml
+++ b/architecture/FIM/db/sequence_diagram.puml
@@ -1,4 +1,4 @@
-' Copyright (C) 2015-2021, Wazuh Inc.
+' Copyright (C) 2015, Wazuh Inc.
 ' Created by Wazuh, Inc. <info@wazuh.com>.
 ' This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 

--- a/src/syscheckd/src/db/include/db.h
+++ b/src/syscheckd/src/db/include/db.h
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * January 24, 2021.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/include/db.hpp
+++ b/src/syscheckd/src/db/include/db.hpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh DB
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * January 12, 2022.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/include/fimCommonDefs.h
+++ b/src/syscheckd/src/db/include/fimCommonDefs.h
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * September 6, 2021.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/src/db.cpp
+++ b/src/syscheckd/src/db/src/db.cpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * August 28, 2021.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/src/dbFileItem.cpp
+++ b/src/syscheckd/src/db/src/dbFileItem.cpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * September 24, 2021.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/src/dbFileItem.hpp
+++ b/src/syscheckd/src/db/src/dbFileItem.hpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * September 23, 2021.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/src/dbItem.hpp
+++ b/src/syscheckd/src/db/src/dbItem.hpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * September 23, 2021.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/src/dbRegistryKey.cpp
+++ b/src/syscheckd/src/db/src/dbRegistryKey.cpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * October 15, 2021.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/src/dbRegistryKey.hpp
+++ b/src/syscheckd/src/db/src/dbRegistryKey.hpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * September 23, 2021.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/src/dbRegistryValue.cpp
+++ b/src/syscheckd/src/db/src/dbRegistryValue.cpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * October 18, 2021.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/src/dbRegistryValue.hpp
+++ b/src/syscheckd/src/db/src/dbRegistryValue.hpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * September 23, 2021.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/src/file.cpp
+++ b/src/syscheckd/src/db/src/file.cpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * September 9, 2021.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/src/fimDB.cpp
+++ b/src/syscheckd/src/db/src/fimDB.cpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * September 27, 2021.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/src/registry.cpp
+++ b/src/syscheckd/src/db/src/registry.cpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * September 9, 2021.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/tests/db/ComponentTest/fileInterface/fileTest.cpp
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/fileInterface/fileTest.cpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * December 31, 2021.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/tests/db/ComponentTest/registryInterface/registryTest.cpp
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/registryInterface/registryTest.cpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * December 31, 2021.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/tests/db/FIMDB/fimDBTests/fimDBImpTests.cpp
+++ b/src/syscheckd/src/db/tests/db/FIMDB/fimDBTests/fimDBImpTests.cpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * November 23, 2021.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/tests/db/FIMDB/fimDBTests/fimDBImpTests.hpp
+++ b/src/syscheckd/src/db/tests/db/FIMDB/fimDBTests/fimDBImpTests.hpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * November 23, 2021.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/tests/db/dbItem/FileItem/dbFileItemTest.cpp
+++ b/src/syscheckd/src/db/tests/db/dbItem/FileItem/dbFileItemTest.cpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * October 5, 2021.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/tests/db/dbItem/FileItem/dbFileItemTest.h
+++ b/src/syscheckd/src/db/tests/db/dbItem/FileItem/dbFileItemTest.h
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * October 5, 2021.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/tests/db/dbItem/RegistryKey/dbRegistryKeyTest.cpp
+++ b/src/syscheckd/src/db/tests/db/dbItem/RegistryKey/dbRegistryKeyTest.cpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * October 15, 2021.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/tests/db/dbItem/RegistryKey/dbRegistryKeyTest.h
+++ b/src/syscheckd/src/db/tests/db/dbItem/RegistryKey/dbRegistryKeyTest.h
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * October 15, 2021.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/tests/db/dbItem/RegistryValue/dbRegistryValueTest.cpp
+++ b/src/syscheckd/src/db/tests/db/dbItem/RegistryValue/dbRegistryValueTest.cpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * October 19, 2021.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/tests/db/dbItem/RegistryValue/dbRegistryValueTest.h
+++ b/src/syscheckd/src/db/tests/db/dbItem/RegistryValue/dbRegistryValueTest.h
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * October 18, 2021.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/testtool/action.h
+++ b/src/syscheckd/src/db/testtool/action.h
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck - Test tool
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * January 21, 2022.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/testtool/cmdArgsHelper.h
+++ b/src/syscheckd/src/db/testtool/cmdArgsHelper.h
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck - Test tool
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * January 21, 2022.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/testtool/factoryAction.h
+++ b/src/syscheckd/src/db/testtool/factoryAction.h
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck - Test tool
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * January 23, 2022.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/testtool/main.cpp
+++ b/src/syscheckd/src/db/testtool/main.cpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck - Test tool
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * January 21, 2022.
  *
  * This program is free software; you can redistribute it

--- a/src/syscheckd/src/db/testtool/testContext.h
+++ b/src/syscheckd/src/db/testtool/testContext.h
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscheck - Test tool
- * Copyright (C) 2015-2021, Wazuh Inc.
+ * Copyright (C) 2015, Wazuh Inc.
  * January 21, 2022.
  *
  * This program is free software; you can redistribute it


### PR DESCRIPTION
|Related issue|
|---|
| N/A |

## Description

As done in https://github.com/wazuh/wazuh/pull/11780, we need to update the copyright header for all the new files of this development.

We decided to remove the current year in order to avoid the recurrent update.