### PR TITLE
Remove hash sending when entire groups DB is sent

### DIFF
--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -690,7 +690,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                                            data_retriever=WazuhDBConnection().run_wdb_command,
                                            get_data_command='global sync-agent-groups-get ',
                                            get_payload={"condition": "all", "set_synced": False,
-                                                        "get_global_hash": True, "last_id": 0}, pivot_key='last_id')
+                                                        "get_global_hash": False, "last_id": 0}, pivot_key='last_id')
         local_agent_groups_information = await sync_object.retrieve_information()
 
         sync_object = c_common.SyncWazuhdb(manager=self, logger=logger, cmd=b'syn_g_m_w_c',


### PR DESCRIPTION
|Related issue|
|---|
|#12780|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR closes #12780. In this PR we have fixed the error reported in #12780. As we have mentioned [here](https://github.com/wazuh/wazuh/issues/12780#issuecomment-1073993085), now the global checksum will not be sent when sending the whole database from the master node to the worker nodes.