### PR TITLE
Fix for groups synchronization between `etc/shared` folder and wazuh-db to allow the addition of groups with a name starting with `.` or `..` to the `group` table in the global.db database

### DIFF
--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -850,7 +850,6 @@ static void * wm_inotify_start(__attribute__((unused)) void * args) {
     char keysfile_dir[PATH_MAX] = KEYS_FILE;
     char * keysfile;
     struct inotify_event *event;
-    char * dirname = NULL;
     ssize_t count;
     size_t i;
 
@@ -876,6 +875,7 @@ static void * wm_inotify_start(__attribute__((unused)) void * args) {
             buffer[count - 1] = '\0';
 
             for (i = 0; i < (size_t)count; i += (ssize_t)(sizeof(struct inotify_event) + event->len)) {
+                char * dirname = NULL;
                 char path[PATH_MAX + 1] = {0};
                 event = (struct inotify_event*)&buffer[i];
                 mtdebug2(WM_DATABASE_LOGTAG, "inotify: i='%zu', name='%s', mask='%u', wd='%d'", i, event->name, event->mask, event->wd);
@@ -903,7 +903,7 @@ static void * wm_inotify_start(__attribute__((unused)) void * args) {
                     continue;
                 }
 
-                snprintf(path, PATH_MAX, "%s/%s", dirname, event->name);
+                snprintf(path, PATH_MAX, "%s/%s", dirname?dirname:"", event->name);
 
                 if (event->name[0] == '.' && IsDir(path)) {
                     mtdebug2(WM_DATABASE_LOGTAG, "Discarding hidden file.");

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -876,6 +876,7 @@ static void * wm_inotify_start(__attribute__((unused)) void * args) {
             buffer[count - 1] = '\0';
 
             for (i = 0; i < (size_t)count; i += (ssize_t)(sizeof(struct inotify_event) + event->len)) {
+                char path[PATH_MAX + 1] = {0};
                 event = (struct inotify_event*)&buffer[i];
                 mtdebug2(WM_DATABASE_LOGTAG, "inotify: i='%zu', name='%s', mask='%u', wd='%d'", i, event->name, event->mask, event->wd);
 
@@ -899,6 +900,13 @@ static void * wm_inotify_start(__attribute__((unused)) void * args) {
                     continue;
                 } else {
                     mterror(WM_DATABASE_LOGTAG, "Unknown watch descriptor '%d', mask='%u'.", event->wd, event->mask);
+                    continue;
+                }
+
+                snprintf(path, PATH_MAX, "%s/%s", dirname, event->name);
+
+                if (event->name[0] == '.' && IsDir(path)) {
+                    mtdebug2(WM_DATABASE_LOGTAG, "Discarding hidden file.");
                     continue;
                 }
 


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/12742 |

## Description

This pull request implements two modifications to allow the addition of groups with a name starting with `.` or `..` to the `group` table in the global.db database in the **wm_database** synchronization logic:

- The periodical synchronization (executed also during the **modulesd** initialization) has been modified to avoid discharging folders starting with `.` or `..`.
- The synchronization mechanism based on **inotify** was modified to avoid discarding items starting with `.` or `..`.

Other changes:

- In addition, it is implemented a modification to avoid duplicating an array with the names of all the groups. Instead, now it works directly with the data received in a JSON from wazuh-db.

## Logs/Alerts example

### Adding a group called `test_group`

- Addition

```
root@UbuntuDEV:/home/diego/wazuh-repos/wazuh# /var/ossec/bin/agent_groups -a -g test_group
Do you want to create the group 'test_group'? [y/N]: y
Group 'test_group' created.
```

- Logs

```
2022/03/16 14:46:43 wazuh-modulesd:database[23627] wm_database.c:880 at wm_inotify_start(): DEBUG: inotify: i='0', name='test_group', mask='1073742080', wd='2'
2022/03/16 14:46:43 wazuh-modulesd:database[23627] wm_database.c:941 at wm_inotify_push(): DEBUG: Adding 'etc/shared/test_group' to path table.
2022/03/16 14:46:43 wazuh-modulesd:database[23627] wm_database.c:972 at wm_inotify_pop(): DEBUG: Taking 'etc/shared/test_group' from path table.
2022/03/16 14:46:43 wazuh-modulesd:database[23627] wm_database.c:670 at wm_sync_file(): DEBUG: Synchronizing file 'etc/shared/test_group'
2022/03/16 14:46:43 wazuh-db[23432] wdb_parser.c:670 at wdb_parse(): DEBUG: Global query: find-group test_group
2022/03/16 14:46:43 wazuh-db[23432] wdb_parser.c:670 at wdb_parse(): DEBUG: Global query: insert-agent-group test_group
2022/03/16 14:46:43 wazuh-modulesd:database[23627] wm_database.c:661 at wm_sync_shared_group(): DEBUG: wm_sync_shared_group(): 0.158 ms.
```

### Adding a group called `.test_group`

- Addition

```
root@UbuntuDEV:/home/diego/wazuh-repos/wazuh# /var/ossec/bin/agent_groups -a -g .test_group
Do you want to create the group '.test_group'? [y/N]: y
Group '.test_group' created.
```

- Logs

```
2022/03/16 14:51:05 wazuh-modulesd:database[23627] wm_database.c:880 at wm_inotify_start(): DEBUG: inotify: i='0', name='.test_group', mask='1073742080', wd='2'
2022/03/16 14:51:05 wazuh-modulesd:database[23627] wm_database.c:941 at wm_inotify_push(): DEBUG: Adding 'etc/shared/.test_group' to path table.
2022/03/16 14:51:05 wazuh-modulesd:database[23627] wm_database.c:972 at wm_inotify_pop(): DEBUG: Taking 'etc/shared/.test_group' from path table.
2022/03/16 14:51:05 wazuh-modulesd:database[23627] wm_database.c:670 at wm_sync_file(): DEBUG: Synchronizing file 'etc/shared/.test_group'
2022/03/16 14:51:05 wazuh-db[23432] wdb_parser.c:670 at wdb_parse(): DEBUG: Global query: find-group .test_group
2022/03/16 14:51:05 wazuh-db[23432] wdb_parser.c:670 at wdb_parse(): DEBUG: Global query: insert-agent-group .test_group
2022/03/16 14:51:05 wazuh-modulesd:database[23627] wm_database.c:661 at wm_sync_shared_group(): DEBUG: wm_sync_shared_group(): 0.117 ms.
```

### Adding a group called `..test_group`

- Addition

```
root@UbuntuDEV:/home/diego/wazuh-repos/wazuh# /var/ossec/bin/agent_groups -a -g ..test_group
Do you want to create the group '..test_group'? [y/N]: y
Group '..test_group' created.
```

- Logs

```
2022/03/16 14:51:51 wazuh-modulesd:database[23627] wm_database.c:880 at wm_inotify_start(): DEBUG: inotify: i='0', name='..test_group', mask='1073742080', wd='2'
2022/03/16 14:51:51 wazuh-modulesd:database[23627] wm_database.c:941 at wm_inotify_push(): DEBUG: Adding 'etc/shared/..test_group' to path table.
2022/03/16 14:51:51 wazuh-modulesd:database[23627] wm_database.c:972 at wm_inotify_pop(): DEBUG: Taking 'etc/shared/..test_group' from path table.
2022/03/16 14:51:51 wazuh-modulesd:database[23627] wm_database.c:670 at wm_sync_file(): DEBUG: Synchronizing file 'etc/shared/..test_group'
2022/03/16 14:51:51 wazuh-db[23432] wdb_parser.c:670 at wdb_parse(): DEBUG: Global query: find-group ..test_group
2022/03/16 14:51:51 wazuh-db[23432] wdb_parser.c:670 at wdb_parse(): DEBUG: Global query: insert-agent-group ..test_group
2022/03/16 14:51:51 wazuh-modulesd:database[23627] wm_database.c:661 at wm_sync_shared_group(): DEBUG: wm_sync_shared_group(): 0.087 ms.
```

### Database verification

```
root@UbuntuDEV:/home/diego/wazuh-repos/wazuh# python3 ../../wazuh-tools/qa/wdb-query.py global 'sql SELECT * FROM `group`'
[
    {
        "id": 1,
        "name": "default"
    },
    {
        "id": 2,
        "name": "test_group"
    },
    {
        "id": 3,
        "name": ".test_group"
    },
    {
        "id": 4,
        "name": "..test_group"
    }
]
```

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

- Memory tests for Linux
  - [x] Scan-build report
  ![image](https://user-images.githubusercontent.com/5703274/158656002-975bc553-0899-4795-8a51-6ac5c20594e0.png)