### PR TITLE
Some vulnerabilities can't be added to the inventory due to socket size limit - Implementation

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_agents.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents.c
@@ -266,6 +266,11 @@ void test_wdb_agents_insert_vuln_cves_error_json(void **state) {
     const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
     const char* type = "PACKAGE";
     const char* status = "VALID";
+    const char* external_references = "[\"https://references.com/ref1.html\",\"https://references.com/ref2.html\"]";
+    const char* condition = "Package unfixed";
+    const char* title = "CVE-2021-1200 affects package";
+    const char* published = "01-01-2021";
+    const char* updated = "02-01-2021";
     bool check_pkg_existence = true;
     const char* severity = "Unknown";
     double cvss2_score = 0.0;
@@ -273,7 +278,9 @@ void test_wdb_agents_insert_vuln_cves_error_json(void **state) {
 
     will_return(__wrap_cJSON_CreateObject, NULL);
 
-    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status, check_pkg_existence, severity, cvss2_score, cvss3_score);
+    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status,
+                                      check_pkg_existence, severity, cvss2_score, cvss3_score,
+                                      external_references, condition, title, published, updated);
 
     assert_null(ret);
 }
@@ -288,6 +295,11 @@ void test_wdb_agents_insert_vuln_cves_update_success(void **state) {
     const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
     const char* type = "PACKAGE";
     const char* status = "VALID";
+    const char* external_references = "[\"https://references.com/ref1.html\",\"https://references.com/ref2.html\"]";
+    const char* condition = "Package unfixed";
+    const char* title = "CVE-2021-1200 affects package";
+    const char* published = "01-01-2021";
+    const char* updated = "02-01-2021";
     bool check_pkg_existence = false;
     const char* severity = "Unknown";
     double cvss2_score = 0.0;
@@ -334,6 +346,16 @@ void test_wdb_agents_insert_vuln_cves_update_success(void **state) {
     expect_value(__wrap_sqlite3_bind_double, value, 0.0);
     expect_value(__wrap_sqlite3_bind_double, index, 10);
     expect_value(__wrap_sqlite3_bind_double, value, 0.0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 11);
+    expect_string(__wrap_sqlite3_bind_text, buffer, external_references);
+    expect_value(__wrap_sqlite3_bind_text, pos, 12);
+    expect_string(__wrap_sqlite3_bind_text, buffer, condition);
+    expect_value(__wrap_sqlite3_bind_text, pos, 13);
+    expect_string(__wrap_sqlite3_bind_text, buffer, title);
+    expect_value(__wrap_sqlite3_bind_text, pos, 14);
+    expect_string(__wrap_sqlite3_bind_text, buffer, published);
+    expect_value(__wrap_sqlite3_bind_text, pos, 15);
+    expect_string(__wrap_sqlite3_bind_text, buffer, updated);
 
     will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
 
@@ -341,8 +363,9 @@ void test_wdb_agents_insert_vuln_cves_update_success(void **state) {
     expect_string(__wrap_cJSON_AddStringToObject, string, "SUCCESS");
     will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
 
-    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status, check_pkg_existence, severity, cvss2_score, cvss3_score);
-
+    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status,
+                                      check_pkg_existence, severity, cvss2_score, cvss3_score,
+                                      external_references, condition, title, published, updated);
     assert_ptr_equal(1, ret);
 }
 
@@ -356,6 +379,11 @@ void test_wdb_agents_insert_vuln_cves_pkg_not_found(void **state) {
     const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
     const char* type = "PACKAGE";
     const char* status = "VALID";
+    const char* external_references = "[\"https://references.com/ref1.html\",\"https://references.com/ref2.html\"]";
+    const char* condition = "Package unfixed";
+    const char* title = "CVE-2021-1200 affects package";
+    const char* published = "01-01-2021";
+    const char* updated = "02-01-2021";
     bool check_pkg_existence = true;
     const char* severity = "Unknown";
     double cvss2_score = 0.0;
@@ -410,6 +438,16 @@ void test_wdb_agents_insert_vuln_cves_pkg_not_found(void **state) {
     expect_value(__wrap_sqlite3_bind_double, value, 0.0);
     expect_value(__wrap_sqlite3_bind_double, index, 10);
     expect_value(__wrap_sqlite3_bind_double, value, 0.0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 11);
+    expect_string(__wrap_sqlite3_bind_text, buffer, external_references);
+    expect_value(__wrap_sqlite3_bind_text, pos, 12);
+    expect_string(__wrap_sqlite3_bind_text, buffer, condition);
+    expect_value(__wrap_sqlite3_bind_text, pos, 13);
+    expect_string(__wrap_sqlite3_bind_text, buffer, title);
+    expect_value(__wrap_sqlite3_bind_text, pos, 14);
+    expect_string(__wrap_sqlite3_bind_text, buffer, published);
+    expect_value(__wrap_sqlite3_bind_text, pos, 15);
+    expect_string(__wrap_sqlite3_bind_text, buffer, updated);
 
     will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
 
@@ -417,8 +455,9 @@ void test_wdb_agents_insert_vuln_cves_pkg_not_found(void **state) {
     expect_string(__wrap_cJSON_AddStringToObject, string, "SUCCESS");
     will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
 
-    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status, check_pkg_existence, severity, cvss2_score, cvss3_score);
-
+    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status,
+                                      check_pkg_existence, severity, cvss2_score, cvss3_score,
+                                      external_references, condition, title, published, updated);
     assert_ptr_equal(1, ret);
 }
 
@@ -432,6 +471,11 @@ void test_wdb_agents_insert_vuln_cves_success_statement_init_fail(void **state) 
     const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
     const char* type = "PACKAGE";
     const char* status = "VALID";
+    const char* external_references = "[\"https://references.com/ref1.html\",\"https://references.com/ref2.html\"]";
+    const char* condition = "Package unfixed";
+    const char* title = "CVE-2021-1200 affects package";
+    const char* published = "01-01-2021";
+    const char* updated = "02-01-2021";
     bool check_pkg_existence = true;
     const char* severity = "Unknown";
     double cvss2_score = 0.0;
@@ -469,8 +513,9 @@ void test_wdb_agents_insert_vuln_cves_success_statement_init_fail(void **state) 
     expect_string(__wrap_cJSON_AddStringToObject, string, "ERROR");
     will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
 
-    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status, check_pkg_existence, severity, cvss2_score, cvss3_score);
-
+    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status,
+                                      check_pkg_existence, severity, cvss2_score, cvss3_score,
+                                      external_references, condition, title, published, updated);
     assert_ptr_equal(1, ret);
 }
 
@@ -484,6 +529,11 @@ void test_wdb_agents_insert_vuln_cves_success_statement_exec_fail(void **state) 
     const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
     const char* type = "PACKAGE";
     const char* status = "VALID";
+    const char* external_references = "[\"https://references.com/ref1.html\",\"https://references.com/ref2.html\"]";
+    const char* condition = "Package unfixed";
+    const char* title = "CVE-2021-1200 affects package";
+    const char* published = "01-01-2021";
+    const char* updated = "02-01-2021";
     bool check_pkg_existence = true;
     const char* severity = "Unknown";
     double cvss2_score = 0.0;
@@ -538,6 +588,16 @@ void test_wdb_agents_insert_vuln_cves_success_statement_exec_fail(void **state) 
     expect_value(__wrap_sqlite3_bind_double, value, 0.0);
     expect_value(__wrap_sqlite3_bind_double, index, 10);
     expect_value(__wrap_sqlite3_bind_double, value, 0.0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 11);
+    expect_string(__wrap_sqlite3_bind_text, buffer, external_references);
+    expect_value(__wrap_sqlite3_bind_text, pos, 12);
+    expect_string(__wrap_sqlite3_bind_text, buffer, condition);
+    expect_value(__wrap_sqlite3_bind_text, pos, 13);
+    expect_string(__wrap_sqlite3_bind_text, buffer, title);
+    expect_value(__wrap_sqlite3_bind_text, pos, 14);
+    expect_string(__wrap_sqlite3_bind_text, buffer, published);
+    expect_value(__wrap_sqlite3_bind_text, pos, 15);
+    expect_string(__wrap_sqlite3_bind_text, buffer, updated);
 
     will_return(__wrap_wdb_exec_stmt_silent, OS_INVALID);
 
@@ -548,8 +608,9 @@ void test_wdb_agents_insert_vuln_cves_success_statement_exec_fail(void **state) 
     expect_string(__wrap_cJSON_AddStringToObject, string, "ERROR");
     will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
 
-    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status, check_pkg_existence, severity, cvss2_score, cvss3_score);
-
+    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status,
+                                      check_pkg_existence, severity, cvss2_score, cvss3_score,
+                                      external_references, condition, title, published, updated);
     assert_ptr_equal(1, ret);
 }
 
@@ -563,6 +624,11 @@ void test_wdb_agents_insert_vuln_cves_success_pkg_found(void **state) {
     const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
     const char* type = "PACKAGE";
     const char* status = "VALID";
+    const char* external_references = "[\"https://references.com/ref1.html\",\"https://references.com/ref2.html\"]";
+    const char* condition = "Package unfixed";
+    const char* title = "CVE-2021-1200 affects package";
+    const char* published = "01-01-2021";
+    const char* updated = "02-01-2021";
     bool check_pkg_existence = true;
     const char* severity = "Unknown";
     double cvss2_score = 0.0;
@@ -617,6 +683,16 @@ void test_wdb_agents_insert_vuln_cves_success_pkg_found(void **state) {
     expect_value(__wrap_sqlite3_bind_double, value, 0.0);
     expect_value(__wrap_sqlite3_bind_double, index, 10);
     expect_value(__wrap_sqlite3_bind_double, value, 0.0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 11);
+    expect_string(__wrap_sqlite3_bind_text, buffer, external_references);
+    expect_value(__wrap_sqlite3_bind_text, pos, 12);
+    expect_string(__wrap_sqlite3_bind_text, buffer, condition);
+    expect_value(__wrap_sqlite3_bind_text, pos, 13);
+    expect_string(__wrap_sqlite3_bind_text, buffer, title);
+    expect_value(__wrap_sqlite3_bind_text, pos, 14);
+    expect_string(__wrap_sqlite3_bind_text, buffer, published);
+    expect_value(__wrap_sqlite3_bind_text, pos, 15);
+    expect_string(__wrap_sqlite3_bind_text, buffer, updated);
 
     will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
 
@@ -624,8 +700,9 @@ void test_wdb_agents_insert_vuln_cves_success_pkg_found(void **state) {
     expect_string(__wrap_cJSON_AddStringToObject, string, "SUCCESS");
     will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
 
-    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status, check_pkg_existence, severity, cvss2_score, cvss3_score);
-
+    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status,
+                                      check_pkg_existence, severity, cvss2_score, cvss3_score,
+                                      external_references, condition, title, published, updated);
     assert_ptr_equal(1, ret);
 }
 

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -1355,6 +1355,7 @@ void test_vuln_cves_insert_command_error(void **state) {
     expect_value(__wrap_wdb_agents_insert_vuln_cves, severity, NULL);
     expect_value(__wrap_wdb_agents_insert_vuln_cves, cvss2_score, 0);
     expect_value(__wrap_wdb_agents_insert_vuln_cves, cvss3_score, 0);
+    will_return(__wrap_cJSON_PrintUnformatted, NULL);
 
     will_return(__wrap_wdb_agents_insert_vuln_cves, NULL);
 
@@ -1376,7 +1377,9 @@ void test_vuln_cves_insert_command_success(void **state) {
     os_strdup("[{\"test\":\"TEST\"}]", result);
     os_strdup("insert {\"name\":\"package\",\"version\":\"2.2\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1500\","
               "\"reference\":\"8549fd9faf9b124635298e9311ccf672c2ad05d1\",\"type\":\"PACKAGE\",\"status\":\"VALID\","
-              "\"check_pkg_existence\":true,\"severity\":\"MEDIUM\",\"cvss2_score\":5.2,\"cvss3_score\":6}", query);
+              "\"check_pkg_existence\":true,\"severity\":\"MEDIUM\",\"cvss2_score\":5.2,\"cvss3_score\":6,"
+              "\"external_references\":[\"https.//refs.com/refs1\",\"https.//refs.com/refs1\"],\"condition\":\"Package unfixes\","
+              "\"title\":\"CVE-2021-1500 affects package\",\"published\":\"01-01-2020\",\"updated\":\"02-01-2020\"}", query);
 
     cJSON *test =  cJSON_CreateObject();
 
@@ -1393,6 +1396,8 @@ void test_vuln_cves_insert_command_success(void **state) {
     expect_value(__wrap_wdb_agents_insert_vuln_cves, cvss2_score, 5.2);
     expect_value(__wrap_wdb_agents_insert_vuln_cves, cvss3_score, 6);
     will_return(__wrap_wdb_agents_insert_vuln_cves, test);
+    will_return(__wrap_cJSON_PrintUnformatted, strdup("[\"https.//refs.com/refs1\",\"https.//refs.com/refs1\"]"));
+
     will_return(__wrap_cJSON_PrintUnformatted, result);
 
     ret = wdb_parse_vuln_cves(data->wdb, query, data->output);

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -391,6 +391,9 @@ static int build_test_cve_report(vu_report* report, int add_condition, int add_i
     // Agent data
     os_strdup("001", report->agent_id);
     os_strdup("Ubuntu_WAgent", report->agent_name);
+    // Build title
+    os_calloc(OS_SIZE_512, sizeof(char), report->title);
+    snprintf(report->title, OS_SIZE_512, "%s affects %s", report->cve, report->software);
 
     return OS_SUCCESS;
 }
@@ -888,6 +891,29 @@ static int setup_alas_list(void **state) {
     alas_list->id = NULL;
 
     return OS_SUCCESS;
+}
+
+/* Configure success/fail mocks to methods */
+
+// wm_vuldet_give_report_format()
+
+void configure_wm_vuldet_give_report_format_success() {
+    // Normalize date
+    char * published;
+    os_calloc(11, sizeof(char), published);
+    snprintf(published, 11, "%s", "2017-04-14");
+    expect_string(__wrap_wstr_replace, string, "2017-04-14");
+    expect_string(__wrap_wstr_replace, search, "/");
+    expect_string(__wrap_wstr_replace, replace, "-");
+    will_return(__wrap_wstr_replace, published);
+
+    char * updated;
+    os_calloc(11, sizeof(char), updated);
+    snprintf(updated, 11, "%s", "2017-07-01");
+    expect_string(__wrap_wstr_replace, string, "2017-07-01");
+    expect_string(__wrap_wstr_replace, search, "/");
+    expect_string(__wrap_wstr_replace, replace, "-");
+    will_return(__wrap_wstr_replace, updated);
 }
 
 /* tests */
@@ -5802,7 +5828,15 @@ void test_wm_vuldet_process_agent_vulnerabilities_vuln_cves_insert_error(void **
     expect_string(__wrap_wdb_insert_vuln_cves, type, VULN_CVES_TYPE_PACKAGE);
     expect_string(__wrap_wdb_insert_vuln_cves, status, "VALID");
     expect_value(__wrap_wdb_insert_vuln_cves, check_pkg_existence, TRUE);
+    expect_string(__wrap_wdb_insert_vuln_cves, external_references_concatenated, "http://rhn.redhat.com/errata/RHSA-2016-2582.html");
+    expect_string(__wrap_wdb_insert_vuln_cves, condition, "Package less than 4.3-2");
+    expect_string(__wrap_wdb_insert_vuln_cves, title, "CVE-2016-6489 affects libhogweed4");
+    expect_string(__wrap_wdb_insert_vuln_cves, published, "2017-04-14");
+    expect_string(__wrap_wdb_insert_vuln_cves, updated, "2017-07-01");
     will_return(__wrap_wdb_insert_vuln_cves, NULL);
+
+    configure_wm_vuldet_give_report_format_success();
+
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "Failed to insert CVE-2016-6489 for package e91d3dd01b9214df53c8f3985f028112268d2173 in the agent 000 database");
     // Sending CVE report
@@ -5873,7 +5907,14 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_error(void **s
     expect_string(__wrap_wdb_insert_vuln_cves, type, VULN_CVES_TYPE_PACKAGE);
     expect_string(__wrap_wdb_insert_vuln_cves, status, "VALID");
     expect_value(__wrap_wdb_insert_vuln_cves, check_pkg_existence, TRUE);
+    expect_string(__wrap_wdb_insert_vuln_cves, external_references_concatenated, "http://rhn.redhat.com/errata/RHSA-2016-2582.html");
+    expect_string(__wrap_wdb_insert_vuln_cves, condition, "Package less than 4.3-2");
+    expect_string(__wrap_wdb_insert_vuln_cves, title, "CVE-2016-6489 affects libhogweed4");
+    expect_string(__wrap_wdb_insert_vuln_cves, published, "2017-04-14");
+    expect_string(__wrap_wdb_insert_vuln_cves, updated, "2017-07-01");
     will_return(__wrap_wdb_insert_vuln_cves, (cJSON *)1);
+
+    configure_wm_vuldet_give_report_format_success();
 
     will_return(__wrap_cJSON_GetObjectItem, j_status);
     will_return(__wrap_cJSON_GetObjectItem, j_action);
@@ -6174,7 +6215,14 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_negative_versi
     expect_string(__wrap_wdb_insert_vuln_cves, type, "PACKAGE");
     expect_string(__wrap_wdb_insert_vuln_cves, status, "VALID");
     expect_value(__wrap_wdb_insert_vuln_cves, check_pkg_existence, TRUE);
+    expect_string(__wrap_wdb_insert_vuln_cves, external_references_concatenated, "http://rhn.redhat.com/errata/RHSA-2016-2582.html");
+    expect_string(__wrap_wdb_insert_vuln_cves, condition, "Package less than 4.3-2");
+    expect_string(__wrap_wdb_insert_vuln_cves, title, "CVE-2016-6489 affects libhogweed4");
+    expect_string(__wrap_wdb_insert_vuln_cves, published, "2017-04-14");
+    expect_string(__wrap_wdb_insert_vuln_cves, updated, "2017-07-01");
     will_return(__wrap_wdb_insert_vuln_cves, (cJSON *)1);
+
+    configure_wm_vuldet_give_report_format_success();
 
     will_return(__wrap_cJSON_GetObjectItem, j_status);
     will_return(__wrap_cJSON_GetObjectItem, j_action);
@@ -6522,7 +6570,14 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors
     expect_string(__wrap_wdb_insert_vuln_cves, type, "PACKAGE");
     expect_string(__wrap_wdb_insert_vuln_cves, status, "VALID");
     expect_value(__wrap_wdb_insert_vuln_cves, check_pkg_existence, TRUE);
+    expect_string(__wrap_wdb_insert_vuln_cves, external_references_concatenated, "http://rhn.redhat.com/errata/RHSA-2016-2582.html");
+    expect_string(__wrap_wdb_insert_vuln_cves, condition, "Package less than 4.3-2");
+    expect_string(__wrap_wdb_insert_vuln_cves, title, "CVE-2016-6489 affects libhogweed4");
+    expect_string(__wrap_wdb_insert_vuln_cves, published, "2017-04-14");
+    expect_string(__wrap_wdb_insert_vuln_cves, updated, "2017-07-01");
     will_return(__wrap_wdb_insert_vuln_cves, (cJSON *)1);
+
+    configure_wm_vuldet_give_report_format_success();
 
     will_return(__wrap_cJSON_GetObjectItem, j_status);
     will_return(__wrap_cJSON_GetObjectItem, j_action);
@@ -6618,30 +6673,10 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors
     expect_string(__wrap_cJSON_AddStringToObject, string, "The CVE description or rationale.");
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
     expect_string(__wrap_cJSON_AddStringToObject, string, "High");
-
-    // Normalize date
-    char * published;
-    os_calloc(11, sizeof(char), published);
-    snprintf(published, 11, "%s", "2017-04-14");
-    expect_string(__wrap_wstr_replace, string, "2017-04-14");
-    expect_string(__wrap_wstr_replace, search, "/");
-    expect_string(__wrap_wstr_replace, replace, "-");
-    will_return(__wrap_wstr_replace, published);
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "published");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2017-04-14");
-
-    char * updated;
-    os_calloc(11, sizeof(char), updated);
-    snprintf(updated, 11, "%s", "2017-07-01");
-    expect_string(__wrap_wstr_replace, string, "2017-07-01");
-    expect_string(__wrap_wstr_replace, search, "/");
-    expect_string(__wrap_wstr_replace, replace, "-");
-    will_return(__wrap_wstr_replace, updated);
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2017-07-01");
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "cwe_reference");
     expect_string(__wrap_cJSON_AddStringToObject, string, "CWE-502");
 
@@ -6890,7 +6925,14 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors
     expect_string(__wrap_wdb_insert_vuln_cves, type, "PACKAGE");
     expect_string(__wrap_wdb_insert_vuln_cves, status, "VALID");
     expect_value(__wrap_wdb_insert_vuln_cves, check_pkg_existence, TRUE);
+    expect_string(__wrap_wdb_insert_vuln_cves, external_references_concatenated, "http://rhn.redhat.com/errata/RHSA-2016-2582.html");
+    expect_string(__wrap_wdb_insert_vuln_cves, condition, "Package matches a vulnerable version");
+    expect_string(__wrap_wdb_insert_vuln_cves, title, "CVE-2016-6489 affects libhogweed4");
+    expect_string(__wrap_wdb_insert_vuln_cves, published, "2017-04-14");
+    expect_string(__wrap_wdb_insert_vuln_cves, updated, "2017-07-01");
     will_return(__wrap_wdb_insert_vuln_cves, (cJSON *)1);
+
+    configure_wm_vuldet_give_report_format_success();
 
     will_return(__wrap_cJSON_GetObjectItem, j_status);
     will_return(__wrap_cJSON_GetObjectItem, j_action);
@@ -6986,30 +7028,10 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors
     expect_string(__wrap_cJSON_AddStringToObject, string, "The CVE description or rationale.");
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
     expect_string(__wrap_cJSON_AddStringToObject, string, "High");
-
-    // Normalize date
-    char * published;
-    os_calloc(11, sizeof(char), published);
-    snprintf(published, 11, "%s", "2017-04-14");
-    expect_string(__wrap_wstr_replace, string, "2017-04-14");
-    expect_string(__wrap_wstr_replace, search, "/");
-    expect_string(__wrap_wstr_replace, replace, "-");
-    will_return(__wrap_wstr_replace, published);
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "published");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2017-04-14");
-
-    char * updated;
-    os_calloc(11, sizeof(char), updated);
-    snprintf(updated, 11, "%s", "2017-07-01");
-    expect_string(__wrap_wstr_replace, string, "2017-07-01");
-    expect_string(__wrap_wstr_replace, search, "/");
-    expect_string(__wrap_wstr_replace, replace, "-");
-    will_return(__wrap_wstr_replace, updated);
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2017-07-01");
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "cwe_reference");
     expect_string(__wrap_cJSON_AddStringToObject, string, "CWE-502");
 
@@ -7953,30 +7975,10 @@ void test_wm_vuldet_send_cve_report_error_j_advisories_create(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
     expect_string(__wrap_cJSON_AddStringToObject, string, vu_severities[VU_HIGH]);
-
-    // Normalize date
-    char * published;
-    os_calloc(21, sizeof(char), published);
-    snprintf(published, 21, "%s", "2020-03-05T15:15:00Z");
-    expect_string(__wrap_wstr_replace, string, "2020-03-05T15:15:00Z");
-    expect_string(__wrap_wstr_replace, search, "/");
-    expect_string(__wrap_wstr_replace, replace, "-");
-    will_return(__wrap_wstr_replace, published);
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "published");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
-
-    char * updated;
-    os_calloc(21, sizeof(char), updated);
-    snprintf(updated, 21, "%s", "2020-05-25T15:15:00Z");
-    expect_string(__wrap_wstr_replace, string, "2020-05-25T15:15:00Z");
-    expect_string(__wrap_wstr_replace, search, "/");
-    expect_string(__wrap_wstr_replace, replace, "-");
-    will_return(__wrap_wstr_replace, updated);
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-05-25T15:15:00Z");
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "cwe_reference");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cwe);
 
@@ -8106,30 +8108,10 @@ void test_wm_vuldet_send_cve_report_error_j_bug_references_create(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
     expect_string(__wrap_cJSON_AddStringToObject, string, vu_severities[VU_HIGH]);
-
-    // Normalize date
-    char * published;
-    os_calloc(21, sizeof(char), published);
-    snprintf(published, 21, "%s", "2020-03-05T15:15:00Z");
-    expect_string(__wrap_wstr_replace, string, "2020-03-05T15:15:00Z");
-    expect_string(__wrap_wstr_replace, search, "/");
-    expect_string(__wrap_wstr_replace, replace, "-");
-    will_return(__wrap_wstr_replace, published);
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "published");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
-
-    char * updated;
-    os_calloc(21, sizeof(char), updated);
-    snprintf(updated, 21, "%s", "2020-05-25T15:15:00Z");
-    expect_string(__wrap_wstr_replace, string, "2020-05-25T15:15:00Z");
-    expect_string(__wrap_wstr_replace, search, "/");
-    expect_string(__wrap_wstr_replace, replace, "-");
-    will_return(__wrap_wstr_replace, updated);
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-05-25T15:15:00Z");
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "cwe_reference");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cwe);
 
@@ -8267,30 +8249,10 @@ void test_wm_vuldet_send_cve_report_error_j_references_create(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
     expect_string(__wrap_cJSON_AddStringToObject, string, vu_severities[VU_HIGH]);
-
-    // Normalize date
-    char * published;
-    os_calloc(21, sizeof(char), published);
-    snprintf(published, 21, "%s", "2020-03-05T15:15:00Z");
-    expect_string(__wrap_wstr_replace, string, "2020-03-05T15:15:00Z");
-    expect_string(__wrap_wstr_replace, search, "/");
-    expect_string(__wrap_wstr_replace, replace, "-");
-    will_return(__wrap_wstr_replace, published);
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "published");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
-
-    char * updated;
-    os_calloc(21, sizeof(char), updated);
-    snprintf(updated, 21, "%s", "2020-05-25T15:15:00Z");
-    expect_string(__wrap_wstr_replace, string, "2020-05-25T15:15:00Z");
-    expect_string(__wrap_wstr_replace, search, "/");
-    expect_string(__wrap_wstr_replace, replace, "-");
-    will_return(__wrap_wstr_replace, updated);
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-05-25T15:15:00Z");
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "cwe_reference");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cwe);
 
@@ -8439,30 +8401,10 @@ void test_wm_vuldet_send_cve_report_without_title(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
     expect_string(__wrap_cJSON_AddStringToObject, string, vu_severities[VU_HIGH]);
-
-    // Normalize date
-    char * published;
-    os_calloc(21, sizeof(char), published);
-    snprintf(published, 21, "%s", "2020-03-05T15:15:00Z");
-    expect_string(__wrap_wstr_replace, string, "2020-03-05T15:15:00Z");
-    expect_string(__wrap_wstr_replace, search, "/");
-    expect_string(__wrap_wstr_replace, replace, "-");
-    will_return(__wrap_wstr_replace, published);
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "published");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
-
-    char * updated;
-    os_calloc(21, sizeof(char), updated);
-    snprintf(updated, 21, "%s", "2020-05-25T15:15:00Z");
-    expect_string(__wrap_wstr_replace, string, "2020-05-25T15:15:00Z");
-    expect_string(__wrap_wstr_replace, search, "/");
-    expect_string(__wrap_wstr_replace, replace, "-");
-    will_return(__wrap_wstr_replace, updated);
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-05-25T15:15:00Z");
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "cwe_reference");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cwe);
 
@@ -8551,8 +8493,6 @@ void test_wm_vuldet_send_cve_report_without_condition(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->version);
     expect_string(__wrap_cJSON_AddStringToObject, name, "architecture");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->arch);
-    expect_string(__wrap_cJSON_AddStringToObject, name, "condition");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "Package CVE-2016-6489 reports as vulnerable all the versions of this package 4.3-2");
     // Adding cvss information
     will_return(__wrap_cJSON_CreateObject, j_cvss);
     expect_function_call(__wrap_cJSON_AddItemToObject);
@@ -8630,30 +8570,10 @@ void test_wm_vuldet_send_cve_report_without_condition(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
     expect_string(__wrap_cJSON_AddStringToObject, string, vu_severities[VU_HIGH]);
-
-    // Normalize date
-    char * published;
-    os_calloc(21, sizeof(char), published);
-    snprintf(published, 21, "%s", "2020-03-05T15:15:00Z");
-    expect_string(__wrap_wstr_replace, string, "2020-03-05T15:15:00Z");
-    expect_string(__wrap_wstr_replace, search, "/");
-    expect_string(__wrap_wstr_replace, replace, "-");
-    will_return(__wrap_wstr_replace, published);
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "published");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
-
-    char * updated;
-    os_calloc(21, sizeof(char), updated);
-    snprintf(updated, 21, "%s", "2020-05-25T15:15:00Z");
-    expect_string(__wrap_wstr_replace, string, "2020-05-25T15:15:00Z");
-    expect_string(__wrap_wstr_replace, search, "/");
-    expect_string(__wrap_wstr_replace, replace, "-");
-    will_return(__wrap_wstr_replace, updated);
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-05-25T15:15:00Z");
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "cwe_reference");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cwe);
 
@@ -8822,30 +8742,10 @@ void test_wm_vuldet_send_cve_report_without_ip(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
     expect_string(__wrap_cJSON_AddStringToObject, string, vu_severities[VU_HIGH]);
-
-    // Normalize date
-    char * published;
-    os_calloc(21, sizeof(char), published);
-    snprintf(published, 21, "%s", "2020-03-05T15:15:00Z");
-    expect_string(__wrap_wstr_replace, string, "2020-03-05T15:15:00Z");
-    expect_string(__wrap_wstr_replace, search, "/");
-    expect_string(__wrap_wstr_replace, replace, "-");
-    will_return(__wrap_wstr_replace, published);
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "published");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
-
-    char * updated;
-    os_calloc(21, sizeof(char), updated);
-    snprintf(updated, 21, "%s", "2020-05-25T15:15:00Z");
-    expect_string(__wrap_wstr_replace, string, "2020-05-25T15:15:00Z");
-    expect_string(__wrap_wstr_replace, search, "/");
-    expect_string(__wrap_wstr_replace, replace, "-");
-    will_return(__wrap_wstr_replace, updated);
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-05-25T15:15:00Z");
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "cwe_reference");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cwe);
 
@@ -9013,30 +8913,10 @@ void test_wm_vuldet_send_cve_report_without_hotfix(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
     expect_string(__wrap_cJSON_AddStringToObject, string, vu_severities[VU_HIGH]);
-
-    // Normalize date
-    char * published;
-    os_calloc(21, sizeof(char), published);
-    snprintf(published, 21, "%s", "2020-03-05T15:15:00Z");
-    expect_string(__wrap_wstr_replace, string, "2020-03-05T15:15:00Z");
-    expect_string(__wrap_wstr_replace, search, "/");
-    expect_string(__wrap_wstr_replace, replace, "-");
-    will_return(__wrap_wstr_replace, published);
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "published");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
-
-    char * updated;
-    os_calloc(21, sizeof(char), updated);
-    snprintf(updated, 21, "%s", "2020-05-25T15:15:00Z");
-    expect_string(__wrap_wstr_replace, string, "2020-05-25T15:15:00Z");
-    expect_string(__wrap_wstr_replace, search, "/");
-    expect_string(__wrap_wstr_replace, replace, "-");
-    will_return(__wrap_wstr_replace, updated);
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-05-25T15:15:00Z");
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "cwe_reference");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cwe);
 
@@ -9204,30 +9084,10 @@ void test_wm_vuldet_send_cve_report_sendmsg_error(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
     expect_string(__wrap_cJSON_AddStringToObject, string, vu_severities[VU_HIGH]);
-
-    // Normalize date
-    char * published;
-    os_calloc(21, sizeof(char), published);
-    snprintf(published, 21, "%s", "2020-03-05T15:15:00Z");
-    expect_string(__wrap_wstr_replace, string, "2020-03-05T15:15:00Z");
-    expect_string(__wrap_wstr_replace, search, "/");
-    expect_string(__wrap_wstr_replace, replace, "-");
-    will_return(__wrap_wstr_replace, published);
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "published");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-03-05T15:15:00Z");
-
-    char * updated;
-    os_calloc(21, sizeof(char), updated);
-    snprintf(updated, 21, "%s", "2020-05-25T15:15:00Z");
-    expect_string(__wrap_wstr_replace, string, "2020-05-25T15:15:00Z");
-    expect_string(__wrap_wstr_replace, search, "/");
-    expect_string(__wrap_wstr_replace, replace, "-");
-    will_return(__wrap_wstr_replace, updated);
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
     expect_string(__wrap_cJSON_AddStringToObject, string, "2020-05-25T15:15:00Z");
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "cwe_reference");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cwe);
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.c
@@ -43,7 +43,11 @@ cJSON* __wrap_wdb_insert_vuln_cves(int id,
     check_expected(reference);
     check_expected(type);
     check_expected(status);
-    check_expected(external_references);
+
+    char* external_references_concatenated = w_strcat_list(external_references, ',');
+    check_expected(external_references_concatenated);
+    os_free(external_references_concatenated);
+
     check_expected(condition);
     check_expected(title);
     check_expected(published);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.c
@@ -25,6 +25,11 @@ cJSON* __wrap_wdb_insert_vuln_cves(int id,
                                    const char *reference,
                                    const char *type,
                                    const char *status,
+                                   char **external_references,
+                                   const char *condition,
+                                   const char *title,
+                                   const char *published,
+                                   const char *updated,
                                    bool check_pkg_existence,
                                    __attribute__((unused)) int *sock) {
     check_expected(id);
@@ -38,6 +43,11 @@ cJSON* __wrap_wdb_insert_vuln_cves(int id,
     check_expected(reference);
     check_expected(type);
     check_expected(status);
+    check_expected(external_references);
+    check_expected(condition);
+    check_expected(title);
+    check_expected(published);
+    check_expected(updated);
     check_expected(check_pkg_existence);
     return mock_ptr_type(cJSON*);
 }

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.h
@@ -24,6 +24,11 @@ cJSON* __wrap_wdb_insert_vuln_cves(int id,
                                    const char *reference,
                                    const char *type,
                                    const char *status,
+                                   char **external_references,
+                                   const char *condition,
+                                   const char *title,
+                                   const char *published,
+                                   const char *updated,
                                    bool check_pkg_existence,
                                    __attribute__((unused)) int *sock);
 

--- a/src/wazuh_db/helpers/wdb_agents_helpers.c
+++ b/src/wazuh_db/helpers/wdb_agents_helpers.c
@@ -137,18 +137,29 @@ cJSON* wdb_insert_vuln_cves(int id,
     cJSON_AddStringToObject(data_in, "updated", updated);
     cJSON_AddBoolToObject(data_in, "check_pkg_existence", check_pkg_existence);
 
+    // Limiting references just in case there are too many or the links are too long
+    char* str_cvs_references = NULL;
+    os_calloc(WDB_MAX_QUERY_SIZE, sizeof(char), str_cvs_references);
     cJSON *j_cvs_references = cJSON_CreateArray();
     int refcount;
     for (refcount = 0; external_references[refcount]; ++refcount)
     {
         cJSON *j_ref_item = cJSON_CreateString(external_references[refcount]);
         cJSON_AddItemToArray(j_cvs_references, j_ref_item);
+
+        cJSON_PrintPreallocated(j_cvs_references, str_cvs_references, WDB_MAX_QUERY_SIZE, FALSE);
+        if (strlen(str_cvs_references) >= VULN_CVES_MAX_REFERENCES) {
+            cJSON_DeleteItemFromArray(j_cvs_references, refcount);
+            mdebug2("External references truncated before inserting in inventory.");
+            break;
+        }
     }
     cJSON_AddItemToObject(data_in, "external_references", j_cvs_references);
+    os_free(str_cvs_references);
 
     data_in_str = cJSON_PrintUnformatted(data_in);
-    os_malloc(WDBQUERY_SIZE, wdbquery);
-    snprintf(wdbquery, WDBQUERY_SIZE, agents_db_commands[WDB_AGENTS_VULN_CVES_INSERT], id, data_in_str);
+    os_malloc(WDB_MAX_QUERY_SIZE, wdbquery);
+    snprintf(wdbquery, WDB_MAX_QUERY_SIZE, agents_db_commands[WDB_AGENTS_VULN_CVES_INSERT], id, data_in_str);
 
     os_malloc(WDBOUTPUT_SIZE, wdboutput);
     cJSON* result = wdbc_query_parse_json(sock?sock:&aux_sock, wdbquery, wdboutput, WDBOUTPUT_SIZE);

--- a/src/wazuh_db/helpers/wdb_agents_helpers.c
+++ b/src/wazuh_db/helpers/wdb_agents_helpers.c
@@ -102,6 +102,11 @@ cJSON* wdb_insert_vuln_cves(int id,
                             const char *reference,
                             const char *type,
                             const char *status,
+                            char **external_references,
+                            const char *condition,
+                            const char *title,
+                            const char *published,
+                            const char *updated,
                             bool check_pkg_existence,
                             int *sock) {
     cJSON *data_in = NULL;
@@ -126,7 +131,20 @@ cJSON* wdb_insert_vuln_cves(int id,
     cJSON_AddStringToObject(data_in, "reference", reference);
     cJSON_AddStringToObject(data_in, "type", type);
     cJSON_AddStringToObject(data_in, "status", status);
+    cJSON_AddStringToObject(data_in, "condition", condition);
+    cJSON_AddStringToObject(data_in, "title", title);
+    cJSON_AddStringToObject(data_in, "published", published);
+    cJSON_AddStringToObject(data_in, "updated", updated);
     cJSON_AddBoolToObject(data_in, "check_pkg_existence", check_pkg_existence);
+
+    cJSON *j_cvs_references = cJSON_CreateArray();
+    int refcount;
+    for (refcount = 0; external_references[refcount]; ++refcount)
+    {
+        cJSON *j_ref_item = cJSON_CreateString(external_references[refcount]);
+        cJSON_AddItemToArray(j_cvs_references, j_ref_item);
+    }
+    cJSON_AddItemToObject(data_in, "external_references", j_cvs_references);
 
     data_in_str = cJSON_PrintUnformatted(data_in);
     os_malloc(WDBQUERY_SIZE, wdbquery);

--- a/src/wazuh_db/helpers/wdb_agents_helpers.h
+++ b/src/wazuh_db/helpers/wdb_agents_helpers.h
@@ -58,6 +58,11 @@ int wdb_set_agent_sys_osinfo_triaged(int id,
  * @param[in] reference The package reference.
  * @param[in] type The package type.
  * @param[in] status The vulnerability status.
+ * @param[in] external_references The vulnerability external references.
+ * @param[in] condition The vulnerability condition.
+*  @param[in] title The vulnerability title.
+*  @param[in] published The vulnerability published date in the feed.
+*  @param[in] updated The vulnerability update date, if any.
  * @param[in] check_pkg_existence If TRUE, it enables a package existence verification in sys_programs table.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return Returns cJSON object with 'action': 'INSERT' | 'UPDATE'.
@@ -79,6 +84,11 @@ cJSON* wdb_insert_vuln_cves(int id,
                             const char *reference,
                             const char *type,
                             const char *status,
+                            char **external_references,
+                            const char *condition,
+                            const char *title,
+                            const char *published,
+                            const char *updated,
                             bool check_pkg_existence,
                             int *sock);
 

--- a/src/wazuh_db/schema_agents.sql
+++ b/src/wazuh_db/schema_agents.sql
@@ -384,6 +384,11 @@ CREATE TABLE IF NOT EXISTS vuln_cves (
     reference TEXT DEFAULT '' NOT NULL,
     type TEXT DEFAULT '' NOT NULL CHECK (type IN ('OS', 'PACKAGE')),
     status TEXT DEFAULT 'PENDING' NOT NULL CHECK (status IN ('VALID', 'PENDING', 'OBSOLETE')),
+    external_references TEXT DEFAULT '',
+    condition TEXT DEFAULT '',
+    title TEXT DEFAULT '',
+    published TEXT '',
+    updated TEXT '',
     PRIMARY KEY (reference, cve)
 );
 CREATE INDEX IF NOT EXISTS packages_id ON vuln_cves (name);

--- a/src/wazuh_db/schema_upgrade_v8.sql
+++ b/src/wazuh_db/schema_upgrade_v8.sql
@@ -68,6 +68,11 @@ CREATE TABLE IF NOT EXISTS vuln_cves (
     reference TEXT DEFAULT '' NOT NULL,
     type TEXT DEFAULT '' NOT NULL CHECK (type IN ('OS', 'PACKAGE')),
     status TEXT DEFAULT 'PENDING' NOT NULL CHECK (status IN ('VALID', 'PENDING', 'OBSOLETE')),
+    external_references TEXT DEFAULT '',
+    condition TEXT DEFAULT '',
+    title TEXT DEFAULT '',
+    published TEXT '',
+    updated TEXT '',
     PRIMARY KEY (reference, cve)
 );
 CREATE INDEX IF NOT EXISTS packages_id ON vuln_cves (name);

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -224,7 +224,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_SYSCOLLECTOR_OSINFO_DELETE_AROUND] = "DELETE FROM sys_osinfo WHERE os_name < ? OR os_name > ? OR checksum = 'legacy' OR checksum = '';",
     [WDB_STMT_SYSCOLLECTOR_OSINFO_DELETE_RANGE] = "DELETE FROM sys_osinfo WHERE os_name > ? AND os_name < ?;",
     [WDB_STMT_SYSCOLLECTOR_OSINFO_CLEAR] = "DELETE FROM sys_osinfo;",
-    [WDB_STMT_VULN_CVES_INSERT] = "INSERT OR REPLACE INTO vuln_cves (name, version, architecture, cve, reference, type, status, severity, cvss2_score, cvss3_score, detection_time) VALUES (?,?,?,?,?,?,?,?,?,?,strftime('%s', 'now'));",
+    [WDB_STMT_VULN_CVES_INSERT] = "INSERT OR REPLACE INTO vuln_cves (name, version, architecture, cve, reference, type, status, severity, cvss2_score, cvss3_score, detection_time, external_references, condition, title, published, updated) VALUES (?,?,?,?,?,?,?,?,?,?,strftime('%s', 'now'),?,?,?,?,?);",
     [WDB_STMT_VULN_CVES_CLEAR] = "DELETE FROM vuln_cves;",
     [WDB_STMT_VULN_CVES_UPDATE] = "UPDATE vuln_cves SET status = ? WHERE status = ?;",
     [WDB_STMT_VULN_CVES_UPDATE_BY_TYPE] = "UPDATE vuln_cves SET status = ? WHERE type = ?;",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -45,6 +45,7 @@
 
 #define WDB_MAX_COMMAND_SIZE    512
 #define WDB_MAX_RESPONSE_SIZE   OS_MAXSTR-WDB_MAX_COMMAND_SIZE
+#define WDB_MAX_QUERY_SIZE      OS_MAXSTR-WDB_MAX_COMMAND_SIZE
 
 #define AGENT_CS_NEVER_CONNECTED "never_connected"
 #define AGENT_CS_PENDING         "pending"
@@ -59,6 +60,8 @@
 
 #define VULN_CVES_TYPE_OS         "OS"
 #define VULN_CVES_TYPE_PACKAGE    "PACKAGE"
+
+#define VULN_CVES_MAX_REFERENCES OS_SIZE_20480
 
 #define WDB_BLOCK_SEND_TIMEOUT_S   1 /* Max time in seconds waiting for the client to receive the information sent with a blocking method*/
 

--- a/src/wazuh_db/wdb_agents.c
+++ b/src/wazuh_db/wdb_agents.c
@@ -92,7 +92,12 @@ cJSON* wdb_agents_insert_vuln_cves(wdb_t *wdb,
                                    bool check_pkg_existence,
                                    const char* severity,
                                    double cvss2_score,
-                                   double cvss3_score) {
+                                   double cvss3_score,
+                                   const char *external_references,
+                                   const char *condition,
+                                   const char *title,
+                                   const char *published,
+                                   const char *updated) {
     char* status_to_insert = NULL;
 
     cJSON* result = cJSON_CreateObject();
@@ -124,9 +129,38 @@ cJSON* wdb_agents_insert_vuln_cves(wdb_t *wdb,
         sqlite3_bind_text(stmt, 5, reference, -1, NULL);
         sqlite3_bind_text(stmt, 6, type, -1, NULL);
         sqlite3_bind_text(stmt, 7, status_to_insert, -1, NULL);
-        sqlite3_bind_text(stmt, 8, severity, -1, NULL);
+        if (severity) {
+            sqlite3_bind_text(stmt, 8, severity, -1, NULL);
+        } else {
+            sqlite3_bind_null(stmt, 8);
+        }
         sqlite3_bind_double(stmt, 9, cvss2_score);
         sqlite3_bind_double(stmt, 10, cvss3_score);
+        if (external_references) {
+            sqlite3_bind_text(stmt, 11, external_references, -1, NULL);
+        } else {
+            sqlite3_bind_null(stmt, 11);
+        }
+        if (condition) {
+            sqlite3_bind_text(stmt, 12, condition, -1, NULL);
+        } else {
+            sqlite3_bind_null(stmt, 12);
+        }
+        if (title) {
+            sqlite3_bind_text(stmt, 13, title, -1, NULL);
+        } else {
+            sqlite3_bind_null(stmt, 13);
+        }
+        if (published) {
+            sqlite3_bind_text(stmt, 14, published, -1, NULL);
+        } else {
+            sqlite3_bind_null(stmt, 14);
+        }
+        if (updated) {
+            sqlite3_bind_text(stmt, 15, updated, -1, NULL);
+        } else {
+            sqlite3_bind_null(stmt, 15);
+        }
 
         if (OS_SUCCESS == wdb_exec_stmt_silent(stmt)) {
             cJSON_AddStringToObject(result, "status", "SUCCESS");

--- a/src/wazuh_db/wdb_agents.h
+++ b/src/wazuh_db/wdb_agents.h
@@ -66,6 +66,11 @@ bool wdb_agents_find_cve(wdb_t *wdb, const char* cve, const char* reference);
  * @param [in] severity A string representing the severity of the vulnerability.
  * @param [in] cvss2_score The vulnerability score according to CVSS v2.
  * @param [in] cvss3_score The vulnerability score according to CVSS v3.
+ * @param [in] external_references The vulnerability external references.
+ * @param [in] condition The vulnerability condition.
+ * @param [in] title The vulnerability title.
+ * @param [in] published The vulnerability published date in the feed.
+ * @param [in] updated The vulnerability update date, if any.
  * @return Returns cJSON object with 'action': 'INSERT' | 'UPDATE'.
  *                               and 'status': 'SUCCESS' | 'ERROR'.
  *         The cJSON object must be freed by the caller.
@@ -81,7 +86,12 @@ cJSON* wdb_agents_insert_vuln_cves(wdb_t *wdb,
                                    bool check_pkg_existence,
                                    const char* severity,
                                    double cvss2_score,
-                                   double cvss3_score);
+                                   double cvss3_score,
+                                   const char *external_references,
+                                   const char *condition,
+                                   const char *title,
+                                   const char *published,
+                                   const char *updated);
 
 /**
  * @brief Function to update the status field in agent database vuln_cves table.

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5974,6 +5974,12 @@ int wdb_parse_agents_insert_vuln_cves(wdb_t* wdb, char* input, char* output) {
         cJSON* j_severity = cJSON_GetObjectItem(data, "severity");
         cJSON* j_cvss2_score = cJSON_GetObjectItem(data, "cvss2_score");
         cJSON* j_cvss3_score = cJSON_GetObjectItem(data, "cvss3_score");
+        cJSON* j_external_references = cJSON_GetObjectItem(data, "external_references");
+        cJSON* j_condition = cJSON_GetObjectItem(data, "condition");
+        cJSON* j_title = cJSON_GetObjectItem(data, "title");
+        cJSON* j_published = cJSON_GetObjectItem(data, "published");
+        cJSON* j_updated = cJSON_GetObjectItem(data, "updated");
+
         // Required fields
         if (!cJSON_IsString(j_name) || !cJSON_IsString(j_version) || !cJSON_IsString(j_architecture) ||!cJSON_IsString(j_cve) ||
             !cJSON_IsString(j_reference) || !cJSON_IsString(j_type) || !cJSON_IsString(j_status) ||!cJSON_IsBool(j_check_pkg_existence)) {
@@ -5981,10 +5987,13 @@ int wdb_parse_agents_insert_vuln_cves(wdb_t* wdb, char* input, char* output) {
             snprintf(output, OS_MAXSTR + 1, "err Invalid JSON data, missing required fields");
         }
         else {
+            char* str_external_references = cJSON_PrintUnformatted(j_external_references);
+
             cJSON* result = wdb_agents_insert_vuln_cves(wdb, cJSON_GetStringValue(j_name), cJSON_GetStringValue(j_version), cJSON_GetStringValue(j_architecture), cJSON_GetStringValue(j_cve),
                                                         cJSON_GetStringValue(j_reference), cJSON_GetStringValue(j_type), cJSON_GetStringValue(j_status), (bool)j_check_pkg_existence->valueint,
                                                         cJSON_GetStringValue(j_severity), cJSON_IsNumber(j_cvss2_score) ? j_cvss2_score->valuedouble : 0,
-                                                        cJSON_IsNumber(j_cvss3_score) ? j_cvss3_score->valuedouble : 0);
+                                                        cJSON_IsNumber(j_cvss3_score) ? j_cvss3_score->valuedouble : 0, str_external_references, cJSON_GetStringValue(j_condition),
+                                                        cJSON_GetStringValue(j_title), cJSON_GetStringValue(j_published), cJSON_GetStringValue(j_updated));
 
             if (result) {
                 char *out = cJSON_PrintUnformatted(result);
@@ -5997,6 +6006,7 @@ int wdb_parse_agents_insert_vuln_cves(wdb_t* wdb, char* input, char* output) {
                 mdebug1("Error inserting vulnerability in vuln_cves.");
                 snprintf(output, OS_MAXSTR + 1, "err Error inserting vulnerability in vuln_cves.");
             }
+            os_free(str_external_references);
         }
     }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1588,7 +1588,7 @@ int wm_vuldet_send_cve_report(vu_report *report) {
         if (report->source) cJSON_AddStringToObject(j_package, "source", report->source);
         if (report->version && *report->version) cJSON_AddStringToObject(j_package, "version", report->version);
         if (report->arch && *report->arch) cJSON_AddStringToObject(j_package, "architecture", report->arch);
-        cJSON_AddStringToObject(j_package, "condition", report->condition);
+        if (report->condition) cJSON_AddStringToObject(j_package, "condition", report->condition);
 
         if (report->cvss2 || report->cvss3) {
             cJSON *j_cvss_node;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1522,7 +1522,7 @@ int wm_vuldet_process_agent_vulnerabilities(sqlite3 *db, OSHash *cve_table, scan
             if (!update) {
                 // Sending CVE report
                 if (wm_vuldet_send_cve_report(report)) {
-                    mterror(WM_VULNDETECTOR_LOGTAG, VU_SEND_AGENT_REPORT_ERROR, report->cve, report->software, scan_ctx->agent_id);
+                    mterror(WM_VULNDETECTOR_LOGTAG, VU_SEND_AGENT_REPORT_ERROR, report->cve ? report->cve : "", report->software ? report->software : "" , scan_ctx->agent_id);
                 } else {
                     if (pkg->feed & VU_SRC_NVD) {
                         vuln_reported_nvd++;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1478,12 +1478,16 @@ int wm_vuldet_process_agent_vulnerabilities(sqlite3 *db, OSHash *cve_table, scan
                 }
             }
 
+            // Adjusting some fields before inserting and sending
+            wm_vuldet_give_report_format(report);
+
             //Save the vulnerability in the agent database
             bool check_pkg_existence = pkg->type && !strcmp(pkg->type, VULN_CVES_TYPE_PACKAGE);
             cJSON* j_result = wdb_insert_vuln_cves(scan_ctx->agent_id, report->software, report->version, report->arch, report->cve,
-                                                   wm_vuldet_get_unified_severity(report->severity), report->cvss2 ? report->cvss2->base_score : 0,
+                                                   report->severity, report->cvss2 ? report->cvss2->base_score : 0,
                                                    report->cvss3 ? report->cvss3->base_score : 0, pkg->reference, pkg->type, VULN_CVES_STATUS_VALID,
-                                                   check_pkg_existence, &sock);
+                                                   report->references, report->condition, report->title, report->published,
+                                                   report->updated, check_pkg_existence, &sock);
 
             bool success = FALSE;
             bool update = FALSE;
@@ -1564,11 +1568,6 @@ int wm_vuldet_send_cve_report(vu_report *report) {
     char alert_msg[OS_MAXSTR + 1];
     // Define time to sleep between messages sent
     int usec = 1000000 / wm_max_eps;
-    char *timestamp = NULL;
-
-    // Build title
-    os_calloc(OS_SIZE_512, sizeof(char), report->title);
-    snprintf(report->title, OS_SIZE_512, "%s affects %s", report->cve, report->software);
 
     if (alert = cJSON_CreateObject(), !alert) {
         return retval;
@@ -1589,15 +1588,7 @@ int wm_vuldet_send_cve_report(vu_report *report) {
         if (report->source) cJSON_AddStringToObject(j_package, "source", report->source);
         if (report->version && *report->version) cJSON_AddStringToObject(j_package, "version", report->version);
         if (report->arch && *report->arch) cJSON_AddStringToObject(j_package, "architecture", report->arch);
-
-        if (report->condition && *report->condition != '\0') {
-            cJSON_AddStringToObject(j_package, "condition", report->condition);
-        } else if (report->operation && report->operation_value) {
-            os_free(report->condition);
-            os_calloc(OS_SIZE_1024 + 1, sizeof(char), report->condition);
-            snprintf(report->condition, OS_SIZE_1024, "Package %s %s", report->operation, report->operation_value);
-            cJSON_AddStringToObject(j_package, "condition", report->condition);
-        }
+        cJSON_AddStringToObject(j_package, "condition", report->condition);
 
         if (report->cvss2 || report->cvss3) {
             cJSON *j_cvss_node;
@@ -1633,12 +1624,12 @@ int wm_vuldet_send_cve_report(vu_report *report) {
         if (report->rationale) {
             cJSON_AddStringToObject(alert_cve, "rationale", report->rationale);
         }
-        cJSON_AddStringToObject(alert_cve, "severity", wm_vuldet_get_unified_severity(report->severity));
-        if (timestamp = wm_vuldet_normalize_date(&report->published), timestamp) {
-            cJSON_AddStringToObject(alert_cve, "published", timestamp);
+        cJSON_AddStringToObject(alert_cve, "severity", report->severity);
+        if (report->published) {
+            cJSON_AddStringToObject(alert_cve, "published", report->published);
         }
-        if (timestamp = wm_vuldet_normalize_date(&report->updated), timestamp) {
-            cJSON_AddStringToObject(alert_cve, "updated", timestamp);
+        if (report->updated) {
+            cJSON_AddStringToObject(alert_cve, "updated", report->updated);
         }
         if (report->cwe) cJSON_AddStringToObject(alert_cve, "cwe_reference", report->cwe);
         cJSON_AddStringToObject(alert_cve, "status", VULN_CVES_STATUS_ACTIVE_LOWERCASE);
@@ -8577,6 +8568,25 @@ int wm_vuldet_get_software(int agent_id, bool not_triaged, cJSON** requested_ite
     }
 
     return result;
+}
+
+void wm_vuldet_give_report_format(vu_report *report) {
+    // Build title
+    os_calloc(OS_SIZE_512, sizeof(char), report->title);
+    snprintf(report->title, OS_SIZE_512, "%s affects %s", report->cve, report->software);
+
+    if (!(report->condition && *report->condition != '\0') && (report->operation && report->operation_value) ) {
+        os_free(report->condition);
+        os_calloc(OS_SIZE_1024 + 1, sizeof(char), report->condition);
+        snprintf(report->condition, OS_SIZE_1024, "Package %s %s", report->operation, report->operation_value);
+    }
+
+    wm_vuldet_normalize_date(&report->published);
+    wm_vuldet_normalize_date(&report->updated);
+
+    const char* severity = wm_vuldet_get_unified_severity(report->severity);
+    os_free(report->severity);
+    w_strdup(severity, report->severity);
 }
 
 #endif

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -1144,6 +1144,13 @@ int wm_vuldet_get_software(int agent_id, bool not_triaged, cJSON** requested_ite
  */
 char* wm_vuldet_normalize_architecture_nvd(char* architecture);
 
+/**
+ * @brief Method to format some fields of the vulnerability detector report.
+ *
+ * @param report The report structure.
+ */
+void wm_vuldet_give_report_format(vu_report *report);
+
 #endif
 #endif
 #endif

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2294,12 +2294,16 @@ int wm_vuldet_process_agent_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd
         w_strdup(agent->agent_name, report->agent_name);
         w_strdup(agent->agent_ip, report->agent_ip);
 
+        // Adjusting some fields before inserting and sending
+        wm_vuldet_give_report_format(report);
+
         //Save the vulnerability in the agent database
         bool check_pkg_existence = report->type && !strcmp(report->type, VULN_CVES_TYPE_PACKAGE);
         cJSON* j_result = wdb_insert_vuln_cves(atoi(agent->agent_id), report->software, report->version, report->arch, report->cve,
-                                               wm_vuldet_get_unified_severity(report->severity), report->cvss2 ? report->cvss2->base_score : 0,
+                                               report->severity, report->cvss2 ? report->cvss2->base_score : 0,
                                                report->cvss3 ? report->cvss3->base_score : 0, report->reference, report->type, VULN_CVES_STATUS_VALID,
-                                               check_pkg_existence, &sock);
+                                               report->references, report->condition, report->title, report->published,
+                                               report->updated, check_pkg_existence, &sock);
 
         bool success = FALSE;
         bool update = FALSE;


### PR DESCRIPTION
|Related issue|
|---|
|#12681|

## Description

This PR increases the maximum size of the query in `wdb_insert_vuln_cves()` and also limits the maximum size of the references so the query can fit in the socket.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
