### PR TITLE
Fix invalid time in agent-groups send task

### DIFF
--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -1453,7 +1453,7 @@ class SyncWazuhdb(SyncTask):
             self.logger.debug(f"Sending chunks.")
             await self.server.send_request(command=self.cmd, data=task_id)
         else:
-            self.logger.info(f"Finished in {(perf_counter() - start_time):.3f}s. Updated 0 chunks.")
+            self.logger.info(f"Finished in {(get_utc_now().timestamp() - start_time):.3f}s. Updated 0 chunks.")
         return True
 
 
@@ -1480,7 +1480,7 @@ def end_sending_agent_information(logger, start_time, response) -> Tuple[bytes, 
         Response message.
     """
     data = json.loads(response)
-    msg = f"Finished in {(perf_counter() - start_time):.3f}s. Updated {data['updated_chunks']} chunks."
+    msg = f"Finished in {(get_utc_now().timestamp() - start_time):.3f}s. Updated {data['updated_chunks']} chunks."
     logger.info(msg) if not data['error_messages'] else logger.error(
         msg + f" There were {len(data['error_messages'])} chunks with errors: {data['error_messages']}")
 

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -700,7 +700,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                                            set_payload={'mode': 'override', 'sync_status': 'synced'})
 
         logger.info("Requested entire agent-groups information by the worker node. Starting.")
-        start_time = perf_counter()
+        start_time = get_utc_now().timestamp()
         await sync_object.sync(start_time=start_time, chunks=local_agent_groups_information)
         logger.info("Sent all agent-groups information from the master node database.")
 

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -889,7 +889,7 @@ async def test_worker_handler_general_agent_sync_task(socket_mock):
                                              get_data_command='global sync-agent-groups-get ',
                                              set_data_command='global sync-agent-groups-set')
 
-    with patch('wazuh.core.cluster.worker.perf_counter', return_value=0) as perf_counter_mock:
+    with patch('wazuh.core.cluster.worker.get_utc_now', side_effect=get_utc_now_mock) as gun_mock:
         with patch.object(sync_object, 'request_permission', side_effect=request_permission_callable):
             with patch.object(sync_object, 'retrieve_information',
                               side_effect=retrieve_information_callable) as retrieve_information_mock:
@@ -906,7 +906,7 @@ async def test_worker_handler_general_agent_sync_task(socket_mock):
 
                                 logger_info_mock.assert_called_with('Starting.')
                                 retrieve_information_mock.assert_called_once()
-                                perf_counter_mock.assert_called()
+                                gun_mock.assert_called()
                                 sync_mock.assert_called_with(start_time=0, chunks=['testing'])
                                 assert w_handler.agent_info_sync_status['date_start'] == 0.0
 

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -686,7 +686,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         while True:
             try:
                 if self.connected:
-                    start_time = perf_counter()
+                    start_time = get_utc_now().timestamp()
                     if await sync_object.request_permission():
                         sync_object.logger.info("Starting.")
                         timer['date_start'] = start_time


### PR DESCRIPTION
## Description

In this PR we will fix a bug recently detected by the workload tests. The agent-groups send task shows negative times as shown below:

![image](https://user-images.githubusercontent.com/15522808/159890616-008c629d-d7dc-46ac-af92-99a7a351ec2b.png)
