### PR TITLE
Fixing warnings for second time in wm_sca.c file

### DIFF
--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -2330,7 +2330,7 @@ static int wm_sca_winreg_querykey(HKEY hKey, const char *full_key_name, char *re
             /* Write value into a string */
             switch (data_type) {
                 int size_available;
-                size_t size_data = 0;
+                size_t size_data;
 
                 case REG_SZ:
                 case REG_EXPAND_SZ:
@@ -2344,7 +2344,7 @@ static int wm_sca_winreg_querykey(HKEY hKey, const char *full_key_name, char *re
                     while (*mt_data) {
                         size_data = strlen(mt_data) + strlen(" ");
 
-                        if (size_available >= size_data) {
+                        if ((size_t)size_available >= size_data) {
                             strncat(var_storage, mt_data, size_available);
                             size_available -= strlen(mt_data);
                             strncat(var_storage, " ", size_available);


### PR DESCRIPTION
|Related issue|
|---|
|#12099|


## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh windows agent project in wm_sca.c. The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Windows Agent</summary>

```
    CC wazuh_modules/wm_osquery_monitor.o
    CC wazuh_modules/wm_task_general.o
    CC wazuh_modules/wm_aws.o
    CC wazuh_modules/wm_syscollector.o
    CC wazuh_modules/wm_keyrequest.o
    CC wazuh_modules/wm_github.o
    CC wazuh_modules/wm_database.o
wazuh_modules/wm_github.c: In function ‘wm_github_execute_scan’:
wazuh_modules/wm_github.c:333:33: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  333 |                                 strncpy(url, next_page, strlen(next_page));
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_modules/wm_download.o
    CC wazuh_modules/wm_docker.o
    CC wazuh_modules/wm_sca.o
    CC wazuh_modules/wm_fluent.o
    CC wazuh_modules/wm_command.o
    CC wazuh_modules/wm_ciscat.o
    CC wazuh_modules/agent_upgrade/wm_agent_upgrade.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.o
    CC wazuh_db/wdb_metadata.o
wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c: In function ‘wm_agent_upgrade_com_open’:
wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c:233:9: warning: ‘strncpy’ output may be truncated copying 260 bytes from a string of length 260 [-Wstringop-truncation]
  233 |         strncpy(file.path, final_path, PATH_MAX);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_db/wdb_agents.o
    CC wazuh_db/wdb_integrity.o
    CC wazuh_db/wdb_global.o
    CC wazuh_db/wdb_syscollector.o
    CC wazuh_db/wdb_upgrade.o
    CC wazuh_db/wdb_task.o
    CC wazuh_db/wdb_delta_event.o
    CC wazuh_db/wdb_scan_info.o
    CC wazuh_db/wdb.o
    CC wazuh_db/wdb_parser.o
    CC wazuh_db/wdb_fim.o
wazuh_db/wdb_parser.c: In function ‘wdb_parse_syscheck’:
wazuh_db/wdb_parser.c:1278:13: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
 1278 |             strncpy(unsc_checksum + unsc_size, mark, mark_size);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```

</details>

## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Windows Agent</summary>

```
    CC config/wmodules-osquery-monitor.o
    CC config/wmodules-sca.o
    CC config/wmodules_syscollector.o
    CC config/wmodules-task-manager.o
    CC config/wmodules-vuln-detector.o
    CC wazuh_modules/wm_aws.o
    CC wazuh_modules/wm_azure.o
    CC wazuh_modules/wm_ciscat.o
    CC wazuh_modules/wmcom.o
    CC wazuh_modules/wm_command.o
    CC wazuh_modules/wm_control.o
    CC wazuh_modules/wm_database.o
    CC wazuh_modules/wm_docker.o
    CC wazuh_modules/wm_download.o
    CC wazuh_modules/wm_exec.o
    CC wazuh_modules/wm_fluent.o
    CC wazuh_modules/wm_gcp.o
    CC wazuh_modules/wm_github.o
    CC wazuh_modules/wm_keyrequest.o
    CC wazuh_modules/wmodules.o
    CC wazuh_modules/wm_office365.o
    CC wazuh_modules/wm_oscap.o
wazuh_modules/wm_office365.c: In function ‘wm_office365_execute_scan’:
wazuh_modules/wm_office365.c:453:33: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  453 |                                 strncpy(url, next_page, strlen(next_page));
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_modules/wm_osquery_monitor.o
    CC wazuh_modules/wm_sca.o
wazuh_modules/wm_github.c: In function ‘wm_github_execute_scan’:
wazuh_modules/wm_github.c:333:33: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  333 |                                 strncpy(url, next_page, strlen(next_page));
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_modules/wm_syscollector.o
    CC wazuh_modules/wm_task_general.o
    CC wazuh_modules/agent_upgrade/wm_agent_upgrade.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.o
    CC wazuh_db/wdb_agents.o
    CC wazuh_db/wdb.o
wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c: In function ‘wm_agent_upgrade_com_open’:
wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c:233:9: warning: ‘strncpy’ output may be truncated copying 260 bytes from a string of length 260 [-Wstringop-truncation]
  233 |         strncpy(file.path, final_path, PATH_MAX);

```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors