### PR TITLE
Fix Logcollector audit log format parser

### DIFF
--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -113,9 +113,10 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
             break;
         }
 
-        // Extract header: "type=\.* msg=audit(\d+.\d+:\d+):"
+        // Extract header: "\.*type=\.* msg=audit(.*):"
+        //                                        --
 
-        if (strncmp(buffer, "type=", 5) || !((id = strstr(buffer + 5, "msg=audit(")) && (p = strstr(id += 10, "): ")))) {
+        if (!((id = strstr(buffer, "type=")) && (id = strstr(id + 5, " msg=audit(")) && (p = strstr(id += 11, "): ")))) {
             merror("Discarding audit message because of invalid syntax.");
             break;
         }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #3342|

## Rationale

The difference between the Logcollector's formats `syslog` and `audit` is that the latter joins those contiguous logs that have the same audit ID:

```
type=SYSCALL msg=audit(1364481363.243:24287): arch=c000003e syscall=2 success=no exit=-13 ...
                       --------------------
```

This way, logs with the same audit ID get delivered as one log to the manager.

Unfortunately, the `audit` log format expects that every line starts with `type=`, otherwise Logcollector will raise an error and discard the line.

However, some custom logs may contain some data before the `type` tag, like:

```
node=hids.socib.co type=USER_START msg=audit(1558101002.000:17948): pid=16484 ...
```

## Fix

Allow leading bytes before `type=` in the `audit` format. In other words, replace this regex:
```
^type=.*msg=audit\((.*)\): .*
```
With this one:
```
.*type=.* msg=audit\((.*)\): .*
```

- Replace `^type=` with `.*type=`.
- Replace `.*msg=` with `.* msg=` (require a whitespace before `msg`).

## Tests

### Input

```
type=SYSCALL msg=audit(1364481363.243:24287): arch=c000003e syscall=2 success=no exit=-13 a0=7fffd19c5592 a1=0 a2=7fffd19c4b50 a3=a items=1 ppid=2686 pid=3538 auid=500 uid=500 gid=500 euid=500 suid=500 fsuid=500 egid=500 sgid=500 fsgid=500 tty=pts0 ses=1 comm="cat" exe="/bin/cat" subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key="sshd_config"
node=hids.socib.co type=USER_START msg=audit(1558101002.000:17948): pid=16484 uid=0 auid=0 ses=1797 msg='op=PAM:session_open grantors=pam_loginuid,pam_keyinit,pam_limits,pam_systemd acct="root" exe="/usr/sbin/crond" hostname=? addr=? terminal=cron res=success'
node=hids.socib.co type=CRED_REFR msg=audit(1558101002.001:17949): pid=16484 uid=0 auid=0 ses=1797 msg='op=PAM:setcred grantors=pam_env,pam_unix acct="root" exe="/usr/sbin/crond" hostname=? addr=? terminal=cron res=success'
node=hids.socib.co type=CRED_DISP msg=audit(1558101002.019:17950): pid=16484 uid=0 auid=0 ses=1797 msg='op=PAM:setcred grantors=pam_env,pam_unix acct="root" exe="/usr/sbin/crond" hostname=? addr=? terminal=cron res=success'
```

### Logs before this fix

- An error at _ossec.log_:
```
2022/03/10 12:13:31 wazuh-logcollector: ERROR: Discarding audit message because of invalid syntax.
```

- Only one log at _archives.log_.

### Logs after this fix

- No errors at _ossec.log_.
- Four valid logs at _archives.log_:

```
2022 Mar 10 12:50:22 Rocket->/root/test/test.log type=SYSCALL msg=audit(1364481363.243:24287): arch=c000003e syscall=2 success=no exit=-13 a0=7fffd19c5592 a1=0 a2=7fffd19c4b50 a3=a items=1 ppid=2686 pid=3538 auid=500 uid=500 gid=500 euid=500 suid=500 fsuid=500 egid=500 sgid=500 fsgid=500 tty=pts0 ses=1 comm="cat" exe="/bin/cat" subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key="sshd_config"
2022 Mar 10 12:50:26 Rocket->/root/test/test.log node=hids.socib.co type=CRED_DISP msg=audit(1558101002.019:17950): pid=16484 uid=0 auid=0 ses=1797 msg='op=PAM:setcred grantors=pam_env,pam_unix acct="root" exe="/usr/sbin/crond" hostname=? addr=? terminal=cron res=success'
2022 Mar 10 12:50:26 Rocket->/root/test/test.log node=hids.socib.co type=CRED_REFR msg=audit(1558101002.001:17949): pid=16484 uid=0 auid=0 ses=1797 msg='op=PAM:setcred grantors=pam_env,pam_unix acct="root" exe="/usr/sbin/crond" hostname=? addr=? terminal=cron res=success'
2022 Mar 10 12:50:26 Rocket->/root/test/test.log node=hids.socib.co type=USER_START msg=audit(1558101002.000:17948): pid=16484 uid=0 auid=0 ses=1797 msg='op=PAM:session_open grantors=pam_loginuid,pam_keyinit,pam_limits,pam_systemd acct="root" exe="/usr/sbin/crond" hostname=? addr=? terminal=cron res=success'
```
