### PR TITLE
HLP - Parser refactor

### DIFF
--- a/src/engine/source/hlp/CMakeLists.txt
+++ b/src/engine/source/hlp/CMakeLists.txt
@@ -28,6 +28,7 @@ set(EXTERNAL_DEPS ${EXTERNAL_DEPS} PARENT_SCOPE)
 add_library(hlp STATIC
     ${ENGINE_HLP_SOURCE_DIR}/hlp.cpp
     ${ENGINE_HLP_SOURCE_DIR}/hlpDetails.hpp
+    ${ENGINE_HLP_SOURCE_DIR}/hlpDetails.cpp
     ${ENGINE_HLP_SOURCE_DIR}/LogQLParser.cpp
     ${ENGINE_HLP_SOURCE_DIR}/LogQLParser.hpp
     ${ENGINE_HLP_SOURCE_DIR}/SpecificParsers.hpp

--- a/src/engine/source/hlp/include/hlp/hlp.hpp
+++ b/src/engine/source/hlp/include/hlp/hlp.hpp
@@ -5,7 +5,7 @@
 #include <unordered_map>
 
 using ParseResult = std::unordered_map<std::string, std::string>;
-using ParserFn = std::function<ParseResult(std::string)>;
+using ParserFn = std::function<bool(std::string, ParseResult& result)>;
 
 ParserFn getParserOp(std::string const &logQl);
 

--- a/src/engine/source/hlp/src/LogQLParser.cpp
+++ b/src/engine/source/hlp/src/LogQLParser.cpp
@@ -93,7 +93,7 @@ static std::vector<std::string> splitSlashSeparatedField(std::string_view str){
     return ret;
 }
 
-static bool parseCapture(Tokenizer &tk, ExpresionList &expresions)
+static bool parseCapture(Tokenizer &tk, ExpressionList &expresions)
 {
     //<name> || <?name> || <name1>?<name2>
     Token token = getToken(tk);
@@ -106,7 +106,7 @@ static bool parseCapture(Tokenizer &tk, ExpresionList &expresions)
 
     if(token.type == TokenType::Literal)
     {
-        expresions.push_back({{token.text, token.len}, ExpresionType::Capture});
+        expresions.push_back({{token.text, token.len}, ExpressionType::Capture});
 
         if(!requireToken(tk, TokenType::CloseAngle))
         {
@@ -117,7 +117,7 @@ static bool parseCapture(Tokenizer &tk, ExpresionList &expresions)
         // TODO check if there's a better way to do this
         if(optional)
         {
-            expresions.back().type = ExpresionType::OptionalCapture;
+            expresions.back().type = ExpressionType::OptionalCapture;
         }
 
         if(peekToken(tk).type == TokenType::QuestionMark)
@@ -133,11 +133,11 @@ static bool parseCapture(Tokenizer &tk, ExpresionList &expresions)
             }
             // Fix up the combType of the previous capture as this is now an OR
             auto &prevCapture = expresions.back();
-            prevCapture.type = ExpresionType::OrCapture;
+            prevCapture.type = ExpressionType::OrCapture;
 
             Token orEnd = getToken(tk);
             expresions.push_back(
-                {{orEnd.text, orEnd.len}, ExpresionType::Capture});
+                {{orEnd.text, orEnd.len}, ExpressionType::Capture});
 
             if(!requireToken(tk, TokenType::CloseAngle))
             {
@@ -165,9 +165,9 @@ static bool parseCapture(Tokenizer &tk, ExpresionList &expresions)
     return true;
 }
 
-ExpresionList parseLogQlExpr(std::string const &expr)
+ExpressionList parseLogQlExpr(std::string const &expr)
 {
-    ExpresionList expresions;
+    ExpressionList expresions;
     Tokenizer tokenizer {expr.c_str()};
 
     bool done = false;
@@ -210,7 +210,7 @@ ExpresionList parseLogQlExpr(std::string const &expr)
             case TokenType::Literal:
             {
                 expresions.push_back(
-                    {{token.text, token.len}, ExpresionType::Literal});
+                    {{token.text, token.len}, ExpressionType::Literal});
                 break;
             }
             case TokenType::EndOfExpr:

--- a/src/engine/source/hlp/src/LogQLParser.hpp
+++ b/src/engine/source/hlp/src/LogQLParser.hpp
@@ -4,9 +4,22 @@
 #include <string>
 #include <vector>
 
-struct Parser;
-using ParserList = std::vector<Parser>;
+enum class ExpresionType
+{
+    Capture,
+    OptionalCapture,
+    OrCapture,
+    Literal,
+};
 
-ParserList parseLogQlExpr(std::string const &expr);
+struct Expresion
+{
+    std::string_view text;
+    ExpresionType type;
+    char endToken;
+};
+
+using ExpresionList = std::vector<Expresion>;
+ExpresionList parseLogQlExpr(std::string const &expr);
 
 #endif //_LOGQL_PARSER_H

--- a/src/engine/source/hlp/src/LogQLParser.hpp
+++ b/src/engine/source/hlp/src/LogQLParser.hpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-enum class ExpresionType
+enum class ExpressionType
 {
     Capture,
     OptionalCapture,
@@ -12,14 +12,14 @@ enum class ExpresionType
     Literal,
 };
 
-struct Expresion
+struct Expression
 {
     std::string_view text;
-    ExpresionType type;
+    ExpressionType type;
     char endToken;
 };
 
-using ExpresionList = std::vector<Expresion>;
-ExpresionList parseLogQlExpr(std::string const &expr);
+using ExpressionList = std::vector<Expression>;
+ExpressionList parseLogQlExpr(std::string const &expr);
 
 #endif //_LOGQL_PARSER_H

--- a/src/engine/source/hlp/src/SpecificParsers.hpp
+++ b/src/engine/source/hlp/src/SpecificParsers.hpp
@@ -2,71 +2,56 @@
 #define _FILE_PATH_PARSER_H
 
 #include <string>
+#include <unordered_map>
 #include <vector>
 
-struct URLResult {
-    std::string domain;
-    std::string fragment;
-    std::string original;
-    std::string password;
-    std::string path;
-    std::string port;
-    std::string query;
-    std::string scheme;
-    std::string username;
-};
+struct Parser;
 
-struct TimeStampResult {
-    std::string year;
-    std::string month;
-    std::string day;
-    std::string hour;
-    std::string minutes;
-    std::string seconds;
-    std::string timezone;
-};
+bool configureMapParser(Parser &parser, std::vector<std::string_view> const& args);
+bool configureTsParser(Parser &parser, std::vector<std::string_view> const& args);
+bool configureFilepathParser(Parser &parser,
+                             std::vector<std::string_view> const &args);
+bool configureDomainParser(Parser &parser,
+                             std::vector<std::string_view> const &args);
 
-// TODO Define which of this fields is really desirable for the response.
-struct DomainResult{
-    std::string protocol;
-    std::string subdomain;
-    std::string top_level_domain;
-    std::string domain;
-    std::string address;
-    std::string registered_domain;
-    std::string route;
-};
-struct FilePathResult{
-    std::string path;           //"file.path": "keyword",
-    std::string drive_letter;   //"file.drive_letter": "keyword",
-    std::string folder;         //"file.directory": "keyword",
-    std::string name;           //"file.name": "keyword",
-    std::string extension;      //"file.extension": "keyword",
-};
+bool parseAny(const char **it,
+              Parser const &parser,
+              std::unordered_map<std::string, std::string> &result);
 
-struct UserAgentResult
-{
-    std::string original;
-};
+bool matchLiteral(const char **it,
+                  Parser const &parser,
+                  std::unordered_map<std::string, std::string> &);
 
-std::string parseAny(const char **it, char endToken);
+bool parseFilePath(const char **it,
+                   Parser const &parser,
+                   std::unordered_map<std::string, std::string> &result);
 
-bool matchLiteral(const char **it, std::string const& literal);
+bool parseJson(const char **it,
+               Parser const &parser,
+               std::unordered_map<std::string, std::string> &result);
 
-void parseFilePath(const char **it, char endToken, std::vector<std::string> const& captureOpts, FilePathResult &result);
+bool parseMap(const char **it,
+              Parser const &parser,
+              std::unordered_map<std::string, std::string> &result);
 
-std::string parseJson(const char **it);
+bool parseIPaddress(const char **it,
+                    Parser const &parser,
+                    std::unordered_map<std::string, std::string> &result);
 
-std::string parseMap(const char **it, char endToken, std::vector<std::string> const& captureOpts);
+bool parseTimeStamp(const char **it,
+                    Parser const &parser,
+                    std::unordered_map<std::string, std::string> &result);
 
-std::string parseIPaddress(const char **it, char endToken);
+bool parseURL(const char **it,
+              Parser const &parser,
+              std::unordered_map<std::string, std::string> &result);
 
-bool parseTimeStamp(const char **it, std::vector<std::string> const& opts, char endToken, TimeStampResult &tsr);
+bool parseDomain(const char **it,
+                 Parser const &parser,
+                 std::unordered_map<std::string, std::string> &result);
 
-bool parseURL(const char **it, char endToken, URLResult &result);
-
-bool parseDomain(const char **it, char endToken, std::vector<std::string> const& captureOpts, DomainResult &result);
-
-bool parseUserAgent(const char** it, char endToken, UserAgentResult& ret);
+bool parseUserAgent(const char **it,
+                    Parser const &parser,
+                    std::unordered_map<std::string, std::string> &result);
 
 #endif //_FILE_PATH_PARSER_H

--- a/src/engine/source/hlp/src/hlpDetails.cpp
+++ b/src/engine/source/hlp/src/hlpDetails.cpp
@@ -1,0 +1,30 @@
+#include "hlpDetails.hpp"
+#include "SpecificParsers.hpp"
+
+const parserConfigFuncPtr kParsersConfig[] = {
+    nullptr,
+    nullptr,
+    nullptr,
+    configureTsParser,
+    nullptr,
+    nullptr,
+    configureMapParser,
+    configureDomainParser,
+    configureFilepathParser,
+    nullptr,
+    nullptr,
+};
+
+const parserFuncPtr kAvailableParsers[] = {
+    parseAny,
+    matchLiteral,
+    parseIPaddress,
+    parseTimeStamp,
+    parseURL,
+    parseJson,
+    parseMap,
+    parseDomain,
+    parseFilePath,
+    parseUserAgent,
+    nullptr,
+};

--- a/src/engine/source/hlp/src/hlpDetails.hpp
+++ b/src/engine/source/hlp/src/hlpDetails.hpp
@@ -17,14 +17,14 @@ enum class ParserType
     Invalid,
 };
 
-enum class ExpresionType;
+enum class ExpressionType;
 
 struct Parser
 {
     std::vector<std::string> options;
     std::string name;
     ParserType type;
-    ExpresionType expType;
+    ExpressionType expType;
     char endToken;
 };
 

--- a/src/engine/source/hlp/src/hlpDetails.hpp
+++ b/src/engine/source/hlp/src/hlpDetails.hpp
@@ -1,15 +1,9 @@
 #include <string>
 #include <vector>
+#include <unordered_map>
 
-enum class CombType {
-    Null,
-    Optional,
-    Or,
-    OrEnd,
-    Invalid,
-};
-
-enum class ParserType {
+enum class ParserType
+{
     Any,
     Literal,
     IP,
@@ -23,11 +17,25 @@ enum class ParserType {
     Invalid,
 };
 
-struct Parser {
-    std::vector<std::string> captureOpts; // TODO The options are split on a list for now
-                                          // This is probably not the best way but works so far
+enum class ExpresionType;
+
+struct Parser
+{
+    std::vector<std::string> options;
     std::string name;
-    ParserType parserType;
-    CombType combType;
+    ParserType type;
+    ExpresionType expType;
     char endToken;
 };
+
+
+using parserFuncPtr =
+    bool (*)(const char **it,
+             Parser const &parser,
+             std::unordered_map<std::string, std::string> &result);
+
+using parserConfigFuncPtr =
+    bool (*)(Parser &parser, std::vector<std::string_view> const& args);
+
+extern const parserFuncPtr kAvailableParsers[];
+extern const parserConfigFuncPtr kParsersConfig[];

--- a/src/engine/source/hlp/tools/hlp_cli.cpp
+++ b/src/engine/source/hlp/tools/hlp_cli.cpp
@@ -38,7 +38,8 @@ int main(int argc, char * argv[])
     auto event_it = events.begin();
     while(exp_it != logql_expressions.end() && event_it != events.end()) {
         auto parseOp = getParserOp(exp_it->c_str());
-        auto result = parseOp(event_it->c_str());
+        ParseResult result;
+        bool ret = parseOp(event_it->c_str(), result);
 
         printf("----------\n");
         printf("LOGQL_EXPRESSION:\n");

--- a/src/engine/test/source/hlp/hlp_test.cpp
+++ b/src/engine/test/source/hlp/hlp_test.cpp
@@ -139,7 +139,7 @@ TEST(hlpTests_URL, url_wrong_format)
     ParseResult result;
     bool ret = parseOp(event, result);
 
-    ASSERT_EQ(result.cend(), result.find("_temp"));
+    ASSERT_FALSE(ret);
 }
 
 TEST(hlpTests_URL, url_success)


### PR DESCRIPTION
|Related issue|
|---|
|#12503|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Refactor of the HLP parser code in an effort to create a separated 'configuration' stage that runs on construction of the environments to be able to separate computation heavy configuration from the execution phase. This is a preparation of the code to be able to make the function helpers later on.

There are three main approaches to do this refactor:
- The first approach is the proposed by this PR, selected because it was the easier to implement with the code that we had already working. Basically we create a configure function for each parser that it needs it and we set that to run when the parser is created. One main limitation right now is that the options are expressed as a `std::vector<std::string>`. This suffices for the time being as the parsers that we have only need strings, but can be made more 'generic' with a `std::vector<std::any> `or a `std::variant ` if needed in the future (minding the performance)
- Other possible approach is to follow a more classic form and have some Parser base class and have each parser be a derived class from that with whatever options they need as members that we can fill up in the configure stage.
- Another explored option was to have something similar on how the current implementation of function helpers work by having a function that returns a lambda that can be later executed so the options in that case are stored as lambda captures
