### PR TITLE
Allowing a syscollector scan on demand

### DIFF
--- a/src/wazuh_modules/syscollector/cppcheckSuppress.txt
+++ b/src/wazuh_modules/syscollector/cppcheckSuppress.txt
@@ -1,4 +1,4 @@
 *:*.c
 *:*syscollector.h
-*:*src/syscollectorImp.cpp:1056
+*:*src/syscollectorImp.cpp:1059
 *:*tests/sysCollectorImp/syscollectorImp_test.cpp

--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -99,12 +99,14 @@ private:
     void syncProcesses();
     void scan();
     void sync();
+    void runOnDemandScan();
     void syncLoop(std::unique_lock<std::mutex>& lock);
     std::shared_ptr<ISysInfo>                                               m_spInfo;
     std::function<void(const std::string&)>                                 m_reportDiffFunction;
     std::function<void(const std::string&)>                                 m_reportSyncFunction;
     std::function<void(const syscollector_log_level_t, const std::string&)> m_logFunction;
     unsigned int                                                            m_intervalValue;
+    unsigned int                                                            m_adjustedIntervalValue;
     bool                                                                    m_scanOnStart;
     bool                                                                    m_hardware;
     bool                                                                    m_os;
@@ -115,7 +117,9 @@ private:
     bool                                                                    m_processes;
     bool                                                                    m_hotfixes;
     bool                                                                    m_stopping;
+    bool                                                                    m_lastScanOnDemand;
     bool                                                                    m_notify;
+    std::time_t                                                             m_lastScanOnDemandTime;
     std::unique_ptr<DBSync>                                                 m_spDBSync;
     std::unique_ptr<RemoteSync>                                             m_spRsync;
     std::condition_variable                                                 m_cv;

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -1680,7 +1680,7 @@ void Syscollector::push(const std::string& data)
 
     if (!m_stopping)
     {
-        if (0 == data.compare("syscollector_run"))
+        if (0 == data.compare("syscollector_scan start"))
         {
             std::thread worker([this] { runOnDemandScan(); });
             worker.detach();

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -1639,7 +1639,7 @@ void Syscollector::syncLoop(std::unique_lock<std::mutex>& lock)
     while (!m_cv.wait_for(lock, std::chrono::seconds{m_adjustedIntervalValue ? m_adjustedIntervalValue : m_intervalValue}, [&]()
 {
     return (m_stopping);
-}))
+    }))
     {
         if (!m_lastScanOnDemand)
         {
@@ -1653,13 +1653,15 @@ void Syscollector::syncLoop(std::unique_lock<std::mutex>& lock)
             std::time_t current_time = std::time(nullptr);
             m_adjustedIntervalValue = m_intervalValue - (current_time - m_lastScanOnDemandTime);
         }
+
         m_lastScanOnDemand = false;
     }
     m_spRsync.reset(nullptr);
     m_spDBSync.reset(nullptr);
 }
 
-void Syscollector::runOnDemandScan() {
+void Syscollector::runOnDemandScan()
+{
     std::unique_lock<std::mutex> lock{m_mutex};
 
     if (!m_stopping)
@@ -1678,10 +1680,13 @@ void Syscollector::push(const std::string& data)
 
     if (!m_stopping)
     {
-        if (0 == data.compare("syscollector_run")) {
-            std::thread worker([this]{ runOnDemandScan(); });
+        if (0 == data.compare("syscollector_run"))
+        {
+            std::thread worker([this] { runOnDemandScan(); });
             worker.detach();
-        } else {
+        }
+        else
+        {
             auto rawData{data};
             Utils::replaceFirst(rawData, "dbsync ", "");
             const auto buff{reinterpret_cast<const uint8_t*>(rawData.c_str())};

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -1879,7 +1879,7 @@ TEST_F(SyscollectorImpTest, pushMessageOk1)
 TEST_F(SyscollectorImpTest, scanOnDemandOk)
 {
     // The command triggers a scan when scanOnStart is false and the interval time didn't expire
-    constexpr auto messageToPush{R"(syscollector_run)"};
+    constexpr auto messageToPush{R"(syscollector_scan start)"};
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
     EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                       R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
@@ -1927,7 +1927,7 @@ TEST_F(SyscollectorImpTest, scanOnDemandOk)
 TEST_F(SyscollectorImpTest, scanOnDemandOk2)
 {
     // Only one scan runs, even when sleep time is enough for interval to expire
-    constexpr auto messageToPush{R"(syscollector_run)"};
+    constexpr auto messageToPush{R"(syscollector_scan start)"};
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
     EXPECT_CALL(*spInfoWrapper, hardware())
     .Times(1)
@@ -1957,7 +1957,7 @@ TEST_F(SyscollectorImpTest, scanOnDemandOk2)
     };
     std::this_thread::sleep_for(std::chrono::seconds{3});
     Syscollector::instance().push(messageToPush);
-    std::this_thread::sleep_for(std::chrono::seconds{4});
+    std::this_thread::sleep_for(std::chrono::seconds{3});
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -1969,7 +1969,7 @@ TEST_F(SyscollectorImpTest, scanOnDemandOk2)
 TEST_F(SyscollectorImpTest, scanOnDemandOk3)
 {
     // The scan runs only twice, even when the sleep time is enough for the interval to expire more than once
-    constexpr auto messageToPush{R"(syscollector_run)"};
+    constexpr auto messageToPush{R"(syscollector_scan start)"};
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
     EXPECT_CALL(*spInfoWrapper, hardware())
     .Times(2)
@@ -1999,7 +1999,7 @@ TEST_F(SyscollectorImpTest, scanOnDemandOk3)
     };
     std::this_thread::sleep_for(std::chrono::seconds{3});
     Syscollector::instance().push(messageToPush);
-    std::this_thread::sleep_for(std::chrono::seconds{9});
+    std::this_thread::sleep_for(std::chrono::seconds{8});
     Syscollector::instance().destroy();
 
     if (t.joinable())

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -299,7 +299,7 @@ int modulesSync(char* args) {
     for (cur_module = wmodules; cur_module; cur_module = cur_module->next) {
         if (strstr(args, cur_module->context->name)) {
             ret = 0;
-            if (strstr(args, "dbsync") && cur_module->context->sync != NULL) {
+            if ( (strstr(args, "dbsync") || strstr(args, "run")) && cur_module->context->sync != NULL) {
                 ret = cur_module->context->sync(args);
             }
             break;

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -297,9 +297,10 @@ int modulesSync(char* args) {
     int ret = -1;
     wmodule *cur_module = NULL;
     for (cur_module = wmodules; cur_module; cur_module = cur_module->next) {
-        if (strstr(args, cur_module->context->name)) {
+        size_t len = strlen(cur_module->context->name);
+        if (!strncmp(args, cur_module->context->name, len)) {
             ret = 0;
-            if ( (strstr(args, "dbsync") || strstr(args, "run")) && cur_module->context->sync != NULL) {
+            if ( (strstr(args, "dbsync") || strstr(args, "scan")) && cur_module->context->sync != NULL) {
                 ret = cur_module->context->sync(args);
             }
             break;


### PR DESCRIPTION
|Related issue|
|---|
|#12552|

## Description

This PR allows a manual execution of the **syscollector** scan and sync actions.
If the agent receives the message `syscollector_run_scan dbsync` the scan will start.

Also, the configured **interval** for **syscollector** is kept considering the last on-demand scan as regular scan.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report

- [x] Added unit tests (for new features)
