### PR TITLE
Fix FIMDB related warnings.

### DIFF
--- a/architecture/FIM/db/class.puml
+++ b/architecture/FIM/db/class.puml
@@ -98,7 +98,6 @@ class "FimDB"  <<(S,#FF7700) Singleton>> {
     - int m_registryLimit
     - int m_syncInterval
     - bool m_stopping
-    - bool m_isWindows
     - mutex m_fimSyncMutex
     - condition_variable m_cv
     - shared_ptr<DBSync> m_dbsyncHandler

--- a/src/syscheckd/src/db/src/fimDB.hpp
+++ b/src/syscheckd/src/db/src/fimDB.hpp
@@ -276,7 +276,6 @@ class FIMDB
 
         unsigned int                                                            m_syncInterval;
         bool                                                                    m_stopping;
-        bool                                                                    m_isWindows;
         std::mutex                                                              m_fimSyncMutex;
         std::condition_variable                                                 m_cv;
         std::shared_ptr<DBSync>                                                 m_dbsyncHandler;

--- a/src/syscheckd/src/db/src/fimDBSpecialization.h
+++ b/src/syscheckd/src/db/src/fimDBSpecialization.h
@@ -170,9 +170,9 @@ template <OSType osType>
 class FIMDBCreator final
 {
     public:
-        static void setLimits(std::shared_ptr<DBSync> DBSyncHandler,
-                              const unsigned int& fileLimit,
-                              const unsigned int& registryLimit)
+        static void setLimits(__attribute__((unused)) std::shared_ptr<DBSync> DBSyncHandler,
+                              __attribute__((unused)) const unsigned int& fileLimit,
+                              __attribute__((unused)) const unsigned int& registryLimit)
         {
             throw std::runtime_error
             {
@@ -188,11 +188,11 @@ class FIMDBCreator final
             };
         }
 
-        static void registerRsync(std::shared_ptr<RemoteSync> RSyncHandler,
-                                  const RSYNC_HANDLE& handle,
-                                  std::function<void(const std::string&)> syncFileMessageFunction,
+        static void registerRsync(__attribute__((unused)) std::shared_ptr<RemoteSync> RSyncHandler,
+                                  __attribute__((unused)) const RSYNC_HANDLE& handle,
+                                  __attribute__((unused)) std::function<void(const std::string&)> syncFileMessageFunction,
                                   __attribute__((unused)) std::function<void(const std::string&)> syncRegistryMessageFunction,
-                                  const bool syncRegistryEnabled)
+                                  __attribute__((unused)) const bool syncRegistryEnabled)
         {
             throw std::runtime_error
             {
@@ -200,9 +200,9 @@ class FIMDBCreator final
             };
         }
 
-        static void sync(std::shared_ptr<RemoteSync> RSyncHandler,
-                         const DBSYNC_HANDLE& handle,
-                         std::function<void(const std::string&)> syncFileMessageFunction,
+        static void sync(__attribute__((unused)) std::shared_ptr<RemoteSync> RSyncHandler,
+                         __attribute__((unused)) const DBSYNC_HANDLE& handle,
+                         __attribute__((unused)) std::function<void(const std::string&)> syncFileMessageFunction,
                          __attribute__((unused)) std::function<void(const std::string&)> syncRegistryMessageFunction)
         {
             throw std::runtime_error
@@ -211,7 +211,7 @@ class FIMDBCreator final
             };
         }
 
-        static void encodeString(std::string& stringToEncode)
+        static void encodeString(__attribute__((unused)) std::string& stringToEncode)
         {
             throw std::runtime_error
             {

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -479,6 +479,7 @@ void * fim_run_realtime(__attribute__((unused)) void * args) {
     w_rwlock_unlock(&syscheck.directories_lock);
 
     pthread_exit(NULL);
+    return NULL;
 }
 #endif
 // LCOV_EXCL_STOP

--- a/src/win32/win_service.c
+++ b/src/win32/win_service.c
@@ -246,8 +246,6 @@ int UninstallService()
 /* "Signal" handler */
 VOID WINAPI OssecServiceCtrlHandler(DWORD dwOpcode)
 {
-    extern bool is_fim_shutdown;
-
     if (ossecServiceStatusHandle) {
         switch (dwOpcode) {
             case SERVICE_CONTROL_STOP:
@@ -257,6 +255,8 @@ VOID WINAPI OssecServiceCtrlHandler(DWORD dwOpcode)
 
                 minfo("Received exit signal. Starting exit process.");
 #ifdef OSSECHIDS
+                extern bool is_fim_shutdown;
+
                 ossecServiceStatus.dwCurrentState           = SERVICE_STOP_PENDING;
                 SetServiceStatus (ossecServiceStatusHandle, &ossecServiceStatus);
                 minfo("Set pending exit signal.");


### PR DESCRIPTION
|Related issue|
|---|
||

This PR aims to fix several warnings found while testing MacOS
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux (GCC 11.2)
  - [X] Windows (MinGW  7.3-win32 20180312)
  - [X] MAC OS X (Apple LLVM version 10.0.1 (clang-1001.0.46.4))
