### PR TITLE
Fix the processing of getconfig requests in FIM

### DIFF
--- a/src/headers/rc.h
+++ b/src/headers/rc.h
@@ -43,5 +43,7 @@
 #define HC_FIM_FILE         "fim_file "
 #define HC_FIM_REGISTRY     "fim_registry "
 #define HC_FORCE_RECONNECT  "force_reconnect"
+#define HC_RESTART          "restart"
+#define HC_GETCONFIG        "getconfig"
 
 #endif /* RC_H */

--- a/src/syscheckd/src/syscom.c
+++ b/src/syscheckd/src/syscom.c
@@ -83,9 +83,17 @@ size_t syscom_dispatch(char * command, char ** output){
 
         fim_sync_push_msg(command);
         return 0;
-    } else if (strncmp(command, HC_SK, strlen(HC_SK)) == 0) {
-        char *rcv_comm = command + strlen(HC_SK);
+    } else if (strncmp(command, HC_SK, strlen(HC_SK)) == 0 ||
+               strncmp(command, HC_GETCONFIG, strlen(HC_GETCONFIG)) == 0 ||
+               strncmp(command, HC_RESTART, strlen(HC_RESTART)) == 0) {
+        char *rcv_comm = NULL;
         char *rcv_args = NULL;
+
+        if (strncmp(command, HC_SK, strlen(HC_SK)) == 0) {
+            rcv_comm = command + strlen(HC_SK);
+        } else {
+            rcv_comm = command;
+        }
 
         if ((rcv_args = strchr(rcv_comm, ' '))){
             *rcv_args = '\0';

--- a/src/unit_tests/syscheckd/test_syscom.c
+++ b/src/unit_tests/syscheckd/test_syscom.c
@@ -34,12 +34,29 @@ static int delete_string(void **state)
 /* tests */
 
 
-void test_syscom_dispatch_getconfig(void **state)
+void test_syscom_dispatch_getconfig_agent(void **state)
 {
     (void) state;
     size_t ret;
 
     char command[] = "syscheck getconfig args";
+    char * output;
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(6283): At SYSCOM getconfig: Could not get 'args' section.");
+
+    ret = syscom_dispatch(command, &output);
+    *state = output;
+
+    assert_string_equal(output, "err Could not get requested section");
+    assert_int_equal(ret, 35);
+}
+
+void test_syscom_dispatch_getconfig_manager(void **state)
+{
+    (void) state;
+    size_t ret;
+
+    char command[] = "getconfig args";
     char * output;
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6283): At SYSCOM getconfig: Could not get 'args' section.");
@@ -102,12 +119,25 @@ void test_syscom_dispatch_dbsync_noargs(void **state)
 }
 
 
-void test_syscom_dispatch_restart(void **state)
+void test_syscom_dispatch_restart_agent(void **state)
 {
     (void) state;
     size_t ret;
 
     char command[] = "syscheck restart";
+    char *output;
+
+    ret = syscom_dispatch(command, &output);
+
+    assert_int_equal(ret, 0);
+}
+
+void test_syscom_dispatch_restart_manager(void **state)
+{
+    (void) state;
+    size_t ret;
+
+    char command[] = "restart";
     char *output;
 
     ret = syscom_dispatch(command, &output);
@@ -280,11 +310,13 @@ void test_syscom_getconfig_null_output(void **state)
 
 int main(void) {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test_teardown(test_syscom_dispatch_getconfig, delete_string),
+        cmocka_unit_test_teardown(test_syscom_dispatch_getconfig_agent, delete_string),
+        cmocka_unit_test_teardown(test_syscom_dispatch_getconfig_manager, delete_string),
         cmocka_unit_test_teardown(test_syscom_dispatch_getconfig_noargs, delete_string),
         cmocka_unit_test(test_syscom_dispatch_dbsync),
         cmocka_unit_test(test_syscom_dispatch_dbsync_noargs),
-        cmocka_unit_test(test_syscom_dispatch_restart),
+        cmocka_unit_test(test_syscom_dispatch_restart_agent),
+        cmocka_unit_test(test_syscom_dispatch_restart_manager),
         cmocka_unit_test_teardown(test_syscom_dispatch_getconfig_unrecognized, delete_string),
         cmocka_unit_test_teardown(test_syscom_dispatch_null_command, delete_string),
         cmocka_unit_test(test_syscom_dispatch_null_output),


### PR DESCRIPTION
|Related issue|
|---|
| Closes #12842 |

## Description

As described in #12842, there was an error when requesting the active configuration of Syscheck for the manager and the agents.

The problem comes from the difference in the requests, for the manager we expect to receive `getconfig syscheck` since it comes from the Syscheck socket directly.

However, when requesting the configuration of an agent, the request is `syscheck getconfig syscheck` because a common socket is used and the target must be specified.

The fix consists of contemplating both possibilities.

## Logs/Alerts example

After the fix, the API request works as expected for manager and agents:

```
# curl -k -X GET "https://localhost:55000/agents/000/config/syscheck/syscheck?pretty=true" -H "Authorization: Bearer $TOKEN"
{
   "data": {
      "syscheck": {
         "disabled": "no",
         "frequency": 43200,
         "skip_nfs": "yes",
         "skip_dev": "yes",
         "skip_sys": "yes",
         "skip_proc": "yes",
         "scan_on_start": "yes",
         "max_files_per_second": 0,
         "db_entry_limit": {
            "enabled": "yes",
            "files": 100000
         },
         "diff": {
            "disk_quota": {
               "enabled": "yes",
               "limit": 1048576
            },
            "file_size": {
               "enabled": "yes",
               "limit": 51200
            }
         },
         "directories": [
            {
               "opts": [
                  "check_md5sum",
                  ...
               ],
               "dir": "/bin",
               "recursion_level": 256,
               "diff_size_limit": 51200
            },
            ...
         ],
         "nodiff": [
            "/etc/ssl/private.key"
         ],
         "ignore": [
            "/etc/mtab",
            ...
         ],
         "ignore_sregex": [
            ".log$|.swp$"
         ],
         "whodata": {
            "restart_audit": "yes",
            "startup_healthcheck": "yes"
         },
         "allow_remote_prefilter_cmd": "no",
         "synchronization": {
            "enabled": "yes",
            "interval": 300,
            "max_eps": 10
         },
         "max_eps": 100,
         "process_priority": 10,
         "database": "disk"
      }
   },
   "error": 0
}
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

- [x] Configuration on-demand reports new parameters
- [x] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)
- [x] Tested affected API request for manager and agent