### PR TITLE
[Agent-groups] Change the logger tag when processing agent-groups DB

### DIFF
--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -447,23 +447,6 @@ def compare_files(good_files, check_files, node_name):
     count : int
         Number of files inside each classification.
     """
-    def check_if_file_correspond_to_agent():
-        """Check if extra-valid agent-groups files correspond to existing agents."""
-        try:
-            _paths = [os.path.basename(file) for file in _files if file.startswith('PATH')]
-            db_agents = []
-            # Each query can have at most 7500 agents to prevent it from being larger than the wazuh-db socket.
-            # 7 digits in the worst case per ID + comma -> 8 * 7500 = 60000 (wazuh-db socket is ~64000)
-            for i in range(0, len(_paths), chunk_size := 7500):
-                with WazuhDBQueryAgents(select=['id'], limit=None, filters={'rbac_ids': _paths[i:i + chunk_size]},
-                                        rbac_negate=False) as db_query:
-                    db_agents.extend(db_query.run()['items'])
-            db_agents = {agent['id'] for agent in db_agents}
-
-            for leftover in set(_paths) - db_agents:
-                _files.pop(os.path.join('PATH', leftover), None)
-        except Exception as e:
-            logger.error(f"Error getting agent IDs while verifying which TYPE files are required: {e}")
 
     def split_on_condition(seq, condition):
         """Split a sequence into two generators based on a condition.

--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -486,7 +486,7 @@ def compare_files(good_files, check_files, node_name):
     # This condition should never take place. The 'PATH' string is a placeholder to indicate the type of variable that
     # we should place.
     # if extra_valid_files:
-    #     check_if_file_correspond_to_agent()
+    #     extra_valid_function()
 
     # 'all_shared' files are the ones present in both sets but with different MD5 checksum.
     all_shared = [x for x in check_files.keys() & good_files.keys() if check_files[x]['md5'] != good_files[x]['md5']]

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -4,12 +4,13 @@
 import asyncio
 import errno
 import json
+import logging
 import os
 import shutil
 from datetime import datetime, timezone
+from time import perf_counter
 from typing import Tuple, Dict, Callable, List
 from typing import Union
-from time import perf_counter
 
 from wazuh.core import cluster as metadata, common, exception, utils
 from wazuh.core.cluster import client, cluster, common as c_common
@@ -20,7 +21,7 @@ from wazuh.core.wdb import WazuhDBConnection
 
 
 class ReceiveAgentGroupsTask(c_common.ReceiveStringTask):
-    """
+    """TODO
     Define the process and variables necessary to receive and process Agent groups from the master.
 
     This task is created when the master finishes sending Agent groups chunks and its destroyed once the worker has
@@ -41,7 +42,43 @@ class ReceiveAgentGroupsTask(c_common.ReceiveStringTask):
 
     def set_up_coro(self) -> Callable:
         """Set up the function to be called when the worker sends its Agent groups."""
-        return self.wazuh_common.recv_agent_groups_local_information
+        return self.wazuh_common.recv_agent_groups_periodic_information
+
+    def done_callback(self, future=None):
+        """Check whether the synchronization process was correct and free its lock.
+
+        Parameters
+        ----------
+        future : asyncio.Future object
+            Synchronization process result.
+        """
+        super().done_callback(future)
+        self.wazuh_common.sync_agent_groups_free = True
+
+
+class ReceiveEntireAgentGroupsTask(c_common.ReceiveStringTask):
+    """TODO
+    Define the process and variables necessary to receive and process Agent groups from the master.
+
+    This task is created when the master finishes sending Agent groups chunks and its destroyed once the worker has
+    updated all the received information.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Class constructor.
+
+        Parameters
+        ----------
+        args
+            Positional arguments for parent constructor class.
+        kwargs
+            Keyword arguments for parent constructor class.
+        """
+        super().__init__(*args, **kwargs, info_type='agent-groups')
+
+    def set_up_coro(self) -> Callable:
+        """Set up the function to be called when the worker sends its Agent groups."""
+        return self.wazuh_common.recv_agent_groups_entire_information
 
     def done_callback(self, future=None):
         """Check whether the synchronization process was correct and free its lock.
@@ -181,6 +218,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         # this way the same code can be shared among all sync tasks and logs will differentiate.
         self.task_loggers = {'Agent-info sync': self.setup_task_logger('Agent-info sync'),
                              'Agent-groups recv': self.setup_task_logger('Agent-groups recv'),
+                             'Agent-groups recv full': self.setup_task_logger('Agent-groups recv full'),
                              'Agent-groups sync': self.setup_task_logger('Agent-groups sync'),
                              'Integrity check': self.setup_task_logger('Integrity check'),
                              'Integrity sync': self.setup_task_logger('Integrity sync')}
@@ -235,7 +273,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             return self.end_receiving_integrity(data.decode())
         elif command == b'syn_m_c_r':
             return self.error_receiving_integrity(data.decode())
-        elif command == b'syn_g_m_w':
+        elif command == b'syn_g_m_w' or command == b'syn_g_m_w_c':
             return self.setup_sync_integrity(command, data)
         elif command == b'syn_m_a_e':
             logger = self.setup_task_logger('Agent-info sync')
@@ -308,6 +346,8 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         """
         if sync_type == b'syn_g_m_w':
             sync_function = ReceiveAgentGroupsTask
+        elif sync_type == b'syn_g_m_w_c':
+            sync_function = ReceiveEntireAgentGroupsTask
         else:
             sync_function = None
 
@@ -470,8 +510,8 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                 self.agent_groups_checksum_mismatch_counter = 0
                 logger.info('Sent request to obtain all agent-groups information from the master node.')
 
-    async def recv_agent_groups_local_information(self, task_id: bytes, info_type: str):
-        """Create a process to receive the master agent-groups information.
+    async def recv_agent_groups_periodic_information(self, task_id: bytes, info_type: str):
+        """Create a process to receive the master periodic agent-groups information.
 
         Parameters
         ----------
@@ -490,6 +530,54 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         error_command = b'syn_w_g_err'
         timeout = self.cluster_items['intervals']['worker']['timeout_agent_groups']
 
+        return await self.recv_agent_groups_information(task_id, info_type, logger, command, error_command, timeout)
+
+    async def recv_agent_groups_entire_information(self, task_id: bytes, info_type: str):
+        """Create a process to receive the master entire agent-groups information.
+
+        Parameters
+        ----------
+        task_id : bytes
+            ID of the string where the JSON chunks are stored.
+        info_type : str
+            Information type handled.
+
+        Returns
+        -------
+        result : bytes
+            Master's response after finishing the synchronization.
+        """
+        logger = self.task_loggers['Agent-groups recv full']
+        command = b'syn_wgc_e'
+        error_command = b'syn_wgc_err'
+        timeout = self.cluster_items['intervals']['worker']['timeout_agent_groups']
+
+        return await self.recv_agent_groups_information(task_id, info_type, logger, command, error_command, timeout)
+
+    async def recv_agent_groups_information(self, task_id: bytes, info_type: str, logger: logging.Logger,
+                                            command: bytes, error_command: bytes, timeout: int):
+        """Create a process to receive the master agent-groups information.
+
+        Parameters
+        ----------
+        task_id : bytes
+            ID of the string where the JSON chunks are stored.
+        info_type : str
+            Information type handled.
+        logger : logging.Logger
+            Logger used to print the function messages.
+        command : bytes
+            Command that will be sent to the master node to indicate the end of the task.
+        error_command : bytes
+            Command that will be sent to the master node in case of error.
+        timeout : int
+            Maximum time to send the information to the database.
+
+        Returns
+        -------
+        result : bytes
+            Master's response after finishing the synchronization.
+        """
         logger.info('Starting.')
         start_time = datetime.utcnow().replace(tzinfo=timezone.utc)
         data = await super().get_chunks_in_task_id(task_id, error_command)

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -21,8 +21,8 @@ from wazuh.core.wdb import WazuhDBConnection
 
 
 class ReceiveAgentGroupsTask(c_common.ReceiveStringTask):
-    """TODO
-    Define the process and variables necessary to receive and process Agent groups from the master.
+    """
+    Define the process and variables necessary to receive and process Agent groups (periodic) from the master.
 
     This task is created when the master finishes sending Agent groups chunks and its destroyed once the worker has
     updated all the received information.
@@ -57,8 +57,8 @@ class ReceiveAgentGroupsTask(c_common.ReceiveStringTask):
 
 
 class ReceiveEntireAgentGroupsTask(c_common.ReceiveStringTask):
-    """TODO
-    Define the process and variables necessary to receive and process Agent groups from the master.
+    """
+    Define the process and variables necessary to receive and process Agent groups (entire) from the master.
 
     This task is created when the master finishes sending Agent groups chunks and its destroyed once the worker has
     updated all the received information.


### PR DESCRIPTION
|Related issue|
|---|
|#12762|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR closes #12762. In this PR we have changed the tag for the loggers when processing the whole database. This change is motivated by the independence of the agent-groups tasks.

```
============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.5, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
rootdir: /mnt/c/Users/adr_i/git/wazuh/framework
plugins: asyncio-0.15.1, trio-0.7.0, cov-2.12.0, metadata-1.11.0, tavern-1.19.0, testinfra-6.4.0, html-3.1.1, aiohttp-0.3.0
collected 281 items

framework/wazuh/core/cluster/tests/test_client.py ................                                                                                                                                         [  5%]
framework/wazuh/core/cluster/tests/test_cluster.py ..................................                                                                                                                      [ 17%]
framework/wazuh/core/cluster/tests/test_common.py .............................................................................                                                                            [ 45%]
framework/wazuh/core/cluster/tests/test_control.py .....                                                                                                                                                   [ 46%]
framework/wazuh/core/cluster/tests/test_local_client.py .............                                                                                                                                      [ 51%]
framework/wazuh/core/cluster/tests/test_local_server.py .......................                                                                                                                            [ 59%]
framework/wazuh/core/cluster/tests/test_master.py .................................................                                                                                                        [ 77%]
framework/wazuh/core/cluster/tests/test_server.py ...................                                                                                                                                      [ 83%]
framework/wazuh/core/cluster/tests/test_utils.py ...........                                                                                                                                               [ 87%]
framework/wazuh/core/cluster/tests/test_worker.py ..................................                                                                                                                       [100%]

======================================================================================= 281 passed, 24 warnings in 29.37s ========================================================================================
```