### PR TITLE
Change mapping of docker-compose file

### DIFF
--- a/api/test/integration/env/base/agent/entrypoint.sh
+++ b/api/test/integration/env/base/agent/entrypoint.sh
@@ -4,15 +4,15 @@
 echo 'wazuh_modules.debug=2' >> /var/ossec/etc/local_internal_options.conf
 
 # Apply test.keys
-cp /tmp/configuration_files/test.keys /var/ossec/etc/test.keys
+cp /tmp_volume/configuration_files/test.keys /var/ossec/etc/test.keys
 
 # Remove ossec_4.x in agents with version 3.x
 if [ "$3" == "agent_old" ]; then
-  rm /tmp/configuration_files/ossec_4.x.conf
+  rm /tmp_volume/configuration_files/ossec_4.x.conf
 fi
 
 # Modify ossec.conf
-for conf_file in /tmp/configuration_files/*.conf; do
+for conf_file in /tmp_volume/configuration_files/*.conf; do
   python3 /tools/xml_parser.py /var/ossec/etc/ossec.conf $conf_file
 done
 
@@ -21,7 +21,7 @@ chown root:wazuh /var/ossec/etc/client.keys
 rm /var/ossec/etc/test.keys
 
 # Agent configuration
-for sh_file in /tmp/configuration_files/*.sh; do
+for sh_file in /tmp_volume/configuration_files/*.sh; do
   . $sh_file
 done
 

--- a/api/test/integration/env/base/agent/new.Dockerfile
+++ b/api/test/integration/env/base/agent/new.Dockerfile
@@ -9,4 +9,4 @@ RUN /wazuh/install.sh
 
 COPY base/agent/entrypoint.sh /scripts/entrypoint.sh
 
-HEALTHCHECK --retries=900 --interval=1s --timeout=30s --start-period=30s CMD /usr/bin/python3 /tmp/healthcheck/healthcheck.py || exit 1
+HEALTHCHECK --retries=900 --interval=1s --timeout=30s --start-period=30s CMD /usr/bin/python3 /tmp_volume/healthcheck/healthcheck.py || exit 1

--- a/api/test/integration/env/base/agent/old.Dockerfile
+++ b/api/test/integration/env/base/agent/old.Dockerfile
@@ -2,4 +2,4 @@ FROM public.ecr.aws/o5x5t0j3/amd64/api_development:integration_test_wazuh-agent_
 
 COPY base/agent/entrypoint.sh /scripts/entrypoint.sh
 
-HEALTHCHECK --retries=900 --interval=1s --timeout=30s --start-period=30s CMD /usr/bin/python3 /tmp/healthcheck/legacy_healthcheck.py || exit 1
+HEALTHCHECK --retries=900 --interval=1s --timeout=30s --start-period=30s CMD /usr/bin/python3 /tmp_volume/healthcheck/legacy_healthcheck.py || exit 1

--- a/api/test/integration/env/base/manager/entrypoint.sh
+++ b/api/test/integration/env/base/manager/entrypoint.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 # Apply API configuration
-cp -rf /tmp/config/* /var/ossec/ && chown -R wazuh:wazuh /var/ossec/api
+cp -rf /tmp_volume/config/* /var/ossec/ && chown -R wazuh:wazuh /var/ossec/api
 
 # Modify ossec.conf
-for conf_file in /tmp/configuration_files/*.conf; do
+for conf_file in /tmp_volume/configuration_files/*.conf; do
   python3 /tools/xml_parser.py /var/ossec/etc/ossec.conf $conf_file
 done
 
@@ -21,7 +21,7 @@ if [ "$3" != "master" ]; then
     sed -i "s:<node_type>master</node_type>:<node_type>worker</node_type>:g" /var/ossec/etc/ossec.conf
 fi
 
-cp -rf /tmp/configuration_files/config/* /var/ossec/
+cp -rf /tmp_volume/configuration_files/config/* /var/ossec/
 chown root:wazuh /var/ossec/etc/client.keys
 chown -R wazuh:wazuh /var/ossec/queue/agent-groups
 chown -R wazuh:wazuh /var/ossec/queue/db
@@ -33,11 +33,11 @@ chown root:wazuh /var/ossec/etc/shared/ar.conf
 sleep 1
 
 # Manager configuration
-for py_file in /tmp/configuration_files/*.py; do
+for py_file in /tmp_volume/configuration_files/*.py; do
   /var/ossec/framework/python/bin/python3 $py_file
 done
 
-for sh_file in /tmp/configuration_files/*.sh; do
+for sh_file in /tmp_volume/configuration_files/*.sh; do
   . $sh_file
 done
 
@@ -46,11 +46,11 @@ echo "" > /var/ossec/logs/api.log
 
 # Master-only configuration
 if [ "$3" == "master" ]; then
-  for py_file in /tmp/configuration_files/master_only/*.py; do
+  for py_file in /tmp_volume/configuration_files/master_only/*.py; do
     /var/ossec/framework/python/bin/python3 $py_file
   done
 
-  for sh_file in /tmp/configuration_files/master_only/*.sh; do
+  for sh_file in /tmp_volume/configuration_files/master_only/*.sh; do
     . $sh_file
   done
 
@@ -69,14 +69,14 @@ if [ "$3" == "master" ]; then
   done
 
   # RBAC configuration
-  for sql_file in /tmp/configuration_files/*.sql; do
-    # Redirect standard error to /tmp/sql_lock_check to check a possible locked database error
+  for sql_file in /tmp_volume/configuration_files/*.sql; do
+    # Redirect standard error to /tmp_volume/sql_lock_check to check a possible locked database error
     # 2>&1 redirects "standard error" to "standard output"
-    sqlite3 /var/ossec/api/configuration/security/rbac.db < $sql_file > /tmp/sql_lock_check 2>&1
+    sqlite3 /var/ossec/api/configuration/security/rbac.db < $sql_file > /tmp_volume/sql_lock_check 2>&1
 
     # Insert the RBAC configuration again if database was locked
     elapsed_time=0
-    while [[ $(grep -c 'database is locked' /tmp/sql_lock_check)  -eq 1 ]] && [[ $exit_flag -eq 0 ]]
+    while [[ $(grep -c 'database is locked' /tmp_volume/sql_lock_check)  -eq 1 ]] && [[ $exit_flag -eq 0 ]]
     do
       if [ $elapsed_time -gt 120 ]; then
         echo "Timeout on RBAC DB callback. Could not apply SQL file to RBAC DB" > /entrypoint_error
@@ -84,11 +84,11 @@ if [ "$3" == "master" ]; then
       fi
       sleep 1
       elapsed_time=$((elapsed_time+1))
-      sqlite3 /var/ossec/api/configuration/security/rbac.db < $sql_file > /tmp/sql_lock_check 2>&1
+      sqlite3 /var/ossec/api/configuration/security/rbac.db < $sql_file > /tmp_volume/sql_lock_check 2>&1
     done
 
     # Remove the temporal file used to check the possible locked database error
-    rm -rf /tmp/sql_lock_check
+    rm -rf /tmp_volume/sql_lock_check
   done
 fi
 

--- a/api/test/integration/env/base/manager/manager.Dockerfile
+++ b/api/test/integration/env/base/manager/manager.Dockerfile
@@ -16,4 +16,4 @@ RUN /wazuh/install.sh
 COPY base/manager/entrypoint.sh /scripts/entrypoint.sh
 
 # HEALTHCHECK
-HEALTHCHECK --retries=900 --interval=1s --timeout=30s --start-period=30s CMD /var/ossec/framework/python/bin/python3 /tmp/healthcheck/healthcheck.py ${ENV_MODE} || exit 1
+HEALTHCHECK --retries=900 --interval=1s --timeout=30s --start-period=30s CMD /var/ossec/framework/python/bin/python3 /tmp_volume/healthcheck/healthcheck.py ${ENV_MODE} || exit 1

--- a/api/test/integration/env/configurations/base/manager/configuration_files/master_only/update_agent_info.py
+++ b/api/test/integration/env/configurations/base/manager/configuration_files/master_only/update_agent_info.py
@@ -4,7 +4,7 @@ import time
 
 import yaml
 
-output_file = '/tmp/configuration_files/agent_info_output'
+output_file = '/tmp_volume/configuration_files/agent_info_output'
 ADDR = '/var/ossec/queue/db/wdb'
 sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 sock.connect(ADDR)
@@ -67,4 +67,4 @@ def create_and_send_query(agent_info_file):
 
 
 if __name__ == "__main__":
-    create_and_send_query('/tmp/configuration_files/master_only/agent_info.yaml')
+    create_and_send_query('/tmp_volume/configuration_files/master_only/agent_info.yaml')

--- a/api/test/integration/env/configurations/cluster/manager/configuration_files/entrypoint.sh
+++ b/api/test/integration/env/configurations/cluster/manager/configuration_files/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 mkdir -p /var/ossec/stats/totals/2019/Aug/
-cp -rf /tmp/configuration_files/ossec-totals-27.log /var/ossec/stats/totals/2019/Aug/ossec-totals-27.log
+cp -rf /tmp_volume/configuration_files/ossec-totals-27.log /var/ossec/stats/totals/2019/Aug/ossec-totals-27.log
 chown -R wazuh:wazuh /var/ossec/stats/totals/2019/Aug/ossec-totals-27.log

--- a/api/test/integration/env/configurations/manager/manager/configuration_files/manager.sh
+++ b/api/test/integration/env/configurations/manager/manager/configuration_files/manager.sh
@@ -4,6 +4,6 @@ if [ "$HOSTNAME" == "wazuh-master" ]; then
   sed -i -e "/<cluster>/,/<\/cluster>/ s|<disabled>[a-z]\+</disabled>|<disabled>yes</disabled>|g" /var/ossec/etc/ossec.conf
   rm -rf /var/ossec/stats/totals/*
   mkdir -p /var/ossec/stats/totals/2019/Aug/
-  cp -rf /tmp/configuration_files/ossec-totals-27.log /var/ossec/stats/totals/2019/Aug/ossec-totals-27.log
+  cp -rf /tmp_volume/configuration_files/ossec-totals-27.log /var/ossec/stats/totals/2019/Aug/ossec-totals-27.log
   chown -R wazuh:wazuh /var/ossec/stats/totals/2019/Aug/ossec-totals-27.log
 fi

--- a/api/test/integration/env/configurations/manager/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/manager/manager/healthcheck/healthcheck.py
@@ -8,8 +8,8 @@ from healthcheck_utils import check, get_api_health
 
 
 def get_master_health():
-    os.system("/var/ossec/bin/wazuh-control status > /tmp/daemons.txt")
-    check0 = check(os.system("diff -q /tmp/daemons.txt /tmp/healthcheck/master_daemons_check.txt"))
+    os.system("/var/ossec/bin/wazuh-control status > /tmp_volume/daemons.txt")
+    check0 = check(os.system("diff -q /tmp_volume/daemons.txt /tmp_volume/healthcheck/master_daemons_check.txt"))
     check1 = get_api_health()
     return check0 or check1
 

--- a/api/test/integration/env/configurations/security/manager/configuration_files/security_config.sh
+++ b/api/test/integration/env/configurations/security/manager/configuration_files/security_config.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # RBAC configuration
-sqlite3 /var/ossec/api/configuration/security/rbac.db < /tmp/configuration_files/schema_security_test.sql
-sqlite3 /var/ossec/api/configuration/security/rbac.db < /tmp/configuration_files/base_security_test.sql
+sqlite3 /var/ossec/api/configuration/security/rbac.db < /tmp_volume/configuration_files/schema_security_test.sql
+sqlite3 /var/ossec/api/configuration/security/rbac.db < /tmp_volume/configuration_files/base_security_test.sql
 chown wazuh:wazuh /var/ossec/api/configuration/security/rbac.db
 chmod 640 /var/ossec/api/configuration/security/rbac.db

--- a/api/test/integration/env/configurations/security/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/security/manager/healthcheck/healthcheck.py
@@ -8,8 +8,8 @@ from healthcheck_utils import check, get_api_health
 
 
 def get_master_health():
-    os.system("/var/ossec/bin/wazuh-control status > /tmp/daemons.txt")
-    check0 = check(os.system("diff -q /tmp/daemons.txt /tmp/healthcheck/daemons_check.txt"))
+    os.system("/var/ossec/bin/wazuh-control status > /tmp_volume/daemons.txt")
+    check0 = check(os.system("diff -q /tmp_volume/daemons.txt /tmp_volume/healthcheck/daemons_check.txt"))
     check1 = get_api_health()
     return check0 or check1
 

--- a/api/test/integration/env/configurations/vulnerability/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/vulnerability/manager/healthcheck/healthcheck.py
@@ -12,7 +12,7 @@ user = 'wazuh'
 password = 'wazuh'
 headers = get_login_header(user, password)
 agents_to_check = ['001', '002']
-HEALTHCHECK_STATE_FILE = '/tmp/healthcheck/healthcheck.state'
+HEALTHCHECK_STATE_FILE = '/tmp_volume/healthcheck/healthcheck.state'
 
 
 # Functions

--- a/api/test/integration/env/docker-compose.yml
+++ b/api/test/integration/env/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     image: integration_test_wazuh-manager
     hostname: wazuh-worker1
     volumes:
-      - ./configurations/tmp/manager:/tmp
+      - ./configurations/tmp/manager:/tmp/manager
       - ./tools/:/tools
     entrypoint:
       - /scripts/entrypoint.sh
@@ -48,7 +48,7 @@ services:
     image: integration_test_wazuh-manager
     hostname: wazuh-worker2
     volumes:
-      - ./configurations/tmp/manager:/tmp
+      - ./configurations/tmp/manager:/tmp/manager
       - ./tools/:/tools
     entrypoint:
       - /scripts/entrypoint.sh
@@ -66,7 +66,7 @@ services:
     image: integration_test_wazuh-agent
     hostname: wazuh-agent1
     volumes:
-      - ./configurations/tmp/agent:/tmp
+      - ./configurations/tmp/agent:/tmp/agent
       - ./tools/:/tools
     entrypoint:
       - /scripts/entrypoint.sh
@@ -85,7 +85,7 @@ services:
     image: integration_test_wazuh-agent
     hostname: wazuh-agent2
     volumes:
-      - ./configurations/tmp/agent:/tmp
+      - ./configurations/tmp/agent:/tmp/agent
       - ./tools/:/tools
     entrypoint:
       - /scripts/entrypoint.sh
@@ -105,7 +105,7 @@ services:
     image: integration_test_wazuh-agent
     hostname: wazuh-agent3
     volumes:
-      - ./configurations/tmp/agent:/tmp
+      - ./configurations/tmp/agent:/tmp/agent
       - ./tools/:/tools
     entrypoint:
       - /scripts/entrypoint.sh
@@ -125,7 +125,7 @@ services:
     image: integration_test_wazuh-agent
     hostname: wazuh-agent4
     volumes:
-      - ./configurations/tmp/agent:/tmp
+      - ./configurations/tmp/agent:/tmp/agent
       - ./tools/:/tools
     entrypoint:
       - /scripts/entrypoint.sh
@@ -145,7 +145,7 @@ services:
     image: integration_test_wazuh-agent_old
     hostname: wazuh-agent5
     volumes:
-      - ./configurations/tmp/agent:/tmp
+      - ./configurations/tmp/agent:/tmp/agent
       - ./tools/:/tools
     entrypoint:
       - /scripts/entrypoint.sh
@@ -166,7 +166,7 @@ services:
     image: integration_test_wazuh-agent_old
     hostname: wazuh-agent6
     volumes:
-      - ./configurations/tmp/agent:/tmp
+      - ./configurations/tmp/agent:/tmp/agent
       - ./tools/:/tools
     entrypoint:
       - /scripts/entrypoint.sh
@@ -187,7 +187,7 @@ services:
     image: integration_test_wazuh-agent_old
     hostname: wazuh-agent7
     volumes:
-      - ./configurations/tmp/agent:/tmp
+      - ./configurations/tmp/agent:/tmp/agent
       - ./tools/:/tools
     entrypoint:
       - /scripts/entrypoint.sh
@@ -208,7 +208,7 @@ services:
     image: integration_test_wazuh-agent_old
     hostname: wazuh-agent8
     volumes:
-      - ./configurations/tmp/agent:/tmp
+      - ./configurations/tmp/agent:/tmp/agent
       - ./tools/:/tools
     entrypoint:
       - /scripts/entrypoint.sh

--- a/api/test/integration/env/docker-compose.yml
+++ b/api/test/integration/env/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     ports:
       - "55000:55000"
     volumes:
-      - ./configurations/tmp/manager:/tmp/manager
+      - ./configurations/tmp/manager:/tmp_volume
       - ./tools/:/tools
     entrypoint:
       - /scripts/entrypoint.sh
@@ -31,7 +31,7 @@ services:
     image: integration_test_wazuh-manager
     hostname: wazuh-worker1
     volumes:
-      - ./configurations/tmp/manager:/tmp/manager
+      - ./configurations/tmp/manager:/tmp_volume
       - ./tools/:/tools
     entrypoint:
       - /scripts/entrypoint.sh
@@ -48,7 +48,7 @@ services:
     image: integration_test_wazuh-manager
     hostname: wazuh-worker2
     volumes:
-      - ./configurations/tmp/manager:/tmp/manager
+      - ./configurations/tmp/manager:/tmp_volume
       - ./tools/:/tools
     entrypoint:
       - /scripts/entrypoint.sh
@@ -66,7 +66,7 @@ services:
     image: integration_test_wazuh-agent
     hostname: wazuh-agent1
     volumes:
-      - ./configurations/tmp/agent:/tmp/agent
+      - ./configurations/tmp/agent:/tmp_volume
       - ./tools/:/tools
     entrypoint:
       - /scripts/entrypoint.sh
@@ -85,7 +85,7 @@ services:
     image: integration_test_wazuh-agent
     hostname: wazuh-agent2
     volumes:
-      - ./configurations/tmp/agent:/tmp/agent
+      - ./configurations/tmp/agent:/tmp_volume
       - ./tools/:/tools
     entrypoint:
       - /scripts/entrypoint.sh
@@ -105,7 +105,7 @@ services:
     image: integration_test_wazuh-agent
     hostname: wazuh-agent3
     volumes:
-      - ./configurations/tmp/agent:/tmp/agent
+      - ./configurations/tmp/agent:/tmp_volume
       - ./tools/:/tools
     entrypoint:
       - /scripts/entrypoint.sh
@@ -125,7 +125,7 @@ services:
     image: integration_test_wazuh-agent
     hostname: wazuh-agent4
     volumes:
-      - ./configurations/tmp/agent:/tmp/agent
+      - ./configurations/tmp/agent:/tmp_volume
       - ./tools/:/tools
     entrypoint:
       - /scripts/entrypoint.sh
@@ -145,7 +145,7 @@ services:
     image: integration_test_wazuh-agent_old
     hostname: wazuh-agent5
     volumes:
-      - ./configurations/tmp/agent:/tmp/agent
+      - ./configurations/tmp/agent:/tmp_volume
       - ./tools/:/tools
     entrypoint:
       - /scripts/entrypoint.sh
@@ -166,7 +166,7 @@ services:
     image: integration_test_wazuh-agent_old
     hostname: wazuh-agent6
     volumes:
-      - ./configurations/tmp/agent:/tmp/agent
+      - ./configurations/tmp/agent:/tmp_volume
       - ./tools/:/tools
     entrypoint:
       - /scripts/entrypoint.sh
@@ -187,7 +187,7 @@ services:
     image: integration_test_wazuh-agent_old
     hostname: wazuh-agent7
     volumes:
-      - ./configurations/tmp/agent:/tmp/agent
+      - ./configurations/tmp/agent:/tmp_volume
       - ./tools/:/tools
     entrypoint:
       - /scripts/entrypoint.sh
@@ -208,7 +208,7 @@ services:
     image: integration_test_wazuh-agent_old
     hostname: wazuh-agent8
     volumes:
-      - ./configurations/tmp/agent:/tmp/agent
+      - ./configurations/tmp/agent:/tmp_volume
       - ./tools/:/tools
     entrypoint:
       - /scripts/entrypoint.sh

--- a/api/test/integration/env/docker-compose.yml
+++ b/api/test/integration/env/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     ports:
       - "55000:55000"
     volumes:
-      - ./configurations/tmp/manager:/tmp
+      - ./configurations/tmp/manager:/tmp/manager
       - ./tools/:/tools
     entrypoint:
       - /scripts/entrypoint.sh

--- a/api/test/integration/env/tools/healthcheck_utils.py
+++ b/api/test/integration/env/tools/healthcheck_utils.py
@@ -16,7 +16,7 @@ password = 'wazuh'
 base_url = "{}://{}:{}".format(protocol, host, port)
 login_url = "{}/security/user/authenticate".format(base_url)
 
-HEALTHCHECK_TOKEN_FILE = '/tmp/healthcheck/healthcheck.token'
+HEALTHCHECK_TOKEN_FILE = '/tmp_volume/healthcheck/healthcheck.token'
 OSSEC_LOG_PATH = '/var/ossec/logs/ossec.log'
 
 # Variable used to compare default daemons_check.txt with an output with cluster disabled
@@ -92,19 +92,19 @@ def check(result):
 
 
 def get_master_health(env_mode):
-    os.system("/var/ossec/bin/agent_control -ls > /tmp/output.txt")
-    os.system("/var/ossec/bin/wazuh-control status > /tmp/daemons.txt")
+    os.system("/var/ossec/bin/agent_control -ls > /tmp_volume/output.txt")
+    os.system("/var/ossec/bin/wazuh-control status > /tmp_volume/daemons.txt")
 
-    check0 = check(os.system("diff -q /tmp/output.txt /tmp/healthcheck/agent_control_check.txt"))
+    check0 = check(os.system("diff -q /tmp_volume/output.txt /tmp_volume/healthcheck/agent_control_check.txt"))
 
     if env_mode == "standalone":
         # If the environment is in standalone mode, the only difference is in the clusterd daemon
         check1 = check(not
-                       (subprocess.run(['diff', '/tmp/daemons.txt', '/tmp/healthcheck/daemons_check.txt'],
+                       (subprocess.run(['diff', '/tmp_volume/daemons.txt', '/tmp_volume/healthcheck/daemons_check.txt'],
                                        stdout=subprocess.PIPE).stdout.decode('utf-8')
                         == CHECK_CLUSTERD_DAEMON))
     else:
-        check1 = check(os.system("diff -q /tmp/daemons.txt /tmp/healthcheck/daemons_check.txt"))
+        check1 = check(os.system("diff -q /tmp_volume/daemons.txt /tmp_volume/healthcheck/daemons_check.txt"))
 
     check2 = get_api_health()
 
@@ -112,8 +112,8 @@ def get_master_health(env_mode):
 
 
 def get_worker_health():
-    os.system("/var/ossec/bin/wazuh-control status > /tmp/daemons.txt")
-    return check(os.system("diff -q /tmp/daemons.txt /tmp/healthcheck/daemons_check.txt"))
+    os.system("/var/ossec/bin/wazuh-control status > /tmp_volume/daemons.txt")
+    return check(os.system("diff -q /tmp_volume/daemons.txt /tmp_volume/healthcheck/daemons_check.txt"))
 
 
 def get_manager_health_base(env_mode):


### PR DESCRIPTION
| Related issue |
|---|
|Closes #12755 |

# Description

In this PR we have fixed an error at API integration tests Docker environment. The problem was that inside the containers we did not have directory permissions at `/tmp`.

The proposed solution has been to change mapped directories at `docker-compose.yml` file. So, in each manager container we have made this change:

```
volumes:
      - ./configurations/tmp/manager:/tmp_volume
      - ./tools/:/tools
```

And in each agent container: 

```
volumes:
      - ./configurations/tmp/agent:/tmp_volume
      - ./tools/:/tools
```

It is also necessary to change all references to `/tmp`  in the enviroment so that it can be built properly.

# Tests performed 

I have tried to update Linux packages in one of the containers, and it has the necessary permissions to access to `/tmp` directory so the execution is correct.

``` 
root@wazuh-master:/# apt update
Hit:1 http://archive.ubuntu.com/ubuntu focal InRelease
Get:2 http://security.ubuntu.com/ubuntu focal-security InRelease [114 kB]
Get:3 http://archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
Get:4 http://archive.ubuntu.com/ubuntu focal-backports InRelease [108 kB]
Get:5 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [2060 kB]
Get:6 http://security.ubuntu.com/ubuntu focal-security/restricted amd64 Packages [1027 kB]
Get:7 http://archive.ubuntu.com/ubuntu focal-updates/restricted amd64 Packages [1096 kB]
Get:8 http://archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 Packages [29.4 kB]
Get:9 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [1142 kB]
Get:10 http://archive.ubuntu.com/ubuntu focal-backports/main amd64 Packages [51.2 kB]
Get:11 http://archive.ubuntu.com/ubuntu focal-backports/universe amd64 Packages [26.0 kB]
Get:12 http://security.ubuntu.com/ubuntu focal-security/multiverse amd64 Packages [25.8 kB]
Get:13 http://security.ubuntu.com/ubuntu focal-security/universe amd64 Packages [859 kB]
Get:14 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages [1646 kB]
Fetched 8298 kB in 2s (3372 kB/s)
Reading package lists... Done
Building dependency tree
Reading state information... Done
105 packages can be upgraded. Run 'apt list --upgradable' to see them.
```

We can also check that in an agent container:
``` 
root@wazuh-agent3:/# apt update
Hit:1 http://archive.ubuntu.com/ubuntu focal InRelease
Get:2 http://security.ubuntu.com/ubuntu focal-security InRelease [114 kB]
Get:3 http://archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
Get:4 http://archive.ubuntu.com/ubuntu focal-backports InRelease [108 kB]
Get:5 http://security.ubuntu.com/ubuntu focal-security/universe amd64 Packages [859 kB]
Get:6 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [1142 kB]
Get:7 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages [1646 kB]
Get:8 http://security.ubuntu.com/ubuntu focal-security/restricted amd64 Packages [1027 kB]
Get:9 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [2060 kB]
Get:10 http://security.ubuntu.com/ubuntu focal-security/multiverse amd64 Packages [25.8 kB]
Get:11 http://archive.ubuntu.com/ubuntu focal-updates/restricted amd64 Packages [1096 kB]
Get:12 http://archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 Packages [29.4 kB]
Get:13 http://archive.ubuntu.com/ubuntu focal-backports/main amd64 Packages [51.2 kB]
Get:14 http://archive.ubuntu.com/ubuntu focal-backports/universe amd64 Packages [26.0 kB]
Fetched 8298 kB in 1s (6285 kB/s)
Reading package lists... Done
Building dependency tree
Reading state information... Done
105 packages can be upgraded. Run 'apt list --upgradable' to see them.
``` 

Additionally all the Integration API endpoints test have passed  after these changes.