### PR TITLE
Changing MariaDB decoder to extract the timeDate field for future nor…

### DIFF
--- a/ruleset/decoders/0378-mariadb_decoders.xml
+++ b/ruleset/decoders/0378-mariadb_decoders.xml
@@ -40,8 +40,8 @@ MariaDB Table events
 
 <decoder name="mariadb-syslog-fields-2">
     <parent>mariadb-syslog</parent>
-    <regex>ip-(\.*),(\.*),(\.*),\.*,\.*,(\.*),(\.*)</regex>
-    <order>mariadb.ip,mariadb.username,mariadb.host,mariadb.action,mariadb.resource</order>
+    <regex>(\.*),ip-(\.*),(\.*),(\.*),\.*,\.*,(\.*),(\.*)</regex>
+    <order>mariadb.datetime,mariadb.ip,mariadb.username,mariadb.host,mariadb.action,mariadb.resource</order>
 </decoder>
 
 


### PR DESCRIPTION

|Related issue|
|---|
None


**General Decoder Contribution**

## Description

The current [mariadb-syslog decoder](https://github.com/wazuh/wazuh-ruleset/blob/master/decoders/0378-mariadb_decoders.xml) does not extract important dateTime fields from the logs. In its current state, there are additional parsing steps that need to be taken by a user to normalise the date of alerts based on these logs. These additional steps could be avoided if the decoder automatically extracted the dateTime field from the original log. This is what the addition to the decoder is doing. 

## Configuration options

No additional configuration options are needed. 

## Logs/Alerts example
_The information below has been anonymized _

``` 20220317 03:07:17,ip-ip,username,host,data,data,QUERY,`test`,'use `test`',0 ```

Decoded output
```
**Phase 2: Completed decoding.
        name: 'mariadb-syslog'
        mariadb.action: 'QUERY'
        mariadb.datetime: '20220317 03:07:17'
        mariadb.host: 'host'
        mariadb.ip: 'ip'
        mariadb.resource: '`test`,'use `test`',0'
        mariadb.username: 'username'
```
## Tests
This has been tested with all the alerts currently documented in the [mariadb-syslog decoder](https://github.com/wazuh/wazuh-ruleset/blob/master/decoders/0378-mariadb_decoders.xml) file of the ruleset, and they still function as expected. The only affected rule, and section of the rule is the timeDate section of the mariadb-syslog-fields-2 decoder.