### PR TITLE
FIM DB: Avoid compilation warnings in HP-UX

### DIFF
--- a/src/syscheckd/src/db/src/dbFileItem.cpp
+++ b/src/syscheckd/src/db/src/dbFileItem.cpp
@@ -34,15 +34,15 @@ void FileItem::createFimEntry()
     data->group_name = const_cast<char*>(m_groupname.c_str());
     data->mtime = m_time;
     data->inode = m_inode;
-    std::strncpy(data->hash_md5, m_md5.c_str(), sizeof(data->hash_md5));
-    std::strncpy(data->hash_sha1, m_sha1.c_str(), sizeof(data->hash_sha1));
-    std::strncpy(data->hash_sha256, m_sha256.c_str(), sizeof(data->hash_sha256));
+    std::snprintf(data->hash_md5, sizeof(data->hash_md5), "%s", m_md5.c_str());
+    std::snprintf(data->hash_sha1, sizeof(data->hash_sha1), "%s", m_sha1.c_str());
+    std::snprintf(data->hash_sha256, sizeof(data->hash_sha256), "%s", m_sha256.c_str());
     data->mode = m_mode;
     data->last_event = m_lastEvent;
     data->dev = m_dev;
     data->scanned = m_scanned;
     data->options = m_options;
-    std::strncpy(data->checksum, m_checksum.c_str(), sizeof(data->checksum));
+    std::snprintf(data->checksum, sizeof(data->checksum), "%s", m_checksum.c_str());
     fim->file_entry.data = data;
     m_fimEntry = std::unique_ptr<fim_entry, FimFileDataDeleter>(fim);
 }

--- a/src/syscheckd/src/db/src/dbRegistryKey.cpp
+++ b/src/syscheckd/src/db/src/dbRegistryKey.cpp
@@ -21,7 +21,7 @@ void RegistryKey::createFimEntry()
 
     fim->type = FIM_TYPE_REGISTRY;
     key->arch = m_arch;
-    std::strncpy(key->checksum, m_checksum.c_str(), sizeof(key->checksum));
+    std::snprintf(key->checksum, sizeof(key->checksum), "%s", m_checksum.c_str());
     key->gid = static_cast<char*>(std::calloc(gid_size + 1, sizeof(char)));
     std::strncpy(key->gid, std::to_string(m_gid).c_str(), gid_size);
     key->group_name = const_cast<char*>(m_groupname.c_str());

--- a/src/syscheckd/src/db/src/dbRegistryValue.cpp
+++ b/src/syscheckd/src/db/src/dbRegistryValue.cpp
@@ -21,13 +21,13 @@ void RegistryValue::createFimEntry()
     value->path = const_cast<char*>(m_path.c_str());
     value->size = m_size;
     value->name = const_cast<char*>(m_identifier.c_str());
-    std::strncpy(value->hash_md5, m_md5.c_str(), sizeof(value->hash_md5));
-    std::strncpy(value->hash_sha1, m_sha1.c_str(), sizeof(value->hash_sha1));
-    std::strncpy(value->hash_sha256, m_sha256.c_str(), sizeof(value->hash_sha256));
+    std::snprintf(value->hash_md5, sizeof(value->hash_md5), "%s", m_md5.c_str());
+    std::snprintf(value->hash_sha1, sizeof(value->hash_sha1), "%s", m_sha1.c_str());
+    std::snprintf(value->hash_sha256, sizeof(value->hash_sha256), "%s", m_sha256.c_str());
     value->mode = m_mode;
     value->last_event = m_lastEvent;
     value->scanned = m_scanned;
-    std::strncpy(value->checksum, m_checksum.c_str(), sizeof(value->checksum));
+    std::snprintf(value->checksum, sizeof(value->checksum), "%s", m_checksum.c_str());
     fim->registry_entry.value = value;
     m_fimEntry = std::unique_ptr<fim_entry, FimRegistryValueDeleter>(fim);
 }

--- a/src/syscheckd/src/db/tests/db/dbItem/FileItem/dbFileItemTest.cpp
+++ b/src/syscheckd/src/db/tests/db/dbItem/FileItem/dbFileItemTest.cpp
@@ -21,13 +21,13 @@ void FileItemTest::SetUp()
     fimEntryTest->type = FIM_TYPE_FILE;
     fimEntryTest->file_entry.path = const_cast<char*>("/etc/wgetrc");
     data->attributes = const_cast<char*>("10");
-    std::strncpy(data->checksum, "a2fbef8f81af27155dcee5e3927ff6243593b91a", sizeof(data->checksum));
+    std::snprintf(data->checksum, sizeof(data->checksum), "a2fbef8f81af27155dcee5e3927ff6243593b91a");
     data->dev = 2051;
     data->gid = const_cast<char*>("0");
     data->group_name = const_cast<char*>("root");
-    std::strncpy(data->hash_md5, "4b531524aa13c8a54614100b570b3dc7", sizeof(data->hash_md5));
-    std::strncpy(data->hash_sha1, "7902feb66d0bcbe4eb88e1bfacf28befc38bd58b", sizeof(data->hash_sha1));
-    std::strncpy(data->hash_sha256, "e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", sizeof(data->hash_sha256));
+    std::snprintf(data->hash_md5, sizeof(data->hash_md5), "4b531524aa13c8a54614100b570b3dc7");
+    std::snprintf(data->hash_sha1, sizeof(data->hash_sha1), "7902feb66d0bcbe4eb88e1bfacf28befc38bd58b");
+    std::snprintf(data->hash_sha256, sizeof(data->hash_sha256), "e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a");
     data->inode = 1152921500312810880;
     data->last_event = 1596489275;
     data->mode = FIM_SCHEDULED;

--- a/src/syscheckd/src/db/tests/db/dbItem/RegistryKey/dbRegistryKeyTest.cpp
+++ b/src/syscheckd/src/db/tests/db/dbItem/RegistryKey/dbRegistryKeyTest.cpp
@@ -20,7 +20,7 @@ void RegistryKeyTest::SetUp()
 
     fimEntryTest->type = FIM_TYPE_REGISTRY;
     key->arch = ARCH_64BIT;
-    std::strncpy(key->checksum, "a2fbef8f81af27155dcee5e3927ff6243593b91a", sizeof(key->checksum));
+    std::snprintf(key->checksum, sizeof(key->checksum), "a2fbef8f81af27155dcee5e3927ff6243593b91a");
     key->gid = const_cast<char*>("0");
     key->group_name = const_cast<char*>("root");
     key->last_event = 1596489275;

--- a/src/syscheckd/src/db/tests/db/dbItem/RegistryValue/dbRegistryValueTest.cpp
+++ b/src/syscheckd/src/db/tests/db/dbItem/RegistryValue/dbRegistryValueTest.cpp
@@ -18,10 +18,10 @@ void RegistryValueTest::SetUp()
     fim_registry_value_data* value = reinterpret_cast<fim_registry_value_data*>(std::calloc(1, sizeof(fim_registry_value_data)));
 
     fimEntryTest->type = FIM_TYPE_REGISTRY;
-    std::strncpy(value->checksum, "a2fbef8f81af27155dcee5e3927ff6243593b91a", sizeof(value->checksum));
-    std::strncpy(value->hash_md5, "4b531524aa13c8a54614100b570b3dc7", sizeof(value->hash_md5));
-    std::strncpy(value->hash_sha1, "7902feb66d0bcbe4eb88e1bfacf28befc38bd58b", sizeof(value->hash_sha1));
-    std::strncpy(value->hash_sha256, "e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", sizeof(value->hash_sha256));
+    std::snprintf(value->checksum, sizeof(value->checksum), "a2fbef8f81af27155dcee5e3927ff6243593b91a");
+    std::snprintf(value->hash_md5, sizeof(value->hash_md5), "4b531524aa13c8a54614100b570b3dc7");
+    std::snprintf(value->hash_sha1, sizeof(value->hash_sha1), "7902feb66d0bcbe4eb88e1bfacf28befc38bd58b");
+    std::snprintf(value->hash_sha256, sizeof(value->hash_sha256), "e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a");
     value->last_event = 1596489275;
     value->mode = FIM_SCHEDULED;
     value->name = const_cast<char*>("testRegistry");


### PR DESCRIPTION
|Related issue|
|---|
|#9103|

## Description

This PR has been created to avoid displaying _Warning_ messages related to the size limit in the variables (potentially causing variable truncation).

These warnings appeared after compiling Wazuh with the development branch `9103-replace-fim-db-dbsync` in a **_HP-UX_** environment. 

To avoid these _Warning_ messages, the `strncpy` function has been changed to `snprintf`, so that it is not necessary to modify the size of the variable to take into account the last character `'/0'` (which caused the _Warning_).

## Warnings example

Warnings that have been avoided are shown below:
```
[  8%] Building CXX object src/db/CMakeFiles/fimdb.dir/src/dbFileItem.cpp.o
/home/zhxzx/wazuh-sources/src/syscheckd/src/db/src/dbFileItem.cpp: In member function 'void FileItem::createFimEntry()':
/home/zhxzx/wazuh-sources/src/syscheckd/src/db/src/dbFileItem.cpp:37:17: warning: 'char* strncpy(char*, const char*, size_t)' specified bound 33 equals destination size [-Wstringop-truncation]
   37 |     std::strncpy(data->hash_md5, m_md5.c_str(), sizeof(data->hash_md5));
      |     ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/zhxzx/wazuh-sources/src/syscheckd/src/db/src/dbFileItem.cpp:38:17: warning: 'char* strncpy(char*, const char*, size_t)' specified bound 41 equals destination size [-Wstringop-truncation]
   38 |     std::strncpy(data->hash_sha1, m_sha1.c_str(), sizeof(data->hash_sha1));
      |     ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/zhxzx/wazuh-sources/src/syscheckd/src/db/src/dbFileItem.cpp:39:17: warning: 'char* strncpy(char*, const char*, size_t)' specified bound 65 equals destination size [-Wstringop-truncation]
   39 |     std::strncpy(data->hash_sha256, m_sha256.c_str(), sizeof(data->hash_sha256));
      |     ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 12%] Building CXX object src/db/CMakeFiles/fimdb.dir/src/dbRegistryKey.cpp.o
[ 16%] Building CXX object src/db/CMakeFiles/fimdb.dir/src/dbRegistryValue.cpp.o
/home/zhxzx/wazuh-sources/src/syscheckd/src/db/src/dbRegistryValue.cpp: In member function 'void RegistryValue::createFimEntry()':
/home/zhxzx/wazuh-sources/src/syscheckd/src/db/src/dbRegistryValue.cpp:24:17: warning: 'char* strncpy(char*, const char*, size_t)' specified bound 33 equals destination size [-Wstringop-truncation]
   24 |     std::strncpy(value->hash_md5, m_md5.c_str(), sizeof(value->hash_md5));
      |     ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/zhxzx/wazuh-sources/src/syscheckd/src/db/src/dbRegistryValue.cpp:25:17: warning: 'char* strncpy(char*, const char*, size_t)' specified bound 41 equals destination size [-Wstringop-truncation]
   25 |     std::strncpy(value->hash_sha1, m_sha1.c_str(), sizeof(value->hash_sha1));
      |     ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/zhxzx/wazuh-sources/src/syscheckd/src/db/src/dbRegistryValue.cpp:26:17: warning: 'char* strncpy(char*, const char*, size_t)' specified bound 65 equals destination size [-Wstringop-truncation]
   26 |     std::strncpy(value->hash_sha256, m_sha256.c_str(), sizeof(value->hash_sha256));
      |     ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/zhxzx/wazuh-sources/src/syscheckd/src/db/src/dbRegistryValue.cpp:30:17: warning: 'char* strncpy(char*, const char*, size_t)' specified bound 41 equals destination size [-Wstringop-truncation]
   30 |     std::strncpy(value->checksum, m_checksum.c_str(), sizeof(value->checksum));
      |     ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

These Warnings do not appear after the changes made.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux 
  - [x] HP-UX
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Valgrind (memcheck and descriptor leaks check)

