### PR TITLE
Fix Windows crash due to invalid free.

### DIFF
--- a/src/syscheckd/cppcheckSuppress.txt
+++ b/src/syscheckd/cppcheckSuppress.txt
@@ -2,4 +2,4 @@
 *:*src/syscheckd/src/db/src/file.cpp:392
 *:*src/db/testtool/action.h:378
 *:*src/syscheckd/src/db/src/db.cpp:100
-*:*src/syscheckd/src/create_db.c:846
+*:*src/syscheckd/src/create_db.c:847

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -660,6 +660,7 @@ void fim_checker(const char *path,
             mdebug1(FIM_STAT_FAILED, path, errno, strerror(errno));
             return;
         }
+
         if((evt_data->mode == FIM_REALTIME && !(configuration->options & REALTIME_ACTIVE)) ||
            (evt_data->mode == FIM_WHODATA && !(configuration->options & WHODATA_ACTIVE))) {
             /* Don't send alert if received mode and mode in configuration aren't the same.

--- a/src/syscheckd/src/registry/registry.c
+++ b/src/syscheckd/src/registry/registry.c
@@ -896,7 +896,7 @@ void fim_read_values(HKEY key_handle,
         }
     }
 
-    fim_registry_free_value_data(new.registry_entry.value);
+    os_free(value_data.name);
     os_free(data_buffer);
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#12642|

## Description
This PR aims to fix a crash due to an invalid free.

The variable `value_data` is allocated in the stack. At the end of the function, there is a call to `fim_registry_free_value_data`  using `value_data` as a parameter. This function frees the content of `value_data` and frees the memory allocated for `value_data`. 

Closes #12642 

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
```xml
  <syscheck>

    <disabled>no</disabled>

    <!-- Frequency that syscheck is executed default every 12 hours -->
    <frequency>4</frequency>

    <!-- Default files to be monitored. -->
	<windows_registry arch="both">HKEY_LOCAL_MACHINE\software\test</windows_registry>
  </syscheck>
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [X] Source installation
- [X] Source upgrade

- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
