### PR TITLE
Updating active-response decoders to fill srcip field

### DIFF
--- a/ruleset/decoders/0010-active-response_decoders.xml
+++ b/ruleset/decoders/0010-active-response_decoders.xml
@@ -73,6 +73,6 @@ Tue 08/28/2018 09:27:23.14 "active-response/bin/netsh.cmd" add "-" "1.2.3.4" "15
 
 <decoder name="ar_log_json_child">
   <parent>ar_log_json</parent>
-  <regex type="pcre2">\"eventdata\":\{.*?\"user\"(?:.*\\\\\\)?([^\"]+)\"</regex>
+  <regex type="pcre2">\"eventdata\":\{.*?\"user\"(?:.*\\\\)?([^\"]+)\"</regex>
   <order>user</order>
 </decoder>

--- a/ruleset/decoders/0010-active-response_decoders.xml
+++ b/ruleset/decoders/0010-active-response_decoders.xml
@@ -45,5 +45,28 @@ Tue 08/28/2018 09:27:23.14 "active-response/bin/netsh.cmd" add "-" "1.2.3.4" "15
 
 <decoder name="ar_log_json">
     <prematch>^\d\d\d\d/\d\d/\d\d \d\d:\d\d:\d\d active-response/bin/\S+: </prematch>
+</decoder>
+
+<decoder name="ar_log_json_child">
+    <parent>ar_log_json</parent>
+    <prematch>^\d\d\d\d/\d\d/\d\d \d\d:\d\d:\d\d active-response/bin/\S+: </prematch>
     <plugin_decoder offset="after_prematch">JSON_Decoder</plugin_decoder>
+</decoder>
+
+<decoder name="ar_log_json_child">
+    <parent>ar_log_json</parent>
+    <regex type="pcre2">\"data\":\{\"srcip\"\:\"([^\"]+)\"</regex>
+    <order>srcip</order>
+</decoder>
+
+<decoder name="ar_log_json_child">
+    <parent>ar_log_json</parent>
+    <regex type="pcre2">\"eventdata\":\{.*?(?:ipAddress|destinationIp)\"\:\"([^\"]+)\"</regex>
+    <order>srcip</order>
+</decoder>
+
+<decoder name="ar_log_json_child">
+    <parent>ar_log_json</parent>
+    <regex type="pcre2">\"data\":\{.*?\"dstuser\"\:\"([^\"]+)\"</regex>
+    <order>user</order>
 </decoder>

--- a/ruleset/decoders/0010-active-response_decoders.xml
+++ b/ruleset/decoders/0010-active-response_decoders.xml
@@ -32,41 +32,47 @@ Tue 08/28/2018 09:27:23.14 "active-response/bin/netsh.cmd" add "-" "1.2.3.4" "15
 </decoder>
 
 <decoder name="ar_log_fields">
-    <parent>ar_log</parent>
-    <regex offset="after_parent">^(\S+) (\S+) \S+ (\S+) (\.+) |^(\S+)" (\S+) "\S+" "(\S+)" "(\.+) </regex>
-    <order>script, type, srcip, id</order>
+  <parent>ar_log</parent>
+  <regex offset="after_parent">^(\S+) (\S+) \S+ (\S+) (\.+) |^(\S+)" (\S+) "\S+" "(\S+)" "(\.+) </regex>
+  <order>script, type, srcip, id</order>
 </decoder>
 
 <decoder name="ar_log_fields">
-    <parent>ar_log</parent>
-    <regex offset="after_regex">^(\d+)|(\.+\))</regex>
-    <order>extra_data</order>
+  <parent>ar_log</parent>
+  <regex offset="after_regex">^(\d+)|(\.+\))</regex>
+  <order>extra_data</order>
 </decoder>
 
 <decoder name="ar_log_json">
-    <prematch>^\d\d\d\d/\d\d/\d\d \d\d:\d\d:\d\d active-response/bin/\S+: </prematch>
+  <prematch>^\d\d\d\d/\d\d/\d\d \d\d:\d\d:\d\d active-response/bin/\S+: </prematch>
 </decoder>
 
 <decoder name="ar_log_json_child">
-    <parent>ar_log_json</parent>
-    <prematch>^\d\d\d\d/\d\d/\d\d \d\d:\d\d:\d\d active-response/bin/\S+: </prematch>
-    <plugin_decoder offset="after_prematch">JSON_Decoder</plugin_decoder>
+  <parent>ar_log_json</parent>
+  <prematch>^\d\d\d\d/\d\d/\d\d \d\d:\d\d:\d\d active-response/bin/\S+: </prematch>
+  <plugin_decoder offset="after_prematch">JSON_Decoder</plugin_decoder>
 </decoder>
 
 <decoder name="ar_log_json_child">
-    <parent>ar_log_json</parent>
-    <regex type="pcre2">\"data\":\{\"srcip\"\:\"([^\"]+)\"</regex>
-    <order>srcip</order>
+  <parent>ar_log_json</parent>
+  <regex type="pcre2">\"data\":\{\"srcip\"\:\"([^\"]+)\"</regex>
+  <order>srcip</order>
 </decoder>
 
 <decoder name="ar_log_json_child">
-    <parent>ar_log_json</parent>
-    <regex type="pcre2">\"eventdata\":\{.*?(?:ipAddress|destinationIp)\"\:\"([^\"]+)\"</regex>
-    <order>srcip</order>
+  <parent>ar_log_json</parent>
+  <regex type="pcre2">\"eventdata\":\{.*?(?:ipAddress|destinationIp)\"\:\"([^\"]+)\"</regex>
+  <order>srcip</order>
 </decoder>
 
 <decoder name="ar_log_json_child">
-    <parent>ar_log_json</parent>
-    <regex type="pcre2">\"data\":\{.*?\"dstuser\"\:\"([^\"]+)\"</regex>
-    <order>user</order>
+  <parent>ar_log_json</parent>
+  <regex type="pcre2">\"data\":\{.*?\"dstuser\"\:\"([^\"]+)\"</regex>
+  <order>user</order>
+</decoder>
+
+<decoder name="ar_log_json_child">
+  <parent>ar_log_json</parent>
+  <regex type="pcre2">\"eventdata\":\{.*?\"user\"(?:.*\\\\\\)?([^\"]+)\"</regex>
+  <order>user</order>
 </decoder>

--- a/ruleset/decoders/0010-active-response_decoders.xml
+++ b/ruleset/decoders/0010-active-response_decoders.xml
@@ -1,10 +1,9 @@
 <!--
-  -  Active response decoders
-  -  Author: Daniel Cid.
-  -  Updated by Wazuh, Inc.
-  -  Copyright (C) 2015, Wazuh Inc.
-  -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  Copyright (C) 2015, Wazuh Inc.
+-->
+
+<!--
+  Wazuh Active Response decoders
 -->
 
 <!--
@@ -25,7 +24,6 @@ Wed 12/07/2016 16:48:15.37 "active-response/bin/route-null.cmd" delete "-" "192.
 Tue 08/28/2018 09:25:23.14 "active-response/bin/netsh.cmd" delete "-" "1.2.3.4" "1535465731.23945822 18258 (some-hostname) any->WinEvtLog (null)"
 Tue 08/28/2018 09:27:23.14 "active-response/bin/netsh.cmd" add "-" "1.2.3.4" "1535466424.24354011 18258 (some-hostname) any->WinEvtLog (null)"
 -->
-
 
 <decoder name="ar_log">
   <prematch>^\w\w\w \w+\s+\d+ \d\d:\d\d:\d\d \p*\w+ \d+ /\S+/active-response/bin/|^\w\w\w \d\d/\d\d/\d\d\d\d \.+"active-response/bin/|^\d\d/\d\d/\d\d\d\d \.+"active-response/bin/</prematch>
@@ -73,6 +71,6 @@ Tue 08/28/2018 09:27:23.14 "active-response/bin/netsh.cmd" add "-" "1.2.3.4" "15
 
 <decoder name="ar_log_json_child">
   <parent>ar_log_json</parent>
-  <regex type="pcre2">\"eventdata\":\{.*?\"user\"(?:.*\\\\)?([^\"]+)\"</regex>
+  <regex type="pcre2">\"eventdata\":\{.*?\"user\"(?:.*\\\\)?([^\"]+)\",</regex>
   <order>user</order>
 </decoder>


### PR DESCRIPTION
|Related issue|
|---|
|[11867](https://github.com/wazuh/wazuh/issues/11867)|

## Description
The main purpose of this PR is complete field srcip in an alert event, when an active-response event is triggered. This change fix some issues related to reports, which use srcip to create a "Top entries for 'Source ip'" section.

## Configuration options
Reports configuration in ossec.conf trigger by any active-response rule, this example use firewall-drop event.

  ```
<reports>
    <title>Daily report</title>
    <rule>651</rule>
    <email_to>zzzzzzz@gmail.com</email_to>
    <showlogs>yes</showlogs>
  </reports>

```
## Logs/Alerts example
Active response example log:

`2022/03/22 20:25:42 active-response/bin/firewall-drop.exe: {"version":1,"origin":{"name":"node01","module":"wazuh-execd"},"command":"add","parameters":{"extra_args":[],"alert":{"timestamp":"2022-03-22T20:25:42.780-0300","rule":{"level":5,"description":"sshd: authentication failed from IP 1.1.1.1.","id":"100001","firedtimes":5,"mail":false,"groups":["local","syslog","sshd","authentication_failed"],"pci_dss":["10.2.4","10.2.5"]},"agent":{"id":"001","name":"DESKTOP-U8OHD3A","ip":"192.168.100.72"},"manager":{"name":"chb-VBox"},"id":"1647991542.13656","full_log":"Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2","predecoder":{"program_name":"sshd","timestamp":"Dec 10 01:02:02","hostname":"host"},"decoder":{"parent":"sshd","name":"sshd"},"data":{"srcip":"1.1.1.1","srcport":"1066","dstuser":"root"},"location":"\\Users\\asus\\test.txt"},"program":"active-response/bin/firewall-drop.exe"}}`

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [x] runtests.py executed without errors