### PR TITLE
Add fields `external_references`, `condition`, `title`, `published` and `updated` to vulnerability API endpoint

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -16798,26 +16798,36 @@ paths:
               example:
                 data:
                   affected_items:
-                    - architecture: amd64
-                      name: binutils
-                      version: 2.34-6ubuntu1.1
-                      type: PACKAGE
-                      severity: Medium
-                      cvss2_score: 7.1
-                      cve: CVE-2021-3487
-                      detection_time: '2021-06-14T07:45:51Z'
-                      cvss3_score: 6.5
-                      status: VALID
-                    - architecture: amd64
-                      name: binutils
-                      version: 2.34-6ubuntu1.1
-                      type: PACKAGE
-                      severity: High
-                      cvss2_score: 6.8
-                      cve: CVE-2021-20294
-                      detection_time: '2021-06-14T07:45:51Z'
+                    - severity: "High"
+                      updated: "2022-01-10"
+                      version: "2.34-6ubuntu1.3"
+                      type: "PACKAGE"
+                      name: "binutils"
+                      external_references: "[\"https://sourceware.org/bugzilla/show_bug.cgi?id=28694\",\"https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=161e87d12167b1e36193385485c1f6ce92f74f02\",\"https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UQBH244M5PV6S6UMHUTCVCWFZDX7Y4M6/\",\"https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UUHLDDT3HH7YEY6TX7IJRGPJUTNNVEL3/\",\"https://security.netapp.com/advisory/ntap-20220107-0002/\",\"https://nvd.nist.gov/vuln/detail/CVE-2021-45078\",\"http://people.canonical.com/~ubuntu-security/cve/2021/CVE-2021-45078.html\",\"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45078\"]"
+                      condition: "Package unfixed"
+                      detection_time: "2022-03-14T11:04:04Z"
                       cvss3_score: 7.8
-                      status: VALID
+                      published: "2021-12-15"
+                      architecture: "amd64"
+                      cve: "CVE-2021-45078"
+                      status: "VALID"
+                      title: "CVE-2021-45078 affects binutils"
+                      cvss2_score: 6.8
+                    - severity: "High"
+                      updated: "2022-01-10"
+                      version: "2.34-6ubuntu1.3"
+                      type: "PACKAGE"
+                      name: "binutils-common"
+                      external_references: "[\"https://sourceware.org/bugzilla/show_bug.cgi?id=28694\",\"https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=161e87d12167b1e36193385485c1f6ce92f74f02\",\"https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UQBH244M5PV6S6UMHUTCVCWFZDX7Y4M6/\",\"https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UUHLDDT3HH7YEY6TX7IJRGPJUTNNVEL3/\",\"https://security.netapp.com/advisory/ntap-20220107-0002/\",\"https://nvd.nist.gov/vuln/detail/CVE-2021-45078\",\"http://people.canonical.com/~ubuntu-security/cve/2021/CVE-2021-45078.html\",\"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45078\"]"
+                      condition: "Package unfixed"
+                      detection_time: "2022-03-14T11:04:04Z"
+                      cvss3_score: 7.8
+                      published: "2021-12-15"
+                      architecture: "amd64"
+                      cve: "CVE-2021-45078"
+                      status: "VALID"
+                      title: "CVE-2021-45078 affects binutils-common"
+                      cvss2_score: 6.8
                   total_affected_items: 2
                   total_failed_items: 0
                   failed_items: []

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -16803,7 +16803,7 @@ paths:
                       version: "2.34-6ubuntu1.3"
                       type: "PACKAGE"
                       name: "binutils"
-                      external_references: "[\"https://sourceware.org/bugzilla/show_bug.cgi?id=28694\",\"https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=161e87d12167b1e36193385485c1f6ce92f74f02\",\"https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UQBH244M5PV6S6UMHUTCVCWFZDX7Y4M6/\",\"https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UUHLDDT3HH7YEY6TX7IJRGPJUTNNVEL3/\",\"https://security.netapp.com/advisory/ntap-20220107-0002/\",\"https://nvd.nist.gov/vuln/detail/CVE-2021-45078\",\"http://people.canonical.com/~ubuntu-security/cve/2021/CVE-2021-45078.html\",\"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45078\"]"
+                      external_references: ["https://sourceware.org/bugzilla/show_bug.cgi?id=28694","https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=161e87d12167b1e36193385485c1f6ce92f74f02","https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UQBH244M5PV6S6UMHUTCVCWFZDX7Y4M6/","https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UUHLDDT3HH7YEY6TX7IJRGPJUTNNVEL3/","https://security.netapp.com/advisory/ntap-20220107-0002/","https://nvd.nist.gov/vuln/detail/CVE-2021-45078","http://people.canonical.com/~ubuntu-security/cve/2021/CVE-2021-45078.html","https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45078"]
                       condition: "Package unfixed"
                       detection_time: "2022-03-14T11:04:04Z"
                       cvss3_score: 7.8
@@ -16818,7 +16818,7 @@ paths:
                       version: "2.34-6ubuntu1.3"
                       type: "PACKAGE"
                       name: "binutils-common"
-                      external_references: "[\"https://sourceware.org/bugzilla/show_bug.cgi?id=28694\",\"https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=161e87d12167b1e36193385485c1f6ce92f74f02\",\"https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UQBH244M5PV6S6UMHUTCVCWFZDX7Y4M6/\",\"https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UUHLDDT3HH7YEY6TX7IJRGPJUTNNVEL3/\",\"https://security.netapp.com/advisory/ntap-20220107-0002/\",\"https://nvd.nist.gov/vuln/detail/CVE-2021-45078\",\"http://people.canonical.com/~ubuntu-security/cve/2021/CVE-2021-45078.html\",\"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45078\"]"
+                      external_references: ["https://sourceware.org/bugzilla/show_bug.cgi?id=28694","https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=161e87d12167b1e36193385485c1f6ce92f74f02","https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UQBH244M5PV6S6UMHUTCVCWFZDX7Y4M6/","https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UUHLDDT3HH7YEY6TX7IJRGPJUTNNVEL3/","https://security.netapp.com/advisory/ntap-20220107-0002/","https://nvd.nist.gov/vuln/detail/CVE-2021-45078","http://people.canonical.com/~ubuntu-security/cve/2021/CVE-2021-45078.html","https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45078"]
                       condition: "Package unfixed"
                       detection_time: "2022-03-14T11:04:04Z"
                       cvss3_score: 7.8

--- a/api/test/integration/mapping/integration_test_api_endpoints.json
+++ b/api/test/integration/mapping/integration_test_api_endpoints.json
@@ -1371,6 +1371,27 @@
         ]
     },
     {
+        "path": "framework/wazuh/core/tests/data/test_vulnerability",
+        "files": [
+            {
+                "name": "schema_cve_test.sql",
+                "tag": "schema",
+                "tests": [
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
         "path": "framework/wazuh/rbac",
         "files": [
             {
@@ -3867,6 +3888,27 @@
         ]
     },
     {
+        "path": "api/test/integration/env/configurations/vulnerability/manager/configuration_files",
+        "files": [
+            {
+                "name": "nvd_providers.sh",
+                "tag": "nvd",
+                "tests": [
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
         "path": "api/test/integration/env/configurations/vulnerability/manager/healthcheck",
         "files": [
             {
@@ -3893,6 +3935,22 @@
             {
                 "name": "healthcheck_utils.py",
                 "tag": "healthcheck",
+                "tests": [
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "print_active_agents.py",
+                "tag": "print",
                 "tests": [
                     "test_agent_DELETE_endpoints.tavern.yaml",
                     "test_agent_GET_endpoints.tavern.yaml",

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -207,7 +207,7 @@ def test_count_elements(response, n_expected_items):
     assert len(response.json()['data']['affected_items']) == n_expected_items
 
 
-def test_expected_value(response, key, expected_values):
+def test_expected_value(response, key, expected_values, empty_response_possible=False):
     """Iterate all items in the response and check that <key> value is within <expected_values>.
 
     Parameters
@@ -218,11 +218,14 @@ def test_expected_value(response, key, expected_values):
         Key whose value is checked.
     expected_values : str, list
         List of values which are allowed.
+    empty_response_possible : bool
+        Indicates whether the response could be empty or not. Set to True when the key value does not depend on the
+        test itself, for instance, node. Default: `False`
     """
     expected_values = set(expected_values.split(',')) if not isinstance(expected_values, list) else set(expected_values)
     affected_items = response.json()['data']['affected_items']
 
-    if not affected_items:
+    if not affected_items and not empty_response_possible:
         raise Exception("No items found in the response")
 
     for item in affected_items:

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -220,8 +220,12 @@ def test_expected_value(response, key, expected_values):
         List of values which are allowed.
     """
     expected_values = set(expected_values.split(',')) if not isinstance(expected_values, list) else set(expected_values)
+    affected_items = response.json()['data']['affected_items']
 
-    for item in response.json()['data']['affected_items']:
+    if not affected_items:
+        raise Exception("No items found in the response")
+
+    for item in affected_items:
         response_set = set(map(str, item[key])) if isinstance(item[key], list) else {str(item[key])}
         assert bool(expected_values.intersection(response_set)), \
             f'Expected values {expected_values} not found in {item[key]}'

--- a/api/test/integration/test_task_endpoints.tavern.yaml
+++ b/api/test/integration/test_task_endpoints.tavern.yaml
@@ -407,6 +407,7 @@ stages:
           extra_kwargs:
             key: "node"
             expected_values: "worker2"
+            empty_response_possible: True
 
   - name: Get all existent tasks with status=In progress
     request:

--- a/api/test/integration/test_vulnerability_endpoints.tavern.yaml
+++ b/api/test/integration/test_vulnerability_endpoints.tavern.yaml
@@ -33,6 +33,11 @@ stages:
               cvss3_score: !anyfloat
               detection_time: !anystr
               severity: !anystr
+              external_references: !anylist
+              condition: !anystr
+              title: !anystr
+              published: !anystr
+              updated: !anystr
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -48,12 +53,17 @@ stages:
           expected_cvss3_score: data.affected_items[0].cvss3_score
           expected_detection_time: data.affected_items[0].detection_time
           expected_severity: data.affected_items[0].severity
+          expected_external_references: data.affected_items[0].external_references
+          expected_condition: data.affected_items[0].condition
+          expected_title: data.affected_items[0].title
+          expected_published: data.affected_items[0].published
+          expected_updated: data.affected_items[0].updated
 
   - name: Get agent's vulnerabilities (filter by Type)
     request:
       <<: *vulnerability_request_001
       params:
-        cve: "{expected_type}"
+        type: "{expected_type}"
     response:
       status_code: 200
       verify_response_with:
@@ -66,7 +76,7 @@ stages:
     request:
       <<: *vulnerability_request_001
       params:
-        cve: "{expected_status}"
+        status: "{expected_status}"
     response:
       status_code: 200
       verify_response_with:
@@ -166,6 +176,72 @@ stages:
             key: "cvss3_score"
             expected_values: "{expected_cvss3_score}"
 
+#  # Uncomment this test case when https://github.com/wazuh/wazuh/issues/12723 is solved
+#  - name: Get agent's vulnerabilities (filter by external references)
+#    request:
+#      <<: *vulnerability_request_001
+#      params:
+#        q: "external_references={expected_external_references}"
+#    response:
+#      status_code: 200
+#      verify_response_with:
+#        - function: tavern_utils:test_expected_value
+#          extra_kwargs:
+#            key: "external_references"
+#            expected_values: "{expected_external_references}"
+
+  - name: Get agent's vulnerabilities (filter by condition)
+    request:
+      <<: *vulnerability_request_001
+      params:
+        q: "condition={expected_condition}"
+    response:
+      status_code: 200
+      verify_response_with:
+        - function: tavern_utils:test_expected_value
+          extra_kwargs:
+            key: "condition"
+            expected_values: "{expected_condition}"
+
+  - name: Get agent's vulnerabilities (filter by title)
+    request:
+      <<: *vulnerability_request_001
+      params:
+        q: "title={expected_title}"
+    response:
+      status_code: 200
+      verify_response_with:
+        - function: tavern_utils:test_expected_value
+          extra_kwargs:
+            key: "title"
+            expected_values: "{expected_title}"
+
+  - name: Get agent's vulnerabilities (filter by publish date)
+    request:
+      <<: *vulnerability_request_001
+      params:
+        q: "published={expected_published}"
+    response:
+      status_code: 200
+      verify_response_with:
+        - function: tavern_utils:test_expected_value
+          extra_kwargs:
+            key: "published"
+            expected_values: "{expected_published}"
+
+  - name: Get agent's vulnerabilities (filter by update date)
+    request:
+      <<: *vulnerability_request_001
+      params:
+        q: "updated={expected_updated}"
+    response:
+      status_code: 200
+      verify_response_with:
+        - function: tavern_utils:test_expected_value
+          extra_kwargs:
+            key: "updated"
+            expected_values: "{expected_updated}"
+
   - name: Try to get agent's vulnerabilities (filter by an unexistent CVSS3 score)
     request:
       <<: *vulnerability_request_001
@@ -236,13 +312,13 @@ stages:
     request:
       <<: *vulnerability_request_001
       params:
-        select: "cve,name"
+        select: "cve,name,external_references"
     response:
       status_code: 200
       verify_response_with:
         - function: tavern_utils:test_select_key_affected_items
           extra_kwargs:
-            select_key: "cve,name"
+            select_key: "cve,name,external_references"
 
   - name: q agent's vulnerabilities
     request:
@@ -286,7 +362,7 @@ stages:
         function: tavern_utils:test_distinct_key
 
   # GET /vulnerabilities/002
-  - name: Get 001 agent's vulnerabilities (limit)
+  - name: Get 002 agent's vulnerabilities (limit)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/vulnerability/002"

--- a/framework/wazuh/core/tests/data/test_vulnerability/schema_cve_test.sql
+++ b/framework/wazuh/core/tests/data/test_vulnerability/schema_cve_test.sql
@@ -1,0 +1,82 @@
+/*
+ * SQL Schema CVE tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * February 23, 2021.
+ * This program is a free software, you can redistribute it
+ * and/or modify it under the terms of GPLv2.
+ */
+
+CREATE TABLE IF NOT EXISTS vuln_cves (
+    name TEXT,
+    version TEXT,
+    architecture TEXT,
+    cve TEXT,
+    detection_time TEXT DEFAULT '',
+    severity TEXT DEFAULT 'Untriaged' CHECK (severity IN ('Critical', 'High', 'Medium', 'Low', 'None', 'Untriaged')),
+    cvss2_score REAL DEFAULT 0,
+    cvss3_score REAL DEFAULT 0,
+    reference TEXT DEFAULT '' NOT NULL,
+    type TEXT DEFAULT '' NOT NULL CHECK (type IN ('OS', 'PACKAGE')),
+    status TEXT DEFAULT 'PENDING' NOT NULL CHECK (status IN ('VALID', 'PENDING', 'OBSOLETE')),
+    external_references TEXT DEFAULT '',
+    condition TEXT DEFAULT '',
+    title TEXT DEFAULT '',
+    published TEXT '',
+    updated TEXT '',
+    PRIMARY KEY (reference, cve)
+);
+CREATE INDEX IF NOT EXISTS packages_id ON vuln_cves (name);
+CREATE INDEX IF NOT EXISTS cves_id ON vuln_cves (cve);
+CREATE INDEX IF NOT EXISTS cve_type ON vuln_cves (type);
+CREATE INDEX IF NOT EXISTS cve_status ON vuln_cves (status);
+
+CREATE TABLE IF NOT EXISTS vuln_metadata (
+    LAST_PARTIAL_SCAN INTEGER,
+    LAST_FULL_SCAN INTEGER
+);
+
+BEGIN;
+
+-- Data from https://www.cvedetails.com/vulnerability-list/
+INSERT INTO vuln_cves (name, version, architecture, cve, type, status, detection_time, severity, cvss2_score,
+                       cvss3_score, reference, external_references, condition, title, published, updated)
+VALUES ('Invenio-previewer', '0.1.0', 'ARM', 'CVE-2019-1020019', 'OS', 'VALID', '1623656751', 'Medium', 4.3, 6.1,
+        '0198aaaadb185181ad323433735248fbf41362b5',
+        '["https://github.com/inveniosoftware/invenio-previewer/security/advisories/GHSA-j9m2-6hq2-4r3c"]',
+        'Package unfixed', 'invenio-previewer before 1.0.0a12 allows XSS.', '2019-07-29', '2019-07-31');
+
+INSERT INTO vuln_cves (name, version, architecture, cve, type, status, detection_time, severity, cvss2_score,
+                       cvss3_score, reference, external_references, condition, title, published, updated)
+VALUES ('Discourse', '0.8.0', 'PowerPC', 'CVE-2019-1020018', 'OS', 'VALID', '1623656751', 'High', 7.5, 7.3,
+        '24cbb88312a71cc2fee7b9fb545cfd404ea7c9a8',
+        '["https://github.com/discourse/discourse/commit/b8340c6c8e50a71ff1bca9654b9126ca5a84ce9a","https://github.com/discourse/discourse/commit/52387be4a44cdeaca5421ee955ba1343e836bade"]',
+        'Package unfixed',
+        'Discourse before 2.3.0 and 2.4.x before 2.4.0.beta3 lacks a confirmation screen when logging in via an email link.',
+        '2019-07-29', '2021-07-21');
+
+INSERT INTO vuln_cves (name, version, architecture, cve, type, status, detection_time, severity, cvss2_score,
+                       cvss3_score, reference, external_references, condition, title, published, updated)
+VALUES ('Ash-aio', '2.0.0.0', 'x86', 'CVE-2019-1020016', 'OS', 'OBSOLETE', '1623656751', 'Low', 1.9, 2.5,
+        'fe22d729473dc47625a583dd97e1d3a779105b19',
+        '["https://github.com/ASHTeam/ash-aio-2/security/advisories/GHSA-cg3m-qj5v-8g48"]', 'Package unfixed',
+        'ASH-AIO before 2.0.0.3 allows an open redirect.', '2019-07-29', '2019-08-01');
+
+INSERT INTO vuln_cves (name, version, architecture, cve, type, status, detection_time, severity, cvss2_score,
+                       cvss3_score, reference, external_references, condition, title, published, updated)
+VALUES ('Credential Helpers', '0.1.0', 'x86', 'CVE-2019-1020014', 'PACKAGE', 'OBSOLETE', '1623656949', 'Critical', 7.5,
+        9.8, '2783fabf4b0d5b5f3217703fb24bb75ec58a8ce3',
+        '["https://usn.ubuntu.com/4103-1/","https://github.com/docker/docker-credential-helpers/releases/tag/v0.6.3","https://usn.ubuntu.com/4103-2/","https://github.com/docker/docker-credential-helpers/commit/1c9f7ede70a5ab9851f4c9cb37d317fd89cd318a","https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/6VVFB6UWUK2GQQN7DVUU6GRRAL637A73/"]',
+        'Package unfixed','docker-credential-helpers before 0.6.3 has a double free in the List functions.',
+        '2019-07-29', '2021-01-14');
+
+INSERT INTO vuln_cves (name, version, architecture, cve, type, status, detection_time, severity, cvss2_score,
+                       cvss3_score, reference, external_references, condition, title, published, updated)
+VALUES ('Smokedetector', '-', 'x86', 'CVE-2019-1020011', 'PACKAGE', 'PENDING', '1623656949', 'High', 6.8, 8.1,
+        'e0680fb636baccbb7484f7b3daf5b4c0ce485960',
+        '["https://github.com/Charcoal-SE/SmokeDetector/security/advisories/GHSA-5w85-7mwr-v44q"]',
+        'Package unfixed',
+        'SmokeDetector intentionally does automatic deployments of updated copies of SmokeDetector without server operator authority.',
+        '2019-07-29', '2021-07-21');
+
+INSERT INTO vuln_metadata (LAST_PARTIAL_SCAN, LAST_FULL_SCAN)
+VALUES (1623656949, 1623656751);

--- a/framework/wazuh/core/tests/test_vulnerability.py
+++ b/framework/wazuh/core/tests/test_vulnerability.py
@@ -10,7 +10,6 @@ with patch('wazuh.core.common.wazuh_uid'):
     with patch('wazuh.core.common.wazuh_gid'):
         from wazuh.core.vulnerability import *
 
-
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data', 'test_agent')
 
 
@@ -27,7 +26,10 @@ def test_WazuhDBQueryVulnerability__init__(mock_conn, mock_info, mock_send, mock
         ANY, offset=500, limit=500, table='vuln_cves', sort=None, search=None, select=None,
         fields={'name': 'name', 'version': 'version', 'architecture': 'architecture', 'cve': 'cve', 'status': 'status',
                 'type': 'type', 'detection_time': 'detection_time', 'severity': 'severity',
-                'cvss2_score': 'cvss2_score', 'cvss3_score': 'cvss3_score'}, filters={}, count=True, get_data=True,
-        date_fields={'detection_time', 'last_partial_scan', 'last_full_scan'}, min_select_fields=set(),  distinct=False,
-        default_sort_field='name', default_sort_order='ASC',  query='version>3.9.81', backend=ANY
+                'cvss2_score': 'cvss2_score', 'cvss3_score': 'cvss3_score',
+                'external_references': 'external_references', 'condition': 'condition', 'title': 'title',
+                'published': 'published', 'updated': 'updated'},
+        filters={}, count=True, get_data=True, date_fields={'detection_time', 'last_partial_scan', 'last_full_scan'},
+        min_select_fields=set(),  distinct=False, default_sort_field='name', default_sort_order='ASC',
+        query='version>3.9.81', backend=ANY
     )

--- a/framework/wazuh/core/tests/test_vulnerability.py
+++ b/framework/wazuh/core/tests/test_vulnerability.py
@@ -5,11 +5,19 @@
 
 import json
 import os
+import sys
 from datetime import datetime
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, patch, MagicMock
 
 with patch('wazuh.core.common.wazuh_uid'):
     with patch('wazuh.core.common.wazuh_gid'):
+        sys.modules['wazuh.rbac.orm'] = MagicMock()
+        import wazuh.rbac.decorators
+        from wazuh.tests.util import RBAC_bypasser
+
+        del sys.modules['wazuh.rbac.orm']
+        wazuh.rbac.decorators.expose_resources = RBAC_bypasser
+
         from api import util
         from wazuh.core import vulnerability
         from wazuh.core.tests import test_agent

--- a/framework/wazuh/core/tests/test_vulnerability.py
+++ b/framework/wazuh/core/tests/test_vulnerability.py
@@ -30,6 +30,38 @@ def test_WazuhDBQueryVulnerability__init__(mock_conn, mock_info, mock_send, mock
                 'external_references': 'external_references', 'condition': 'condition', 'title': 'title',
                 'published': 'published', 'updated': 'updated'},
         filters={}, count=True, get_data=True, date_fields={'detection_time', 'last_partial_scan', 'last_full_scan'},
-        min_select_fields=set(),  distinct=False, default_sort_field='name', default_sort_order='ASC',
+        min_select_fields=set(), distinct=False, default_sort_field='name', default_sort_order='ASC',
         query='version>3.9.81', backend=ANY
     )
+
+
+def test_WazuhDBQueryVulnerability_format_data_into_dictionary():
+    """Check that WazuhDBQueryVulnerability's method _format_data_into_dictionary works properly."""
+    data = [
+        {"version": "5.0-6ubuntu1.1", "detection_time": "1647338576",
+         "external_references": '["https://www.youtube.com/watch?v=-wGtxJ8opa8",'
+                                '"https://github.com/bminor/bash/commit/951bdaad7a18cc0dc1036bba86b18b90874d39ff",'
+                                '"http://packetstormsecurity.com/files/155498/Bash-5.0-Patch-11-Privilege-Escalation'
+                                '.html","https://security.netapp.com/advisory/ntap-20200430-0003/",'
+                                '"https://lists.apache.org/thread.html'
+                                '/rf9fa47ab66495c78bb4120b0754dd9531ca2ff0430f6685ac9b07772@%3Cdev.mina.apache.org%3E'
+                                '","https://security.gentoo.org/glsa/202105-34",'
+                                '"https://nvd.nist.gov/vuln/detail/CVE-2019-18276",'
+                                '"http://people.canonical.com/~ubuntu-security/cve/2019/CVE-2019-18276.html",'
+                                '"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18276"]',
+         "title": "CVE-2019-18276 affects bash", "cve": "CVE-2019-18276", "name": "bash", "published": "2019-11-28",
+         "updated": "2021-05-26", "cvss2_score": 7.2, "condition": "Package unfixed", "architecture": "amd64",
+         "type": "PACKAGE", "cvss3_score": 7.8, "severity": "High", "status": "VALID"}
+    ]
+
+    with patch('wazuh.core.vulnerability.WazuhDBBackend.__init__', return_value=None), \
+            patch('wazuh.core.vulnerability.Agent.get_basic_information', return_value=None):
+        wdb_vuln = WazuhDBQueryVulnerability(1)
+
+    wdb_vuln._data = data
+    result = wdb_vuln._format_data_into_dictionary()
+
+    item = result['items'][0]
+    assert all(item[field] == data[0][field] for field in item.keys() - {'external_references', 'detection_time'})
+    assert item['external_references'] == eval(data[0]['external_references'])
+    assert item['detection_time'] == datetime.utcfromtimestamp(int(data[0]['detection_time']))

--- a/framework/wazuh/core/tests/test_vulnerability.py
+++ b/framework/wazuh/core/tests/test_vulnerability.py
@@ -57,12 +57,14 @@ def test_WazuhDBQueryVulnerability_format_data_into_dictionary(socket_mock, send
     with vulnerability.WazuhDBQueryVulnerability(agent_id='001', limit=1) as db_query:
         item = db_query.run()['items'][0]
 
-    expected_item = {
+    data = {
         'severity': 'Low', 'cvss3_score': 2.5, 'title': 'ASH-AIO before 2.0.0.3 allows an open redirect.', 'type': 'OS',
         'cve': 'CVE-2019-1020016', 'architecture': 'x86', 'updated': '2019-08-01', 'condition': 'Package unfixed',
-        'published': '2019-07-29', 'status': 'OBSOLETE', 'detection_time': datetime(2021, 6, 14, 7, 45, 51),
-        'cvss2_score': 1.9, 'name': 'Ash-aio', 'version': '2.0.0.0',
-        'external_references': ['https://github.com/ASHTeam/ash-aio-2/security/advisories/GHSA-cg3m-qj5v-8g48']
+        'published': '2019-07-29', 'status': 'OBSOLETE', 'detection_time': '1623656751', 'cvss2_score': 1.9,
+        'name': 'Ash-aio', 'version': '2.0.0.0',
+        'external_references': '["https://github.com/ASHTeam/ash-aio-2/security/advisories/GHSA-cg3m-qj5v-8g48"]'
     }
 
-    assert all(item[field] == expected_item[field] for field in item.keys())
+    assert all(item[field] == data[field] for field in item.keys() - {'external_references', 'detection_time'})
+    assert item['external_references'] == json.loads(data['external_references'])
+    assert item['detection_time'] == datetime.utcfromtimestamp(int(data['detection_time']))

--- a/framework/wazuh/core/tests/test_vulnerability.py
+++ b/framework/wazuh/core/tests/test_vulnerability.py
@@ -3,14 +3,29 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
+import json
 import os
+from datetime import datetime
 from unittest.mock import ANY, patch
 
 with patch('wazuh.core.common.wazuh_uid'):
     with patch('wazuh.core.common.wazuh_gid'):
-        from wazuh.core.vulnerability import *
+        from api import util
+        from wazuh.core import vulnerability
+        from wazuh.core.tests import test_agent
 
-test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data', 'test_agent')
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+test_data = test_agent.InitAgent()
+test_data_cve = test_agent.InitAgent(data_path=os.path.join(test_data_path, 'test_vulnerability'),
+                                     db_name='schema_cve_test.sql')
+
+
+def send_msg_to_wdb(msg, raw=False):
+    query = msg[msg.find('sql') + len('sql '):]
+    result = test_data.cur.execute(query).fetchall() if msg.startswith('global') else test_data_cve.cur.execute(
+        query).fetchall()
+    result = list(map(util.remove_nones_to_dict, map(dict, result)))
+    return ['ok', json.dumps(result)] if raw else result
 
 
 @patch("wazuh.core.vulnerability.WazuhDBBackend")
@@ -20,7 +35,7 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 @patch('socket.socket.connect')
 def test_WazuhDBQueryVulnerability__init__(mock_conn, mock_info, mock_send, mock_wazuhDBQuery, mock_backend):
     """Test if method __init__ of WazuhDBQueryVulnerability calls WazuhDBQuery with expected params"""
-    WazuhDBQueryVulnerability(agent_id='001', offset=500, limit=500, query='version>3.9.81')
+    vulnerability.WazuhDBQueryVulnerability(agent_id='001', offset=500, limit=500, query='version>3.9.81')
     mock_backend.assert_called_once_with('001')
     mock_wazuhDBQuery.assert_called_once_with(
         ANY, offset=500, limit=500, table='vuln_cves', sort=None, search=None, select=None,
@@ -35,33 +50,19 @@ def test_WazuhDBQueryVulnerability__init__(mock_conn, mock_info, mock_send, mock
     )
 
 
-def test_WazuhDBQueryVulnerability_format_data_into_dictionary():
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_WazuhDBQueryVulnerability_format_data_into_dictionary(socket_mock, send_mock):
     """Check that WazuhDBQueryVulnerability's method _format_data_into_dictionary works properly."""
-    data = [
-        {"version": "5.0-6ubuntu1.1", "detection_time": "1647338576",
-         "external_references": '["https://www.youtube.com/watch?v=-wGtxJ8opa8",'
-                                '"https://github.com/bminor/bash/commit/951bdaad7a18cc0dc1036bba86b18b90874d39ff",'
-                                '"http://packetstormsecurity.com/files/155498/Bash-5.0-Patch-11-Privilege-Escalation'
-                                '.html","https://security.netapp.com/advisory/ntap-20200430-0003/",'
-                                '"https://lists.apache.org/thread.html'
-                                '/rf9fa47ab66495c78bb4120b0754dd9531ca2ff0430f6685ac9b07772@%3Cdev.mina.apache.org%3E'
-                                '","https://security.gentoo.org/glsa/202105-34",'
-                                '"https://nvd.nist.gov/vuln/detail/CVE-2019-18276",'
-                                '"http://people.canonical.com/~ubuntu-security/cve/2019/CVE-2019-18276.html",'
-                                '"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18276"]',
-         "title": "CVE-2019-18276 affects bash", "cve": "CVE-2019-18276", "name": "bash", "published": "2019-11-28",
-         "updated": "2021-05-26", "cvss2_score": 7.2, "condition": "Package unfixed", "architecture": "amd64",
-         "type": "PACKAGE", "cvss3_score": 7.8, "severity": "High", "status": "VALID"}
-    ]
+    with vulnerability.WazuhDBQueryVulnerability(agent_id='001', limit=1) as db_query:
+        item = db_query.run()['items'][0]
 
-    with patch('wazuh.core.vulnerability.WazuhDBBackend.__init__', return_value=None), \
-            patch('wazuh.core.vulnerability.Agent.get_basic_information', return_value=None):
-        wdb_vuln = WazuhDBQueryVulnerability(1)
+    expected_item = {
+        'severity': 'Low', 'cvss3_score': 2.5, 'title': 'ASH-AIO before 2.0.0.3 allows an open redirect.', 'type': 'OS',
+        'cve': 'CVE-2019-1020016', 'architecture': 'x86', 'updated': '2019-08-01', 'condition': 'Package unfixed',
+        'published': '2019-07-29', 'status': 'OBSOLETE', 'detection_time': datetime(2021, 6, 14, 7, 45, 51),
+        'cvss2_score': 1.9, 'name': 'Ash-aio', 'version': '2.0.0.0',
+        'external_references': ['https://github.com/ASHTeam/ash-aio-2/security/advisories/GHSA-cg3m-qj5v-8g48']
+    }
 
-    wdb_vuln._data = data
-    result = wdb_vuln._format_data_into_dictionary()
-
-    item = result['items'][0]
-    assert all(item[field] == data[0][field] for field in item.keys() - {'external_references', 'detection_time'})
-    assert item['external_references'] == eval(data[0]['external_references'])
-    assert item['detection_time'] == datetime.utcfromtimestamp(int(data[0]['detection_time']))
+    assert all(item[field] == expected_item[field] for field in item.keys())

--- a/framework/wazuh/core/vulnerability.py
+++ b/framework/wazuh/core/vulnerability.py
@@ -14,12 +14,15 @@ class WazuhDBQueryVulnerability(WazuhDBQuery):
     fields = {
         'name': 'name', 'version': 'version', 'architecture': 'architecture', 'cve': 'cve', 'status': 'status',
         'type': 'type', 'detection_time': 'detection_time', 'severity': 'severity', 'cvss2_score': 'cvss2_score',
-        'cvss3_score': 'cvss3_score'
+        'cvss3_score': 'cvss3_score', 'external_references': 'external_references', 'condition': 'condition',
+        'title': 'title', 'published': 'published', 'updated': 'updated'
     }
 
     def __init__(self, agent_id, offset=0, limit=common.database_limit, sort=None, search=None, select=None, query='',
-                 count=True, get_data=True, distinct=False, default_sort_field='name', filters=None, fields=fields,
+                 count=True, get_data=True, distinct=False, default_sort_field='name', filters=None, fields=None,
                  table='vuln_cves'):
+        if fields is None:
+            fields = WazuhDBQueryVulnerability.fields
         if filters is None:
             filters = {}
         # Check if the agent exists

--- a/framework/wazuh/core/vulnerability.py
+++ b/framework/wazuh/core/vulnerability.py
@@ -42,7 +42,7 @@ class WazuhDBQueryVulnerability(WazuhDBQuery):
                 except (ValueError, TypeError):
                     pass
 
-            return value
+            return value if field_name != 'external_references' else eval(value)
 
         self._data = [{key: format_fields(key, value) for key, value in item.items()} for item in self._data]
 

--- a/framework/wazuh/core/vulnerability.py
+++ b/framework/wazuh/core/vulnerability.py
@@ -2,6 +2,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GP
 
+import json
 from datetime import datetime
 
 from wazuh.core import common
@@ -42,7 +43,10 @@ class WazuhDBQueryVulnerability(WazuhDBQuery):
                 except (ValueError, TypeError):
                     pass
 
-            return value if field_name != 'external_references' else eval(value)
+            elif field_name == 'external_references':
+                return json.loads(value)
+
+            return value
 
         self._data = [{key: format_fields(key, value) for key, value in item.items()} for item in self._data]
 
@@ -51,6 +55,7 @@ class WazuhDBQueryVulnerability(WazuhDBQuery):
 
 class WazuhDBQueryGroupByVulnerability(WazuhDBQueryGroupBy, WazuhDBQueryVulnerability):
     """Class to obtain CVEs summary information."""
+
     def __init__(self, filter_fields, *args, **kwargs):
         WazuhDBQueryVulnerability.__init__(self, *args, **kwargs)
         date_fields = self.date_fields

--- a/framework/wazuh/tests/data/schema_cve_test.sql
+++ b/framework/wazuh/tests/data/schema_cve_test.sql
@@ -38,19 +38,45 @@ CREATE TABLE IF NOT EXISTS vuln_metadata (
 BEGIN;
 
 -- Data from https://www.cvedetails.com/vulnerability-list/
-INSERT INTO vuln_cves (name,version,architecture,cve,type,status,detection_time,severity,cvss2_score,cvss3_score,reference)
-VALUES ('Invenio-previewer', '0.1.0', 'ARM', 'CVE-2019-1020019', 'OS', 'VALID', '1623656751', 'Medium', 4.3, 6.1, '0198aaaadb185181ad323433735248fbf41362b5');
+INSERT INTO vuln_cves (name, version, architecture, cve, type, status, detection_time, severity, cvss2_score,
+                       cvss3_score, reference, external_references, condition, title, published, updated)
+VALUES ('Invenio-previewer', '0.1.0', 'ARM', 'CVE-2019-1020019', 'OS', 'VALID', '1623656751', 'Medium', 4.3, 6.1,
+        '0198aaaadb185181ad323433735248fbf41362b5',
+        '["https://github.com/inveniosoftware/invenio-previewer/security/advisories/GHSA-j9m2-6hq2-4r3c"]',
+        'Package unfixed', 'invenio-previewer before 1.0.0a12 allows XSS.', '2019-07-29', '2019-07-31');
 
-INSERT INTO vuln_cves (name,version,architecture,cve,type,status,detection_time,severity,cvss2_score,cvss3_score,reference)
-VALUES ('Discourse', '0.8.0', 'PowerPC', 'CVE-2019-1020018', 'OS', 'VALID', '1623656751', 'High', 7.5, 7.3, '24cbb88312a71cc2fee7b9fb545cfd404ea7c9a8');
+INSERT INTO vuln_cves (name, version, architecture, cve, type, status, detection_time, severity, cvss2_score,
+                       cvss3_score, reference, external_references, condition, title, published, updated)
+VALUES ('Discourse', '0.8.0', 'PowerPC', 'CVE-2019-1020018', 'OS', 'VALID', '1623656751', 'High', 7.5, 7.3,
+        '24cbb88312a71cc2fee7b9fb545cfd404ea7c9a8',
+        '["https://github.com/discourse/discourse/commit/b8340c6c8e50a71ff1bca9654b9126ca5a84ce9a","https://github.com/discourse/discourse/commit/52387be4a44cdeaca5421ee955ba1343e836bade"]',
+        'Package unfixed',
+        'Discourse before 2.3.0 and 2.4.x before 2.4.0.beta3 lacks a confirmation screen when logging in via an email link.',
+        '2019-07-29', '2021-07-21');
 
-INSERT INTO vuln_cves (name,version,architecture,cve,type,status,detection_time,severity,cvss2_score,cvss3_score,reference)
-VALUES ('Ash-aio', '2.0.0.0', 'x86', 'CVE-2019-1020016', 'OS', 'OBSOLETE', '1623656751', 'Low', 1.9, 2.5, 'fe22d729473dc47625a583dd97e1d3a779105b19');
+INSERT INTO vuln_cves (name, version, architecture, cve, type, status, detection_time, severity, cvss2_score,
+                       cvss3_score, reference, external_references, condition, title, published, updated)
+VALUES ('Ash-aio', '2.0.0.0', 'x86', 'CVE-2019-1020016', 'OS', 'OBSOLETE', '1623656751', 'Low', 1.9, 2.5,
+        'fe22d729473dc47625a583dd97e1d3a779105b19',
+        '["https://github.com/ASHTeam/ash-aio-2/security/advisories/GHSA-cg3m-qj5v-8g48"]', 'Package unfixed',
+        'ASH-AIO before 2.0.0.3 allows an open redirect.', '2019-07-29', '2019-08-01');
 
-INSERT INTO vuln_cves (name,version,architecture,cve,type,status,detection_time,severity,cvss2_score,cvss3_score,reference)
-VALUES ('Credential Helpers', '0.1.0', 'x86', 'CVE-2019-1020014', 'PACKAGE', 'OBSOLETE', '1623656949', 'Critical', 7.5, 9.8, '2783fabf4b0d5b5f3217703fb24bb75ec58a8ce3');
+INSERT INTO vuln_cves (name, version, architecture, cve, type, status, detection_time, severity, cvss2_score,
+                       cvss3_score, reference, external_references, condition, title, published, updated)
+VALUES ('Credential Helpers', '0.1.0', 'x86', 'CVE-2019-1020014', 'PACKAGE', 'OBSOLETE', '1623656949', 'Critical', 7.5,
+        9.8, '2783fabf4b0d5b5f3217703fb24bb75ec58a8ce3',
+        '["https://usn.ubuntu.com/4103-1/","https://github.com/docker/docker-credential-helpers/releases/tag/v0.6.3","https://usn.ubuntu.com/4103-2/","https://github.com/docker/docker-credential-helpers/commit/1c9f7ede70a5ab9851f4c9cb37d317fd89cd318a","https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/6VVFB6UWUK2GQQN7DVUU6GRRAL637A73/"]',
+        'Package unfixed','docker-credential-helpers before 0.6.3 has a double free in the List functions.',
+        '2019-07-29', '2021-01-14');
 
-INSERT INTO vuln_cves (name,version,architecture,cve,type,status,detection_time,severity,cvss2_score,cvss3_score,reference)
-VALUES ('Smokedetector', '-', 'x86', 'CVE-2019-1020011', 'PACKAGE', 'PENDING', '1623656949', 'High', 6.8, 8.1, 'e0680fb636baccbb7484f7b3daf5b4c0ce485960');
+INSERT INTO vuln_cves (name, version, architecture, cve, type, status, detection_time, severity, cvss2_score,
+                       cvss3_score, reference, external_references, condition, title, published, updated)
+VALUES ('Smokedetector', '-', 'x86', 'CVE-2019-1020011', 'PACKAGE', 'PENDING', '1623656949', 'High', 6.8, 8.1,
+        'e0680fb636baccbb7484f7b3daf5b4c0ce485960',
+        '["https://github.com/Charcoal-SE/SmokeDetector/security/advisories/GHSA-5w85-7mwr-v44q"]',
+        'Package unfixed',
+        'SmokeDetector intentionally does automatic deployments of updated copies of SmokeDetector without server operator authority.',
+        '2019-07-29', '2021-07-21');
 
-INSERT INTO vuln_metadata (LAST_PARTIAL_SCAN, LAST_FULL_SCAN) VALUES (1623656949, 1623656751);
+INSERT INTO vuln_metadata (LAST_PARTIAL_SCAN, LAST_FULL_SCAN)
+VALUES (1623656949, 1623656751);

--- a/framework/wazuh/tests/test_vulnerability.py
+++ b/framework/wazuh/tests/test_vulnerability.py
@@ -70,6 +70,10 @@ def send_msg_to_wdb(msg, raw=False):
     ({'q': 'name=Ash-aio;version>2.5'}, 'cve', []),
     ({'q': 'architecture=ARM,architecture=PowerPC'}, 'cve', ['CVE-2019-1020018', 'CVE-2019-1020019']),
     ({'q': '(architecture=ARM,architecture=PowerPC);version>0.5'}, 'cve', ['CVE-2019-1020018']),
+    ({'q': 'external_references~inveniosoftware'}, 'cve', ['CVE-2019-1020019']),
+    ({'q': 'condition!=Package unfixed'}, 'cve', []),
+    ({'q': 'published>2019-07-28;updated<2019-08-31'}, 'cve', ['CVE-2019-1020016', 'CVE-2019-1020019']),
+    ({'q': 'title~docker-credential-helpers before 0.6.3'}, 'cve', ['CVE-2019-1020014']),
     ({'select': ['architecture'], 'distinct': False}, 'architecture', ['x86', 'x86', 'PowerPC', 'ARM', 'x86']),
     ({'select': ['architecture'], 'distinct': True}, 'architecture', ['x86', 'PowerPC', 'ARM']),
 ])


### PR DESCRIPTION
|Related issue|
|---|
| #12619 |

This PR closes #12619.

In this pull request, I have updated the `GET /vulnerabilty/{agent_id}` to return new fields: `external_references`, `condition`, `title`, `published` and `updated`.

For the `external_references` field, I have updated the `_format_data_into_dictionary` function of `core/vulnerability` to transform the string representation of a list into a list.

I have also updated unit and API integration tests to include the new fields.


The `test_expected_value` function of `tavern_utils` has also been updated as it was not detecting some errors properly.
For instance, in one of the vulnerability API integration test cases, the `cve` filter was being used with a `type` value, so no affected items were returned and the test was passing, which was wrong.
As this function is used to test that the affected items have been filtered properly, there should be at least one item in the response.


### Manual tests

Request: `GET /vulnerability/001?limit=1`

Response:

```
{
  "data": {
    "affected_items": [
      {
        "severity": "High",
        "cvss3_score": 7.8,
        "cvss2_score": 6.8,
        "status": "VALID",
        "condition": "Package unfixed",
        "name": "binutils",
        "detection_time": "2022-03-15T09:04:05Z",
        "title": "CVE-2021-45078 affects binutils",
        "updated": "2022-01-10",
        "external_references": "[\"https://sourceware.org/bugzilla/show_bug.cgi?id=28694\",\"https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=161e87d12167b1e36193385485c1f6ce92f74f02\",\"https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UQBH244M5PV6S6UMHUTCVCWFZDX7Y4M6/\",\"https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UUHLDDT3HH7YEY6TX7IJRGPJUTNNVEL3/\",\"https://security.netapp.com/advisory/ntap-20220107-0002/\",\"https://nvd.nist.gov/vuln/detail/CVE-2021-45078\",\"http://people.canonical.com/~ubuntu-security/cve/2021/CVE-2021-45078.html\",\"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45078\"]",
        "version": "2.34-6ubuntu1.1",
        "architecture": "amd64",
        "type": "PACKAGE",
        "published": "2021-12-15",
        "cve": "CVE-2021-45078"
      }
    ],
    "total_affected_items": 342,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected vulnerabilities were returned",
  "error": 0
}
```



After changing `_format_data_into_dictionary` to return a list instead of a raw string (`external_references`):

```
{
  "data": {
    "affected_items": [
      {
        "updated": "2021-05-26",
        "detection_time": "2022-03-15T10:02:56Z",
        "version": "5.0-6ubuntu1.1",
        "architecture": "amd64",
        "title": "CVE-2019-18276 affects bash",
        "status": "VALID",
        "type": "PACKAGE",
        "cvss2_score": 7.2,
        "name": "bash",
        "condition": "Package unfixed",
        "cve": "CVE-2019-18276",
        "cvss3_score": 7.8,
        "severity": "High",
        "external_references": [
          "https://www.youtube.com/watch?v=-wGtxJ8opa8",
          "https://github.com/bminor/bash/commit/951bdaad7a18cc0dc1036bba86b18b90874d39ff",
          "http://packetstormsecurity.com/files/155498/Bash-5.0-Patch-11-Privilege-Escalation.html",
          "https://security.netapp.com/advisory/ntap-20200430-0003/",
          "https://lists.apache.org/thread.html/rf9fa47ab66495c78bb4120b0754dd9531ca2ff0430f6685ac9b07772@%3Cdev.mina.apache.org%3E",
          "https://security.gentoo.org/glsa/202105-34",
          "https://nvd.nist.gov/vuln/detail/CVE-2019-18276",
          "http://people.canonical.com/~ubuntu-security/cve/2019/CVE-2019-18276.html",
          "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18276"
        ],
        "published": "2019-11-28"
      },
      ...
```


### Test results

```
============================= test session starts ==============================
collecting ... collected 1 item

test_vulnerability.py::test_WazuhDBQueryVulnerability_format_data_into_dictionary PASSED [100%]

======================== 1 passed, 2 warnings in 0.12s =========================
```

```
============================= test session starts ==============================
collecting ... collected 32 items

test_vulnerability.py::test_get_agent_cve[params0-cve-expected_items0] PASSED [  3%]
test_vulnerability.py::test_get_agent_cve[params1-cve-expected_items1] PASSED [  6%]
test_vulnerability.py::test_get_agent_cve[params2-cve-expected_items2] PASSED [  9%]
test_vulnerability.py::test_get_agent_cve[params3-name-expected_items3] PASSED [ 12%]
test_vulnerability.py::test_get_agent_cve[params4-name-expected_items4] PASSED [ 15%]
test_vulnerability.py::test_get_agent_cve[params5-cve-expected_items5] PASSED [ 18%]
test_vulnerability.py::test_get_agent_cve[params6-cve-expected_items6] PASSED [ 21%]
test_vulnerability.py::test_get_agent_cve[params7-cve-expected_items7] PASSED [ 25%]
test_vulnerability.py::test_get_agent_cve[params8-cve-expected_items8] PASSED [ 28%]
test_vulnerability.py::test_get_agent_cve[params9-cve-expected_items9] PASSED [ 31%]
test_vulnerability.py::test_get_agent_cve[params10-cve-expected_items10] PASSED [ 34%]
test_vulnerability.py::test_get_agent_cve[params11-cve-expected_items11] PASSED [ 37%]
test_vulnerability.py::test_get_agent_cve[params12-cve-expected_items12] PASSED [ 40%]
test_vulnerability.py::test_get_agent_cve[params13-cve-expected_items13] PASSED [ 43%]
test_vulnerability.py::test_get_agent_cve[params14-cve-expected_items14] PASSED [ 46%]
test_vulnerability.py::test_get_agent_cve[params15-cve-expected_items15] PASSED [ 50%]
test_vulnerability.py::test_get_agent_cve[params16-cve-expected_items16] PASSED [ 53%]
test_vulnerability.py::test_get_agent_cve[params17-cve-expected_items17] PASSED [ 56%]
test_vulnerability.py::test_get_agent_cve[params18-cve-expected_items18] PASSED [ 59%]
test_vulnerability.py::test_get_agent_cve[params19-cve-expected_items19] PASSED [ 62%]
test_vulnerability.py::test_get_agent_cve[params20-cve-expected_items20] PASSED [ 65%]
test_vulnerability.py::test_get_agent_cve[params21-cve-expected_items21] PASSED [ 68%]
test_vulnerability.py::test_get_agent_cve[params22-cve-expected_items22] PASSED [ 71%]
test_vulnerability.py::test_get_agent_cve[params23-cve-expected_items23] PASSED [ 75%]
test_vulnerability.py::test_get_agent_cve[params24-cve-expected_items24] PASSED [ 78%]
test_vulnerability.py::test_get_agent_cve[params25-cve-expected_items25] PASSED [ 81%]
test_vulnerability.py::test_get_agent_cve[params26-cve-expected_items26] PASSED [ 84%]
test_vulnerability.py::test_get_agent_cve[params27-cve-expected_items27] PASSED [ 87%]
test_vulnerability.py::test_get_agent_cve[params28-cve-expected_items28] PASSED [ 90%]
test_vulnerability.py::test_get_agent_cve[params29-cve-expected_items29] PASSED [ 93%]
test_vulnerability.py::test_get_agent_cve[params30-architecture-expected_items30] PASSED [ 96%]
test_vulnerability.py::test_get_agent_cve[params31-architecture-expected_items31] PASSED [100%]

======================== 32 passed, 9 warnings in 0.62s ========================
```

Tests using test_expected_value have also been performed.

```

test_cluster_endpoints.tavern.yaml 
	 45 passed, 47 warnings

test_manager_endpoints.tavern.yaml 
	 31 passed, 33 warnings

test_rootcheck_endpoints.tavern.yaml 
	 4 passed, 6 warnings

test_task_endpoints.tavern.yaml 
	 2 passed, 4 warnings

test_vulnerability_endpoints.tavern.yaml 
	 2 passed, 4 warnings
```