### PR TITLE
KVDB function helpers implementation

### DIFF
--- a/src/engine/source/builder/CMakeLists.txt
+++ b/src/engine/source/builder/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(builders OBJECT
     builders/opBuilderMap.cpp
     builders/opBuilderMapReference.cpp
     builders/opBuilderMapValue.cpp
+    builders/opBuilderKVDB.cpp
     builders/stageBuilderCheck.cpp
     builders/stageBuilderNormalize.cpp
     builders/stageBuilderOutputs.cpp

--- a/src/engine/source/builder/CMakeLists.txt
+++ b/src/engine/source/builder/CMakeLists.txt
@@ -52,4 +52,4 @@ target_include_directories(builders
 )
 
 #TODO do this better. Also, who 'owns' the rxcpp dep
-target_link_libraries(builders base hlp re2)
+target_link_libraries(builders base hlp kvdb re2)

--- a/src/engine/source/builder/builders/opBuilderKVDB.cpp
+++ b/src/engine/source/builder/builders/opBuilderKVDB.cpp
@@ -47,14 +47,14 @@ types::Lifter opBuilderKVDBExtract(const types::DocumentValue & def)
     // Get DB
     KVDBManager& kvdbManager = KVDBManager::get();
     KVDB& kvdb = kvdbManager.getDB(parametersArr[1]);
-    if (kvdb.getState() != KVDB::State::Open)
+    if (!kvdb.isReady())
     {
         auto msg = fmt::format("[{}] DB isn't available for usage", parametersArr[1]);
         throw std::runtime_error(std::move(msg));
     }
 
     // Get reference key
-    std::string key = std::move(parametersArr[2]);
+    std::string& key = parametersArr[2];
     bool isReference = false;
     if (key[0] == REFERENCE_ANCHOR) {
         key = json::formatJsonPath(key.substr(1));
@@ -136,7 +136,7 @@ types::Lifter opBuilderKVDBExistanceCheck(const types::DocumentValue & def, bool
 
     KVDBManager& kvdbManager = KVDBManager::get();
     KVDB& kvdb = kvdbManager.getDB(parametersArr[1]);
-    if (kvdb.getState() != KVDB::State::Open)
+    if (!kvdb.isReady())
     {
         auto msg = fmt::format("[{}] DB isn't available for usage", parametersArr[1]);
         throw std::runtime_error(std::move(msg));

--- a/src/engine/source/builder/builders/opBuilderKVDB.cpp
+++ b/src/engine/source/builder/builders/opBuilderKVDB.cpp
@@ -9,10 +9,7 @@
 
 #include "opBuilderKVDB.hpp"
 
-#include <algorithm>
-#include <optional>
 #include <string>
-#include <re2/re2.h>
 
 #include <fmt/format.h>
 #include <utils/stringUtils.hpp>
@@ -48,7 +45,7 @@ types::Lifter opBuilderKVDBExtract(const types::DocumentValue & def)
     }
 
     // Get DB
-    KVDBManager& kvdbManager = KVDBManager::getInstance();
+    KVDBManager& kvdbManager = KVDBManager::get();
     KVDB& kvdb = kvdbManager.getDB(parametersArr[1]);
     if (kvdb.getState() != KVDB::State::Open)
     {
@@ -137,7 +134,7 @@ types::Lifter opBuilderKVDBExistanceCheck(const types::DocumentValue & def, bool
         throw std::runtime_error("Invalid number of parameters for kvdb matching operator");
     }
 
-    KVDBManager& kvdbManager = KVDBManager::getInstance();
+    KVDBManager& kvdbManager = KVDBManager::get();
     KVDB& kvdb = kvdbManager.getDB(parametersArr[1]);
     if (kvdb.getState() != KVDB::State::Open)
     {
@@ -157,7 +154,7 @@ types::Lifter opBuilderKVDBExistanceCheck(const types::DocumentValue & def, bool
                 {
                     auto value = &e->get(key);
                     if (value && value->IsString()) {
-                        if (kvdb.exist(value->GetString())) {
+                        if (kvdb.hasKey(value->GetString())) {
                             found = true;
                         }
                     }

--- a/src/engine/source/builder/builders/opBuilderKVDB.cpp
+++ b/src/engine/source/builder/builders/opBuilderKVDB.cpp
@@ -1,0 +1,135 @@
+/* Copyright (C) 2015-2022, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <algorithm>
+#include <optional>
+#include <string>
+#include <re2/re2.h>
+
+#include "opBuilderKVDB.hpp"
+#include "syntax.hpp"
+#include "stringUtils.hpp"
+
+namespace builder::internals::builders
+{
+
+using builder::internals::syntax::REFERENCE_ANCHOR;
+
+// <field>: +kvdb_extract/<DB>/<ref_key>
+types::Lifter opBuilderKVDBExtract(const types::DocumentValue & def)
+{
+    // Get target of the extraction
+    std::string target {def.MemberBegin()->name.GetString()};
+
+    // Get the raw value of parameter
+    if (!def.MemberBegin()->value.IsString())
+    {
+        throw std::runtime_error(
+            "Invalid parameter type for kvdb extracting operator (str expected)");
+    }
+
+    // Parse parameters
+    std::string params {def.MemberBegin()->value.GetString()};
+    auto parametersArr {utils::string::split(params, '/')};
+    if (parametersArr.size() < 2 || parametersArr.size() > 3)
+    {
+        throw std::runtime_error("Invalid number of parameters for kvdb extracting operator");
+    }
+    std::string db = std::move(parametersArr[1]);
+    std::string key = std::move(parametersArr[2]);
+    bool is_reference = false;
+    if (key[0] == REFERENCE_ANCHOR) {
+        key = key.substr(1); //TODO We can define a type "reference" with a tuple or a struct with this two values.
+        is_reference = true;
+    }
+
+    // Return Lifter
+    return [target, db, key, is_reference](types::Observable o)
+    {
+        // Append rxcpp operation
+        return o.map(
+            [=](types::Event e)
+            {
+                std::string_view db_key;
+                if (is_reference){
+                    auto value = e.get(key);//TODO: Is this handling multilevel json?? I don´t think so...
+                    if (value && value->IsString()){
+                        db_key = value->GetString();
+                    }
+                    else {
+                        //TODO error
+                        return e;
+                    }
+                }
+                else {
+                    db_key = key;
+                }
+                std::string DUMMY = db+key;
+                auto v = rapidjson::Value(DUMMY.c_str(), e.m_doc.GetAllocator());
+                e.set(target, v);
+                return e;
+            });
+    };
+}
+
+types::Lifter opBuilderKVDBExistanceCheck(const types::DocumentValue & def, bool check_exist)
+{
+    // Get key of the match
+    std::string key {def.MemberBegin()->name.GetString()};
+
+    // Get the raw value of parameter
+    if (!def.MemberBegin()->value.IsString())
+    {
+        throw std::runtime_error(
+            "Invalid parameter type for kvdb matching operator (str expected)");
+    }
+
+    // Parse parameters
+    std::string params {def.MemberBegin()->value.GetString()};
+    auto parametersArr {utils::string::split(params, '/')};
+    if (parametersArr.size() != 2)
+    {
+        throw std::runtime_error("Invalid number of parameters for kvdb matching operator");
+    }
+    std::string db = std::move(parametersArr[1]);
+
+    // Return Lifter
+    return [db, key, check_exist](types::Observable o)
+    {
+        // Append rxcpp operations
+        return o.filter(
+            [=](types::Event e)
+            {
+                auto value = e.get("/" + key);
+                bool found;
+                if (value && value->IsString()) {
+                    // Call KVDB
+                    found = true;
+                }
+                else {
+                    //TODO error
+                    found = false;
+                }
+                return check_exist ? found : !found;
+            });
+    };
+}
+
+// <field>: +kvdb_match/<DB>
+types::Lifter opBuilderKVDBMatch(const types::DocumentValue & def) {
+    return opBuilderKVDBExistanceCheck(def, true);
+}
+
+// <field>: +kvdb_not_match/<DB>
+types::Lifter opBuilderKVDBNotMatch(const types::DocumentValue & def) {
+    return opBuilderKVDBExistanceCheck(def, false);
+}
+
+
+} // namespace builder::internals::builders

--- a/src/engine/source/builder/builders/opBuilderKVDB.hpp
+++ b/src/engine/source/builder/builders/opBuilderKVDB.hpp
@@ -15,8 +15,28 @@
 namespace builder::internals::builders
 {
 
+/**
+ * @brief Builds KVDB extract function helper
+ *
+ * @param def
+ * @return types::Lifter
+ */
 types::Lifter opBuilderKVDBExtract(const types::DocumentValue & def);
+
+/**
+ * @brief Builds KVDB match function helper
+ *
+ * @param def
+ * @return types::Lifter
+ */
 types::Lifter opBuilderKVDBMatch(const types::DocumentValue & def);
+
+/**
+ * @brief Builds KVDB not-match function helper
+ *
+ * @param def
+ * @return types::Lifter
+ */
 types::Lifter opBuilderKVDBNotMatch(const types::DocumentValue & def);
 
 }

--- a/src/engine/source/builder/builders/opBuilderKVDB.hpp
+++ b/src/engine/source/builder/builders/opBuilderKVDB.hpp
@@ -1,0 +1,26 @@
+/* Copyright (C) 2015-2021, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _OP_BUILDER_KVDB_H
+#define _OP_BUILDER_KVDB_H
+
+#include "builderTypes.hpp"
+
+namespace builder::internals::builders
+{
+
+types::Lifter opBuilderKVDBExtract(const types::DocumentValue & def);
+types::Lifter opBuilderKVDBMatch(const types::DocumentValue & def);
+types::Lifter opBuilderKVDBNotMatch(const types::DocumentValue & def);
+
+}
+
+// namespace builder::internals::builders
+
+#endif // _OP_BUILDER_MAP_H

--- a/src/engine/source/builder/register.hpp
+++ b/src/engine/source/builder/register.hpp
@@ -29,6 +29,7 @@
 #include <builders/opBuilderMap.hpp>
 #include <builders/opBuilderMapReference.hpp>
 #include <builders/opBuilderMapValue.hpp>
+#include <builders/opBuilderKVDB.hpp>
 #include <builders/stageBuilderCheck.hpp>
 #include <builders/stageBuilderNormalize.hpp>
 #include <builders/stageBuilderOutputs.hpp>
@@ -72,6 +73,10 @@ void registerBuilders()
     Registry::registerBuilder("helper.r_not_match", builders::opBuilderHelperRegexNotMatch);
     Registry::registerBuilder("helper.r_ext", builders::opBuilderHelperRegexExtract);
     Registry::registerBuilder("helper.ip_cidr", builders::opBuilderHelperIPCIDR);
+    // KVDB Helpers
+    Registry::registerBuilder("helper.kvdb_extract", builders::opBuilderKVDBExtract);
+    Registry::registerBuilder("helper.kvdb_match", builders::opBuilderKVDBMatch);
+    Registry::registerBuilder("helper.kvdb_notmatch", builders::opBuilderKVDBNotMatch);
     // Combinators
     Registry::registerBuilder("combinator.chain", builders::combinatorBuilderChain);
     Registry::registerBuilder("combinator.broadcast", builders::combinatorBuilderBroadcast);

--- a/src/engine/source/kvdb/include/kvdb/kvdb.hpp
+++ b/src/engine/source/kvdb/include/kvdb/kvdb.hpp
@@ -36,6 +36,8 @@ public:
         return m_state;
     }
 
+    bool isReady();
+
     bool createColumn(const std::string &columnName);
 
     // TODO: all the default column names should be changed, one option is to

--- a/src/engine/source/kvdb/include/kvdb/kvdbManager.hpp
+++ b/src/engine/source/kvdb/include/kvdb/kvdbManager.hpp
@@ -26,7 +26,7 @@ public:
     }
     KVDBManager(KVDBManager const &) = delete;
     void operator=(KVDBManager const &) = delete;
-    KVDB &createDB(const std::string &Name, bool overwrite = true);
+    bool createDBfromCDB(const std::filesystem::path& path, bool replace = true);
     bool createDBfromCDB(const std::filesystem::path &path,
                          bool overwrite = true);
     bool deleteDB(const std::string &name);

--- a/src/engine/source/kvdb/include/kvdb/kvdbManager.hpp
+++ b/src/engine/source/kvdb/include/kvdb/kvdbManager.hpp
@@ -26,7 +26,7 @@ public:
     }
     KVDBManager(KVDBManager const &) = delete;
     void operator=(KVDBManager const &) = delete;
-    bool createDBfromCDB(const std::filesystem::path& path, bool replace = true);
+    KVDB &createDB(const std::string &Name, bool overwrite = true);
     bool createDBfromCDB(const std::filesystem::path &path,
                          bool overwrite = true);
     bool deleteDB(const std::string &name);

--- a/src/engine/source/kvdb/src/kvdb.cpp
+++ b/src/engine/source/kvdb/src/kvdb.cpp
@@ -504,3 +504,13 @@ bool KVDB::readPinned(const std::string &key,
                     s.ToString());
     return false;
 }
+
+/**
+ * @brief Check if the DB is able to be used.
+ *
+ * @return true if the DB can be used
+ * @return false if the DB can´t be used
+ */
+bool KVDB::isReady() {
+    return (m_state == State::Open);
+}

--- a/src/engine/source/kvdb/src/kvdb.cpp
+++ b/src/engine/source/kvdb/src/kvdb.cpp
@@ -454,7 +454,8 @@ bool KVDB::writeToTransaction(
  */
 bool KVDB::hasKey(const std::string &key, const std::string &columnName)
 {
-    // TODO: this should be done with a pinnable read
+    //TODO: this should be done with a pinnable read
+    //TODO: We are returning False if we inserted a KEY VALUE like: "KEY",""
     std::string result = read(key, columnName);
     return !result.empty();
 }

--- a/src/engine/test/source/builder/CMakeLists.txt
+++ b/src/engine/test/source/builder/CMakeLists.txt
@@ -30,7 +30,7 @@ include_directories(
 )
 
 #TODO do this better
-link_libraries(gtest_main hlp builders)
+link_libraries(gtest_main hlp kvdb builders)
 
 ####################################################################################################
 # Builder targets
@@ -119,10 +119,8 @@ add_executable(outputTest
 gtest_discover_tests(outputTest)
 
 add_executable(opBuilderKVDBTest
-  ${BUILDER_ENGINE_SOURCE_DIR}/registry.cpp
-  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
-  ${ENGINE_SOURCE_DIR}/shared/ipUtils.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderKVDBExtract_test.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderKVDBMatch_test.cpp
-  ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderKVDB.cpp)
-gtest_discover_tests(opBuilderKVDBExtractTest)
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderKVDBNotMatch_test.cpp
+)
+gtest_discover_tests(opBuilderKVDBTest)

--- a/src/engine/test/source/builder/CMakeLists.txt
+++ b/src/engine/test/source/builder/CMakeLists.txt
@@ -116,5 +116,13 @@ add_executable(outputTest
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderFileOutput_test.cpp
   ${TEST_SOURCE_DIR}/builder/outputs/fileOutput_test.cpp
 )
-
 gtest_discover_tests(outputTest)
+
+add_executable(opBuilderKVDBTest
+  ${BUILDER_ENGINE_SOURCE_DIR}/registry.cpp
+  ${ENGINE_SOURCE_DIR}/shared/stringUtils.cpp
+  ${ENGINE_SOURCE_DIR}/shared/ipUtils.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderKVDBExtract_test.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderKVDBMatch_test.cpp
+  ${BUILDER_BUILDERS_ENGINE_SOURCE_DIR}/opBuilderKVDB.cpp)
+gtest_discover_tests(opBuilderKVDBExtractTest)

--- a/src/engine/test/source/builder/builders/opBuilderKVDBExtract_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderKVDBExtract_test.cpp
@@ -1,0 +1,25 @@
+/* Copyright (C) 2015-2022, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <vector>
+#include <gtest/gtest.h>
+#include "testUtils.hpp"
+#include "opBuilderKVDB.hpp"
+
+using namespace builder::internals::builders;
+
+// Build ok
+TEST(opBuilderKVDBExtract, Builds)
+{
+    Document doc{R"({
+        "map":
+            {"field2extract": "+kvdb_extract/DB/ref_key"}
+    })"};
+    ASSERT_NO_THROW(opBuilderKVDBExtract(*doc.get("/map")));
+}

--- a/src/engine/test/source/builder/builders/opBuilderKVDBExtract_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderKVDBExtract_test.cpp
@@ -8,18 +8,244 @@
  */
 
 #include <vector>
+
 #include <gtest/gtest.h>
+#include <kvdb/kvdbManager.hpp>
+
 #include "testUtils.hpp"
 #include "opBuilderKVDB.hpp"
 
 using namespace builder::internals::builders;
 
+namespace {
+class opBuilderKVDBExtractTest : public ::testing::Test {
+
+protected:
+    KVDBManager& kvdbManager = KVDBManager::getInstance();
+
+    opBuilderKVDBExtractTest() {
+    }
+
+    virtual ~opBuilderKVDBExtractTest() {
+    }
+
+    virtual void SetUp() {
+        kvdbManager.createDB("TEST_DB");
+    }
+
+    virtual void TearDown() {
+        kvdbManager.DeleteDB("TEST_DB");
+    }
+};
+
 // Build ok
-TEST(opBuilderKVDBExtract, Builds)
+TEST_F(opBuilderKVDBExtractTest, Builds)
 {
     Document doc{R"({
         "map":
-            {"field2extract": "+kvdb_extract/DB/ref_key"}
+            {"field2extract": "+kvdb_extract/TEST_DB/ref_key"}
     })"};
-    ASSERT_NO_THROW(opBuilderKVDBExtract(*doc.get("/map")));
+    ASSERT_NO_THROW(opBuilderKVDBExtract(doc.get("/map")));
 }
+
+// Build incorrect number of arguments
+TEST_F(opBuilderKVDBExtractTest, Builds_incorrect_number_of_arguments)
+{
+    Document doc{R"({
+        "check":
+            {"field2match": "+kvdb_extract/TEST_DB"}
+    })"};
+    ASSERT_THROW(opBuilderKVDBExtract(doc.get("/check")), std::runtime_error);
+}
+
+// Build invalid DB
+TEST_F(opBuilderKVDBExtractTest, Builds_incorrect_invalid_db)
+{
+    Document doc{R"({
+        "check":
+            {"field2match": "+kvdb_extract/INVALID_DB/ref_key"}
+    })"};
+    ASSERT_THROW(opBuilderKVDBExtract(doc.get("/check")), std::runtime_error);
+}
+
+// Static key
+TEST_F(opBuilderKVDBExtractTest, Static_key)
+{
+    KVDB& kvdb = kvdbManager.getDB("TEST_DB");
+    kvdb.write("KEY", "VALUE");
+
+    Document doc{R"({
+        "map":
+            {"field2extract": "+kvdb_extract/TEST_DB/KEY"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(std::make_shared<json::Document>(R"(
+                {"dummy_field": "qwe"}
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
+                {"dummy_field": "ASD123asd"}
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
+                {"dummy_field": "ASD"}
+            )"));
+            s.on_completed();
+        });
+
+    Lifter lift = opBuilderKVDBExtract(doc.get("/map"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 3);
+    ASSERT_STREQ(expected[0]->get("/field2extract").GetString(), "VALUE");
+    ASSERT_STREQ(expected[1]->get("/field2extract").GetString(), "VALUE");
+    ASSERT_STREQ(expected[2]->get("/field2extract").GetString(), "VALUE");
+}
+
+// Dynamic key
+TEST_F(opBuilderKVDBExtractTest, Dynamic)
+{
+    KVDB& kvdb = kvdbManager.getDB("TEST_DB");
+    kvdb.write("KEY", "VALUE");
+
+    Document doc{R"({
+        "map":
+            {"field2extract": "+kvdb_extract/TEST_DB/$key"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(std::make_shared<json::Document>(R"(
+                {"key": "KEY"}
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
+                {"inexistent_key": "KEY"}
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
+                {"invalid_string": 123}
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
+                {"invalid_key": "INVALID_KEY"}
+            )"));
+            s.on_completed();
+        });
+
+    Lifter lift = opBuilderKVDBExtract(doc.get("/map"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 4);
+    ASSERT_STREQ(expected[0]->get("/field2extract").GetString(), "VALUE");
+    ASSERT_FALSE(expected[1]->exists("/field2extract"));
+    ASSERT_FALSE(expected[2]->exists("/field2extract"));
+    ASSERT_FALSE(expected[3]->exists("/field2extract"));
+}
+
+// Multi level key
+TEST_F(opBuilderKVDBExtractTest, Multi_level_key)
+{
+    KVDB& kvdb = kvdbManager.getDB("TEST_DB");
+    kvdb.write("KEY", "VALUE");
+
+    Document doc{R"({
+        "map":
+            {"field2extract": "+kvdb_extract/TEST_DB/$a.b.key"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(std::make_shared<json::Document>(R"(
+                 {"a":{"b":{"key":"KEY"}}}
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
+                 {"a":{"b":{"inexistent_key":"KEY"}}}
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
+                 {"a":{"b":{"invalid_key":"INVALID_KEY"}}}
+            )"));
+            s.on_completed();
+        });
+
+    Lifter lift = opBuilderKVDBExtract(doc.get("/map"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 3);
+    ASSERT_STREQ(expected[0]->get("/field2extract").GetString(), "VALUE");
+    ASSERT_FALSE(expected[1]->exists("/field2extract"));
+    ASSERT_FALSE(expected[2]->exists("/field2extract"));
+}
+
+// Multi level target
+TEST_F(opBuilderKVDBExtractTest, Multi_level_target)
+{
+    KVDB& kvdb = kvdbManager.getDB("TEST_DB");
+    kvdb.write("KEY", "VALUE");
+
+    Document doc{R"({
+        "map":
+            {"a.b.field2extract": "+kvdb_extract/TEST_DB/KEY"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(std::make_shared<json::Document>(R"(
+                {"not_fieldToCreate": "qwe"}
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
+                {"not_fieldToCreate": "ASD123asd"}
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
+                {"not_fieldToCreate": "ASD"}
+            )"));
+            s.on_completed();
+        });
+
+    Lifter lift = opBuilderKVDBExtract(doc.get("/map"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 3);
+    ASSERT_STREQ(expected[0]->get("/a/b/field2extract").GetString(), "VALUE");
+    ASSERT_STREQ(expected[1]->get("/a/b/field2extract").GetString(), "VALUE");
+    ASSERT_STREQ(expected[2]->get("/a/b/field2extract").GetString(), "VALUE");
+}
+
+// Existent target
+TEST_F(opBuilderKVDBExtractTest, Existent_target)
+{
+    KVDB& kvdb = kvdbManager.getDB("TEST_DB");
+    kvdb.write("KEY", "VALUE");
+
+    Document doc{R"({
+        "map":
+            {"field2extract": "+kvdb_extract/TEST_DB/KEY"}
+    })"};
+
+    Observable input = observable<>::create<Event>(
+        [=](auto s)
+        {
+            s.on_next(std::make_shared<json::Document>(R"(
+                {"dummy_data": "dummy_value"}
+            )"));
+            s.on_next(std::make_shared<json::Document>(R"(
+                {"field2extract": "PRE_VALUE"}
+            )"));
+            s.on_completed();
+        });
+
+    Lifter lift = opBuilderKVDBExtract(doc.get("/map"));
+    Observable output = lift(input);
+    vector<Event> expected;
+    output.subscribe([&](Event e) { expected.push_back(e); });
+    ASSERT_EQ(expected.size(), 2);
+    ASSERT_STREQ(expected[0]->get("/field2extract").GetString(), "VALUE");
+    ASSERT_STREQ(expected[0]->get("/field2extract").GetString(), "VALUE");
+}
+
+} // namespace

--- a/src/engine/test/source/builder/builders/opBuilderKVDBExtract_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderKVDBExtract_test.cpp
@@ -21,7 +21,7 @@ namespace {
 class opBuilderKVDBExtractTest : public ::testing::Test {
 
 protected:
-    KVDBManager& kvdbManager = KVDBManager::getInstance();
+    KVDBManager& kvdbManager = KVDBManager::get();
 
     opBuilderKVDBExtractTest() {
     }
@@ -34,7 +34,7 @@ protected:
     }
 
     virtual void TearDown() {
-        kvdbManager.DeleteDB("TEST_DB");
+        kvdbManager.deleteDB("TEST_DB");
     }
 };
 

--- a/src/engine/test/source/builder/builders/opBuilderKVDBMatch_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderKVDBMatch_test.cpp
@@ -1,0 +1,34 @@
+/* Copyright (C) 2015-2022, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <vector>
+#include <gtest/gtest.h>
+#include "testUtils.hpp"
+#include "opBuilderKVDB.hpp"
+
+using namespace builder::internals::builders;
+
+// Build ok
+TEST(opBuilderKVDBMatch, Builds)
+{
+    Document doc{R"({
+        "check":
+            {"field2match": "+kvdb_match/DB"}
+    })"};
+    ASSERT_NO_THROW(opBuilderKVDBMatch(*doc.get("/check")));
+}
+
+TEST(opBuilderKVDBNotMatch, Builds)
+{
+    Document doc{R"({
+        "check":
+            {"field2match": "+kvdb_not_match/DB"}
+    })"};
+    ASSERT_NO_THROW(opBuilderKVDBNotMatch(*doc.get("/check")));
+}

--- a/src/engine/test/source/builder/builders/opBuilderKVDBMatch_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderKVDBMatch_test.cpp
@@ -21,7 +21,7 @@ namespace {
 class opBuilderKVDBMatchTest : public ::testing::Test {
 
 protected:
-    KVDBManager& kvdbManager = KVDBManager::getInstance();
+    KVDBManager& kvdbManager = KVDBManager::get();
 
     opBuilderKVDBMatchTest() {
     }
@@ -34,7 +34,7 @@ protected:
     }
 
     virtual void TearDown() {
-        kvdbManager.DeleteDB("TEST_DB");
+        kvdbManager.deleteDB("TEST_DB");
     }
 };
 

--- a/src/engine/test/source/builder/builders/opBuilderKVDBNotMatch_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderKVDBNotMatch_test.cpp
@@ -18,15 +18,15 @@
 using namespace builder::internals::builders;
 
 namespace {
-class opBuilderKVDBMatchTest : public ::testing::Test {
+class opBuilderKVDBNotMatchTest : public ::testing::Test {
 
 protected:
     KVDBManager& kvdbManager = KVDBManager::getInstance();
 
-    opBuilderKVDBMatchTest() {
+    opBuilderKVDBNotMatchTest() {
     }
 
-    virtual ~opBuilderKVDBMatchTest() {
+    virtual ~opBuilderKVDBNotMatchTest() {
     }
 
     virtual void SetUp() {
@@ -39,38 +39,39 @@ protected:
 };
 
 // Build ok
-TEST_F(opBuilderKVDBMatchTest, Builds)
+TEST_F(opBuilderKVDBNotMatchTest, Builds)
 {
     Document doc{R"({
         "check":
-            {"field2match": "+kvdb_match/TEST_DB"}
+            {"field2match": "+kvdb_not_match/TEST_DB"}
     })"};
-    ASSERT_NO_THROW(opBuilderKVDBMatch(doc.get("/check")));
+    ASSERT_NO_THROW(opBuilderKVDBNotMatch(doc.get("/check")));
 }
 
 // Build incorrect number of arguments
-TEST_F(opBuilderKVDBMatchTest, Builds_incorrect_number_of_arguments)
+TEST_F(opBuilderKVDBNotMatchTest, Builds_incorrect_number_of_arguments)
 {
     Document doc{R"({
         "check":
-            {"field2match": "+kvdb_match"}
+            {"field2match": "+kvdb_not_match"}
     })"};
-    ASSERT_THROW(opBuilderKVDBMatch(doc.get("/check")), std::runtime_error);
+    ASSERT_THROW(opBuilderKVDBNotMatch(doc.get("/check")), std::runtime_error);
 }
 
 // Build invalid DB
-TEST_F(opBuilderKVDBMatchTest, Builds_incorrect_invalid_db)
+TEST_F(opBuilderKVDBNotMatchTest, Builds_incorrect_invalid_db)
 {
     Document doc{R"({
         "check":
-            {"field2match": "+kvdb_match/INVALID_DB"}
+            {"field2match": "+kvdb_not_match/INVALID_DB"}
     })"};
-    ASSERT_THROW(opBuilderKVDBMatch(doc.get("/check")), std::runtime_error);
+    ASSERT_THROW(opBuilderKVDBNotMatch(doc.get("/check")), std::runtime_error);
 }
 
-// Single level
-TEST_F(opBuilderKVDBMatchTest, Single_level_target_ok)
+// Test ok: static values
+TEST_F(opBuilderKVDBNotMatchTest, Static_string_ok)
 {
+    // Set Up KVDB
     KVDB& kvdb = kvdbManager.getDB("TEST_DB");
     kvdb.write("KEY", "DUMMY"); // TODO: Remove DUMMY Use non-value overload
 
@@ -85,6 +86,9 @@ TEST_F(opBuilderKVDBMatchTest, Single_level_target_ok)
             s.on_next(std::make_shared<json::Document>(R"(
                 {"field2match":"KEY"}
             )"));
+            s.on_next(std::make_shared<json::Document>(R"(
+                {"field2match":"INEXISTENT_KEY"}
+            )"));
             // Other fields will be ignored
             s.on_next(std::make_shared<json::Document>(R"(
                 {"otherfield":"KEY"}
@@ -92,46 +96,50 @@ TEST_F(opBuilderKVDBMatchTest, Single_level_target_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderKVDBMatch(doc.get("/check"));
+    Lifter lift = opBuilderKVDBNotMatch(doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
 
-    ASSERT_EQ(expected.size(), 1);
-    ASSERT_STREQ(expected[0]->get("/field2match").GetString(), "KEY");
+    ASSERT_EQ(expected.size(), 2);
+    ASSERT_STREQ(expected[0]->get("/field2match").GetString(), "INEXISTENT_KEY");
+    ASSERT_STREQ(expected[1]->get("/otherfield").GetString(), "KEY");
 }
 
-// Multi level
-TEST_F(opBuilderKVDBMatchTest, Multilevel_target_ok)
+TEST_F(opBuilderKVDBNotMatchTest, Multilevel_target)
 {
     KVDB& kvdb = kvdbManager.getDB("TEST_DB");
     kvdb.write("KEY", "DUMMY"); // TODO: Remove DUMMY Use non-value overload
 
     Document doc{R"({
         "check":
-            {"a.b.field2match": "+kvdb_match/TEST_DB"}
+            {"a.b.field2match": "+kvdb_not_match/TEST_DB"}
     })"};
 
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
             s.on_next(std::make_shared<json::Document>(R"(
-                {"a":{"b":{"field2match":"KEY"}}}
+                {"a": {"b":{"field2match":"KEY"}}}
             )"));
-            // Other fields will be ignored
             s.on_next(std::make_shared<json::Document>(R"(
-                {"a":{"b":{"otherfield":"KEY"}}}
+                {"a": {"b":{"field2match":"INEXISTENT_KEY"}}}
+            )"));
+            // Other fields will continue
+            s.on_next(std::make_shared<json::Document>(R"(
+                {"a": {"b":{"otherfield":"KEY"}}}
             )"));
             s.on_completed();
         });
 
-    Lifter lift = opBuilderKVDBMatch(doc.get("/check"));
+    Lifter lift = opBuilderKVDBNotMatch(doc.get("/check"));
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
 
-    ASSERT_EQ(expected.size(), 1);
-    ASSERT_STREQ(expected[0]->get("/a/b/field2match").GetString(), "KEY");
+    ASSERT_EQ(expected.size(), 2);
+    ASSERT_STREQ(expected[0]->get("/a/b/field2match").GetString(), "INEXISTENT_KEY");
+    ASSERT_STREQ(expected[1]->get("/a/b/otherfield").GetString(), "KEY");
 }
 
 } // namespace

--- a/src/engine/test/source/builder/builders/opBuilderKVDBNotMatch_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderKVDBNotMatch_test.cpp
@@ -21,7 +21,7 @@ namespace {
 class opBuilderKVDBNotMatchTest : public ::testing::Test {
 
 protected:
-    KVDBManager& kvdbManager = KVDBManager::getInstance();
+    KVDBManager& kvdbManager = KVDBManager::get();
 
     opBuilderKVDBNotMatchTest() {
     }
@@ -34,7 +34,7 @@ protected:
     }
 
     virtual void TearDown() {
-        kvdbManager.DeleteDB("TEST_DB");
+        kvdbManager.deleteDB("TEST_DB");
     }
 };
 


### PR DESCRIPTION
|Related issue|
|---|
|#12629|

This PR adds three new function helpers to access KVDB:
- opBuilderKVDBExtract() to perform a mapping action. The Value obtained from the DB is appended to the event.
- opBuilderKVDBMatch() and opBuilderKVDBNotMatch() to perform a filtering action. If the field value is found (or not) in the DB, the event is allowed or blocked.
Also, this PR adds UT for the different usages cases of these Function Helpers