### PR TITLE
Fix api.yaml path suggested at exception.py

### DIFF
--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -92,7 +92,7 @@ class WazuhException(Exception):
         1119: "Directory '/tmp' needs read, write & execution permission for 'wazuh' user",
         1121: {'message': "Error connecting with socket"},
         1122: {'message': 'Experimental features are disabled',
-               'remediation': 'Experimental features can be enabled in WAZUH_PATH/configuration/api.yaml or '
+               'remediation': 'Experimental features can be enabled in WAZUH_PATH/api/configuration/api.yaml or '
                               'using API endpoint https://documentation.wazuh.com/current/user-manual/api/'
                               'reference.html#operation/api.controllers.manager_controller.put_api_config or '
                               'https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/'


### PR DESCRIPTION
|Related issue|
|---|
| #12549 |

## Description

This PR closes [#12549](https://github.com/wazuh/wazuh/issues/12549). It updates api.yaml path suggested as remediation at `exception.py`. Now the path indicated at 1122 error is `WAZUH_PATH/api/configuration/api.yaml`