### PR TITLE
Fix to process unknown registry value types in FIM sync

### DIFF
--- a/src/syscheckd/include/syscheck.h
+++ b/src/syscheckd/include/syscheck.h
@@ -112,6 +112,10 @@ typedef struct fim_txn_context_s {
 /* Flags to know if a directory/file's watcher has been removed */
 #define FIM_RT_HANDLE_CLOSED 0
 #define FIM_RT_HANDLE_OPEN 1
+
+/* Default value type for cases where type is undefined.
+   0x0000000C is the one after the last defined type, REG_QWORD (0x0000000B) */
+#define REG_UNKNOWN 0x0000000C
 #endif
 
 /* Win32 does not have lstat */

--- a/src/syscheckd/src/db/src/fimDBSpecializationWindows.cpp
+++ b/src/syscheckd/src/db/src/fimDBSpecializationWindows.cpp
@@ -14,6 +14,8 @@
 #include <windows.h>
 #include "encodingWindowsHelper.h"
 
+#define REG_UNKNOWN 0x0000000C
+
 const std::string WindowsSpecialization::registryTypeToText(const int type)
 {
     static const std::map<int, std::string> VALUE_TYPE =
@@ -29,7 +31,8 @@ const std::string WindowsSpecialization::registryTypeToText(const int type)
         { REG_RESOURCE_LIST, "REG_RESOURCE_LIST" },
         { REG_FULL_RESOURCE_DESCRIPTOR, "REG_FULL_RESOURCE_DESCRIPTOR" },
         { REG_RESOURCE_REQUIREMENTS_LIST, "REG_RESOURCE_REQUIREMENTS_LIST" },
-        { REG_QWORD, "REG_QWORD" }
+        { REG_QWORD, "REG_QWORD" },
+        { REG_UNKNOWN, "REG_UNKNOWN" }
     };
     return VALUE_TYPE.at(type);
 }
@@ -39,4 +42,3 @@ void WindowsSpecialization::encodeString(std::string& str)
 
     str = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(str);
 }
-

--- a/src/syscheckd/src/registry/events.c
+++ b/src/syscheckd/src/registry/events.c
@@ -28,6 +28,7 @@ static const char *VALUE_TYPE[] = {
     [REG_FULL_RESOURCE_DESCRIPTOR] = "REG_FULL_RESOURCE_DESCRIPTOR",
     [REG_RESOURCE_REQUIREMENTS_LIST] = "REG_RESOURCE_REQUIREMENTS_LIST",
     [REG_QWORD] = "REG_QWORD",
+    [REG_UNKNOWN] = "REG_UNKNOWN"
 };
 
 
@@ -171,7 +172,7 @@ cJSON *fim_registry_value_attributes_json(const cJSON* dbsync_event, const fim_r
     cJSON_AddStringToObject(attributes, "type", "registry_value");
 
     if (data) {
-        if (configuration->opts & CHECK_TYPE && data->type <= REG_QWORD) {
+        if (configuration->opts & CHECK_TYPE) {
             cJSON_AddStringToObject(attributes, "value_type", VALUE_TYPE[data->type]);
         }
 

--- a/src/syscheckd/src/registry/registry.c
+++ b/src/syscheckd/src/registry/registry.c
@@ -860,7 +860,7 @@ void fim_read_values(HKEY key_handle,
         }
 
         new.registry_entry.value->name = value_buffer;
-        new.registry_entry.value->type = data_type;
+        new.registry_entry.value->type = data_type <= REG_QWORD ? data_type : REG_UNKNOWN;
         new.registry_entry.value->size = data_size;
         new.registry_entry.value->last_event = time(NULL);
         new.registry_entry.value->scanned = 0;


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/12835|



## Description

This PR fixes the problem related to an unrecognized error that we were getting in the FIM synchronization. 
It was produced in the register sync, that after the investigation we have seen that it was due to some types of values that were not mapped. Added REG_UNKNOWN to value types.

Closes #12835

## Configuration options

    <windows_registry arch="64bit">HKEY_LOCAL_MACHINE\Security\SAM\Domains\Builtin\Aliases\Names\Duplicadores</windows_registry>


## Logs/Alerts example

`2022/02/26 20:13:16 wazuh-agent[4496] run_check.c:117 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"event","data":{"path":"HKEY_LOCAL_MACHINE\\Security\\SAM\\Domains\\Builtin\\Aliases\\Names\\Duplicadores","version":2,"mode":"scheduled","type":"modified","arch":"[x64]","value_name":"","timestamp":1645902796,"attributes":{"type":"registry_value","value_type":"REG_UNKNOWN","size":1,"hash_md5":"d3d9446802a44259755d38e6d163e820","hash_sha1":"b1d5781111d84f7b3fe45a0852e59758cd7a87e5","hash_sha256":"4a44dc15364204a80fe80e9039455cc1608281820fe2b24f1e5233ade6af1dd5","checksum":"d41d520aa518fdf21dc41330881660dc62c3f5a7"},"old_attributes":{"type":"registry_value","size":0,"value_type":"REG_UNKNOWN","hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},"changed_attributes":["size","md5","sha1","sha256"]}}`

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
- Memory tests for Windows
  - [ ] Scan-build report
