### PR TITLE
Delete registry entries from wazuh db after delete alerts.

### DIFF
--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -41,6 +41,8 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_FIM_INSERT_ENTRY2] = "INSERT OR REPLACE INTO fim_entry (file, type, date, size, perm, uid, gid, md5, sha1, uname, gname, mtime, inode, sha256, attributes, symbolic_path, checksum, arch, value_name, value_type, full_path) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
     [WDB_STMT_FIM_UPDATE_ENTRY] = "UPDATE fim_entry SET date = strftime('%s', 'now'), changes = ?, size = ?, perm = ?, uid = ?, gid = ?, md5 = ?, sha1 = ?, uname = ?, gname = ?, mtime = ?, inode = ?, sha256 = ?, attributes = ?, symbolic_path = ? WHERE file = ?;",
     [WDB_STMT_FIM_DELETE] = "DELETE FROM fim_entry WHERE full_path = ?;",
+    [WDB_STMT_FIM_DELETE_REGISTRY_KEY] = "DELETE FROM fim_entry WHERE arch = ? AND file = ?;",
+    [WDB_STMT_FIM_DELETE_REGISTRY_VALUE] = "DELETE FROM fim_entry WHERE arch = ? AND file = ? AND value_name = ?;",
     [WDB_STMT_FIM_UPDATE_DATE] = "UPDATE fim_entry SET date = strftime('%s', 'now') WHERE file = ?;",
     [WDB_STMT_FIM_FIND_DATE_ENTRIES] = "SELECT full_path, changes, size, perm, uid, gid, md5, sha1, uname, gname, mtime, inode, sha256, date, attributes, symbolic_path FROM fim_entry WHERE date < ?;",
     [WDB_STMT_FIM_GET_ATTRIBUTES] = "SELECT file, attributes from fim_entry WHERE attributes IS NOT '0';",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -69,6 +69,8 @@ typedef enum wdb_stmt {
     WDB_STMT_FIM_INSERT_ENTRY2,
     WDB_STMT_FIM_UPDATE_ENTRY,
     WDB_STMT_FIM_DELETE,
+    WDB_STMT_FIM_DELETE_REGISTRY_KEY,
+    WDB_STMT_FIM_DELETE_REGISTRY_VALUE,
     WDB_STMT_FIM_UPDATE_DATE,
     WDB_STMT_FIM_FIND_DATE_ENTRIES,
     WDB_STMT_FIM_GET_ATTRIBUTES,
@@ -458,6 +460,7 @@ int wdb_fim_insert_entry2(wdb_t * wdb, const cJSON * data);
 int wdb_fim_update_entry(wdb_t * wdb, const char * file, const sk_sum_t * sum);
 
 int wdb_fim_delete(wdb_t * wdb, const char * file);
+int wdb_fim_delete_registry(wdb_t * wdb, const char * file);
 
 /* Insert configuration assessment entry. Returns ID on success or -1 on error. */
 int wdb_rootcheck_insert(wdb_t * wdb, const rk_event_t *event);

--- a/src/wazuh_db/wdb_fim.c
+++ b/src/wazuh_db/wdb_fim.c
@@ -759,6 +759,69 @@ int wdb_fim_update_entry(wdb_t * wdb, const char * file, const sk_sum_t * sum) {
     }
 }
 
+
+int wdb_fim_delete_registry(wdb_t *wdb, const char *data) {
+    cJSON * json_data = cJSON_Parse(data);
+    sqlite3_stmt *stmt = NULL;
+    wdb_stmt delete_stmt = WDB_STMT_FIM_DELETE_REGISTRY_KEY;
+    int retval = -1;
+
+    if (data == NULL) {
+        merror("Cannot parse JSON data for delete registry: %s", data);
+        return -1;
+    }
+
+    cJSON *arch_json = cJSON_GetObjectItem(json_data, "arch");
+    cJSON *key_path_json = cJSON_GetObjectItem(json_data, "path");
+    cJSON *value_name_json = cJSON_GetObjectItem(json_data, "value_name");
+
+    if (arch_json == NULL || key_path_json == NULL) {
+        merror("JSON data for delete registry without 'path' or 'arch' %s.", data);
+        goto end;
+    }
+
+    // check if all the fields sent in data are strings
+    if (cJSON_IsString(arch_json) == 0 || cJSON_IsString(key_path_json) == 0) {
+        goto end;
+    }
+
+    if (value_name_json != NULL && cJSON_IsString(value_name_json) == 0) {
+        goto end;
+    }
+
+    // If 'value_name' is not in the JSON, this means that a registry key entry needs to be deleted.
+    if (value_name_json != NULL) {
+        delete_stmt = WDB_STMT_FIM_DELETE_REGISTRY_VALUE;
+    }
+
+    if (wdb_stmt_cache(wdb, delete_stmt) < 0) {
+        merror("DB(%s) Can't cache statement", wdb->id);
+        goto end;
+    }
+
+    stmt = wdb->stmt[delete_stmt];
+
+    sqlite3_bind_text(stmt, 1, cJSON_GetStringValue(arch_json), -1, NULL);
+    sqlite3_bind_text(stmt, 2, cJSON_GetStringValue(key_path_json), -1, NULL);
+
+    if (delete_stmt == WDB_STMT_FIM_DELETE_REGISTRY_VALUE) {
+        sqlite3_bind_text(stmt, 3, cJSON_GetStringValue(value_name_json), -1, NULL);
+    }
+
+    int res = sqlite3_step(stmt);
+    if (res == SQLITE_ROW || res == SQLITE_DONE) {
+        retval = 0;
+        goto end;
+    }
+
+    mdebug1("DB(%s) sqlite3_step(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+
+end:
+    cJSON_Delete(json_data);
+    return retval;
+}
+
+
 // Delete file entry: returns 1 if found, 0 if not, or -1 on error.
 int wdb_fim_delete(wdb_t * wdb, const char * path) {
     sqlite3_stmt *stmt = NULL;

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -1232,6 +1232,15 @@ int wdb_parse_syscheck(wdb_t * wdb, wdb_component_t component, char * input, cha
         }
 
         return result;
+    } else if (strcmp(curr, "delete_registry") == 0) {
+        if (result = wdb_fim_delete_registry(wdb, next), result < 0) {
+            mdebug1("DB(%s) Cannot delete FIM registry key entry.", wdb->id);
+            snprintf(output, OS_MAXSTR + 1, "err Cannot delete Syscheck");
+        } else {
+            snprintf(output, OS_MAXSTR + 1, "ok");
+        }
+
+        return result;
     } else if (strcmp(curr, "save") == 0) {
         curr = next;
 


### PR DESCRIPTION
|Related issue|
|---|
|#12678|


## Description

Closes  #12678
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux

- [X] Source installation
- [X] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
