### PR TITLE
Fix cluster unittests after 4.3 merge

### DIFF
--- a/framework/wazuh/core/cluster/tests/test_cluster.py
+++ b/framework/wazuh/core/cluster/tests/test_cluster.py
@@ -344,6 +344,7 @@ async def test_async_decompress_files(decompress_files_mock):
     decompress_files_mock.assert_called_once_with(zip_path, 'files_metadata.json')
 
 
+@pytest.mark.asyncio
 @patch('zlib.decompress')
 @patch('os.makedirs')
 @patch('os.path.exists', side_effect=[False, True, True])
@@ -372,6 +373,7 @@ async def test_decompress_files_ok(json_loads_mock, mkdir_with_mode_mock, remove
                                             call('/foo/bar/dir/path2', 'wb'), call('/foo/bar/dir/files_metadata.json')]
 
 
+@pytest.mark.asyncio
 @patch('shutil.rmtree')
 @patch('zlib.decompress', return_value=Exception)
 @patch('wazuh.core.cluster.cluster.mkdir_with_mode')

--- a/framework/wazuh/core/cluster/tests/test_control.py
+++ b/framework/wazuh/core/cluster/tests/test_control.py
@@ -17,6 +17,7 @@ with patch('wazuh.common.getgrnam'):
                 from wazuh import WazuhInternalError, WazuhError
 
 
+@pytest.mark.asyncio
 async def async_local_client(command, data, wait_for_complete):
     return None
 

--- a/framework/wazuh/core/cluster/tests/test_local_client.py
+++ b/framework/wazuh/core/cluster/tests/test_local_client.py
@@ -124,6 +124,7 @@ def test_localclient_initialization(mock_get_running_loop):
     assert lc.transport is None
 
 
+@pytest.mark.asyncio
 async def test_localclient_start():
     """Check that the start method works correctly. Exceptions are not tested."""
 
@@ -143,6 +144,7 @@ async def test_localclient_start():
                 assert lc.transport == "transport"
 
 
+@pytest.mark.asyncio
 @patch("wazuh.core.cluster.client.asyncio.get_running_loop")
 async def test_localclient_start_ko(mock_get_running_loop):
     """Check the behavior of the start function for the different types of exceptions that may occur."""

--- a/framework/wazuh/core/cluster/tests/test_server.py
+++ b/framework/wazuh/core/cluster/tests/test_server.py
@@ -298,14 +298,14 @@ async def test_AbstractServer_check_clients_keepalive(loop_mock, sleep_mock):
                        return_value=logger):
                 abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
                                                  cluster_items={"test4": 4}, enable_ssl=True, logger=logger)
-                tester = "check_clients_keepalive"
+                tester = 4
                 abstract_server.cluster_items = {"intervals": {"master": {"check_worker_lastkeepalive": tester}}}
                 try:
                     await abstract_server.check_clients_keepalive()
                 except IndexError:
                     pass
                 mock_debug.assert_has_calls([call("Calculated."), call("Calculating.")], any_order=True)
-                sleep_mock.assert_called_once_with(tester)
+                sleep_mock.assert_any_call(tester)
 
                 abstract_server.cluster_items = {"intervals": {"master": {"max_allowed_time_without_keepalive": 0,
                                                                           "check_worker_lastkeepalive": tester}}}


### PR DESCRIPTION
## Description

In this PR we have fixed two bugs in the cluster tests after the 4.3 merge. 

The first of these bugs had to do with the incorrect use of asynchronous tests, this caused the execution of the tests to stop on certain occasions.

The second bug had to do with a race condition in test_server.py which we have solved by being less strict.

```
============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.5, pytest-6.2.5, py-1.10.0, pluggy-0.13.1 -- /home/adriiiprodri/.venvs/wazuh/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.10.60.1-microsoft-standard-WSL2-x86_64-with-glibc2.31', 'Packages': {'pytest': '6.2.5', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'asyncio': '0.15.1', 'trio': '0.7.0', 'cov': '2.12.0', 'metadata': '1.11.0', 'tavern': '1.19.0', 'testinfra': '6.4.0', 'html': '3.1.1', 'aiohttp': '0.3.0'}}
rootdir: /mnt/c/Users/adr_i/git/wazuh/framework
plugins: asyncio-0.15.1, trio-0.7.0, cov-2.12.0, metadata-1.11.0, tavern-1.19.0, testinfra-6.4.0, html-3.1.1, aiohttp-0.3.0
collected 254 items

framework/wazuh/core/cluster/tests/test_client.py::test_acm_init PASSED                                                                                                                                    [  0%]
framework/wazuh/core/cluster/tests/test_client.py::test_acm_add_tasks PASSED                                                                                                                               [  0%]
framework/wazuh/core/cluster/tests/test_client.py::test_acm_start PASSED                                                                                                                                   [  1%]
framework/wazuh/core/cluster/tests/test_client.py::test_ac_init PASSED                                                                                                                                     [  1%]
framework/wazuh/core/cluster/tests/test_client.py::test_ac_connection_result PASSED                                                                                                                        [  1%]
framework/wazuh/core/cluster/tests/test_client.py::test_ac_connection_made PASSED                                                                                                                          [  2%]
framework/wazuh/core/cluster/tests/test_client.py::test_ac_connection_lost PASSED                                                                                                                          [  2%]
framework/wazuh/core/cluster/tests/test_client.py::test_ac_cancel_all_tasks PASSED                                                                                                                         [  3%]
framework/wazuh/core/cluster/tests/test_client.py::test_ac_process_response PASSED                                                                                                                         [  3%]
framework/wazuh/core/cluster/tests/test_client.py::test_ac_process_request PASSED                                                                                                                          [  3%]
framework/wazuh/core/cluster/tests/test_client.py::test_ac_echo_client PASSED                                                                                                                              [  4%]
framework/wazuh/core/cluster/tests/test_client.py::test_ac_client_echo_ok PASSED                                                                                                                           [  4%]
framework/wazuh/core/cluster/tests/test_client.py::test_ac_performance_test_client PASSED                                                                                                                  [  5%]
framework/wazuh/core/cluster/tests/test_client.py::test_ac_concurrency_test_client PASSED                                                                                                                  [  5%]
framework/wazuh/core/cluster/tests/test_client.py::test_ac_send_file_task PASSED                                                                                                                           [  5%]
framework/wazuh/core/cluster/tests/test_client.py::test_ac_send_string_task PASSED                                                                                                                         [  6%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_check_cluster_config_ko[read_config0-Unspecified key] PASSED                                                                                      [  6%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_check_cluster_config_ko[read_config1-Key must be] PASSED                                                                                          [  7%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_check_cluster_config_ko[read_config2-Invalid node type] PASSED                                                                                    [  7%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_check_cluster_config_ko[read_config3-Port has to] PASSED                                                                                          [  7%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_check_cluster_config_ko[read_config4-Port must be] PASSED                                                                                         [  8%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_check_cluster_config_ko[read_config5-Port must be] PASSED                                                                                         [  8%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_check_cluster_config_ko[read_config6-Invalid elements] PASSED                                                                                     [  9%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_check_cluster_config_ko[read_config7-Invalid elements] PASSED                                                                                     [  9%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_check_cluster_config_ko[read_config8-Invalid elements] PASSED                                                                                     [  9%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_check_cluster_config_ko[read_config9-Invalid elements] PASSED                                                                                     [ 10%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_check_cluster_config_ko[read_config10-Invalid elements] PASSED                                                                                    [ 10%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_get_node PASSED                                                                                                                                   [ 11%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_check_cluster_status PASSED                                                                                                                       [ 11%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_walk_dir PASSED                                                                                                                                   [ 11%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_walk_dir_ko PASSED                                                                                                                                [ 12%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_get_files_status PASSED                                                                                                                           [ 12%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_update_cluster_control[/test_file0-False-expected_result0] PASSED                                                                                 [ 12%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_update_cluster_control[/test_file1-False-expected_result1] PASSED                                                                                 [ 13%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_update_cluster_control[/test_file2-False-expected_result2] PASSED                                                                                 [ 13%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_update_cluster_control[/test_file0-True-expected_result3] PASSED                                                                                  [ 14%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_update_cluster_control[/test_file1-True-expected_result4] PASSED                                                                                  [ 14%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_update_cluster_control[/test_file2-True-expected_result5] PASSED                                                                                  [ 14%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_compress_files_ok PASSED                                                                                                                          [ 15%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_compress_files_ko PASSED                                                                                                                          [ 15%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_async_decompress_files PASSED                                                                                                                     [ 16%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_decompress_files_ok PASSED                                                                                                                        [ 16%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_decompress_files_ko PASSED                                                                                                                        [ 16%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_compare_files PASSED                                                                                                                              [ 17%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_compare_files_ko PASSED                                                                                                                           [ 17%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_clean_up_ok PASSED                                                                                                                                [ 18%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_clean_up_ko PASSED                                                                                                                                [ 18%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_merge_info PASSED                                                                                                                                 [ 18%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_unmerge_info PASSED                                                                                                                               [ 19%]
framework/wazuh/core/cluster/tests/test_cluster.py::test_run_in_pool PASSED                                                                                                                                [ 19%]
framework/wazuh/core/cluster/tests/test_common.py::test_response_init PASSED                                                                                                                               [ 20%]
framework/wazuh/core/cluster/tests/test_common.py::test_response_read PASSED                                                                                                                               [ 20%]
framework/wazuh/core/cluster/tests/test_common.py::test_response_write PASSED                                                                                                                              [ 20%]
framework/wazuh/core/cluster/tests/test_common.py::test_inbuffer_init PASSED                                                                                                                               [ 21%]
framework/wazuh/core/cluster/tests/test_common.py::test_inbuffer_get_info_from_header PASSED                                                                                                               [ 21%]
framework/wazuh/core/cluster/tests/test_common.py::test_inbuffer_receive_data PASSED                                                                                                                       [ 22%]
framework/wazuh/core/cluster/tests/test_common.py::test_rst_init PASSED                                                                                                                                    [ 22%]
framework/wazuh/core/cluster/tests/test_common.py::test_rst_str_method PASSED                                                                                                                              [ 22%]
framework/wazuh/core/cluster/tests/test_common.py::test_rst_set_up_coro_ko PASSED                                                                                                                          [ 23%]
framework/wazuh/core/cluster/tests/test_common.py::test_rst_done_callback PASSED                                                                                                                           [ 23%]
framework/wazuh/core/cluster/tests/test_common.py::test_rft_init PASSED                                                                                                                                    [ 24%]
framework/wazuh/core/cluster/tests/test_common.py::test_rft_str_method PASSED                                                                                                                              [ 24%]
framework/wazuh/core/cluster/tests/test_common.py::test_rft_set_up_coro PASSED                                                                                                                             [ 24%]
framework/wazuh/core/cluster/tests/test_common.py::test_rft_done_callback PASSED                                                                                                                           [ 25%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_init PASSED                                                                                                                                [ 25%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_push PASSED                                                                                                                                [ 25%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_next_counter PASSED                                                                                                                        [ 26%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_msg_build_ok PASSED                                                                                                                        [ 26%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_msg_build_ko PASSED                                                                                                                        [ 27%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_msg_parse PASSED                                                                                                                           [ 27%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_get_messages_ok PASSED                                                                                                                     [ 27%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_get_messages_ko PASSED                                                                                                                     [ 28%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_send_request_ok PASSED                                                                                                                     [ 28%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_send_request_ko PASSED                                                                                                                     [ 29%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_send_file_ok PASSED                                                                                                                        [ 29%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_send_file_ko PASSED                                                                                                                        [ 29%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_send_string PASSED                                                                                                                         [ 30%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_get_manager PASSED                                                                                                                         [ 30%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_forward_dapi_response_ok PASSED                                                                                                            [ 31%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_forward_dapi_response_ko PASSED                                                                                                            [ 31%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_forward_sendsync_response_ok PASSED                                                                                                        [ 31%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_forward_sendsync_response_ko PASSED                                                                                                        [ 32%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_data_received_ok PASSED                                                                                                                    [ 32%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_data_received_ko PASSED                                                                                                                    [ 33%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_dispatch PASSED                                                                                                                            [ 33%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_close PASSED                                                                                                                               [ 33%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_process_request PASSED                                                                                                                     [ 34%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_process_response PASSED                                                                                                                    [ 34%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_echo PASSED                                                                                                                                [ 35%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_receive_file PASSED                                                                                                                        [ 35%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_update_file PASSED                                                                                                                         [ 35%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_end_file PASSED                                                                                                                            [ 36%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_cancel_task[abcd] PASSED                                                                                                                   [ 36%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_cancel_task[None] PASSED                                                                                                                   [ 37%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_receive_str PASSED                                                                                                                         [ 37%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_str_upd PASSED                                                                                                                             [ 37%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_process_error_str PASSED                                                                                                                   [ 38%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_process_unknown_cmd PASSED                                                                                                                 [ 38%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_process_error_from_peer PASSED                                                                                                             [ 38%]
framework/wazuh/core/cluster/tests/test_common.py::test_handler_setup_task_logger PASSED                                                                                                                   [ 39%]
framework/wazuh/core/cluster/tests/test_common.py::test_wazuh_common_init PASSED                                                                                                                           [ 39%]
framework/wazuh/core/cluster/tests/test_common.py::test_wazuh_common_get_logger PASSED                                                                                                                     [ 40%]
framework/wazuh/core/cluster/tests/test_common.py::test_wazuh_common_setup_receive_file PASSED                                                                                                             [ 40%]
framework/wazuh/core/cluster/tests/test_common.py::test_wazuh_common_end_receiving_file_ok PASSED                                                                                                          [ 40%]
framework/wazuh/core/cluster/tests/test_common.py::test_wazuh_common_end_receiving_file_ko PASSED                                                                                                          [ 41%]
framework/wazuh/core/cluster/tests/test_common.py::test_wazuh_common_error_receiving_file_ok PASSED                                                                                                        [ 41%]
framework/wazuh/core/cluster/tests/test_common.py::test_wazuh_common_error_receiving_file_ko PASSED                                                                                                        [ 42%]
framework/wazuh/core/cluster/tests/test_common.py::test_wazuh_common_get_node PASSED                                                                                                                       [ 42%]
framework/wazuh/core/cluster/tests/test_common.py::test_asyncio_exception_handler PASSED                                                                                                                   [ 42%]
framework/wazuh/core/cluster/tests/test_common.py::test_wazuh_json_encoder_default PASSED                                                                                                                  [ 43%]
framework/wazuh/core/cluster/tests/test_common.py::test_as_wazuh_object_ok PASSED                                                                                                                          [ 43%]
framework/wazuh/core/cluster/tests/test_common.py::test_as_wazuh_object_ko PASSED                                                                                                                          [ 44%]
framework/wazuh/core/cluster/tests/test_control.py::test_get_nodes PASSED                                                                                                                                  [ 44%]
framework/wazuh/core/cluster/tests/test_control.py::test_get_node PASSED                                                                                                                                   [ 44%]
framework/wazuh/core/cluster/tests/test_control.py::test_get_health PASSED                                                                                                                                 [ 45%]
framework/wazuh/core/cluster/tests/test_control.py::test_get_agents PASSED                                                                                                                                 [ 45%]
framework/wazuh/core/cluster/tests/test_control.py::test_get_system_nodes PASSED                                                                                                                           [ 46%]
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclienthandler_initialization PASSED                                                                                                     [ 46%]
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclienthandler_connection_made PASSED                                                                                                    [ 46%]
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclienthandler_cancel_all_tasks PASSED                                                                                                   [ 47%]
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclienthandler_process_request PASSED                                                                                                    [ 47%]
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclienthandler_process_error_from_peer PASSED                                                                                            [ 48%]
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclienthandler_connection_lost PASSED                                                                                                    [ 48%]
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclient_initialization PASSED                                                                                                            [ 48%]
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclient_start PASSED                                                                                                                     [ 49%]
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclient_start_ko PASSED                                                                                                                  [ 49%]
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclient_send_api_request PASSED                                                                                                          [ 50%]
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclient_send_api_request_ko PASSED                                                                                                       [ 50%]
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclient_execute PASSED                                                                                                                   [ 50%]
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclient_send_file PASSED                                                                                                                 [ 51%]
framework/wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandler_connection_made PASSED                                                                                                    [ 51%]
framework/wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandler_process_request PASSED                                                                                                    [ 51%]
framework/wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandler_get_config PASSED                                                                                                         [ 52%]
framework/wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandler_get_node PASSED                                                                                                           [ 52%]
framework/wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandler_get_nodes PASSED                                                                                                          [ 53%]
framework/wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandler_get_health PASSED                                                                                                         [ 53%]
framework/wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandler_send_file_request PASSED                                                                                                  [ 53%]
framework/wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandler_get_send_file_response PASSED                                                                                             [ 54%]
framework/wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandler_send_res_callback PASSED                                                                                                  [ 54%]
framework/wazuh/core/cluster/tests/test_local_server.py::test_LocalServer_init PASSED                                                                                                                      [ 55%]
framework/wazuh/core/cluster/tests/test_local_server.py::test_LocalServer_start PASSED                                                                                                                     [ 55%]
framework/wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandlerMaster_process_request PASSED                                                                                              [ 55%]
framework/wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandlerMaster_get_nodes PASSED                                                                                                    [ 56%]
framework/wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandlerMaster_get_health PASSED                                                                                                   [ 56%]
framework/wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandlerMaster_send_file_request PASSED                                                                                            [ 57%]
framework/wazuh/core/cluster/tests/test_local_server.py::test_LocalServerMaster_init PASSED                                                                                                                [ 57%]
framework/wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandlerWorker_process_request PASSED                                                                                              [ 57%]
framework/wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandlerWorker_get_nodes PASSED                                                                                                    [ 58%]
framework/wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandlerWorker_get_health PASSED                                                                                                   [ 58%]
framework/wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandlerWorker_send_request_to_master PASSED                                                                                       [ 59%]
framework/wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandlerWorker_get_api_response PASSED                                                                                             [ 59%]
framework/wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandlerWorker_send_file_request PASSED                                                                                            [ 59%]
framework/wazuh/core/cluster/tests/test_local_server.py::test_LocalServerWorker_init PASSED                                                                                                                [ 60%]
framework/wazuh/core/cluster/tests/test_master.py::test_rit_init PASSED                                                                                                                                    [ 60%]
framework/wazuh/core/cluster/tests/test_master.py::test_rit_set_up_coro PASSED                                                                                                                             [ 61%]
framework/wazuh/core/cluster/tests/test_master.py::test_rit_done_callback PASSED                                                                                                                           [ 61%]
framework/wazuh/core/cluster/tests/test_master.py::test_revt_init PASSED                                                                                                                                   [ 61%]
framework/wazuh/core/cluster/tests/test_master.py::test_revt_set_up_coro PASSED                                                                                                                            [ 62%]
framework/wazuh/core/cluster/tests/test_master.py::test_revt_done_callback PASSED                                                                                                                          [ 62%]
framework/wazuh/core/cluster/tests/test_master.py::test_rait_init PASSED                                                                                                                                   [ 62%]
framework/wazuh/core/cluster/tests/test_master.py::test_rait_set_up_coro PASSED                                                                                                                            [ 63%]
framework/wazuh/core/cluster/tests/test_master.py::test_rait_done_callback PASSED                                                                                                                          [ 63%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_init PASSED                                                                                                                         [ 64%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_to_dict PASSED                                                                                                                      [ 64%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_process_request PASSED                                                                                                              [ 64%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_execute_ok PASSED                                                                                                                   [ 65%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_execute_ko PASSED                                                                                                                   [ 65%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_hello_ok PASSED                                                                                                                     [ 66%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_hello_ko PASSED                                                                                                                     [ 66%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_get_manager PASSED                                                                                                                  [ 66%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_process_dapi_res_ok PASSED                                                                                                          [ 67%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_process_dapi_res_ko PASSED                                                                                                          [ 67%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_get_nodes PASSED                                                                                                                    [ 68%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_get_health PASSED                                                                                                                   [ 68%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_get_permission PASSED                                                                                                               [ 68%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_setup_sync_integrity PASSED                                                                                                         [ 69%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_process_sync_error_from_worker PASSED                                                                                               [ 69%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_end_receiving_integrity_checksums PASSED                                                                                            [ 70%]
framework/wazuh/core/cluster/tests/test_master.py::test_manager_handler_send_data_to_wdb_ok PASSED                                                                                                         [ 70%]
framework/wazuh/core/cluster/tests/test_master.py::test_manager_handler_send_data_to_wdb_ko PASSED                                                                                                         [ 70%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_sync_wazuh_db_info_ok PASSED                                                                                                        [ 71%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_sync_wazuh_db_info_ko PASSED                                                                                                        [ 71%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_sync_worker_files_ok PASSED                                                                                                         [ 72%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_sync_worker_files_ko PASSED                                                                                                         [ 72%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_sync_extra_valid PASSED                                                                                                             [ 72%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_sync_integrity_ok PASSED                                                                                                            [ 73%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_sync_integrity_ko PASSED                                                                                                            [ 73%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_process_files_from_worker_ok PASSED                                                                                                 [ 74%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_get_logger PASSED                                                                                                                   [ 74%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_handler_connection_lost PASSED                                                                                                              [ 74%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_init PASSED                                                                                                                                 [ 75%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_to_dict PASSED                                                                                                                              [ 75%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_file_status_update_ok PASSED                                                                                                                [ 75%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_get_health PASSED                                                                                                                           [ 76%]
framework/wazuh/core/cluster/tests/test_master.py::test_master_get_node PASSED                                                                                                                             [ 76%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServerHandler_init PASSED                                                                                                                  [ 77%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServerHandler_to_dict PASSED                                                                                                               [ 77%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServerHandler_connection_made PASSED                                                                                                       [ 77%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServerHandler_process_request PASSED                                                                                                       [ 78%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServerHandler_echo_master PASSED                                                                                                           [ 78%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServerHandler_hello PASSED                                                                                                                 [ 79%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServerHandler_process_response PASSED                                                                                                      [ 79%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServerHandler_connection_lost PASSED                                                                                                       [ 79%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_init PASSED                                                                                                                         [ 80%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_to_dict PASSED                                                                                                                      [ 80%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_setup_task_logger PASSED                                                                                                            [ 81%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_get_connected_nodes PASSED                                                                                                          [ 81%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_get_connected_nodes_ko PASSED                                                                                                       [ 81%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_check_clients_keepalive PASSED                                                                                                      [ 82%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_echo PASSED                                                                                                                         [ 82%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_performance_test PASSED                                                                                                             [ 83%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_concurrency_test PASSED                                                                                                             [ 83%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_start PASSED                                                                                                                        [ 83%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_start_ko PASSED                                                                                                                     [ 84%]
framework/wazuh/core/cluster/tests/test_utils.py::test_read_cluster_config PASSED                                                                                                                          [ 84%]
framework/wazuh/core/cluster/tests/test_utils.py::test_get_manager_status PASSED                                                                                                                           [ 85%]
framework/wazuh/core/cluster/tests/test_utils.py::test_get_manager_status_ko[PermissionError] PASSED                                                                                                       [ 85%]
framework/wazuh/core/cluster/tests/test_utils.py::test_get_manager_status_ko[FileNotFoundError] PASSED                                                                                                     [ 85%]
framework/wazuh/core/cluster/tests/test_utils.py::test_get_cluster_status PASSED                                                                                                                           [ 86%]
framework/wazuh/core/cluster/tests/test_utils.py::test_manager_restart PASSED                                                                                                                              [ 86%]
framework/wazuh/core/cluster/tests/test_utils.py::test_get_cluster_items PASSED                                                                                                                            [ 87%]
framework/wazuh/core/cluster/tests/test_utils.py::test_ClusterFilter PASSED                                                                                                                                [ 87%]
framework/wazuh/core/cluster/tests/test_utils.py::test_ClusterLogger PASSED                                                                                                                                [ 87%]
framework/wazuh/core/cluster/tests/test_worker.py::test_rit_set_up_coro PASSED                                                                                                                             [ 88%]
framework/wazuh/core/cluster/tests/test_worker.py::test_rit_done_callback PASSED                                                                                                                           [ 88%]
framework/wazuh/core/cluster/tests/test_worker.py::test_sync_task_init PASSED                                                                                                                              [ 88%]
framework/wazuh/core/cluster/tests/test_worker.py::test_sync_task_request_permission PASSED                                                                                                                [ 89%]
framework/wazuh/core/cluster/tests/test_worker.py::test_sync_task_sync PASSED                                                                                                                              [ 89%]
framework/wazuh/core/cluster/tests/test_worker.py::test_sync_files_sync_ok PASSED                                                                                                                          [ 90%]
framework/wazuh/core/cluster/tests/test_worker.py::test_sync_files_sync_ko PASSED                                                                                                                          [ 90%]
framework/wazuh/core/cluster/tests/test_worker.py::test_sync_wazuh_db_init PASSED                                                                                                                          [ 90%]
framework/wazuh/core/cluster/tests/test_worker.py::test_sync_wazuh_db_sync_ok PASSED                                                                                                                       [ 91%]
framework/wazuh/core/cluster/tests/test_worker.py::test_sync_wazuh_db_sync_ko PASSED                                                                                                                       [ 91%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_init PASSED                                                                                                                         [ 92%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_connection_result PASSED                                                                                                            [ 92%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_process_request_ok PASSED                                                                                                           [ 92%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_process_request_ko PASSED                                                                                                           [ 93%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_get_manager PASSED                                                                                                                  [ 93%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_setup_receive_files_from_master PASSED                                                                                              [ 94%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_end_receiving_integrity PASSED                                                                                                      [ 94%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_error_receiving_integrity PASSED                                                                                                    [ 94%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_sync_integrity_ok_from_master PASSED                                                                                                [ 95%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_sync_agent_info_from_master PASSED                                                                                                  [ 95%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_error_receiving_agent_info PASSED                                                                                                   [ 96%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_sync_integrity PASSED                                                                                                               [ 96%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_sync_agent_info PASSED                                                                                                              [ 96%]
framework/wazuh/core/cluster/tests/test_worker.py::test_wazuh_handler_sync_extra_valid PASSED                                                                                                              [ 97%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_process_files_from_master_ok PASSED                                                                                                 [ 97%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_process_files_from_master_ko PASSED                                                                                                 [ 98%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_update_master_files_in_worker_ok PASSED                                                                                             [ 98%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_handler_get_logger PASSED                                                                                                                   [ 98%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_init PASSED                                                                                                                                 [ 99%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_add_tasks PASSED                                                                                                                            [ 99%]
framework/wazuh/core/cluster/tests/test_worker.py::test_worker_get_node PASSED                                                                                                                             [100%]

======================================================================================= 254 passed, 25 warnings in 40.21s ========================================================================================
```