### PR TITLE
Fix `NoneType: None` error

### DIFF
--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -173,7 +173,7 @@ if __name__ == '__main__':
 
     cluster_status = wazuh.core.cluster.utils.get_cluster_status()
     if cluster_status['running'] == 'yes':
-        main_logger.error("Cluster is already running.")
+        main_logger.error("Cluster is already running.", exc_info=False)
         sys.exit(1)
 
     # clean

--- a/framework/wazuh/core/cluster/client.py
+++ b/framework/wazuh/core/cluster/client.py
@@ -205,7 +205,7 @@ class AbstractClient(common.Handler):
             self.logger.info('The master closed the connection')
         else:
             self.logger.error(f"Connection closed due to an unhandled error: {exc}\n"
-                              f"{''.join(traceback.format_tb(exc.__traceback__))}")
+                              f"{''.join(traceback.format_tb(exc.__traceback__))}", exc_info=False)
 
         if not self.on_con_lost.done():
             self.on_con_lost.set_result(True)
@@ -316,7 +316,7 @@ class AbstractClient(common.Handler):
             result = await self.send_request(b'echo', b'a' * test_size)
             after = perf_counter()
             if len(result) != test_size:
-                self.logger.error(result)
+                self.logger.error(result, exc_info=False)
             else:
                 self.logger.info(f"Received size: {len(result)} // Time: {after - before}")
             await asyncio.sleep(3)

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -692,15 +692,15 @@ class APIRequestQueue(WazuhRequestQueue):
                 task_id = b'Error in distributed API: ' + str(e).encode()
 
             if task_id.startswith(b'Error'):
-                self.logger.error(task_id.decode())
+                self.logger.error(task_id.decode(), exc_info=False)
                 result = await node.send_request(b'dapi_err', name_2.encode() + task_id)
             else:
                 result = await node.send_request(b'dapi_res', name_2.encode() + task_id)
             if not isinstance(result, WazuhException):
                 if result.startswith(b'Error'):
-                    self.logger.error(result.decode())
+                    self.logger.error(result.decode(), exc_info=False)
             else:
-                self.logger.error(result.message)
+                self.logger.error(result.message, exc_info=False)
 
 
 class SendSyncRequestQueue(WazuhRequestQueue):
@@ -738,7 +738,7 @@ class SendSyncRequestQueue(WazuhRequestQueue):
                 task_id = f'Error in SendSync (parameters {request}): {str(e)}'.encode()
 
             if task_id.startswith(b'Error'):
-                self.logger.error(task_id.decode())
+                self.logger.error(task_id.decode(), exc_info=False)
                 result = await node.send_request(b'sendsyn_err', name_2.encode() + task_id)
             else:
                 result = await node.send_request(b'sendsyn_res', name_2.encode() + task_id)

--- a/framework/wazuh/core/cluster/local_server.py
+++ b/framework/wazuh/core/cluster/local_server.py
@@ -165,7 +165,7 @@ class LocalServerHandler(server.AbstractServerHandler):
         if not future.cancelled():
             exc = future.exception()
             if exc:
-                self.logger.error(exc)
+                self.logger.error(exc, exc_info=False)
 
 
 class LocalServer(server.AbstractServer):

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -602,11 +602,12 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
 
         # Log information about the results
         for error in result['error_messages']['others']:
-            logger.error(error)
+            logger.error(error, exc_info=False)
 
         for error in result['error_messages']['chunks']:
             logger.debug2(f'Chunk {error[0] + 1}/{len(data["chunks"])}: {data["chunks"][error[0]]}')
-            logger.error(f'Wazuh-db response for chunk {error[0] + 1}/{len(data["chunks"])} was not "ok": {error[1]}')
+            logger.error(f'Wazuh-db response for chunk {error[0] + 1}/{len(data["chunks"])} was not "ok": {error[1]}',
+                         exc_info=False)
 
         logger.debug(f'{result["updated_chunks"]}/{len(data["chunks"])} chunks updated in wazuh-db '
                      f'in {result["time_spent"]:3f}s.')
@@ -729,7 +730,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
 
                 # Notify what is the zip path for the current taskID.
                 result = await self.send_request(command=b'syn_m_c_e', data=task_id + b' ' + os.path.relpath(
-                                                     compressed_data, common.WAZUH_PATH).encode())
+                    compressed_data, common.WAZUH_PATH).encode())
 
                 if isinstance(result, Exception):
                     raise result
@@ -754,7 +755,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                         self.cluster_items['intervals']['communication']['min_zip_size'],
                         sent_size * (1 - self.cluster_items['intervals']['communication']['zip_limit_tolerance'])
                     )
-                    self.logger.debug(f"Decreasing sync size limit to {self.current_zip_limit / (1024**2):.2f} MB.")
+                    self.logger.debug(f"Decreasing sync size limit to {self.current_zip_limit / (1024 ** 2):.2f} MB.")
                 except KeyError:
                     # Increase max zip size if two conditions are met:
                     #   1. Current zip limit is lower than default.
@@ -767,7 +768,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                             self.current_zip_limit * (
                                     1 / (1 - self.cluster_items['intervals']['communication']['zip_limit_tolerance'])
                             ))
-                        self.logger.debug(f"Increasing sync size limit to {self.current_zip_limit / (1024**2):.2f} MB.")
+                        self.logger.debug(
+                            f"Increasing sync size limit to {self.current_zip_limit / (1024 ** 2):.2f} MB.")
 
                 # Remove local file.
                 os.unlink(compressed_data)
@@ -854,9 +856,9 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         # Log any possible error found in the process.
         self.integrity_sync_status['total_extra_valid'] = result['total_updated']
         if result['errors_per_folder']:
-            logger.error(f"Errors updating worker files: {dict(result['errors_per_folder'])}")
+            logger.error(f"Errors updating worker files: {dict(result['errors_per_folder'])}", exc_info=False)
         for error in result['generic_errors']:
-            logger.error(error)
+            logger.error(error, exc_info=False)
 
     @staticmethod
     def process_files_from_worker(files_metadata: Dict, decompressed_files_path: str, cluster_items: dict,

--- a/framework/wazuh/core/cluster/server.py
+++ b/framework/wazuh/core/cluster/server.py
@@ -179,15 +179,16 @@ class AbstractServerHandler(c_common.Handler):
                 self.logger.debug(f"Disconnected {self.name}.")
             else:
                 self.logger.error(f"Error during connection with '{self.name}': {exc}.\n"
-                                  f"{''.join(traceback.format_tb(exc.__traceback__))}")
+                                  f"{''.join(traceback.format_tb(exc.__traceback__))}", exc_info=False)
 
             if self.name in self.server.clients:
                 del self.server.clients[self.name]
         else:
             if exc is not None:
-                self.logger.error(f"Error during handshake with incoming connection: {exc}", exc_info=True)
+                self.logger.error(f"Error during handshake with incoming connection: {exc}. \n"
+                                  f"{''.join(traceback.format_tb(exc.__traceback__))}", exc_info=False)
             else:
-                self.logger.error("Error during handshake with incoming connection.")
+                self.logger.error("Error during handshake with incoming connection.", exc_info=False)
 
 
 class AbstractServer:
@@ -344,7 +345,7 @@ class AbstractServer:
             for client_name, client in self.clients.copy().items():
                 if curr_timestamp - client.last_keepalive > self.cluster_items['intervals']['master']['max_allowed_time_without_keepalive']:
                     keep_alive_logger.error("No keep alives have been received from {} in the last minute. "
-                                            "Disconnecting".format(client_name))
+                                            "Disconnecting".format(client_name), exc_info=False)
                     client.transport.close()
             keep_alive_logger.debug("Calculated.")
             await asyncio.sleep(self.cluster_items['intervals']['master']['check_worker_lastkeepalive'])

--- a/framework/wazuh/core/cluster/tests/test_client.py
+++ b/framework/wazuh/core/cluster/tests/test_client.py
@@ -274,7 +274,8 @@ def test_ac_connection_lost(cancel_tasks_mock):
     # Test the second condition
     with patch.object(logging.getLogger('wazuh'), "error") as logger_mock:
         abstract_client.connection_lost(exc=WazuhException(1001))
-        logger_mock.assert_called_once_with(f"Connection closed due to an unhandled error: {WazuhException(1001)}\n")
+        logger_mock.assert_called_once_with(f"Connection closed due to an unhandled error: {WazuhException(1001)}\n",
+                                            exc_info=False)
 
 
 def test_ac_cancel_all_tasks():
@@ -397,7 +398,7 @@ async def test_ac_performance_test_client(send_request_mock, perf_counter_mock, 
             except Exception:
                 pass
 
-            logger_mock.assert_called_with("ok")
+            logger_mock.assert_called_with("ok", exc_info=False)
             send_request_mock.assert_called_with(b'echo', b'a' * 10)
 
         with patch.object(logging.getLogger("wazuh"), "info") as logger_mock:

--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -223,7 +223,7 @@ def test_rst_done_callback(setup_coro_mock, create_task_mock):
             string_task.done_callback()
             assert string_task.wazuh_common.in_str == {b"011": b"123456789"}
             assert string_task.wazuh_common.sync_tasks == {b"011": b"123456789"}
-            logger_mock.assert_called_once_with(Exception)
+            logger_mock.assert_called_once_with(Exception, exc_info=False)
 
 
 # Test ReceiveFileTask methods
@@ -332,7 +332,7 @@ def test_rft_done_callback(set_up_coro_mock, create_task_mock, event_mock):
                                                        logger=logging.getLogger('wazuh'), task_id=b"010")
             file_task.done_callback()
             assert file_task.wazuh_common.sync_tasks == {"011": b"123456789"}
-            logger_mock.assert_called_once_with(Exception)
+            logger_mock.assert_called_once_with(Exception, exc_info=False)
 
 
 # Test Handler class methods
@@ -555,7 +555,8 @@ async def test_handler_send_string():
     with patch('wazuh.core.cluster.common.Handler.send_request', return_value=b"Error"):
         with patch.object(logging.getLogger("wazuh"), "error") as logger_mock:
             assert (await handler.send_string(b"something") == b"Error")
-            logger_mock.assert_called_once_with(f'There was an error while trying to send a string: {b"Error"}')
+            logger_mock.assert_called_once_with(f'There was an error while trying to send a string: {b"Error"}',
+                                                exc_info=False)
 
 
 def test_handler_get_manager():

--- a/framework/wazuh/core/cluster/tests/test_local_server.py
+++ b/framework/wazuh/core/cluster/tests/test_local_server.py
@@ -163,7 +163,7 @@ def test_LocalServerHandler_send_res_callback():
                 lsh = LocalServerHandler(server=None, loop=loop, fernet_key=None, cluster_items={},
                                          logger=logger)
                 lsh.send_res_callback(future=future)
-                logger_error_mock.assert_called_once_with("testing")
+                logger_error_mock.assert_called_once_with("testing", exc_info=False)
 
 
 @patch("asyncio.get_running_loop", return_value=loop)

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -896,7 +896,7 @@ async def test_master_handler_sync_wazuh_db_info_ok(send_request_mock, loads_moc
             """Auxiliary method."""
             self._debug2.append(data)
 
-        def error(self, data):
+        def error(self, data, exc_info=False):
             """Auxiliary method."""
             self._error.append(data)
 

--- a/framework/wazuh/core/cluster/tests/test_server.py
+++ b/framework/wazuh/core/cluster/tests/test_server.py
@@ -161,18 +161,20 @@ def test_AbstractServerHandler_connection_lost():
                                                         cluster_items={"test": "server"})
         with patch.object(logger, "error") as mock_error_logger:
             abstract_server_handler.connection_lost(exc=None)
-            mock_error_logger.assert_called_once_with("Error during handshake with incoming connection.")
+            mock_error_logger.assert_called_once_with("Error during handshake with incoming connection.",
+                                                      exc_info=False)
 
         with patch.object(logger, "error") as mock_error_logger:
             abstract_server_handler.connection_lost(exc=Exception("Test_connection_lost"))
             mock_error_logger.assert_called_once_with(
-                "Error during handshake with incoming connection: Test_connection_lost", exc_info=True)
+                "Error during handshake with incoming connection: Test_connection_lost. \n", exc_info=False)
 
         abstract_server_handler.name = "unit"
         abstract_server_handler.server = ServerMock()
         with patch.object(logger, "error") as mock_error_logger:
             abstract_server_handler.connection_lost(exc=Exception("Test_connection_lost_if"))
-            mock_error_logger.assert_called_once_with("Error during connection with 'unit': Test_connection_lost_if.\n")
+            mock_error_logger.assert_called_once_with("Error during connection with 'unit': Test_connection_lost_if.\n",
+                                                      exc_info=False)
             assert "unit" not in abstract_server_handler.server.clients.keys()
 
         with patch.object(logger, "debug") as mock_debug_logger:
@@ -313,7 +315,7 @@ async def test_AbstractServer_check_clients_keepalive(loop_mock, sleep_mock):
                 except IndexError:
                     pass
                 mock_error.assert_called_once_with("No keep alives have been received from "
-                                                   "worker_test in the last minute. Disconnecting")
+                                                   "worker_test in the last minute. Disconnecting", exc_info=False)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/12790|

## Description 

This closes https://github.com/wazuh/wazuh/issues/12790. The aim of this issue is to fix the appearance of the log `NoneType: None` when in debug mode. It was discovered that this happens due to an incorrect calling of the `logger.error` method when the error is not raised, but stored in a variable. 