### PR TITLE
Add field count to WazuhDBQueryGroup class

### DIFF
--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -2467,6 +2467,20 @@ stages:
             reverse: true
       status_code: 200
 
+  - name: Sort by count
+    request:
+      verify: False
+      <<: *get_agents_groups
+      params:
+        sort: -count
+    response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "count"
+            reverse: true
+      status_code: 200
+
   - name: Try to show groups with wrong sort
     request:
       verify: False

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -190,6 +190,11 @@ class WazuhDBQueryGroup(WazuhDBQuery):
     def _add_select_to_query(self):
         pass
 
+    def _add_sort_to_query(self):
+        # Consider the option to sort by count
+        self.fields['count'] = 'count(id_group)'
+        super()._add_sort_to_query()
+
     def _add_search_to_query(self):
         super()._add_search_to_query()
         self.query = self.query.replace('WHERE  AND', 'WHERE')

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -372,6 +372,20 @@ def test_WazuhDBQueryGroupByAgents(mock_socket_conn, send_mock, filter_fields, e
     assert result['items'] == expected_response
 
 
+@pytest.mark.parametrize('expected_response', [
+    [{'name': 'group-2', 'count': 1}, {'name': 'group-1', 'count': 1}]
+])
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_WazuhDBQueryGroup(mock_socket_conn, send_mock, expected_response):
+    query_group = WazuhDBQueryGroup(offset=0, sort={"fields":["count"],"order":"desc"}, search=None, select=None, 
+                                    get_data=True, query='', filters=None, count=True, default_sort_field='name', 
+                                    min_select_fields=None, remove_extra_fields=True, rbac_negate=True)
+
+    query_data = query_group.run()
+    assert query_data['items'] == expected_response
+
+
 @patch('socket.socket.connect')
 def test_WazuhDBQueryMultigroups__init__(mock_socket_conn):
     """Tests if method __init__ of WazuhDBQueryMultigroups works properly."""

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -372,18 +372,14 @@ def test_WazuhDBQueryGroupByAgents(mock_socket_conn, send_mock, filter_fields, e
     assert result['items'] == expected_response
 
 
-@pytest.mark.parametrize('expected_response', [
-    [{'name': 'group-2', 'count': 1}, {'name': 'group-1', 'count': 1}]
-])
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
-def test_WazuhDBQueryGroup(mock_socket_conn, send_mock, expected_response):
-    query_group = WazuhDBQueryGroup(offset=0, sort={"fields":["count"],"order":"desc"}, search=None, select=None, 
-                                    get_data=True, query='', filters=None, count=True, default_sort_field='name', 
-                                    min_select_fields=None, remove_extra_fields=True, rbac_negate=True)
+def test_WazuhDBQueryGroup__add_sort_to_query(mock_socket_conn, send_mock):
+    """Tests if _add_sort_to_query method of WazuhDBQueryGroup works properly"""
+    query_group = WazuhDBQueryGroup()
+    query_group._add_sort_to_query()
 
-    query_data = query_group.run()
-    assert query_data['items'] == expected_response
+    assert 'count' in query_group.fields and query_group.fields['count'] == 'count(id_group)' 
 
 
 @patch('socket.socket.connect')


### PR DESCRIPTION
| Related issue |
|---|
|Closes #12432 |

# Description

In this PR we have enabled the sort option for the field count in /groups API method. 

# Tests performed 

Until now the sort option for the field count was not valid. The output was:

```
root@wazuh-master:/# curl -k -X GET "https://localhost:55000/groups?pretty=true&sort=count" -H  "Authorization: Bearer $TOKEN"
{"title": "Bad Request", "detail": "Not a valid sort field : Allowed sort fields: ['name']. Fields: count", "remediation": "Please, use only allowed sort fields", "dapi_errors": {"master-node": {"error": "Not a valid sort field : Allowed sort fields: ['name']. Fields: count"}}, "error": 1403}
```

After these changes we have the option to sort the groups of agents according to the field count.

```
root@wazuh-master:/# curl -k -X GET "https://localhost:55000/groups?pretty=true&sort=count" -H  "Authorization: Bearer $TOKEN"
{
   "data": {
      "affected_items": [
         {
            "name": "group3",
            "count": 4,
            "mergedSum": "ac734e0a17076b5594699a19915d178a",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00"
         },
         {
            "name": "group1",
            "count": 5,
            "mergedSum": "aae3aa7668cdd99c359389c3f8d459c0",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00"
         },
         {
            "name": "group2",
            "count": 5,
            "mergedSum": "530241bb258d1a0149d2a0d392bd8ae6",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00"
         },
         {
            "name": "default",
            "count": 10,
            "mergedSum": "4a8724b20dee0124ff9656783c490c4e",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00"
         }
      ],
      "total_affected_items": 4,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "All selected groups information was returned",
   "error": 0
}
```

As we can see, the sort order is ascending  which is the default order assigned in the API. If we want to see first the groups with more agents we can indicate the option `-` before `count` so that it is a descending order.

```
root@wazuh-master:/# curl -k -X GET "https://localhost:55000/groups?pretty=true&sort=-count" -H  "Authorization: Bearer $TOKEN"
{
   "data": {
      "affected_items": [
         {
            "name": "default",
            "count": 10,
            "mergedSum": "4a8724b20dee0124ff9656783c490c4e",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00"
         },
         {
            "name": "group2",
            "count": 5,
            "mergedSum": "530241bb258d1a0149d2a0d392bd8ae6",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00"
         },
         {
            "name": "group1",
            "count": 5,
            "mergedSum": "aae3aa7668cdd99c359389c3f8d459c0",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00"
         },
         {
            "name": "group3",
            "count": 4,
            "mergedSum": "ac734e0a17076b5594699a19915d178a",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00"
         }
      ],
      "total_affected_items": 4,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "All selected groups information was returned",
   "error": 0
}
```