### PR TITLE
Replace 'sucess' by 'success'

### DIFF
--- a/framework/wazuh/core/cluster/client.py
+++ b/framework/wazuh/core/cluster/client.py
@@ -175,7 +175,7 @@ class AbstractClient(common.Handler):
             self.logger.error(f"Could not connect to master: {response_msg}.")
             self.transport.close()
         else:
-            self.logger.info("Sucessfully connected to master.")
+            self.logger.info("Successfully connected to master.")
             self.connected = True
 
     def connection_made(self, transport):
@@ -232,7 +232,7 @@ class AbstractClient(common.Handler):
             Result message.
         """
         if command == b'ok-m':
-            return b"Sucessful response from master: " + payload
+            return b"Successful response from master: " + payload
         else:
             return super().process_response(command, payload)
 

--- a/framework/wazuh/core/cluster/tests/test_client.py
+++ b/framework/wazuh/core/cluster/tests/test_client.py
@@ -229,7 +229,7 @@ def test_ac_connection_result():
         abstract_client.transport = m_mock
 
         abstract_client.connection_result(m_mock)
-        logger_mock.assert_called_once_with("Sucessfully connected to master.")
+        logger_mock.assert_called_once_with("Successfully connected to master.")
         assert abstract_client.connected is True
 
 
@@ -301,7 +301,7 @@ def test_ac_process_response():
 
     # Test the fist condition
     assert (abstract_client.process_response(command=b'ok-m',
-                                             payload=b"payload") == b"Sucessful response from master: " + b"payload")
+                                             payload=b"payload") == b"Successful response from master: " + b"payload")
 
     # Test the second condition
     with patch('wazuh.core.cluster.common.Handler.process_response', return_value=b'ok') as pr_mock:

--- a/framework/wazuh/tests/test_group.py
+++ b/framework/wazuh/tests/test_group.py
@@ -29,9 +29,9 @@ class AgentMock:
 @patch('wazuh.core.agent.Agent.get_agents_group_file')
 @patch('wazuh.core.agent.Agent.set_agent_group_file')
 @patch('wazuh.core.agent.Agent')
-def test_sucessfully_remove_single_group_agent(agent_patch, set_agent_group_patch, get_groups_patch, agent_groups,
+def test_successfully_remove_single_group_agent(agent_patch, set_agent_group_patch, get_groups_patch, agent_groups,
                                                agent_id, group_id, expected_new_group):
-    """Test sucessfully unsseting a group from an agent. Test cases:
+    """Test successfully unset a group from an agent. Test cases:
         * The agent only belongs to one group. It must be assigned to the default one.
         * The agent belongs to two groups, it must be assigned to the remaining group.
         * The agent belongs to three groups, the group to remove must be removed from the multigroup.

--- a/ruleset/rules/0585-win-application_rules.xml
+++ b/ruleset/rules/0585-win-application_rules.xml
@@ -1159,7 +1159,7 @@
     <if_sid>60726</if_sid>
     <field name="win.system.eventID">^5616$</field>
     <options>no_full_log</options>
-    <description>WMI core, provider subsystem and event subsystem initialized sucessfully.</description>
+    <description>WMI core, provider subsystem and event subsystem initialized successfully.</description>
     <mitre>
       <id>T1047</id>
     </mitre>

--- a/src/headers/labels_op.h
+++ b/src/headers/labels_op.h
@@ -48,7 +48,7 @@ wlabel_t * labels_dup(const wlabel_t * labels);
  * with labels_free().
  * 
  * @param json_labels The JSON with the labels taken from Wazuh DB.
- * @retval A wlabel_t structure with all the labels on sucess. Null on error or when no labels.
+ * @retval A wlabel_t structure with all the labels on success. Null on error or when no labels.
  */
 wlabel_t* labels_parse(cJSON *json_labels);
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1343,7 +1343,7 @@ wdb_t * wdb_backup_global(wdb_t *wdb, int version);
  *
  * @param [in] wdb The global.db database to backup.
  * @param [in] version The global.db database version to backup.
- * @return wdb OS_SUCESS on success or OS_INVALID on error.
+ * @return wdb OS_SUCCESS on success or OS_INVALID on error.
  */
 int wdb_create_backup_global(int version);
 
@@ -1434,7 +1434,7 @@ int wdb_enable_foreign_keys(sqlite3 *db);
  * @param [in] wdb The MITRE struct database.
  * @param [in] id MITRE technique's ID.
  * @param [out] output MITRE technique's name.
- * @retval 1 Sucess: name found on MITRE database.
+ * @retval 1 Success: name found on MITRE database.
  * @retval 0 On error: name not found on MITRE database.
  * @retval -1 On error: invalid DB query syntax.
  */


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/12716|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This closes https://github.com/wazuh/wazuh/issues/12716. The aim of this issue was to change the spelling of the word `success`, from `sucess` to `success`.
