### PR TITLE
Fixed warnings in file_op.h, setup-shared.h, setup-win.c and setup-syscheck.c files

### DIFF
--- a/src/win32/setup-shared.h
+++ b/src/win32/setup-shared.h
@@ -15,6 +15,7 @@
 #include <sys/types.h>
 #include <dirent.h>
 #include <time.h>
+#include <winsock2.h>
 #include <windows.h>
 #include "os_regex/os_regex.h"
 #include "headers/file_op.h"


### PR DESCRIPTION
|Related issue|
|---|
|#12099|

## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh windows agent project in file_op.h, setup-shared.h, setup-win.c and setup-syscheck.c. The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Windows Agent</summary>

```
    CC logcollector/read_syslog-event.o
    CC logcollector/read_audit-event.o
    CC logcollector/read_multiline_regex-event.o
logcollector/read_audit.c: In function ‘audit_send_msg’:
logcollector/read_audit.c:31:13: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
   31 |             strncpy(message + n, cache[i], z);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_audit.c:25:13: note: length computed here
   25 |         z = strlen(cache[i]);
      |             ^~~~~~~~~~~~~~~~
    CC logcollector/read_nmapg-event.o
    CC logcollector/read_command-event.o
logcollector/read_nmapg.c: In function ‘read_nmapg’:
logcollector/read_nmapg.c:246:13: warning: ‘strncat’ output may be truncated copying between 27 and 65533 bytes from a string of length 65536 [-Wstringop-truncation]
  246 |             strncat(final_msg, buffer, final_msg_s);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_mysql_log-event.o
    CC logcollector/read_ucs2_be-event.o
    CC logcollector/read_multiline-event.o
    CC logcollector/macos_log-event.o
    CC logcollector/read_fullcommand-event.o
logcollector/read_multiline.c: In function ‘read_multiline’:
logcollector/read_multiline.c:96:9: warning: ‘strncpy’ output may be truncated copying between 0 and 65534 bytes from a string of length 65536 [-Wstringop-truncation]
   96 |         strncpy(buffer + buffer_size, str, OS_MAXSTR - buffer_size - 2);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_snortfull-event.o
    CC win32/win_service_rk.o
logcollector/read_snortfull.c: In function ‘read_snortfull’:
logcollector/read_snortfull.c:54:17: warning: ‘strncpy’ output may be truncated copying 65536 bytes from a string of length 65536 [-Wstringop-truncation]
   54 |                 strncpy(f_msg, str, OS_MAXSTR);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC addagent/read_from_user.o
    CC addagent/main.o
    CC addagent/manage_keys.o
    CC addagent/manage_agents.o
    CC win32/setup-win.o
    CC win32/setup-shared.o
    CC win32/setup-syscheck.o
    CC win32/setup-iis.o
    CC win32/ui/common.o
    CC win32/ui/os_win32ui.o
    CC os_auth/main-client.o
cd shared_modules/dbsync/ && mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix   .. && make
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/shared_modules/dbsync/build
make[2]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[3]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 10%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync.cpp.obj
cd data_provider/ && mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix    .. && make
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/data_provider/build
make[2]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
make[3]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
Scanning dependencies of target sysinfo
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
[ 14%] Building CXX object CMakeFiles/sysinfo.dir/src/network/networkInterfaceWindows.cpp.obj
[ 28%] Building CXX object CMakeFiles/sysinfo.dir/src/osinfo/sysOsInfoWin.cpp.obj
[ 20%] Building CXX object CMakeFiles/dbsync.dir/src/dbsyncPipelineFactory.cpp.obj
[ 42%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfoWin.cpp.obj
/home/hanes/wazuh/src/data_provider/src/sysInfoWin.cpp:463:56: warning: multi-character character constant [-Wmultichar]
  463 |             const auto size {pfnGetSystemFirmwareTable('RSMB', 0, nullptr, 0)};
      |                                                        ^~~~~~
/home/hanes/wazuh/src/data_provider/src/sysInfoWin.cpp:472:51: warning: multi-character character constant [-Wmultichar]
  472 |                     if (pfnGetSystemFirmwareTable('RSMB', 0, spBuff.get(), size) == size)
      |                                                   ^~~~~~
[ 30%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync_implementation.cpp.obj
[ 40%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_dbengine.cpp.obj
[ 57%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfo.cpp.obj
[ 50%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_wrapper.cpp.obj
[ 60%] Linking CXX shared library bin/dbsync.dll
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 60%] Built target dbsync
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync_example
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 70%] Building CXX object example/CMakeFiles/dbsync_example.dir/main.cpp.obj
[ 80%] Linking CXX executable ../bin/dbsync_example.exe
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 80%] Built target dbsync_example
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 71%] Linking CXX shared library bin/sysinfo.dll
Scanning dependencies of target dbsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 90%] Building CXX object testtool/CMakeFiles/dbsync_test_tool.dir/main.cpp.obj
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
[ 71%] Built target sysinfo
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
Scanning dependencies of target sysinfo_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
[ 85%] Building CXX object testtool/CMakeFiles/sysinfo_test_tool.dir/main.cpp.obj
[100%] Linking CXX executable ../bin/sysinfo_test_tool.exe
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
[100%] Built target sysinfo_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
    LINK libwazuh.a
i686-w64-mingw32-ar: `u' modifier ignored since `D' is the default (see `U')
    RANLIB libwazuh.a
    CC win32/wazuh-agent.exe
    CC win32/wazuh-agent-eventchannel.exe
    CC win32/manage_agents.exe
    CC win32/setup-windows.exe
    CC win32/setup-syscheck.exe
    CC win32/setup-iis.exe
    CC win32/os_win32ui.exe
    CC win32/agent-auth.exe
[100%] Linking CXX executable ../bin/dbsync_test_tool.exe
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[100%] Built target dbsync_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
cd shared_modules/rsync/ &&  mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix   .. && make
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/shared_modules/rsync/build
make[2]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[3]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
Scanning dependencies of target rsync
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[ 12%] Building CXX object CMakeFiles/rsync.dir/src/rsync.cpp.obj
[ 25%] Building CXX object CMakeFiles/rsync.dir/src/rsyncImplementation.cpp.obj
[ 37%] Linking CXX shared library bin/rsync.dll
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[ 37%] Built target rsync
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
Scanning dependencies of target rsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[ 50%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/main.cpp.obj
[ 62%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/agentEmulator.cpp.obj
[ 75%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/oneTimeSync.cpp.obj
[ 87%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/managerEmulator.cpp.obj
[100%] Linking CXX executable ../bin/rsync_test_tool.exe
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[100%] Built target rsync_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
cd wazuh_modules/syscollector/ && mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix   .. && make
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/wazuh_modules/syscollector/build
make[2]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[3]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
Scanning dependencies of target syscollector
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[ 16%] Building CXX object CMakeFiles/syscollector.dir/src/syscollector.cpp.obj
[ 33%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorImp.cpp.obj
[ 50%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorNormalizer.cpp.obj
[ 66%] Linking CXX shared library bin/syscollector.dll
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[ 66%] Built target syscollector
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
Scanning dependencies of target syscollector_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[ 83%] Building CXX object testtool/CMakeFiles/syscollector_test_tool.dir/main.cpp.obj
[100%] Linking CXX executable ../bin/syscollector_test_tool.exe
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[100%] Built target syscollector_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[1]: Leaving directory '/home/hanes/wazuh/src'
make win32/restart-wazuh.exe win32/route-null.exe win32/netsh.exe CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
make[1]: Entering directory '/home/hanes/wazuh/src'
grep: /etc/redhat-release: No such file or directory
    CC shared/file_op_proc.o
    CC shared/debug_op_proc.o
shared/file_op.c: In function ‘getuname’:
shared/file_op.c:1910:81: warning: format ‘%d’ expects argument of type ‘int’, but argument 7 has type ‘DWORD’ {aka ‘long unsigned int’} [-Wformat=]
 1910 |                                 snprintf(__wp,  sizeof(__wp), " [Ver: %d.%d.%s.%d]", (unsigned int)winMajor, (unsigned int)winMinor, wincomp, buildRevision);
      |                                                                                ~^                                                             ~~~~~~~~~~~~~
      |                                                                                 |                                                             |
      |                                                                                 int                                                           DWORD {aka long unsigned int}
      |                                                                                %ld
shared/file_op.c:1946:77: warning: format ‘%d’ expects argument of type ‘int’, but argument 6 has type ‘DWORD’ {aka ‘long unsigned int’} [-Wformat=]
 1946 |                                 snprintf(__wp, sizeof(__wp), " [Ver: %s.%s.%d]", winver, wincomp, buildRevision);
      |                                                                            ~^                     ~~~~~~~~~~~~~
      |                                                                             |                     |
      |                                                                             int                   DWORD {aka long unsigned int}
      |                                                                            %ld
    CC active-response/restart-wazuh.o
    CC active-response/route-null.o
    CC active-response/netsh.o
active-response/route-null.c: In function ‘main’:
active-response/route-null.c:130:21: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
  130 |                     strncpy(gateway, ptr+2, strlen(ptr+2)-1);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
active-response/route-null.c:130:45: note: length computed here
  130 |                     strncpy(gateway, ptr+2, strlen(ptr+2)-1);
      |                                             ^~~~~~~~~~~~~
    CC libwazuhshared.dll
    CC win32/restart-wazuh.exe
    CC win32/route-null.exe
    CC win32/netsh.exe
make[1]: Leaving directory '/home/hanes/wazuh/src'
cd win32/ && ./unix2dos.pl ossec.conf > default-ossec.conf
cd win32/ && ./unix2dos.pl help.txt > help_win.txt
cd win32/ && ./unix2dos.pl ../../etc/internal_options.conf > internal_options.conf
cd win32/ && ./unix2dos.pl ../../etc/local_internal_options-win.conf > default-local_internal_options.conf
cd win32/ && ./unix2dos.pl ../../LICENSE > LICENSE.txt
cd win32/ && ./unix2dos.pl ../VERSION > VERSION
cd win32/ && ./unix2dos.pl ../REVISION > REVISION
cd win32/ && makensis wazuh-installer.nsi
Processing config: /etc/nsisconf.nsh
Processing script file: "wazuh-installer.nsi" (UTF8)

Processed 1 file, writing output (x86-ansi):
warning 7998: ANSI targets are deprecated

Output: "wazuh-agent-4.4.0.exe"
Install: 6 pages (384 bytes), 3 sections (12360 bytes), 1152 instructions (32256 bytes), 402 strings (33233 bytes), 1 language table (346 bytes).
Uninstall: 4 pages (320 bytes), 1 section (4120 bytes), 401 instructions (11228 bytes), 207 strings (3694 bytes), 1 language table (290 bytes).

Using zlib compression.

EXE header size:              112128 / 78336 bytes
Install code:                  16764 / 69827 bytes
Install data:                8104642 / 22839720 bytes
Uninstall code+data:           48188 / 70343 bytes
CRC (0xD19EBB66):                  4 / 4 bytes

Total size:                  8281726 / 23058230 bytes (35.9%)

1 warning:
  7998: ANSI targets are deprecated
make settings
make[1]: Entering directory '/home/hanes/wazuh/src'
grep: /etc/redhat-release: No such file or directory

General settings:
    TARGET:             winagent
    V:                  
    DEBUG:              
    DEBUGAD             
    INSTALLDIR:         
    DATABASE:           
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/16
    EXTERNAL_SRC_ONLY:  
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_ZEROMQ:         no
    USE_GEOIP:          no
    USE_PRELUDE:        no
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          no
    DISABLE_SYSC:       no
    DISABLE_CISCAT:     no
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DENABLE_SYSC -DENABLE_CISCAT
Compiler:
    CFLAGS            -pthread -DNDEBUG -O2 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DENABLE_SYSC -DENABLE_CISCAT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Ishared_modules/common -Ishared_modules/dbsync/include -Ishared_modules/rsync/include -Iwazuh_modules/syscollector/include  -Idata_provider/include  -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include 
    LDFLAGS           -pthread -O2 -Lshared_modules/dbsync/build/bin -Lshared_modules/rsync/build/bin  -Lwazuh_modules/syscollector/build/bin -Ldata_provider/build/bin
    LIBS              
    CC                gcc
    MAKE              make
make[1]: Leaving directory '/home/hanes/wazuh/src'

Done building winagent
```

</details>

## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Windows Agent</summary>

```
    CC logcollector/read_nmapg-event.o
logcollector/read_multiline.c: In function ‘read_multiline’:
logcollector/read_multiline.c:96:9: warning: ‘strncpy’ output may be truncated copying between 0 and 65534 bytes from a string of length 65536 [-Wstringop-truncation]
   96 |         strncpy(buffer + buffer_size, str, OS_MAXSTR - buffer_size - 2);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_ossecalert-event.o
    CC logcollector/read_postgresql_log-event.o
    CC logcollector/read_snortfull-event.o
logcollector/read_nmapg.c: In function ‘read_nmapg’:
logcollector/read_nmapg.c:246:13: warning: ‘strncat’ output may be truncated copying between 27 and 65533 bytes from a string of length 65536 [-Wstringop-truncation]
  246 |             strncat(final_msg, buffer, final_msg_s);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_syslog-event.o
    CC logcollector/read_ucs2_be-event.o
logcollector/read_postgresql_log.c: In function ‘read_postgresql_log’:
logcollector/read_postgresql_log.c:114:17: warning: ‘strncpy’ output may be truncated copying between 35 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  114 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_postgresql_log.c:106:17: warning: ‘strncpy’ output may be truncated copying between 35 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_ucs2_le-event.o
logcollector/read_snortfull.c: In function ‘read_snortfull’:
logcollector/read_snortfull.c:54:17: warning: ‘strncpy’ output may be truncated copying 65536 bytes from a string of length 65536 [-Wstringop-truncation]
   54 |                 strncpy(f_msg, str, OS_MAXSTR);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_win_el-event.o
    CC logcollector/read_win_event_channel-event.o
    CC logcollector/state-event.o
    CC win32/win_service_rk.o
    CC addagent/main.o
    CC addagent/manage_agents.o
    CC addagent/manage_keys.o
    CC addagent/read_from_user.o
    CC win32/setup-win.o
    CC win32/setup-shared.o
    CC win32/setup-syscheck.o
    CC win32/setup-iis.o
    CC win32/ui/common.o
    CC win32/ui/os_win32ui.o
    CC os_auth/main-client.o
cd shared_modules/dbsync/ && mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix   .. && make
-- The C compiler identification is GNU 10.0.0
cd data_provider/ && mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix    .. && make
-- The CXX compiler identification is GNU 10.0.0
-- The C compiler identification is GNU 10.0.0
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc
-- The CXX compiler identification is GNU 10.0.0
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc
    LINK libwazuh.a
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - works
i686-w64-mingw32-ar: `u' modifier ignored since `D' is the default (see `U')
-- Detecting C compiler ABI info
    RANLIB libwazuh.a
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - works
-- Detecting C compiler ABI info
    CC win32/wazuh-agent.exe
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - works
-- Detecting CXX compiler ABI info
    CC win32/wazuh-agent-eventchannel.exe
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build
-- Detecting CXX compiler ABI info - done
make[2]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[3]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 10%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync.cpp.obj
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/wazuh/src/data_provider/build
make[2]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[3]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
    CC win32/manage_agents.exe
Scanning dependencies of target sysinfo
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
[ 14%] Building CXX object CMakeFiles/sysinfo.dir/src/network/networkInterfaceWindows.cpp.obj
    CC win32/setup-windows.exe
[ 28%] Building CXX object CMakeFiles/sysinfo.dir/src/osinfo/sysOsInfoWin.cpp.obj
[ 20%] Building CXX object CMakeFiles/dbsync.dir/src/dbsyncPipelineFactory.cpp.obj
[ 42%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfoWin.cpp.obj
[ 57%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfo.cpp.obj
/home/hanes/wazuh/wazuh/src/data_provider/src/sysInfoWin.cpp:463:56: warning: multi-character character constant [-Wmultichar]
  463 |             const auto size {pfnGetSystemFirmwareTable('RSMB', 0, nullptr, 0)};
      |                                                        ^~~~~~
/home/hanes/wazuh/wazuh/src/data_provider/src/sysInfoWin.cpp:472:51: warning: multi-character character constant [-Wmultichar]
  472 |                     if (pfnGetSystemFirmwareTable('RSMB', 0, spBuff.get(), size) == size)
      |                                                   ^~~~~~
[ 30%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync_implementation.cpp.obj
[ 40%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_dbengine.cpp.obj
    CC win32/setup-syscheck.exe
[ 50%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_wrapper.cpp.obj
    CC win32/setup-iis.exe
    CC win32/os_win32ui.exe
    CC win32/agent-auth.exe
In file included from /home/hanes/wazuh/wazuh/src/data_provider/include/sysInfoInterface.h:15,
                 from /home/hanes/wazuh/wazuh/src/data_provider/include/sysInfo.hpp:28,
                 from /home/hanes/wazuh/wazuh/src/data_provider/src/sysInfoWin.cpp:26:
/home/hanes/wazuh/wazuh/src/external/nlohmann/json.hpp: In function ‘nlohmann::json getProcessInfo(const PROCESSENTRY32&)’:
/home/hanes/wazuh/wazuh/src/external/nlohmann/json.hpp:3676:62: warning: ‘process.SysInfoProcess::m_virtualSize’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 3676 |     external_constructor<value_t::number_unsigned>::construct(j, static_cast<typename BasicJsonType::number_unsigned_t>(val));
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/hanes/wazuh/wazuh/src/data_provider/src/sysInfoWin.cpp:353:24: note: ‘process.SysInfoProcess::m_virtualSize’ was declared here
  353 |         SysInfoProcess process(pId, processHandle);
      |                        ^~~~~~~
In file included from /home/hanes/wazuh/wazuh/src/data_provider/include/sysInfoInterface.h:15,
                 from /home/hanes/wazuh/wazuh/src/data_provider/include/sysInfo.hpp:28,
                 from /home/hanes/wazuh/wazuh/src/data_provider/src/sysInfoWin.cpp:26:
/home/hanes/wazuh/wazuh/src/external/nlohmann/json.hpp:3676:62: warning: ‘process.SysInfoProcess::m_pageFileUsage’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 3676 |     external_constructor<value_t::number_unsigned>::construct(j, static_cast<typename BasicJsonType::number_unsigned_t>(val));
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/hanes/wazuh/wazuh/src/data_provider/src/sysInfoWin.cpp:353:24: note: ‘process.SysInfoProcess::m_pageFileUsage’ was declared here
  353 |         SysInfoProcess process(pId, processHandle);
      |                        ^~~~~~~
[ 60%] Linking CXX shared library bin/dbsync.dll
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 60%] Built target dbsync
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync_example
Scanning dependencies of target dbsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 70%] Building CXX object example/CMakeFiles/dbsync_example.dir/main.cpp.obj
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 80%] Building CXX object testtool/CMakeFiles/dbsync_test_tool.dir/main.cpp.obj
[ 90%] Linking CXX executable ../bin/dbsync_example.exe
[ 71%] Linking CXX shared library bin/sysinfo.dll
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 90%] Built target dbsync_example
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
[ 71%] Built target sysinfo
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
Scanning dependencies of target sysinfo_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
[ 85%] Building CXX object testtool/CMakeFiles/sysinfo_test_tool.dir/main.cpp.obj
[100%] Linking CXX executable ../bin/sysinfo_test_tool.exe
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
[100%] Built target sysinfo_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[2]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
[100%] Linking CXX executable ../bin/dbsync_test_tool.exe
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[100%] Built target dbsync_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[2]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
cd shared_modules/rsync/ &&  mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix   .. && make
-- The C compiler identification is GNU 10.0.0
-- The CXX compiler identification is GNU 10.0.0
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/wazuh/src/shared_modules/rsync/build
make[2]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[3]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
Scanning dependencies of target rsync
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
[ 12%] Building CXX object CMakeFiles/rsync.dir/src/rsync.cpp.obj
[ 25%] Building CXX object CMakeFiles/rsync.dir/src/rsyncImplementation.cpp.obj
[ 37%] Linking CXX shared library bin/rsync.dll
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
[ 37%] Built target rsync
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
Scanning dependencies of target rsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
[ 62%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/agentEmulator.cpp.obj
[ 62%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/main.cpp.obj
[ 75%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/oneTimeSync.cpp.obj
[ 87%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/managerEmulator.cpp.obj
[100%] Linking CXX executable ../bin/rsync_test_tool.exe
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
[100%] Built target rsync_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[2]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
cd wazuh_modules/syscollector/ && mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix   .. && make
-- The C compiler identification is GNU 10.0.0
-- The CXX compiler identification is GNU 10.0.0
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build
make[2]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[3]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
Scanning dependencies of target syscollector
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
[ 50%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorNormalizer.cpp.obj
[ 50%] Building CXX object CMakeFiles/syscollector.dir/src/syscollector.cpp.obj
[ 50%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorImp.cpp.obj
[ 66%] Linking CXX shared library bin/syscollector.dll
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
[ 66%] Built target syscollector
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
Scanning dependencies of target syscollector_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
[ 83%] Building CXX object testtool/CMakeFiles/syscollector_test_tool.dir/main.cpp.obj
[100%] Linking CXX executable ../bin/syscollector_test_tool.exe
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
[100%] Built target syscollector_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[2]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[1]: Leaving directory '/home/hanes/wazuh/wazuh/src'
make win32/restart-wazuh.exe win32/route-null.exe win32/netsh.exe CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
make[1]: Entering directory '/home/hanes/wazuh/wazuh/src'
grep: /etc/redhat-release: No such file or directory
    CC shared/file_op_proc.o
    CC shared/debug_op_proc.o
    CC active-response/restart-wazuh.o
    CC active-response/route-null.o
active-response/route-null.c: In function ‘main’:
active-response/route-null.c:130:21: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
  130 |                     strncpy(gateway, ptr+2, strlen(ptr+2)-1);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
active-response/route-null.c:130:45: note: length computed here
  130 |                     strncpy(gateway, ptr+2, strlen(ptr+2)-1);
      |                                             ^~~~~~~~~~~~~
    CC active-response/netsh.o
shared/file_op.c: In function ‘getuname’:
shared/file_op.c:1910:81: warning: format ‘%d’ expects argument of type ‘int’, but argument 7 has type ‘DWORD’ {aka ‘long unsigned int’} [-Wformat=]
 1910 |                                 snprintf(__wp,  sizeof(__wp), " [Ver: %d.%d.%s.%d]", (unsigned int)winMajor, (unsigned int)winMinor, wincomp, buildRevision);
      |                                                                                ~^                                                             ~~~~~~~~~~~~~
      |                                                                                 |                                                             |
      |                                                                                 int                                                           DWORD {aka long unsigned int}
      |                                                                                %ld
shared/file_op.c:1946:77: warning: format ‘%d’ expects argument of type ‘int’, but argument 6 has type ‘DWORD’ {aka ‘long unsigned int’} [-Wformat=]
 1946 |                                 snprintf(__wp, sizeof(__wp), " [Ver: %s.%s.%d]", winver, wincomp, buildRevision);
      |                                                                            ~^                     ~~~~~~~~~~~~~
      |                                                                             |                     |
      |                                                                             int                   DWORD {aka long unsigned int}
      |                                                                            %ld
    CC libwazuhshared.dll
    CC win32/restart-wazuh.exe
    CC win32/route-null.exe
    CC win32/netsh.exe
make[1]: Leaving directory '/home/hanes/wazuh/wazuh/src'
cd win32/ && ./unix2dos.pl ossec.conf > default-ossec.conf
cd win32/ && ./unix2dos.pl help.txt > help_win.txt
cd win32/ && ./unix2dos.pl ../../etc/internal_options.conf > internal_options.conf
cd win32/ && ./unix2dos.pl ../../etc/local_internal_options-win.conf > default-local_internal_options.conf
cd win32/ && ./unix2dos.pl ../../LICENSE > LICENSE.txt
cd win32/ && ./unix2dos.pl ../VERSION > VERSION
cd win32/ && ./unix2dos.pl ../REVISION > REVISION
cd win32/ && makensis wazuh-installer.nsi
Processing config: /etc/nsisconf.nsh
Processing script file: "wazuh-installer.nsi" (UTF8)

Processed 1 file, writing output (x86-ansi):
warning 7998: ANSI targets are deprecated

Output: "wazuh-agent-4.4.0.exe"
Install: 6 pages (384 bytes), 3 sections (12360 bytes), 1152 instructions (32256 bytes), 402 strings (33233 bytes), 1 language table (346 bytes).
Uninstall: 4 pages (320 bytes), 1 section (4120 bytes), 401 instructions (11228 bytes), 207 strings (3694 bytes), 1 language table (290 bytes).

Using zlib compression.

EXE header size:              112640 / 78848 bytes
Install code:                  16771 / 69827 bytes
Install data:                7511843 / 20474313 bytes
Uninstall code+data:           48169 / 70324 bytes
CRC (0xD0A7795F):                  4 / 4 bytes

Total size:                  7689427 / 20693316 bytes (37.1%)

1 warning:
  7998: ANSI targets are deprecated
make settings
make[1]: Entering directory '/home/hanes/wazuh/wazuh/src'
grep: /etc/redhat-release: No such file or directory

General settings:
    TARGET:             winagent
    V:                  
    DEBUG:              
    DEBUGAD             
    INSTALLDIR:         
    DATABASE:           
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/16
    EXTERNAL_SRC_ONLY:  
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_ZEROMQ:         no
    USE_GEOIP:          no
    USE_PRELUDE:        no
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          no
    DISABLE_SYSC:       no
    DISABLE_CISCAT:     no
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DENABLE_SYSC -DENABLE_CISCAT
Compiler:
    CFLAGS            -pthread -DNDEBUG -O2 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DENABLE_SYSC -DENABLE_CISCAT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Ishared_modules/common -Ishared_modules/dbsync/include -Ishared_modules/rsync/include -Iwazuh_modules/syscollector/include  -Idata_provider/include  -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include 
    LDFLAGS           -pthread -O2 -Lshared_modules/dbsync/build/bin -Lshared_modules/rsync/build/bin  -Lwazuh_modules/syscollector/build/bin -Ldata_provider/build/bin
    LIBS              
    CC                gcc
    MAKE              make
make[1]: Leaving directory '/home/hanes/wazuh/wazuh/src'

Done building winagent
```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors