### PR TITLE
Fix the residual child process removal

### DIFF
--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -19,8 +19,8 @@ from functools import wraps
 from itertools import groupby, chain
 from os import chmod, chown, listdir, mkdir, curdir, rename, utime, remove, walk, path
 from pyexpat import ExpatError
-from shutil import Error, copyfile, move
-from signal import signal, alarm, SIGALRM
+from shutil import Error, move, copyfile
+from signal import signal, alarm, SIGALRM, SIGKILL
 from subprocess import CalledProcessError, check_output
 from xml.etree.ElementTree import ElementTree
 
@@ -56,9 +56,11 @@ def clean_pid_files(daemon):
     for pid_file in os.listdir(pidfiles_path):
         if match := re.match(regex, pid_file):
             try:
-                os.kill(int(match.group(1)), 0)
+                os.kill(int(match.group(1)), SIGKILL)
+                print(f"{daemon}: Orphan child process {match.group(1)} was terminated.")
             except OSError:
-                print(f'{daemon}: Process {match.group(1)} not used by Wazuh, removing...')
+                print(f'{daemon}: Non existent process {match.group(1)}, removing from {common.wazuh_path}/var/run...')
+            finally:
                 os.remove(path.join(pidfiles_path, pid_file))
 
 


### PR DESCRIPTION
|Related issue|
|---|
|#12783|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This closes #12783. The aim of this issue is to change how residual child processes are being deleted before new processes are started. This is done to avoid a scenario where 'zombie' children are still active meanwhile the father was unexpectedly terminated.
