### PR TITLE
Dev 12699 engine integrate hlp

### DIFF
--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -109,7 +109,7 @@ add_subdirectory(${ENGINE_SOURCE_DIR}/builder)
 add_subdirectory(${ENGINE_SOURCE_DIR}/cliParser)
 add_subdirectory(${ENGINE_SOURCE_DIR}/hlp)
 
-target_link_libraries(main  ${EXTERNAL_DEPS})
+target_link_libraries(main  hlp ${EXTERNAL_DEPS})
 
 # Build test
 if(ENGINE_BUILD_TEST)

--- a/src/engine/source/builder/CMakeLists.txt
+++ b/src/engine/source/builder/CMakeLists.txt
@@ -79,6 +79,7 @@ target_sources(main PRIVATE
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/assetBuilderFilter.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/assetBuilderRule.cpp
   ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/assetBuilderDecoder.cpp
+  ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/stageParse.cpp
 )
 
 target_include_directories(main PUBLIC

--- a/src/engine/source/builder/builders/stageParse.cpp
+++ b/src/engine/source/builder/builders/stageParse.cpp
@@ -1,0 +1,125 @@
+/* Copyright (C) 2015-2021, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "stageBuilderNormalize.hpp"
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <glog/logging.h>
+
+#include "registry.hpp"
+#include <hlp/hlp.hpp>
+
+#include <rapidjson/prettywriter.h>
+
+namespace builder::internals::builders
+{
+
+types::Lifter stageBuilderParse(const types::DocumentValue &def)
+{
+    // Assert value is as expected
+    if(!def.IsObject())
+    {
+        std::string msg = "Stage parse builder, expected array but got " +
+                          std::to_string(def.GetType());
+        LOG(ERROR) << msg;
+        throw std::invalid_argument(msg);
+    }
+
+    auto parseObj = def.GetObj();
+
+    if(!parseObj["logql"].IsArray())
+    {
+        //TODO ERROR
+        throw std::invalid_argument("Config format error. Check the parser section.");
+    }
+
+    auto const& logqlArr = parseObj["logql"];
+    if(logqlArr.Empty())
+    {
+        //TODO error
+        throw std::invalid_argument("Must have some expressions configured.");
+    }
+
+    std::vector<types::Lifter> parsers;
+    for(auto const& item : logqlArr.GetArray())
+    {
+        if(!item.IsObject())
+        {
+            throw std::invalid_argument("Could not find expression.");
+        }
+
+        auto logQlExpr = item["event.original"].GetString();
+
+        auto newOp = [parserOp = getParserOp(logQlExpr)](types::Observable o)
+        {
+            return o.map(
+                [parserOp = std::move(parserOp)](types::Event e)
+                {
+                    rapidjson::StringBuffer s;
+                    rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(s);
+                    e->m_doc.Accept(writer);
+
+                    auto ev = e->get("/message");
+                    if(!ev->IsString())
+                    {
+                        // TODO error
+                        return e;
+                    }
+
+                    ParseResult result;
+                    bool ok = parserOp(ev->GetString(), result);
+                    if(!ok)
+                    {
+                        // TODO error
+                        return e;
+                    }
+
+                    for(auto const &val : result)
+                    {
+                        auto obj = e->getObject();
+                        rapidjson::Value name;
+                        rapidjson::Value v;
+                        v.SetString(val.second.c_str(),
+                                    val.second.size(),
+                                    e->getAllocator());
+                        name.SetString(val.first.c_str(),
+                                       val.first.size(),
+                                       e->getAllocator());
+                        obj.AddMember(name, v, e->getAllocator());
+                    }
+
+                    std::cout << "----RESULT----\n" << s.GetString();
+
+                    return e;
+                });
+        };
+
+        parsers.emplace_back(newOp);
+    }
+
+    try
+    {
+        auto check = std::get<types::CombinatorBuilder>(
+            Registry::getBuilder("combinator.chain"))(parsers);
+        return check;
+    }
+    catch(std::exception &e)
+    {
+        const char *msg = "Stage parse builder encountered exception "
+                          "chaining all mappings.";
+        LOG(ERROR) << msg << " From exception: " << e.what();
+        std::throw_with_nested(std::runtime_error(msg));
+    }
+
+}
+
+} // namespace builder::internals::builders

--- a/src/engine/source/builder/builders/stageParse.hpp
+++ b/src/engine/source/builder/builders/stageParse.hpp
@@ -1,0 +1,28 @@
+/* Copyright (C) 2015-2021, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _STAGE_BUILDER_PARSING_H
+#define _STAGE_BUILDER_PARSING_H
+
+#include "builderTypes.hpp"
+
+namespace builder::internals::builders
+{
+
+/**
+ * @brief Builds stage parsing
+ *
+ * @param def
+ * @return types::Lifter
+ */
+types::Lifter stageBuilderParse(const types::DocumentValue &def);
+
+} // namespace builder::internals::builders
+
+#endif // _STAGE_BUILDER_PARSING_H

--- a/src/engine/source/builder/register.hpp
+++ b/src/engine/source/builder/register.hpp
@@ -32,6 +32,7 @@
 #include "stageBuilderCheck.hpp"
 #include "stageBuilderNormalize.hpp"
 #include "stageBuilderOutputs.hpp"
+#include "stageParse.hpp"
 
 namespace builder::internals
 {
@@ -77,6 +78,7 @@ void registerBuilders()
     // Stages
     Registry::registerBuilder("check", builders::stageBuilderCheck);
     Registry::registerBuilder("allow", builders::stageBuilderCheck);
+    Registry::registerBuilder("parse", builders::stageBuilderParse);
     Registry::registerBuilder("normalize", builders::stageBuilderNormalize);
     Registry::registerBuilder("outputs", builders::stageBuilderOutputs);
     // Assets

--- a/src/engine/source/hlp/include/hlp/hlp.hpp
+++ b/src/engine/source/hlp/include/hlp/hlp.hpp
@@ -5,7 +5,7 @@
 #include <unordered_map>
 
 using ParseResult = std::unordered_map<std::string, std::string>;
-using ParserFn = std::function<bool(std::string, ParseResult& result)>;
+using ParserFn = std::function<bool(std::string_view const&, ParseResult& result)>;
 
 /**
  * @brief Gets a parser operator from a logQL expression.
@@ -14,6 +14,6 @@ using ParserFn = std::function<bool(std::string, ParseResult& result)>;
  *
 * @return ParserFn A Parser Function capable to parse an event.
  */
-ParserFn getParserOp(std::string const &logQl);
+ParserFn getParserOp(std::string_view const &logQl);
 
 #endif // _HLP_H

--- a/src/engine/source/hlp/src/LogQLParser.cpp
+++ b/src/engine/source/hlp/src/LogQLParser.cpp
@@ -165,11 +165,10 @@ static bool parseCapture(Tokenizer &tk, ExpressionList &expresions)
     return true;
 }
 
-ExpressionList parseLogQlExpr(std::string const &expr)
+ExpressionList parseLogQlExpr(const char* expr)
 {
     ExpressionList expresions;
-    Tokenizer tokenizer {expr.c_str()};
-
+    Tokenizer tokenizer {expr};
     bool done = false;
     while(!done)
     {

--- a/src/engine/source/hlp/src/LogQLParser.hpp
+++ b/src/engine/source/hlp/src/LogQLParser.hpp
@@ -35,6 +35,6 @@ using ExpressionList = std::vector<Expression>;
  * @note This function requires that the original string live for the duration
  *       that you need each piece as the vector refers to the original string
  */
-ExpressionList parseLogQlExpr(std::string const &expr);
+ExpressionList parseLogQlExpr(const char *expr);
 
 #endif //_LOGQL_PARSER_H

--- a/src/engine/source/hlp/src/hlp.cpp
+++ b/src/engine/source/hlp/src/hlp.cpp
@@ -165,11 +165,11 @@ std::vector<Parser> getParserList(ExpressionList const &expresions)
     return parsers;
 }
 
-static bool executeParserList(std::string const &event,
+static bool executeParserList(std::string_view const &event,
                               ParserList const &parsers,
                               ParseResult &result)
 {
-    const char *eventIt = event.c_str();
+    const char *eventIt = event.data();
 
     // TODO This implementation is super simple for the POC
     // but we will want to re-do it or revise it to implement
@@ -209,7 +209,7 @@ static bool executeParserList(std::string const &event,
     return true;
 }
 
-ParserFn getParserOp(std::string const &logQl)
+ParserFn getParserOp(std::string_view const &logQl)
 {
     if(logQl.empty())
     {
@@ -217,7 +217,7 @@ ParserFn getParserOp(std::string const &logQl)
         return {};
     }
 
-    ExpressionList expresions = parseLogQlExpr(logQl);
+    ExpressionList expresions = parseLogQlExpr(logQl.data());
     if(expresions.empty())
     {
         // TODO some error occurred while parsing the logQl expr
@@ -231,8 +231,8 @@ ParserFn getParserOp(std::string const &logQl)
         return {};
     }
 
-    ParserFn parseFn = [expr = logQl, parserList = std::move(parserList)](
-                           std::string const &event, ParseResult &result)
+    ParserFn parseFn = [parserList = std::move(parserList)](
+                           std::string_view const &event, ParseResult &result)
     {
         return executeParserList(event, parserList, result);
     };

--- a/src/engine/test/acceptance_test/utils/test_logs.txt
+++ b/src/engine/test/acceptance_test/utils/test_logs.txt
@@ -1,35 +1,35 @@
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #1
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #2
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #3
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #4
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #5
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #6
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #7
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #8
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #9
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #10
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #11
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #12
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #13
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #14
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #15
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #16
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #17
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #18
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #19
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #20
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #21
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #22
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #23
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #24
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #25
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #26
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #27
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #28
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #29
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #30
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #31
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #32
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #33
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #34
-Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #35
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #1
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #2
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #3
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #4
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #5
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #6
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #7
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #8
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #9
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #10
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #11
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #12
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #13
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #14
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #15
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #16
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #17
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #18
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #19
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #20
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #21
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #22
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #23
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #24
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #25
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #26
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #27
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #28
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #29
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #30
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #31
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #32
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #33
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #34
+[Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: Test_example for acceptation test #35

--- a/src/engine/test/assets/decoders/decoder_test.yml
+++ b/src/engine/test/assets/decoders/decoder_test.yml
@@ -4,6 +4,11 @@ check:
   - location: +exists
   - message: +exists
 
+parse:
+  logql:
+    #Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #10
+    - event.original: "[<timestamp/ANSIC>] <host> <tloc>[<locNum>]: <logLine>#<index>"
+
 normalize:
   - decoded.queue: decoded_queue
   - decoded.location: decoded_location


### PR DESCRIPTION
|Related issue|
|---|
|#12699|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Integrating new stage `Parse` to the new engine development. The new parse stage expects an object `LogQl ` that contains an array of objects `jsonref : logql-expr`. 
```
parse:
  logql:
    #Dec 10 01:02:02 host test_decoder_example[1234]: Test_example for acceptation test #10
    - event.original: "[<timestamp/ANSIC>] <host> <tloc>[<locNum>]: <logLine>#<index>"
```
The new stage will use the HLP code to parse the original log message into pieces dictated by the logql expression and add them to the resulting event.