### PR TITLE
Run modulesd as root:root but create its queue as root:wazuh

### DIFF
--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -106,6 +106,11 @@ https://www.gnu.org/licenses/gpl.html\n"
 #define GROUPGLOBAL     "wazuh"
 #endif
 
+// Standard super user UID and GID
+#define ROOT_UID (0)
+
+#define ROOT_GID (0)
+
 // Wazuh home environment variable
 #define WAZUH_HOME_ENV  "WAZUH_HOME"
 

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -133,8 +133,8 @@ int OS_Bindportudp(u_int16_t _port, const char *_ip, int ipv6)
 }
 
 #ifndef WIN32
-/* Bind to a Unix domain, using DGRAM sockets */
-int OS_BindUnixDomain(const char *path, int type, int max_msg_size)
+/* Bind to a Unix domain, DGRAM sockets while allowing the caller to specify owner and permission bits. */
+int OS_BindUnixDomainWithPerms(const char *path, int type, int max_msg_size, uid_t uid, gid_t gid, mode_t mode)
 {
     struct sockaddr_un n_us;
     int ossock = 0;
@@ -156,7 +156,13 @@ int OS_BindUnixDomain(const char *path, int type, int max_msg_size)
     }
 
     /* Change permissions */
-    if (chmod(path, 0660) < 0) {
+    if (fchmod(ossock, mode) < 0) {
+        OS_CloseSocket(ossock);
+        return (OS_SOCKTERR);
+    }
+
+    /* Change owner */
+    if (fchown(ossock, uid, gid) < 0) {
         OS_CloseSocket(ossock);
         return (OS_SOCKTERR);
     }
@@ -178,6 +184,12 @@ int OS_BindUnixDomain(const char *path, int type, int max_msg_size)
     }
 
     return (ossock);
+}
+
+/* Bind to a Unix domain, using DGRAM sockets */
+int OS_BindUnixDomain(const char *path, int type, int max_msg_size)
+{
+    return OS_BindUnixDomainWithPerms(path, type, max_msg_size, getuid(), getgid(), 0660);
 }
 
 /* Open a client Unix domain socket

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -28,6 +28,7 @@ int OS_Bindportudp(u_int16_t _port, const char *_ip, int ipv6);
  * a Unix Domain socket.
  */
 int OS_BindUnixDomain(const char *path, int type, int max_msg_size) __attribute__((nonnull));
+int OS_BindUnixDomainWithPerms(const char *path, int type, int max_msg_size, uid_t uid, gid_t gid, mode_t mode) __attribute__((nonnull));
 int OS_ConnectUnixDomain(const char *path, int type, int max_msg_size) __attribute__((nonnull));
 int OS_getsocketsize(int ossock);
 

--- a/src/wazuh_modules/main.c
+++ b/src/wazuh_modules/main.c
@@ -126,7 +126,6 @@ void wm_help()
 
 void wm_setup()
 {
-    gid_t gid;
     struct sigaction action = { .sa_handler = wm_handler };
 
     // Read XML settings and internal options
@@ -140,16 +139,6 @@ void wm_setup()
     if (!flag_foreground) {
         goDaemon();
         nowDaemon();
-    }
-
-    // Set group
-
-    if (gid = Privsep_GetGroup(GROUPGLOBAL), gid == (gid_t) -1) {
-        merror_exit(USER_ERROR, "", GROUPGLOBAL, strerror(errno), errno);
-    }
-
-    if (Privsep_SetGroup(gid) < 0) {
-        merror_exit(SETGID_ERROR, GROUPGLOBAL, errno, strerror(errno));
     }
 
     if (wm_check() < 0) {

--- a/src/wazuh_modules/wmcom.c
+++ b/src/wazuh_modules/wmcom.c
@@ -118,10 +118,16 @@ void * wmcom_main(__attribute__((unused)) void * arg) {
     char *response = NULL;
     ssize_t length;
     fd_set fdset;
+    gid_t gid;
 
     mdebug1("Local requests thread ready");
+    gid = Privsep_GetGroup(GROUPGLOBAL);
+    if (gid == (gid_t) OS_INVALID) {
+        merror(USER_ERROR, "-", GROUPGLOBAL, strerror(errno), errno);
+        return NULL;
+    }
 
-    if (sock = OS_BindUnixDomain(WM_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR), sock < 0) {
+    if (sock = OS_BindUnixDomainWithPerms(WM_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR, getuid(), gid, 0660), sock < 0) {
         merror("Unable to bind to socket '%s': (%d) %s.", WM_LOCAL_SOCK, errno, strerror(errno));
         return NULL;
     }


### PR DESCRIPTION
|Related issue|
|---|
|#10828|

## Description
This PR makes wazuh-modulesd as root:root but changes the unix socket creation process so that the owner of the socket modulesd creates is owned by the root user and wazuh group.


