### PR TITLE
Fixing posible vulnerability detector segmentation fault

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
@@ -119,6 +119,71 @@ void test_wdb_insert_vuln_cves_error_json(void **state)
     free_strarray(external_references);
 }
 
+void test_wdb_insert_vuln_cves_null_parameters(void **state)
+{
+    cJSON *ret = NULL;
+    int id = 1;
+    const char *name = NULL;
+    const char *version = NULL;
+    const char *architecture = NULL;
+    const char *cve = NULL;
+    const char* severity = NULL;
+    double cvss2_score = 0;
+    double cvss3_score = 0;
+    const char *reference = NULL;
+    const char *type = NULL;
+    const char *status = NULL;
+    char **external_references = NULL;
+    const char *condition = NULL;
+    const char *title = NULL;
+    const char *published = NULL;
+    const char *updated = NULL;
+    bool check_pkg_existence = false;
+
+    const char *json_str = NULL;
+
+    os_strdup("{}", json_str);
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+     // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "name");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "version");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "architecture");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "cve");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "cvss2_score");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
+    will_return(__wrap_cJSON_AddNumberToObject, NULL);
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "cvss3_score");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
+    will_return(__wrap_cJSON_AddNumberToObject, NULL);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "reference");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "type");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "status");
+    will_return(__wrap_cJSON_AddBoolToObject, (cJSON *)0);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "condition");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "title");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "published");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "updated");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+
+    // Calling Wazuh DB
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, (cJSON *)1);
+
+    //Cleaning  memory
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret = wdb_insert_vuln_cves(id, name, version, architecture, cve, severity, cvss2_score, cvss3_score, reference, type, status,
+                               external_references, condition, title, published, updated, check_pkg_existence, NULL);
+
+    assert_ptr_equal(1, ret);
+}
+
 void test_wdb_insert_vuln_cves_error_sql_execution(void **state)
 {
     cJSON *ret = NULL;
@@ -1340,6 +1405,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_get_sys_osinfo_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         /* Tests wdb_insert_vuln_cves*/
         cmocka_unit_test_setup_teardown(test_wdb_insert_vuln_cves_error_json, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_insert_vuln_cves_null_parameters, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_insert_vuln_cves_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_insert_vuln_cves_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         /* Tests wdb_update_vuln_cves_status*/

--- a/src/wazuh_db/helpers/wdb_agents_helpers.c
+++ b/src/wazuh_db/helpers/wdb_agents_helpers.c
@@ -138,24 +138,26 @@ cJSON* wdb_insert_vuln_cves(int id,
     cJSON_AddBoolToObject(data_in, "check_pkg_existence", check_pkg_existence);
 
     // Limiting references just in case there are too many or the links are too long
-    char* str_cvs_references = NULL;
-    os_calloc(WDB_MAX_QUERY_SIZE, sizeof(char), str_cvs_references);
-    cJSON *j_cvs_references = cJSON_CreateArray();
-    int refcount;
-    for (refcount = 0; external_references[refcount]; ++refcount)
-    {
-        cJSON *j_ref_item = cJSON_CreateString(external_references[refcount]);
-        cJSON_AddItemToArray(j_cvs_references, j_ref_item);
+    if (external_references) {
+        char* str_cvs_references = NULL;
+        os_calloc(WDB_MAX_QUERY_SIZE, sizeof(char), str_cvs_references);
+        cJSON *j_cvs_references = cJSON_CreateArray();
+        int refcount;
+        for (refcount = 0; external_references[refcount]; ++refcount)
+        {
+            cJSON *j_ref_item = cJSON_CreateString(external_references[refcount]);
+            cJSON_AddItemToArray(j_cvs_references, j_ref_item);
 
-        cJSON_PrintPreallocated(j_cvs_references, str_cvs_references, WDB_MAX_QUERY_SIZE, FALSE);
-        if (strlen(str_cvs_references) >= VULN_CVES_MAX_REFERENCES) {
-            cJSON_DeleteItemFromArray(j_cvs_references, refcount);
-            mdebug2("External references truncated before inserting in inventory.");
-            break;
+            cJSON_PrintPreallocated(j_cvs_references, str_cvs_references, WDB_MAX_QUERY_SIZE, FALSE);
+            if (strlen(str_cvs_references) >= VULN_CVES_MAX_REFERENCES) {
+                cJSON_DeleteItemFromArray(j_cvs_references, refcount);
+                mdebug2("External references truncated before inserting in inventory.");
+                break;
+            }
         }
+        cJSON_AddItemToObject(data_in, "external_references", j_cvs_references);
+        os_free(str_cvs_references);
     }
-    cJSON_AddItemToObject(data_in, "external_references", j_cvs_references);
-    os_free(str_cvs_references);
 
     data_in_str = cJSON_PrintUnformatted(data_in);
     os_malloc(WDB_MAX_QUERY_SIZE, wdbquery);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5244,6 +5244,7 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
         j_field = cJSON_GetObjectItem(j_agent_info->child, "node_name");
         if(cJSON_IsString(j_field) && j_field->valuestring != NULL) {
             if (0 != strcmp(j_field->valuestring, vuldet->node_name)) {
+                mtdebug1(WM_VULNDETECTOR_LOGTAG, "Skipping agent '%.3d' because it reports to node '%s' and the current node is '%s'.", id, j_field->valuestring, vuldet->node_name);
                 goto next;
             }
         }


### PR DESCRIPTION
|Related issue|
|---|
|#12921|


## Description

This PR prevents a possible segmentation fault in the Vulnerability Detector module in case the `wdb_insert_vuln_cves()` helper is called to insert a vulnerability in the alerts inventory without any references. 
Also, an UT is added to cover this situation and a new debug message to help further debugging similar situations.



## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report

- [x] Added unit tests (for new features)
