### PR TITLE
Trigger alerts when the registry key limit is reached

### DIFF
--- a/ruleset/rules/0016-wazuh_rules.xml
+++ b/ruleset/rules/0016-wazuh_rules.xml
@@ -186,32 +186,64 @@
   <rule id="235" level="7">
     <if_sid>230</if_sid>
     <field name="alert_type">80_percentage</field>
-    <field name="fim_db_table">registry_data</field>
-    <description>The maximun limit of registry values monitored is close to being reached. At this moment there are $(values_count) registry values and the limit is $(values_limit). If the limit is reached some events can be lost. You can modify this setting in the centralized configuration or locally in the agent.</description>
+    <field name="fim_db_table">registry_key</field>
+    <description>The maximun limit of registry keys monitored is close to being reached. At this moment there are $(keys_count) registry values and the limit is $(registry_limit). If the limit is reached some events can be lost. You can modify this setting in the centralized configuration or locally in the agent.</description>
     <group>syscheck,fim_db_state,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="236" level="9">
     <if_sid>230</if_sid>
     <field name="alert_type">90_percentage</field>
-    <field name="fim_db_table">registry_data</field>
-    <description>The maximun limit of registry values monitored is close to being reached. At this moment there are $(values_count) registry values and the limit is $(values_limit). If the limit is reached some events can be lost. You can modify this setting in the centralized configuration or locally in the agent.</description>
+    <field name="fim_db_table">registry_key</field>
+    <description>The maximun limit of registry keys monitored is close to being reached. At this moment there are $(keys_count) registry values and the limit is $(registry_limit). If the limit is reached some events can be lost. You can modify this setting in the centralized configuration or locally in the agent.</description>
     <group>syscheck,fim_db_state,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="237" level="12">
     <if_sid>230</if_sid>
     <field name="alert_type">full</field>
-    <field name="fim_db_table">registry_data</field>
-    <description>The maximun limit of registry values monitored has been reached. At this moment there are $(values_count) registry values and the limit is $(values_limit). From this moment some events can be lost. You can modify this setting in the centralized configuration or locally in the agent.</description>
+    <field name="fim_db_table">registry_key</field>
+    <description>The maximun limit of registry keys monitored has been reached. At this moment there are $(keys_count) registry values and the limit is $(registry_limit). From this moment some events can be lost. You can modify this setting in the centralized configuration or locally in the agent.</description>
     <group>syscheck,fim_db_state,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="238" level="3">
     <if_sid>230</if_sid>
     <field name="alert_type">normal</field>
+    <field name="fim_db_table">registry_key</field>
+    <description>At this moment there are $(keys_count) registry keys monitored and the limit is $(registry_limit).</description>
+    <group>syscheck,fim_db_state,</group>
+  </rule>
+
+  <rule id="239" level="7">
+    <if_sid>230</if_sid>
+    <field name="alert_type">80_percentage</field>
     <field name="fim_db_table">registry_data</field>
-    <description>At this moment there are $(values_count) registry values monitored and the limit is $(values_limit).</description>
+    <description>The maximun limit of registry values monitored is close to being reached. At this moment there are $(values_count) registry values and the limit is $(registry_limit). If the limit is reached some events can be lost. You can modify this setting in the centralized configuration or locally in the agent.</description>
+    <group>syscheck,fim_db_state,gdpr_IV_35.7.d,</group>
+  </rule>
+
+  <rule id="240" level="9">
+    <if_sid>230</if_sid>
+    <field name="alert_type">90_percentage</field>
+    <field name="fim_db_table">registry_data</field>
+    <description>The maximun limit of registry values monitored is close to being reached. At this moment there are $(values_count) registry values and the limit is $(registry_limit). If the limit is reached some events can be lost. You can modify this setting in the centralized configuration or locally in the agent.</description>
+    <group>syscheck,fim_db_state,gdpr_IV_35.7.d,</group>
+  </rule>
+
+  <rule id="241" level="12">
+    <if_sid>230</if_sid>
+    <field name="alert_type">full</field>
+    <field name="fim_db_table">registry_data</field>
+    <description>The maximun limit of registry values monitored has been reached. At this moment there are $(values_count) registry values and the limit is $(registry_limit). From this moment some events can be lost. You can modify this setting in the centralized configuration or locally in the agent.</description>
+    <group>syscheck,fim_db_state,gdpr_IV_35.7.d,</group>
+  </rule>
+
+  <rule id="242" level="3">
+    <if_sid>230</if_sid>
+    <field name="alert_type">normal</field>
+    <field name="fim_db_table">registry_data</field>
+    <description>At this moment there are $(values_count) registry values monitored and the limit is $(registry_limit).</description>
     <group>syscheck,fim_db_state,</group>
   </rule>
 

--- a/src/syscheckd/cppcheckSuppress.txt
+++ b/src/syscheckd/cppcheckSuppress.txt
@@ -2,4 +2,4 @@
 *:*src/syscheckd/src/db/src/file.cpp:392
 *:*src/db/testtool/action.h:378
 *:*src/syscheckd/src/db/src/db.cpp:100
-*:*src/syscheckd/src/create_db.c:853
+*:*src/syscheckd/src/create_db.c:859

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -2603,6 +2603,8 @@ static void test_fim_scan_db_full_double_scan(void **state) {
     will_return(__wrap_fim_db_get_count_file_entry, 1);
     will_return(__wrap_fim_db_get_count_file_entry, 1);
     will_return(__wrap_fim_db_get_count_registry_data, 1);
+    will_return(__wrap_fim_db_get_count_registry_key, 1);
+
     snprintf(test_file_path, 160, "%s\\test_file", expanded_dirs[0]);
 
     expect_function_call(__wrap_fim_db_transaction_deleted_rows);
@@ -2667,6 +2669,8 @@ static void test_fim_scan_db_full_not_double_scan(void **state) {
     will_return(__wrap_fim_db_get_count_file_entry, 1);
     will_return(__wrap_fim_db_get_count_file_entry, 1);
     will_return(__wrap_fim_db_get_count_registry_data, 1);
+    will_return(__wrap_fim_db_get_count_registry_key, 1);
+
     expect_function_call(__wrap_fim_db_transaction_deleted_rows);
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_ENDED);
 


### PR DESCRIPTION
|Related issue|
|---|
|#12809|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR aims to trigger alerts when the limit of the registry key table is reached. 
Closes #12809 

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
```xml
  <syscheck>
    <disabled>no</disabled>
    <frequency>5</frequency>
    <windows_registry arch="64bit">HKEY_LOCAL_MACHINE\SOFTWARE\test</windows_registry>
     <db_entry_limit>
         <enabled>yes</enabled>
        <registries>10</registries>
     </db_entry_limit>
  </syscheck>

```
<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example
### 80 % alert
```
** Alert 1648026858.11458: - wazuh,syscheck,fim_db_state,gdpr_IV_35.7.d,
2022 Mar 23 09:14:18 (win2016) any->syscheck
Rule: 235 (level 7) -> 'The maximun limit of registry keys monitored is close to being reached. At this moment there are 4 registry values and the limit is 5. If the limit is reached some events can be lost. You can modify this setting in the centralized configuration or locally in the agent.'
wazuh: FIM DB: {"fim_db_table":"registry_key","registry_limit":5,"values_count":2,"keys_count":4,"alert_type":"80_percentage"}
fim_db_table: registry_key
registry_limit: 5
values_count: 2
keys_count: 4
alert_type: 80_percentage
```
### 90 % alert
```
** Alert 1648034669.74906: - wazuh,syscheck,fim_db_state,gdpr_IV_35.7.d,
2022 Mar 23 11:24:29 (win2016) any->syscheck
Rule: 236 (level 9) -> 'The maximun limit of registry keys monitored is close to being reached. At this moment there are 9 registry values and the limit is 10. If the limit is reached some events can be lost. You can modify this setting in the centralized configuration or locally in the agent.'
wazuh: FIM DB: {"fim_db_table":"registry_key","registry_limit":10,"values_count":2,"keys_count":9,"alert_type":"90_percentage"}
fim_db_table: registry_key
registry_limit: 10
values_count: 2
keys_count: 9
alert_type: 90_percentage
```
### Full DB alert
```
** Alert 1648034661.72439: mail  - wazuh,syscheck,fim_db_state,gdpr_IV_35.7.d,
2022 Mar 23 11:24:21 (win2016) any->syscheck
Rule: 237 (level 12) -> 'The maximun limit of registry keys monitored has been reached. At this moment there are 6 registry values and the limit is 6. From this moment some events can be lost. You can modify this setting in the centralized configuration or locally in the agent.'
wazuh: FIM DB: {"fim_db_table":"registry_key","registry_limit":6,"values_count":2,"keys_count":6,"alert_type":"full"}
fim_db_table: registry_key
registry_limit: 6
values_count: 2
keys_count: 6
alert_type: full
```
### Back to normal alert

```
** Alert 1648034821.81000: - wazuh,syscheck,fim_db_state,
2022 Mar 23 11:27:01 (win2016) any->syscheck
Rule: 238 (level 3) -> 'At this moment there are 7 registry keys monitored and the limit is 10.'
wazuh: FIM DB: {"fim_db_table":"registry_key","registry_limit":10,"values_count":2,"keys_count":7,"alert_type":"normal"}
fim_db_table: registry_key
registry_limit: 10
values_count: 2
keys_count: 7
alert_type: normal
```

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
- [X] Source installation
- [X] Source upgrade
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory