### PR TITLE
Add flag on libcurl compilation, to avoid link issues during the link…

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1113,7 +1113,7 @@ $(EXTERNAL_CURL)Makefile:
 else
 ifeq (${uname_S},Darwin)
 $(EXTERNAL_CURL)Makefile:
-	cd $(EXTERNAL_CURL) && ${LIBCURL_CFLAGS} ./configure ${LIBCURL_COMMON_CONFIGURE_FLAGS} --with-darwinssl
+	cd $(EXTERNAL_CURL) && ${LIBCURL_CFLAGS} ./configure ${LIBCURL_COMMON_CONFIGURE_FLAGS} --with-darwinssl --without-nghttp2 --without-rtmp
 else
 $(EXTERNAL_CURL)Makefile: $(OPENSSL_LIB)
 ifeq (${uname_S},Linux)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1113,7 +1113,7 @@ $(EXTERNAL_CURL)Makefile:
 else
 ifeq (${uname_S},Darwin)
 $(EXTERNAL_CURL)Makefile:
-	cd $(EXTERNAL_CURL) && ${LIBCURL_CFLAGS} ./configure ${LIBCURL_COMMON_CONFIGURE_FLAGS} --with-darwinssl --without-nghttp2 --without-rtmp
+	cd $(EXTERNAL_CURL) && ${LIBCURL_CFLAGS} ./configure ${LIBCURL_COMMON_CONFIGURE_FLAGS} --with-darwinssl --without-nghttp2
 else
 $(EXTERNAL_CURL)Makefile: $(OPENSSL_LIB)
 ifeq (${uname_S},Linux)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #13010 |

# Description
Currently, there's a problem during libwazuhext.dylib creation due to libcurl external dependency missing symbols related to nghttp2.

## Steps to reproduce
1- Clone wazuh/wazuh repo
2- Download agent dependencies, forcing to use only its sources `make EXTERNAL_SRC_ONLY=y  TARGET=agent deps -C src`
3- Complile the wazuh agent `make TARGET=agent -C src`
## Expected result
3- Wazuh agent was successfully built.
## Actual result
3- Wazuh agent compilation fails
![image](https://user-images.githubusercontent.com/1791430/161290458-7ff2c72e-2b62-433b-94b5-41e258398aea.png)
## RCA
This issue seems to be related to macOS BigSur/Monterey libnghttp2 default installed package, causing that libcurl `configure` step try to add it. This can avoid using `--without-nghttp2` parameter