### PR TITLE
Fixed warnings in file_op.c file.

### DIFF
--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -1907,7 +1907,7 @@ const char *getuname()
                                 snprintf(__wp,  sizeof(__wp), " [Ver: %d.%d.%s]", (unsigned int)winMajor, (unsigned int)winMinor, wincomp);
                             }
                             else {
-                                snprintf(__wp,  sizeof(__wp), " [Ver: %d.%d.%s.%d]", (unsigned int)winMajor, (unsigned int)winMinor, wincomp, buildRevision);
+                                snprintf(__wp,  sizeof(__wp), " [Ver: %d.%d.%s.%lu]", (unsigned int)winMajor, (unsigned int)winMinor, wincomp, buildRevision);
                             }
 
                             char *endptr = NULL, *osVersion = NULL;
@@ -1943,7 +1943,7 @@ const char *getuname()
                                 snprintf(__wp, sizeof(__wp), " [Ver: %s.%s]", winver,wincomp);
                             }
                             else {
-                                snprintf(__wp, sizeof(__wp), " [Ver: %s.%s.%d]", winver, wincomp, buildRevision);
+                                snprintf(__wp, sizeof(__wp), " [Ver: %s.%s.%lu]", winver, wincomp, buildRevision);
                             }
                         }
                     }


### PR DESCRIPTION
|Related issue|
|---|
|#12099|


## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh windows agent project in file_op.c. The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Windows Agent</summary>

```
    CC shared/store_op.o
    CC shared/bzip2_op.o
    CC shared/exec_op.o
    CC shared/mem_op.o
    CC shared/request_op.o
shared/mem_op.c: In function ‘os_LoadString’:
shared/mem_op.c:112:9: warning: ‘strncat’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  112 |         strncat(at, str, strsize);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~
shared/mem_op.c:101:26: note: length computed here
  101 |         size_t strsize = strlen(str);
      |                          ^~~~~~~~~~~
    CC shared/log_builder.o
    CC shared/time_op.o
    CC shared/file_op.o
    CC shared/pthreads_op.o
    CC shared/integrity_op.o
    CC shared/queue_linked_op.o
    CC shared/os_utils.o
    CC shared/rbtree_op.o
    CC shared/fs_op.o
    CC shared/cluster_utils.o
    CC shared/read-agents.o
    CC shared/audit_op.o
    CC shared/syscheck_op.o
    CC shared/yaml2json.o
    CC shared/buffer_op.o
shared/syscheck_op.c: In function ‘get_registry_permissions’:
shared/syscheck_op.c:1116:11: warning: unused variable ‘dwErrorCode’ [-Wunused-variable]
 1116 |     DWORD dwErrorCode = 0;
      |           ^~~~~~~~~~~
    CC shared/report_op.o
    CC shared/sig_op.o
    CC shared/sym_load.o
    CC shared/wait_op.o
    CC shared/help.o
    CC shared/labels_op.o
    CC shared/auth_client.o
    CC shared/list_op.o
    CC shared/privsep_op.o
    CC shared/hash_op.o
    CC shared/b64.o

```

</details>

## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Windows Agent</summary>

```
      |                              ^~~~~~~~~~~~~
    CC shared/exec_op.o
    CC shared/expression.o
shared/enrollment_op.c: In function ‘w_enrollment_concat_src_ip’:
shared/enrollment_op.c:547:13: warning: ‘strncat’ output may be truncated copying 254 bytes from a string of length 255 [-Wstringop-truncation]
  547 |             strncat(buff,opt_buf,254);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~
    CC shared/file_op.o
    CC shared/file-queue.o
    CC shared/fs_op.o
    CC shared/hash_op.o
    CC shared/help.o
    CC shared/integrity_op.o
    CC shared/json_op.o
    CC shared/json-queue.o
    CC shared/labels_op.o
    CC shared/list_op.o
    CC shared/log_builder.o
    CC shared/math_op.o
    CC shared/mem_op.o
    CC shared/mq_op.o
    CC shared/notify_op.o
    CC shared/os_utils.o
    CC shared/privsep_op.o
    CC shared/pthreads_op.o
    CC shared/queue_linked_op.o
    CC shared/queue_op.o
    CC shared/randombytes.o
    CC shared/rbtree_op.o
    CC shared/read-agents.o
    CC shared/read-alert.o
    CC shared/regex_op.o
    CC shared/remoted_op.o
    CC shared/report_op.o
    CC shared/request_op.o
    CC shared/rootcheck_op.o
    CC shared/rules_op.o
    CC shared/schedule_scan.o
    CC shared/sig_op.o
    CC shared/store_op.o
    CC shared/string_op.o
    CC shared/sym_load.o
shared/string_op.c: In function ‘wstr_split’:
shared/string_op.c:612:17: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
  612 |                 strncpy(new_term_it, acc_strs[count], strlen(acc_strs[count]));
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
shared/string_op.c:609:21: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  609 |                     strncpy(new_term_it, new_delim, new_delim_size);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
shared/string_op.c:569:29: note: length computed here
  569 |     size_t new_delim_size = strlen(replace_delim ? replace_delim : delim);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC shared/syscheck_op.o

```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors