### PR TITLE
Fixed fim_checker flow in case of stat fail (deleted file)

### DIFF
--- a/src/syscheckd/cppcheckSuppress.txt
+++ b/src/syscheckd/cppcheckSuppress.txt
@@ -2,4 +2,4 @@
 *:*src/syscheckd/src/db/src/file.cpp:392
 *:*src/db/testtool/action.h:378
 *:*src/syscheckd/src/db/src/db.cpp:100
-*:*src/syscheckd/src/create_db.c:846
+*:*src/syscheckd/src/create_db.c:847

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -683,8 +683,9 @@ void fim_checker(const char *path,
             {
                 fim_diff_process_delete_file(path);
             }
-            return;
         }
+
+        return;
     }
 
 #ifdef WIN_WHODATA


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/12674|


## Description
This PR is to fix a bug found in fim_checker when the path being processed does not exist. It is missing a return at the end of the analysis. Since the flow is continued by the fim_checker code after failing the stat function.
Closes #12674 


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

- [X] Source installation
- [X] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report