### PR TITLE
Extract and strip macOS symbols

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -86,11 +86,15 @@ DISABLE_SYSC?=no
 DISABLE_CISCAT?=no
 DISABLE_STRIP_SYMBOLS?=no
 
-ifeq (${uname_S}, Linux)
 ifneq (${TARGET}, winagent)
+ifeq (${uname_S}, Linux)
 EXECUTABLE_FILES := $(shell find . -maxdepth 1 -type f ! -name "*.so"  -perm /a=x)
 EXECUTABLE_FILES += $(shell find . -type f -not -path "./external/*" -name "*.so" -perm /a=x)
 EXECUTABLE_FILES:= $(EXECUTABLE_FILES:./%=%)
+endif
+ifeq (${uname_S}, Darwin)
+EXECUTABLE_FILES=$(shell find . -maxdepth 1 -type f -exec /bin/sh -c "file {} | grep 'bit executable' > /dev/null" \; -print)
+EXECUTABLE_FILES+=$(shell find . -type f -not -path "./external/*" -not -path "./symbols/*" -name  "*.dylib" -print)
 endif
 endif
 
@@ -801,14 +805,15 @@ $(SELINUX_MODULE): $(SELINUX_ENFORCEMENT)
 ifeq (${TARGET}, agent)
 strip: ${BUILD_AGENT} ${BUILD_CMAKE_PROJECTS}
 else
-ifneq (${TARGET}, winagent)
 strip: ${BUILD_SERVER} ${BUILD_CMAKE_PROJECTS}
 endif
-endif
-ifeq (${uname_S}, Linux)
 ifneq (${TARGET}, winagent)
 ifeq (,$(filter ${DISABLE_STRIP_SYMBOLS},YES yes y Y 1))
+ifeq (${uname_S}, Linux)
 	@$(foreach var, ${EXECUTABLE_FILES}, objcopy --only-keep-debug $(var) symbols/$(basename $(notdir $(var))).debug; objcopy --strip-unneeded $(var);)
+endif
+ifeq (${uname_S}, Darwin)
+	@$(foreach var, ${EXECUTABLE_FILES}, dsymutil -o symbols/$(var).dSYM $(var) && strip -S $(var);)
 endif
 endif
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -805,7 +805,9 @@ $(SELINUX_MODULE): $(SELINUX_ENFORCEMENT)
 ifeq (${TARGET}, agent)
 strip: ${BUILD_AGENT} ${BUILD_CMAKE_PROJECTS}
 else
+ifneq (${TARGET}, winagent)
 strip: ${BUILD_SERVER} ${BUILD_CMAKE_PROJECTS}
+endif
 endif
 ifneq (${TARGET}, winagent)
 ifeq (,$(filter ${DISABLE_STRIP_SYMBOLS},YES yes y Y 1))


### PR DESCRIPTION
|Related issue|
|---|
|#12711|

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR modifies the Makefile so that it (by default) extracts and strips all executables and shared libraries, leaving symbols in the `<repo root>/src/symbols` directory. 


### How was this tested?
The default behavior of compiling the agent with the `make TARGET=agent` command is to extract and strip the binaries of its debugging symbols. Extraction and stripping either happen together or they don't at all. Symbols are extracted to the `<repo root>/src/symbols` directory.

<details>
<summary>No DISABLE_STRIP_SYMBOLS parameter (i.e. symbol stripping on by default)</summary>

```
➜ src git:(12712-strip-macos-symbols) ✗ make -j TARGET=agent
/Library/Developer/CommandLineTools/usr/bin/make build_sysinfo build_shared_modules build_syscollector
cd data_provider/ && mkdir -p build && cd build && cmake  -DCMAKE_SYSTEM_NAME=Darwin  -DCMAKE_BUILD_TYPE=RelWithDbgInfo .. && /Library/Developer/CommandLineTools/usr/bin/make
cd shared_modules/dbsync/ && mkdir -p build && cd build && cmake   -DCMAKE_BUILD_TYPE=RelWithDbgInfo .. && /Library/Developer/CommandLineTools/usr/bin/make
-- The C compiler identification is AppleClang 13.1.6.13160021
-- The C compiler identification is AppleClang 13.1.6.13160021
-- The CXX compiler identification is AppleClang 13.1.6.13160021
-- The CXX compiler identification is AppleClang 13.1.6.13160021
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting C compiler ABI info - done
-- Detecting CXX compiler ABI info
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Configuring done
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/ramiro/repos/wazuh/src/data_provider/build
-- Generating done
-- Build files have been written to: /Users/ramiro/repos/wazuh/src/shared_modules/dbsync/build
[ 11%] Building CXX object CMakeFiles/sysinfo.dir/src/network/networkInterfaceBSD.cpp.o
[ 22%] Building CXX object CMakeFiles/sysinfo.dir/src/osinfo/sysOsParsers.cpp.o
[ 33%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageMac.cpp.o
[ 44%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfoCommonBSD.cpp.o
[ 55%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfoMac.cpp.o
[ 66%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfo.cpp.o
[ 10%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync.cpp.o
[ 20%] Building CXX object CMakeFiles/dbsync.dir/src/dbsyncPipelineFactory.cpp.o
[ 30%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync_implementation.cpp.o
[ 40%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_dbengine.cpp.o
[ 50%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_wrapper.cpp.o
[ 77%] Linking CXX shared library lib/libsysinfo.dylib
[ 77%] Built target sysinfo
[ 88%] Building CXX object testtool/CMakeFiles/sysinfo_test_tool.dir/main.cpp.o
[ 60%] Linking CXX shared library lib/libdbsync.dylib
[ 60%] Built target dbsync
[ 70%] Building CXX object testtool/CMakeFiles/dbsync_test_tool.dir/main.cpp.o
[ 80%] Building CXX object example/CMakeFiles/dbsync_example.dir/main.cpp.o
[ 90%] Linking CXX executable ../bin/dbsync_example
[ 90%] Built target dbsync_example
[100%] Linking CXX executable ../bin/sysinfo_test_tool
[100%] Built target sysinfo_test_tool
[100%] Linking CXX executable ../bin/dbsync_test_tool
[100%] Built target dbsync_test_tool
cd shared_modules/rsync/ && mkdir -p build && cd build && cmake    -DCMAKE_BUILD_TYPE=RelWithDbgInfo .. && /Library/Developer/CommandLineTools/usr/bin/make
-- The C compiler identification is AppleClang 13.1.6.13160021
-- The CXX compiler identification is AppleClang 13.1.6.13160021
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/ramiro/repos/wazuh/src/shared_modules/rsync/build
[ 25%] Building CXX object CMakeFiles/rsync.dir/src/rsyncImplementation.cpp.o
[ 25%] Building CXX object CMakeFiles/rsync.dir/src/rsync.cpp.o
[ 37%] Linking CXX shared library lib/librsync.dylib
[ 37%] Built target rsync
[ 75%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/agentEmulator.cpp.o
[ 87%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/managerEmulator.cpp.o
[ 87%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/main.cpp.o
[ 87%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/oneTimeSync.cpp.o
[100%] Linking CXX executable ../bin/rsync_test_tool
[100%] Built target rsync_test_tool
cd wazuh_modules/syscollector/ && mkdir -p build && cd build && cmake    -DCMAKE_BUILD_TYPE=RelWithDbgInfo .. && /Library/Developer/CommandLineTools/usr/bin/make
-- The C compiler identification is AppleClang 13.1.6.13160021
-- The CXX compiler identification is AppleClang 13.1.6.13160021
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/ramiro/repos/wazuh/src/wazuh_modules/syscollector/build
[ 50%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorImp.cpp.o
[ 50%] Building CXX object CMakeFiles/syscollector.dir/src/syscollector.cpp.o
[ 50%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorNormalizer.cpp.o
[ 66%] Linking CXX shared library lib/libsyscollector.dylib
[ 66%] Built target syscollector
[ 83%] Building CXX object testtool/CMakeFiles/syscollector_test_tool.dir/main.cpp.o
[100%] Linking CXX executable ../bin/syscollector_test_tool
[100%] Built target syscollector_test_tool
/Library/Developer/CommandLineTools/usr/bin/make wazuh-agentd agent-auth wazuh-logcollector wazuh-syscheckd wazuh-execd manage_agents active-responses wazuh-modulesd
cd data_provider/ && mkdir -p build && cd build && cmake  -DCMAKE_SYSTEM_NAME=Darwin  -DCMAKE_BUILD_TYPE=RelWithDbgInfo .. && /Library/Developer/CommandLineTools/usr/bin/make
cd shared_modules/dbsync/ && mkdir -p build && cd build && cmake   -DCMAKE_BUILD_TYPE=RelWithDbgInfo .. && /Library/Developer/CommandLineTools/usr/bin/make
-- Configuring done
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/ramiro/repos/wazuh/src/data_provider/build
-- Generating done
-- Build files have been written to: /Users/ramiro/repos/wazuh/src/shared_modules/dbsync/build
Consolidate compiler generated dependencies of target dbsync
Consolidate compiler generated dependencies of target sysinfo
[ 60%] Built target dbsync
[ 77%] Built target sysinfo
Consolidate compiler generated dependencies of target dbsync_example
Consolidate compiler generated dependencies of target sysinfo_test_tool
Consolidate compiler generated dependencies of target dbsync_test_tool
[ 80%] Built target dbsync_example
[100%] Built target dbsync_test_tool
[100%] Built target sysinfo_test_tool
cd shared_modules/rsync/ && mkdir -p build && cd build && cmake    -DCMAKE_BUILD_TYPE=RelWithDbgInfo .. && /Library/Developer/CommandLineTools/usr/bin/make
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/ramiro/repos/wazuh/src/shared_modules/rsync/build
Consolidate compiler generated dependencies of target rsync
[ 37%] Built target rsync
Consolidate compiler generated dependencies of target rsync_test_tool
[100%] Built target rsync_test_tool
cd wazuh_modules/syscollector/ && mkdir -p build && cd build && cmake    -DCMAKE_BUILD_TYPE=RelWithDbgInfo .. && /Library/Developer/CommandLineTools/usr/bin/make
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/ramiro/repos/wazuh/src/wazuh_modules/syscollector/build
Consolidate compiler generated dependencies of target syscollector
[ 66%] Built target syscollector
Consolidate compiler generated dependencies of target syscollector_test_tool
[100%] Built target syscollector_test_tool
/Library/Developer/CommandLineTools/usr/bin/make settings

General settings:
    TARGET:                  agent
    V:                       
    DEBUG:                   
    DEBUGAD                  
    INSTALLDIR:              
    DATABASE:                
    ONEWAY:                  no
    CLEANFULL:               no
    RESOURCES_URL:           https://packages.wazuh.com/deps/16-9913
    EXTERNAL_SRC_ONLY:       
User settings:
    WAZUH_GROUP:             wazuh
    WAZUH_USER:              wazuh
USE settings:
    USE_ZEROMQ:              no
    USE_GEOIP:               no
    USE_PRELUDE:             no
    USE_INOTIFY:             no
    USE_BIG_ENDIAN:          no
    USE_SELINUX:             no
    USE_AUDIT:               no
    DISABLE_SYSC:            no
    DISABLE_CISCAT:          no
    DISABLE_STRIP_SYMBOLS:   no
Mysql settings:
    includes:                
    libs:                    
Pgsql settings:
    includes:                
    libs:                    
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DDarwin -DDarwin -DHIGHFIRST -DENABLE_SYSC -DENABLE_CISCAT -DCLIENT
Compiler:
    CFLAGS                   -pthread -g -O0 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DDarwin -DDarwin -DHIGHFIRST -DENABLE_SYSC -DENABLE_CISCAT -DCLIENT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Ishared_modules/common -Ishared_modules/dbsync/include -Ishared_modules/rsync/include -Iwazuh_modules/syscollector/include  -Idata_provider/include  -Iexternal/libpcre2/include -I/builddir/output/include 
    LDFLAGS                  -pthread -Xlinker -rpath -Xlinker @executable_path/../lib -O0 -Lshared_modules/dbsync/build/lib -Lshared_modules/rsync/build/lib  -Lwazuh_modules/syscollector/build/lib -Ldata_provider/build/lib
    LIBS                     -framework Security 
    CC                       cc
    MAKE                     /Library/Developer/CommandLineTools/usr/bin/make

Done building agent

➜  src git:(12712-strip-macos-symbols) ✗ ls symbols 
agent-auth.dSYM            disable-account.dSYM       ip-customblock.dSYM        libwazuhext.dylib.dSYM     npf.dSYM                   route-null.dSYM            wazuh-execd.dSYM           wazuh-slack.dSYM
data_provider              firewalld-drop.dSYM        ipfw.dSYM                  libwazuhshared.dylib.dSYM  pf.dSYM                    shared_modules             wazuh-logcollector.dSYM    wazuh-syscheckd.dSYM
default-firewall-drop.dSYM host-deny.dSYM             kaspersky.dSYM             manage_agents.dSYM         restart-wazuh.dSYM         wazuh-agentd.dSYM          wazuh-modulesd.dSYM        wazuh_modules
```
</details>

<details>
<summary>DISABLE_STRIP_SYMBOLS=yes (i.e. keep symbols embedded in binaries)</summary>

```
➜  src git:(12712-strip-macos-symbols) ✗ make -j TARGET=agent DISABLE_STRIP_SYMBOLS=yes 
/Library/Developer/CommandLineTools/usr/bin/make build_sysinfo build_shared_modules build_syscollector
cd data_provider/ && mkdir -p build && cd build && cmake  -DCMAKE_SYSTEM_NAME=Darwin  -DCMAKE_BUILD_TYPE=RelWithDbgInfo .. && /Library/Developer/CommandLineTools/usr/bin/make
cd shared_modules/dbsync/ && mkdir -p build && cd build && cmake   -DCMAKE_BUILD_TYPE=RelWithDbgInfo .. && /Library/Developer/CommandLineTools/usr/bin/make
-- The C compiler identification is AppleClang 13.1.6.13160021
-- The C compiler identification is AppleClang 13.1.6.13160021
-- The CXX compiler identification is AppleClang 13.1.6.13160021
-- The CXX compiler identification is AppleClang 13.1.6.13160021
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting CXX compile features - done
-- Configuring done
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/ramiro/repos/wazuh/src/data_provider/build
-- Generating done
-- Build files have been written to: /Users/ramiro/repos/wazuh/src/shared_modules/dbsync/build
[ 11%] Building CXX object CMakeFiles/sysinfo.dir/src/network/networkInterfaceBSD.cpp.o
[ 22%] Building CXX object CMakeFiles/sysinfo.dir/src/osinfo/sysOsParsers.cpp.o
[ 33%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageMac.cpp.o
[ 44%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfoCommonBSD.cpp.o
[ 55%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfoMac.cpp.o
[ 10%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync.cpp.o
[ 66%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfo.cpp.o
[ 20%] Building CXX object CMakeFiles/dbsync.dir/src/dbsyncPipelineFactory.cpp.o
[ 30%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync_implementation.cpp.o
[ 40%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_dbengine.cpp.o
[ 50%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_wrapper.cpp.o
[ 77%] Linking CXX shared library lib/libsysinfo.dylib
[ 77%] Built target sysinfo
[ 88%] Building CXX object testtool/CMakeFiles/sysinfo_test_tool.dir/main.cpp.o
[ 60%] Linking CXX shared library lib/libdbsync.dylib
[ 60%] Built target dbsync
[ 80%] Building CXX object example/CMakeFiles/dbsync_example.dir/main.cpp.o
[ 80%] Building CXX object testtool/CMakeFiles/dbsync_test_tool.dir/main.cpp.o
[ 90%] Linking CXX executable ../bin/dbsync_example
[ 90%] Built target dbsync_example
[100%] Linking CXX executable ../bin/sysinfo_test_tool
[100%] Built target sysinfo_test_tool
[100%] Linking CXX executable ../bin/dbsync_test_tool
[100%] Built target dbsync_test_tool
cd shared_modules/rsync/ && mkdir -p build && cd build && cmake    -DCMAKE_BUILD_TYPE=RelWithDbgInfo .. && /Library/Developer/CommandLineTools/usr/bin/make
-- The C compiler identification is AppleClang 13.1.6.13160021
-- The CXX compiler identification is AppleClang 13.1.6.13160021
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/ramiro/repos/wazuh/src/shared_modules/rsync/build
[ 12%] Building CXX object CMakeFiles/rsync.dir/src/rsync.cpp.o
[ 25%] Building CXX object CMakeFiles/rsync.dir/src/rsyncImplementation.cpp.o
[ 37%] Linking CXX shared library lib/librsync.dylib
[ 37%] Built target rsync
[ 87%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/agentEmulator.cpp.o
[ 87%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/main.cpp.o
[ 87%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/managerEmulator.cpp.o
[ 87%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/oneTimeSync.cpp.o
[100%] Linking CXX executable ../bin/rsync_test_tool
[100%] Built target rsync_test_tool
cd wazuh_modules/syscollector/ && mkdir -p build && cd build && cmake    -DCMAKE_BUILD_TYPE=RelWithDbgInfo .. && /Library/Developer/CommandLineTools/usr/bin/make
-- The C compiler identification is AppleClang 13.1.6.13160021
-- The CXX compiler identification is AppleClang 13.1.6.13160021
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/ramiro/repos/wazuh/src/wazuh_modules/syscollector/build
[ 50%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorNormalizer.cpp.o
[ 50%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorImp.cpp.o
[ 50%] Building CXX object CMakeFiles/syscollector.dir/src/syscollector.cpp.o
[ 66%] Linking CXX shared library lib/libsyscollector.dylib
[ 66%] Built target syscollector
[ 83%] Building CXX object testtool/CMakeFiles/syscollector_test_tool.dir/main.cpp.o
[100%] Linking CXX executable ../bin/syscollector_test_tool
[100%] Built target syscollector_test_tool
/Library/Developer/CommandLineTools/usr/bin/make wazuh-agentd agent-auth wazuh-logcollector wazuh-syscheckd wazuh-execd manage_agents active-responses wazuh-modulesd
cd data_provider/ && mkdir -p build && cd build && cmake  -DCMAKE_SYSTEM_NAME=Darwin  -DCMAKE_BUILD_TYPE=RelWithDbgInfo .. && /Library/Developer/CommandLineTools/usr/bin/make
cd shared_modules/dbsync/ && mkdir -p build && cd build && cmake   -DCMAKE_BUILD_TYPE=RelWithDbgInfo .. && /Library/Developer/CommandLineTools/usr/bin/make
-- Configuring done
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/ramiro/repos/wazuh/src/data_provider/build
-- Generating done
-- Build files have been written to: /Users/ramiro/repos/wazuh/src/shared_modules/dbsync/build
Consolidate compiler generated dependencies of target sysinfo
Consolidate compiler generated dependencies of target dbsync
[ 77%] Built target sysinfo
[ 60%] Built target dbsync
Consolidate compiler generated dependencies of target sysinfo_test_tool
Consolidate compiler generated dependencies of target dbsync_example
Consolidate compiler generated dependencies of target dbsync_test_tool
[100%] Built target sysinfo_test_tool
[100%] Built target dbsync_test_tool
[100%] Built target dbsync_example
cd shared_modules/rsync/ && mkdir -p build && cd build && cmake    -DCMAKE_BUILD_TYPE=RelWithDbgInfo .. && /Library/Developer/CommandLineTools/usr/bin/make
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/ramiro/repos/wazuh/src/shared_modules/rsync/build
Consolidate compiler generated dependencies of target rsync
[ 37%] Built target rsync
Consolidate compiler generated dependencies of target rsync_test_tool
[100%] Built target rsync_test_tool
cd wazuh_modules/syscollector/ && mkdir -p build && cd build && cmake    -DCMAKE_BUILD_TYPE=RelWithDbgInfo .. && /Library/Developer/CommandLineTools/usr/bin/make
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/ramiro/repos/wazuh/src/wazuh_modules/syscollector/build
Consolidate compiler generated dependencies of target syscollector
[ 66%] Built target syscollector
Consolidate compiler generated dependencies of target syscollector_test_tool
[100%] Built target syscollector_test_tool
/Library/Developer/CommandLineTools/usr/bin/make settings

General settings:
    TARGET:                  agent
    V:                       
    DEBUG:                   
    DEBUGAD                  
    INSTALLDIR:              
    DATABASE:                
    ONEWAY:                  no
    CLEANFULL:               no
    RESOURCES_URL:           https://packages.wazuh.com/deps/16-9913
    EXTERNAL_SRC_ONLY:       
User settings:
    WAZUH_GROUP:             wazuh
    WAZUH_USER:              wazuh
USE settings:
    USE_ZEROMQ:              no
    USE_GEOIP:               no
    USE_PRELUDE:             no
    USE_INOTIFY:             no
    USE_BIG_ENDIAN:          no
    USE_SELINUX:             no
    USE_AUDIT:               no
    DISABLE_SYSC:            no
    DISABLE_CISCAT:          no
    DISABLE_STRIP_SYMBOLS:   yes
Mysql settings:
    includes:                
    libs:                    
Pgsql settings:
    includes:                
    libs:                    
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DDarwin -DDarwin -DHIGHFIRST -DENABLE_SYSC -DENABLE_CISCAT -DCLIENT
Compiler:
    CFLAGS                   -pthread -g -O0 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DDarwin -DDarwin -DHIGHFIRST -DENABLE_SYSC -DENABLE_CISCAT -DCLIENT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Ishared_modules/common -Ishared_modules/dbsync/include -Ishared_modules/rsync/include -Iwazuh_modules/syscollector/include  -Idata_provider/include  -Iexternal/libpcre2/include -I/builddir/output/include 
    LDFLAGS                  -pthread -Xlinker -rpath -Xlinker @executable_path/../lib -O0 -Lshared_modules/dbsync/build/lib -Lshared_modules/rsync/build/lib  -Lwazuh_modules/syscollector/build/lib -Ldata_provider/build/lib
    LIBS                     -framework Security 
    CC                       cc
    MAKE                     /Library/Developer/CommandLineTools/usr/bin/make

Done building agent

➜  src git:(12712-strip-macos-symbols) ✗ ls symbols 
➜  src git:(12712-strip-macos-symbols) ✗ 
```
</details>


## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [x] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors