### PR TITLE
Fix group related framework code when using restricted agent names

### DIFF
--- a/api/test/integration/test_agent_POST_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_POST_endpoints.tavern.yaml
@@ -353,6 +353,21 @@ stages:
       json:
         <<: *error_spec
 
+    # POST /groups
+  - name: Try to create a group with a forbidden name
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      method: POST
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      json:
+        group_id: "ar.conf"
+    response:
+      status_code: 400
+      json:
+        error: 1713
+
 ---
 test_name: POST /agents/insert
 

--- a/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
@@ -47,6 +47,19 @@ stages:
       json:
         <<: *error_spec
 
+  - name: Try to assign an agent to a forbidden group id (it must count as non existent)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        agents_list: "001"
+        group_id: 'ar.conf'
+    response:
+      <<: *resource_not_found_group
+
     # PUT /agents/group?group_id=default&agents_list=998,999
   - name: Try to assign non existing agents to group default
     request:

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -621,7 +621,10 @@ def create_group(group_id):
     group_path = path.join(common.SHARED_PATH, group_id)
 
     if group_id.lower() == "default" or path.exists(group_path):
-        raise WazuhError(1711, extra_message=group_id)
+        if not path.isfile(group_path):
+            raise WazuhError(1711, extra_message=group_id)
+        else:
+            raise WazuhError(1713, extra_message=group_id)
 
     # Create group in /etc/shared
     agent_conf_template = path.join(common.SHARED_PATH, 'agent-template.conf')

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -794,7 +794,7 @@ class Agent:
         if not InputValidator().group(group_id):
             raise WazuhError(1722)
 
-        if path.exists(path.join(common.SHARED_PATH, group_id)):
+        if path.isdir(path.join(common.SHARED_PATH, group_id)):
             return True
         else:
             return False

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -250,6 +250,8 @@ class WazuhException(Exception):
                               f'{DOCU_VERSION}/user-manual/agents/grouping-agents.html)'
                               'to get more information'
                },
+        1713: {'message': 'Invalid group ID. Some IDs are restricted for internal purposes',
+               'remediation': 'Please, use another group ID'},
         1722: {'message': 'Incorrect format for group_id',
                'remediation': 'Characters supported  a-z, A-Z, 0-9, ., _ and -. Max length is 255'
                },

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -1044,7 +1044,7 @@ def test_agent_group_exists(group_exists):
     group_exists : bool
         Expected result
     """
-    with patch('os.path.exists', return_value=group_exists):
+    with patch('os.path.isdir', return_value=group_exists):
         result = Agent.group_exists('default')
         assert result == group_exists, f'Group exists should return {group_exists}'
 

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -584,7 +584,7 @@ def test_create_group(chown_mock, uid_mock, gid_mock, group_id):
         result = create_group(group_id)
         assert isinstance(result, WazuhResult), 'The returned object is not an "WazuhResult" instance.'
         assert len(result.dikt) == 1, \
-            f'Result dikt lenght is "{len(result.dikt)}" instead of "1". Result dikt content is: {result.dikt}'
+            f'Result dikt length is "{len(result.dikt)}" instead of "1". Result dikt content is: {result.dikt}'
         assert result.dikt['message'] == expected_msg, \
             f'The "result.dikt[\'message\']" received is not the expected.\n' \
             f'Expected: "{expected_msg}"\n' \
@@ -600,7 +600,9 @@ def test_create_group(chown_mock, uid_mock, gid_mock, group_id):
     ('default', WazuhError, 1711),
     ('group-1', WazuhError, 1711),
     ('invalid!', WazuhError, 1722),
-    ('delete-me', WazuhInternalError, 1005)
+    ('delete-me', WazuhInternalError, 1005),
+    ('ar.conf', WazuhError, 1713),
+    ('agent-template.conf', WazuhError, 1713)
 ])
 @patch('wazuh.core.common.SHARED_PATH', new=test_shared_path)
 def test_create_group_exceptions(group_id, exception, exception_code):


### PR DESCRIPTION
|Related issue|
|---|
|closes #12754 |

## Description

This PR prevents the API and CLIs from using restricted agent groups such as `ar.conf` or `agent-template.conf` when creating new groups or assigning agents to them, as it was reported in the issue.

## Tests performed
### Manual testing
```shellsession
root@wazuh-master:/var/ossec# bin/agent_groups -a -g "agent-template.conf" -i 001
Do you want to add the group '['agent-template.conf']' to the agent '['001']'? [y/N]: y
Error 1710: The group does not exist
root@wazuh-master:/var/ossec# 
root@wazuh-master:/var/ossec# bin/agent_groups -a -g "agent-template.conf"       
Do you want to create the group 'agent-template.conf'? [y/N]: y
Error 1713: Invalid group ID. Some IDs are restricted for internal purposes: agent-template.conf
root@wazuh-master:/var/ossec# 
root@wazuh-master:/var/ossec# 

```

### Unit tests
```shellsession
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.9, pytest-7.0.0, pluggy-1.0.0
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.18.1, cov-3.0.0
asyncio: mode=legacy
collected 261 items                                                                                                                                                                                               

wazuh/core/tests/test_agent.py ...............................................................................................................................................                              [ 54%]
wazuh/tests/test_agent.py ......................................................................................................................                                                            [100%]

======================================================================================== 261 passed, 10 warnings in 4.72s =========================================================================================
```

### API integration tests
```shellsesion
test_agent_POST_endpoints_cluster - Cluster environment
	 6 passed, 7 warnings

test_agent_PUT_endpoints_cluster - Cluster environment
	 10 passed, 11 warnings
```

Regards,
Víctor