### PR TITLE
Add mutual exclusion for concurrent operations.

### DIFF
--- a/src/shared_modules/dbsync/src/dbengine.h
+++ b/src/shared_modules/dbsync/src/dbengine.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <vector>
 #include <functional>
+#include <shared_mutex>
 #include "json.hpp"
 #include "commonDefs.h"
 
@@ -35,11 +36,13 @@ namespace DbSync
                                     const bool inTransaction = true) = 0;
 
             virtual void refreshTableData(const nlohmann::json& data,
-                                          const ResultCallback callback) = 0;
+                                          const ResultCallback callback,
+                                          std::unique_lock<std::shared_timed_mutex>& lock) = 0;
 
             virtual void syncTableRowData(const nlohmann::json& jsInput,
                                           const ResultCallback callback,
-                                          const bool inTransaction = false) = 0;
+                                          const bool inTransaction,
+                                          std::function<void()> unlockMutex) = 0;
 
             virtual void setMaxRows(const std::string& table,
                                     const unsigned long long maxRows) = 0;
@@ -50,11 +53,13 @@ namespace DbSync
 
             virtual void returnRowsMarkedForDelete(const nlohmann::json& tableNames,
                                                    const DbSync::ResultCallback callback,
-                                                   const nlohmann::json& options = {}) = 0;
+                                                   const nlohmann::json& options,
+                                                   std::unique_lock<std::shared_timed_mutex>& lock) = 0;
 
             virtual void selectData(const std::string& table,
                                     const nlohmann::json& query,
-                                    const ResultCallback& callback) = 0;
+                                    const ResultCallback& callback,
+                                    std::unique_lock<std::shared_timed_mutex>& lock) = 0;
 
             virtual void deleteTableRowsData(const std::string& table,
                                              const nlohmann::json& jsDeletionData) = 0;

--- a/src/shared_modules/dbsync/src/dbsync_implementation.cpp
+++ b/src/shared_modules/dbsync/src/dbsync_implementation.cpp
@@ -46,6 +46,7 @@ void DBSyncImplementation::insertBulkData(const DBSYNC_HANDLE   handle,
                                           const nlohmann::json& json)
 {
     const auto ctx{ dbEngineContext(handle) };
+    std::lock_guard<std::shared_timed_mutex> lock{ ctx->m_syncMutex };
     ctx->m_dbEngine->bulkInsert(json.at("table"), json.at("data"));
 }
 
@@ -54,9 +55,14 @@ void DBSyncImplementation::syncRowData(const DBSYNC_HANDLE      handle,
                                        const ResultCallback     callback)
 {
     const auto ctx{ dbEngineContext(handle) };
+    std::unique_lock<std::shared_timed_mutex> lock{ ctx->m_syncMutex };
     ctx->m_dbEngine->syncTableRowData(json,
                                       callback,
-                                      false);
+                                      false,
+                                      [&lock]()
+    {
+        lock.unlock();
+    });
 }
 
 void DBSyncImplementation::syncRowData(const DBSYNC_HANDLE      handle,
@@ -72,15 +78,22 @@ void DBSyncImplementation::syncRowData(const DBSYNC_HANDLE      handle,
         throw dbsync_error{INVALID_TABLE};
     }
 
+    std::shared_lock<std::shared_timed_mutex> lock{ ctx->m_syncMutex };
     ctx->m_dbEngine->syncTableRowData(json,
                                       callback,
-                                      true);
+                                      true,
+                                      [&lock]()
+    {
+        lock.unlock();
+    });
 }
 
 void DBSyncImplementation::deleteRowsData(const DBSYNC_HANDLE   handle,
                                           const nlohmann::json& json)
 {
     const auto ctx{ dbEngineContext(handle) };
+    std::lock_guard<std::shared_timed_mutex> lock{ ctx->m_syncMutex };
+
     ctx->m_dbEngine->deleteTableRowsData(json.at("table"),
                                          json.at("query"));
 }
@@ -90,7 +103,9 @@ void DBSyncImplementation::updateSnapshotData(const DBSYNC_HANDLE   handle,
                                               const ResultCallback  callback)
 {
     const auto ctx{ dbEngineContext(handle) };
-    ctx->m_dbEngine->refreshTableData(json, callback);
+
+    std::unique_lock<std::shared_timed_mutex> lock{ ctx->m_syncMutex };
+    ctx->m_dbEngine->refreshTableData(json, callback, lock);
 }
 
 std::shared_ptr<DBSyncImplementation::DbEngineContext> DBSyncImplementation::dbEngineContext(const DBSYNC_HANDLE handle)
@@ -111,6 +126,8 @@ void DBSyncImplementation::setMaxRows(const DBSYNC_HANDLE handle,
                                       const unsigned long long maxRows)
 {
     const auto ctx{ dbEngineContext(handle) };
+
+    std::lock_guard<std::shared_timed_mutex> lock{ ctx->m_syncMutex };
     ctx->m_dbEngine->setMaxRows(table, maxRows);
 }
 
@@ -122,6 +139,8 @@ TXN_HANDLE DBSyncImplementation::createTransaction(const DBSYNC_HANDLE      hand
     {
         std::make_shared<TransactionContext>(json)
     };
+
+    std::lock_guard<std::shared_timed_mutex> lock{ ctx->m_syncMutex };
     ctx->addTransactionContext(spTransactionContext);
     ctx->m_dbEngine->initializeStatusField(spTransactionContext->m_tables);
 
@@ -134,6 +153,7 @@ void DBSyncImplementation::closeTransaction(const DBSYNC_HANDLE handle,
     const auto& ctx{ dbEngineContext(handle) };
     const auto& tnxCtx { ctx->transactionContext(txn) };
 
+    std::lock_guard<std::shared_timed_mutex> lock{ ctx->m_syncMutex };
     ctx->m_dbEngine->deleteRowsByStatusField(tnxCtx->m_tables);
     ctx->deleteTransactionContext(txn);
 }
@@ -146,7 +166,8 @@ void DBSyncImplementation::getDeleted(const DBSYNC_HANDLE   handle,
     const auto& ctx{ dbEngineContext(handle) };
     const auto& tnxCtx { ctx->transactionContext(txnHandle) };
 
-    ctx->m_dbEngine->returnRowsMarkedForDelete(tnxCtx->m_tables, callback, options);
+    std::unique_lock<std::shared_timed_mutex> lock{ ctx->m_syncMutex };
+    ctx->m_dbEngine->returnRowsMarkedForDelete(tnxCtx->m_tables, callback, options, lock);
 }
 
 void DBSyncImplementation::selectData(const DBSYNC_HANDLE   handle,
@@ -154,14 +175,19 @@ void DBSyncImplementation::selectData(const DBSYNC_HANDLE   handle,
                                       const ResultCallback& callback)
 {
     const auto ctx{ dbEngineContext(handle) };
+
+    std::unique_lock<std::shared_timed_mutex> lock{ ctx->m_syncMutex };
     ctx->m_dbEngine->selectData(json.at("table"),
                                 json.at("query"),
-                                callback);
+                                callback,
+                                lock);
 }
 
 void DBSyncImplementation::addTableRelationship(const DBSYNC_HANDLE   handle,
                                                 const nlohmann::json& json)
 {
     const auto ctx{ dbEngineContext(handle) };
+
+    std::lock_guard<std::shared_timed_mutex> lock{ ctx->m_syncMutex };
     ctx->m_dbEngine->addTableRelationship(json);
 }

--- a/src/shared_modules/dbsync/src/dbsync_implementation.h
+++ b/src/shared_modules/dbsync/src/dbsync_implementation.h
@@ -15,6 +15,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include "dbengine_factory.h"
 #include "commonDefs.h"
 #include "json.hpp"
@@ -123,6 +124,8 @@ namespace DbSync
                         std::lock_guard<std::mutex> lock{m_mutex};
                         m_transactionContexts.erase(txnHandle);
                     }
+
+                    std::shared_timed_mutex m_syncMutex;
                 private:
                     std::map<TXN_HANDLE, std::shared_ptr<TransactionContext>> m_transactionContexts;
                     std::mutex m_mutex;

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.h
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.h
@@ -121,11 +121,13 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
                         const bool inTransaction = true) override;
 
         void refreshTableData(const nlohmann::json& data,
-                              const DbSync::ResultCallback callback) override;
+                              const DbSync::ResultCallback callback,
+                              std::unique_lock<std::shared_timed_mutex>& lock) override;
 
         void syncTableRowData(const nlohmann::json& jsInput,
                               const DbSync::ResultCallback callback,
-                              const bool inTransaction = false) override;
+                              const bool inTransaction,
+                              std::function<void()> unlockMutex) override;
 
         void setMaxRows(const std::string& table,
                         const unsigned long long maxRows) override;
@@ -136,11 +138,13 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
 
         void returnRowsMarkedForDelete(const nlohmann::json& tableNames,
                                        const DbSync::ResultCallback callback,
-                                       const nlohmann::json& options = {}) override;
+                                       const nlohmann::json& options,
+                                       std::unique_lock<std::shared_timed_mutex>& lock) override;
 
         void selectData(const std::string& table,
                         const nlohmann::json& query,
-                        const DbSync::ResultCallback& callback) override;
+                        const DbSync::ResultCallback& callback,
+                        std::unique_lock<std::shared_timed_mutex>& lock) override;
 
         void deleteTableRowsData(const std::string& table,
                                  const nlohmann::json& jsDeletionData) override;
@@ -183,7 +187,8 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
 
         bool removeNotExistsRows(const std::string& table,
                                  const std::vector<std::string>& primaryKeyList,
-                                 const DbSync::ResultCallback callback);
+                                 const DbSync::ResultCallback callback,
+                                 std::unique_lock<std::shared_timed_mutex>& lock);
 
         bool getRowDiff(const std::vector<std::string>& primaryKeyList,
                         const nlohmann::json& ignoredColumns,
@@ -194,7 +199,8 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
 
         bool insertNewRows(const std::string& table,
                            const std::vector<std::string>& primaryKeyList,
-                           const DbSync::ResultCallback callback);
+                           const DbSync::ResultCallback callback,
+                           std::unique_lock<std::shared_timed_mutex>& lock);
 
         bool deleteRows(const std::string& table,
                         const std::vector<std::string>& primaryKeyList,
@@ -243,7 +249,8 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
 
         int changeModifiedRows(const std::string& table,
                                const std::vector<std::string>& primaryKeyList,
-                               const DbSync::ResultCallback callback);
+                               const DbSync::ResultCallback callback,
+                               std::unique_lock<std::shared_timed_mutex>& lock);
 
         std::string buildSelectMatchingPKsSqlQuery(const std::string& table,
                                                    const std::vector<std::string>& primaryKeyList);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #12824 |

## Description
This issue aims to solve the case in which while performing a synchronization operation on a record/element, it is not possible to perform an atomic operation at the same time.


## Actual
Atomic operations can be executed in parallel with the transaction.

## Expected
Atomic Operations should not be executed in parallel with the transaction.