### PR TITLE
Improve AWS integration's `decompress_file` error handling

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -864,7 +864,6 @@ class AWSBucket(WazuhIntegration):
             gzip_file = gzip.open(filename=raw_object, mode='rt')
             # Ensure that the file is not corrupted by reading from it
             gzip_file.read()
-            gzip_file.seek(0)
             return gzip_file
         except (gzip.BadGzipFile, zlib.error, TypeError):
             print(f'ERROR: invalid gzip file received.')

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -44,6 +44,7 @@ import gzip
 import zipfile
 import re
 import io
+import zlib.error
 from os import path
 import operator
 from datetime import datetime
@@ -845,22 +846,63 @@ class AWSBucket(WazuhIntegration):
 
         return event
 
-    def decompress_file(self, log_key):
-        def decompress_gzip(raw_object):
-            # decompress gzip file in text mode.
-            try:
-                # Python 3
-                return gzip.open(filename=raw_object, mode='rt')
-            except TypeError:
-                # Python 2
-                return gzip.GzipFile(fileobj=raw_object, mode='r')
+    def _decompress_gzip(self, raw_object: io.BytesIO):
+        """
+        Method that decompress gzip compressed data.
 
-        raw_object = io.BytesIO(self.client.get_object(Bucket=self.bucket, Key=log_key)['Body'].read())
-        if log_key[-3:] == '.gz':
-            return decompress_gzip(raw_object)
-        elif log_key[-4:] == '.zip':
+        Parameters
+        ----------
+        raw_object : io.BytesIO
+            Buffer with the gzip compressed object.
+
+        Returns
+        -------
+        file_object
+            Decompressed object.
+        """
+        try:
+            return gzip.open(filename=raw_object, mode='rt')
+        except (gzip.BadGZipFile, zlib.error):
+            print(f'ERROR: invalid gzip file received.')
+            if not self.skip_on_error:
+                sys.exit(8)
+
+    def _decompress_zip(self, raw_object: io.BytesIO):
+        """
+        Method that decompress zip compressed data.
+
+        Parameters
+        ----------
+        raw_object : io.BytesIO
+            Buffer with the zip compressed object.
+
+        Returns
+        -------
+        file_object
+            Decompressed object.
+        """
+        try:
             zipfile_object = zipfile.ZipFile(raw_object, compression=zipfile.ZIP_DEFLATED)
             return io.TextIOWrapper(zipfile_object.open(zipfile_object.namelist()[0]))
+        except zipfile.BadZipFile:
+            print('ERROR: invalid zip file received.')
+        if not self.skip_on_error:
+            sys.exit(8)
+
+    def decompress_file(self, log_key: str):
+        """
+        Method that returns a file stored in a bucket decompressing it if necessary.
+
+        Parameters
+        ----------
+        log_key : str
+            Name of the file that should be returned.
+        """
+        raw_object = io.BytesIO(self.client.get_object(Bucket=self.bucket, Key=log_key)['Body'].read())
+        if log_key[-3:] == '.gz':
+            return self._decompress_gzip(raw_object)
+        elif log_key[-4:] == '.zip':
+            return self._decompress_zip(raw_object)
         elif log_key[-7:] == '.snappy':
             print(f"ERROR: couldn't decompress the {log_key} file, snappy compression is not supported.")
             if not self.skip_on_error:

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -864,6 +864,7 @@ class AWSBucket(WazuhIntegration):
             gzip_file = gzip.open(filename=raw_object, mode='rt')
             # Ensure that the file is not corrupted by reading from it
             gzip_file.read()
+            gzip_file.seek(0)
             return gzip_file
         except (gzip.BadGzipFile, zlib.error, TypeError):
             print(f'ERROR: invalid gzip file received.')

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -44,7 +44,7 @@ import gzip
 import zipfile
 import re
 import io
-import zlib.error
+import zlib
 from os import path
 import operator
 from datetime import datetime
@@ -861,8 +861,12 @@ class AWSBucket(WazuhIntegration):
             Decompressed object.
         """
         try:
-            return gzip.open(filename=raw_object, mode='rt')
-        except (gzip.BadGZipFile, zlib.error):
+            gzip_file = gzip.open(filename=raw_object, mode='rt')
+            # Ensure that the file is not corrupted by reading from it
+            gzip_file.read()
+            gzip_file.seek(0)
+            return gzip_file
+        except (gzip.BadGzipFile, zlib.error, TypeError):
             print(f'ERROR: invalid gzip file received.')
             if not self.skip_on_error:
                 sys.exit(8)

--- a/wodles/aws/tests/conftest.py
+++ b/wodles/aws/tests/conftest.py
@@ -2,8 +2,10 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
+import os
 import sys
 import pytest
+import tempfile
 from unittest.mock import patch, MagicMock
 from copy import deepcopy
 
@@ -111,3 +113,20 @@ def aws_custom_bucket(request):
          patch('sqlite3.connect'), \
          patch('utils.get_wazuh_version'):
         return aws_s3.AWSCustomBucket(**{k: v for i in request.param for k, v in i.items()})   
+
+
+@pytest.fixture(params=['.gz', '.zip'])
+def bad_compressed_file(request):
+    """
+    Return an invalid zip or gzip file.
+
+    Parameters
+    request : pytest.fixtures.SubRequest
+        Object that contains information about the current test.
+    """
+    tmp_file = tempfile.NamedTemporaryFile(suffix=request.param)
+    tmp_file.write(os.urandom(512))
+
+    yield tmp_file
+
+    tmp_file.close()


### PR DESCRIPTION
|Related issue|
|---|
|Closes #12649|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
In this PR we start handling the exceptions that could be raised by the methods called by the `AWSBucket.decompress_file` method. We add an error message to indicate that the error was due to a corrupt file to avoid having json decoding errors that would be more difficult to debug.

We also remove a code snippet that referred to a Python2 use case, since the module only supports Python 3.6 onwards now.

### Unit tests
The unit tests pass without any problems:

```
(wazuh-unit) ➜  wodles git:(master) ✗ pytest 
==================================== test session starts ====================================
platform linux -- Python 3.10.4, pytest-6.2.5, py-1.11.0, pluggy-0.13.1
rootdir: /home/gonzz/git/wazuh/wodles
plugins: asyncio-0.15.1
collected 55 items                                                                          

aws/tests/test_aws.py ......................................                          [ 69%]
gcloud/tests/test_access_logs.py .                                                    [ 70%]
gcloud/tests/test_bucket.py ...                                                       [ 76%]
gcloud/tests/test_gcloud.py .....                                                     [ 85%]
gcloud/tests/test_integration.py .....                                                [ 94%]
gcloud/tests/test_subscriber.py ...                                                   [100%]

===================================== warnings summary ======================================
aws/aws_s3.py:538
  /home/gonzz/git/wazuh/wodles/aws/aws_s3.py:538: DeprecationWarning: invalid escape sequence '\d'
    self.prefix_regex= re.compile("^\d{12}$")

../../../venv/wazuh-unit/lib/python3.10/site-packages/google/pubsub_v1/services/publisher/client.py:17
  /home/gonzz/venv/wazuh-unit/lib/python3.10/site-packages/google/pubsub_v1/services/publisher/client.py:17: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
    from distutils import util

-- Docs: https://docs.pytest.org/en/stable/warnings.html
============================== 55 passed, 2 warnings in 0.49s ===============================
```

### Other tests
We uploaded three different files to the `wazuh-aws-wodle-cloudtrail` bucket, two one of them compressed using the supported compression algorithms and one in plain text to ensure that the module works as expected after the changes. Executing it shows the following output:

#### Test in a 4.4 manager
```
root@8895de820dd8:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -d2  -p dev 
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on 166157441623 - us-west-1
DEBUG: +++ Marker: AWSLogs/166157441623/CloudTrail/us-west-1/2022/03/30
DEBUG: ++ Found new log: AWSLogs/166157441623/CloudTrail/us-west-1/2022/03/30/166157441623_CloudTrail_us-west-1_20220330T0000Z_HASDoKlxgfdNInHa.json.gz
DEBUG: ++ Found new log: AWSLogs/166157441623/CloudTrail/us-west-1/2022/03/30/166157441623_CloudTrail_us-west-1_20220330T0000Z_HASDoKlxgfdNInHa.json.zip
DEBUG: ++ Found new log: AWSLogs/166157441623/CloudTrail/us-west-1/2022/03/30/166157441623_CloudTrail_us-west-1_20220330T0000Z_HASDoKlxgfdkdIOa.json.txt
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2022/03/30
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-west-1
DEBUG: +++ DB Maintenance
```
#### Test in a 4.4 agent with Python 3.6

```
[root@81223fab675c aws]# python3 ./aws-s3  -b wazuh-aws-wodle-cloudtrail -p dev -d 2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on 166157441623 - us-west-1
DEBUG: +++ Marker: AWSLogs/166157441623/CloudTrail/us-west-1/2022/03/30
DEBUG: ++ Found new log: AWSLogs/166157441623/CloudTrail/us-west-1/2022/03/30/166157441623_CloudTrail_us-west-1_20220330T0000Z_HASDoKlxgfdNInHa.json.gz
DEBUG: ++ Found new log: AWSLogs/166157441623/CloudTrail/us-west-1/2022/03/30/166157441623_CloudTrail_us-west-1_20220330T0000Z_HASDoKlxgfdNInHa.json.zip
DEBUG: ++ Found new log: AWSLogs/166157441623/CloudTrail/us-west-1/2022/03/30/166157441623_CloudTrail_us-west-1_20220330T0000Z_HASDoKlxgfdkdIOa.json.txt
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2022/03/30
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-west-1
DEBUG: +++ DB Maintenance
[root@81223fab675c aws]# python3 --version
Python 3.6.8
```
