### PR TITLE
Fixed warnings in syscheck_op.c file.

### DIFF
--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1113,7 +1113,6 @@ end:
 DWORD get_registry_permissions(HKEY hndl, cJSON **output_acl) {
     PSECURITY_DESCRIPTOR pSecurityDescriptor;
     DWORD dwRtnCode = 0;
-    DWORD dwErrorCode = 0;
     DWORD lpcbSecurityDescriptor = 0;
 
     dwRtnCode = RegGetKeySecurity(hndl, DACL_SECURITY_INFORMATION, NULL, &lpcbSecurityDescriptor);


### PR DESCRIPTION
|Related issue|
|---|
|#12099|


## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh windows agent project in syscheck_op.c. The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Windows Agent</summary>

```
    CC shared/file_op.o
    CC shared/pthreads_op.o
    CC shared/integrity_op.o
shared/file_op.c: In function ‘getuname’:
shared/file_op.c:1910:81: warning: format ‘%d’ expects argument of type ‘int’, but argument 7 has type ‘DWORD’ {aka ‘long unsigned int’} [-Wformat=]
 1910 |                                 snprintf(__wp,  sizeof(__wp), " [Ver: %d.%d.%s.%d]", (unsigned int)winMajor, (unsigned int)winMinor, wincomp, buildRevision);
      |                                                                                ~^                                                             ~~~~~~~~~~~~~
      |                                                                                 |                                                             |
      |                                                                                 int                                                           DWORD {aka long unsigned int}
      |                                                                                %ld
shared/file_op.c:1946:77: warning: format ‘%d’ expects argument of type ‘int’, but argument 6 has type ‘DWORD’ {aka ‘long unsigned int’} [-Wformat=]
 1946 |                                 snprintf(__wp, sizeof(__wp), " [Ver: %s.%s.%d]", winver, wincomp, buildRevision);
      |                                                                            ~^                     ~~~~~~~~~~~~~
      |                                                                             |                     |
      |                                                                             int                   DWORD {aka long unsigned int}
      |                                                                            %ld
    CC shared/queue_linked_op.o
    CC shared/os_utils.o
    CC shared/rbtree_op.o
    CC shared/fs_op.o
    CC shared/cluster_utils.o
    CC shared/read-agents.o
    CC shared/audit_op.o
    CC shared/syscheck_op.o
    CC shared/yaml2json.o
    CC shared/buffer_op.o
    CC shared/report_op.o
    CC shared/sig_op.o
    CC shared/sym_load.o
    CC shared/wait_op.o
    CC shared/help.o
    CC shared/labels_op.o
    CC shared/auth_client.o
    CC shared/list_op.o
    CC shared/privsep_op.o
    CC shared/hash_op.o
    CC shared/b64.o
    CC shared/file-queue.o
    CC shared/math_op.o
    CC shared/atomic.o
    CC shared/rules_op.o
    CC shared/string_op.o
    CC shared/url.o
shared/string_op.c: In function ‘wstr_split’:
shared/string_op.c:612:17: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  612 |                 strncpy(new_term_it, acc_strs[count], strlen(acc_strs[count]));
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
shared/string_op.c:609:21: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  609 |                     strncpy(new_term_it, new_delim, new_delim_size);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
shared/string_op.c:569:29: note: length computed here
  569 |     size_t new_delim_size = strlen(replace_delim ? replace_delim : delim);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC shared/version_op.o
    CC shared/enrollment_op.o

```

</details>

## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Windows Agent</summary>

```
      |                                                                                 |                                                             |
      |                                                                                 int                                                           DWORD {aka long unsigned int}
      |                                                                                %ld
shared/file_op.c:1946:77: warning: format ‘%d’ expects argument of type ‘int’, but argument 6 has type ‘DWORD’ {aka ‘long unsigned int’} [-Wformat=]
 1946 |                                 snprintf(__wp, sizeof(__wp), " [Ver: %s.%s.%d]", winver, wincomp, buildRevision);
      |                                                                            ~^                     ~~~~~~~~~~~~~
      |                                                                             |                     |
      |                                                                             int                   DWORD {aka long unsigned int}
      |                                                                            %ld
    CC shared/help.o
    CC shared/integrity_op.o
    CC shared/json_op.o
    CC shared/json-queue.o
    CC shared/labels_op.o
    CC shared/list_op.o
    CC shared/log_builder.o
    CC shared/math_op.o
    CC shared/mem_op.o
    CC shared/mq_op.o
    CC shared/notify_op.o
    CC shared/os_utils.o
    CC shared/privsep_op.o
    CC shared/pthreads_op.o
    CC shared/queue_linked_op.o
    CC shared/queue_op.o
    CC shared/randombytes.o
    CC shared/rbtree_op.o
    CC shared/read-agents.o
    CC shared/read-alert.o
    CC shared/regex_op.o
    CC shared/remoted_op.o
    CC shared/report_op.o
    CC shared/request_op.o
    CC shared/rootcheck_op.o
    CC shared/rules_op.o
    CC shared/schedule_scan.o
    CC shared/sig_op.o
    CC shared/store_op.o
    CC shared/string_op.o
    CC shared/sym_load.o
    CC shared/syscheck_op.o
shared/string_op.c: In function ‘wstr_split’:
shared/string_op.c:612:17: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
  612 |                 strncpy(new_term_it, acc_strs[count], strlen(acc_strs[count]));
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
shared/string_op.c:609:21: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  609 |                     strncpy(new_term_it, new_delim, new_delim_size);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
shared/string_op.c:569:29: note: length computed here
  569 |     size_t new_delim_size = strlen(replace_delim ? replace_delim : delim);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC shared/sysinfo_utils.o
    CC shared/time_op.o
    CC shared/url.o
    CC shared/utf8_op.o
    CC shared/validate_op.o
    CC shared/vector_op.o
    CC shared/version_op.o
    CC shared/wait_op.o
    CC shared/wazuhdb_op.o
    CC shared/yaml2json.o
    CC os_net/os_net.o
    CC os_regex/os_match.o

```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors