### PR TITLE
Fix wrong UID and GID in old attributes

### DIFF
--- a/src/syscheckd/cppcheckSuppress.txt
+++ b/src/syscheckd/cppcheckSuppress.txt
@@ -2,4 +2,4 @@
 *:*src/syscheckd/src/db/src/file.cpp:392
 *:*src/db/testtool/action.h:378
 *:*src/syscheckd/src/db/src/db.cpp:100
-*:*src/syscheckd/src/create_db.c:849
+*:*src/syscheckd/src/create_db.c:853

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -82,7 +82,9 @@ cJSON * fim_calculate_dbsync_difference(const fim_file_data *data,
 
     if (data->options & CHECK_OWNER) {
         if (aux = cJSON_GetObjectItem(changed_data, "uid"), aux != NULL) {
-            cJSON_AddStringToObject(old_attributes, "uid", cJSON_GetStringValue(aux));
+            char uid_str [OS_SIZE_64] = {0};
+            snprintf(uid_str, OS_SIZE_64, "%d", aux->valueint);
+            cJSON_AddStringToObject(old_attributes, "uid", uid_str);
             cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("uid"));
 
         } else {
@@ -92,7 +94,9 @@ cJSON * fim_calculate_dbsync_difference(const fim_file_data *data,
 
     if (data->options & CHECK_GROUP) {
         if (aux = cJSON_GetObjectItem(changed_data, "gid"), aux != NULL) {
-            cJSON_AddStringToObject(old_attributes, "gid", cJSON_GetStringValue(aux));
+            char gid_str [OS_SIZE_64] = {0};
+            snprintf(gid_str, OS_SIZE_64, "%d", aux->valueint);
+            cJSON_AddStringToObject(old_attributes, "gid", gid_str);
             cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("gid"));
 
         } else {

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -3994,13 +3994,13 @@ void test_fim_calculate_dbsync_difference_no_attributes(void **state){
 void test_fim_calculate_dbsync_difference(void **state){
 
     #ifndef TEST_WINAGENT
-        char* changed_data = "{\"size\":0, \"perm\":\"rw-rw-r--\", \"attributes\":\"NULL\", \"uid\":\"1000\", \"gid\":\"1000\", \
+        char* changed_data = "{\"size\":0, \"perm\":\"rw-rw-r--\", \"attributes\":\"NULL\", \"uid\":1000, \"gid\":1000, \
         \"user_name\":\"root\", \"group_name\":\"root\", \"mtime\":123456789, \"inode\":1, \"hash_md5\":\"0123456789abcdef0123456789abcdef\", \
         \"hash_sha1\":\"0123456789abcdef0123456789abcdef01234567\", \"hash_sha256\":\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\", \
         \"checksum\":\"0123456789abcdef0123456789abcdef01234567\" }";
     #else
         DEFAULT_FILE_DATA.options |= CHECK_ATTRS;
-        char* changed_data = "{\"size\":0, \"perm\":\"rw-rw-r--\", \"attributes\":\"NULL\", \"uid\":\"1000\", \"gid\":\"1000\", \
+        char* changed_data = "{\"size\":0, \"perm\":\"rw-rw-r--\", \"attributes\":\"NULL\", \"uid\":1000, \"gid\":1000, \
         \"user_name\":\"root\", \"group_name\":\"root\", \"mtime\":123456789, \"inode\":1, \"hash_md5\":\"0123456789abcdef0123456789abcdef\", \
         \"hash_sha1\":\"0123456789abcdef0123456789abcdef01234567\", \"hash_sha256\":\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\", \
         \"checksum\":\"0123456789abcdef0123456789abcdef01234567\" }";


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Hi team! 

This PR aims to fix a small failure when calculating the old attributes:
DBSync stores the uid and gid as an integer, but FIM uses strings to handle them. When calculating the `old_attributes` field, this change wasn't done properly. This PR aims to fix the behavior. 

This problem was causing some ITs to fail.
<!--
Add a clear description of how the problem has been solved.
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [ ] Windows
- [X] Source installation
- [X] Source upgrade
<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
