### PR TITLE
Fix a memory leak at wazuh-logtest-legacy when matching a level-0 rule

### DIFF
--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -402,7 +402,7 @@ int main(int argc, char **argv)
                 rulesfiles = Config.includes;
                 while (rulesfiles && *rulesfiles) {
                     mdebug1("Reading rules file: '%s'", *rulesfiles);
-                    if (Rules_OP_ReadRules(*rulesfiles, &os_analysisd_rulelist, &os_analysisd_cdblists, 
+                    if (Rules_OP_ReadRules(*rulesfiles, &os_analysisd_rulelist, &os_analysisd_cdblists,
                                            &os_analysisd_last_events, &os_analysisd_decoder_store, list_msg) < 0) {
                         error_exit = 1;
                     }
@@ -672,6 +672,7 @@ void OS_ReadMSG(char *ut_str)
 
                 /* Ignore level 0 */
                 if (currently_rule->level == 0) {
+                    lf->generated_rule = NULL;
                     break;
                 }
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #12651|

This PR fixes a memory leak at `wazuh-logtest-legacy` that happens when the input matches a level-0 rule.

## Sample

```json
{"integration":"aws","aws":{"terminatingRuleId":"Default_Action","terminatingRuleType":"REGULAR","log_info":{"s3bucket":"XXXXXXXXXXXXXXXXX","log_file":"xxxxxx/xxxx/xx/xx/xx/xxx-xxx-logs-xxx-x-xxxx-xx-xx-xx"},"ruleGroupList":[{"excludedRules":null,"terminatingRule":null,"nonTerminatingMatchingRules":[],"ruleGroupId":"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"},{"excludedRules":null,"terminatingRule":null,"nonTerminatingMatchingRules":[],"ruleGroupId":"XXXXXXXXXXXXXXXXXXXXXXXX"}],"source":"waf","httpSourceId":"XXXXXXXXXXXXXXX","webaclId":"XXXXXXXXXXXXXXXXXXXXXXXXXXX","action":"ALLOW","httpRequest":{"headers":[{"name":"Host","value":"XXXXXXXXXXXX"},{"name":"Connection","value":"keep-alive"},{"name":"Cache-Control","value":"max-age=0"},{"name":"XXXXXXXXXXXXXXXXXXXXXXXXXXX","value":"1"},{"name":"XXXXXXX","value":"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"},{"name":"Accept","value":"XXXXXXXXXXXXXXXXXXXXXXXXXXXX"},{"name":"XXXX","value":"XXXX"},{"name":"XXXX","value":"navigate"},{"name":"XXXX","value":"?1"},{"name":"XXXXX","value":"document"},{"name":"XXXXX","value":"\"XXXXXXXXXXXX\";v=\"89\", \"XXXXXXX\";v=\"89\", \";Not A Brand\";v=\"99\""},{"name":"XXXXXXXXXXXXXX","value":"?0"},{"name":"Referer","value":"XXXXXXXXXXXXXXXXXXXXXXXXXXX"},{"name":"Accept-Encoding","value":"XXXXXXXXXXXX"},{"name":"XXXXXXXXXXXXXXXX","value":"XXX"},{"name":"XXXX","value":"XXXXXXXXXXXXXXXXXXXXXXXXX"}],"country":"XX","httpVersion":"XX/XX","requestId":"XXX","clientIp":"XXXXX","httpMethod":"GET","uri":"/prefill"},"rateBasedRuleList":{"limitValue":"XXXXXX","rateBasedRuleName":"rate-XXXX","rateBasedRuleId":"XXXXXXX","maxRateAllowed":"2000","limitKey":"IP"},"httpSourceName":"XXX","nonTerminatingMatchingRules":[],"formatVersion":"1","terminatingRuleMatchDetails":[],"timestamp":"XXXXXXXXXXXXXXXXXXX"}}
```

### Logtest-legacy result

```
**Phase 3: Completed filtering (rules).
       Rule id: '80441'
       Level: '0'
       Description: 'AWS WAF - Allowed request.'
```

### Valgrind report

```
==8182== HEAP SUMMARY:
==8182==     in use at exit: 21,398,332 bytes in 111,423 blocks
==8182==   total heap usage: 771,448 allocs, 660,025 frees, 2,490,177,410 bytes allocated
==8182==
==8182== LEAK SUMMARY:
==8182==    definitely lost: 0 bytes in 0 blocks
==8182==    indirectly lost: 0 bytes in 0 blocks
==8182==      possibly lost: 0 bytes in 0 blocks
==8182==    still reachable: 21,398,332 bytes in 111,423 blocks
==8182==         suppressed: 0 bytes in 0 blocks
```

## Tests

- [x] Input for level-0 rule on Valgrind.