### PR TITLE
Resolve manager address by Agentd after creating the PIDfile

### DIFF
--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -141,16 +141,15 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
             mdebug2("Resolving server hostname: %s", agt->server[rc].rip);
             resolve_hostname(&agt->server[rc].rip, 5);
             int rip_l = strlen(agt->server[rc].rip);
-            mdebug2("Server hostname resolved: %.*s", agt->server[rc].rip[rip_l - 1] == '/' ? rip_l - 1 : rip_l, agt->server[rc].rip);
-        }
-        rc++;
-    }
 
-    /* Connect remote */
-    rc = 0;
-    while (rc < agt->server_count) {
-        int rip_l = strlen(agt->server[rc].rip);
-        minfo("Server IP Address: %.*s", agt->server[rc].rip[rip_l - 1] == '/' ? rip_l - 1 : rip_l, agt->server[rc].rip);
+            if (agt->server[rc].rip[rip_l - 1] == '/') {
+                mwarn("Could not resolve server hostname: %.*s", rip_l - 1, agt->server[rc].rip);
+            } else {
+                minfo("Server hostname resolved: %s", agt->server[rc].rip);
+            }
+        } else {
+            minfo("Server IP Address: %s", agt->server[rc].rip);
+        }
         rc++;
     }
 

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -57,18 +57,6 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
     minfo(ENC_READ);
     OS_ReadKeys(&keys, W_DUAL_KEY, 0);
 
-    // Resolve hostnames
-    rc = 0;
-    while (rc < agt->server_count) {
-        if (OS_IsValidIP(agt->server[rc].rip, NULL) != 1) {
-            mdebug2("Resolving server hostname: %s", agt->server[rc].rip);
-            resolve_hostname(&agt->server[rc].rip, 5);
-            int rip_l = strlen(agt->server[rc].rip);
-            mdebug2("Server hostname resolved: %.*s", agt->server[rc].rip[rip_l - 1] == '/' ? rip_l - 1 : rip_l, agt->server[rc].rip);
-        }
-        rc++;
-    }
-
     minfo("Using notify time: %d and max time to reconnect: %d", agt->notify_time, agt->max_time_reconnect_try);
     if (agt->force_reconnect_interval) {
         minfo("Using force reconnect interval, Wazuh Agent will reconnect every %ld %s", w_seconds_to_time_value(agt->force_reconnect_interval), w_seconds_to_time_unit(agt->force_reconnect_interval, TRUE));
@@ -128,14 +116,6 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
         minfo(DISABLED_BUFFER);
     }
 
-    /* Connect remote */
-    rc = 0;
-    while (rc < agt->server_count) {
-        int rip_l = strlen(agt->server[rc].rip);
-        minfo("Server IP Address: %.*s", agt->server[rc].rip[rip_l - 1] == '/' ? rip_l - 1 : rip_l, agt->server[rc].rip);
-        rc++;
-    }
-
     /* Configure and start statistics */
     w_agentd_state_init();
     w_create_thread(state_main, NULL);
@@ -152,6 +132,26 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
                    "queue (disabled).");
             agt->execdq = -1;
         }
+    }
+
+    // Resolve hostnames
+    rc = 0;
+    while (rc < agt->server_count) {
+        if (OS_IsValidIP(agt->server[rc].rip, NULL) != 1) {
+            mdebug2("Resolving server hostname: %s", agt->server[rc].rip);
+            resolve_hostname(&agt->server[rc].rip, 5);
+            int rip_l = strlen(agt->server[rc].rip);
+            mdebug2("Server hostname resolved: %.*s", agt->server[rc].rip[rip_l - 1] == '/' ? rip_l - 1 : rip_l, agt->server[rc].rip);
+        }
+        rc++;
+    }
+
+    /* Connect remote */
+    rc = 0;
+    while (rc < agt->server_count) {
+        int rip_l = strlen(agt->server[rc].rip);
+        minfo("Server IP Address: %.*s", agt->server[rc].rip[rip_l - 1] == '/' ? rip_l - 1 : rip_l, agt->server[rc].rip);
+        rc++;
     }
 
     start_agent(1);

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -134,25 +134,6 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
         }
     }
 
-    // Resolve hostnames
-    rc = 0;
-    while (rc < agt->server_count) {
-        if (OS_IsValidIP(agt->server[rc].rip, NULL) != 1) {
-            mdebug2("Resolving server hostname: %s", agt->server[rc].rip);
-            resolve_hostname(&agt->server[rc].rip, 5);
-            int rip_l = strlen(agt->server[rc].rip);
-
-            if (agt->server[rc].rip[rip_l - 1] == '/') {
-                mwarn("Could not resolve server hostname: %.*s", rip_l - 1, agt->server[rc].rip);
-            } else {
-                minfo("Server hostname resolved: %s", agt->server[rc].rip);
-            }
-        } else {
-            minfo("Server IP Address: %s", agt->server[rc].rip);
-        }
-        rc++;
-    }
-
     start_agent(1);
 
     os_delwait();

--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -125,6 +125,8 @@ int verifyRemoteConf();
 // Clear merged.mg hash cache value.
 void clear_merged_hash_cache();
 
+// Resolve manager hostnames
+void agent_setup_hostnames();
 
 size_t agcom_dispatch(char * command, char ** output);
 size_t agcom_getconfig(const char * section, char ** output);

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -134,6 +134,7 @@ void start_agent(int is_startup)
 {
 
     if (is_startup) {
+        agent_setup_hostnames();
         w_agentd_keys_init();
     }
 
@@ -401,4 +402,25 @@ void send_agent_stopped_message() {
 
     /* Send shutdown message */
     send_msg(msg, -1);
+}
+
+/**
+ * @brief Resolve manager hostnames
+ */
+void agent_setup_hostnames() {
+    for (int rc = 0; rc < agt->server_count; rc++) {
+        if (OS_IsValidIP(agt->server[rc].rip, NULL) != 1) {
+            mdebug2("Resolving server hostname: %s", agt->server[rc].rip);
+            resolve_hostname(&agt->server[rc].rip, 5);
+            int rip_l = strlen(agt->server[rc].rip);
+
+            if (agt->server[rc].rip[rip_l - 1] == '/') {
+                mwarn("Could not resolve server hostname: %.*s", rip_l - 1, agt->server[rc].rip);
+            } else {
+                minfo("Server hostname resolved: %s", agt->server[rc].rip);
+            }
+        } else {
+            minfo("Server IP Address: %s", agt->server[rc].rip);
+        }
+    }
 }

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -31,6 +31,7 @@ set(START_AGENT_BASE_FLAGS "-Wl,--wrap,w_rotate_log -Wl,--wrap,getDefine_Int -Wl
                             -Wl,--wrap,OS_ConnectTCP -Wl,--wrap,OS_SetRecvTimeout -Wl,--wrap,resolve_hostname \
                             -Wl,--wrap,send_msg -Wl,--wrap,recv -Wl,--wrap,OS_RecvSecureTCP -Wl,--wrap,fseek \
                             -Wl,--wrap,fprintf -Wl,--wrap,fflush -Wl,--wrap,ReadSecMSG -Wl,--wrap,wnet_select \
+                            -Wl,--wrap,_minfo,--wrap,_mdebug2,--wrap,_mwarn \
                             -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,OS_SendUDPbySize -Wl,--wrap,getpid ${DEBUG_OP_WRAPPERS}")
 if(${TARGET} STREQUAL "winagent")
     list(APPEND client-agent_flags "${START_AGENT_BASE_FLAGS} -Wl,--wrap,os_random")

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -50,7 +50,6 @@ void stop_wmodules()
 /* Locally start (after service/win init) */
 int local_start()
 {
-    int rc;
     char *cfg = OSSECCONF;
     WSADATA wsaData;
     DWORD  threadID;
@@ -111,17 +110,6 @@ int local_start()
     if (agt->force_reconnect_interval) {
         minfo("Using force reconnect interval, Wazuh Agent will reconnect every %ld %s", \
                w_seconds_to_time_value(agt->force_reconnect_interval), w_seconds_to_time_unit(agt->force_reconnect_interval, TRUE));
-    }
-
-    // Resolve hostnames
-    rc = 0;
-    while (rc < agt->server_count) {
-        if (OS_IsValidIP(agt->server[rc].rip, NULL) != 1) {
-            mdebug2("Resolving server hostname: %s", agt->server[rc].rip);
-            resolve_hostname(&agt->server[rc].rip, 5);
-            mdebug2("Server hostname resolved: %s", agt->server[rc].rip);
-        }
-        rc++;
     }
 
     /* Read logcollector config file */


### PR DESCRIPTION
|Related issue|
|---|
|Closes #12703|

This change delays the manager hostname resolution until Agentd performs these tasks at less:
- Create the PID-file: _var/run/wazuh-agent-*.pid_.
- Create the state file: _var/run/wazuh-agentd.state_.
- Create the agent's queue: _queue/sockets/queue_.

In addition, we've changed UNIX and Windows agent to log the result of the hostname resolution, as we will see in the logs.

## Logs

### Linux

- Valid hostname:
```
2022/03/14 17:50:36 wazuh-agentd: INFO: (1410): Reading authentication keys file.
2022/03/14 17:50:36 wazuh-agentd: INFO: Started (pid: 59114).
2022/03/14 17:50:36 wazuh-agentd: INFO: Server hostname resolved: groovy/192.168.33.22
```
- Unknown hostname:
```
2022/03/14 17:50:23 wazuh-agentd: INFO: (1410): Reading authentication keys file.
2022/03/14 17:50:23 wazuh-agentd: INFO: Started (pid: 59104).

2022/03/14 17:50:29 wazuh-agentd: WARNING: Could not resolve server hostname: unknown
```
- IP address:
```
2022/03/14 17:56:21 wazuh-agentd: INFO: (1410): Reading authentication keys file.
2022/03/14 17:56:21 wazuh-agentd: INFO: Started (pid: 62642).
2022/03/14 17:56:21 wazuh-agentd: INFO: Server IP Address: 172.26.150.45
```

### Windows
- Valid hostname:
```
2022/03/14 17:58:55 wazuh-agent: INFO: (1410): Reading authentication keys file.
2022/03/14 17:58:55 wazuh-agent: INFO: Started (pid: 2112).
2022/03/14 17:58:55 wazuh-agent: INFO: Server hostname resolved: groovy/192.168.33.22
```
- Unknown hostname:
```
2022/03/14 17:44:33 wazuh-agent: INFO: (1410): Reading authentication keys file.
2022/03/14 17:44:33 wazuh-agent: INFO: Started (pid: 23284).

2022/03/14 17:44:53 wazuh-agent: WARNING: Could not resolve server hostname: unknown
```
- IP address:
```
2022/03/14 17:58:36 wazuh-agent: INFO: (1410): Reading authentication keys file.
2022/03/14 17:58:36 wazuh-agent: INFO: Started (pid: 20164).
2022/03/14 17:58:36 wazuh-agent: INFO: Server IP Address: 172.26.150.45
```


## Tests

- [x] Agentd creates the state files immediately on start, even with an unknown server hostname.
- [x] Valgrind
- [x] Cppcheck
- [x] Coverity