### PR TITLE
Standardize GCloud integration's logging

### DIFF
--- a/src/config/wmodules-gcp.c
+++ b/src/config/wmodules-gcp.c
@@ -69,7 +69,6 @@ int wm_gcp_pubsub_read(xml_node **nodes, wmodule *module) {
         gcp->subscription_name = NULL;
         gcp->credentials_file = NULL;
         gcp->pull_on_start = 1;
-        gcp->logging = 2;
         module->context = &WM_GCP_PUBSUB_CONTEXT;
         module->tag = strdup(module->context->name);
         module->data = gcp;
@@ -185,25 +184,7 @@ int wm_gcp_pubsub_read(xml_node **nodes, wmodule *module) {
             gcp->pull_on_start = pull_on_start;
         }
         else if (!strcmp(nodes[i]->element, XML_LOGGING)) {
-            if (!strcmp(nodes[i]->content, "disabled")) {
-                gcp->logging = 0;
-            } else if (!strcmp(nodes[i]->content, "debug")) {
-                gcp->logging = 1;
-            } else if (!strcmp(nodes[i]->content, "info")) {
-                gcp->logging = 2;
-            } else if (!strcmp(nodes[i]->content, "warning")) {
-                gcp->logging = 3;
-            } else if (!strcmp(nodes[i]->content, "error")) {
-                gcp->logging = 4;
-            } else if (!strcmp(nodes[i]->content, "critical")) {
-                gcp->logging = 5;
-            } else if (strlen(nodes[i]->content) == 0) {
-                merror("Empty content for tag '%s'", XML_LOGGING);
-                return OS_INVALID;
-            } else {
-                merror("Invalid content for tag '%s'", XML_LOGGING);
-                return OS_INVALID;
-            }
+            mdebug1("Tag '%s' from the '%s' module is deprecated. This setting will be skipped.", XML_LOGGING, WM_GCP_PUBSUB_CONTEXT.name);
         }
         else if (is_sched_tag(nodes[i]->element)) {
             // Do nothing
@@ -248,7 +229,6 @@ int wm_gcp_bucket_read(const OS_XML *xml, xml_node **nodes, wmodule *module) {
         sched_scan_init(&(gcp->scan_config));
         gcp->scan_config.interval = WM_GCP_DEF_INTERVAL;
         gcp->run_on_start = 1;
-        gcp->logging = 2;
         module->context = &WM_GCP_BUCKET_CONTEXT;
         module->tag = strdup(module->context->name);
         module->data = gcp;
@@ -287,26 +267,9 @@ int wm_gcp_bucket_read(const OS_XML *xml, xml_node **nodes, wmodule *module) {
             gcp->run_on_start = run_on_start;
         }
         else if (!strcmp(nodes[i]->element, XML_LOGGING)) {
-            if (!strcmp(nodes[i]->content, "disabled")) {
-                gcp->logging = 0;
-            } else if (!strcmp(nodes[i]->content, "debug")) {
-                gcp->logging = 1;
-            } else if (!strcmp(nodes[i]->content, "info")) {
-                gcp->logging = 2;
-            } else if (!strcmp(nodes[i]->content, "warning")) {
-                gcp->logging = 3;
-            } else if (!strcmp(nodes[i]->content, "error")) {
-                gcp->logging = 4;
-            } else if (!strcmp(nodes[i]->content, "critical")) {
-                gcp->logging = 5;
-            } else if (strlen(nodes[i]->content) == 0) {
-                merror("Empty content for tag '%s'", XML_LOGGING);
-                return OS_INVALID;
-            } else {
-                merror("Invalid content for tag '%s'", XML_LOGGING);
-                return OS_INVALID;
-            }
-        } else if (!strcmp(nodes[i]->element, XML_BUCKET)) {
+	    mdebug1("Tag '%s' from the '%s' module is deprecated. This setting will be skipped.", XML_LOGGING, WM_GCP_BUCKET_CONTEXT.name);
+	}
+        else if (!strcmp(nodes[i]->element, XML_BUCKET)) {
             mtdebug2(WM_GCP_BUCKET_LOGTAG, "Found a bucket tag");
             // Create bucket node
             if (cur_bucket) {

--- a/src/config/wmodules-gcp.c
+++ b/src/config/wmodules-gcp.c
@@ -184,7 +184,7 @@ int wm_gcp_pubsub_read(xml_node **nodes, wmodule *module) {
             gcp->pull_on_start = pull_on_start;
         }
         else if (!strcmp(nodes[i]->element, XML_LOGGING)) {
-            mdebug1("Tag '%s' from the '%s' module is deprecated. This setting will be skipped.", XML_LOGGING, WM_GCP_PUBSUB_CONTEXT.name);
+            mtdebug1(WM_GCP_PUBSUB_LOGTAG, "Tag '%s' from the '%s' module is deprecated. This setting will be skipped.", XML_LOGGING, WM_GCP_PUBSUB_CONTEXT.name);
         }
         else if (is_sched_tag(nodes[i]->element)) {
             // Do nothing
@@ -267,7 +267,7 @@ int wm_gcp_bucket_read(const OS_XML *xml, xml_node **nodes, wmodule *module) {
             gcp->run_on_start = run_on_start;
         }
         else if (!strcmp(nodes[i]->element, XML_LOGGING)) {
-	    mdebug1("Tag '%s' from the '%s' module is deprecated. This setting will be skipped.", XML_LOGGING, WM_GCP_BUCKET_CONTEXT.name);
+	    mtdebug1(WM_GCP_BUCKET_LOGTAG, "Tag '%s' from the '%s' module is deprecated. This setting will be skipped.", XML_LOGGING, WM_GCP_BUCKET_CONTEXT.name);
 	}
         else if (!strcmp(nodes[i]->element, XML_BUCKET)) {
             mtdebug2(WM_GCP_BUCKET_LOGTAG, "Found a bucket tag");

--- a/src/unit_tests/wazuh_modules/gcp/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/gcp/CMakeLists.txt
@@ -13,7 +13,7 @@ list(APPEND tests_names "test_wm_gcp")
 list(APPEND tests_flags "-Wl,--wrap,wm_exec \
                          -Wl,--wrap,sched_scan_dump,--wrap,sched_scan_get_time_until_next_scan \
                          -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,FOREVER,--wrap,w_get_timestamp \
-                         -Wl,--wrap,w_sleep_until ${DEBUG_OP_WRAPPERS}")
+                         -Wl,--wrap,w_sleep_until,--wrap,isDebug ${DEBUG_OP_WRAPPERS}")
 list(APPEND use_shared_libs 0)
 
 list(APPEND tests_names "test_wmodules_gcp")

--- a/src/unit_tests/wazuh_modules/gcp/test_wm_gcp.c
+++ b/src/unit_tests/wazuh_modules/gcp/test_wm_gcp.c
@@ -408,7 +408,7 @@ static void test_wm_gcp_pubsub_run_unknown_error(void **state) {
     expect_value(__wrap_wm_exec, secs, 0);
     expect_value(__wrap_wm_exec, add_path, NULL);
 
-    will_return(__wrap_wm_exec, "Unknown error - This is an unknown error.");
+    will_return(__wrap_wm_exec, "gcloud_wodleUnknown error - This is an unknown error.");
     will_return(__wrap_wm_exec, 1);
     will_return(__wrap_wm_exec, 0);
 
@@ -631,7 +631,7 @@ static void test_wm_gcp_pubsub_run_logging_warning_message_warning(void **state)
     expect_value(__wrap_wm_exec, secs, 0);
     expect_value(__wrap_wm_exec, add_path, NULL);
 
-    will_return(__wrap_wm_exec, "Test output - WARNING - This is a warning message");
+    will_return(__wrap_wm_exec, ":gcloud_wodle:Test output - WARNING - This is a warning message");
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_isDebug, 0);
@@ -703,7 +703,7 @@ static void test_wm_gcp_pubsub_run_logging_debug_message_not_debug(void **state)
     expect_value(__wrap_wm_exec, secs, 0);
     expect_value(__wrap_wm_exec, add_path, NULL);
 
-    will_return(__wrap_wm_exec, "Test output - INFO - This is an info message");
+    will_return(__wrap_wm_exec, ":gcloud_wodle:Test output - INFO - This is an info message");
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_isDebug, 2);
@@ -740,7 +740,7 @@ static void test_wm_gcp_pubsub_run_logging_info_message_info(void **state) {
     expect_value(__wrap_wm_exec, secs, 0);
     expect_value(__wrap_wm_exec, add_path, NULL);
 
-    will_return(__wrap_wm_exec, "Test output - INFO - This is an info message");
+    will_return(__wrap_wm_exec, ":gcloud_wodle:Test output - INFO - This is an info message");
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_isDebug, 1);
@@ -777,7 +777,7 @@ static void test_wm_gcp_pubsub_run_logging_info_message_debug(void **state) {
     expect_value(__wrap_wm_exec, secs, 0);
     expect_value(__wrap_wm_exec, add_path, NULL);
 
-    will_return(__wrap_wm_exec, "Test output - DEBUG - This is an info message");
+    will_return(__wrap_wm_exec, "gcloud_wodleTest output - DEBUG - This is an info message");
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_isDebug, 1);
@@ -811,7 +811,7 @@ static void test_wm_gcp_pubsub_run_logging_info_message_warning(void **state) {
     expect_value(__wrap_wm_exec, secs, 0);
     expect_value(__wrap_wm_exec, add_path, NULL);
 
-    will_return(__wrap_wm_exec, "Test output - WARNING - This is a warning message");
+    will_return(__wrap_wm_exec, ":gcloud_wodle:Test output - WARNING - This is a warning message");
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_isDebug, 1);
@@ -846,13 +846,89 @@ static void test_wm_gcp_pubsub_run_logging_warning_message_error(void **state) {
     expect_value(__wrap_wm_exec, secs, 0);
     expect_value(__wrap_wm_exec, add_path, NULL);
 
-    will_return(__wrap_wm_exec, "Test output - ERROR - This is an error message");
+    will_return(__wrap_wm_exec, ":gcloud_wodle:Test output - ERROR - This is an error message");
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_isDebug, 0);
 
     expect_string(__wrap__mterror, tag, WM_GCP_PUBSUB_LOGTAG);
     expect_string(__wrap__mterror, formatted_msg, "This is an error message");
+    wm_gcp_pubsub_run(gcp_config);
+}
+
+static void test_wm_gcp_pubsub_run_logging_warning_multiline_message_error(void **state) {
+    wm_gcp_pubsub *gcp_config = *state;
+
+    snprintf(gcp_config->project_id, OS_SIZE_1024, "wazuh-gcp-test");
+    snprintf(gcp_config->subscription_name, OS_SIZE_1024, "wazuh-subscription-test");
+    snprintf(gcp_config->credentials_file, OS_SIZE_1024, "/wazuh/credentials/test.json");
+
+    gcp_config->max_messages = 10;
+    gcp_config->num_threads = 2;
+
+    expect_string(__wrap__mtdebug2, tag, WM_GCP_PUBSUB_LOGTAG);
+    expect_string(__wrap__mtdebug2, formatted_msg, "Create argument list");
+    will_return(__wrap_isDebug, 0);
+
+    expect_string(__wrap__mtdebug1, tag, WM_GCP_PUBSUB_LOGTAG);
+    expect_string(__wrap__mtdebug1, formatted_msg, "Launching command: "
+        "wodles/gcloud/gcloud --integration_type pubsub --project wazuh-gcp-test --subscription_id wazuh-subscription-test "
+        "--credentials_file /wazuh/credentials/test.json --max_messages 10 --num_threads 2");
+
+    expect_string(__wrap_wm_exec, command,
+        "wodles/gcloud/gcloud --integration_type pubsub --project wazuh-gcp-test --subscription_id wazuh-subscription-test "
+        "--credentials_file /wazuh/credentials/test.json --max_messages 10 --num_threads 2");
+    expect_value(__wrap_wm_exec, secs, 0);
+    expect_value(__wrap_wm_exec, add_path, NULL);
+
+    will_return(__wrap_wm_exec, ":gcloud_wodle:Test output - ERROR - This is a \nmultiline\nerror message");
+    will_return(__wrap_wm_exec, 0);
+    will_return(__wrap_wm_exec, 0);
+    will_return(__wrap_isDebug, 0);
+
+    expect_string(__wrap__mterror, tag, WM_GCP_PUBSUB_LOGTAG);
+    expect_string(__wrap__mterror, formatted_msg, "This is a \nmultiline\nerror message");
+    wm_gcp_pubsub_run(gcp_config);
+}
+
+static void test_wm_gcp_pubsub_run_logging_warning_multimessage_message_error(void **state) {
+    wm_gcp_pubsub *gcp_config = *state;
+
+    snprintf(gcp_config->project_id, OS_SIZE_1024, "wazuh-gcp-test");
+    snprintf(gcp_config->subscription_name, OS_SIZE_1024, "wazuh-subscription-test");
+    snprintf(gcp_config->credentials_file, OS_SIZE_1024, "/wazuh/credentials/test.json");
+
+    gcp_config->max_messages = 10;
+    gcp_config->num_threads = 2;
+
+    expect_string(__wrap__mtdebug2, tag, WM_GCP_PUBSUB_LOGTAG);
+    expect_string(__wrap__mtdebug2, formatted_msg, "Create argument list");
+    will_return(__wrap_isDebug, 0);
+
+    expect_string(__wrap__mtdebug1, tag, WM_GCP_PUBSUB_LOGTAG);
+    expect_string(__wrap__mtdebug1, formatted_msg, "Launching command: "
+        "wodles/gcloud/gcloud --integration_type pubsub --project wazuh-gcp-test --subscription_id wazuh-subscription-test "
+        "--credentials_file /wazuh/credentials/test.json --max_messages 10 --num_threads 2");
+
+    expect_string(__wrap_wm_exec, command,
+        "wodles/gcloud/gcloud --integration_type pubsub --project wazuh-gcp-test --subscription_id wazuh-subscription-test "
+        "--credentials_file /wazuh/credentials/test.json --max_messages 10 --num_threads 2");
+    expect_value(__wrap_wm_exec, secs, 0);
+    expect_value(__wrap_wm_exec, add_path, NULL);
+
+    will_return(__wrap_wm_exec, ":gcloud_wodle:Test output - ERROR - This is a \nmultiline\nerror message\n"
+		":gcloud_wodle:Test output - ERROR - This is the second message\n"
+		":gcloud_wodle:Test output - CRITICAL - This is a critical message\n");
+    will_return(__wrap_wm_exec, 0);
+    will_return(__wrap_wm_exec, 0);
+    will_return(__wrap_isDebug, 0);
+
+    expect_string(__wrap__mterror, tag, WM_GCP_PUBSUB_LOGTAG);
+    expect_string(__wrap__mterror, formatted_msg, "This is a \nmultiline\nerror message");
+    expect_string(__wrap__mterror, tag, WM_GCP_PUBSUB_LOGTAG);
+    expect_string(__wrap__mterror, formatted_msg, "This is the second message");
+    expect_string(__wrap__mterror, tag, WM_GCP_PUBSUB_LOGTAG);
+    expect_string(__wrap__mterror, formatted_msg, "This is a critical message");
     wm_gcp_pubsub_run(gcp_config);
 }
 
@@ -1571,7 +1647,7 @@ static void test_wm_gcp_bucket_run_logging_debug_message_debug(void **state) {
     expect_value(__wrap_wm_exec, secs, 0);
     expect_value(__wrap_wm_exec, add_path, NULL);
 
-    will_return(__wrap_wm_exec, "Test output - DEBUG - This is a debug message");
+    will_return(__wrap_wm_exec, ":gcloud_wodle:Test output - DEBUG - This is a debug message");
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_isDebug, 2);
@@ -1609,7 +1685,7 @@ static void test_wm_gcp_bucket_run_logging_debug_message_not_debug_discarded(voi
     expect_value(__wrap_wm_exec, secs, 0);
     expect_value(__wrap_wm_exec, add_path, NULL);
 
-    will_return(__wrap_wm_exec, "Test output - This is a discarded message");
+    will_return(__wrap_wm_exec, ":gcloud_wodle:Test output - This is a discarded message");
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_isDebug, 2);
@@ -1644,7 +1720,7 @@ static void test_wm_gcp_bucket_run_logging_debug_message_not_debug(void **state)
     expect_value(__wrap_wm_exec, secs, 0);
     expect_value(__wrap_wm_exec, add_path, NULL);
 
-    will_return(__wrap_wm_exec, "Test output - INFO - This is an info message");
+    will_return(__wrap_wm_exec, ":gcloud_wodle:Test output - INFO - This is an info message\n");
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_isDebug, 2);
@@ -1681,7 +1757,7 @@ static void test_wm_gcp_bucket_run_logging_info_message_info(void **state) {
     expect_value(__wrap_wm_exec, secs, 0);
     expect_value(__wrap_wm_exec, add_path, NULL);
 
-    will_return(__wrap_wm_exec, "Test output - INFO - This is an info message");
+    will_return(__wrap_wm_exec, ":gcloud_wodle:Test output - INFO - This is an info message");
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_isDebug, 1);
@@ -1756,7 +1832,7 @@ static void test_wm_gcp_bucket_run_logging_info_message_warning(void **state) {
     expect_value(__wrap_wm_exec, secs, 0);
     expect_value(__wrap_wm_exec, add_path, NULL);
 
-    will_return(__wrap_wm_exec, "Test output - WARNING - This is a warning message");
+    will_return(__wrap_wm_exec, ":gcloud_wodle:Test output - WARNING - This is a warning message");
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_isDebug, 1);
@@ -1793,7 +1869,7 @@ static void test_wm_gcp_bucket_run_logging_warning_message_warning(void **state)
     expect_value(__wrap_wm_exec, secs, 0);
     expect_value(__wrap_wm_exec, add_path, NULL);
 
-    will_return(__wrap_wm_exec, "Test output - WARNING - This is a warning message");
+    will_return(__wrap_wm_exec, ":gcloud_wodle:Test output - WARNING - This is a warning message");
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
 
@@ -1865,13 +1941,96 @@ static void test_wm_gcp_bucket_run_logging_warning_message_error(void **state) {
     expect_value(__wrap_wm_exec, secs, 0);
     expect_value(__wrap_wm_exec, add_path, NULL);
 
-    will_return(__wrap_wm_exec, "Test output - ERROR - This is an error message");
+    will_return(__wrap_wm_exec, ":gcloud_wodle:Test output - ERROR - This is an error message");
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_isDebug, 0);
 
     expect_string(__wrap__mterror, tag, WM_GCP_BUCKET_LOGTAG);
     expect_string(__wrap__mterror, formatted_msg, "This is an error message");
+    wm_gcp_bucket_run(gcp_config, cur_bucket);
+}
+
+static void test_wm_gcp_bucket_run_logging_warning_multiline_message_error(void **state) {
+    wm_gcp_bucket_base *gcp_config = *state;
+    wm_gcp_bucket *cur_bucket = gcp_config->buckets;
+
+    snprintf(cur_bucket->bucket, OS_SIZE_1024, "wazuh-gcp-test");
+    snprintf(cur_bucket->type, OS_SIZE_1024, "access_logs");
+    snprintf(cur_bucket->credentials_file, OS_SIZE_1024, "/wazuh/credentials/test.json");
+    snprintf(cur_bucket->prefix, OS_SIZE_1024, "access_logs/");
+    snprintf(cur_bucket->only_logs_after, OS_SIZE_1024, "2021-JAN-01");
+
+    cur_bucket->remove_from_bucket = 1; // enabled
+
+    expect_string(__wrap__mtdebug2, tag, WM_GCP_BUCKET_LOGTAG);
+    expect_string(__wrap__mtdebug2, formatted_msg, "Create argument list");
+
+    will_return(__wrap_isDebug, 0);
+
+    expect_string(__wrap__mtdebug1, tag, WM_GCP_BUCKET_LOGTAG);
+    expect_string(__wrap__mtdebug1, formatted_msg, "Launching command: "
+        "wodles/gcloud/gcloud --integration_type access_logs --bucket_name wazuh-gcp-test --credentials_file "
+        "/wazuh/credentials/test.json --prefix access_logs/ --only_logs_after 2021-JAN-01 --remove");
+
+    expect_string(__wrap_wm_exec, command,
+        "wodles/gcloud/gcloud --integration_type access_logs --bucket_name wazuh-gcp-test --credentials_file "
+        "/wazuh/credentials/test.json --prefix access_logs/ --only_logs_after 2021-JAN-01 --remove");
+    expect_value(__wrap_wm_exec, secs, 0);
+    expect_value(__wrap_wm_exec, add_path, NULL);
+
+    will_return(__wrap_wm_exec, ":gcloud_wodle:Test output - ERROR - This is a\nmultiline\n error message\n");
+    will_return(__wrap_wm_exec, 0);
+    will_return(__wrap_wm_exec, 0);
+    will_return(__wrap_isDebug, 0);
+
+    expect_string(__wrap__mterror, tag, WM_GCP_BUCKET_LOGTAG);
+    expect_string(__wrap__mterror, formatted_msg, "This is a\nmultiline\n error message");
+    wm_gcp_bucket_run(gcp_config, cur_bucket);
+}
+
+static void test_wm_gcp_bucket_run_logging_warning_multimessage_message_error(void **state) {
+    wm_gcp_bucket_base *gcp_config = *state;
+    wm_gcp_bucket *cur_bucket = gcp_config->buckets;
+
+    snprintf(cur_bucket->bucket, OS_SIZE_1024, "wazuh-gcp-test");
+    snprintf(cur_bucket->type, OS_SIZE_1024, "access_logs");
+    snprintf(cur_bucket->credentials_file, OS_SIZE_1024, "/wazuh/credentials/test.json");
+    snprintf(cur_bucket->prefix, OS_SIZE_1024, "access_logs/");
+    snprintf(cur_bucket->only_logs_after, OS_SIZE_1024, "2021-JAN-01");
+
+    cur_bucket->remove_from_bucket = 1; // enabled
+
+    expect_string(__wrap__mtdebug2, tag, WM_GCP_BUCKET_LOGTAG);
+    expect_string(__wrap__mtdebug2, formatted_msg, "Create argument list");
+
+    will_return(__wrap_isDebug, 1);
+    will_return(__wrap_isDebug, 1);
+
+    expect_string(__wrap__mtdebug1, tag, WM_GCP_BUCKET_LOGTAG);
+    expect_string(__wrap__mtdebug1, formatted_msg, "Launching command: "
+        "wodles/gcloud/gcloud --integration_type access_logs --bucket_name wazuh-gcp-test --credentials_file "
+        "/wazuh/credentials/test.json --prefix access_logs/ --only_logs_after 2021-JAN-01 --remove --log_level 1");
+
+    expect_string(__wrap_wm_exec, command,
+        "wodles/gcloud/gcloud --integration_type access_logs --bucket_name wazuh-gcp-test --credentials_file "
+        "/wazuh/credentials/test.json --prefix access_logs/ --only_logs_after 2021-JAN-01 --remove --log_level 1");
+    expect_value(__wrap_wm_exec, secs, 0);
+    expect_value(__wrap_wm_exec, add_path, NULL);
+
+    will_return(__wrap_wm_exec, ":gcloud_wodle:Test output - ERROR - This is a\nmultimessage\n error message\n"
+		":gcloud_wodle:Test critical - CRITICAL - This is another error message\n"
+		":gcloud_wodle:Test info - INFO - This is a test info message\n");
+    will_return(__wrap_wm_exec, 0);
+    will_return(__wrap_wm_exec, 0);
+    will_return(__wrap_isDebug, 1);
+
+    expect_string(__wrap__mterror, tag, WM_GCP_BUCKET_LOGTAG);
+    expect_string(__wrap__mterror, formatted_msg, "This is a\nmultimessage\n error message");
+    expect_string(__wrap__mterror, tag, WM_GCP_BUCKET_LOGTAG);
+    expect_string(__wrap__mterror, formatted_msg, "This is another error message");
+    expect_string(__wrap__mtinfo, tag, WM_GCP_BUCKET_LOGTAG);
+    expect_string(__wrap__mtinfo, formatted_msg, "This is a test info message");
     wm_gcp_bucket_run(gcp_config, cur_bucket);
 }
 
@@ -2335,6 +2494,8 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_run_generic_error, setup_group_pubsub, teardown_group_pubsub),
         cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_run_generic_error_no_description, setup_group_pubsub, teardown_group_pubsub),
         cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_run_logging_warning_message_warning, setup_group_pubsub, teardown_group_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_run_logging_warning_multiline_message_error, setup_group_pubsub, teardown_group_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_run_logging_warning_multimessage_message_error, setup_group_pubsub, teardown_group_pubsub),
         cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_run_logging_debug_message_not_debug, setup_group_pubsub, teardown_group_pubsub),
         cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_run_logging_debug_message_not_debug_discarded, setup_group_pubsub, teardown_group_pubsub),
         cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_run_logging_info_message_info, setup_group_pubsub, teardown_group_pubsub),
@@ -2376,12 +2537,13 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_run_logging_warning_message_warning, setup_group_bucket, teardown_group_bucket),
         cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_run_logging_warning_message_debug, setup_group_bucket, teardown_group_bucket),
         cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_run_logging_warning_message_error, setup_group_bucket, teardown_group_bucket),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_run_logging_warning_multiline_message_error, setup_group_bucket, teardown_group_bucket),
+	cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_run_logging_warning_multimessage_message_error, setup_group_bucket, teardown_group_bucket),
 
         /* wm_gcp_bucket_dump */
         cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_dump_success, setup_gcp_bucket_dump, teardown_gcp_bucket_dump),
         cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_dump_error_allocating_wm_wd, setup_gcp_bucket_dump, teardown_gcp_bucket_dump),
         cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_dump_error_allocating_root, setup_gcp_bucket_dump, teardown_gcp_bucket_dump),
-
 
         /* wm_gcp_bucket_destroy */
         cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_destroy, setup_gcp_bucket_destroy, teardown_gcp_bucket_destroy),

--- a/src/unit_tests/wazuh_modules/gcp/test_wm_gcp.c
+++ b/src/unit_tests/wazuh_modules/gcp/test_wm_gcp.c
@@ -28,7 +28,7 @@ cJSON *wm_gcp_pubsub_dump(const wm_gcp_pubsub *data);
 void wm_gcp_pubsub_destroy(wm_gcp_pubsub * data);
 void* wm_gcp_pubsub_main(wm_gcp_pubsub *data);
 
-void wm_gcp_bucket_run(const wm_gcp_bucket_base *data, wm_gcp_bucket *exec_bucket);
+void wm_gcp_bucket_run(wm_gcp_bucket *exec_bucket);
 cJSON *wm_gcp_bucket_dump(const wm_gcp_bucket_base *data);
 void wm_gcp_bucket_destroy(wm_gcp_bucket_base *data);
 void* wm_gcp_bucket_main(wm_gcp_bucket_base *data);
@@ -408,7 +408,7 @@ static void test_wm_gcp_pubsub_run_unknown_error(void **state) {
     expect_value(__wrap_wm_exec, secs, 0);
     expect_value(__wrap_wm_exec, add_path, NULL);
 
-    will_return(__wrap_wm_exec, "gcloud_wodleUnknown error - This is an unknown error.");
+    will_return(__wrap_wm_exec, ":gcloud_wodle:Unknown error - This is an unknown error.");
     will_return(__wrap_wm_exec, 1);
     will_return(__wrap_wm_exec, 0);
 
@@ -777,7 +777,7 @@ static void test_wm_gcp_pubsub_run_logging_info_message_debug(void **state) {
     expect_value(__wrap_wm_exec, secs, 0);
     expect_value(__wrap_wm_exec, add_path, NULL);
 
-    will_return(__wrap_wm_exec, "gcloud_wodleTest output - DEBUG - This is an info message");
+    will_return(__wrap_wm_exec, ":gcloud_wodle:Test output - DEBUG - This is an info message");
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_isDebug, 1);
@@ -1345,7 +1345,7 @@ static void test_wm_gcp_bucket_run_success(void **state) {
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_isDebug, 0);
 
-    wm_gcp_bucket_run(gcp_config, cur_bucket);
+    wm_gcp_bucket_run(cur_bucket);
 }
 
 static void test_wm_gcp_bucket_run_error_running_command(void **state)  {
@@ -1383,7 +1383,7 @@ static void test_wm_gcp_bucket_run_error_running_command(void **state)  {
     expect_string(__wrap__mterror, tag, WM_GCP_BUCKET_LOGTAG);
     expect_string(__wrap__mterror, formatted_msg, "Internal error. Exiting...");
 
-    wm_gcp_bucket_run(gcp_config, cur_bucket);
+    wm_gcp_bucket_run(cur_bucket);
 }
 
 static void test_wm_gcp_bucket_run_error(void **state) {
@@ -1422,7 +1422,7 @@ static void test_wm_gcp_bucket_run_error(void **state) {
     expect_string(__wrap__mtwarn, tag, WM_GCP_BUCKET_LOGTAG);
     expect_string(__wrap__mtwarn, formatted_msg, "Command returned exit code 1");
 
-    wm_gcp_bucket_run(gcp_config, cur_bucket);
+    wm_gcp_bucket_run(cur_bucket);
 }
 
 static void test_wm_gcp_bucket_run_error_no_description(void **state) {
@@ -1460,7 +1460,7 @@ static void test_wm_gcp_bucket_run_error_no_description(void **state) {
     expect_string(__wrap__mtwarn, tag, WM_GCP_BUCKET_LOGTAG);
     expect_string(__wrap__mtwarn, formatted_msg, "Command returned exit code 1");
 
-    wm_gcp_bucket_run(gcp_config, cur_bucket);
+    wm_gcp_bucket_run(cur_bucket);
 }
 
 static void test_wm_gcp_bucket_run_error_parsing_args(void **state) {
@@ -1499,7 +1499,7 @@ static void test_wm_gcp_bucket_run_error_parsing_args(void **state) {
     expect_string(__wrap__mtwarn, tag, WM_GCP_BUCKET_LOGTAG);
     expect_string(__wrap__mtwarn, formatted_msg, "Command returned exit code 2");
 
-    wm_gcp_bucket_run(gcp_config, cur_bucket);
+    wm_gcp_bucket_run(cur_bucket);
 }
 
 static void test_wm_gcp_bucket_run_error_parsing_args_no_description(void **state) {
@@ -1538,7 +1538,7 @@ static void test_wm_gcp_bucket_run_error_parsing_args_no_description(void **stat
     expect_string(__wrap__mtwarn, tag, WM_GCP_BUCKET_LOGTAG);
     expect_string(__wrap__mtwarn, formatted_msg, "Command returned exit code 2");
 
-    wm_gcp_bucket_run(gcp_config, cur_bucket);
+    wm_gcp_bucket_run(cur_bucket);
 }
 
 static void test_wm_gcp_bucket_run_generic_error(void **state) {
@@ -1576,7 +1576,7 @@ static void test_wm_gcp_bucket_run_generic_error(void **state) {
 
     will_return(__wrap_isDebug, 0);
 
-    wm_gcp_bucket_run(gcp_config, cur_bucket);
+    wm_gcp_bucket_run(cur_bucket);
 }
 
 static void test_wm_gcp_bucket_run_generic_error_no_description(void **state) {
@@ -1615,7 +1615,7 @@ static void test_wm_gcp_bucket_run_generic_error_no_description(void **state) {
 
     will_return(__wrap_isDebug, 0);
 
-    wm_gcp_bucket_run(gcp_config, cur_bucket);
+    wm_gcp_bucket_run(cur_bucket);
 }
 
 static void test_wm_gcp_bucket_run_logging_debug_message_debug(void **state) {
@@ -1655,7 +1655,7 @@ static void test_wm_gcp_bucket_run_logging_debug_message_debug(void **state) {
     expect_string(__wrap__mtdebug1, tag, WM_GCP_BUCKET_LOGTAG);
     expect_string(__wrap__mtdebug1, formatted_msg, "This is a debug message");
 
-    wm_gcp_bucket_run(gcp_config, cur_bucket);
+    wm_gcp_bucket_run(cur_bucket);
 }
 
 static void test_wm_gcp_bucket_run_logging_debug_message_not_debug_discarded(void **state) {
@@ -1690,7 +1690,7 @@ static void test_wm_gcp_bucket_run_logging_debug_message_not_debug_discarded(voi
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_isDebug, 2);
 
-    wm_gcp_bucket_run(gcp_config, cur_bucket);
+    wm_gcp_bucket_run(cur_bucket);
 }
 
 static void test_wm_gcp_bucket_run_logging_debug_message_not_debug(void **state) {
@@ -1727,7 +1727,7 @@ static void test_wm_gcp_bucket_run_logging_debug_message_not_debug(void **state)
 
     expect_string(__wrap__mtinfo, tag, WM_GCP_BUCKET_LOGTAG);
     expect_string(__wrap__mtinfo, formatted_msg, "This is an info message");
-    wm_gcp_bucket_run(gcp_config, cur_bucket);
+    wm_gcp_bucket_run(cur_bucket);
 }
 
 static void test_wm_gcp_bucket_run_logging_info_message_info(void **state) {
@@ -1765,7 +1765,7 @@ static void test_wm_gcp_bucket_run_logging_info_message_info(void **state) {
     expect_string(__wrap__mtinfo, tag, WM_GCP_BUCKET_LOGTAG);
     expect_string(__wrap__mtinfo, formatted_msg, "This is an info message");
 
-    wm_gcp_bucket_run(gcp_config, cur_bucket);
+    wm_gcp_bucket_run(cur_bucket);
 }
 
 static void test_wm_gcp_bucket_run_logging_info_message_debug(void **state) {
@@ -1802,7 +1802,7 @@ static void test_wm_gcp_bucket_run_logging_info_message_debug(void **state) {
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_isDebug, 1);
 
-    wm_gcp_bucket_run(gcp_config, cur_bucket);
+    wm_gcp_bucket_run(cur_bucket);
 }
 
 static void test_wm_gcp_bucket_run_logging_info_message_warning(void **state) {
@@ -1840,7 +1840,7 @@ static void test_wm_gcp_bucket_run_logging_info_message_warning(void **state) {
     expect_string(__wrap__mtwarn, tag, WM_GCP_BUCKET_LOGTAG);
     expect_string(__wrap__mtwarn, formatted_msg, "This is a warning message");
 
-    wm_gcp_bucket_run(gcp_config, cur_bucket);
+    wm_gcp_bucket_run(cur_bucket);
 }
 
 static void test_wm_gcp_bucket_run_logging_warning_message_warning(void **state) {
@@ -1876,7 +1876,7 @@ static void test_wm_gcp_bucket_run_logging_warning_message_warning(void **state)
     expect_string(__wrap__mtwarn, tag, WM_GCP_BUCKET_LOGTAG);
     expect_string(__wrap__mtwarn, formatted_msg, "This is a warning message");
     will_return(__wrap_isDebug, 1);
-    wm_gcp_bucket_run(gcp_config, cur_bucket);
+    wm_gcp_bucket_run(cur_bucket);
 }
 
 static void test_wm_gcp_bucket_run_logging_warning_message_debug(void **state) {
@@ -1910,7 +1910,7 @@ static void test_wm_gcp_bucket_run_logging_warning_message_debug(void **state) {
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_isDebug, 0);
 
-    wm_gcp_bucket_run(gcp_config, cur_bucket);
+    wm_gcp_bucket_run(cur_bucket);
 }
 
 static void test_wm_gcp_bucket_run_logging_warning_message_error(void **state) {
@@ -1948,7 +1948,7 @@ static void test_wm_gcp_bucket_run_logging_warning_message_error(void **state) {
 
     expect_string(__wrap__mterror, tag, WM_GCP_BUCKET_LOGTAG);
     expect_string(__wrap__mterror, formatted_msg, "This is an error message");
-    wm_gcp_bucket_run(gcp_config, cur_bucket);
+    wm_gcp_bucket_run(cur_bucket);
 }
 
 static void test_wm_gcp_bucket_run_logging_warning_multiline_message_error(void **state) {
@@ -1986,7 +1986,7 @@ static void test_wm_gcp_bucket_run_logging_warning_multiline_message_error(void 
 
     expect_string(__wrap__mterror, tag, WM_GCP_BUCKET_LOGTAG);
     expect_string(__wrap__mterror, formatted_msg, "This is a\nmultiline\n error message");
-    wm_gcp_bucket_run(gcp_config, cur_bucket);
+    wm_gcp_bucket_run(cur_bucket);
 }
 
 static void test_wm_gcp_bucket_run_logging_warning_multimessage_message_error(void **state) {
@@ -2031,7 +2031,7 @@ static void test_wm_gcp_bucket_run_logging_warning_multimessage_message_error(vo
     expect_string(__wrap__mterror, formatted_msg, "This is another error message");
     expect_string(__wrap__mtinfo, tag, WM_GCP_BUCKET_LOGTAG);
     expect_string(__wrap__mtinfo, formatted_msg, "This is a test info message");
-    wm_gcp_bucket_run(gcp_config, cur_bucket);
+    wm_gcp_bucket_run(cur_bucket);
 }
 
 /* wm_gcp_bucket_dump */

--- a/src/unit_tests/wazuh_modules/gcp/test_wmodules_gcp.c
+++ b/src/unit_tests/wazuh_modules/gcp/test_wmodules_gcp.c
@@ -171,7 +171,6 @@ static int setup_test_pubsub(void **state) {
                         "<project_id>wazuh-gcp-pubsub-tests</project_id>"
                         "<subscription_name>testing-id</subscription_name>"
                         "<credentials_file>credentials.json</credentials_file>"
-                        "<logging>disabled</logging>"
                         "<max_messages>100</max_messages>"
                         "<num_threads>2</num_threads>"
                         "<day>15</day>";
@@ -193,7 +192,6 @@ static int setup_test_pubsub_no_project_id(void **state) {
                         "<pull_on_start>no</pull_on_start>"
                         "<subscription_name>testing-id</subscription_name>"
                         "<credentials_file>credentials.json</credentials_file>"
-                        "<logging>disabled</logging>"
                         "<max_messages>100</max_messages>"
                         "<num_threads>2</num_threads>"
                         "<day>15</day>";
@@ -215,7 +213,6 @@ static int setup_test_pubsub_no_subscription_name(void **state) {
                         "<pull_on_start>no</pull_on_start>"
                         "<project_id>wazuh-gcp-pubsub-tests</project_id>"
                         "<credentials_file>credentials.json</credentials_file>"
-                        "<logging>disabled</logging>"
                         "<max_messages>100</max_messages>"
                         "<num_threads>2</num_threads>"
                         "<day>15</day>";
@@ -237,7 +234,6 @@ static int setup_test_pubsub_no_credentials_file(void **state) {
                         "<pull_on_start>no</pull_on_start>"
                         "<project_id>wazuh-gcp-pubsub-tests</project_id>"
                         "<subscription_name>testing-id</subscription_name>"
-                        "<logging>disabled</logging>"
                         "<max_messages>100</max_messages>"
                         "<num_threads>2</num_threads>"
                         "<day>15</day>";
@@ -277,7 +273,6 @@ static int setup_test_bucket(void **state) {
     group_data_t *data = *state;
     char *base_config = "<enabled>yes</enabled>"
                         "<run_on_start>no</run_on_start>"
-                        "<logging>disabled</logging>"
                         "<bucket type='access_logs'>"
                           "<name>wazuh-gcp-bucket-tests</name>"
                           "<credentials_file>credentials.json</credentials_file>"
@@ -307,8 +302,7 @@ static int setup_test_bucket(void **state) {
 static int setup_test_no_bucket(void **state) {
     group_data_t *data = *state;
     char *base_config = "<enabled>yes</enabled>"
-                        "<run_on_start>no</run_on_start>"
-                        "<logging>disabled</logging>";
+                        "<run_on_start>no</run_on_start>";
 
     if(OS_ReadXMLString(base_config, data->xml) != 0){
         return -1;
@@ -324,7 +318,6 @@ static int setup_test_element_invalid(void **state) {
     group_data_t *data = *state;
     char *base_config = "<enabled>yes</enabled>"
                         "<run_on_start>no</run_on_start>"
-                        "<logging>disabled</logging>"
                         "<bucket type='access_logs'>"
                           "<invalid>wazuh-gcp-bucket-tests</invalid>"
                         "</bucket>";
@@ -343,7 +336,6 @@ static int setup_test_bucket_attribute_invalid(void **state) {
     group_data_t *data = *state;
     char *base_config = "<enabled>yes</enabled>"
                         "<run_on_start>no</run_on_start>"
-                        "<logging>disabled</logging>"
                         "<bucket invalid='access_logs'>"
                           "<name>wazuh-gcp-bucket-tests</name>"
                           "<credentials_file>credentials.json</credentials_file>"
@@ -366,7 +358,6 @@ static int setup_test_bucket_no_bucket(void **state) {
     group_data_t *data = *state;
     char *base_config = "<enabled>yes</enabled>"
                         "<run_on_start>no</run_on_start>"
-                        "<logging>disabled</logging>"
                         "<bucket type='access_logs'>"
                           "<credentials_file>credentials.json</credentials_file>"
                           "<only_logs_after>2021-JUN-01</only_logs_after>"
@@ -389,7 +380,6 @@ static int setup_test_bucket_no_bucket_type(void **state) {
     group_data_t *data = *state;
     char *base_config = "<enabled>yes</enabled>"
                         "<run_on_start>no</run_on_start>"
-                        "<logging>disabled</logging>"
                         "<bucket>"
                           "<name>wazuh-gcp-bucket-tests</name>"
                           "<credentials_file>credentials.json</credentials_file>"
@@ -414,7 +404,6 @@ static int setup_test_bucket_no_only_logs_after(void **state) {
     group_data_t *data = *state;
     char *base_config = "<enabled>yes</enabled>"
                         "<run_on_start>no</run_on_start>"
-                        "<logging>disabled</logging>"
                         "<bucket type='access_logs'>"
                           "<name>wazuh-gcp-bucket-tests</name>"
                           "<credentials_file>credentials.json</credentials_file>"
@@ -437,7 +426,6 @@ static int setup_test_bucket_no_credentials_file(void **state) {
     group_data_t *data = *state;
     char *base_config = "<enabled>yes</enabled>"
                         "<run_on_start>no</run_on_start>"
-                        "<logging>disabled</logging>"
                         "<bucket type='access_logs'>"
                           "<name>wazuh-gcp-bucket-tests</name>"
                           "<credentials_file>credentials.json</credentials_file>"
@@ -467,7 +455,6 @@ static int setup_test_bucket_no_path(void **state) {
     group_data_t *data = *state;
     char *base_config = "<enabled>yes</enabled>"
                         "<run_on_start>no</run_on_start>"
-                        "<logging>disabled</logging>"
                         "<bucket type='access_logs'>"
                           "<name>wazuh-gcp-bucket-tests</name>"
                           "<credentials_file>credentials.json</credentials_file>"
@@ -490,7 +477,6 @@ static int setup_test_bucket_no_remove(void **state) {
     group_data_t *data = *state;
     char *base_config = "<enabled>yes</enabled>"
                         "<run_on_start>no</run_on_start>"
-                        "<logging>disabled</logging>"
                         "<bucket type='access_logs'>"
                           "<name>wazuh-gcp-bucket-tests</name>"
                           "<credentials_file>credentials.json</credentials_file>"
@@ -574,7 +560,6 @@ static void test_wm_gcp_pubsub_read_full_configuration(void **state) {
     assert_string_equal(gcp->project_id, "wazuh-gcp-pubsub-tests");
     assert_string_equal(gcp->subscription_name, "testing-id");
     assert_string_equal(gcp->credentials_file, "credentials.json");
-    assert_int_equal(gcp->logging, 0);
     assert_int_equal(gcp->max_messages, 100);
     assert_int_equal(gcp->num_threads, 2);
 
@@ -713,7 +698,6 @@ static void test_wm_gcp_pubsub_read_credentials_file_full_path(void **state) {
     assert_string_equal(gcp->project_id, "wazuh-gcp-pubsub-tests");
     assert_string_equal(gcp->subscription_name, "testing-id");
     assert_string_equal(gcp->credentials_file, "/some/path/credentials.json");
-    assert_int_equal(gcp->logging, 0);
     assert_int_equal(gcp->max_messages, 100);
     assert_int_equal(gcp->num_threads, 2);
 
@@ -895,236 +879,6 @@ static void test_wm_gcp_pubsub_read_pull_on_start_tag_invalid(void **state) {
     assert_int_equal(ret, OS_INVALID);
 }
 
-static void test_wm_gcp_pubsub_read_logging_tag_debug(void **state) {
-    group_data_t *data = *state;
-    wm_gcp_pubsub *gcp;
-    int ret;
-
-    if(replace_configuration_value(data->nodes, XML_LOGGING, "debug") != 0)
-        fail();
-
-    expect_string(__wrap_realpath, path, "credentials.json");
-    will_return(__wrap_realpath, "credentials.json");
-
-    expect_string(__wrap_IsFile, file, "credentials.json");
-    will_return(__wrap_IsFile, 0);
-
-    expect_value(__wrap_sched_scan_read, nodes, data->nodes);
-    expect_string(__wrap_sched_scan_read, MODULE_NAME, GCP_PUBSUB_WM_NAME);
-    will_return(__wrap_sched_scan_read, 0);
-
-    ret = wm_gcp_pubsub_read(data->nodes, data->module);
-
-    assert_int_equal(ret, 0);
-
-    gcp = data->module->data;
-
-    assert_non_null(gcp);
-    assert_int_equal(gcp->enabled, 1);
-    assert_int_equal(gcp->pull_on_start, 0);
-    assert_string_equal(gcp->project_id, "wazuh-gcp-pubsub-tests");
-    assert_string_equal(gcp->subscription_name, "testing-id");
-    assert_string_equal(gcp->credentials_file, "credentials.json");
-    assert_int_equal(gcp->logging, 1);
-    assert_int_equal(gcp->max_messages, 100);
-    assert_int_equal(gcp->num_threads, 2);
-
-    assert_ptr_equal(data->module->context, &WM_GCP_PUBSUB_CONTEXT);
-    assert_string_equal(data->module->tag, GCP_PUBSUB_WM_NAME);
-}
-
-static void test_wm_gcp_pubsub_read_logging_tag_info(void **state) {
-    group_data_t *data = *state;
-    wm_gcp_pubsub *gcp;
-    int ret;
-
-    if(replace_configuration_value(data->nodes, XML_LOGGING, "info") != 0)
-        fail();
-
-    expect_string(__wrap_realpath, path, "credentials.json");
-    will_return(__wrap_realpath, "credentials.json");
-
-    expect_string(__wrap_IsFile, file, "credentials.json");
-    will_return(__wrap_IsFile, 0);
-
-    expect_value(__wrap_sched_scan_read, nodes, data->nodes);
-    expect_string(__wrap_sched_scan_read, MODULE_NAME, GCP_PUBSUB_WM_NAME);
-    will_return(__wrap_sched_scan_read, 0);
-
-    ret = wm_gcp_pubsub_read(data->nodes, data->module);
-
-    assert_int_equal(ret, 0);
-
-    gcp = data->module->data;
-
-    assert_non_null(gcp);
-    assert_int_equal(gcp->enabled, 1);
-    assert_int_equal(gcp->pull_on_start, 0);
-    assert_string_equal(gcp->project_id, "wazuh-gcp-pubsub-tests");
-    assert_string_equal(gcp->subscription_name, "testing-id");
-    assert_string_equal(gcp->credentials_file, "credentials.json");
-    assert_int_equal(gcp->logging, 2);
-    assert_int_equal(gcp->max_messages, 100);
-    assert_int_equal(gcp->num_threads, 2);
-
-    assert_ptr_equal(data->module->context, &WM_GCP_PUBSUB_CONTEXT);
-    assert_string_equal(data->module->tag, GCP_PUBSUB_WM_NAME);
-}
-
-static void test_wm_gcp_pubsub_read_logging_tag_warning(void **state) {
-    group_data_t *data = *state;
-    wm_gcp_pubsub *gcp;
-    int ret;
-
-    if(replace_configuration_value(data->nodes, XML_LOGGING, "warning") != 0)
-        fail();
-
-    expect_string(__wrap_realpath, path, "credentials.json");
-    will_return(__wrap_realpath, "credentials.json");
-
-    expect_string(__wrap_IsFile, file, "credentials.json");
-    will_return(__wrap_IsFile, 0);
-
-    expect_value(__wrap_sched_scan_read, nodes, data->nodes);
-    expect_string(__wrap_sched_scan_read, MODULE_NAME, GCP_PUBSUB_WM_NAME);
-    will_return(__wrap_sched_scan_read, 0);
-
-    ret = wm_gcp_pubsub_read(data->nodes, data->module);
-
-    assert_int_equal(ret, 0);
-
-    gcp = data->module->data;
-
-    assert_non_null(gcp);
-    assert_int_equal(gcp->enabled, 1);
-    assert_int_equal(gcp->pull_on_start, 0);
-    assert_string_equal(gcp->project_id, "wazuh-gcp-pubsub-tests");
-    assert_string_equal(gcp->subscription_name, "testing-id");
-    assert_string_equal(gcp->credentials_file, "credentials.json");
-    assert_int_equal(gcp->logging, 3);
-    assert_int_equal(gcp->max_messages, 100);
-    assert_int_equal(gcp->num_threads, 2);
-
-    assert_ptr_equal(data->module->context, &WM_GCP_PUBSUB_CONTEXT);
-    assert_string_equal(data->module->tag, GCP_PUBSUB_WM_NAME);
-}
-
-static void test_wm_gcp_pubsub_read_logging_tag_error(void **state) {
-    group_data_t *data = *state;
-    wm_gcp_pubsub *gcp;
-    int ret;
-
-    if(replace_configuration_value(data->nodes, XML_LOGGING, "error") != 0)
-        fail();
-
-    expect_string(__wrap_realpath, path, "credentials.json");
-    will_return(__wrap_realpath, "credentials.json");
-
-    expect_string(__wrap_IsFile, file, "credentials.json");
-    will_return(__wrap_IsFile, 0);
-
-    expect_value(__wrap_sched_scan_read, nodes, data->nodes);
-    expect_string(__wrap_sched_scan_read, MODULE_NAME, GCP_PUBSUB_WM_NAME);
-    will_return(__wrap_sched_scan_read, 0);
-
-    ret = wm_gcp_pubsub_read(data->nodes, data->module);
-
-    assert_int_equal(ret, 0);
-
-    gcp = data->module->data;
-
-    assert_non_null(gcp);
-    assert_int_equal(gcp->enabled, 1);
-    assert_int_equal(gcp->pull_on_start, 0);
-    assert_string_equal(gcp->project_id, "wazuh-gcp-pubsub-tests");
-    assert_string_equal(gcp->subscription_name, "testing-id");
-    assert_string_equal(gcp->credentials_file, "credentials.json");
-    assert_int_equal(gcp->logging, 4);
-    assert_int_equal(gcp->max_messages, 100);
-    assert_int_equal(gcp->num_threads, 2);
-
-    assert_ptr_equal(data->module->context, &WM_GCP_PUBSUB_CONTEXT);
-    assert_string_equal(data->module->tag, GCP_PUBSUB_WM_NAME);
-}
-
-static void test_wm_gcp_pubsub_read_logging_tag_critical(void **state) {
-    group_data_t *data = *state;
-    wm_gcp_pubsub *gcp;
-    int ret;
-
-    if(replace_configuration_value(data->nodes, XML_LOGGING, "critical") != 0)
-        fail();
-
-    expect_string(__wrap_realpath, path, "credentials.json");
-    will_return(__wrap_realpath, "credentials.json");
-
-    expect_string(__wrap_IsFile, file, "credentials.json");
-    will_return(__wrap_IsFile, 0);
-
-    expect_value(__wrap_sched_scan_read, nodes, data->nodes);
-    expect_string(__wrap_sched_scan_read, MODULE_NAME, GCP_PUBSUB_WM_NAME);
-    will_return(__wrap_sched_scan_read, 0);
-
-    ret = wm_gcp_pubsub_read(data->nodes, data->module);
-
-    assert_int_equal(ret, 0);
-
-    gcp = data->module->data;
-
-    assert_non_null(gcp);
-    assert_int_equal(gcp->enabled, 1);
-    assert_int_equal(gcp->pull_on_start, 0);
-    assert_string_equal(gcp->project_id, "wazuh-gcp-pubsub-tests");
-    assert_string_equal(gcp->subscription_name, "testing-id");
-    assert_string_equal(gcp->credentials_file, "credentials.json");
-    assert_int_equal(gcp->logging, 5);
-    assert_int_equal(gcp->max_messages, 100);
-    assert_int_equal(gcp->num_threads, 2);
-
-    assert_ptr_equal(data->module->context, &WM_GCP_PUBSUB_CONTEXT);
-    assert_string_equal(data->module->tag, GCP_PUBSUB_WM_NAME);
-}
-
-static void test_wm_gcp_pubsub_read_logging_tag_invalid(void **state) {
-    group_data_t *data = *state;
-    int ret;
-
-    if(replace_configuration_value(data->nodes, XML_LOGGING, "invalid") != 0)
-        fail();
-
-    expect_string(__wrap_realpath, path, "credentials.json");
-    will_return(__wrap_realpath, "credentials.json");
-
-    expect_string(__wrap_IsFile, file, "credentials.json");
-    will_return(__wrap_IsFile, 0);
-
-    expect_string(__wrap__merror, formatted_msg, "Invalid content for tag 'logging'");
-
-    ret = wm_gcp_pubsub_read(data->nodes, data->module);
-
-    assert_int_equal(ret, OS_INVALID);
-}
-
-static void test_wm_gcp_pubsub_read_logging_tag_empty(void **state) {
-    group_data_t *data = *state;
-    int ret;
-
-    if(replace_configuration_value(data->nodes, XML_LOGGING, "") != 0)
-        fail();
-
-    expect_string(__wrap_realpath, path, "credentials.json");
-    will_return(__wrap_realpath, "credentials.json");
-
-    expect_string(__wrap_IsFile, file, "credentials.json");
-    will_return(__wrap_IsFile, 0);
-
-    expect_string(__wrap__merror, formatted_msg, "Empty content for tag 'logging'");
-
-    ret = wm_gcp_pubsub_read(data->nodes, data->module);
-
-    assert_int_equal(ret, OS_INVALID);
-}
-
 static void test_wm_gcp_pubsub_read_invalid_tag(void **state) {
     group_data_t *data = *state;
     int ret;
@@ -1200,7 +954,6 @@ static void test_wm_gcp_bucket_read_full_configuration(void **state) {
     assert_non_null(gcp);
     assert_int_equal(gcp->enabled, 1);
     assert_int_equal(gcp->run_on_start, 0);
-    assert_int_equal(gcp->logging, 0);
     assert_string_equal(gcp->buckets->bucket, "wazuh-gcp-bucket-tests");
     assert_string_equal(gcp->buckets->only_logs_after, "2021-JUN-01");
     assert_string_equal(gcp->buckets->credentials_file, "credentials.json");
@@ -1459,7 +1212,6 @@ static void test_wm_gcp_bucket_read_credentials_file_full_path(void **state) {
     assert_non_null(gcp);
     assert_int_equal(gcp->enabled, 1);
     assert_int_equal(gcp->run_on_start, 0);
-    assert_int_equal(gcp->logging, 0);
     assert_string_equal(gcp->buckets->bucket, "wazuh-gcp-bucket-tests");
     assert_string_equal(gcp->buckets->only_logs_after, "2021-JUN-01");
     assert_string_equal(gcp->buckets->credentials_file, "/some/path/credentials.json");
@@ -1581,239 +1333,6 @@ static void test_wm_gcp_bucket_read_run_on_start_tag_invalid(void **state) {
     assert_int_equal(ret, OS_INVALID);
 }
 
-static void test_wm_gcp_bucket_read_logging_tag_debug(void **state) {
-    group_data_t *data = *state;
-    wm_gcp_bucket_base *gcp;
-    int ret;
-
-    expect_any_always(__wrap__mtdebug2, tag);
-    expect_any_always(__wrap__mtdebug2, formatted_msg);
-
-    if(replace_configuration_value(data->nodes, XML_LOGGING, "debug") != 0)
-        fail();
-
-    expect_string_count(__wrap_realpath, path, "credentials.json", 2);
-    will_return_count(__wrap_realpath, "credentials.json", 2);
-
-    expect_string_count(__wrap_IsFile, file, "credentials.json", 2);
-    will_return_count(__wrap_IsFile, 0, 2);
-
-    expect_value(__wrap_sched_scan_read, nodes, data->nodes);
-    expect_string(__wrap_sched_scan_read, MODULE_NAME, GCP_BUCKET_WM_NAME);
-    will_return(__wrap_sched_scan_read, 0);
-
-    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
-
-    assert_int_equal(ret, 0);
-
-    gcp = data->module->data;
-
-    assert_non_null(gcp);
-    assert_int_equal(gcp->enabled, 1);
-    assert_int_equal(gcp->run_on_start, 0);
-    assert_int_equal(gcp->logging, 1);
-    assert_string_equal(gcp->buckets->bucket, "wazuh-gcp-bucket-tests");
-    assert_string_equal(gcp->buckets->only_logs_after, "2021-JUN-01");
-    assert_string_equal(gcp->buckets->credentials_file, "credentials.json");
-    assert_string_equal(gcp->buckets->prefix, "access_logs/");
-    assert_int_equal(gcp->buckets->remove_from_bucket, 0);
-
-    assert_ptr_equal(data->module->context, &WM_GCP_BUCKET_CONTEXT);
-    assert_string_equal(data->module->tag, GCP_BUCKET_WM_NAME);
-}
-
-static void test_wm_gcp_bucket_read_logging_tag_info(void **state) {
-    group_data_t *data = *state;
-    wm_gcp_bucket_base *gcp;
-    int ret;
-
-    expect_any_always(__wrap__mtdebug2, tag);
-    expect_any_always(__wrap__mtdebug2, formatted_msg);
-
-    if(replace_configuration_value(data->nodes, XML_LOGGING, "info") != 0)
-        fail();
-
-    expect_string_count(__wrap_realpath, path, "credentials.json", 2);
-    will_return_count(__wrap_realpath, "credentials.json", 2);
-
-    expect_string_count(__wrap_IsFile, file, "credentials.json", 2);
-    will_return_count(__wrap_IsFile, 0, 2);
-
-    expect_value(__wrap_sched_scan_read, nodes, data->nodes);
-    expect_string(__wrap_sched_scan_read, MODULE_NAME, GCP_BUCKET_WM_NAME);
-    will_return(__wrap_sched_scan_read, 0);
-
-    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
-
-    assert_int_equal(ret, 0);
-
-    gcp = data->module->data;
-
-    assert_non_null(gcp);
-    assert_int_equal(gcp->enabled, 1);
-    assert_int_equal(gcp->run_on_start, 0);
-    assert_int_equal(gcp->logging, 2);
-    assert_string_equal(gcp->buckets->bucket, "wazuh-gcp-bucket-tests");
-    assert_string_equal(gcp->buckets->only_logs_after, "2021-JUN-01");
-    assert_string_equal(gcp->buckets->credentials_file, "credentials.json");
-    assert_string_equal(gcp->buckets->prefix, "access_logs/");
-    assert_int_equal(gcp->buckets->remove_from_bucket, 0);
-
-    assert_ptr_equal(data->module->context, &WM_GCP_BUCKET_CONTEXT);
-    assert_string_equal(data->module->tag, GCP_BUCKET_WM_NAME);
-}
-
-static void test_wm_gcp_bucket_read_logging_tag_warning(void **state) {
-    group_data_t *data = *state;
-    wm_gcp_bucket_base *gcp;
-    int ret;
-
-    expect_any_always(__wrap__mtdebug2, tag);
-    expect_any_always(__wrap__mtdebug2, formatted_msg);
-
-    if(replace_configuration_value(data->nodes, XML_LOGGING, "warning") != 0)
-        fail();
-
-    expect_string_count(__wrap_realpath, path, "credentials.json", 2);
-    will_return_count(__wrap_realpath, "credentials.json", 2);
-
-    expect_string_count(__wrap_IsFile, file, "credentials.json", 2);
-    will_return_count(__wrap_IsFile, 0, 2);
-
-    expect_value(__wrap_sched_scan_read, nodes, data->nodes);
-    expect_string(__wrap_sched_scan_read, MODULE_NAME, GCP_BUCKET_WM_NAME);
-    will_return(__wrap_sched_scan_read, 0);
-
-    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
-
-    assert_int_equal(ret, 0);
-
-    gcp = data->module->data;
-
-    assert_non_null(gcp);
-    assert_int_equal(gcp->enabled, 1);
-    assert_int_equal(gcp->run_on_start, 0);
-    assert_int_equal(gcp->logging, 3);
-    assert_string_equal(gcp->buckets->bucket, "wazuh-gcp-bucket-tests");
-    assert_string_equal(gcp->buckets->only_logs_after, "2021-JUN-01");
-    assert_string_equal(gcp->buckets->credentials_file, "credentials.json");
-    assert_string_equal(gcp->buckets->prefix, "access_logs/");
-    assert_int_equal(gcp->buckets->remove_from_bucket, 0);
-
-    assert_ptr_equal(data->module->context, &WM_GCP_BUCKET_CONTEXT);
-    assert_string_equal(data->module->tag, GCP_BUCKET_WM_NAME);
-}
-
-static void test_wm_gcp_bucket_read_logging_tag_error(void **state) {
-    group_data_t *data = *state;
-    wm_gcp_bucket_base *gcp;
-    int ret;
-
-    expect_any_always(__wrap__mtdebug2, tag);
-    expect_any_always(__wrap__mtdebug2, formatted_msg);
-
-    if(replace_configuration_value(data->nodes, XML_LOGGING, "error") != 0)
-        fail();
-
-    expect_string_count(__wrap_realpath, path, "credentials.json", 2);
-    will_return_count(__wrap_realpath, "credentials.json", 2);
-
-    expect_string_count(__wrap_IsFile, file, "credentials.json", 2);
-    will_return_count(__wrap_IsFile, 0, 2);
-
-    expect_value(__wrap_sched_scan_read, nodes, data->nodes);
-    expect_string(__wrap_sched_scan_read, MODULE_NAME, GCP_BUCKET_WM_NAME);
-    will_return(__wrap_sched_scan_read, 0);
-
-    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
-
-    assert_int_equal(ret, 0);
-
-    gcp = data->module->data;
-
-    assert_non_null(gcp);
-    assert_int_equal(gcp->enabled, 1);
-    assert_int_equal(gcp->run_on_start, 0);
-    assert_int_equal(gcp->logging, 4);
-    assert_string_equal(gcp->buckets->bucket, "wazuh-gcp-bucket-tests");
-    assert_string_equal(gcp->buckets->only_logs_after, "2021-JUN-01");
-    assert_string_equal(gcp->buckets->credentials_file, "credentials.json");
-    assert_string_equal(gcp->buckets->prefix, "access_logs/");
-    assert_int_equal(gcp->buckets->remove_from_bucket, 0);
-
-    assert_ptr_equal(data->module->context, &WM_GCP_BUCKET_CONTEXT);
-    assert_string_equal(data->module->tag, GCP_BUCKET_WM_NAME);
-}
-
-static void test_wm_gcp_bucket_read_logging_tag_critical(void **state) {
-    group_data_t *data = *state;
-    wm_gcp_bucket_base *gcp;
-    int ret;
-
-    expect_any_always(__wrap__mtdebug2, tag);
-    expect_any_always(__wrap__mtdebug2, formatted_msg);
-
-    if(replace_configuration_value(data->nodes, XML_LOGGING, "critical") != 0)
-        fail();
-
-    expect_string_count(__wrap_realpath, path, "credentials.json", 2);
-    will_return_count(__wrap_realpath, "credentials.json", 2);
-
-    expect_string_count(__wrap_IsFile, file, "credentials.json", 2);
-    will_return_count(__wrap_IsFile, 0, 2);
-
-    expect_value(__wrap_sched_scan_read, nodes, data->nodes);
-    expect_string(__wrap_sched_scan_read, MODULE_NAME, GCP_BUCKET_WM_NAME);
-    will_return(__wrap_sched_scan_read, 0);
-
-    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
-
-    assert_int_equal(ret, 0);
-
-    gcp = data->module->data;
-
-    assert_non_null(gcp);
-    assert_int_equal(gcp->enabled, 1);
-    assert_int_equal(gcp->run_on_start, 0);
-    assert_int_equal(gcp->logging, 5);
-    assert_string_equal(gcp->buckets->bucket, "wazuh-gcp-bucket-tests");
-    assert_string_equal(gcp->buckets->only_logs_after, "2021-JUN-01");
-    assert_string_equal(gcp->buckets->credentials_file, "credentials.json");
-    assert_string_equal(gcp->buckets->prefix, "access_logs/");
-    assert_int_equal(gcp->buckets->remove_from_bucket, 0);
-
-    assert_ptr_equal(data->module->context, &WM_GCP_BUCKET_CONTEXT);
-    assert_string_equal(data->module->tag, GCP_BUCKET_WM_NAME);
-}
-
-static void test_wm_gcp_bucket_read_logging_tag_invalid(void **state) {
-    group_data_t *data = *state;
-    int ret;
-
-    if(replace_configuration_value(data->nodes, XML_LOGGING, "invalid") != 0)
-        fail();
-
-    expect_string(__wrap__merror, formatted_msg, "Invalid content for tag 'logging'");
-
-    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
-
-    assert_int_equal(ret, OS_INVALID);
-}
-
-static void test_wm_gcp_bucket_read_logging_tag_empty(void **state) {
-    group_data_t *data = *state;
-    int ret;
-
-    if(replace_configuration_value(data->nodes, XML_LOGGING, "") != 0)
-        fail();
-
-    expect_string(__wrap__merror, formatted_msg, "Empty content for tag 'logging'");
-
-    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
-
-    assert_int_equal(ret, OS_INVALID);
-}
-
 static void test_wm_gcp_bucket_read_invalid_tag(void **state) {
     group_data_t *data = *state;
     int ret;
@@ -1877,13 +1396,6 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_num_threads_tag_empty, setup_test_pubsub, teardown_test_pubsub),
         cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_num_threads_tag_not_digit, setup_test_pubsub, teardown_test_pubsub),
         cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_pull_on_start_tag_invalid, setup_test_pubsub, teardown_test_pubsub),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_logging_tag_debug, setup_test_pubsub, teardown_test_pubsub),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_logging_tag_info, setup_test_pubsub, teardown_test_pubsub),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_logging_tag_warning, setup_test_pubsub, teardown_test_pubsub),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_logging_tag_error, setup_test_pubsub, teardown_test_pubsub),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_logging_tag_critical, setup_test_pubsub, teardown_test_pubsub),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_logging_tag_invalid, setup_test_pubsub, teardown_test_pubsub),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_logging_tag_empty, setup_test_pubsub, teardown_test_pubsub),
         cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_invalid_tag, setup_test_pubsub, teardown_test_pubsub),
         cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_invalid_element, setup_test_pubsub, teardown_test_pubsub),
         cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_invalid_nodes, setup_test_pubsub, teardown_test_pubsub),
@@ -1908,13 +1420,6 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_credentials_file_tag_file_not_found, setup_test_bucket, teardown_test_bucket),
         cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_no_credentials_file_tag, setup_test_bucket_no_credentials_file, teardown_test_bucket),
         cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_run_on_start_tag_invalid, setup_test_bucket, teardown_test_bucket),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_logging_tag_debug, setup_test_bucket, teardown_test_bucket),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_logging_tag_info, setup_test_bucket, teardown_test_bucket),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_logging_tag_warning, setup_test_bucket, teardown_test_bucket),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_logging_tag_error, setup_test_bucket, teardown_test_bucket),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_logging_tag_critical, setup_test_bucket, teardown_test_bucket),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_logging_tag_invalid, setup_test_bucket, teardown_test_bucket),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_logging_tag_empty, setup_test_bucket, teardown_test_bucket),
         cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_invalid_tag, setup_test_bucket, teardown_test_bucket),
         cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_invalid_element, setup_test_bucket, teardown_test_bucket),
         cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_invalid_nodes, setup_test_bucket, teardown_test_bucket),

--- a/src/wazuh_modules/wm_gcp.c
+++ b/src/wazuh_modules/wm_gcp.c
@@ -287,10 +287,11 @@ void wm_gcp_pubsub_run(const wm_gcp_pubsub *data) {
         wm_strcat(&command, int_to_string, ' ');
         os_free(int_to_string);
     }
-    if (data->logging) {
+
+    if (isDebug()){
         char *int_to_string;
         os_malloc(OS_SIZE_1024, int_to_string);
-        sprintf(int_to_string, "%d", data->logging);
+        sprintf(int_to_string, "%d", isDebug());
         wm_strcat(&command, "--log_level", ' ');
         wm_strcat(&command, int_to_string, ' ');
         os_free(int_to_string);
@@ -312,73 +313,40 @@ void wm_gcp_pubsub_run(const wm_gcp_pubsub *data) {
         pthread_exit(NULL);
     } else if (status > 0) {
         mtwarn(WM_GCP_PUBSUB_LOGTAG, "Command returned exit code %d", status);
-        if(status == 1) {
-            char * unknown_error_msg = strstr(output,"Unknown error");
-            if (unknown_error_msg == NULL)
-                mtwarn(WM_GCP_PUBSUB_LOGTAG, "Unknown error.");
-            else
-                mtwarn(WM_GCP_PUBSUB_LOGTAG, "%s", unknown_error_msg);
-        } else if(status == 2) {
-            char * ptr;
-            if (ptr = strstr(output, "integration.py: error:"), ptr) {
-                ptr += 16;
-                mtwarn(WM_GCP_PUBSUB_LOGTAG, "Error parsing arguments: %s", ptr);
-            } else {
-                mtwarn(WM_GCP_PUBSUB_LOGTAG, "Error parsing arguments.");
-            }
-        } else {
-            char * ptr;
-            if (ptr = strstr(output, "ERROR: "), ptr) {
-                ptr += 7;
-                mtwarn(WM_GCP_PUBSUB_LOGTAG, "%s", ptr);
-            } else {
-                mtwarn(WM_GCP_PUBSUB_LOGTAG, "%s", output);
-            }
-        }
-        mtdebug1(WM_GCP_PUBSUB_LOGTAG, "OUTPUT: %s", output);
     }
 
     char *line;
     char *save_ptr = NULL;
+    int debug_level = isDebug();
 
     for (line = strtok_r(output, "\n", &save_ptr); line; line = strtok_r(NULL, "\n", &save_ptr)) {
-        switch (data->logging) {
-            case 0:
-                mtinfo(WM_GCP_PUBSUB_LOGTAG, "Logging disabled.");
-                break;
-            case 1:
-                if (strstr(line, "- DEBUG -")) {
-                    mtdebug1(WM_GCP_PUBSUB_LOGTAG, "%s", line);
-                } else if (!strstr(line, "- WARNING -") && !strstr(line, "- INFO -")
-                && !strstr(line, "- ERROR -") && !strstr(line, "- CRITICAL -")) {
-                    mtdebug1(WM_GCP_PUBSUB_LOGTAG, "%s", line);
-                }
-                break;
-            case 2:
-                if (line = strstr(line, "- INFO -"), line) {
-                    mtinfo(WM_GCP_PUBSUB_LOGTAG, "%s", line);
-                }
-                break;
-            case 3:
-                if (line = strstr(line, "- WARNING -"), line) {
-                    mtwarn(WM_GCP_PUBSUB_LOGTAG, "%s", line);
-                }
-                break;
-            case 4:
-                if (line = strstr(line, "- ERROR -"), line) {
-                    mterror(WM_GCP_PUBSUB_LOGTAG, "%s", line);
-                }
-                break;
-            case 5:
-                if (line = strstr(line, "- CRITICAL -"), line) {
-                    mterror(WM_GCP_PUBSUB_LOGTAG, "%s", line);
-                }
-                break;
-            default:
-                if (line = strstr(line, "- INFO -"), line) {
-                    mtinfo(WM_GCP_PUBSUB_LOGTAG, "%s", line);
-                }
-                break;
+        char *p_line = NULL;
+
+        if (debug_level >= 2) {
+            if ((p_line = strstr(line, "- DEBUG - "))) {
+                p_line += 10;
+                mtdebug1(WM_GCP_PUBSUB_LOGTAG, "%s", p_line);
+            }
+        }
+        if (debug_level >= 1) {
+            if ((p_line = strstr(line, "- INFO - "))) {
+                p_line += 9;
+                mtinfo(WM_GCP_PUBSUB_LOGTAG, "%s", p_line);
+            }
+        }
+        if (debug_level >= 0) {
+            if ((p_line = strstr(line, "- CRITICAL - "))) {
+                p_line += 13;
+                mterror(WM_GCP_PUBSUB_LOGTAG, "%s", p_line);
+            }
+            if ((p_line = strstr(line, "- ERROR - "))) {
+                p_line += 10;
+                mterror(WM_GCP_PUBSUB_LOGTAG, "%s", p_line);
+            }
+            if ((p_line = strstr(line, "- WARNING - "))) {
+                p_line += 12;
+                mtwarn(WM_GCP_PUBSUB_LOGTAG, "%s", p_line);
+            }
         }
     }
 
@@ -386,6 +354,7 @@ void wm_gcp_pubsub_run(const wm_gcp_pubsub *data) {
 }
 
 void wm_gcp_bucket_run(const wm_gcp_bucket_base *data, wm_gcp_bucket *exec_bucket) {
+    (void) data; // Unused
     int status;
     char *output = NULL;
     char *command = NULL;
@@ -422,10 +391,11 @@ void wm_gcp_bucket_run(const wm_gcp_bucket_base *data, wm_gcp_bucket *exec_bucke
     if (exec_bucket->remove_from_bucket) {
         wm_strcat(&command, "--remove", ' ');
     }
-    if (data->logging) {
+
+    if (isDebug()){
         char *int_to_string;
         os_malloc(OS_SIZE_1024, int_to_string);
-        sprintf(int_to_string, "%d", data->logging);
+        sprintf(int_to_string, "%d", isDebug());
         wm_strcat(&command, "--log_level", ' ');
         wm_strcat(&command, int_to_string, ' ');
         os_free(int_to_string);
@@ -447,73 +417,41 @@ void wm_gcp_bucket_run(const wm_gcp_bucket_base *data, wm_gcp_bucket *exec_bucke
         pthread_exit(NULL);
     } else if (status > 0) {
         mtwarn(WM_GCP_BUCKET_LOGTAG, "Command returned exit code %d", status);
-        if(status == 1) {
-            char * unknown_error_msg = strstr(output,"Unknown error");
-            if (unknown_error_msg == NULL)
-                mtwarn(WM_GCP_BUCKET_LOGTAG, "Unknown error.");
-            else
-                mtwarn(WM_GCP_BUCKET_LOGTAG, "%s", unknown_error_msg);
-        } else if(status == 2) {
-            char * ptr;
-            if (ptr = strstr(output, "integration.py: error:"), ptr) {
-                ptr += 16;
-                mtwarn(WM_GCP_BUCKET_LOGTAG, "Error parsing arguments: %s", ptr);
-            } else {
-                mtwarn(WM_GCP_BUCKET_LOGTAG, "Error parsing arguments.");
-            }
-        } else {
-            char * ptr;
-            if (ptr = strstr(output, "ERROR: "), ptr) {
-                ptr += 7;
-                mtwarn(WM_GCP_BUCKET_LOGTAG, "%s", ptr);
-            } else {
-                mtwarn(WM_GCP_BUCKET_LOGTAG, "%s", output);
-            }
-        }
-        mtdebug1(WM_GCP_BUCKET_LOGTAG, "OUTPUT: %s", output);
     }
 
     char *line;
     char *save_ptr = NULL;
+    int debug_level = isDebug();
 
     for (line = strtok_r(output, "\n", &save_ptr); line; line = strtok_r(NULL, "\n", &save_ptr)) {
-        switch (data->logging) {
-            case 0:
-                mtinfo(WM_GCP_BUCKET_LOGTAG, "Logging disabled.");
-                break;
-            case 1:
-                if (strstr(line, "- DEBUG -")) {
-                    mtdebug1(WM_GCP_BUCKET_LOGTAG, "%s", line);
-                } else if (!strstr(line, "- WARNING -") && !strstr(line, "- INFO -")
-                && !strstr(line, "- ERROR -") && !strstr(line, "- CRITICAL -")) {
-                    mtdebug1(WM_GCP_BUCKET_LOGTAG, "%s", line);
-                }
-                break;
-            case 2:
-                if (line = strstr(line, "- INFO -"), line) {
-                    mtinfo(WM_GCP_BUCKET_LOGTAG, "%s", line);
-                }
-                break;
-            case 3:
-                if (line = strstr(line, "- WARNING -"), line) {
-                    mtwarn(WM_GCP_BUCKET_LOGTAG, "%s", line);
-                }
-                break;
-            case 4:
-                if (line = strstr(line, "- ERROR -"), line) {
-                    mterror(WM_GCP_BUCKET_LOGTAG, "%s", line);
-                }
-                break;
-            case 5:
-                if (line = strstr(line, "- CRITICAL -"), line) {
-                    mterror(WM_GCP_BUCKET_LOGTAG, "%s", line);
-                }
-                break;
-            default:
-                if (line = strstr(line, "- INFO -"), line) {
-                    mtinfo(WM_GCP_BUCKET_LOGTAG, "%s", line);
-                }
-                break;
+
+        char *p_line = NULL;
+
+        if (debug_level >= 2) {
+            if ((p_line = strstr(line, "- DEBUG - "))) {
+                p_line += 10;
+                mtdebug1(WM_GCP_BUCKET_LOGTAG, "%s", p_line);
+            }
+        }
+        if (debug_level >= 1) {
+            if ((p_line = strstr(line, "- INFO - "))) {
+                p_line += 9;
+                mtinfo(WM_GCP_BUCKET_LOGTAG, "%s", p_line);
+            }
+        }
+        if (debug_level >= 0) {
+            if ((p_line = strstr(line, "- CRITICAL - "))) {
+                p_line += 13;
+                mterror(WM_GCP_BUCKET_LOGTAG, "%s", p_line);
+            }
+            if ((p_line = strstr(line, "- ERROR - "))) {
+                p_line += 10;
+                mterror(WM_GCP_BUCKET_LOGTAG, "%s", p_line);
+            }
+            if ((p_line = strstr(line, "- WARNING - "))) {
+                p_line += 12;
+                mtwarn(WM_GCP_BUCKET_LOGTAG, "%s", p_line);
+            }
         }
     }
 
@@ -573,27 +511,11 @@ cJSON *wm_gcp_pubsub_dump(const wm_gcp_pubsub *data) {
     if (data->subscription_name) cJSON_AddStringToObject(wm_wd, "subscription_name", data->subscription_name);
     if (data->credentials_file) cJSON_AddStringToObject(wm_wd, "credentials_file", data->credentials_file);
 
-    switch (data->logging) {
-        case 0:
-            cJSON_AddStringToObject(wm_wd, "logging", "disabled");
-            break;
-        case 1:
-            cJSON_AddStringToObject(wm_wd, "logging", "debug");
-            break;
-        case 3:
-            cJSON_AddStringToObject(wm_wd, "logging", "warning");
-            break;
-        case 4:
-            cJSON_AddStringToObject(wm_wd, "logging", "error");
-            break;
-        case 5:
-            cJSON_AddStringToObject(wm_wd, "logging", "critical");
-            break;
-        case 2:
-        default:
-            cJSON_AddStringToObject(wm_wd, "logging", "info");
-            break;
-    }
+    int debug_level = isDebug();
+
+    if (debug_level >= 2) cJSON_AddStringToObject(wm_wd, "logging", "debug");
+    if (debug_level == 1) cJSON_AddStringToObject(wm_wd, "logging", "info");
+    if (debug_level == 0) cJSON_AddStringToObject(wm_wd, "logging", "warning");
 
     cJSON_AddItemToObject(root, "gcp-pubsub", wm_wd);
 
@@ -628,27 +550,11 @@ cJSON *wm_gcp_bucket_dump(const wm_gcp_bucket_base *data) {
         }
     }
 
-    switch (data->logging) {
-        case 0:
-            cJSON_AddStringToObject(wm_wd, "logging", "disabled");
-            break;
-        case 1:
-            cJSON_AddStringToObject(wm_wd, "logging", "debug");
-            break;
-        case 3:
-            cJSON_AddStringToObject(wm_wd, "logging", "warning");
-            break;
-        case 4:
-            cJSON_AddStringToObject(wm_wd, "logging", "error");
-            break;
-        case 5:
-            cJSON_AddStringToObject(wm_wd, "logging", "critical");
-            break;
-        case 2:
-        default:
-            cJSON_AddStringToObject(wm_wd, "logging", "info");
-            break;
-    }
+    int debug_level = isDebug();
+
+    if (debug_level >= 2) cJSON_AddStringToObject(wm_wd, "logging", "debug");
+    if (debug_level == 1) cJSON_AddStringToObject(wm_wd, "logging", "info");
+    if (debug_level == 0) cJSON_AddStringToObject(wm_wd, "logging", "warning");
 
     cJSON_AddItemToObject(root, "gcp-bucket", wm_wd);
 

--- a/src/wazuh_modules/wm_gcp.c
+++ b/src/wazuh_modules/wm_gcp.c
@@ -83,10 +83,9 @@ static void wm_gcp_bucket_destroy(wm_gcp_bucket_base *gcp_config);        // Des
 #endif
 /**
  * @brief Run module function for Google Cloud bucket
- * @param data Module configuration structure
  * @param exec_bucket Bucket configuration structure
  */
-static void wm_gcp_bucket_run(const wm_gcp_bucket_base *data, wm_gcp_bucket *exec_bucket);            // Running python script
+static void wm_gcp_bucket_run(wm_gcp_bucket *exec_bucket);            // Running python script
 
 /**
  * @brief Dump configuration structure in JSON for Google Cloud bucket
@@ -228,7 +227,7 @@ void* wm_gcp_bucket_main(wm_gcp_bucket_base *data) {
             wm_strcat(&log_info, ")", '\0');
 
             mtinfo(WM_GCP_BUCKET_LOGTAG, "%s", log_info);
-            wm_gcp_bucket_run(data, cur_bucket);
+            wm_gcp_bucket_run(cur_bucket);
             free(log_info);
         }
 
@@ -382,8 +381,7 @@ static void wm_gcp_parse_output(char *output, char *tag){
     }
 }
 
-void wm_gcp_bucket_run(const wm_gcp_bucket_base *data, wm_gcp_bucket *exec_bucket) {
-    (void) data; // Unused
+void wm_gcp_bucket_run(wm_gcp_bucket *exec_bucket) {
     int status;
     char *output = NULL;
     char *command = NULL;

--- a/src/wazuh_modules/wm_gcp.c
+++ b/src/wazuh_modules/wm_gcp.c
@@ -335,7 +335,7 @@ static void wm_gcp_parse_output(char *output, char *tag){
     for (line = strstr(parsing_output, WM_GCP_LOGGING_TOKEN); line; line = strstr(parsing_output, WM_GCP_LOGGING_TOKEN)) {
         char * tokenized_line;
         os_calloc(WM_STRING_MAX, sizeof(char), tokenized_line);
-	char * next_lines;
+        char * next_lines;
 
         line += strlen(WM_GCP_LOGGING_TOKEN);
         next_lines = strstr(line, WM_GCP_LOGGING_TOKEN);
@@ -346,7 +346,7 @@ static void wm_gcp_parse_output(char *output, char *tag){
         int cp_length = 1 + strlen(line) - next_lines_chars > WM_STRING_MAX ? WM_STRING_MAX : 1 + strlen(line) - next_lines_chars;
         snprintf(tokenized_line, cp_length, "%s", line);
         if (tokenized_line[cp_length - 2] == '\n') tokenized_line[cp_length - 2] = '\0'; 
-        
+
         char *p_line = NULL;
 
         if (debug_level >= 2) {
@@ -376,7 +376,7 @@ static void wm_gcp_parse_output(char *output, char *tag){
             }
         }
 
-	parsing_output += cp_length + strlen(WM_GCP_LOGGING_TOKEN) - 1;
+        parsing_output += cp_length + strlen(WM_GCP_LOGGING_TOKEN) - 1;
         os_free(tokenized_line);
     }
 }

--- a/src/wazuh_modules/wm_gcp.h
+++ b/src/wazuh_modules/wm_gcp.h
@@ -21,7 +21,6 @@
 typedef struct wm_gcp_pubsub {
     int enabled;
     int pull_on_start;
-    int logging;
     int max_messages;
     int num_threads;
     time_t next_time;
@@ -44,7 +43,6 @@ typedef struct wm_gcp_bucket {
 typedef struct wm_gcp_bucket_base {
     unsigned int enabled:1;
     unsigned int run_on_start:1;
-    int logging;
     sched_scan_config scan_config;
     time_t next_time;                   // Absolute time for next scan
     wm_gcp_bucket *buckets;             // buckets (linked list)

--- a/src/wazuh_modules/wm_gcp.h
+++ b/src/wazuh_modules/wm_gcp.h
@@ -15,6 +15,7 @@
 #define WM_GCP_PUBSUB_LOGTAG ARGV0 ":gcp-pubsub"
 #define WM_GCP_BUCKET_LOGTAG ARGV0 ":gcp-bucket"
 #define WM_GCP_SCRIPT_PATH "wodles/gcloud/gcloud"
+#define WM_GCP_LOGGING_TOKEN ":gcloud_wodle:"
 
 #define WM_GCP_DEF_INTERVAL 3600
 

--- a/wodles/gcloud/gcloud.py
+++ b/wodles/gcloud/gcloud.py
@@ -24,11 +24,12 @@ except TypeError:
 
 
 def main():
+    logger = tools.get_stdout_logger(tools.logger_name)
 
     try:
         # get script arguments
         arguments = tools.get_script_arguments()
-        logger = tools.get_stdout_logger(tools.logger_name, arguments.log_level)
+        logger.setLevel(arguments.log_level)
         credentials_file = arguments.credentials_file
         max_messages = arguments.max_messages
         log_level = arguments.log_level
@@ -102,7 +103,7 @@ def main():
         exit(gcloud_exception.errcode)
 
     except Exception:
-        logger.critical('An exception happened while running the wodle',
+        logger.critical('Unknown error',
                         exc_info=True)
         exit(exceptions.UNKNOWN_ERROR_ERRCODE)
 

--- a/wodles/gcloud/tools.py
+++ b/wodles/gcloud/tools.py
@@ -18,13 +18,9 @@ from pytz import UTC
 
 logger_name = 'gcloud_wodle'
 logger = logging.getLogger(logger_name)
-log_levels = {0: logging.NOTSET,
-              1: logging.DEBUG,
-              2: logging.INFO,
-              3: logging.WARNING,
-              4: logging.ERROR,
-              5: logging.CRITICAL,
-              }
+log_levels = {0: logging.WARNING,
+              1: logging.INFO,
+              2: logging.DEBUG}
 logging_format = logging.Formatter('%(name)s - %(levelname)s - %(message)s')
 min_num_threads = 1
 min_num_messages = 1
@@ -59,7 +55,7 @@ def get_script_arguments():
                         help='Number of maximum messages pulled in each iteration', default=100)
 
     parser.add_argument('-l', '--log_level', dest='log_level', type=int,
-                        help='Log level', required=False, default=3)
+                        help='Log level', required=False, default=0)
 
     parser.add_argument('-b', '--bucket_name', dest='bucket_name', type=str,
                         help='The name of the bucket to read the logs from')

--- a/wodles/gcloud/tools.py
+++ b/wodles/gcloud/tools.py
@@ -16,7 +16,7 @@ from logging.handlers import TimedRotatingFileHandler
 from pytz import UTC
 
 
-logger_name = 'gcloud_wodle'
+logger_name = ':gcloud_wodle:'
 logger = logging.getLogger(logger_name)
 log_levels = {0: logging.WARNING,
               1: logging.INFO,
@@ -78,7 +78,7 @@ def get_script_arguments():
     return parser.parse_args()
 
 
-def get_stdout_logger(name: str, level: int = 3) -> logging.Logger:
+def get_stdout_logger(name: str, level: int = 0) -> logging.Logger:
     """Create a logger which returns the messages by stdout.
 
     Parameters


### PR DESCRIPTION
|Related issue|
|---|
|Closes #10334|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
In this PR we modifiy the GCP module to stop using a custom  `<logging>` parameter and use *wazuh_modules* debug value instead, as the other modules currently do. This will ease the task of maintaining all the external integration in an homogeneous way.

Since a parameter was deprecated, several tests had to be removed or modified to adapt them to the state of the module.

Runing valgrind while passing the tests shows the following output:

```
➜  build git:(feature/10334-standardize-gcp-logging) ✗ valgrind ctest --test-dir wazuh_modules/gcp
==245058== Memcheck, a memory error detector
==245058== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==245058== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==245058== Command: ctest --test-dir wazuh_modules/gcp
==245058== 
Internal ctest changing into directory: /home/gonzz/git/wazuh/src/unit_tests/build/wazuh_modules/gcp
Test project /home/gonzz/git/wazuh/src/unit_tests/build/wazuh_modules/gcp
    Start 1: test_wm_gcp
1/2 Test #1: test_wm_gcp ......................   Passed    0.05 sec
    Start 2: test_wmodules_gcp
2/2 Test #2: test_wmodules_gcp ................   Passed    0.07 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =   0.39 sec
==245058== 
==245058== HEAP SUMMARY:
==245058==     in use at exit: 0 bytes in 0 blocks
==245058==   total heap usage: 5,061 allocs, 5,061 frees, 1,405,700 bytes allocated
==245058== 
==245058== All heap blocks were freed -- no leaks are possible
==245058== 
==245058== For lists of detected and suppressed errors, rerun with: -s
==245058== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

On the other hand, running pytest shows the following output:

```
(wazuh-unit) ➜  wodles git:(feature/10334-standardize-gcp-logging) ✗ pytest gcloud
==================================== test session starts ====================================
platform linux -- Python 3.10.2, pytest-6.2.5, py-1.11.0, pluggy-0.13.1
rootdir: /home/gonzz/git/wazuh/wodles
plugins: asyncio-0.15.1
collected 17 items                                                                          

gcloud/tests/test_access_logs.py .                                                    [  5%]
gcloud/tests/test_bucket.py ...                                                       [ 23%]
gcloud/tests/test_gcloud.py .....                                                     [ 52%]
gcloud/tests/test_integration.py .....                                                [ 82%]
gcloud/tests/test_subscriber.py ...                                                   [100%]

===================================== warnings summary ======================================
../../../venv/wazuh-unit/lib/python3.10/site-packages/google/pubsub_v1/services/publisher/client.py:17
  /home/gonzz/venv/wazuh-unit/lib/python3.10/site-packages/google/pubsub_v1/services/publisher/client.py:17: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
    from distutils import util

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=============================== 17 passed, 1 warning in 0.07s ===============================
```

### Deprecation messages
When running the module in debug 2 mode,it will output a message saying that the `logging` parameter was deprecated.

#### Pub/Sub

```
2022/03/17 16:34:49 wazuh-modulesd[2083] wmodules-gcp.c:187 at wm_gcp_pubsub_read(): DEBUG: Tag 'logging' from the 'gcp-pubsub' module is deprecated. This setting will be skipped.
2022/03/17 16:34:49 wazuh-modulesd[2083] main.c:94 at main(): DEBUG: Created new thread for the 'gcp-pubsub' module.
...
...
```
#### Buckets
```
2022/03/17 16:36:37 wazuh-modulesd[5147] wmodules-gcp.c:270 at wm_gcp_bucket_read(): DEBUG: Tag 'logging' from the 'gcp-bucket' module is deprecated. This setting will be skipped.
2022/03/17 16:36:37 wazuh-modulesd:gcp-bucket[5147] wmodules-gcp.c:273 at wm_gcp_bucket_read(): DEBUG: Found a bucket tag
...
...
```

### Tests
To test that the modules are working as expected, we performed some manual tests.

#### Manual tests Pub/Sub

The configuration used for the tests is the following:

```
<gcp-pubsub>
    <pull_on_start>yes</pull_on_start>
    <interval>1d</interval>
    <project_id>wazuh-dev-123456</project_id>
    <subscription_name>test_gcloud_blog</subscription_name>
    <logging>debug</logging>
    <credentials_file>/var/ossec/wodles/gcloud/credentials.json</credentials_file>
</gcp-pubsub>
```

##### Test with debug disabled
Only `WARNING`, `ERROR` and `CRITICAL` messages should be captured. We modified the configuration snippet to trigger the error message.

```
2022/03/17 16:50:47 wazuh-modulesd:gcp-pubsub: ERROR: An exception happened while running the wodle: GCloudPubSubSubscriptionError: The 'wazuh-dev-123456' subscription is incorrect or the user credentials are not valid
```

##### Test with debug=1
`INFO` messages should be captured too.

```
2022/03/17 16:57:16 wazuh-modulesd:gcp-pubsub[5220] wm_gcp.c:334 at wm_gcp_pubsub_run(): INFO: Received and acknowledged 0 messages
```

##### Test with debug=2
`DEBUG` messages should be captured too.

```
2022/03/17 16:58:48 wazuh-modulesd:gcp-pubsub[7008] wm_gcp.c:328 at wm_gcp_pubsub_run(): DEBUG: Setting 1 thread to pull 100 messages in total
```

#### Manual tests buckets
The configuration used for the tests is the following:

```
 <gcp-bucket>
    <run_on_start>yes</run_on_start>
    <interval>1m</interval>
    <logging>debug</logging>

    <bucket type="access_logs">
        <name>framework-test-bucket</name>
        <credentials_file>/var/ossec/wodles/gcloud/credentials.json</credentials_file>
        <only_logs_after>2021-oct-01</only_logs_after>
    </bucket>
</gcp-bucket>
```

##### Test with debug disabled
Only `WARNING`, `ERROR` and `CRITICAL` messages should be captured from the Python script. We modified the configuration snippet to trigger the error message.

```
2022/03/17 17:02:38 wazuh-modulesd:gcp-bucket: ERROR: An exception happened while running the wodle: GCloudBucketNotFound: The bucket 'fframework-test-bucket' does not exist
```

##### Test with debug=1
`INFO` messages should be captured too.

```
2022/03/17 17:03:48 wazuh-modulesd:gcp-bucket[11608] wm_gcp.c:439 at wm_gcp_bucket_run(): INFO: Processing test_1_new.txt
2022/03/17 17:03:48 wazuh-modulesd:gcp-bucket[11608] wm_gcp.c:439 at wm_gcp_bucket_run(): INFO: Processing test_22.txt
2022/03/17 17:03:48 wazuh-modulesd:gcp-bucket[11608] wm_gcp.c:439 at wm_gcp_bucket_run(): INFO: Processing test_2_new.txt
```

##### Test with debug=2
`DEBUG` messages should be captured too. Since the buckets don't have any debug message yet, we modified the script adding a test debug message to ensure this was working too.

```
2022/03/17 17:07:15 wazuh-modulesd:gcp-bucket[14839] wm_gcp.c:433 at wm_gcp_bucket_run(): DEBUG: This is a test message
```
#### Test multiline messages 
The C module now supports multiline messages. This is useful when the user faces unknown errors because the full exception trace will be available for both the user and developers to fix the issue. To test this we temporarily modified the `gcloud.py` script to forcefully raise an exception.
    ```
	2022/03/21 12:03:49 wazuh-modulesd:gcp-pubsub[40107] wm_gcp.c:324 at wm_gcp_pubsub_run(): WARNING: Command returned exit code 231
	2022/03/21 12:03:49 wazuh-modulesd:gcp-pubsub[40107] wm_gcp.c:368 at wm_gcp_parse_output(): ERROR: Unknown error
	Traceback (most recent call last):
	  File "/var/ossec/wodles/gcloud/gcloud.py", line 36, in main
		raise TypeError("\nmultiline\nerror\nraise")
	TypeError: 
	multiline
	error
	raised
    ...
    ```

##### Test that the greater log levels include messages from the precedent ones
The different debug levels include the precedent ones, that is, using debug level 1 includes the `WARNING`, `ERROR`, and `CRITICAL` messages that would be returned by debug level 0. Debug level 2 onwards will also include the aforementioned levels, along with the `INFO` -pertaining to debug level 1- and `DEBUG` ones.
###### Debug level 1
To test this we temporarily modified the `gcloud.py` script to forcefully raise an exception. Then we reverted the file to its previous state. To ensure that we would successfully capture a `INFO` log from the Python module.

```
2022/03/21 15:05:03 wazuh-modulesd:gcp-pubsub[59090] wm_gcp.c:324 at wm_gcp_pubsub_run(): WARNING: Command returned exit code 231
2022/03/21 15:05:03 wazuh-modulesd:gcp-pubsub[59090] wm_gcp.c:368 at wm_gcp_parse_output(): ERROR: Unknown error
Traceback (most recent call last):
  File "/var/ossec/wodles/gcloud/gcloud.py", line 37, in main
    raise TypeError("This\nis\nnot\na\ntype\nerror")
TypeError: This
is
not
a
type
error
2022/03/21 15:05:03 wazuh-modulesd:gcp-pubsub[59090] wm_gcp.c:161 at wm_gcp_pubsub_main(): DEBUG: Fetching logs finished.
...
2022/03/21 15:02:14 wazuh-modulesd:gcp-pubsub[57209] wm_gcp.c:362 at wm_gcp_parse_output(): INFO: Received and acknowledged 0 messages
```

###### Debug level 2
For example, executing the module in debug level 2 will return the following output.

    ```
    2022/03/21 12:11:27 wazuh-modulesd:gcp-pubsub[43103] wm_gcp.c:356 at wm_gcp_parse_output(): DEBUG: Setting 10 threads to pull 100 messages in total
    ...
    2022/03/21 12:11:27 wazuh-modulesd:gcp-pubsub[43103] wm_gcp.c:356 at wm_gcp_parse_output(): DEBUG: Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": ...}'"
    ...
    2022/03/21 12:11:27 wazuh-modulesd:gcp-pubsub[43103] wm_gcp.c:362 at wm_gcp_parse_output(): INFO: Received and acknowledged 100 messages

    ```
