### PR TITLE
Fix FIM max_eps option

### DIFF
--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -123,12 +123,12 @@ void send_syscheck_msg(const cJSON *_msg) {
         return;
     }
 
-    /*static atomic_int_t n_msg_sent = ATOMIC_INT_INITIALIZER(0);
+    static atomic_int_t n_msg_sent = ATOMIC_INT_INITIALIZER(0);
 
     if (atomic_int_inc(&n_msg_sent) >= syscheck.max_eps) {
         sleep(1);
         atomic_int_set(&n_msg_sent, 0);
-    }*/
+    }
 }
 
 // Send a scan info event

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -814,6 +814,8 @@ void test_fim_send_scan_info(void **state) {
 #ifndef TEST_WINAGENT
     will_return(__wrap_time, 1);
 #endif
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_string(__wrap__mdebug2, formatted_msg, "(6321): Sending FIM event: {\"type\":\"scan_start\",\"data\":{\"timestamp\":1}}");
     expect_w_send_sync_msg(msg, SYSCHECK, SYSCHECK_MQ, fim_shutdown_process_on, 0);
     fim_send_scan_info(FIM_SCAN_START);


### PR DESCRIPTION
|Related issue|
|---|
||

This PR aims to fix the max EPS configured for FIM


<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
- [X] Source installation
- [X] Source upgrade