### PR TITLE
Allow option to have debug symbols in a folder for Linux OS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -801,7 +801,9 @@ $(SELINUX_MODULE): $(SELINUX_ENFORCEMENT)
 ifeq (${TARGET}, agent)
 strip: ${BUILD_AGENT} ${BUILD_CMAKE_PROJECTS}
 else
+ifneq (${TARGET}, winagent)
 strip: ${BUILD_SERVER} ${BUILD_CMAKE_PROJECTS}
+endif
 endif
 ifeq (${uname_S}, Linux)
 ifneq (${TARGET}, winagent)

--- a/src/Makefile
+++ b/src/Makefile
@@ -87,9 +87,11 @@ DISABLE_CISCAT?=no
 DISABLE_STRIP_SYMBOLS?=no
 
 ifeq (${uname_S}, Linux)
+ifneq (${TARGET}, winagent)
 EXECUTABLE_FILES := $(shell find . -maxdepth 1 -type f ! -name "*.so"  -perm /a=x)
 EXECUTABLE_FILES += $(shell find . -type f -not -path "./external/*" -name "*.so" -perm /a=x)
 EXECUTABLE_FILES:= $(EXECUTABLE_FILES:./%=%)
+endif
 endif
 
 
@@ -752,7 +754,7 @@ ifneq (${uname_S},HP-UX)
 	${MAKE} ${BUILD_CMAKE_PROJECTS}
 endif
 	${MAKE} ${BUILD_SERVER}
-	@${MAKE} strip DISABLE_STRIP_SYMBOLS=${DISABLE_STRIP_SYMBOLS}
+	@${MAKE} strip TARGET=${TARGET} DISABLE_STRIP_SYMBOLS=${DISABLE_STRIP_SYMBOLS}
 
 ifeq (${MAKECMDGOALS},local)
 $(error Do not use 'local' directly, use 'TARGET=local')
@@ -762,7 +764,7 @@ ifneq (${uname_S},HP-UX)
 	${MAKE} ${BUILD_CMAKE_PROJECTS}
 endif
 	${MAKE} ${BUILD_SERVER}
-	@${MAKE} strip DISABLE_STRIP_SYMBOLS=${DISABLE_STRIP_SYMBOLS}
+	@${MAKE} strip TARGET=${TARGET} DISABLE_STRIP_SYMBOLS=${DISABLE_STRIP_SYMBOLS}
 
 ifeq (${MAKECMDGOALS},hybrid)
 $(error Do not use 'hybrid' directly, use 'TARGET=hybrid')
@@ -772,7 +774,7 @@ ifneq (${uname_S},HP-UX)
 	${MAKE} ${BUILD_CMAKE_PROJECTS}
 endif
 	${MAKE} ${BUILD_SERVER}
-	@${MAKE} strip DISABLE_STRIP_SYMBOLS=${DISABLE_STRIP_SYMBOLS}
+	@${MAKE} strip TARGET=${TARGET} DISABLE_STRIP_SYMBOLS=${DISABLE_STRIP_SYMBOLS}
 
 ifeq (${MAKECMDGOALS},agent)
 $(error Do not use 'agent' directly, use 'TARGET=agent')
@@ -782,7 +784,7 @@ ifneq (${uname_S},HP-UX)
 	${MAKE} ${BUILD_CMAKE_PROJECTS}
 endif
 	${MAKE} ${BUILD_AGENT}
-	@${MAKE} strip DISABLE_STRIP_SYMBOLS=${DISABLE_STRIP_SYMBOLS}
+	@${MAKE} strip TARGET=${TARGET} DISABLE_STRIP_SYMBOLS=${DISABLE_STRIP_SYMBOLS}
 
 ifneq (,$(filter ${USE_SELINUX},YES yes y Y 1))
 server local hybrid agent: selinux
@@ -802,8 +804,10 @@ else
 strip: ${BUILD_SERVER} ${BUILD_CMAKE_PROJECTS}
 endif
 ifeq (${uname_S}, Linux)
+ifneq (${TARGET}, winagent)
 ifeq (,$(filter ${DISABLE_STRIP_SYMBOLS},YES yes y Y 1))
 	@$(foreach var, ${EXECUTABLE_FILES}, objcopy --only-keep-debug $(var) symbols/$(basename $(notdir $(var))).debug; objcopy --strip-unneeded $(var);)
+endif
 endif
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -86,6 +86,13 @@ DISABLE_SYSC?=no
 DISABLE_CISCAT?=no
 DISABLE_STRIP_SYMBOLS?=no
 
+ifeq (${uname_S}, Linux)
+EXECUTABLE_FILES := $(shell find . -maxdepth 1 -type f ! -name "*.so"  -perm /a=x)
+EXECUTABLE_FILES += $(shell find . -type f -not -path "./external/*" -name "*.so" -perm /a=x)
+EXECUTABLE_FILES:= $(EXECUTABLE_FILES:./%=%)
+endif
+
+
 ifneq (,$(filter ${DISABLE_STRIP_SYMBOLS},YES yes y Y 1))
 ifeq (${DBG_SYM_SUPPORT},no)
 $(error Option not available for current OS)
@@ -745,6 +752,7 @@ ifneq (${uname_S},HP-UX)
 	${MAKE} ${BUILD_CMAKE_PROJECTS}
 endif
 	${MAKE} ${BUILD_SERVER}
+	@${MAKE} strip DISABLE_STRIP_SYMBOLS=${DISABLE_STRIP_SYMBOLS}
 
 ifeq (${MAKECMDGOALS},local)
 $(error Do not use 'local' directly, use 'TARGET=local')
@@ -754,6 +762,7 @@ ifneq (${uname_S},HP-UX)
 	${MAKE} ${BUILD_CMAKE_PROJECTS}
 endif
 	${MAKE} ${BUILD_SERVER}
+	@${MAKE} strip DISABLE_STRIP_SYMBOLS=${DISABLE_STRIP_SYMBOLS}
 
 ifeq (${MAKECMDGOALS},hybrid)
 $(error Do not use 'hybrid' directly, use 'TARGET=hybrid')
@@ -763,6 +772,7 @@ ifneq (${uname_S},HP-UX)
 	${MAKE} ${BUILD_CMAKE_PROJECTS}
 endif
 	${MAKE} ${BUILD_SERVER}
+	@${MAKE} strip DISABLE_STRIP_SYMBOLS=${DISABLE_STRIP_SYMBOLS}
 
 ifeq (${MAKECMDGOALS},agent)
 $(error Do not use 'agent' directly, use 'TARGET=agent')
@@ -772,6 +782,7 @@ ifneq (${uname_S},HP-UX)
 	${MAKE} ${BUILD_CMAKE_PROJECTS}
 endif
 	${MAKE} ${BUILD_AGENT}
+	@${MAKE} strip DISABLE_STRIP_SYMBOLS=${DISABLE_STRIP_SYMBOLS}
 
 ifneq (,$(filter ${USE_SELINUX},YES yes y Y 1))
 server local hybrid agent: selinux
@@ -784,6 +795,17 @@ $(SELINUX_POLICY): $(SELINUX_MODULE)
 
 $(SELINUX_MODULE): $(SELINUX_ENFORCEMENT)
 	checkmodule -M -m -o $@ $?
+
+ifeq (${TARGET}, agent)
+strip: ${BUILD_AGENT} ${BUILD_CMAKE_PROJECTS}
+else
+strip: ${BUILD_SERVER} ${BUILD_CMAKE_PROJECTS}
+endif
+ifeq (${uname_S}, Linux)
+ifeq (,$(filter ${DISABLE_STRIP_SYMBOLS},YES yes y Y 1))
+	@$(foreach var, ${EXECUTABLE_FILES}, objcopy --only-keep-debug $(var) symbols/$(basename $(notdir $(var))).debug; objcopy --strip-unneeded $(var);)
+endif
+endif
 
 WINDOWS_BINS:=win32/wazuh-agent.exe win32/wazuh-agent-eventchannel.exe win32/manage_agents.exe win32/setup-windows.exe win32/setup-syscheck.exe win32/setup-iis.exe win32/os_win32ui.exe win32/agent-auth.exe win32/syscollector
 WINDOWS_ACTIVE_RESPONSES:=win32/restart-wazuh.exe win32/route-null.exe win32/netsh.exe
@@ -2535,6 +2557,7 @@ clean-internals: clean-unit-tests
 	rm -rf $(SYSINFO)build
 	rm -rf libwazuhext
 	rm -f libgcc_s.so.1
+	rm -rf symbols/*
 
 clean-unit-tests:
 	rm -f ${wrappers_syscheck_o}

--- a/src/symbols/.gitignore
+++ b/src/symbols/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
|Related issue|
|---|
|#12623|

## Description

This PR aims to generate debug symbols inside of `symbols` folder when the option `DISABLE_STRIP_SYMBOLS` is disabled. After the change, some tests were done and the result of the binaries size was:

### SERVER
<details>
<summary>DISABLE_STRIP_SYMBOLS enable</summary>

![image](https://user-images.githubusercontent.com/58960358/160207982-587feadb-0263-48d7-8cd2-2f2297e854ac.png)

 </details>

<details>
<summary>DISABLE_STRIP_SYMBOLS disable</summary>

![image](https://user-images.githubusercontent.com/58960358/160208209-296dc635-6f3e-413b-8784-9698246617b8.png)

 </details>

<details>
<summary>Debug symbols</summary>

![image](https://user-images.githubusercontent.com/58960358/160415615-31e8b1e8-b5e1-4db4-a99c-43105d4c50f5.png)

</details>


### AGENT

<details>
<summary>DISABLE_STRIP_SYMBOLS enable</summary>

![image](https://user-images.githubusercontent.com/58960358/160208453-710211c1-0f58-41fd-b827-7c459ef4cab4.png)

 </details>

<details>
<summary>DISABLE_STRIP_SYMBOLS disable</summary>

![image](https://user-images.githubusercontent.com/58960358/160208588-bede38b7-4525-4819-a022-44169b467373.png)

 </details>

<details>
<summary>Debug symbols</summary>

![image](https://user-images.githubusercontent.com/58960358/160416329-2ca8d344-7958-404e-88e2-c84993a35335.png)

</details>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors