### PR TITLE
Change some sync related messages to debug mode

### DIFF
--- a/src/syscheckd/src/db/src/fimDB.cpp
+++ b/src/syscheckd/src/db/src/fimDB.cpp
@@ -34,13 +34,13 @@ void FIMDB::sync()
 
     if (!m_stopping)
     {
-        m_loggingFunction(LOG_INFO, "Executing FIM sync.");
+        m_loggingFunction(LOG_DEBUG, "Executing FIM sync.");
         FIMDBCreator<OS_TYPE>::sync(m_rsyncHandler,
                                     m_dbsyncHandler->handle(),
                                     m_syncFileMessageFunction,
                                     m_syncRegistryMessageFunction,
                                     m_syncRegistryEnabled);
-        m_loggingFunction(LOG_INFO, "Finished FIM sync.");
+        m_loggingFunction(LOG_DEBUG, "Finished FIM sync.");
     }
 }
 

--- a/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
@@ -88,8 +88,8 @@ TEST_F(DBTestFixture, TestFimSyncPushMsg)
     fim_db_file_update(fileFIMTest->toFimEntry(), callback_data_added);
     EXPECT_CALL(*mockLog, loggingFunction(LOG_DEBUG_VERBOSE, std::string("Message pushed: ") + test)).Times(1);
     EXPECT_CALL(*mockLog, loggingFunction(LOG_INFO, "FIM sync module started.")).Times(1);
-    EXPECT_CALL(*mockLog, loggingFunction(LOG_INFO, "Executing FIM sync.")).Times(1);
-    EXPECT_CALL(*mockLog, loggingFunction(LOG_INFO, "Finished FIM sync.")).Times(1);
+    EXPECT_CALL(*mockLog, loggingFunction(LOG_DEBUG, "Executing FIM sync.")).Times(1);
+    EXPECT_CALL(*mockLog, loggingFunction(LOG_DEBUG, "Finished FIM sync.")).Times(1);
     EXPECT_CALL(*mockSync, syncMsg("fim_file", testing::_)).Times(1);
     EXPECT_NO_THROW(
     {
@@ -101,8 +101,8 @@ TEST_F(DBTestFixture, TestFimSyncPushMsg)
 TEST_F(DBTestFixture, TestFimRunIntegrity)
 {
     EXPECT_CALL(*mockLog, loggingFunction(LOG_INFO, "FIM sync module started.")).Times(1);
-    EXPECT_CALL(*mockLog, loggingFunction(LOG_INFO, "Executing FIM sync.")).Times(1);
-    EXPECT_CALL(*mockLog, loggingFunction(LOG_INFO, "Finished FIM sync.")).Times(1);
+    EXPECT_CALL(*mockLog, loggingFunction(LOG_DEBUG, "Executing FIM sync.")).Times(1);
+    EXPECT_CALL(*mockLog, loggingFunction(LOG_DEBUG, "Finished FIM sync.")).Times(1);
 
     EXPECT_NO_THROW(
     {
@@ -114,8 +114,8 @@ TEST_F(DBTestFixture, TestFimRunIntegrityInitTwice)
 {
     EXPECT_CALL(*mockLog, loggingFunction(LOG_ERROR, "FIM integrity thread already running.")).Times(1);
     EXPECT_CALL(*mockLog, loggingFunction(LOG_INFO, "FIM sync module started.")).Times(1);
-    EXPECT_CALL(*mockLog, loggingFunction(LOG_INFO, "Executing FIM sync.")).Times(1);
-    EXPECT_CALL(*mockLog, loggingFunction(LOG_INFO, "Finished FIM sync.")).Times(1);
+    EXPECT_CALL(*mockLog, loggingFunction(LOG_DEBUG, "Executing FIM sync.")).Times(1);
+    EXPECT_CALL(*mockLog, loggingFunction(LOG_DEBUG, "Finished FIM sync.")).Times(1);
 
     EXPECT_NO_THROW(
     {

--- a/src/syscheckd/src/db/tests/db/FIMDB/fimDBTests/fimDBImpTests.cpp
+++ b/src/syscheckd/src/db/tests/db/FIMDB/fimDBTests/fimDBImpTests.cpp
@@ -234,9 +234,9 @@ TEST_F(FimDBFixture, loopRSyncSuccess)
     std::mutex test_mutex;
 
     EXPECT_CALL(*mockLog, loggingFunction(LOG_INFO, "FIM sync module started."));
-    EXPECT_CALL(*mockLog, loggingFunction(LOG_INFO, "Executing FIM sync."));
+    EXPECT_CALL(*mockLog, loggingFunction(LOG_DEBUG, "Executing FIM sync."));
     EXPECT_CALL(*mockRSync, startSync(testing::_, testing::_, testing::_)).Times(testing::AtLeast(1));
-    EXPECT_CALL(*mockLog, loggingFunction(LOG_INFO, "Finished FIM sync."));
+    EXPECT_CALL(*mockLog, loggingFunction(LOG_DEBUG, "Finished FIM sync."));
     EXPECT_CALL(*mockRSync, registerSyncID(testing::_, testing::_, testing::_, testing::_)).Times(testing::AtLeast(1));
 
     fimDBMock.runIntegrity();


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/9103|

## Description
In this PR we have changed the messages announcing the start and end of the synchronization so that they do not flooder the log file. They have been changed from info mode to debug mode. We have also added the necessary changes to the unit tests. 

## Logs/Alerts example
```
2022/03/18 13:34:23 wazuh-syscheckd[10128] logging_helper.c:56 at loggingFunction(): INFO: FIM sync module started.
2022/03/18 13:34:23 wazuh-syscheckd[10128] logging_helper.c:62 at loggingFunction(): DEBUG: Executing FIM sync.
2022/03/18 13:34:23 wazuh-syscheckd[10128] logging_helper.c:62 at loggingFunction(): DEBUG: Finished FIM sync.

```

## Tests



<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language
