### PR TITLE
Fixed warnings in router-null.c file.

### DIFF
--- a/src/active-response/route-null.c
+++ b/src/active-response/route-null.c
@@ -126,8 +126,7 @@ int main (int argc, char **argv) {
             while (fgets(output_buf, OS_MAXSTR, fp)) {
                 char *ptr = strchr(output_buf, ':');
                 if (ptr != NULL) {
-                    memset(gateway, '\0', IPSIZE + 1);
-                    strncpy(gateway, ptr+2, strlen(ptr+2)-1);
+                    snprintf(gateway, sizeof(gateway), "%s", ptr + 2);
                 }
             }
             fclose(fp);


### PR DESCRIPTION
|Related issue|
|---|
|#12099|

## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh windows agent project in router-null.c. The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Windows Agent</summary>

```
make[1]: Leaving directory '/home/hanes/wazuh/src'
make win32/restart-wazuh.exe win32/route-null.exe win32/netsh.exe CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
make[1]: Entering directory '/home/hanes/wazuh/src'
grep: /etc/redhat-release: No such file or directory
    CC shared/file_op_proc.o
    CC shared/debug_op_proc.o
shared/file_op.c: In function ‘getuname’:
shared/file_op.c:1910:81: warning: format ‘%d’ expects argument of type ‘int’, but argument 7 has type ‘DWORD’ {aka ‘long unsigned int’} [-Wformat=]
 1910 |                                 snprintf(__wp,  sizeof(__wp), " [Ver: %d.%d.%s.%d]", (unsigned int)winMajor, (unsigned int)winMinor, wincomp, buildRevision);
      |                                                                                ~^                                                             ~~~~~~~~~~~~~
      |                                                                                 |                                                             |
      |                                                                                 int                                                           DWORD {aka long unsigned int}
      |                                                                                %ld
shared/file_op.c:1946:77: warning: format ‘%d’ expects argument of type ‘int’, but argument 6 has type ‘DWORD’ {aka ‘long unsigned int’} [-Wformat=]
 1946 |                                 snprintf(__wp, sizeof(__wp), " [Ver: %s.%s.%d]", winver, wincomp, buildRevision);
      |                                                                            ~^                     ~~~~~~~~~~~~~
      |                                                                             |                     |
      |                                                                             int                   DWORD {aka long unsigned int}
      |                                                                            %ld
    CC active-response/restart-wazuh.o
    CC active-response/route-null.o
    CC active-response/netsh.o
    CC libwazuhshared.dll
    CC win32/restart-wazuh.exe
    CC win32/route-null.exe
    CC win32/netsh.exe
make[1]: Leaving directory '/home/hanes/wazuh/src'
cd win32/ && ./unix2dos.pl ossec.conf > default-ossec.conf
cd win32/ && ./unix2dos.pl help.txt > help_win.txt
cd win32/ && ./unix2dos.pl ../../etc/internal_options.conf > internal_options.conf
cd win32/ && ./unix2dos.pl ../../etc/local_internal_options-win.conf > default-local_internal_options.conf
cd win32/ && ./unix2dos.pl ../../LICENSE > LICENSE.txt
cd win32/ && ./unix2dos.pl ../VERSION > VERSION
cd win32/ && ./unix2dos.pl ../REVISION > REVISION
cd win32/ && makensis wazuh-installer.nsi
Processing config: /etc/nsisconf.nsh
Processing script file: "wazuh-installer.nsi" (UTF8)

Processed 1 file, writing output (x86-ansi):
warning 7998: ANSI targets are deprecated

Output: "wazuh-agent-4.4.0.exe"
Install: 6 pages (384 bytes), 3 sections (12360 bytes), 1152 instructions (32256 bytes), 402 strings (33233 bytes), 1 language table (346 bytes).
Uninstall: 4 pages (320 bytes), 1 section (4120 bytes), 401 instructions (11228 bytes), 207 strings (3694 bytes), 1 language table (290 bytes).

Using zlib compression.

EXE header size:              112128 / 78336 bytes
Install code:                  16764 / 69827 bytes
Install data:                8104595 / 22839720 bytes
Uninstall code+data:           48188 / 70343 bytes
CRC (0xEDDD200A):                  4 / 4 bytes

Total size:                  8281679 / 23058230 bytes (35.9%)

1 warning:
  7998: ANSI targets are deprecated
make settings
make[1]: Entering directory '/home/hanes/wazuh/src'
grep: /etc/redhat-release: No such file or directory

General settings:
    TARGET:             winagent
    V:                  
    DEBUG:              
    DEBUGAD             
    INSTALLDIR:         
    DATABASE:           
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/16
    EXTERNAL_SRC_ONLY:  
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_ZEROMQ:         no
    USE_GEOIP:          no
    USE_PRELUDE:        no
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          no
    DISABLE_SYSC:       no
    DISABLE_CISCAT:     no
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DENABLE_SYSC -DENABLE_CISCAT
Compiler:
    CFLAGS            -pthread -DNDEBUG -O2 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DENABLE_SYSC -DENABLE_CISCAT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Ishared_modules/common -Ishared_modules/dbsync/include -Ishared_modules/rsync/include -Iwazuh_modules/syscollector/include  -Idata_provider/include  -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include 
    LDFLAGS           -pthread -O2 -Lshared_modules/dbsync/build/bin -Lshared_modules/rsync/build/bin  -Lwazuh_modules/syscollector/build/bin -Ldata_provider/build/bin
    LIBS              
    CC                gcc
    MAKE              make
make[1]: Leaving directory '/home/hanes/wazuh/src'

Done building winagent
```

</details>

## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Windows Agent</summary>

```
make win32/restart-wazuh.exe win32/route-null.exe win32/netsh.exe CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
make[1]: Entering directory '/home/hanes/wazuh/wazuh/src'
grep: /etc/redhat-release: No such file or directory
    CC shared/file_op_proc.o
    CC shared/debug_op_proc.o
    CC active-response/restart-wazuh.o
    CC active-response/route-null.o
shared/file_op.c: In function ‘getuname’:
shared/file_op.c:1910:81: warning: format ‘%d’ expects argument of type ‘int’, but argument 7 has type ‘DWORD’ {aka ‘long unsigned int’} [-Wformat=]
 1910 |                                 snprintf(__wp,  sizeof(__wp), " [Ver: %d.%d.%s.%d]", (unsigned int)winMajor, (unsigned int)winMinor, wincomp, buildRevision);
      |                                                                                ~^                                                             ~~~~~~~~~~~~~
      |                                                                                 |                                                             |
      |                                                                                 int                                                           DWORD {aka long unsigned int}
      |                                                                                %ld
shared/file_op.c:1946:77: warning: format ‘%d’ expects argument of type ‘int’, but argument 6 has type ‘DWORD’ {aka ‘long unsigned int’} [-Wformat=]
 1946 |                                 snprintf(__wp, sizeof(__wp), " [Ver: %s.%s.%d]", winver, wincomp, buildRevision);
      |                                                                            ~^                     ~~~~~~~~~~~~~
      |                                                                             |                     |
      |                                                                             int                   DWORD {aka long unsigned int}
      |                                                                            %ld
    CC active-response/netsh.o
    CC libwazuhshared.dll
    CC win32/restart-wazuh.exe
    CC win32/route-null.exe
    CC win32/netsh.exe
make[1]: Leaving directory '/home/hanes/wazuh/wazuh/src'
cd win32/ && ./unix2dos.pl ossec.conf > default-ossec.conf
cd win32/ && ./unix2dos.pl help.txt > help_win.txt
cd win32/ && ./unix2dos.pl ../../etc/internal_options.conf > internal_options.conf
cd win32/ && ./unix2dos.pl ../../etc/local_internal_options-win.conf > default-local_internal_options.conf
cd win32/ && ./unix2dos.pl ../../LICENSE > LICENSE.txt
cd win32/ && ./unix2dos.pl ../VERSION > VERSION
cd win32/ && ./unix2dos.pl ../REVISION > REVISION
cd win32/ && makensis wazuh-installer.nsi
Processing config: /etc/nsisconf.nsh
Processing script file: "wazuh-installer.nsi" (UTF8)

Processed 1 file, writing output (x86-ansi):
warning 7998: ANSI targets are deprecated

Output: "wazuh-agent-4.4.0.exe"
Install: 6 pages (384 bytes), 3 sections (12360 bytes), 1152 instructions (32256 bytes), 402 strings (33233 bytes), 1 language table (346 bytes).
Uninstall: 4 pages (320 bytes), 1 section (4120 bytes), 401 instructions (11228 bytes), 207 strings (3694 bytes), 1 language table (290 bytes).

Using zlib compression.

EXE header size:              112640 / 78848 bytes
Install code:                  16773 / 69827 bytes
Install data:                7511810 / 20473801 bytes
Uninstall code+data:           48169 / 70324 bytes
CRC (0x33348695):                  4 / 4 bytes

Total size:                  7689396 / 20692804 bytes (37.1%)

1 warning:
  7998: ANSI targets are deprecated
make settings
make[1]: Entering directory '/home/hanes/wazuh/wazuh/src'
grep: /etc/redhat-release: No such file or directory

General settings:
    TARGET:             winagent
    V:                  
    DEBUG:              
    DEBUGAD             
    INSTALLDIR:         
    DATABASE:           
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/16
    EXTERNAL_SRC_ONLY:  
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_ZEROMQ:         no
    USE_GEOIP:          no
    USE_PRELUDE:        no
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          no
    DISABLE_SYSC:       no
    DISABLE_CISCAT:     no
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DENABLE_SYSC -DENABLE_CISCAT
Compiler:
    CFLAGS            -pthread -DNDEBUG -O2 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DENABLE_SYSC -DENABLE_CISCAT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Ishared_modules/common -Ishared_modules/dbsync/include -Ishared_modules/rsync/include -Iwazuh_modules/syscollector/include  -Idata_provider/include  -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include 
    LDFLAGS           -pthread -O2 -Lshared_modules/dbsync/build/bin -Lshared_modules/rsync/build/bin  -Lwazuh_modules/syscollector/build/bin -Ldata_provider/build/bin
    LIBS              
    CC                gcc
    MAKE              make
make[1]: Leaving directory '/home/hanes/wazuh/wazuh/src'

Done building winagent
```

</details>


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors