### PR TITLE
Fix for rolling OS versions on WPK upgrade

### DIFF
--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
@@ -260,6 +260,32 @@ void test_wm_agent_upgrade_validate_system_invalid_arch(void **state)
     assert_int_equal(ret, WM_UPGRADE_GLOBAL_DB_FAILURE);
 }
 
+void test_wm_agent_upgrade_validate_system_rolling_opensuse(void **state)
+{
+    (void) state;
+    char *platform = "opensuse-tumbleweed";
+    char *os_major = "";
+    char *os_minor = "";
+    char *arch = "x64";
+
+    int ret = wm_agent_upgrade_validate_system(platform, os_major, os_minor, arch);
+
+    assert_int_equal(ret, WM_UPGRADE_SUCCESS);
+}
+
+void test_wm_agent_upgrade_validate_system_rolling_archlinux(void **state)
+{
+    (void) state;
+    char *platform = "arch";
+    char *os_major = "";
+    char *os_minor = "";
+    char *arch = "x64";
+
+    int ret = wm_agent_upgrade_validate_system(platform, os_major, os_minor, arch);
+
+    assert_int_equal(ret, WM_UPGRADE_SUCCESS);
+}
+
 void test_wm_agent_upgrade_compare_versions_equal_patch(void **state)
 {
     (void) state;
@@ -1295,6 +1321,8 @@ int main(void) {
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_invalid_platform_rhel),
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_invalid_platform_centos),
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_invalid_arch),
+        cmocka_unit_test(test_wm_agent_upgrade_validate_system_rolling_opensuse),
+        cmocka_unit_test(test_wm_agent_upgrade_validate_system_rolling_archlinux),
         // wm_agent_upgrade_compare_versions
         cmocka_unit_test(test_wm_agent_upgrade_compare_versions_equal_patch),
         cmocka_unit_test(test_wm_agent_upgrade_compare_versions_equal_minor),

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
@@ -29,6 +29,11 @@ static const char* invalid_platforms[] = {
     "bsd"
 };
 
+static const char* rolling_platforms[] = {
+    "opensuse-tumbleweed",
+    "arch"
+};
+
 int wm_agent_upgrade_validate_id(int agent_id) {
     int return_code = WM_UPGRADE_SUCCESS;
 
@@ -51,16 +56,18 @@ int wm_agent_upgrade_validate_status(const char* connection_status) {
 
 int wm_agent_upgrade_validate_system(const char *platform, const char *os_major, const char *os_minor, const char *arch) {
     int invalid_platforms_len = 0;
-    int invalid_platforms_it = 0;
+    int rolling_platforms_len = 0;
+    int platforms_it = 0;
     int return_code = WM_UPGRADE_GLOBAL_DB_FAILURE;
 
     if (platform) {
         if (!strcmp(platform, "windows") || (os_major && arch && (strcmp(platform, "ubuntu") || os_minor))) {
             return_code = WM_UPGRADE_SUCCESS;
-            invalid_platforms_len = sizeof(invalid_platforms) / sizeof(invalid_platforms[0]);
 
-            for(invalid_platforms_it = 0; invalid_platforms_it < invalid_platforms_len; ++invalid_platforms_it) {
-                if(!strcmp(invalid_platforms[invalid_platforms_it], platform)) {
+            // Blacklist for invalid OS platforms
+            invalid_platforms_len = array_size(invalid_platforms);
+            for(platforms_it = 0; platforms_it < invalid_platforms_len; ++platforms_it) {
+                if(!strcmp(invalid_platforms[platforms_it], platform)) {
                     return_code = WM_UPGRADE_SYSTEM_NOT_SUPPORTED;
                     break;
                 }
@@ -72,6 +79,15 @@ int wm_agent_upgrade_validate_system(const char *platform, const char *os_major,
                     (!strcmp(platform, "centos") && !strcmp(os_major, "5"))) {
                     return_code = WM_UPGRADE_SYSTEM_NOT_SUPPORTED;
                 }
+            }
+        }
+
+        // Whitelist for OS platforms with 'rolling' version
+        rolling_platforms_len = array_size(rolling_platforms);
+        for(platforms_it = 0; platforms_it < rolling_platforms_len; ++platforms_it) {
+            if(!strcmp(rolling_platforms[platforms_it], platform)) {
+                return_code = WM_UPGRADE_SUCCESS;
+                break;
             }
         }
     }


### PR DESCRIPTION
|Related issue|Backport|
|---|---|
|#12301|#12403|

This PR is a backport of #12403 for 4.3.0.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
<!--
- [ ] QA templates contemplate the added capabilities
-->

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for `wm_agent_upgrade_validate_system`)
 - `100% tests passed, 0 tests failed out of 138` and 100% coverage
- [ ] Stress test for affected components

---
# TEST: openSUSE Tumbleweed

## From Wazuh-Agent v4.3 (same version)
### :yellow_circle: UPGRADE FAIL  

- [ ] The wazuh home backup is restored correctly (no traces of the installation, but only the `.tar.gz` backup and the logs).
- [ ] The permissions and owners of the following directories did NOT change:
      - `/`
      - `/var`
      - `/usr`, `/usr/lib/`, `/usr/lib/systemd/`, `/usr/lib/systemd/system/`
      - `/etc`, `/etc/systemd/`, `/etc/systemd/system/`, `/etc/rc.d`, `/etc/initd.d/`, `/etc/initd.d/rc.d/`
- [ ] ~Wazuh service runs wazuh-control (`systemctl cat wazuh-agent.service`)~
- [ ] Wazuh service runs ossec-control (`systemctl cat wazuh-agent.service`)
- [ ] The service was enabled (`systemctl is-enabled wazuh-agent.service`)
- [ ] ~Init file runs wazuh-control (`cat /etc/rc.d/init.d/wazuh-agent`)~
- [ ] Init file runs ossec-control (`cat /etc/rc.d/init.d/wazuh-agent`)
- [ ] ~Wazuh as service is enabled `chkconfig --list`~ 
- [ ] Wazuh starts and connects when the backup is restored (`cat /var/ossec/var/run/ossec-agentd.state`)
- [ ] Wazuh starts and connects automatically when the system is rebooted.
- [ ] Restore SELinux policies (`semodule -l | grep -i wazuh`) (DISABLED)

### :yellow_circle: UPGRADE OK

- [ ] Upgrade is performed successfully (agent connects to the manager after upgrading)
- [ ] Service starts automatically after rebooting
- [ ] Agent connects to the manager after rebooting