### PR TITLE
Fix inode overflow on MAC

### DIFF
--- a/architecture/FIM/db/class.puml
+++ b/architecture/FIM/db/class.puml
@@ -40,7 +40,7 @@ package "item" <<Folder>> {
         - int m_gid
         - string m_groupname
         - time_t m_time
-        - unsigned long int m_inode
+        - unsigned long long int m_inode
         - string m_md5
         - string m_sha1
         - string m_sha256

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -278,7 +278,7 @@ typedef struct fim_file_data {
     char * user_name;
     char * group_name;
     unsigned int mtime;
-    unsigned long int inode;
+    unsigned long long int inode;
     os_md5 hash_md5;
     os_sha1 hash_sha1;
     os_sha256 hash_sha256;

--- a/src/syscheckd/cppcheckSuppress.txt
+++ b/src/syscheckd/cppcheckSuppress.txt
@@ -2,4 +2,4 @@
 *:*src/syscheckd/src/db/src/file.cpp:392
 *:*src/db/testtool/action.h:378
 *:*src/syscheckd/src/db/src/db.cpp:100
-*:*src/syscheckd/src/create_db.c:847
+*:*src/syscheckd/src/create_db.c:848

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -1321,7 +1321,7 @@ void fim_get_checksum (fim_file_data * data) {
 
     size = snprintf(0,
             0,
-            "%d:%s:%s:%s:%s:%s:%s:%u:%lu:%s:%s:%s",
+            "%d:%s:%s:%s:%s:%s:%s:%u:%llu:%s:%s:%s",
             data->size,
             data->perm ? data->perm : "",
             data->attributes ? data->attributes : "",
@@ -1338,7 +1338,7 @@ void fim_get_checksum (fim_file_data * data) {
     os_calloc(size + 1, sizeof(char), checksum);
     snprintf(checksum,
             size + 1,
-            "%d:%s:%s:%s:%s:%s:%s:%u:%lu:%s:%s:%s",
+            "%d:%s:%s:%s:%s:%s:%s:%u:%llu:%s:%s:%s",
             data->size,
             data->perm ? data->perm : "",
             data->attributes ? data->attributes : "",

--- a/src/syscheckd/src/db/include/db.h
+++ b/src/syscheckd/src/db/include/db.h
@@ -111,7 +111,7 @@ void fim_db_file_update(fim_entry* data, callback_context_t callback);
  * @param dev Device.
  * @param data Pointer to the data structure where the callback context will be stored.
  */
-FIMDBErrorCode fim_db_file_inode_search(unsigned long int inode, unsigned long int dev, callback_context_t data);
+FIMDBErrorCode fim_db_file_inode_search(unsigned long long int inode, unsigned long int dev, callback_context_t data);
 
 /**
  * @brief Push a message to the syscheck queue

--- a/src/syscheckd/src/db/src/dbFileItem.hpp
+++ b/src/syscheckd/src/db/src/dbFileItem.hpp
@@ -117,7 +117,7 @@ class FileItem final : public DBItem
         int                                             m_uid;
         unsigned int                                    m_size;
         unsigned long int                               m_dev;
-        unsigned long int                               m_inode;
+        unsigned long long int                          m_inode;
         time_t                                          m_time;
         std::string                                     m_attributes;
         std::string                                     m_groupname;

--- a/src/syscheckd/src/db/src/file.cpp
+++ b/src/syscheckd/src/db/src/file.cpp
@@ -605,7 +605,9 @@ void fim_db_file_update(fim_entry* data, callback_context_t callback)
     }
 }
 
-FIMDBErrorCode fim_db_file_inode_search(const unsigned long inode, const unsigned long dev, callback_context_t callback)
+FIMDBErrorCode fim_db_file_inode_search(const unsigned long long int inode,
+                                        const unsigned long dev,
+                                        callback_context_t callback)
 {
     auto retVal { FIMDB_ERR };
 

--- a/src/syscheckd/src/db/tests/db/dbItem/FileItem/dbFileItemTest.cpp
+++ b/src/syscheckd/src/db/tests/db/dbItem/FileItem/dbFileItemTest.cpp
@@ -28,7 +28,7 @@ void FileItemTest::SetUp()
     std::strncpy(data->hash_md5, "4b531524aa13c8a54614100b570b3dc7", sizeof(data->hash_md5));
     std::strncpy(data->hash_sha1, "7902feb66d0bcbe4eb88e1bfacf28befc38bd58b", sizeof(data->hash_sha1));
     std::strncpy(data->hash_sha256, "e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", sizeof(data->hash_sha256));
-    data->inode = 18277083;
+    data->inode = 1152921500312810880;
     data->last_event = 1596489275;
     data->mode = FIM_SCHEDULED;
     data->mtime = 1578075431;
@@ -101,7 +101,7 @@ TEST_F(FileItemTest, fileItemConstructorFromJSON)
         {
             "attributes":"10", "checksum":"a2fbef8f81af27155dcee5e3927ff6243593b91a", "dev":2051, "gid":0, "group_name":"root",
             "hash_md5":"4b531524aa13c8a54614100b570b3dc7", "hash_sha1":"7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
-            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":18277083, "last_event":1596489275,
+            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":1152921500312810880, "last_event":1596489275,
             "mode":0, "mtime":1578075431, "options":131583, "path":"/etc/wgetrc", "perm":"-rw-rw-r--", "scanned":1, "size":4925,
             "uid":0, "user_name":"fakeUser"
         }
@@ -148,7 +148,7 @@ TEST_F(FileItemTest, getFIMEntryWithJSONCtr)
         {
             "attributes":"10", "checksum":"a2fbef8f81af27155dcee5e3927ff6243593b91a", "dev":2051, "gid":0, "group_name":"root",
             "hash_md5":"4b531524aa13c8a54614100b570b3dc7", "hash_sha1":"7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
-            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":18277083, "last_event":1596489275,
+            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":1152921500312810880, "last_event":1596489275,
             "mode":0, "mtime":1578075431, "options":131583, "path":"/etc/wgetrc", "perm":"-rw-rw-r--", "scanned":1, "size":4925,
             "uid":0, "user_name":"fakeUser"
         }
@@ -186,7 +186,7 @@ TEST_F(FileItemTest, getJSONWithFimCtr)
             "table": "file_entry",
             "data":[{"attributes":"10", "checksum":"a2fbef8f81af27155dcee5e3927ff6243593b91a", "dev":2051, "gid":0, "group_name":"root",
             "hash_md5":"4b531524aa13c8a54614100b570b3dc7", "hash_sha1":"7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
-            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":18277083, "last_event":1596489275,
+            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":1152921500312810880, "last_event":1596489275,
             "mode":0, "mtime":1578075431, "options":131583, "path":"/etc/wgetrc", "perm":"-rw-rw-r--", "scanned":1, "size":4925,
             "uid":0, "user_name":"fakeUser"}]
         }
@@ -203,7 +203,7 @@ TEST_F(FileItemTest, getJSONWithJSONCtr)
             "table": "file_entry",
             "data":[{"attributes":"10", "checksum":"a2fbef8f81af27155dcee5e3927ff6243593b91a", "dev":2051, "gid":0, "group_name":"root",
             "hash_md5":"4b531524aa13c8a54614100b570b3dc7", "hash_sha1":"7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
-            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":18277083, "last_event":1596489275,
+            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":1152921500312810880, "last_event":1596489275,
             "mode":0, "mtime":1578075431, "options":131583, "path":"/etc/wgetrc", "perm":"-rw-rw-r--", "scanned":1, "size":4925,
             "uid":0, "user_name":"fakeUser"}]
         }
@@ -220,7 +220,7 @@ TEST_F(FileItemTest, fileItemReportOldData)
             "table": "file_entry",
             "data":[{"attributes":"10", "checksum":"a2fbef8f81af27155dcee5e3927ff6243593b91a", "dev":2051, "gid":0, "group_name":"root",
             "hash_md5":"4b531524aa13c8a54614100b570b3dc7", "hash_sha1":"7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
-            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":18277083, "last_event":1596489275,
+            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":1152921500312810880, "last_event":1596489275,
             "mode":0, "mtime":1578075431, "options":131583, "path":"/etc/wgetrc", "perm":"-rw-rw-r--", "scanned":1, "size":4925,
             "uid":0, "user_name":"fakeUser"}],"options":{"return_old_data": true, "ignore":["last_event"]}
         }

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -199,7 +199,7 @@ static int setup_fim_data(void **state) {
     fim_data->new_data->user_name = strdup("test1");
     fim_data->new_data->group_name = strdup("testing1");
     fim_data->new_data->mtime = 1570184224;
-    fim_data->new_data->inode = 606061;
+    fim_data->new_data->inode = 1152921500312810880;
     strcpy(fim_data->new_data->hash_md5, "3691689a513ace7e508297b583d7550d");
     strcpy(fim_data->new_data->hash_sha1, "07f05add1049244e7e75ad0f54f24d8094cd8f8b");
     strcpy(fim_data->new_data->hash_sha256, "672a8ceaea40a441f0268ca9bbb33e9959643c6262667b61fbe57694df224d40");


### PR DESCRIPTION
|EPIC|Component|
|---|---|
| https://github.com/wazuh/wazuh/issues/9103 | FIM |

|Issue|
|---|
| Closes #12583  | FIM |


### Description
Fix bug in MAC OS when it is saved a long inode inside FIM DB 

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Unit tests passed
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] cppcheck (static code analysis)
  - [x] Coverage (unit tests coverage code)
  - [x] Sformat (code style)
  - [x] Scan build
 