### PR TITLE
Add framework security unit tests database fix from `master`

### DIFF
--- a/framework/wazuh/tests/test_security.py
+++ b/framework/wazuh/tests/test_security.py
@@ -6,12 +6,12 @@
 
 import glob
 import os
-from contextvars import ContextVar
 from importlib import reload
 from unittest.mock import patch
 
 import pytest
 from sqlalchemy import create_engine
+from sqlalchemy import orm as sqlalchemy_orm
 from sqlalchemy.exc import OperationalError
 from yaml import safe_load
 
@@ -72,6 +72,14 @@ def db_setup():
             with patch('shutil.chown'), patch('os.chmod'):
                 with patch('api.constants.SECURITY_PATH', new=test_data_path):
                     import wazuh.rbac.orm as orm
+                    # Clear mappers
+                    sqlalchemy_orm.clear_mappers()
+                    # Invalidate in-memory database
+                    conn = orm._engine.connect()
+                    orm._Session().close()
+                    conn.invalidate()
+                    orm._engine.dispose()
+
                     reload(orm)
                     orm.create_rbac_db()
                     import wazuh.rbac.decorators as decorators
@@ -210,6 +218,7 @@ def test_add_new_default_policies(new_default_resources):
 def test_migrate_default_policies(new_default_resources):
     """Check that the migration process overwrites default policies in the user range including their relationships
     and positions."""
+
     def mock_open_default_resources(*args, **kwargs):
         args = list(args)
         file_path = args[0]


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/11957|

## Description

Initially, #11957 was only detected on `master (v4.4.0)`, but in the latest RC for `4.3`, it appeared as well. That is why we are adding the same fix to this version. This error only affects to the python unit tests, code is not related.

Regards,
Víctor