### PR TITLE
Modify agent on manager synchro headers.

### DIFF
--- a/src/analysisd/decoders/dbsync.c
+++ b/src/analysisd/decoders/dbsync.c
@@ -30,14 +30,12 @@ extern void mock_assert(const int result, const char* const expression,
 
 static void dispatch_send_local(dbsync_context_t * ctx, const char * query) {
     int sock;
-    bool is_wmodule = false;
 
     if (strncmp(ctx->component, "syscheck", 8) == 0 ||
         strncmp(ctx->component, "fim_file", 8) == 0) {
         sock = OS_ConnectUnixDomain(SYS_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR);
     } else if (strncmp(ctx->component, "syscollector", 12) == 0) {
         sock = OS_ConnectUnixDomain(WM_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR);
-        is_wmodule = true;
     }else {
         merror("dbsync: unknown location '%s'", ctx->component);
         return;
@@ -48,16 +46,15 @@ static void dispatch_send_local(dbsync_context_t * ctx, const char * query) {
         return;
     }
 
-
-    if (is_wmodule) {
-        char * buffer;
-        os_malloc(OS_MAXSTR, buffer);
-        snprintf(buffer, OS_MAXSTR, "%s %s", ctx->component, query);
-        OS_SendSecureTCP(sock, strlen(buffer), buffer);
-        os_free(buffer);
-    } else {
-        OS_SendSecureTCP(sock, strlen(query), query);
+    size_t request_size = snprintf(NULL, 0, "%s %s", ctx->component, query);
+    if (request_size > 0) {
+        char * request = NULL;
+        os_calloc(request_size + 1, sizeof(char), request);
+        snprintf(request, request_size + 1, "%s %s", ctx->component, query);
+        OS_SendSecureTCP(sock, request_size, request);
+        os_free(request);
     }
+
     close(sock);
 }
 

--- a/src/unit_tests/analysisd/test_dbsync.c
+++ b/src/unit_tests/analysisd/test_dbsync.c
@@ -215,8 +215,8 @@ static void test_dispatch_send_local_success(void **state) {
     will_return(__wrap_OS_ConnectUnixDomain, 65555);
 
     expect_value(__wrap_OS_SendSecureTCP, sock, 65555);
-    expect_value(__wrap_OS_SendSecureTCP, size, 45);
-    expect_string(__wrap_OS_SendSecureTCP, msg, "This is a mock query, it won't go anywhere...");
+    expect_value(__wrap_OS_SendSecureTCP, size, 0x36);
+    expect_string(__wrap_OS_SendSecureTCP, msg, "syscheck This is a mock query, it won't go anywhere...");
     will_return(__wrap_OS_SendSecureTCP, 0);
 
     // Assertions to this function are done through wrappers.
@@ -399,8 +399,8 @@ static void test_dispatch_answer_local_success(void **state) {
     will_return(__wrap_OS_ConnectUnixDomain, 65555);
 
     expect_value(__wrap_OS_SendSecureTCP, sock, 65555);
-    expect_value(__wrap_OS_SendSecureTCP, size, 54);
-    expect_string(__wrap_OS_SendSecureTCP, msg, "dbsync result_text {\"begin\":\"/a/path\",\"end\":\"/z/path\"}");
+    expect_value(__wrap_OS_SendSecureTCP, size, 0x3f);
+    expect_string(__wrap_OS_SendSecureTCP, msg, "syscheck dbsync result_text {\"begin\":\"/a/path\",\"end\":\"/z/path\"}");
     will_return(__wrap_OS_SendSecureTCP, 0);
 
     dispatch_answer(data->ctx, result);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #12689 |

# Description

This PR aims to solve an issue during the synchronization on the internal agent from a manager installation.

Basically, the issue become from the headers on the dbsync decoder reply on the manager side doesn't contain the component.


### Test suggestion:
- Stop manager service
- Remove 000.db
- Start manager service.
- run sqlite3 /var/ossec/queue/db/000.db "select * from fim_entry;" | wc -l
- Check the previous one result quantity is > 0