### PR TITLE
Modify default empty value to avoid an empty severity in Vulnerability Detector

### DIFF
--- a/framework/wazuh/tests/data/schema_cve_test.sql
+++ b/framework/wazuh/tests/data/schema_cve_test.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS vuln_cves (
     architecture TEXT,
     cve TEXT,
     detection_time TEXT DEFAULT '',
-    severity TEXT DEFAULT '-' CHECK (severity IN ('Critical', 'High', 'Medium', 'Low', 'None', '-')),
+    severity TEXT DEFAULT 'Untriaged' CHECK (severity IN ('Critical', 'High', 'Medium', 'Low', 'None', 'Untriaged')),
     cvss2_score REAL DEFAULT 0,
     cvss3_score REAL DEFAULT 0,
     reference TEXT DEFAULT '' NOT NULL,

--- a/ruleset/rules/0520-vulnerability-detector_rules.xml
+++ b/ruleset/rules/0520-vulnerability-detector_rules.xml
@@ -32,7 +32,7 @@
       <if_sid>23501</if_sid>
       <options>no_full_log</options>
       <field name="vulnerability.status">Active</field>
-      <field name="vulnerability.severity">Medium|-</field>
+      <field name="vulnerability.severity">Medium|Untriaged</field>
       <description>$(vulnerability.cve) affects $(vulnerability.package.name)</description>
   </rule>
 

--- a/src/wazuh_db/schema_agents.sql
+++ b/src/wazuh_db/schema_agents.sql
@@ -378,7 +378,7 @@ CREATE TABLE IF NOT EXISTS vuln_cves (
     architecture TEXT,
     cve TEXT,
     detection_time TEXT DEFAULT '',
-    severity TEXT DEFAULT '-' CHECK (severity IN ('Critical', 'High', 'Medium', 'Low', 'None', '-')),
+    severity TEXT DEFAULT 'Untriaged' CHECK (severity IN ('Critical', 'High', 'Medium', 'Low', 'None', 'Untriaged')),
     cvss2_score REAL DEFAULT 0,
     cvss3_score REAL DEFAULT 0,
     reference TEXT DEFAULT '' NOT NULL,

--- a/src/wazuh_db/schema_upgrade_v8.sql
+++ b/src/wazuh_db/schema_upgrade_v8.sql
@@ -62,7 +62,7 @@ CREATE TABLE IF NOT EXISTS vuln_cves (
     architecture TEXT,
     cve TEXT,
     detection_time TEXT DEFAULT '',
-    severity TEXT DEFAULT '-' CHECK (severity IN ('Critical', 'High', 'Medium', 'Low', 'None', '-')),
+    severity TEXT DEFAULT 'Untriaged' CHECK (severity IN ('Critical', 'High', 'Medium', 'Low', 'None', 'Untriaged')),
     cvss2_score REAL DEFAULT 0,
     cvss3_score REAL DEFAULT 0,
     reference TEXT DEFAULT '' NOT NULL,

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -607,8 +607,7 @@ const char *vu_severities[] = {
     "Critical",
     "None",
     "Negligible",
-    "Untriaged",
-    "-"
+    "Untriaged"
 };
 
 const char *vu_cpe_dic_option[] = {
@@ -5737,8 +5736,8 @@ int wm_vuldet_nvd_empty() {
 
 const char *wm_vuldet_get_unified_severity(char *severity) {
 
-    if (!severity || strcasestr(severity, vu_severities[VU_UNKNOWN]) || strcasestr(severity, vu_severities[VU_UNTR])) {
-        return vu_severities[VU_UNDEFINED_SEV];
+    if (!severity || strcasestr(severity, vu_severities[VU_UNKNOWN])) {
+        return vu_severities[VU_UNTR];
     } else if (strcasestr(severity, vu_severities[VU_LOW]) || strcasestr(severity, vu_severities[VU_NEGL])) {
         return vu_severities[VU_LOW];
     } else if (strcasestr(severity, vu_severities[VU_MEDIUM]) || strcasestr(severity, vu_severities[VU_MODERATE])) {
@@ -5750,7 +5749,7 @@ const char *wm_vuldet_get_unified_severity(char *severity) {
     } else if (strcasestr(severity, vu_severities[VU_NONE])) {
         return vu_severities[VU_NONE];
     }
-    return vu_severities[VU_UNDEFINED_SEV];
+    return vu_severities[VU_UNTR];
 }
 
 void wm_vuldet_get_package_os(const char *version, const char **os_major, char **os_minor) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -154,8 +154,7 @@ typedef enum vu_severity {
     VU_CRITICAL,
     VU_NONE,
     VU_NEGL,
-    VU_UNTR,
-    VU_UNDEFINED_SEV
+    VU_UNTR
 } vu_severity;
 
 typedef enum vu_logic {


### PR DESCRIPTION
|Related issue|
|---|
|#12675|


## Description

The default value of the severity field has been modified in cases where the severity field is empty or unknown, as can be seen in the examples in the issue: #12675. 

With the change applied in the PR, now instead of getting the value "`-`", we get the value "`Untriaged`". This way, the reason for the problem is more descriptive.

## Configuration options

```xml
  <vulnerability-detector>
    <enabled>yes</enabled>
    <interval>5m</interval>
    <min_full_scan_interval>6h</min_full_scan_interval>
    <run_on_start>yes</run_on_start>

    <!-- Debian OS vulnerabilities -->
    <provider name="debian">
      <enabled>yes</enabled>
      <os>stretch</os>
      <os>buster</os>
      <os>bullseye</os>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Aggregate vulnerabilities -->
    <provider name="nvd">
      <enabled>yes</enabled>
      <update_from_year>2010</update_from_year>
      <update_interval>1h</update_interval>
    </provider>

  </vulnerability-detector>
```

## Alerts example

```
** Alert 1647017428.6570136: - vulnerability-detector,gdpr_IV_35.7.d,pci_dss_11.2.1,pci_dss_11.2.3,tsc_CC7.1,tsc_CC7.2,
2022 Mar 11 16:50:28 (debian10) any->vulnerability-detector
Rule: 23504 (level 7) -> 'CVE-2022-23960 affects linux-compiler-gcc-8-x86'
{"vulnerability":{"package":{"name":"linux-compiler-gcc-8-x86","source":"linux","version":"4.19.208-1","architecture":"amd64","condition":"Package unfixed"},"cve":"CVE-2022-23960","title":"CVE-2022-23960 affects linux-compiler-gcc-8-x86","rationale":"","severity":"Untriaged","status":"Active","type":"PACKAGE","references":["https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23960"]}}
vulnerability.package.name: linux-compiler-gcc-8-x86
vulnerability.package.source: linux
vulnerability.package.version: 4.19.208-1
vulnerability.package.architecture: amd64
vulnerability.package.condition: Package unfixed
vulnerability.cve: CVE-2022-23960
vulnerability.title: CVE-2022-23960 affects linux-compiler-gcc-8-x86
vulnerability.severity: Untriaged
vulnerability.status: Active
vulnerability.type: PACKAGE
vulnerability.references: ["https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23960"]
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
