### PR TITLE
Fixing warnings in sysInfoWin.cpp file

### DIFF
--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -59,7 +59,9 @@ class SysInfoProcess final
               m_hProcess{ processHandle },
               m_creationTime{},
               m_kernelModeTime{},
-              m_userModeTime{}
+              m_userModeTime{},
+              m_pageFileUsage{},
+              m_virtualSize{}
         {
             setProcessTimes();
             setProcessMemInfo();

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -22,7 +22,6 @@
 #include <winternl.h>
 #include <ntstatus.h>
 #include <netioapi.h>
-#include <utility>
 #include "sysinfoapi.h"
 #include "sysInfo.hpp"
 #include "cmdHelper.h"
@@ -45,7 +44,12 @@ const std::string UNINSTALL_REGISTRY{"SOFTWARE\\Microsoft\\Windows\\CurrentVersi
 constexpr auto SYSTEM_IDLE_PROCESS_NAME {"System Idle Process"};
 constexpr auto SYSTEM_PROCESS_NAME {"System"};
 
-static std::map<std::string, DWORD> FIRMWARE_TABLE_PROVIDER_SIGNATURE { {"ACPI", 0x41435049}, {"FIRM", 0x4649524D}, {"RSMB", 0x52534D42}};
+static const std::map<std::string, DWORD> gs_firmwareTableProviderSignature
+{
+    {"ACPI", 0x41435049},
+    {"FIRM", 0x4649524D},
+    {"RSMB", 0x52534D42}
+};
 
 class SysInfoProcess final
 {
@@ -463,7 +467,7 @@ std::string SysInfo::getSerialNumber() const
 
         if (pfnGetSystemFirmwareTable)
         {
-            const auto size {pfnGetSystemFirmwareTable(FIRMWARE_TABLE_PROVIDER_SIGNATURE.at("RSMB"), 0, nullptr, 0)};
+            const auto size {pfnGetSystemFirmwareTable(gs_firmwareTableProviderSignature.at("RSMB"), 0, nullptr, 0)};
 
             if (size)
             {
@@ -472,7 +476,7 @@ std::string SysInfo::getSerialNumber() const
                 if (spBuff)
                 {
                     // Get raw SMBIOS firmware table
-                    if (pfnGetSystemFirmwareTable(FIRMWARE_TABLE_PROVIDER_SIGNATURE.at("RSMB"), 0, spBuff.get(), size) == size)
+                    if (pfnGetSystemFirmwareTable(gs_firmwareTableProviderSignature.at("RSMB"), 0, spBuff.get(), size) == size)
                     {
                         PRawSMBIOSData smbios{reinterpret_cast<PRawSMBIOSData>(spBuff.get())};
                         // Parse SMBIOS structures

--- a/src/rootcheck/common_rcl.c
+++ b/src/rootcheck/common_rcl.c
@@ -273,8 +273,10 @@ int rkcl_get_entry(FILE *fp, const char *msg, OSList *p_list)
     int type = 0, condition = 0;
     char *nbuf;
     char buf[OS_SIZE_1024 + 2] = {0};
+#ifdef WIN32
     char root_dir[OS_SIZE_1024 + 2] = {0};
     char final_file[2048 + 1] = {0};
+#endif
     char ref[255 + 1] = {0};
     char *value;
     char *name = NULL;


### PR DESCRIPTION
|Related issue|
|---|
|#12099|

## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh windows agent project in sysInfoWin.cpp. The output of the compilation after the changes was:

## Compilation using GCC 9.3

<details>
<summary>Wazuh Windows Agent</summary>

```
[ 10%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync.cpp.obj
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/data_provider/build
make[2]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
make[3]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
Scanning dependencies of target sysinfo
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
[ 14%] Building CXX object CMakeFiles/sysinfo.dir/src/network/networkInterfaceWindows.cpp.obj
[ 28%] Building CXX object CMakeFiles/sysinfo.dir/src/osinfo/sysOsInfoWin.cpp.obj
[ 20%] Building CXX object CMakeFiles/dbsync.dir/src/dbsyncPipelineFactory.cpp.obj
[ 42%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfoWin.cpp.obj
[ 30%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync_implementation.cpp.obj
[ 40%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_dbengine.cpp.obj
[ 57%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfo.cpp.obj
[ 50%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_wrapper.cpp.obj
[ 60%] Linking CXX shared library bin/dbsync.dll
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 60%] Built target dbsync
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync_example
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 70%] Building CXX object example/CMakeFiles/dbsync_example.dir/main.cpp.obj
[ 80%] Linking CXX executable ../bin/dbsync_example.exe
[ 71%] Linking CXX shared library bin/sysinfo.dll
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 80%] Built target dbsync_example
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 90%] Building CXX object testtool/CMakeFiles/dbsync_test_tool.dir/main.cpp.obj
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
[ 71%] Built target sysinfo
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
Scanning dependencies of target sysinfo_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'

```

</details>

## Compilation using GCC 10.2.1

<details>
<summary>Wazuh Windows Agent</summary>

```
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/wazuh/src/data_provider/build
make[2]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[3]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
Scanning dependencies of target sysinfo
    CC win32/setup-windows.exe
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
[ 14%] Building CXX object CMakeFiles/sysinfo.dir/src/network/networkInterfaceWindows.cpp.obj
    CC win32/setup-syscheck.exe
[ 30%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync_implementation.cpp.obj
[ 40%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_dbengine.cpp.obj
[ 50%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_wrapper.cpp.obj
[ 28%] Building CXX object CMakeFiles/sysinfo.dir/src/osinfo/sysOsInfoWin.cpp.obj
[ 42%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfoWin.cpp.obj
[ 57%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfo.cpp.obj
    CC win32/setup-iis.exe
    CC win32/os_win32ui.exe
    CC win32/agent-auth.exe
[ 60%] Linking CXX shared library bin/dbsync.dll
In file included from /home/hanes/wazuh/wazuh/src/data_provider/include/sysInfoInterface.h:15,
                 from /home/hanes/wazuh/wazuh/src/data_provider/include/sysInfo.hpp:28,
                 from /home/hanes/wazuh/wazuh/src/data_provider/src/sysInfoWin.cpp:27:
/home/hanes/wazuh/wazuh/src/external/nlohmann/json.hpp: In function ‘nlohmann::json getProcessInfo(const PROCESSENTRY32&)’:
/home/hanes/wazuh/wazuh/src/external/nlohmann/json.hpp:3676:62: warning: ‘process.SysInfoProcess::m_virtualSize’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 3676 |     external_constructor<value_t::number_unsigned>::construct(j, static_cast<typename BasicJsonType::number_unsigned_t>(val));
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/hanes/wazuh/wazuh/src/data_provider/src/sysInfoWin.cpp:356:24: note: ‘process.SysInfoProcess::m_virtualSize’ was declared here
  356 |         SysInfoProcess process(pId, processHandle);
      |                        ^~~~~~~
In file included from /home/hanes/wazuh/wazuh/src/data_provider/include/sysInfoInterface.h:15,
                 from /home/hanes/wazuh/wazuh/src/data_provider/include/sysInfo.hpp:28,
                 from /home/hanes/wazuh/wazuh/src/data_provider/src/sysInfoWin.cpp:27:
/home/hanes/wazuh/wazuh/src/external/nlohmann/json.hpp:3676:62: warning: ‘process.SysInfoProcess::m_pageFileUsage’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 3676 |     external_constructor<value_t::number_unsigned>::construct(j, static_cast<typename BasicJsonType::number_unsigned_t>(val));
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/hanes/wazuh/wazuh/src/data_provider/src/sysInfoWin.cpp:356:24: note: ‘process.SysInfoProcess::m_pageFileUsage’ was declared here
  356 |         SysInfoProcess process(pId, processHandle);
      |                        ^~~~~~~
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 60%] Built target dbsync
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync
```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors