### PR TITLE
Change log location and message

### DIFF
--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -1448,8 +1448,8 @@ class SyncWazuhdb(SyncTask):
                                                                       f'not be sent to the master node: {task_id}')
 
             # Specify under which task_id the JSON can be found in the master/worker.
+            self.logger.debug(f"Sending chunks.")
             await self.server.send_request(command=self.cmd, data=task_id)
-            self.logger.debug(f"All chunks sent.")
         else:
             self.logger.info(f"Finished in {(perf_counter() - start_time):.3f}s (0 chunks sent).")
         return True

--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -1421,7 +1421,7 @@ async def test_sync_wazuh_db_sync_ok(perf_counter_mock, json_dumps_mock):
                 send_request_mock.assert_called_once_with(command=b"cmd", data=b"OK")
                 json_dumps_mock.assert_called_with({'set_data_command': 'set_command',
                                                     'payload': {}, 'chunks': ['a', 'b']})
-                logger_debug_mock.assert_has_calls([call(f"All chunks sent.")])
+                logger_debug_mock.assert_has_calls([call(f"Sending chunks.")])
 
             send_string_mock.assert_called_with(b"")
 


### PR DESCRIPTION
|Related issue|
|---|
|#12702|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This closes #12702. The aim of this pull is to change the log location and message in order to avoid a race condition. This race condition could happen if the `Finished in...` log is sent before the `All chunks sent` one. 