### PR TITLE
Add vulnerability information in solved alerts

### DIFF
--- a/ruleset/rules/0520-vulnerability-detector_rules.xml
+++ b/ruleset/rules/0520-vulnerability-detector_rules.xml
@@ -23,6 +23,7 @@
   <rule id="23503" level="5">
       <if_sid>23501</if_sid>
       <options>no_full_log</options>
+      <field name="vulnerability.status">Active</field>
       <field name="vulnerability.severity">Low</field>
       <description>$(vulnerability.cve) affects $(vulnerability.package.name)</description>
   </rule>
@@ -30,6 +31,7 @@
   <rule id="23504" level="7">
       <if_sid>23501</if_sid>
       <options>no_full_log</options>
+      <field name="vulnerability.status">Active</field>
       <field name="vulnerability.severity">Medium|-</field>
       <description>$(vulnerability.cve) affects $(vulnerability.package.name)</description>
   </rule>
@@ -37,6 +39,7 @@
   <rule id="23505" level="10">
       <if_sid>23501</if_sid>
       <options>no_full_log</options>
+      <field name="vulnerability.status">Active</field>
       <field name="vulnerability.severity">High</field>
       <description>$(vulnerability.cve) affects $(vulnerability.package.name)</description>
   </rule>
@@ -44,6 +47,7 @@
   <rule id="23506" level="13">
       <if_sid>23501</if_sid>
       <options>no_full_log</options>
+      <field name="vulnerability.status">Active</field>
       <field name="vulnerability.severity">Critical</field>
       <description>$(vulnerability.cve) affects $(vulnerability.package.name)</description>
   </rule>

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
@@ -36,7 +36,7 @@ list(APPEND vulndetector_flags "-Wl,--wrap,_merror -Wl,--wrap,_mterror -Wl,--wra
                                 -Wl,--wrap,cJSON_CreateString -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_PrintUnformatted \
                                 -Wl,--wrap,pkg_version_relate -Wl,--wrap,cJSON_Parse -Wl,--wrap,cJSON_GetObjectItem \
                                 -Wl,--wrap,_mtwarn -Wl,--wrap,sqlite3_column_int -Wl,--wrap,wm_vuldet_win_nvd_vulnerabilities \
-                                -Wl,--wrap,wm_vuldet_linux_nvd_vulnerabilities \
+                                -Wl,--wrap,wm_vuldet_linux_nvd_vulnerabilities -Wl,--wrap,cJSON_AddNumberToObject \
                                 -Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 -Wl,--wrap,time -Wl,--wrap,wstr_end -Wl,--wrap=fgetc \
                                 -Wl,--wrap,json_fread -Wl,--wrap,remove -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,wurl_request -Wl,--wrap,sleep \
                                 -Wl,--wrap,sqlite3_open_v2 -Wl,--wrap,fgets -Wl,--wrap,fwrite -Wl,--wrap,localtime -Wl,--wrap,OS_GetOneContentforElement \

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -19968,7 +19968,7 @@ void test_wm_vuldet_find_obsolete_vulnerabilities_report_fail() {
     int retval;
     scan_ctx_t scan_ctx;
     wm_max_eps = 1;
-    cJSON* j_obsolete_vulns= __real_cJSON_CreateArray();
+    cJSON* j_obsolete_vulns = __real_cJSON_CreateArray();
     cJSON* j_vuln = __real_cJSON_CreateObject();
     __real_cJSON_AddItemToArray(j_obsolete_vulns, j_vuln);
 
@@ -19986,7 +19986,7 @@ void test_wm_vuldet_find_obsolete_vulnerabilities_report_fail() {
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5490): The vulnerability 'CVE' affecting 'PACKAGE' was solved");
     // wm_vuldet_send_removed_cve_report
-    will_return_count(__wrap_cJSON_GetStringValue, NULL, 5);
+    will_return_count(__wrap_cJSON_GetStringValue, NULL, 9);
 
     // Vulnerability removed log (nvd)
     will_return(__wrap_cJSON_GetStringValue, "PACKAGE_nvd");
@@ -19994,7 +19994,7 @@ void test_wm_vuldet_find_obsolete_vulnerabilities_report_fail() {
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5490): The vulnerability 'CVE_nvd' affecting 'PACKAGE_nvd' was solved");
     // wm_vuldet_send_removed_cve_report (nvd)
-    will_return_count(__wrap_cJSON_GetStringValue, NULL, 5);
+    will_return_count(__wrap_cJSON_GetStringValue, NULL, 9);
 
     // wm_vuldet_send_removed_cve_report
     will_return_count(__wrap_cJSON_GetObjectItem, NULL, -1);
@@ -20049,7 +20049,10 @@ void test_wm_vuldet_send_removed_cve_report_ip_assigned_success() {
     wm_max_eps = 1;
 
     char* alert = "{\"vulnerability\":{\"package\":{\"name\":\"ncurses\",\"version\":\"5.9-14.20130511.el7_4\","
-                  "\"architecture\":\"x86_64\"},\"cve\":\"CVE-2019-17594\", \"status\":\"Solved\"}}";
+                  "\"architecture\":\"x86_64\"},\"cve\":\"CVE-2019-17594\",\"status\":\"Solved\","
+                  "\"severity\":\"High\",\"published\":\"2022-03-10\",\"updated\":\"2022-03-11\","
+                  "\"references\":[\"https://url1\",\"https://url2\",\"https://url3\"],"
+                  "\"cvss\":{\"cvss2\":{\"base_score\":8.0},\"cvss3\":{\"base_score\":9.0}}}}";
     char* alert_cpy = NULL;
     char alert_message[OS_MAXSTR + 1];
 
@@ -20060,18 +20063,28 @@ void test_wm_vuldet_send_removed_cve_report_ip_assigned_success() {
     scan_ctx.agent_name = "test_agent";
     scan_ctx.agent_ip = "any";
 
-    will_return_count(__wrap_cJSON_GetObjectItem, NULL, -1);
+    will_return_count(__wrap_cJSON_GetObjectItem, NULL, 9);
     will_return(__wrap_cJSON_GetStringValue, "ncurses");
     will_return(__wrap_cJSON_GetStringValue, "5.9-14.20130511.el7_4");
     will_return(__wrap_cJSON_GetStringValue, "x86_64");
     will_return(__wrap_cJSON_GetStringValue, "CVE-2019-17594");
     will_return(__wrap_cJSON_GetStringValue, "PACKAGE");
+    will_return(__wrap_cJSON_GetStringValue, "High");
+    will_return(__wrap_cJSON_GetStringValue, "2022-03-10");
+    will_return(__wrap_cJSON_GetStringValue, "2022-03-11");
+    will_return(__wrap_cJSON_GetStringValue, "[\"https://url1\",\"https://url2\",\"https://url3\"]");
 
-    will_return_count(__wrap_cJSON_CreateObject, (cJSON*)1, -1);
+    // CVSS get values
+    cJSON* j_cvss2_score = __real_cJSON_CreateNumber(8.0);
+    cJSON* j_cvss3_score = __real_cJSON_CreateNumber(9.0);
+    will_return(__wrap_cJSON_GetObjectItem, j_cvss2_score);
+    will_return(__wrap_cJSON_GetObjectItem, j_cvss3_score);
+
+    will_return_count(__wrap_cJSON_CreateObject, (cJSON*)1, 3);
     expect_function_calls(__wrap_cJSON_AddItemToObject, 2);
-    will_return_count(__wrap_cJSON_AddItemToObject, TRUE, -1);
+    will_return_count(__wrap_cJSON_AddItemToObject, TRUE, 2);
 
-    will_return_count(__wrap_cJSON_AddStringToObject, NULL, -1);
+    will_return_count(__wrap_cJSON_AddStringToObject, NULL, 10);
     expect_string(__wrap_cJSON_AddStringToObject, name, "name");
     expect_string(__wrap_cJSON_AddStringToObject, string, "ncurses");
     expect_string(__wrap_cJSON_AddStringToObject, name, "version");
@@ -20086,6 +20099,30 @@ void test_wm_vuldet_send_removed_cve_report_ip_assigned_success() {
     expect_string(__wrap_cJSON_AddStringToObject, string, "PACKAGE");
     expect_string(__wrap_cJSON_AddStringToObject, name, "title");
     expect_string(__wrap_cJSON_AddStringToObject, string, "CVE-2019-17594 affecting ncurses was solved");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "High");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "published");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "2022-03-10");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "2022-03-11");
+
+    // CVSS score
+    will_return_count(__wrap_cJSON_CreateObject, (cJSON*)1, 3);
+    expect_function_calls(__wrap_cJSON_AddItemToObject, 3);
+    will_return_count(__wrap_cJSON_AddItemToObject, TRUE, 3);
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "base_score");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 8.0);
+    will_return(__wrap_cJSON_AddNumberToObject, 1);
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "base_score");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 9.0);
+    will_return(__wrap_cJSON_AddNumberToObject, 1);
+
+    // References
+    char* refs = "[\"https://url1\",\"https://url2\",\"https://url3\"]";
+    cJSON* j_references = __real_cJSON_Parse(refs);
+    will_return(__wrap_cJSON_Parse, j_references);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, TRUE);
 
     will_return(__wrap_cJSON_PrintUnformatted, alert_cpy);
     will_return(__wrap_wm_sendmsg, 0);
@@ -20112,6 +20149,9 @@ void test_wm_vuldet_send_removed_cve_report_ip_assigned_success() {
     retval = wm_vuldet_send_removed_cve_report(j_vuln, &scan_ctx);
 
     assert_int_equal(retval, OS_SUCCESS);
+    __real_cJSON_Delete(j_cvss2_score);
+    __real_cJSON_Delete(j_cvss3_score);
+    __real_cJSON_Delete(j_references);
     os_free(vuldet);
 }
 
@@ -20122,24 +20162,37 @@ void test_wm_vuldet_send_removed_cve_report_no_ip_success() {
     wm_max_eps = 1;
 
     char* alert = "{\"vulnerability\":{\"package\":{\"name\":\"ncurses\",\"version\":\"5.9-14.20130511.el7_4\","
-                  "\"architecture\":\"x86_64\"},\"cve\":\"CVE-2019-17594\", \"status\":\"Solved\"}}";
+                  "\"architecture\":\"x86_64\"},\"cve\":\"CVE-2019-17594\",\"status\":\"Solved\","
+                  "\"severity\":\"High\",\"published\":\"2022-03-10\",\"updated\":\"2022-03-11\","
+                  "\"references\":[\"https://url1\",\"https://url2\",\"https://url3\"],"
+                  "\"cvss\":{\"cvss2\":{\"base_score\":8.0},\"cvss3\":{\"base_score\":9.0}}}}";
     char* alert_cpy = NULL;
 
     os_strdup(alert, alert_cpy);
     scan_ctx.agent_ip = NULL;
 
-    will_return_count(__wrap_cJSON_GetObjectItem, NULL, -1);
+    will_return_count(__wrap_cJSON_GetObjectItem, NULL, 9);
     will_return(__wrap_cJSON_GetStringValue, "ncurses");
     will_return(__wrap_cJSON_GetStringValue, "5.9-14.20130511.el7_4");
     will_return(__wrap_cJSON_GetStringValue, "x86_64");
     will_return(__wrap_cJSON_GetStringValue, "CVE-2019-17594");
     will_return(__wrap_cJSON_GetStringValue, "PACKAGE");
+    will_return(__wrap_cJSON_GetStringValue, "High");
+    will_return(__wrap_cJSON_GetStringValue, "2022-03-10");
+    will_return(__wrap_cJSON_GetStringValue, "2022-03-11");
+    will_return(__wrap_cJSON_GetStringValue, "[\"https://url1\",\"https://url2\",\"https://url3\"]");
 
-    will_return_count(__wrap_cJSON_CreateObject, (cJSON*)1, -1);
+    // CVSS get values
+    cJSON* j_cvss2_score = __real_cJSON_CreateNumber(8.0);
+    cJSON* j_cvss3_score = __real_cJSON_CreateNumber(9.0);
+    will_return(__wrap_cJSON_GetObjectItem, j_cvss2_score);
+    will_return(__wrap_cJSON_GetObjectItem, j_cvss3_score);
+
+    will_return_count(__wrap_cJSON_CreateObject, (cJSON*)1, 3);
     expect_function_calls(__wrap_cJSON_AddItemToObject, 2);
-    will_return_count(__wrap_cJSON_AddItemToObject, TRUE, -1);
+    will_return_count(__wrap_cJSON_AddItemToObject, TRUE, 2);
 
-    will_return_count(__wrap_cJSON_AddStringToObject, NULL, -1);
+    will_return_count(__wrap_cJSON_AddStringToObject, NULL, 10);
     expect_string(__wrap_cJSON_AddStringToObject, name, "name");
     expect_string(__wrap_cJSON_AddStringToObject, string, "ncurses");
     expect_string(__wrap_cJSON_AddStringToObject, name, "version");
@@ -20154,6 +20207,30 @@ void test_wm_vuldet_send_removed_cve_report_no_ip_success() {
     expect_string(__wrap_cJSON_AddStringToObject, string, "PACKAGE");
     expect_string(__wrap_cJSON_AddStringToObject, name, "title");
     expect_string(__wrap_cJSON_AddStringToObject, string, "CVE-2019-17594 affecting ncurses was solved");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "High");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "published");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "2022-03-10");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "2022-03-11");
+
+    // CVSS score
+    will_return_count(__wrap_cJSON_CreateObject, (cJSON*)1, 3);
+    expect_function_calls(__wrap_cJSON_AddItemToObject, 3);
+    will_return_count(__wrap_cJSON_AddItemToObject, TRUE, 3);
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "base_score");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 8.0);
+    will_return(__wrap_cJSON_AddNumberToObject, 1);
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "base_score");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 9.0);
+    will_return(__wrap_cJSON_AddNumberToObject, 1);
+
+    // References
+    char* refs = "[\"https://url1\",\"https://url2\",\"https://url3\"]";
+    cJSON* j_references = __real_cJSON_Parse(refs);
+    will_return(__wrap_cJSON_Parse, j_references);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, TRUE);
 
     will_return(__wrap_cJSON_PrintUnformatted, alert_cpy);
     will_return(__wrap_wm_sendmsg, 0);
@@ -20180,6 +20257,9 @@ void test_wm_vuldet_send_removed_cve_report_no_ip_success() {
     retval = wm_vuldet_send_removed_cve_report(j_vuln, &scan_ctx);
 
     assert_int_equal(retval, OS_SUCCESS);
+    __real_cJSON_Delete(j_cvss2_score);
+    __real_cJSON_Delete(j_cvss3_score);
+    __real_cJSON_Delete(j_references);
     os_free(vuldet);
 }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1719,6 +1719,13 @@ int wm_vuldet_send_removed_cve_report (cJSON* j_vuln, scan_ctx_t* scan_ctx) {
     char* package_architecture = cJSON_GetStringValue(cJSON_GetObjectItem(j_vuln, "architecture"));
     char* cve_id = cJSON_GetStringValue(cJSON_GetObjectItem(j_vuln, "cve"));
     char* cve_type = cJSON_GetStringValue(cJSON_GetObjectItem(j_vuln, "type"));
+    char* severity = cJSON_GetStringValue(cJSON_GetObjectItem(j_vuln, "severity"));
+    char* published = cJSON_GetStringValue(cJSON_GetObjectItem(j_vuln, "published"));
+    char* updated = cJSON_GetStringValue(cJSON_GetObjectItem(j_vuln, "updated"));
+    char* external_references = cJSON_GetStringValue(cJSON_GetObjectItem(j_vuln, "external_references"));
+    cJSON* j_cvss2_score = cJSON_GetObjectItem(j_vuln, "cvss2_score");
+    cJSON* j_cvss3_score = cJSON_GetObjectItem(j_vuln, "cvss3_score");
+
     // Define time to sleep between messages sent
     int usec = 1000000 / wm_max_eps;
 
@@ -1727,7 +1734,7 @@ int wm_vuldet_send_removed_cve_report (cJSON* j_vuln, scan_ctx_t* scan_ctx) {
 
     cJSON* j_alert = cJSON_CreateObject();
     cJSON* j_alert_cve = cJSON_CreateObject();
-    cJSON *j_package = cJSON_CreateObject();
+    cJSON* j_package = cJSON_CreateObject();
     cJSON_AddItemToObject(j_alert, "vulnerability", j_alert_cve);
     cJSON_AddItemToObject(j_alert_cve, "package", j_package);
 
@@ -1740,6 +1747,32 @@ int wm_vuldet_send_removed_cve_report (cJSON* j_vuln, scan_ctx_t* scan_ctx) {
         cJSON_AddStringToObject(j_alert_cve, "status", VULN_CVES_STATUS_SOLVED_LOWERCASE);
         cJSON_AddStringToObject(j_alert_cve, "type", cve_type);
         cJSON_AddStringToObject(j_alert_cve, "title", alert_title);
+        cJSON_AddStringToObject(j_alert_cve, "severity", severity);
+        cJSON_AddStringToObject(j_alert_cve, "published", published);
+        cJSON_AddStringToObject(j_alert_cve, "updated", updated);
+
+        // Add CVSS base score
+        if (j_cvss2_score
+            && j_cvss2_score->valuedouble != 0.0
+            && j_cvss3_score
+            && j_cvss3_score->valuedouble != 0.0)
+        {
+            cJSON* j_cvss = cJSON_CreateObject();
+            cJSON* j_cvss2 = cJSON_CreateObject();
+            cJSON* j_cvss3 = cJSON_CreateObject();
+
+            cJSON_AddItemToObject(j_alert_cve, "cvss", j_cvss);
+            cJSON_AddItemToObject(j_cvss, "cvss2", j_cvss2);
+            cJSON_AddItemToObject(j_cvss, "cvss3", j_cvss3);
+            cJSON_AddNumberToObject(j_cvss2, "base_score", j_cvss2_score->valuedouble);
+            cJSON_AddNumberToObject(j_cvss3, "base_score", j_cvss3_score->valuedouble);
+        }
+
+        // Add external references
+        if (external_references) {
+            cJSON *j_references = cJSON_Parse(external_references);
+            cJSON_AddItemToObject(j_alert_cve, "references", j_references);
+        }
 
         alert = cJSON_PrintUnformatted(j_alert);
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1752,20 +1752,23 @@ int wm_vuldet_send_removed_cve_report (cJSON* j_vuln, scan_ctx_t* scan_ctx) {
         cJSON_AddStringToObject(j_alert_cve, "updated", updated);
 
         // Add CVSS base score
-        if (j_cvss2_score
-            && j_cvss2_score->valuedouble != 0.0
-            && j_cvss3_score
-            && j_cvss3_score->valuedouble != 0.0)
-        {
+        if ((j_cvss2_score && j_cvss2_score->valuedouble >= 0.1)
+             || (j_cvss3_score && j_cvss3_score->valuedouble >= 0.1)) {
             cJSON* j_cvss = cJSON_CreateObject();
-            cJSON* j_cvss2 = cJSON_CreateObject();
-            cJSON* j_cvss3 = cJSON_CreateObject();
-
             cJSON_AddItemToObject(j_alert_cve, "cvss", j_cvss);
-            cJSON_AddItemToObject(j_cvss, "cvss2", j_cvss2);
-            cJSON_AddItemToObject(j_cvss, "cvss3", j_cvss3);
-            cJSON_AddNumberToObject(j_cvss2, "base_score", j_cvss2_score->valuedouble);
-            cJSON_AddNumberToObject(j_cvss3, "base_score", j_cvss3_score->valuedouble);
+
+            // 0.0 score means the CVSS is untriaged, so it isn't include in alerts
+            if (j_cvss2_score && j_cvss2_score->valuedouble >= 0.1) {
+                cJSON* j_cvss2 = cJSON_CreateObject();
+                cJSON_AddItemToObject(j_cvss, "cvss2", j_cvss2);
+                cJSON_AddNumberToObject(j_cvss2, "base_score", j_cvss2_score->valuedouble);
+            }
+
+            if (j_cvss3_score && j_cvss3_score->valuedouble >= 0.1) {
+                cJSON* j_cvss3 = cJSON_CreateObject();
+                cJSON_AddItemToObject(j_cvss, "cvss3", j_cvss3);
+                cJSON_AddNumberToObject(j_cvss3, "base_score", j_cvss3_score->valuedouble);
+            }
         }
 
         // Add external references


### PR DESCRIPTION
|Related issue|
|---|
| Closes #12584 |

## Description

This pull request adds the following fields when Vulnerability Detector triggers an alert to report a vulnerability has been solved:
- **severity**
- **references**
- **published**
- **updated**
- **cvss2_score**
- **cvss3_score**

Rules have also been adapted to take the `status` and `severity` into account. That way, rule 23502 is always fired when a vulnerability is solved.

## Logs/Alerts example

Here we can see an alert with the added fields
```
** Alert 1646993782.80559: - vulnerability-detector,gdpr_IV_35.7.d,pci_dss_11.2.1,pci_dss_11.2.3,tsc_CC7.1,tsc_CC7.2,
2022 Mar 11 11:16:22 (wazuh) 127.0.0.1->vulnerability-detector
Rule: 23502 (level 3) -> 'The CVE-2022-0529 that affected unzip was solved due to a package removal/update or a system upgrade'
{"vulnerability":{"package":{"name":"unzip","version":"6.0-25ubuntu1","architecture":"amd64"},"cve":"CVE-2022-0529","status":"Solved","type":"PACKAGE","title":"CVE-2022-0529 affecting unzip was solved","severity":"High","published":"2022-02-09","updated":"2022-02-24","cvss":{"cvss2":{"base_score":6.8},"cvss3":{"base_score":7.8}},"references":["https://github.com/ByteHackr/unzip_poc","https://bugzilla.redhat.com/show_bug.cgi?id=2051395","https://nvd.nist.gov/vuln/detail/CVE-2022-0529","http://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-0529.html","https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-0529"]}}
vulnerability.package.name: unzip
vulnerability.package.version: 6.0-25ubuntu1
vulnerability.package.architecture: amd64
vulnerability.cve: CVE-2022-0529
vulnerability.status: Solved
vulnerability.type: PACKAGE
vulnerability.title: CVE-2022-0529 affecting unzip was solved
vulnerability.severity: High
vulnerability.published: 2022-02-09
vulnerability.updated: 2022-02-24
vulnerability.cvss.cvss2.base_score: 6.800000
vulnerability.cvss.cvss3.base_score: 7.800000
vulnerability.references: ["https://github.com/ByteHackr/unzip_poc", "https://bugzilla.redhat.com/show_bug.cgi?id=2051395", "https://nvd.nist.gov/vuln/detail/CVE-2022-0529", "http://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-0529.html", "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-0529"]
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
- [x] Added unit tests (for new features)
