### PR TITLE
Run external SCA commands as root:root

### DIFF
--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -106,6 +106,10 @@ https://www.gnu.org/licenses/gpl.html\n"
 #define GROUPGLOBAL     "wazuh"
 #endif
 
+#define ROOT_UID (0)
+
+#define ROOT_GID (0)
+
 // Wazuh home environment variable
 #define WAZUH_HOME_ENV  "WAZUH_HOME"
 

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -47,6 +47,11 @@ static volatile HANDLE wm_children[WM_POOL_SIZE] = { NULL };   // Child process 
 
 // Execute command with timeout of secs
 
+int wm_exec_as(char *command, char **output, int *status, int secs, const char * add_path, uid_t uid, gid_t gid)
+{
+    return wm_exec(command, output, status, secs, add_path);
+}
+
 int wm_exec(char *command, char **output, int *status, int secs, const char * add_path) {
     HANDLE hThread = NULL;
     DWORD dwCreationFlags;

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -47,7 +47,7 @@ static volatile HANDLE wm_children[WM_POOL_SIZE] = { NULL };   // Child process 
 
 // Execute command with timeout of secs
 
-int wm_exec_as(char *command, char **output, int *status, int secs, const char * add_path, uid_t uid, gid_t gid)
+int wm_exec_as(char *command, char **output, int *status, int secs, const char * add_path, __attribute__((unused)) uid_t uid, __attribute__((unused)) gid_t gid)
 {
     return wm_exec(command, output, status, secs, add_path);
 }

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -272,8 +272,12 @@ static void* reader(void *args);   // Reading thread's start point
 static volatile pid_t wm_children[WM_POOL_SIZE] = { 0 };                // Child process pool
 
 // Execute command with timeout of secs
-
 int wm_exec(char *command, char **output, int *exitcode, int secs, const char * add_path)
+{
+    return wm_exec_as(command, output, exitcode, secs, add_path, getuid(), getgid());
+}
+
+int wm_exec_as(char *command, char **output, int *exitcode, int secs, const char * add_path, uid_t uid, gid_t gid)
 {
     char **argv;
     pid_t pid;
@@ -317,6 +321,16 @@ int wm_exec(char *command, char **output, int *exitcode, int secs, const char * 
     case 0:
 
         // Child
+
+        // Change process user and group
+
+        if (setuid(uid) == -1) {
+            merror_exit("Cannot UID to  %d: %d (%s).", uid, errno, strerror(errno));
+        }
+
+        if (setgid(gid) == -1) {
+            merror_exit("Cannot change GID to %d: %d (%s).", gid, errno, strerror(errno));
+        }
 
         // Add environment variable if exists
 

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -1638,7 +1638,7 @@ static int wm_sca_read_command(char *command, char *pattern, wm_sca_t * data, ch
     char *cmd_output = NULL;
     int result_code;
 
-    switch (wm_exec(command, &cmd_output, &result_code, data->commands_timeout, NULL)) {
+    switch (wm_exec_as(command, &cmd_output, &result_code, data->commands_timeout, NULL, ROOT_UID, ROOT_GID)) {
     case 0:
         mdebug1("Command '%s' returned code %d", command, result_code);
         break;

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -119,6 +119,18 @@ void wm_module_free(wmodule * config);
  */
 int wm_exec(char *command, char **output, int *exitcode, int secs, const char * add_path);
 
+/* Same as wm_exec, but runs the command with the credentials specified.
+ *
+ * command is a mutable string.
+ * output is a pointer to dynamic string. Caller is responsible for freeing it!
+ * uid and gid are the user and group ID we should change to before forking.
+ * On success, return 0. On another error, returns -1.
+ * If the called program timed-out, returns WM_ERROR_TIMEOUT and output may
+ * contain data.
+ * env_path is a pointer to an string to add to the PATH environment variable.
+ */
+int wm_exec_as(char *command, char **output, int *exitcode, int secs, const char * add_path, uid_t uid, gid_t gid);
+
 #ifdef WIN32
 // Add process to pool
 void wm_append_handle(HANDLE hProcess);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #10828|

## Description

This PR makes SCA run external commands with UID=0 and GID=0 to solve a bug where an external command would corrupt permissions because of being run was root:wazuh (#10828).

This PR is the alternative solution to running all Wazuh processes as root (https://github.com/wazuh/wazuh/pull/12530)

## Tests

This fix was tested by following the bug reproduction steps on #10828. That is:
1. Verify the permissions of the /var/lib/rpm/__db.* files are root:root.
2. Compiling and installing the wazuh agent from sources
3. Enable and run service 
4. Verify the permissions of the /var/lib/rpm/__db.* files again. They continue to be root:root.
