### PR TITLE
[Agent-groups] Change log order to avoid race condition

### DIFF
--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -701,8 +701,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
 
         logger.info("Requested entire agent-groups information by the worker node. Starting.")
         start_time = get_utc_now().timestamp()
+        logger.info("Sending all agent-groups information from the master node database.")
         await sync_object.sync(start_time=start_time, chunks=local_agent_groups_information)
-        logger.info("Sent all agent-groups information from the master node database.")
 
         return b'ok', b'Sent'
 

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -1031,7 +1031,7 @@ async def test_manager_handler_send_entire_agent_groups_information(WazuhDBConne
     with patch('wazuh.core.cluster.master.c_common.SyncWazuhdb', SyncWazuhdbMock):
         assert await master_handler.send_entire_agent_groups_information() == (b'ok', b'Sent')
     assert 'Requested entire agent-groups information by the worker node. Starting.' in logger._info
-    assert 'Sent all agent-groups information from the master node database.' in logger._info
+    assert 'Sending all agent-groups information from the master node database.' in logger._info
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

<!--
Add a clear description of how the problem has been solved.
-->

In this PR we changed the order of the agent-groups related information submission log. The change is because of the asynchrony of the agent-groups task code, it is possible that the task completion log appears before the task submission log. The condition occurs as a result of this code fragment:

```
logger.info("Requested entire agent-groups information by the worker node. Starting.")
start_time = get_utc_now().timestamp()
await sync_object.sync(start_time=start_time, chunks=local_agent_groups_information)
logger.info("Sent all agent-groups information from the master node database.")
```

This fragment is inside the task of sending agent-groups to the worker nodes. Once we reach the await of the sync, the request is sent to the worker and it is possible that this one responds before the log `Sent all agent-groups information from the master node database.` is printed due to the position in the queue of asyncio events.

To solve this bug we have chosen to change the order of the log as follows:

```
logger.info("Requested entire agent-groups information by the worker node. Starting.")
start_time = get_utc_now().timestamp()
logger.info("Sending all agent-groups information from the master node database.")
await sync_object.sync(start_time=start_time, chunks=local_agent_groups_information)
```

This way, we guarantee the order of the sending and receiving logs.