### PR TITLE
Update `database_limit` variable name in API vulnerability functions

### DIFF
--- a/api/api/controllers/test/test_vulnerability_controller.py
+++ b/api/api/controllers/test/test_vulnerability_controller.py
@@ -13,7 +13,7 @@ with patch('wazuh.common.wazuh_uid'):
         from api.controllers.vulnerability_controller import get_last_scan_agent, get_vulnerability_agent, \
             get_vulnerabilities_field_summary
         from wazuh import vulnerability
-        from wazuh.core.common import database_limit
+        from wazuh.core.common import DATABASE_LIMIT
         from wazuh.tests.util import RBAC_bypasser
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser
         del sys.modules['wazuh.rbac.orm']
@@ -94,7 +94,7 @@ async def test_get_vulnerabilities_severity_summary(mock_exc, mock_dapi, mock_re
     f_kwargs = {
         'agent_list': [None],
         'field': None,
-        'limit': database_limit
+        'limit': DATABASE_LIMIT
     }
     mock_dapi.assert_called_once_with(f=vulnerability.get_inventory_summary,
                                       f_kwargs=mock_remove.return_value,

--- a/api/api/controllers/vulnerability_controller.py
+++ b/api/api/controllers/vulnerability_controller.py
@@ -10,7 +10,7 @@ from api.encoder import dumps, prettify
 from api.util import parse_api_param, remove_nones_to_dict, raise_if_exc
 from wazuh import vulnerability
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
-from wazuh.core.common import database_limit
+from wazuh.core.common import DATABASE_LIMIT
 
 logger = logging.getLogger('wazuh-api')
 
@@ -127,7 +127,7 @@ async def get_last_scan_agent(request, pretty=False, wait_for_complete=False, ag
 
 
 async def get_vulnerabilities_field_summary(request, pretty=False, wait_for_complete=False, agent_id=None, field=None,
-                                            limit=database_limit):
+                                            limit=DATABASE_LIMIT):
     """Return a summary of the vulnerabilities' field of a given agent.
 
     Parameters

--- a/framework/wazuh/core/tests/test_vulnerability.py
+++ b/framework/wazuh/core/tests/test_vulnerability.py
@@ -75,4 +75,4 @@ def test_WazuhDBQueryVulnerability_format_data_into_dictionary(socket_mock, send
 
     assert all(item[field] == data[field] for field in item.keys() - {'external_references', 'detection_time'})
     assert item['external_references'] == json.loads(data['external_references'])
-    assert item['detection_time'] == datetime.utcfromtimestamp(int(data['detection_time']))
+    assert item['detection_time'] == vulnerability.get_date_from_timestamp(int(data['detection_time']))

--- a/framework/wazuh/vulnerability.py
+++ b/framework/wazuh/vulnerability.py
@@ -86,7 +86,7 @@ def last_scan(agent_list=None):
 
 
 @expose_resources(actions=["vulnerability:read"], resources=["agent:id:{agent_list}"], post_proc_func=None)
-def get_inventory_summary(agent_list=None, field='', limit=common.database_limit):
+def get_inventory_summary(agent_list=None, field='', limit=common.DATABASE_LIMIT):
     """Return a summary of the agent vulnerabilities' given field.
 
     Parameters


### PR DESCRIPTION
|Related issue|
|---|
|#12841|

This PR closes #12841 .

After the merge from 4.3 into master, the API vulnerability functions were updated and the old `database_limit` variable from `wazuh.core.common` was used. This PR updates the variable name as now it is `DATABASE_LIMIT`.