### PR TITLE
Add unittests for `agent_upgrade` script

### DIFF
--- a/framework/scripts/agent_upgrade.py
+++ b/framework/scripts/agent_upgrade.py
@@ -38,6 +38,31 @@ def signal_handler(n_signal, frame):
     exit(1)
 
 
+def get_script_arguments():
+    """Get script arguments.
+
+    Returns
+    -------
+    ArgumentParser object
+        Arguments passed to the script.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-a", "--agents", nargs='+', help="Agent IDs to upgrade.")
+    parser.add_argument("-r", "--repository", type=str, help="Specify a repository URL. [Default: {0}]".format(
+        common.WPK_REPO_URL_4_X))
+    parser.add_argument("-v", "--version", type=str, help="Version to upgrade. [Default: latest Wazuh version]")
+    parser.add_argument("-F", "--force", action="store_true",
+                        help="Allows reinstall same version and downgrade version.")
+    parser.add_argument("-s", "--silent", action="store_true", help="Do not show output.")
+    parser.add_argument("-l", "--list_outdated", action="store_true", help="Generates a list with all outdated agents.")
+    parser.add_argument("-f", "--file", type=str, help="Custom WPK filename.")
+    parser.add_argument("-x", "--execute", type=str,
+                        help="Executable filename in the WPK custom file. [Default: upgrade.sh]")
+    parser.add_argument("--http", action="store_true", help="Uses http protocol instead of https.")
+
+    return parser
+
+
 def list_outdated():
     agents = wazuh.agent.get_outdated_agents()
     if agents.total_affected_items == 0:
@@ -50,16 +75,17 @@ def list_outdated():
 
 
 def get_agents_versions(agents):
-    """Get the current versions of the specified agents
+    """Get the current versions of the specified agents.
 
     Parameters
     ----------
     agents : list
-        List of agent's IDs
+        List of agent's IDs.
 
     Returns
     -------
-    Dictionary with the current version (prev_version)
+    dict
+        Dictionary with the current version (prev_version).
     """
     agents_versions = dict()
     for agent_id in agents:
@@ -75,11 +101,12 @@ def get_agents_versions(agents):
 
 
 def create_command():
-    """Create a custom command based on the CLI arguments
+    """Create a custom command based on the CLI arguments.
 
     Returns
     -------
-    Dictionary with upgrade command
+    Dict
+        Dictionary with upgrade command.
     """
     if not args.file and not args.execute:
         f_kwargs = {'agent_list': args.agents, 'wpk_repo': args.repository, 'version': args.version,
@@ -93,20 +120,21 @@ def create_command():
 
 def send_command(function, command, local_master=False):
     """Send the command to the specified function.
-    If local_master is True, the request type must be local_master (upgrade_result)
+
+    If local_master is True, the request type must be local_master (upgrade_result).
 
     Parameters
     ----------
     function : func
-        Upgrade function
+        Upgrade function.
     command : dict
-        Arguments for the specified function
+        Arguments for the specified function.
     local_master : bool
-        True for get the upgrade results, False for send upgrade command
+        True for get the upgrade results, False for send upgrade command.
 
     Returns
     -------
-    Distributed API request result
+    Distributed API request result.
     """
     dapi = DistributedAPI(f=function, f_kwargs=command,
                           request_type='distributed_master' if not local_master else 'local_master',
@@ -116,14 +144,14 @@ def send_command(function, command, local_master=False):
 
 
 def print_result(agents_versions, failed_agents):
-    """Print the operation's result
+    """Print the operation's result.
 
     Parameters
     ----------
     agents_versions : dict
-        Dictionary with the previous version an the new one
+        Dictionary with the previous version and the new one.
     failed_agents : dict
-        Contain the error's information
+        Contain the error's information.
     """
     len(agents_versions.keys()) > 0 and print('\nUpgraded agents:')
     for agent_id, versions in agents_versions.items():
@@ -135,18 +163,18 @@ def print_result(agents_versions, failed_agents):
 
 
 def check_status(affected_agents, result_dict, failed_agents, silent):
-    """Check the agent's upgrade status
+    """Check the agent's upgrade status.
 
     Parameters
     ----------
     affected_agents : list
-        Result of the upgrade task check
+        Result of the upgrade task check.
     result_dict : dict
-        Dictionary with the previous version and the new one
+        Dictionary with the previous version and the new one.
     failed_agents : dict
-        Contain the error's information
+        Contain the error's information.
     silent : bool
-        Do not show output if it is True
+        Do not show output if it is True.
     """
     affected_agents = set(affected_agents)
     len(affected_agents) and print('\nUpgrading...')
@@ -171,53 +199,33 @@ def check_status(affected_agents, result_dict, failed_agents, silent):
 
 
 def main():
-    # Capture Ctrl + C
-    signal(SIGINT, signal_handler)
-
-    # Check arguments
-    if args.list_outdated:
-        list_outdated()
-        exit(0)
-
-    if not args.agents:
-        arg_parser.print_help()
-        exit(0)
-
-    result = send_command(function=upgrade_agents, command=create_command())
-
-    not args.silent and len(result.failed_items.keys()) > 0 and print("Agents that cannot be upgraded:")
-    if not args.silent:
-        for agent_result, agent_ids in result.failed_items.items():
-            print(f"\tAgent {', '.join(agent_ids)} upgrade failed. Status: {agent_result}")
-
-    result.affected_items = [task["agent"] for task in result.affected_items]
-    agents_versions = get_agents_versions(agents=result.affected_items)
-
-    failed_agents = dict()
-    check_status(affected_agents=result.affected_items, result_dict=agents_versions,
-                 failed_agents=failed_agents, silent=args.silent)
-
-
-if __name__ == "__main__":
-
-    arg_parser = argparse.ArgumentParser()
-    arg_parser.add_argument("-a", "--agents", nargs='+', help="Agent IDs to upgrade.")
-    arg_parser.add_argument("-r", "--repository", type=str, help="Specify a repository URL. [Default: {0}]".format(
-        common.WPK_REPO_URL_4_X))
-    arg_parser.add_argument("-v", "--version", type=str, help="Version to upgrade. [Default: latest Wazuh version]")
-    arg_parser.add_argument("-F", "--force", action="store_true",
-                            help="Allows reinstall same version and downgrade version.")
-    arg_parser.add_argument("-s", "--silent", action="store_true", help="Do not show output.")
-    arg_parser.add_argument("-l", "--list_outdated", action="store_true",
-                            help="Generates a list with all outdated agents.")
-    arg_parser.add_argument("-f", "--file", type=str, help="Custom WPK filename.")
-    arg_parser.add_argument("-x", "--execute", type=str,
-                            help="Executable filename in the WPK custom file. [Default: upgrade.sh]")
-    arg_parser.add_argument("--http", action="store_true", help="Uses http protocol instead of https.")
-    args = arg_parser.parse_args()
-
     try:
-        main()
+        # Capture Ctrl + C
+        signal(SIGINT, signal_handler)
+
+        # Check arguments
+        if args.list_outdated:
+            list_outdated()
+            exit(0)
+
+        if not args.agents:
+            arg_parser.print_help()
+            exit(0)
+
+        result = send_command(function=upgrade_agents, command=create_command())
+
+        not args.silent and len(result.failed_items.keys()) > 0 and print("Agents that cannot be upgraded:")
+        if not args.silent:
+            for agent_result, agent_ids in result.failed_items.items():
+                print(f"\tAgent {', '.join(agent_ids)} upgrade failed. Status: {agent_result}")
+
+        result.affected_items = [task["agent"] for task in result.affected_items]
+        agents_versions = get_agents_versions(agents=result.affected_items)
+
+        failed_agents = dict()
+        check_status(affected_agents=result.affected_items, result_dict=agents_versions,
+                     failed_agents=failed_agents, silent=args.silent)
+
     except WazuhError as e:
         print(f"Error {e.code}: {e.message}")
         if args.debug:
@@ -226,3 +234,9 @@ if __name__ == "__main__":
         print(f"Internal error: {str(e)}")
         if args.debug:
             raise
+
+
+if __name__ == "__main__":
+    arg_parser = get_script_arguments()
+    args = arg_parser.parse_args()
+    main()

--- a/framework/scripts/tests/test_agent_upgrade.py
+++ b/framework/scripts/tests/test_agent_upgrade.py
@@ -1,0 +1,200 @@
+# Copyright (C) 2015, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import framework.scripts.agent_upgrade as agent_upgrade
+from wazuh.core.results import AffectedItemsWazuhResult
+import pytest
+from unittest.mock import call, ANY, patch, MagicMock
+from wazuh.core.exception import WazuhError
+
+
+@patch('framework.scripts.agent_upgrade.exit')
+def test_signal_handler(mock_exit):
+    """Check if exit is called in signal_handler function."""
+    agent_upgrade.signal_handler('test', 'test')
+    mock_exit.assert_called_once_with(1)
+
+
+@patch('framework.scripts.agent_upgrade.argparse.ArgumentParser')
+def test_get_script_arguments(mock_ArgumentParser):
+    agent_upgrade.get_script_arguments()
+    mock_ArgumentParser.assert_called_once_with()
+    mock_ArgumentParser.return_value.add_argument.assert_has_calls([
+        call('-a', '--agents', nargs='+', help='Agent IDs to upgrade.'),
+        call('-r', '--repository', type=str, help='Specify a repository URL. [Default: packages.wazuh.com/4.x/wpk/]'),
+        call('-v', '--version', type=str, help='Version to upgrade. [Default: latest Wazuh version]'),
+        call('-F', '--force', action='store_true', help='Allows reinstall same version and downgrade version.'),
+        call('-s', '--silent', action='store_true', help='Do not show output.'),
+        call('-l', '--list_outdated', action='store_true', help='Generates a list with all outdated agents.'),
+        call('-f', '--file', type=str, help='Custom WPK filename.'),
+        call('-x', '--execute', type=str, help='Executable filename in the WPK custom file. [Default: upgrade.sh]'),
+        call('--http', action='store_true', help='Uses http protocol instead of https.')
+    ])
+
+
+@pytest.mark.parametrize('api_response, total_affected_items', [
+    ({'version': 'Wazuh v4.2.1', 'id': '002', 'name': 'test'}, 1),
+    ({}, 0)
+])
+def test_list_outdated(capfd, api_response, total_affected_items):
+    """Check if expected message is printed in list_outdated function.
+
+    Parameters
+    ----------
+    api_response : dict
+        Outdated agents that the API should return.
+    total_affected_items : int
+        Number of affected items.
+    """
+    result = AffectedItemsWazuhResult()
+    result.affected_items = [api_response]
+    result.total_affected_items = total_affected_items
+
+    with patch('wazuh.agent.get_outdated_agents', return_value=result):
+        agent_upgrade.list_outdated()
+        out, err = capfd.readouterr()
+        if total_affected_items:
+            assert all(value in out for value in api_response.values())
+        else:
+            assert out == 'All agents are updated.\n'
+
+
+@patch('framework.scripts.agent_upgrade.Agent')
+def test_get_agents_versions(mock_agent):
+    """Check if expected result is returned in get_agents_versions function."""
+    agents_list = ['test0', 'test1']
+    result = agent_upgrade.get_agents_versions(agents_list)
+    assert mock_agent.call_args_list == [call(agent) for agent in agents_list]
+    assert all(result[agent] == {'prev_version': ANY, 'new_version': None} for agent in agents_list)
+
+
+def test_create_command():
+    """Check that expected result is returned in create_command function"""
+    agent_upgrade.args = MagicMock()
+    result = agent_upgrade.create_command()
+    assert result == {'agent_list': ANY, 'installer': ANY, 'file_path': ANY}
+
+    agent_upgrade.args.file = ''
+    agent_upgrade.args.execute = ''
+    result = agent_upgrade.create_command()
+    assert result == {'agent_list': ANY, 'wpk_repo': ANY, 'version': ANY, 'use_http': ANY, 'force': ANY}
+
+
+@patch('framework.scripts.agent_upgrade.DistributedAPI')
+@patch('framework.scripts.agent_upgrade.concurrent')
+@patch('framework.scripts.agent_upgrade.raise_if_exc')
+def test_send_command(mock_raise_if_exc, mock_concurrent, mock_distributed_api):
+    """Check if methods inside send_command function are run with expected parameters."""
+    agent_upgrade.send_command('test_function', {'test_command': 'test'})
+    mock_distributed_api.assert_called_once_with(f='test_function', f_kwargs={'test_command': 'test'},
+                                                 request_type='distributed_master', is_async=False,
+                                                 wait_for_complete=True, logger=ANY)
+    mock_concurrent.futures.ThreadPoolExecutor.assert_called_once()
+    mock_raise_if_exc.assert_called_once()
+
+
+@pytest.mark.parametrize('agents_versions, failed_agents, expected_output', [
+    ({'001': {'prev_version': '4.2.0', 'new_version': '4.3.0'}}, {'001': 'test_error'},
+     '\nUpgraded agents:\n\tAgent 001 upgraded: 4.2.0 -> 4.3.0\n\nFailed upgrades:\n\tAgent 001 status: test_error\n'),
+    ({}, {}, ''),
+    ({'001': {'prev_version': '4.2.0', 'new_version': '4.3.0'}}, {},
+     '\nUpgraded agents:\n\tAgent 001 upgraded: 4.2.0 -> 4.3.0\n'),
+    ({}, {'001': 'test_error'}, '\nFailed upgrades:\n\tAgent 001 status: test_error\n')
+])
+def test_print_result(capfd, agents_versions, failed_agents, expected_output):
+    """Check that expected output is printed for each combination of parameters.
+
+    Parameters
+    ----------
+    agents_versions : dict
+        Dictionary with the previous version and the new one.
+    failed_agents : dict
+        Contain the error's information.
+    expected_output : str
+        Message that should be printed in the function.
+    """
+    agent_upgrade.print_result(agents_versions=agents_versions, failed_agents=failed_agents)
+    out, err = capfd.readouterr()
+    assert out == expected_output
+
+
+@pytest.mark.parametrize('silent', [
+    True, False
+])
+@patch('framework.scripts.agent_upgrade.print_result')
+@patch('framework.scripts.agent_upgrade.sleep')
+@patch('framework.scripts.agent_upgrade.Agent')
+def test_check_status(mock_agent, mock_sleep, mock_print_result, silent):
+    """Check if methods inside check_status function are run with expected parameters.
+
+    Parameters
+    ----------
+    silent : bool
+        Do not show output if it is True.
+    """
+
+    task_results = MagicMock()
+    task_results.affected_items = [{'agent': '001', 'status': 'Updated'},
+                                   {'agent': '002', 'status': 'Error', 'error_msg': 'test_error'}]
+    agent_upgrade.args = MagicMock()
+    agent_upgrade.args.version = '4.2.0'
+    with patch('framework.scripts.agent_upgrade.send_command', return_value=task_results) as mock_send_command:
+        agent_upgrade.check_status(affected_agents=['001', '002'],
+                                   result_dict={'001': {'new_version': '4.3.0'}, '002': {'new_version': '4.3.0'}},
+                                   failed_agents={}, silent=silent)
+
+        mock_send_command.assert_called_once_with(function=agent_upgrade.get_upgrade_result,
+                                                  command={'agent_list': ANY}, local_master=True)
+        mock_agent.assert_called_once_with('001')
+        if not silent:
+            mock_print_result.assert_called_once_with(agents_versions={'001': {'new_version': '4.2.0'}},
+                                                      failed_agents={'002': 'test_error'})
+        else:
+            mock_print_result.assert_not_called()
+
+
+@patch('framework.scripts.agent_upgrade.signal')
+@patch('framework.scripts.agent_upgrade.exit')
+@patch('framework.scripts.agent_upgrade.list_outdated')
+@patch('framework.scripts.agent_upgrade.get_agents_versions')
+@patch('framework.scripts.agent_upgrade.check_status')
+def test_main(mock_check_status, mock_get_agents_versions, mock_list_outdated, mock_exit, mock_signal, capfd):
+    """Check if methods inside main function are run with expected parameters"""
+    agent_upgrade.arg_parser = MagicMock()
+    agent_upgrade.args = MagicMock()
+    agent_upgrade.args.list_outdated = ['001']
+    agent_upgrade.args.agents = []
+    agent_upgrade.args.silent = False
+    task_results = MagicMock()
+    task_results.failed_items = {'1000': ['001', '002']}
+    task_results.affected_items = [{'agent': '003'}]
+
+    with patch('framework.scripts.agent_upgrade.send_command', return_value=task_results) as mock_send_command:
+        agent_upgrade.main()
+        mock_signal.assert_called_once_with(agent_upgrade.SIGINT, agent_upgrade.signal_handler)
+        mock_list_outdated.assert_called_once()
+        mock_exit.assert_has_calls([call(0), call(0)])
+        agent_upgrade.arg_parser.print_help.assert_called_once()
+        mock_get_agents_versions.assert_called_with(agents=['003'])
+        mock_check_status.assert_called_with(affected_agents=['003'], result_dict=ANY, failed_agents={}, silent=False)
+        out, err = capfd.readouterr()
+        assert out == 'Agents that cannot be upgraded:\n\tAgent 001, 002 upgrade failed. Status: 1000\n'
+
+
+def test_main_ko(capfd):
+    """Check that expected exceptions are raised in main function."""
+    agent_upgrade.args = MagicMock()
+    agent_upgrade.args.list_outdated = ['001']
+
+    with patch('framework.scripts.agent_upgrade.list_outdated', side_effect=WazuhError(1000)):
+        with pytest.raises(WazuhError, match='.* 1000 .*'):
+            agent_upgrade.main()
+        out, err = capfd.readouterr()
+        assert out == 'Error 1000: Wazuh Internal Error\n'
+
+    with patch('framework.scripts.agent_upgrade.list_outdated', side_effect=Exception):
+        with pytest.raises(Exception):
+            agent_upgrade.main()
+        out, err = capfd.readouterr()
+        assert out == 'Internal error: \n'

--- a/framework/scripts/tests/test_agent_upgrade.py
+++ b/framework/scripts/tests/test_agent_upgrade.py
@@ -2,9 +2,16 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
+import sys
 from unittest.mock import call, ANY, patch, MagicMock
 
 import pytest
+
+sys.modules['wazuh.rbac.orm'] = MagicMock()
+import wazuh.rbac.decorators
+from wazuh.tests.util import RBAC_bypasser
+del sys.modules['wazuh.rbac.orm']
+wazuh.rbac.decorators.expose_resources = RBAC_bypasser
 
 import scripts.agent_upgrade as agent_upgrade
 from wazuh.core.exception import WazuhError


### PR DESCRIPTION
|Related issue|
|---|
| Closes #12813 |

## Description

This PR adds unit tests for the `framework/scripts/agent_upgrade.py` module. Some changes were also applied on the module itself to achieve a higher coverage.

## Tests

```
python3.9 -m pytest framework/scripts/tests/test_agent_upgrade.py -xvv --cov
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.9.5, pytest-7.0.1, pluggy-1.0.0 -- /home/selu/venv/3.9-unittest-env/bin/python3.9
cachedir: .pytest_cache
rootdir: /home/selu/Git/wazuh/framework
plugins: anyio-3.5.0, asyncio-0.18.1, aiohttp-1.0.4, cov-3.0.0
asyncio: mode=auto
collected 15 items                                                                                                                                                                                          

framework/scripts/tests/test_agent_upgrade.py::test_signal_handler PASSED                                                                                                                             [  6%]
framework/scripts/tests/test_agent_upgrade.py::test_get_script_arguments PASSED                                                                                                                       [ 13%]
framework/scripts/tests/test_agent_upgrade.py::test_list_outdated[api_response0-1] PASSED                                                                                                             [ 20%]
framework/scripts/tests/test_agent_upgrade.py::test_list_outdated[api_response1-0] PASSED                                                                                                             [ 26%]
framework/scripts/tests/test_agent_upgrade.py::test_get_agents_versions PASSED                                                                                                                        [ 33%]
framework/scripts/tests/test_agent_upgrade.py::test_create_command PASSED                                                                                                                             [ 40%]
framework/scripts/tests/test_agent_upgrade.py::test_send_command PASSED                                                                                                                               [ 46%]
framework/scripts/tests/test_agent_upgrade.py::test_print_result[agents_versions0-failed_agents0-\nUpgraded agents:\n\tAgent 001 upgraded: 4.2.0 -> 4.3.0\n\nFailed upgrades:\n\tAgent 001 status: test_error\n] PASSED [ 53%]
framework/scripts/tests/test_agent_upgrade.py::test_print_result[agents_versions1-failed_agents1-] PASSED                                                                                             [ 60%]
framework/scripts/tests/test_agent_upgrade.py::test_print_result[agents_versions2-failed_agents2-\nUpgraded agents:\n\tAgent 001 upgraded: 4.2.0 -> 4.3.0\n] PASSED                                   [ 66%]
framework/scripts/tests/test_agent_upgrade.py::test_print_result[agents_versions3-failed_agents3-\nFailed upgrades:\n\tAgent 001 status: test_error\n] PASSED                                         [ 73%]
framework/scripts/tests/test_agent_upgrade.py::test_check_status[True] PASSED                                                                                                                         [ 80%]
framework/scripts/tests/test_agent_upgrade.py::test_check_status[False] PASSED                                                                                                                        [ 86%]
framework/scripts/tests/test_agent_upgrade.py::test_main PASSED                                                                                                                                       [ 93%]
framework/scripts/tests/test_agent_upgrade.py::test_main_ko PASSED                                                                                                                                    [100%]

============================================================================================= warnings summary ==============================================================================================
../../venv/3.9-unittest-env/lib/python3.9/site-packages/pytest_aiohttp/plugin.py:28
  /home/selu/venv/3.9-unittest-env/lib/python3.9/site-packages/pytest_aiohttp/plugin.py:28: DeprecationWarning: The 'asyncio_mode' is 'legacy', switching to 'auto' for the sake of pytest-aiohttp backward compatibility. Please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
    config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

----------- coverage: platform linux, python 3.9.5-final-0 -----------
Name                                            Stmts   Miss  Cover
-------------------------------------------------------------------
[...]
framework/scripts/agent_upgrade.py                115      6    95%
[...]


======================================================================================= 15 passed, 1 warning in 1.42s =======================================================================================
```
