### PR TITLE
Modify cache stmt to shared_ptr.

### DIFF
--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.h
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.h
@@ -168,7 +168,7 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
 
         ColumnType columnTypeName(const std::string& type);
 
-        bool bindJsonData(const std::unique_ptr<SQLite::IStatement>& stmt,
+        bool bindJsonData(const std::shared_ptr<SQLite::IStatement> stmt,
                           const ColumnData& cd,
                           const nlohmann::json::value_type& valueType,
                           const unsigned int cid);
@@ -207,13 +207,13 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
         void deleteRowsbyPK(const std::string& table,
                             const nlohmann::json& data);
 
-        void getTableData(std::unique_ptr<SQLite::IStatement>const& stmt,
+        void getTableData(std::shared_ptr<SQLite::IStatement>const stmt,
                           const int32_t index,
                           const ColumnType& type,
                           const std::string& fieldName,
                           Row& row);
 
-        void bindFieldData(const std::unique_ptr<SQLite::IStatement>& stmt,
+        void bindFieldData(const std::shared_ptr<SQLite::IStatement> stmt,
                            const int32_t index,
                            const TableField& fieldData);
 
@@ -279,7 +279,7 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
 
         SQLiteDBEngine& operator=(const SQLiteDBEngine&) = delete;
 
-        std::unique_ptr<SQLite::IStatement>const& getStatement(const std::string& sql);
+        std::shared_ptr<SQLite::IStatement>const getStatement(const std::string& sql);
 
         std::string getSelectAllQuery(const std::string& table,
                                       const TableColumns& tableFields) const;
@@ -292,7 +292,7 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
                                                const std::vector<std::string>&  primaryKeys);
 
         Utils::MapWrapperSafe<std::string, TableColumns> m_tableFields;
-        std::deque<std::pair<std::string, std::unique_ptr<SQLite::IStatement>>> m_statementsCache;
+        std::deque<std::pair<std::string, std::shared_ptr<SQLite::IStatement>>> m_statementsCache;
         const std::shared_ptr<ISQLiteFactory> m_sqliteFactory;
         std::shared_ptr<SQLite::IConnection> m_sqliteConnection;
         std::mutex m_stmtMutex;


### PR DESCRIPTION
|Related issue|
|---|
|Closes #12787 |

## Description
This issue aims to fix a problem that occurs when using bulk STMT, which causes a nullptr to dereference.

This is because we are using a reference to a unique_ptr which is removed from the container and subsequently dereferenced.

The solution is to use a shared_ptr for the cache so that the deletion of the container does not instantly cause the deallocation of the object, but rather when the reference count is 0.

## Actual
crash, nullptr dereference.

## Expected
no nullptr dereference.
