### PR TITLE
Unescape value name properly in state message.

### DIFF
--- a/src/syscheckd/src/db/src/db.cpp
+++ b/src/syscheckd/src/db/src/db.cpp
@@ -184,9 +184,9 @@ void fim_db_init(int storage,
                         if (type == REG_VALUE)
                         {
                             const auto registryType { json.at("data").at("attributes").at("value_type").get<uint32_t>() };
-                            std::string value_name = keyValue.second;
-                            Utils::replaceAll(value_name, "\\:", ":");
-                            json["data"]["value_name"] = value_name;
+                            auto valueName { keyValue.second };
+                            Utils::replaceAll(valueName, "\\:", ":");
+                            json["data"]["value_name"] = valueName;
                             json["data"]["attributes"]["value_type"] = RegistryTypes<OS_TYPE>::typeText(registryType);
                             json["data"]["attributes"]["type"] = "registry_value";
                         }

--- a/src/syscheckd/src/db/src/db.cpp
+++ b/src/syscheckd/src/db/src/db.cpp
@@ -184,7 +184,9 @@ void fim_db_init(int storage,
                         if (type == REG_VALUE)
                         {
                             const auto registryType { json.at("data").at("attributes").at("value_type").get<uint32_t>() };
-                            json["data"]["value_name"] = keyValue.second;
+                            std::string value_name = keyValue.second;
+                            Utils::replaceAll(value_name, "\\:", ":");
+                            json["data"]["value_name"] = value_name;
                             json["data"]["attributes"]["value_type"] = RegistryTypes<OS_TYPE>::typeText(registryType);
                             json["data"]["attributes"]["type"] = "registry_value";
                         }


### PR DESCRIPTION
|Related issue|
|---|
|#12845|

## Description
Hi team!

This PR aims to properly escape the value name field in order to avoid the problem described in #12845 
Closes #12845  
## Configuration options
```xml
  <syscheck>
    <disabled>no</disabled>
    <frequency>10000</frequency>
    <windows_registry arch="64bit">HKEY_LOCAL_MACHINE\SOFTWARE\random_key</windows_registry>
    <synchronization>
	<interval>10</interval>
	<max_interval>20</max_interval>
	</synchronization>
  </syscheck>
```
<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example
### Creating value `:value:1`
```json
{
    "component": "fim_registry",
    "data": {
        "arch": "[x64]",
        "attributes": {
            "checksum": "4ca7b88b201728c31afb691707c41d35a984317d",
            "hash_md5": "d41d8cd98f00b204e9800998ecf8427e",
            "hash_sha1": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
            "hash_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
            "size": 1,
            "type": "registry_value",
            "value_type": "REG_SZ"
        },
        "index": "HKEY_LOCAL_MACHINE\\SOFTWARE\\random_key\\:subkey1",
        "timestamp": 1648463996,
        "value_name": ":value:1",
        "version": 2
    },
    "type": "state"
}
```
### Creating :value1
```json
{
    "component": "fim_registry",
    "data": {
        "arch": "[x64]",
        "attributes": {
            "checksum": "4ca7b88b201728c31afb691707c41d35a984317d",
            "hash_md5": "d41d8cd98f00b204e9800998ecf8427e",
            "hash_sha1": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
            "hash_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
            "size": 1,
            "type": "registry_value",
            "value_type": "REG_SZ"
        },
        "index": "HKEY_LOCAL_MACHINE\\SOFTWARE\\random_key\\:subkey1",
        "timestamp": 1648463996,
        "value_name": ":value1",
        "version": 2
    },
    "type": "state"
}
```
### Manager database
```
oot@ubuntumanager:/home/vagrant# sqlite3 /var/ossec/queue/db/009.db "select full_path,file,value_name,checksum,size from fim_entry";
[x64] HKEY_LOCAL_MACHINE\\SOFTWARE\\random_key|HKEY_LOCAL_MACHINE\SOFTWARE\random_key||3ad6e03f1197ce4edf45e442afe3ce20acf8a870|
[x64] HKEY_LOCAL_MACHINE\\SOFTWARE\\random_key:|HKEY_LOCAL_MACHINE\SOFTWARE\random_key||8910ead8bddab2ff501940646def6eb267e62130|10
[x64] HKEY_LOCAL_MACHINE\\SOFTWARE\\random_key\\\:subkey1:\:value1|HKEY_LOCAL_MACHINE\SOFTWARE\random_key\:subkey1|:value1|4ca7b88b201728c31afb691707c41d35a984317d|1
[x64] HKEY_LOCAL_MACHINE\\SOFTWARE\\random_key\\\:subkey1|HKEY_LOCAL_MACHINE\SOFTWARE\random_key\:subkey1||525e7c00a18175a6aca91d60845f20812c50054a|
[x64] HKEY_LOCAL_MACHINE\\SOFTWARE\\random_key\\\:subkey1:\:value\:1|HKEY_LOCAL_MACHINE\SOFTWARE\random_key\:subkey1|:value:1|4ca7b88b201728c31afb691707c41d35a984317d|1

```
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
  - [ ] MAC OS X
- [X] Source installation
- [X] Source upgrade
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory