### PR TITLE
Fixing several warnings compilation wazuh agent

### DIFF
--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -201,7 +201,7 @@ int SysInfo::getCpuMHz() const
         constexpr auto CPU_FREQ_DIRNAME_PATTERN {"cpu[0-9]+"};
         const std::regex cpuDirectoryRegex {CPU_FREQ_DIRNAME_PATTERN};
 
-        for (const auto cpu : cpusInfo)
+        for (const auto& cpu : cpusInfo)
         {
             if (std::regex_match(cpu, cpuDirectoryRegex))
             {

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -46,23 +46,24 @@
 #define LOGLEVEL_INFO 1
 #define LOGLEVEL_DEBUG 0
 
-#define OS_MAXSTR       OS_SIZE_65536       /* Size for logs, sockets, etc      */
-#define OS_BUFFER_SIZE  OS_SIZE_2048        /* Size of general buffers          */
-#define OS_FLSIZE       OS_SIZE_256         /* Maximum file size                */
-#define OS_HEADER_SIZE  OS_SIZE_128         /* Maximum header size              */
-#define OS_LOG_HEADER   OS_SIZE_256         /* Maximum log header size          */
-#define OS_SK_HEADER    OS_SIZE_6144        /* Maximum syscheck header size     */
-#define IPSIZE          INET6_ADDRSTRLEN    /* IP Address size                  */
-#define AUTH_POOL       1000                /* Max number of connections        */
-#define BACKLOG         128                 /* Socket input queue length        */
-#define MAX_EVENTS      1024                /* Max number of epoll events       */
-#define EPOLL_MILLIS    -1                  /* Epoll wait time                  */
-#define MAX_TAG_COUNTER 256                 /* Max retrying counter             */
-#define SOCK_RECV_TIME0 300                 /* Socket receiving timeout (s)     */
-#define MIN_ORDER_SIZE  32                  /* Minimum size of orders array     */
-#define KEEPALIVE_SIZE  700                 /* Random keepalive string size     */
-#define MAX_DYN_STR     4194304             /* Max message size received 4MiB   */
-#define DATE_LENGTH     64                  /* Format date time %D %T           */
+#define OS_MAXSTR       OS_SIZE_65536               /* Size for logs, sockets, etc      */
+#define OS_BUFFER_SIZE  OS_SIZE_2048                /* Size of general buffers          */
+#define OS_FLSIZE       OS_SIZE_256                 /* Maximum file size                */
+#define OS_HEADER_SIZE  OS_SIZE_128                 /* Maximum header size              */
+#define OS_LOG_HEADER   OS_SIZE_256                 /* Maximum log header size          */
+#define OS_SK_HEADER    OS_SIZE_6144                /* Maximum syscheck header size     */
+#define IPSIZE          INET6_ADDRSTRLEN            /* IP Address size                  */
+#define AUTH_POOL       1000                        /* Max number of connections        */
+#define BACKLOG         128                         /* Socket input queue length        */
+#define MAX_EVENTS      1024                        /* Max number of epoll events       */
+#define EPOLL_MILLIS    -1                          /* Epoll wait time                  */
+#define MAX_TAG_COUNTER 256                         /* Max retrying counter             */
+#define SOCK_RECV_TIME0 300                         /* Socket receiving timeout (s)     */
+#define MIN_ORDER_SIZE  32                          /* Minimum size of orders array     */
+#define KEEPALIVE_SIZE  700                         /* Random keepalive string size     */
+#define MAX_DYN_STR     4194304                     /* Max message size received 4MiB   */
+#define DATE_LENGTH     64                          /* Format date time %D %T           */
+#define OS_MAX_LOG_SIZE OS_MAXSTR - OS_LOG_HEADER   /* Maximum log size with a header protection */
 
 /* Some global names */
 #define __ossec_name    "Wazuh"

--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -19,19 +19,19 @@ static void audit_send_msg(char **cache, int top, const char *file, int drop_it,
     int i;
     size_t n = 0;
     size_t z;
-    char message[OS_MAXSTR];
+    char message[OS_MAX_LOG_SIZE] = {0};
 
     for (i = 0; i < top; i++) {
         z = strlen(cache[i]);
 
-        if (n + z + 1 < OS_MAXSTR) {
+        if (n + z + 1 < sizeof(message)) {
             if (n > 0)
                 message[n++] = ' ';
 
-            strncpy(message + n, cache[i], z);
+            strncat(message + n, cache[i], OS_MAX_LOG_SIZE - 1 - n);
+            n += z;
         }
 
-        n += z;
         free(cache[i]);
     }
 
@@ -45,7 +45,7 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
     char *cache[MAX_CACHE];
     char header[MAX_HEADER] = { '\0' };
     int icache = 0;
-    char buffer[OS_MAXSTR];
+    char buffer[OS_MAX_LOG_SIZE];
     char *id;
     char *p;
     size_t z;
@@ -61,7 +61,7 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
     offset = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, offset);
 
-    for (offset = w_ftell(lf->fp); can_read() && fgets(buffer, OS_MAXSTR, lf->fp) && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
+    for (offset = w_ftell(lf->fp); can_read() && fgets(buffer, OS_MAX_LOG_SIZE, lf->fp) && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;
 
         /* Flow control */
@@ -84,9 +84,9 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
                 continue;
             }
         } else {
-            if (rbytes == OS_MAXSTR - 1) {
+            if (rbytes == OS_MAX_LOG_SIZE - 1) {
                 // Message too large, discard line
-                for (offset += rbytes; fgets(buffer, OS_MAXSTR, lf->fp); offset += rbytes) {
+                for (offset += rbytes; fgets(buffer, OS_MAX_LOG_SIZE, lf->fp); offset += rbytes) {
                     rbytes = w_ftell(lf->fp) - offset;
 
                     /* Flow control */

--- a/src/logcollector/read_djb_multilog.c
+++ b/src/logcollector/read_djb_multilog.c
@@ -81,10 +81,9 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
     size_t str_len = 0;
     int need_clear = 0;
     char *p;
-    char str[OS_MAXSTR + 1];
-    char buffer[OS_MAXSTR + 1];
+    char str[OS_MAX_LOG_SIZE] = {0};
+    char buffer[OS_MAX_LOG_SIZE] = {0};
     int lines = 0;
-    str[OS_MAXSTR] = '\0';
     *rc = 0;
 
     /* Must have a valid program name */
@@ -98,7 +97,7 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     /* Get new entry */
-    while (can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
+    while (can_read() && fgets(str, OS_MAX_LOG_SIZE, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
 
         if (is_valid_context_file) {
             OS_SHA1_Stream(&context, NULL, str);
@@ -145,7 +144,7 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
                     (p[12] == ':') &&
                     (p[15] == ' ')) {
                 p += 16;
-                strncpy(buffer, p, OS_MAXSTR);
+                snprintf(buffer, sizeof(buffer), "%s", p);
             } else {
                 /* We will add a proper syslog header */
                 time_t djbtime;
@@ -155,7 +154,7 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
                 localtime_r(&djbtime, &tm_result);
 
                 /* Syslog time: Apr 27 14:50:32  */
-                snprintf(buffer, OS_MAXSTR, "%s %02d %02d:%02d:%02d %s %s: %s",
+                const int size = snprintf(buffer, sizeof(buffer), "%s %02d %02d:%02d:%02d %s %s: %s",
                          djb_month[tm_result.tm_mon],
                          tm_result.tm_mday,
                          tm_result.tm_hour,
@@ -164,6 +163,12 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
                          djb_host,
                          lf->djb_program_name,
                          p);
+
+                if (size < 0) {
+                    merror("Error %d (%s) while reading message: '%s' (length = " FTELL_TT "): '%s'...", errno, strerror(errno), lf->file, FTELL_INT64 size, buffer);
+                } else if ((size_t)size >= sizeof(buffer)) {
+                    merror("Message size too big on file '%s' (length = " FTELL_TT "): '%s'...", lf->file, FTELL_INT64 size, buffer);
+                }
             }
         }
 

--- a/src/logcollector/read_mssql_log.c
+++ b/src/logcollector/read_mssql_log.c
@@ -28,13 +28,13 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
     size_t str_len = 0;
     int need_clear = 0;
     char *p;
-    char str[OS_MAXSTR + 1];
-    char buffer[OS_MAXSTR + 1];
+    char str[OS_MAX_LOG_SIZE];
+    char buffer[OS_MAX_LOG_SIZE];
     int lines = 0;
     /* Zero buffer and str */
     buffer[0] = '\0';
-    buffer[OS_MAXSTR] = '\0';
-    str[OS_MAXSTR] = '\0';
+    buffer[OS_MAX_LOG_SIZE - 1] = '\0';
+    str[OS_MAX_LOG_SIZE - 1] = '\0';
     *rc = 0;
 
     /* Obtain context to calculate hash */
@@ -43,7 +43,7 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     /* Get new entry */
-    while (can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
+    while (can_read() && fgets(str, OS_MAX_LOG_SIZE, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
 
         lines++;
         /* Get buffer size */
@@ -105,7 +105,7 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
 
             /* If the saved message is empty, set it and continue */
             if (buffer[0] == '\0') {
-                strncpy(buffer, str, str_len + 2);
+                snprintf(buffer, sizeof(buffer), "%s", str);
                 continue;
             }
 
@@ -114,7 +114,7 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
                 __send_mssql_msg(lf, drop_it, buffer);
 
                 /* Store current one at the buffer */
-                strncpy(buffer, str, str_len + 2);
+                snprintf(buffer, sizeof(buffer), "%s", str);
             }
         }
 
@@ -133,7 +133,7 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
             }
 
             /* Add additional message to the saved buffer */
-            if (sizeof(buffer) - buffer_len > str_len + 256) {
+            if (sizeof(buffer) - buffer_len > str_len) {
                 /* Here we make sure that the size of the buffer
                  * minus what was used (strlen) is greater than
                  * the length of the received message.

--- a/src/logcollector/read_nmapg.c
+++ b/src/logcollector/read_nmapg.c
@@ -16,6 +16,7 @@
 #define NMAPG_PORT  "Ports:"
 #define NMAPG_OPEN  "open/"
 #define NMAPG_STAT  "Status:"
+#define PORT_PROTO  " %s(%s)"
 
 /* Prototypes */
 static char *__go_after(char *x, const char *y);
@@ -125,34 +126,29 @@ static char *__go_after(char *x, const char *y)
 /* Read Nmap grepable files */
 void *read_nmapg(logreader *lf, int *rc, int drop_it) {
     int final_msg_s;
+    int index = 0;
     int need_clear = 0;
 
-    char str[OS_MAXSTR + 1];
-    char final_msg[OS_MAXSTR + 1];
-    char buffer[OS_MAXSTR + 1];
-    char port[17];
-    char proto[17];
+    char str[OS_MAX_LOG_SIZE] = {0};
+    char final_msg[OS_MAX_LOG_SIZE] = {0};
+    char port[17] = {0};
+    char proto[17] = {0};
 
     char *ip = NULL;
     char *p;
     char *q;
 
     int lines = 0;
+    int bytes_written = 0;
 
     *rc = 0;
-    str[OS_MAXSTR] = '\0';
-    final_msg[OS_MAXSTR] = '\0';
-    buffer[OS_MAXSTR] = '\0';
-
-    port[16] = '\0';
-    proto[16] = '\0';
 
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
-    while (can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
+    while (can_read() && fgets(str, sizeof(str), lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
 
         lines++;
 
@@ -219,9 +215,18 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
         }
 
         /* Generate final msg */
-        snprintf(final_msg, OS_MAXSTR, "Host: %s, open ports:",
+        bytes_written = snprintf(final_msg, sizeof(final_msg), "Host: %s, open ports:",
                  ip);
-        final_msg_s = OS_MAXSTR - ((strlen(final_msg) + 3));
+
+        if (bytes_written < 0) {
+            final_msg_s = 0;
+            merror("Error %d (%s) formatting string from file '%s' (length = " FTELL_TT "): '%s'...", errno, strerror(errno), lf->file, FTELL_INT64 bytes_written, final_msg);
+        } else if ((size_t)bytes_written < sizeof(final_msg)) {
+            final_msg_s = OS_MAX_LOG_SIZE - strlen(final_msg);
+        } else {
+            final_msg_s = 0;
+            merror("Large message size from file '%s' (length = " FTELL_TT "): '%s'...", lf->file, FTELL_INT64 bytes_written, final_msg);
+        }
 
         /* Get port and protocol */
         do {
@@ -242,9 +247,9 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
             }
 
             /* Add ports */
-            snprintf(buffer, OS_MAXSTR, " %s(%s)", port, proto);
-            strncat(final_msg, buffer, final_msg_s);
-            final_msg_s -= (strlen(buffer) + 2);
+            index = strlen(final_msg);
+            index = snprintf((final_msg + index), final_msg_s, PORT_PROTO, port, proto);
+            final_msg_s -= index;
 
         } while (*p == ',' && (p++));
 

--- a/src/rootcheck/check_rc_dev.c
+++ b/src/rootcheck/check_rc_dev.c
@@ -37,11 +37,21 @@ static int read_dev_file(const char *file_name)
 
     else if (S_ISREG(statbuf.st_mode)) {
         char op_msg[OS_SIZE_1024 + 1];
+        const char op_msg_fmt[] = "File '%*s' present on /dev. Possible hidden file.";
 
-        snprintf(op_msg, OS_SIZE_1024, "File '%s' present on /dev."
-                 " Possible hidden file.", file_name);
-        notify_rk(ALERT_SYSTEM_CRIT, op_msg);
+        const int size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
 
+        if (size >= 0) {
+            if ((size_t)size < sizeof(op_msg)) {
+                snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
+            }
+            else {
+                const unsigned int surplus = size - sizeof(op_msg) + 1;
+                snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(strlen(file_name) - surplus), file_name);
+            }
+
+            notify_rk(ALERT_SYSTEM_CRIT, op_msg);
+        }
         _dev_errors++;
     }
 

--- a/src/rootcheck/check_rc_dev.c
+++ b/src/rootcheck/check_rc_dev.c
@@ -44,13 +44,14 @@ static int read_dev_file(const char *file_name)
         if (size >= 0) {
             if ((size_t)size < sizeof(op_msg)) {
                 snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
-            }
-            else {
+            } else {
                 const unsigned int surplus = size - sizeof(op_msg) + 1;
                 snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(strlen(file_name) - surplus), file_name);
             }
 
             notify_rk(ALERT_SYSTEM_CRIT, op_msg);
+        } else {
+            mtdebug2(ARGV0, "Error %d (%s) with snprintf with file %s\n", errno, strerror(errno), file_name);
         }
         _dev_errors++;
     }

--- a/src/rootcheck/check_rc_files.c
+++ b/src/rootcheck/check_rc_files.c
@@ -159,17 +159,23 @@ void check_rc_files(const char *basedir, FILE *fp)
             }
             continue;
         }
-
+        int bytes_written = 0;
         // Check if it is a full path
 #ifdef WIN32
         if (strlen(file) > 3 && file[1] == ':' && file[2] == '\\') {
 #else
         if (*file == '/') {
 #endif
-            snprintf(file_path, OS_SIZE_1024, "%s", file);
+            bytes_written = snprintf(file_path, sizeof(file_path), "%s", file);
         } else {
-            snprintf(file_path, OS_SIZE_1024, "%s%c%s", basedir, PATH_SEP, file);
+            bytes_written = snprintf(file_path, sizeof(file_path), "%s%c%s", basedir, PATH_SEP, file);
         }
+
+       if (bytes_written < 0 || (size_t)bytes_written > (sizeof(file_path) - 1)) {
+            mtdebug2(ARGV0, "Path file was truncated (%s)\n", file_path);
+            continue;
+       }
+
 
         if (_file_name = strrchr(file_path, PATH_SEP), !_file_name) {
             continue;
@@ -185,15 +191,27 @@ void check_rc_files(const char *basedir, FILE *fp)
         }
 
         if (is_file(file_path)) {
+            const char op_msg_fmt[] = "Rootkit '%s' detected by the presence of file '%*s'.";
             char op_msg[OS_SIZE_2048];
 
+            const int size = snprintf(NULL, 0, op_msg_fmt, name, (int)strlen(file_path), file_path);
+
+            if (size >= 0) {
+                if ((size_t)size < sizeof(op_msg)) {
+                    snprintf(op_msg, sizeof(op_msg), op_msg_fmt, name, (int)strlen(file_path), file_path);
+                }
+                else {
+                    const unsigned int surplus = size - sizeof(op_msg) + 1;
+                    snprintf(op_msg, sizeof(op_msg), op_msg_fmt, name, (int)(strlen(file_path) - surplus), file_path);
+                }
+
+                notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
+            } else {
+                mtdebug2(ARGV0, "Error %d (%s) with snprintf with file %s", errno, strerror(errno), file_path);
+            }
+
             _errors = 1;
-            snprintf(op_msg, OS_SIZE_2048, "Rootkit '%s' detected "
-                     "by the presence of file '%s'.", name, file_path);
-
-            notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
         }
-
 newline:
         continue;
     }

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -36,12 +36,24 @@ static int read_sys_file(const char *file_name, int do_read)
 #endif
     if (lstat(file_name, &statbuf) < 0) {
 #ifndef WIN32
+        const char op_msg_fmt[] = "Anomaly detected in file '%*s'. Hidden from stats, but showing up on readdir. Possible kernel level rootkit.";
         char op_msg[OS_SIZE_1024 + 1];
-        snprintf(op_msg, OS_SIZE_1024, "Anomaly detected in file '%s'. "
-                 "Hidden from stats, but showing up on readdir. "
-                 "Possible kernel level rootkit.",
-                 file_name);
-        notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
+
+        const int size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
+
+        if (size >= 0) {
+            if ((size_t)size < sizeof(op_msg)) {
+                snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
+            } else {
+                const unsigned int surplus = size - sizeof(op_msg) + 1;
+                snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(strlen(file_name) - surplus), file_name);
+            }
+
+            notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
+        } else {
+            mtdebug2(ARGV0, "Error %d (%s) with snprintf with file %s", errno, strerror(errno), file_name);
+        }
+
         _sys_errors++;
 #endif
         return (-1);
@@ -89,12 +101,24 @@ static int read_sys_file(const char *file_name, int do_read)
                 if ((lstat(file_name, &statbuf2) == 0) &&
                         (total != statbuf2.st_size) &&
                         (statbuf.st_size == statbuf2.st_size)) {
+                    const char op_msg_fmt[] = "Anomaly detected in file '%*s'. File size doesn't match what we found. Possible kernel level rootkit.";
                     char op_msg[OS_SIZE_1024 + 1];
-                    snprintf(op_msg, OS_SIZE_1024, "Anomaly detected in file "
-                             "'%s'. File size doesn't match what we found. "
-                             "Possible kernel level rootkit.",
-                             file_name);
-                    notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
+
+                    const int size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
+
+                    if (size >= 0) {
+                        if ((size_t)size < sizeof(op_msg)) {
+                            snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
+                        } else {
+                            const unsigned int surplus = size - sizeof(op_msg) + 1;
+                            snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(strlen(file_name) - surplus), file_name);
+                        }
+
+                        notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
+                    } else {
+                        mtdebug2(ARGV0, "Error %d (%s) with snprintf with file %s", errno, strerror(errno), file_name);
+                    }
+
                     _sys_errors++;
                 }
             }
@@ -119,18 +143,46 @@ static int read_sys_file(const char *file_name, int do_read)
         if (statbuf.st_uid == 0) {
             char op_msg[OS_SIZE_1024 + 1];
 #ifdef OSSECHIDS
-            snprintf(op_msg, OS_SIZE_1024, "File '%s' is owned by root "
-                     "and has written permissions to anyone.", file_name);
-#else
-            snprintf(op_msg, OS_SIZE_1024, "File '%s' is: \n"
-                     "          - owned by root,\n"
-                     "          - has write permissions to anyone.",
-                     file_name);
-#endif
-            notify_rk(ALERT_SYSTEM_CRIT, op_msg);
+            const char op_msg_fmt[] = "File '%*s' is owned by root and has written permissions to anyone.";
 
+            const int size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
+
+            if (size >= 0) {
+                if ((size_t)size < sizeof(op_msg)) {
+                    snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
+                } else {
+                    const unsigned int surplus = size - sizeof(op_msg) + 1;
+                    snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(strlen(file_name) - surplus), file_name);
+                }
+
+                notify_rk(ALERT_SYSTEM_CRIT, op_msg);
+            } else {
+                mtdebug2(ARGV0, "Error %d (%s) with snprintf with file %s", errno, strerror(errno), file_name);
+            }
+
+            _sys_errors++;
+
+#else
+            const char op_msg_fmt[] = "File '%*s' is: \n          - owned by root,\n          - has write permissions to anyone.";
+
+            const int size = snprintf(NULL, 0, op_msg_fmt, (int)strlen(file_name), file_name);
+
+            if (size >= 0) {
+                if ((size_t)size < sizeof(op_msg)) {
+                    snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)strlen(file_name), file_name);
+                } else {
+                    const unsigned int surplus = size - sizeof(op_msg) + 1;
+                    snprintf(op_msg, sizeof(op_msg), op_msg_fmt, (int)(strlen(file_name) - surplus), file_name);
+                }
+
+                notify_rk(ALERT_SYSTEM_CRIT, op_msg);
+            } else {
+                mtdebug2(ARGV0, "Error %d (%s) with snprintf with file %s", errno, strerror(errno), file_name);
+            }
+
+            _sys_errors++;
+#endif
         }
-        _sys_errors++;
     } else if ((statbuf.st_mode & S_ISUID) == S_ISUID) {
         if (_suid) {
             fprintf(_suid, "%s\n", file_name);

--- a/src/rootcheck/unix-process.c
+++ b/src/rootcheck/unix-process.c
@@ -25,7 +25,13 @@ static char *_os_get_runps(const char *ps, int mpid)
     command[0] = '\0';
     command[OS_SIZE_1024] = '\0';
 
-    snprintf(command, OS_SIZE_1024, "%s -p %d 2> /dev/null", ps, mpid);
+    const int size = snprintf(command, sizeof(command), "%s -p %d 2> /dev/null", ps, mpid);
+
+    if (size < 0 || (size_t)size >= sizeof(command)) {
+        return (NULL);
+    }
+
+
     fp = popen(command, "r");
     if (fp) {
         while (fgets(buf, OS_SIZE_2048, fp) != NULL) {

--- a/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
+++ b/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
@@ -230,7 +230,7 @@ STATIC char * wm_agent_upgrade_com_open(const cJSON* json_object) {
     }
 
     if (file.fp = fopen(final_path, mode_obj->valuestring), file.fp) {
-        strncpy(file.path, final_path, PATH_MAX);
+        snprintf(file.path, sizeof(file.path), "%s", final_path);
         return wm_agent_upgrade_command_ack(ERROR_OK, error_messages[ERROR_OK]);
     } else {
         mterror(WM_AGENT_UPGRADE_LOGTAG, FOPEN_ERROR, file_path_obj->valuestring, errno, strerror(errno));


### PR DESCRIPTION
|Related issue|
|---|
|#12100|


## Description

Hi Team

This PR aims to resolve the warnings when compiling the Wazuh agent project. During the development, I solved the compile warnings only for the agent. Warnings for the server and windows agent will be resolved in other issues (https://github.com/wazuh/wazuh/issues/12098 and https://github.com/wazuh/wazuh/issues/12099). The output of the compilation after the changes was:

## Compilation using GCC 9.4

<details>
<summary>Output</summary>

```
cd shared_modules/dbsync/ && mkdir -p build && cd build && cmake    .. && make
-- The C compiler identification is GNU 9.4.0
-- The C compiler identification is GNU 9.4.0
-- The CXX compiler identification is GNU 9.4.0
-- The CXX compiler identification is GNU 9.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting CXX compile features - done
-- Configuring done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/data_provider/build
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/shared_modules/dbsync/build
make[2]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
make[2]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[3]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
make[3]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target sysinfo
Scanning dependencies of target dbsync
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 10%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync.cpp.o
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
[  7%] Building CXX object CMakeFiles/sysinfo.dir/src/network/networkInterfaceLinux.cpp.o
[ 15%] Building CXX object CMakeFiles/sysinfo.dir/src/osinfo/sysOsParsers.cpp.o
[ 20%] Building CXX object CMakeFiles/dbsync.dir/src/dbsyncPipelineFactory.cpp.o
[ 30%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync_implementation.cpp.o
[ 23%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserDeb.cpp.o
[ 40%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_dbengine.cpp.o
[ 30%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserExtra.cpp.o
[ 38%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserRpm.cpp.o
[ 46%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserRpmLegacy.cpp.o
[ 50%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_wrapper.cpp.o
[ 53%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/rpmPackageManager.cpp.o
[ 60%] Linking CXX shared library lib/libdbsync.so
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 60%] Built target dbsync
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync_example
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 70%] Building CXX object example/CMakeFiles/dbsync_example.dir/main.cpp.o
[ 61%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfoLinux.cpp.o
[ 80%] Linking CXX executable ../bin/dbsync_example
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 80%] Built target dbsync_example
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 90%] Building CXX object testtool/CMakeFiles/dbsync_test_tool.dir/main.cpp.o
[ 69%] Building CXX object CMakeFiles/sysinfo.dir/src/utilsWrapperLinux.cpp.o
[ 76%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfo.cpp.o
[100%] Linking CXX executable ../bin/dbsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[100%] Built target dbsync_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
cd shared_modules/rsync/ && mkdir -p build && cd build && cmake     .. && make
-- The C compiler identification is GNU 9.4.0
-- The CXX compiler identification is GNU 9.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/shared_modules/rsync/build
make[2]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[3]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
Scanning dependencies of target rsync
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[ 12%] Building CXX object CMakeFiles/rsync.dir/src/rsync.cpp.o
[ 84%] Linking CXX shared library lib/libsysinfo.so
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
[ 84%] Built target sysinfo
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
Scanning dependencies of target sysinfo_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
[ 92%] Building CXX object testtool/CMakeFiles/sysinfo_test_tool.dir/main.cpp.o
[ 25%] Building CXX object CMakeFiles/rsync.dir/src/rsyncImplementation.cpp.o
[100%] Linking CXX executable ../bin/sysinfo_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
[100%] Built target sysinfo_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
[ 37%] Linking CXX shared library lib/librsync.so
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[ 37%] Built target rsync
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
Scanning dependencies of target rsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[ 50%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/agentEmulator.cpp.o
[ 62%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/main.cpp.o
[ 75%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/oneTimeSync.cpp.o
[ 87%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/managerEmulator.cpp.o
[100%] Linking CXX executable ../bin/rsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[100%] Built target rsync_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
cd wazuh_modules/syscollector/ && mkdir -p build && cd build && cmake     .. && make
-- The C compiler identification is GNU 9.4.0
-- The CXX compiler identification is GNU 9.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/wazuh_modules/syscollector/build
make[2]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[3]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
Scanning dependencies of target syscollector
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[ 16%] Building CXX object CMakeFiles/syscollector.dir/src/syscollector.cpp.o
[ 33%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorImp.cpp.o
[ 50%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorNormalizer.cpp.o
[ 66%] Linking CXX shared library lib/libsyscollector.so
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[ 66%] Built target syscollector
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
Scanning dependencies of target syscollector_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[ 83%] Building CXX object testtool/CMakeFiles/syscollector_test_tool.dir/main.cpp.o
[100%] Linking CXX executable ../bin/syscollector_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[100%] Built target syscollector_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[1]: Leaving directory '/home/hanes/wazuh/src'
make wazuh-agentd agent-auth wazuh-logcollector wazuh-syscheckd wazuh-execd manage_agents active-responses wazuh-modulesd
make[1]: Entering directory '/home/hanes/wazuh/src'
    CC client-agent/state.o
    CC client-agent/sendmsg.o
    CC client-agent/request.o
    CC client-agent/agentd.o
    CC client-agent/config.o
    CC client-agent/event-forward.o
    CC client-agent/rotate_log.o
    CC client-agent/receiver-win.o
    CC client-agent/main.o
    CC client-agent/restart_agent.o
    CC client-agent/receiver.o
    CC client-agent/buffer.o
    CC client-agent/start_agent.o
    CC client-agent/agcom.o
    CC client-agent/notify.o
    CC monitord/rotate_log.o
    CC monitord/compress_log.o
    CC config/wmodules-aws.o
    CC config/localfile-config.o
    CC config/rootcheck-config.o
    CC config/remote-config.o
    CC config/active-response.o
    CC config/wmodules-osquery-monitor.o
    CC config/integrator-config.o
    CC config/wmodules-agent-upgrade.o
    CC config/socket-config.o
    CC config/reports-config.o
    CC config/alerts-config.o
    CC config/agentlessd-config.o
    CC config/wmodules_syscollector.o
    CC config/wmodules-oscap.o
    CC config/config.o
    CC config/wmodules-github.o
    CC config/wmodules-docker.o
    CC config/syscheck-config.o
    CC config/global-config.o
    CC config/client-config.o
    CC config/labels-config.o
    CC config/email-alerts-config.o
    CC config/wmodules-sca.o
    CC config/wmodules-fluent.o
    CC config/wmodules-office365.o
    CC config/cluster-config.o
    CC config/rules-config.o
    CC config/dbd-config.o
    CC config/wmodules-key-request.o
    CC config/wmodules-vuln-detector.o
    CC config/wmodules-azure.o
    CC config/authd-config.o
    CC config/wmodules-task-manager.o
    CC config/buffer-config.o
    CC config/wmodules-command.o
    CC config/csyslogd-config.o
    CC config/wmodules-ciscat.o
    CC config/wmodules-gcp.o
    CC config/logtest-config.o
    CC config/wmodules-config.o
    CC wazuh_modules/wm_control.o
    CC wazuh_modules/wmcom.o
    CC wazuh_modules/wm_oscap.o
    CC wazuh_modules/wm_gcp.o
    CC wazuh_modules/wmodules.o
    CC wazuh_modules/wm_azure.o
    CC wazuh_modules/wm_office365.o
    CC wazuh_modules/wm_exec.o
    CC wazuh_modules/wm_osquery_monitor.o
    CC wazuh_modules/wm_task_general.o
    CC wazuh_modules/wm_aws.o
    CC wazuh_modules/wm_syscollector.o
    CC wazuh_modules/wm_keyrequest.o
    CC wazuh_modules/wm_github.o
    CC wazuh_modules/wm_database.o
    CC wazuh_modules/wm_download.o
    CC wazuh_modules/wm_docker.o
    CC wazuh_modules/wm_sca.o
    CC wazuh_modules/wm_fluent.o
    CC wazuh_modules/wm_command.o
    CC wazuh_modules/wm_ciscat.o
    CC wazuh_modules/agent_upgrade/wm_agent_upgrade.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.o
    CC wazuh_db/wdb_metadata.o
    CC wazuh_db/wdb_agents.o
    CC wazuh_db/wdb_integrity.o
    CC wazuh_db/wdb_global.o
    CC wazuh_db/wdb_syscollector.o
    CC wazuh_db/wdb_upgrade.o
    CC wazuh_db/wdb_task.o
    CC wazuh_db/wdb_delta_event.o
    CC wazuh_db/wdb_scan_info.o
    CC wazuh_db/wdb.o
    CC wazuh_db/wdb_parser.o
    CC wazuh_db/wdb_fim.o
    CC wazuh_db/wdb_sca.o
    CC wazuh_db/wdb_rootcheck.o
    CC wazuh_db/wdb_ciscat.o
    CC wazuh_db/helpers/wdb_global_helpers.o
    CC wazuh_db/helpers/wdb_agents_helpers.o
    CC wazuh_db/schema_global_upgrade_v2.o
    CC wazuh_db/schema_upgrade_v3.o
    CC wazuh_db/schema_upgrade_v1.o
    CC wazuh_db/schema_upgrade_v8.o
    CC wazuh_db/schema_agents.o
    CC wazuh_db/schema_upgrade_v6.o
    CC wazuh_db/schema_task_manager.o
    CC wazuh_db/schema_global_upgrade_v1.o
    CC wazuh_db/schema_upgrade_v4.o
    CC wazuh_db/schema_global.o
    CC wazuh_db/schema_upgrade_v2.o
    CC wazuh_db/schema_upgrade_v5.o
    CC wazuh_db/schema_global_upgrade_v3.o
    CC wazuh_db/schema_vuln_detector.o
    CC wazuh_db/schema_upgrade_v7.o
    CC os_crypto/md5/md5_op.o
    CC os_crypto/blowfish/bf_op.o
    CC os_crypto/sha1/sha1_op.o
    CC os_crypto/shared/keys.o
    CC os_crypto/shared/msgs.o
    CC os_crypto/md5_sha1/md5_sha1_op.o
    CC os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.o
    CC os_crypto/sha256/sha256_op.o
    CC os_crypto/sha512/sha512_op.o
    CC os_crypto/aes/aes_op.o
    CC os_crypto/hmac/hmac.o
    CC os_crypto/signature/signature.o
    CC shared/json-queue.o
    CC shared/read-alert.o
    CC shared/rootcheck_op.o
    CC shared/notify_op.o
    CC shared/regex_op.o
    CC shared/store_op.o
    CC shared/bzip2_op.o
    CC shared/exec_op.o
    CC shared/mem_op.o
    CC shared/request_op.o
    CC shared/log_builder.o
    CC shared/time_op.o
    CC shared/file_op.o
    CC shared/pthreads_op.o
    CC shared/integrity_op.o
    CC shared/queue_linked_op.o
    CC shared/os_utils.o
    CC shared/rbtree_op.o
    CC shared/fs_op.o
    CC shared/cluster_utils.o
    CC shared/read-agents.o
    CC shared/audit_op.o
    CC shared/syscheck_op.o
    CC shared/yaml2json.o
    CC shared/buffer_op.o
    CC shared/report_op.o
    CC shared/sig_op.o
    CC shared/sym_load.o
    CC shared/wait_op.o
    CC shared/help.o
    CC shared/labels_op.o
    CC shared/auth_client.o
    CC shared/list_op.o
    CC shared/privsep_op.o
    CC shared/hash_op.o
    CC shared/b64.o
    CC shared/file-queue.o
    CC shared/math_op.o
    CC shared/atomic.o
    CC shared/rules_op.o
    CC shared/string_op.o
    CC shared/url.o
    CC shared/version_op.o
    CC shared/enrollment_op.o
    CC shared/vector_op.o
    CC shared/mq_op.o
    CC shared/sysinfo_utils.o
    CC shared/custom_output_search_replace.o
    CC shared/validate_op.o
    CC shared/json_op.o
    CC shared/schedule_scan.o
    CC shared/expression.o
    CC shared/debug_op.o
    CC shared/remoted_op.o
    CC shared/bqueue_op.o
    CC shared/queue_op.o
    CC shared/utf8_op.o
    CC shared/randombytes.o
    CC shared/agent_op.o
    CC shared/wazuhdb_op.o
    CC os_net/os_net.o
    CC os_regex/os_regex_match.o
    CC os_regex/os_regex.o
    CC os_regex/os_regex_str.o
    CC os_regex/os_match.o
    CC os_regex/os_regex_compile.o
    CC os_regex/os_regex_startswith.o
    CC os_regex/os_regex_free_pattern.o
    CC os_regex/os_match_compile.o
    CC os_regex/os_regex_strbreak.o
    CC os_regex/os_match_free_pattern.o
    CC os_regex/os_regex_maps.o
    CC os_regex/os_regex_execute.o
    CC os_regex/os_match_execute.o
    CC os_xml/os_xml_variables.o
    CC os_xml/os_xml.o
    CC os_xml/os_xml_access.o
    CC os_xml/os_xml_node_access.o
    CC os_xml/os_xml_writer.o
    CC os_zlib/os_zlib.o
    CC os_auth/ssl.o
    CC os_auth/check_cert.o
    CC addagent/validate.o
    CC analysisd/logmsg.o
    CC os_auth/main-client.o
    CC logcollector/read_ossecalert.o
    CC logcollector/state.o
    CC logcollector/config.o
    CC logcollector/logcollector.o
    CC logcollector/read_djb_multilog.o
    CC logcollector/read_postgresql_log.o
    CC logcollector/read_ucs2_le.o
    CC logcollector/read_mssql_log.o
    CC logcollector/read_win_el.o
    CC logcollector/lccom.o
    CC logcollector/read_macos.o
    CC logcollector/read_json.o
    CC logcollector/read_win_event_channel.o
    CC logcollector/read_syslog.o
    CC logcollector/main.o
    CC logcollector/read_audit.o
    CC logcollector/read_multiline_regex.o
    CC logcollector/read_nmapg.o
    CC logcollector/read_command.o
    CC logcollector/read_mysql_log.o
    CC logcollector/read_ucs2_be.o
    CC logcollector/read_multiline.o
    CC logcollector/macos_log.o
    CC logcollector/read_fullcommand.o
    CC logcollector/read_snortfull.o
    CC syscheckd/db/schema_fim_db.o
    CC syscheckd/run_realtime.o
    CC syscheckd/config.o
    CC syscheckd/create_db.o
    CC syscheckd/run_check.o
    CC syscheckd/syscheck.o
    CC syscheckd/fim_diff_changes.o
    CC syscheckd/fim_sync.o
    CC syscheckd/syscom.o
    CC syscheckd/main.o
    CC syscheckd/db/fim_db.o
    CC syscheckd/db/fim_db_files.o
    CC syscheckd/db/fim_db_registries.o
    CC syscheckd/whodata/audit_healthcheck.o
    CC syscheckd/whodata/audit_rule_handling.o
    CC syscheckd/whodata/syscheck_audit.o
    CC syscheckd/whodata/audit_parse.o
    CC syscheckd/whodata/win_whodata.o
    CC syscheckd/registry/registry.o
    CC syscheckd/registry/events.o
    CC rootcheck/common_rcl.o
    CC rootcheck/config.o
    CC rootcheck/check_rc_files.o
    CC rootcheck/check_rc_ports.o
    CC rootcheck/win-process.o
    CC rootcheck/unix-process.o
    CC rootcheck/common.o
    CC rootcheck/rootcheck.o
    CC rootcheck/check_rc_if.o
    CC rootcheck/check_open_ports.o
    CC rootcheck/os_string.o
    CC rootcheck/win-common.o
    CC rootcheck/check_rc_readproc.o
    CC rootcheck/check_rc_dev.o
    CC rootcheck/check_rc_sys.o
    CC rootcheck/run_rk_check.o
    CC rootcheck/check_rc_policy.o
    CC rootcheck/check_rc_pids.o
    CC rootcheck/check_rc_trojans.o
    CC os_execd/exec.o
    CC os_execd/config.o
    CC os_execd/wcom.o
    CC os_execd/execd.o
    CC os_execd/win_execd.o
    CC active-response/active_responses.o
    CC addagent/read_from_user.o
    CC addagent/main.o
    CC addagent/manage_keys.o
    CC addagent/manage_agents.o
    CC active-response/firewalls/default-firewall-drop.o
    CC shared/file_op_proc.o
    CC shared/debug_op_proc.o
    CC active-response/firewalls/pf.o
    CC active-response/firewalls/npf.o
    CC active-response/firewalls/ipfw.o
    CC active-response/firewalld-drop.o
    CC active-response/disable-account.o
    CC active-response/host-deny.o
    CC active-response/ip-customblock.o
    CC active-response/restart-wazuh.o
    CC active-response/route-null.o
    CC active-response/kaspersky.o
    CC active-response/wazuh-slack.o
    CC wazuh_modules/main.o
    LINK libwazuh.a
```

</details>

## Compilation using GCC 10.2.1

<details>
<summary>Output</summary>

```
cd shared_modules/dbsync/ && mkdir -p build && cd build && cmake    .. && make
-- The C compiler identification is GNU 10.2.1
-- The C compiler identification is GNU 10.2.1
-- The CXX compiler identification is GNU 10.2.1
-- The CXX compiler identification is GNU 10.2.1
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc - works
-- Detecting C compiler ABI info
-- Check for working C compiler: /usr/bin/cc - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ - works
-- Detecting CXX compiler ABI info
-- Check for working CXX compiler: /usr/bin/c++ - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/wazuh/src/data_provider/build
make[2]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build
make[2]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[3]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
Scanning dependencies of target sysinfo
make[3]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 10%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync.cpp.o
[ 30%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync_implementation.cpp.o
[ 30%] Building CXX object CMakeFiles/dbsync.dir/src/dbsyncPipelineFactory.cpp.o
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
[  7%] Building CXX object CMakeFiles/sysinfo.dir/src/network/networkInterfaceLinux.cpp.o
[ 15%] Building CXX object CMakeFiles/sysinfo.dir/src/osinfo/sysOsParsers.cpp.o
[ 40%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_dbengine.cpp.o
[ 50%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_wrapper.cpp.o
[ 23%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserDeb.cpp.o
[ 30%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserExtra.cpp.o
[ 38%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserRpm.cpp.o
[ 46%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserRpmLegacy.cpp.o
[ 60%] Linking CXX shared library lib/libdbsync.so
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 60%] Built target dbsync
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync_example
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 70%] Building CXX object example/CMakeFiles/dbsync_example.dir/main.cpp.o
[ 53%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/rpmPackageManager.cpp.o
[ 80%] Linking CXX executable ../bin/dbsync_example
[ 61%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfoLinux.cpp.o
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 80%] Built target dbsync_example
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 90%] Building CXX object testtool/CMakeFiles/dbsync_test_tool.dir/main.cpp.o
[ 69%] Building CXX object CMakeFiles/sysinfo.dir/src/utilsWrapperLinux.cpp.o
[ 76%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfo.cpp.o
[ 84%] Linking CXX shared library lib/libsysinfo.so
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
[ 84%] Built target sysinfo
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
Scanning dependencies of target sysinfo_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
[ 92%] Building CXX object testtool/CMakeFiles/sysinfo_test_tool.dir/main.cpp.o
[100%] Linking CXX executable ../bin/dbsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[100%] Built target dbsync_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[2]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
cd shared_modules/rsync/ && mkdir -p build && cd build && cmake     .. && make
-- The C compiler identification is GNU 10.2.1
-- The CXX compiler identification is GNU 10.2.1
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/wazuh/src/shared_modules/rsync/build
make[2]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[3]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
Scanning dependencies of target rsync
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
[ 12%] Building CXX object CMakeFiles/rsync.dir/src/rsync.cpp.o
[ 25%] Building CXX object CMakeFiles/rsync.dir/src/rsyncImplementation.cpp.o
[100%] Linking CXX executable ../bin/sysinfo_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
[100%] Built target sysinfo_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[2]: Leaving directory '/home/hanes/wazuh/wazuh/src/data_provider/build'
[ 37%] Linking CXX shared library lib/librsync.so
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
[ 37%] Built target rsync
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
Scanning dependencies of target rsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
[ 50%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/main.cpp.o
[ 75%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/agentEmulator.cpp.o
[ 75%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/oneTimeSync.cpp.o
[ 87%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/managerEmulator.cpp.o
[100%] Linking CXX executable ../bin/rsync_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
[100%] Built target rsync_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[2]: Leaving directory '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
cd wazuh_modules/syscollector/ && mkdir -p build && cd build && cmake     .. && make
-- The C compiler identification is GNU 10.2.1
-- The CXX compiler identification is GNU 10.2.1
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build
make[2]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[3]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
Scanning dependencies of target syscollector
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
[ 16%] Building CXX object CMakeFiles/syscollector.dir/src/syscollector.cpp.o
[ 33%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorImp.cpp.o
[ 50%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorNormalizer.cpp.o
[ 66%] Linking CXX shared library lib/libsyscollector.so
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
[ 66%] Built target syscollector
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
Scanning dependencies of target syscollector_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
[ 83%] Building CXX object testtool/CMakeFiles/syscollector_test_tool.dir/main.cpp.o
[100%] Linking CXX executable ../bin/syscollector_test_tool
make[4]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
[100%] Built target syscollector_test_tool
make[3]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[2]: Leaving directory '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[1]: Leaving directory '/home/hanes/wazuh/wazuh/src'
make wazuh-agentd agent-auth wazuh-logcollector wazuh-syscheckd wazuh-execd manage_agents active-responses wazuh-modulesd
make[1]: Entering directory '/home/hanes/wazuh/wazuh/src'
    CC client-agent/agcom.o
    CC client-agent/agentd.o
    CC client-agent/buffer.o
    CC client-agent/config.o
    CC client-agent/event-forward.o
    CC client-agent/main.o
    CC client-agent/notify.o
    CC client-agent/receiver.o
    CC client-agent/receiver-win.o
    CC client-agent/request.o
    CC client-agent/restart_agent.o
    CC client-agent/rotate_log.o
    CC client-agent/sendmsg.o
    CC client-agent/start_agent.o
    CC client-agent/state.o
    CC monitord/rotate_log.o
    CC monitord/compress_log.o
    CC config/active-response.o
    CC config/agentlessd-config.o
    CC config/alerts-config.o
    CC config/authd-config.o
    CC config/buffer-config.o
    CC config/client-config.o
    CC config/cluster-config.o
    CC config/config.o
    CC config/csyslogd-config.o
    CC config/dbd-config.o
    CC config/email-alerts-config.o
    CC config/global-config.o
    CC config/integrator-config.o
    CC config/labels-config.o
    CC config/localfile-config.o
    CC config/logtest-config.o
    CC config/remote-config.o
    CC config/reports-config.o
    CC config/rootcheck-config.o
    CC config/rules-config.o
    CC config/socket-config.o
    CC config/syscheck-config.o
    CC config/wmodules-agent-upgrade.o
    CC config/wmodules-aws.o
    CC config/wmodules-azure.o
    CC config/wmodules-ciscat.o
    CC config/wmodules-command.o
    CC config/wmodules-config.o
    CC config/wmodules-docker.o
    CC config/wmodules-fluent.o
    CC config/wmodules-gcp.o
    CC config/wmodules-github.o
    CC config/wmodules-key-request.o
    CC config/wmodules-office365.o
    CC config/wmodules-oscap.o
    CC config/wmodules-osquery-monitor.o
    CC config/wmodules-sca.o
    CC config/wmodules_syscollector.o
    CC config/wmodules-task-manager.o
    CC config/wmodules-vuln-detector.o
    CC wazuh_modules/wm_aws.o
    CC wazuh_modules/wm_azure.o
    CC wazuh_modules/wm_ciscat.o
    CC wazuh_modules/wmcom.o
    CC wazuh_modules/wm_command.o
    CC wazuh_modules/wm_control.o
    CC wazuh_modules/wm_database.o
    CC wazuh_modules/wm_docker.o
    CC wazuh_modules/wm_download.o
    CC wazuh_modules/wm_exec.o
    CC wazuh_modules/wm_fluent.o
    CC wazuh_modules/wm_gcp.o
    CC wazuh_modules/wm_github.o
    CC wazuh_modules/wm_keyrequest.o
    CC wazuh_modules/wmodules.o
    CC wazuh_modules/wm_office365.o
    CC wazuh_modules/wm_oscap.o
    CC wazuh_modules/wm_osquery_monitor.o
    CC wazuh_modules/wm_sca.o
    CC wazuh_modules/wm_syscollector.o
    CC wazuh_modules/wm_task_general.o
    CC wazuh_modules/agent_upgrade/wm_agent_upgrade.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.o
    CC wazuh_db/wdb_agents.o
    CC wazuh_db/wdb.o
    CC wazuh_db/wdb_ciscat.o
    CC wazuh_db/wdb_delta_event.o
    CC wazuh_db/wdb_fim.o
    CC wazuh_db/wdb_global.o
    CC wazuh_db/wdb_integrity.o
    CC wazuh_db/wdb_metadata.o
    CC wazuh_db/wdb_parser.o
    CC wazuh_db/wdb_rootcheck.o
    CC wazuh_db/wdb_sca.o
    CC wazuh_db/wdb_scan_info.o
    CC wazuh_db/wdb_syscollector.o
    CC wazuh_db/wdb_task.o
    CC wazuh_db/wdb_upgrade.o
    CC wazuh_db/helpers/wdb_agents_helpers.o
    CC wazuh_db/helpers/wdb_global_helpers.o
    CC wazuh_db/schema_agents.o
    CC wazuh_db/schema_global.o
    CC wazuh_db/schema_global_upgrade_v1.o
    CC wazuh_db/schema_global_upgrade_v2.o
    CC wazuh_db/schema_global_upgrade_v3.o
    CC wazuh_db/schema_task_manager.o
    CC wazuh_db/schema_upgrade_v1.o
    CC wazuh_db/schema_upgrade_v2.o
    CC wazuh_db/schema_upgrade_v3.o
    CC wazuh_db/schema_upgrade_v4.o
    CC wazuh_db/schema_upgrade_v5.o
    CC wazuh_db/schema_upgrade_v6.o
    CC wazuh_db/schema_upgrade_v7.o
    CC wazuh_db/schema_upgrade_v8.o
    CC wazuh_db/schema_vuln_detector.o
    CC os_crypto/blowfish/bf_op.o
    CC os_crypto/md5/md5_op.o
    CC os_crypto/sha1/sha1_op.o
    CC os_crypto/shared/keys.o
    CC os_crypto/shared/msgs.o
    CC os_crypto/md5_sha1/md5_sha1_op.o
    CC os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.o
    CC os_crypto/sha256/sha256_op.o
    CC os_crypto/sha512/sha512_op.o
    CC os_crypto/aes/aes_op.o
    CC os_crypto/hmac/hmac.o
    CC os_crypto/signature/signature.o
    CC shared/agent_op.o
    CC shared/atomic.o
    CC shared/audit_op.o
    CC shared/auth_client.o
    CC shared/b64.o
    CC shared/bqueue_op.o
    CC shared/buffer_op.o
    CC shared/bzip2_op.o
    CC shared/cluster_utils.o
    CC shared/custom_output_search_replace.o
    CC shared/debug_op.o
    CC shared/enrollment_op.o
    CC shared/exec_op.o
    CC shared/expression.o
    CC shared/file_op.o
    CC shared/file-queue.o
    CC shared/fs_op.o
    CC shared/hash_op.o
    CC shared/help.o
    CC shared/integrity_op.o
    CC shared/json_op.o
    CC shared/json-queue.o
    CC shared/labels_op.o
    CC shared/list_op.o
    CC shared/log_builder.o
    CC shared/math_op.o
    CC shared/mem_op.o
    CC shared/mq_op.o
    CC shared/notify_op.o
    CC shared/os_utils.o
    CC shared/privsep_op.o
    CC shared/pthreads_op.o
    CC shared/queue_linked_op.o
    CC shared/queue_op.o
    CC shared/randombytes.o
    CC shared/rbtree_op.o
    CC shared/read-agents.o
    CC shared/read-alert.o
    CC shared/regex_op.o
    CC shared/remoted_op.o
    CC shared/report_op.o
    CC shared/request_op.o
    CC shared/rootcheck_op.o
    CC shared/rules_op.o
    CC shared/schedule_scan.o
    CC shared/sig_op.o
    CC shared/store_op.o
    CC shared/string_op.o
    CC shared/sym_load.o
    CC shared/syscheck_op.o
    CC shared/sysinfo_utils.o
    CC shared/time_op.o
    CC shared/url.o
    CC shared/utf8_op.o
    CC shared/validate_op.o
    CC shared/vector_op.o
    CC shared/version_op.o
    CC shared/wait_op.o
    CC shared/wazuhdb_op.o
    CC shared/yaml2json.o
    CC os_net/os_net.o
    CC os_regex/os_match.o
    CC os_regex/os_match_compile.o
    CC os_regex/os_match_execute.o
    CC os_regex/os_match_free_pattern.o
    CC os_regex/os_regex.o
    CC os_regex/os_regex_compile.o
    CC os_regex/os_regex_execute.o
    CC os_regex/os_regex_free_pattern.o
    CC os_regex/os_regex_maps.o
    CC os_regex/os_regex_match.o
    CC os_regex/os_regex_startswith.o
    CC os_regex/os_regex_strbreak.o
    CC os_regex/os_regex_str.o
    CC os_xml/os_xml_access.o
    CC os_xml/os_xml.o
    CC os_xml/os_xml_node_access.o
    CC os_xml/os_xml_variables.o
    CC os_xml/os_xml_writer.o
    CC os_zlib/os_zlib.o
    CC os_auth/ssl.o
    CC os_auth/check_cert.o
    CC addagent/validate.o
    CC analysisd/logmsg.o
    CC os_auth/main-client.o
    CC logcollector/config.o
    CC logcollector/lccom.o
    CC logcollector/logcollector.o
    CC logcollector/macos_log.o
    CC logcollector/main.o
    CC logcollector/read_audit.o
    CC logcollector/read_command.o
    CC logcollector/read_djb_multilog.o
    CC logcollector/read_fullcommand.o
    CC logcollector/read_json.o
    CC logcollector/read_macos.o
    CC logcollector/read_mssql_log.o
    CC logcollector/read_multiline.o
    CC logcollector/read_multiline_regex.o
    CC logcollector/read_mysql_log.o
    CC logcollector/read_nmapg.o
    CC logcollector/read_ossecalert.o
    CC logcollector/read_postgresql_log.o
    CC logcollector/read_snortfull.o
    CC logcollector/read_syslog.o
    CC logcollector/read_ucs2_be.o
    CC logcollector/read_ucs2_le.o
    CC logcollector/read_win_el.o
    CC logcollector/read_win_event_channel.o
    CC logcollector/state.o
    CC syscheckd/db/schema_fim_db.o
    CC syscheckd/config.o
    CC syscheckd/create_db.o
    CC syscheckd/fim_diff_changes.o
    CC syscheckd/fim_sync.o
    CC syscheckd/main.o
    CC syscheckd/run_check.o
    CC syscheckd/run_realtime.o
    CC syscheckd/syscheck.o
    CC syscheckd/syscom.o
    CC syscheckd/db/fim_db.o
    CC syscheckd/db/fim_db_files.o
    CC syscheckd/db/fim_db_registries.o
    CC syscheckd/whodata/audit_healthcheck.o
    CC syscheckd/whodata/audit_parse.o
    CC syscheckd/whodata/audit_rule_handling.o
    CC syscheckd/whodata/syscheck_audit.o
    CC syscheckd/whodata/win_whodata.o
    CC syscheckd/registry/events.o
    CC syscheckd/registry/registry.o
    CC rootcheck/check_open_ports.o
    CC rootcheck/check_rc_dev.o
    CC rootcheck/check_rc_files.o
    CC rootcheck/check_rc_if.o
    CC rootcheck/check_rc_pids.o
    CC rootcheck/check_rc_policy.o
    CC rootcheck/check_rc_ports.o
    CC rootcheck/check_rc_readproc.o
    CC rootcheck/check_rc_sys.o
    CC rootcheck/check_rc_trojans.o
    CC rootcheck/common.o
    CC rootcheck/common_rcl.o
    CC rootcheck/config.o
    CC rootcheck/os_string.o
    CC rootcheck/rootcheck.o
    CC rootcheck/run_rk_check.o
    CC rootcheck/unix-process.o
    CC rootcheck/win-common.o
    CC rootcheck/win-process.o
    CC os_execd/config.o
    CC os_execd/exec.o
    CC os_execd/execd.o
    CC os_execd/wcom.o
    CC os_execd/win_execd.o
    CC active-response/active_responses.o
    CC addagent/main.o
    CC addagent/manage_agents.o
    CC addagent/manage_keys.o
    CC addagent/read_from_user.o
    CC active-response/firewalls/default-firewall-drop.o
    CC shared/file_op_proc.o
    CC shared/debug_op_proc.o
    CC active-response/firewalls/pf.o
    CC active-response/firewalls/npf.o
    CC active-response/firewalls/ipfw.o
    CC active-response/firewalld-drop.o
    CC active-response/disable-account.o
    CC active-response/host-deny.o
    CC active-response/ip-customblock.o
    CC active-response/restart-wazuh.o
    CC active-response/route-null.o
    CC active-response/kaspersky.o
    CC active-response/wazuh-slack.o
    CC wazuh_modules/main.o
    LINK libwazuh.a
```

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors