### PR TITLE
Add 'Finished in' log in agent sync tasks

### DIFF
--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -645,7 +645,7 @@ async def test_handler_update_chunks_wdb(send_request_mock):
                                                                                'generic_errors': ['ERR'],
                                                                                'time_spent': 6,
                                                                                'total_updated': 0, 'updated_chunks': 2}
-                    logger_debug_mock.assert_has_calls([call('2/5 chunks updated in wazuh-db in 6.000000s.')])
+                    logger_debug_mock.assert_has_calls([call('2/5 chunks updated in wazuh-db in 6.000s.')])
                     logger_debug2_mock.assert_has_calls([call('Chunk 1/5: 0'), call('Chunk 2/5: 1')])
                     logger_error_mock.assert_has_calls([call('other1'), call('other2'),
                                                         call('Wazuh-db response for chunk 1/5 was not "ok": 0'),
@@ -1427,8 +1427,8 @@ async def test_sync_wazuh_db_sync_ok(perf_counter_mock, json_dumps_mock):
 
     # Test else
     with patch.object(sync_wazuh_db.logger, "info") as logger_info_mock:
-        assert await sync_wazuh_db.sync(start_time=10, chunks=[]) is True
-        logger_info_mock.assert_called_once_with(f"Finished in -10.000s (0 chunks sent).")
+        assert await sync_wazuh_db.sync(start_time=-10, chunks=[]) is True
+        logger_info_mock.assert_called_once_with(f"Finished in 10.000s. Updated 0 chunks.")
 
     # Test except
     with patch("wazuh.core.cluster.common.Handler.send_string", return_value=b'Error 1'):
@@ -1454,13 +1454,13 @@ def test_end_sending_agent_information(perf_counter_mock, json_loads_mock):
         with patch.object(logger, "info") as logger_info_mock:
             assert cluster_common.end_sending_agent_information(logger, 0, "response") == (b'ok', b'Thanks')
             json_loads_mock.assert_called_once_with("response")
-            logger_info_mock.assert_called_once_with("Finished in 0.000s (10 chunks updated).")
+            logger_info_mock.assert_called_once_with("Finished in 0.000s. Updated 10 chunks.")
 
         with patch.object(logger, "error") as logger_error_mock:
             json_loads_mock.return_value = {"updated_chunks": 10, "error_messages": "error"}
             assert cluster_common.end_sending_agent_information(logger, 0, "response") == (b'ok', b'Thanks')
             logger_error_mock.assert_called_once_with(
-                "Finished in 0.000s (10 chunks updated). There were 5 chunks with errors: error")
+                "Finished in 0.000s. Updated 10 chunks. There were 5 chunks with errors: error")
 
 
 def test_error_receiving_agent_information():

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -825,7 +825,7 @@ async def test_worker_handler_general_agent_sync_task(socket_mock):
                                              get_data_command='global sync-agent-groups-get ',
                                              set_data_command='global sync-agent-groups-set')
 
-    with patch('wazuh.core.cluster.worker.get_utc_now', side_effect=get_utc_now_mock) as get_utc_now_mock:
+    with patch('wazuh.core.cluster.worker.perf_counter', return_value=0) as perf_counter_mock:
         with patch.object(sync_object, 'request_permission', side_effect=request_permission_callable):
             with patch.object(sync_object, 'retrieve_information',
                               side_effect=retrieve_information_callable) as retrieve_information_mock:
@@ -842,7 +842,7 @@ async def test_worker_handler_general_agent_sync_task(socket_mock):
 
                                 logger_info_mock.assert_called_with('Starting.')
                                 retrieve_information_mock.assert_called_once()
-                                get_utc_now_mock.assert_called()
+                                perf_counter_mock.assert_called()
                                 sync_mock.assert_called_with(start_time=0, chunks=['testing'])
                                 assert w_handler.agent_info_sync_status['date_start'] == 0.0
 

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -598,16 +598,12 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         while True:
             try:
                 if self.connected:
-                    start_time = get_utc_now().timestamp()
+                    start_time = perf_counter()
                     if await sync_object.request_permission():
                         sync_object.logger.info("Starting.")
                         timer['date_start'] = start_time
                         chunks = await sync_object.retrieve_information()
-                        if chunks != ['[]'] and chunks != ['[{"data":[]}]']:
-                            await sync_object.sync(start_time=start_time, chunks=chunks)
-                        else:
-                            sync_object.logger.debug('There is no agent information that needs '
-                                                     'to be synchronized in the local database. Skipping...')
+                        await sync_object.sync(start_time=start_time, chunks=chunks)
             except Exception as e:
                 sync_object.logger.error(f"Error synchronizing agent information: {e}")
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #12758 |

## Description

This PR changes some logs as requested at #12758. Until now, only this `Agent-group sync` message was shown in the workers if debug logs were disabled and there were no info to sync:
```
2022/03/21 09:48:45 INFO: [Worker worker1] [Agent-groups sync] Starting.
```

When debug level was enabled, these were the logs:
```
2022/03/21 09:49:59 INFO: [Worker worker1] [Agent-groups sync] Starting.
2022/03/21 09:49:59 DEBUG: [Worker worker1] [Agent-groups sync] Obtained 1 chunks of data in 0.001s.
2022/03/21 09:49:59 DEBUG: [Worker worker1] [Agent-groups sync] There is no agent information that needs to be synchronized in the local database. Skipping...
```

After this PR, the `Agent-group sync` logs look like this (debug disabled):
```
2022/03/21 09:02:42 INFO: [Worker worker1] [Agent-groups sync] Starting.
2022/03/21 09:02:42 INFO: [Worker worker1] [Agent-groups sync] Finished in 0.005s. Updated 0 chunks.
```

And these are the logs when debug is enabled:
```
2022/03/21 10:05:25 INFO: [Worker worker1] [Agent-groups sync] Starting.
2022/03/21 10:05:25 DEBUG: [Worker worker1] [Agent-groups sync] Obtained 0 chunks of data in 0.001s.
2022/03/21 10:05:25 INFO: [Worker worker1] [Agent-groups sync] Finished in 0.005s. Updated 0 chunks.
```