### PR TITLE
Get agents information outside collect agents method

### DIFF
--- a/src/wazuh_db/helpers/wdb_global_helpers.c
+++ b/src/wazuh_db/helpers/wdb_global_helpers.c
@@ -1094,8 +1094,7 @@ int* wdb_get_agents_by_connection_status(const char* connection_status, int *soc
         snprintf(wdbquery, sizeof(wdbquery), global_db_commands[WDB_GET_AGENTS_BY_CONNECTION_STATUS], last_id, connection_status);
         if (wdbc_query_ex(sock?sock:&aux_sock, wdbquery, wdboutput, sizeof(wdboutput)) == 0) {
             status = wdb_parse_chunk_to_int(wdboutput, &array, "id", &last_id, &len);
-        }
-        else {
+        } else {
             status = WDBC_ERROR;
         }
     }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -197,13 +197,24 @@ STATIC vu_feed wm_vuldet_set_allowed_feed(const char *os_name, const char *os_ve
 time_t wm_vuldet_get_last_feed_update(vu_feed feed);
 
 /**
- * @brief Initialize the main structure(linked list) of all Syscollector agents
- * for later analysis.
+ * @brief Initialize the main structure linked list of agents for later analysis.
  *
- * @param vuldet The vulnearibility detector main data structure.
+ * @param vuldet The vulnerability detector main data structure.
+ * @param scan_by_interval Flag if set, specifies that only connected agents will be collected.
  * @return 0 on success, -1 otherwise.
  */
-STATIC int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet);
+STATIC int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet, bool scan_by_interval);
+
+/**
+ * @brief Collects information from a given agent ID.
+ *
+ * @param agent_id Agent identifier.
+ * @param vuldet The vulnerability detector main data structure.
+ * @param agents The agent main data structure.
+ * @param sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
+ * @return 0 on success, -1 otherwise.
+ */
+STATIC int wm_vuldet_collect_agent_info(int agent_id, wm_vuldet_t *vuldet, scan_agent *agents, int *sock);
 
 /**
  * @brief Compare two packages structures (src_name, bin_name, version and arch).
@@ -5175,7 +5186,337 @@ void *wm_vuldet_main(wm_vuldet_t * vuldet) {
     return NULL;
 }
 
-int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
+int wm_vuldet_collect_agent_info(int agent_id, wm_vuldet_t *vuldet, scan_agent *agents, int *sock) {
+    cJSON *j_agent_info = NULL;
+    cJSON *j_osinfo = NULL;
+    cJSON *j_field = NULL;
+    vu_feed agent_dist_ver = -1;
+    vu_feed agent_dist = -1;
+    bool is_centos = FALSE;
+    int dist_error = -1;
+    bool is_rolling = FALSE;
+    w_err_t ret = OS_SUCCESS;
+
+    // Getting agent-info data from global.db.
+    j_agent_info = wdb_get_agent_info(agent_id, sock);
+    if (!j_agent_info) {
+        mdebug1("Failed to get agent '%.3d' information from Wazuh DB.", agent_id);
+        ret = OS_INVALID;
+        goto next;
+    }
+
+    j_field = cJSON_GetObjectItem(j_agent_info->child, "node_name");
+    if(cJSON_IsString(j_field) && j_field->valuestring != NULL) {
+        if (0 != strcmp(j_field->valuestring, vuldet->node_name)) {
+            ret = OS_INVALID;
+            goto next;
+        }
+    }
+
+    j_field = cJSON_GetObjectItem(j_agent_info->child, "os_name");
+    char *agti_os_name = NULL;
+    if(cJSON_IsString(j_field) && j_field->valuestring != NULL) {
+        agti_os_name = j_field->valuestring;
+    }
+
+    j_field = cJSON_GetObjectItem(j_agent_info->child, "os_major");
+    char *agti_os_major = NULL;
+    if(cJSON_IsString(j_field) && j_field->valuestring != NULL) {
+        agti_os_major = j_field->valuestring;
+    }
+
+    j_field = cJSON_GetObjectItem(j_agent_info->child, "name");
+    char *agti_name = NULL;
+    if(cJSON_IsString(j_field) && j_field->valuestring != NULL) {
+        agti_name = j_field->valuestring;
+    }
+
+    j_field = cJSON_GetObjectItem(j_agent_info->child, "os_build");
+    int agti_build = 0;
+    if(cJSON_IsNumber(j_field)){
+        agti_build = j_field->valueint;
+    }
+
+    j_field = cJSON_GetObjectItem(j_agent_info->child, "version");
+    char *agti_version = NULL;
+    if (cJSON_IsString(j_field) && j_field->valuestring != NULL) {
+        agti_version = j_field->valuestring;
+    }
+
+    j_field = cJSON_GetObjectItem(j_agent_info->child, "os_platform");
+    char *agti_os_platform = NULL;
+    if (cJSON_IsString(j_field) && j_field->valuestring != NULL) {
+        agti_os_platform = j_field->valuestring;
+    }
+
+    if (!agti_os_name) {
+        if (agti_name) {
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_NEVER_CON, agti_name);
+        }
+        ret = OS_INVALID;
+        goto next;
+    } else if (!agti_os_platform) {
+        mtdebug1(WM_VULNDETECTOR_LOGTAG, "Failed to read platform from agent '%.3d'", agent_id);
+        ret = OS_INVALID;
+        goto next;
+    } else if (!agti_os_major) {
+        int rolling_distros_len = array_size(vu_os_platform_rolling_distros);
+        for (int distro_it = 0; distro_it < rolling_distros_len; ++distro_it) {
+            if (!strcmp(agti_os_platform, vu_os_platform_rolling_distros[distro_it])) {
+                is_rolling = TRUE;
+            }
+        }
+        if (!is_rolling) {
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UNS_OS_VERSION, agent_id, agti_name?agti_name:"");
+            ret = OS_INVALID;
+            goto next;
+        } else {
+            agti_os_major = "";
+        }
+    }
+
+    if (strcasestr(agti_os_name, vu_feed_ext[FEED_UBUNTU])) {
+        if (strstr(agti_os_major, "20")) {
+            agent_dist_ver = FEED_FOCAL;
+        } else if (strstr(agti_os_major, "18")) {
+            agent_dist_ver = FEED_BIONIC;
+        } else if (strstr(agti_os_major, "16")) {
+            agent_dist_ver = FEED_XENIAL;
+        } else if (strstr(agti_os_major, "14")) {
+            agent_dist_ver = FEED_TRUSTY;
+        } else {
+            dist_error = FEED_UBUNTU;
+        }
+        agent_dist = FEED_UBUNTU;
+    } else if (strcasestr(agti_os_name, vu_feed_ext[FEED_DEBIAN])) {
+        if (strstr(agti_os_major, "9")) {
+            agent_dist_ver = FEED_STRETCH;
+        } else if (strstr(agti_os_major, "10")) {
+            agent_dist_ver = FEED_BUSTER;
+        } else if (strstr(agti_os_major, "11")) {
+            agent_dist_ver = FEED_BULLSEYE;
+        } else {
+            dist_error = FEED_DEBIAN;
+        }
+        agent_dist = FEED_DEBIAN;
+    }  else if (strcasestr(agti_os_name, vu_feed_ext[FEED_REDHAT])) {
+        if (strstr(agti_os_major, "8")) {
+            agent_dist_ver = FEED_RHEL8;
+        } else if (strstr(agti_os_major, "7")) {
+            agent_dist_ver = FEED_RHEL7;
+        } else if (strstr(agti_os_major, "6")) {
+            agent_dist_ver = FEED_RHEL6;
+        } else if (strstr(agti_os_major, "5")) {
+            agent_dist_ver = FEED_RHEL5;
+        } else {
+            dist_error = FEED_REDHAT;
+        }
+        agent_dist = FEED_REDHAT;
+    } else if (strcasestr(agti_os_name, vu_feed_ext[FEED_ALAS])) {
+    /*
+    * The versioning and naming standards differ in both Amazon Linux and Amazon Linux 2 systems. Currently, the
+    * most reliable sources to determine the exact distribution of Amazon Linux are the @os_major field for
+    * Amazon Linux 2 systems (always "2"), and the @os_name field for Amazon Linux 1 (always "Amazon Linux AMI").
+    * This behavior should be reconsidered when new Amazon Linux distributions are released.
+    */
+        if (!strcmp(agti_os_major, "2")) {
+            agent_dist_ver = FEED_ALAS2;
+        } else if (strstr(agti_os_name, "AMI")) {
+            agent_dist_ver = FEED_ALAS1;
+        } else {
+            dist_error = FEED_ALAS;
+        }
+        agent_dist = FEED_ALAS;
+    } else if (strcasestr(agti_os_name, vu_feed_ext[FEED_CENTOS])) {
+        if (strstr(agti_os_major, "8")) {
+            agent_dist_ver = FEED_RHEL8;
+        } else if (strstr(agti_os_major, "7")) {
+            agent_dist_ver = FEED_RHEL7;
+        } else if (strstr(agti_os_major, "6")) {
+            agent_dist_ver = FEED_RHEL6;
+        } else if (strstr(agti_os_major, "5")) {
+            agent_dist_ver = FEED_RHEL5;
+        } else {
+            dist_error = FEED_CENTOS;
+        }
+        agent_dist = FEED_REDHAT;
+        is_centos = TRUE;
+    } else if (strcasestr(agti_os_name, vu_feed_ext[FEED_ARCH])) {
+        agent_dist_ver = FEED_ARCH;
+        agent_dist= FEED_ARCH;
+    } else if (strcasestr(agti_os_name, vu_feed_ext[FEED_WIN])) {
+        agent_dist_ver = wm_vuldet_decode_win_os(agti_os_name);
+        agent_dist = FEED_WIN;
+    } else if (strcasestr(agti_os_platform, vu_feed_ext[FEED_MAC])) {
+        char *version = NULL;
+        char *save_ptr = NULL;
+        w_strdup(agti_version, version);
+
+        if (agti_version) {
+            strtok_r(agti_version, "v", &save_ptr);
+            char *tmp_major = strtok_r(NULL, ".", &save_ptr);
+            char *tmp_minor = strtok_r(NULL, ".", &save_ptr);
+            if (!tmp_major || !tmp_minor) {
+                dist_error = -2;
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_VER_INVALID_FORMAT, agent_id);
+            } else {
+                if (atoi(tmp_major) > 4 || (atoi(tmp_major) == 4 && atoi(tmp_minor) > 0)) {
+                    agent_dist_ver = FEED_MAC;
+                    agent_dist = FEED_MAC;
+                } else {
+                    dist_error = -2;
+                    mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AGENT_UNSOPPORTED, agent_id, version);
+                }
+            }
+        } else {
+            dist_error = -2;
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_VER_READING_ERROR, agent_id);
+        }
+        os_free(version);
+    } else {
+        // Operating system not supported in any of its versions.
+        dist_error = -2;
+    }
+
+    if (dist_error != -1) {
+        // Check if the agent OS can be matched with a OVAL.
+        if (agent_dist_ver = wm_vuldet_set_allowed_feed(agti_os_name, agti_os_major, vuldet->updates, &agent_dist), agent_dist_ver == FEED_UNKNOWN) {
+            if (dist_error == -2) {
+                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UNS_OS, agent_id, agti_os_name);
+            } else {
+                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UNS_OS_VERSION, agent_id, vu_feed_ext[dist_error]);
+            }
+            ret = OS_INVALID;
+            goto next;
+        }
+    }
+
+    j_field = cJSON_GetObjectItem(j_agent_info->child, "register_ip");
+    char *agti_register_ip = NULL;
+    if(cJSON_IsString(j_field) && j_field->valuestring != NULL){
+        agti_register_ip = j_field->valuestring;
+    }
+
+    if (!agti_register_ip) {
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_NULL_AGENT_IP, agent_id);
+        ret = OS_INVALID;
+        goto next;
+    }
+
+    j_field = cJSON_GetObjectItem(j_agent_info->child, "os_arch");
+    char *agti_arch = NULL;
+    if(cJSON_IsString(j_field) && j_field->valuestring != NULL){
+        agti_arch = j_field->valuestring;
+    }
+
+    // Getting sys_osinfo data from agent database.
+    if (j_osinfo = wdb_get_agent_sys_osinfo(agent_id, sock), !j_osinfo) {
+        mdebug1("Failed to get agent '%.3d' OS information from Wazuh DB.", agent_id);
+        ret = OS_INVALID;
+        goto next;
+    }
+
+    j_field = cJSON_GetObjectItem(j_osinfo->child, "triaged");
+    int osinfo_triaged = 0;
+    if (cJSON_IsNumber(j_field))
+        osinfo_triaged = j_field->valueint;
+
+    j_field = cJSON_GetObjectItem(j_osinfo->child, "reference");
+    char *osinfo_reference = NULL;
+    if (cJSON_IsString(j_field))
+        osinfo_reference = j_field->valuestring;
+
+    j_field = cJSON_GetObjectItem(j_osinfo->child, "os_version");
+    char *osinfo_version = NULL;
+    if (cJSON_IsString(j_field))
+        osinfo_version = j_field->valuestring;
+
+    j_field = cJSON_GetObjectItem(j_osinfo->child, "os_major");
+    char *osinfo_major = NULL;
+    if (cJSON_IsString(j_field))
+        osinfo_major = j_field->valuestring;
+
+    j_field = cJSON_GetObjectItem(j_osinfo->child, "os_minor");
+    char *osinfo_minor = NULL;
+    if (cJSON_IsString(j_field))
+        osinfo_minor = j_field->valuestring;
+
+    j_field = cJSON_GetObjectItem(j_osinfo->child, "os_patch");
+    char *osinfo_patch = NULL;
+    if (cJSON_IsString(j_field))
+        osinfo_patch = j_field->valuestring;
+
+    j_field = cJSON_GetObjectItem(j_osinfo->child, "os_release");
+    char *osinfo_os_release = NULL;
+    if (cJSON_IsString(j_field))
+        osinfo_os_release = j_field->valuestring;
+
+    j_field = cJSON_GetObjectItem(j_osinfo->child, "os_display_version");
+    char *osinfo_os_display_version = NULL;
+    if (cJSON_IsString(j_field))
+        osinfo_os_display_version = j_field->valuestring;
+
+    j_field = cJSON_GetObjectItem(j_osinfo->child, "release");
+    char *osinfo_release = NULL;
+    if (cJSON_IsString(j_field))
+        osinfo_release = j_field->valuestring;
+
+    j_field = cJSON_GetObjectItem(j_osinfo->child, "architecture");
+    char *osinfo_arch = NULL;
+    if (cJSON_IsString(j_field))
+        osinfo_arch = j_field->valuestring;
+
+    // Writing information.
+    os_strdup(agti_register_ip, agents->agent_ip);
+
+    agents->build = agti_build;
+
+    char str_id[OS_SIZE_128] = "";
+    snprintf(str_id, sizeof(str_id), "%d", agent_id);
+    os_strdup(str_id, agents->agent_id);
+
+    if (agti_name) {
+        os_strdup(agti_name, agents->agent_name);
+    }
+
+    if (osinfo_arch) {
+        os_strdup(osinfo_arch, agents->arch);
+    } else if (agti_arch) {
+        os_strdup(agti_arch, agents->arch);
+    }
+
+    agents->dist = agent_dist;
+    agents->dist_ver = agent_dist_ver;
+    agents->flags.centos = is_centos;
+    agents->os_triaged = osinfo_triaged;
+    agents->pending_attempts = WM_VULNDETECTOR_MAX_AGENT_SCAN_ATTEMPS;
+    w_strdup(osinfo_reference, agents->os_reference);
+    w_strdup(osinfo_version, agents->os_version);
+    w_strdup(agti_os_name, agents->os_name);
+    if (agent_dist == FEED_WIN) {
+        w_strdup(osinfo_os_release, agents->os_release);
+        w_strdup(osinfo_os_display_version, agents->os_display_version);
+        // The windows agent requires the architecture in the NVD format.
+        char* nvd_architecture = wm_vuldet_normalize_architecture_nvd(agents->arch);
+        if (nvd_architecture) {
+            os_free(agents->arch);
+            agents->arch = nvd_architecture;
+        }
+    } else {
+        w_strdup(osinfo_release, agents->kernel_release);
+        if (!is_rolling) {
+            wm_vuldet_build_unix_os_release(agents, osinfo_major, osinfo_minor, osinfo_patch);
+        }
+    }
+
+next:
+    if (j_agent_info) cJSON_Delete(j_agent_info);
+    if (j_osinfo) cJSON_Delete(j_osinfo);
+
+    return ret;
+}
+
+int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet, bool scan_by_interval) {
     scan_agent *agents = NULL;
     scan_agent *f_agent = NULL;
     int set_manager = 1;
@@ -5188,288 +5529,23 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
         return OS_INVALID;
     }
 
-    id_array = wdb_get_agents_by_connection_status(AGENT_CS_ACTIVE, &sock);
+    if (scan_by_interval) {
+        id_array = wdb_get_agents_by_connection_status(AGENT_CS_ACTIVE, &sock);
+    } else {
+        //id_array = TODO: Scan on demand;
+        set_manager = 0;
+    }
 
     while (set_manager || (id_array && id_array[i] != -1)) {
-        cJSON *j_agent_info = NULL;
-        cJSON *j_osinfo = NULL;
-        cJSON *j_field = NULL;
-        vu_feed agent_dist_ver = -1;
-        vu_feed agent_dist = -1;
-        bool is_centos = FALSE;
-        int dist_error = -1;
         int id = 0;
-        bool is_rolling = FALSE;
 
         if (set_manager) {
             id = --set_manager;
-        }
-        else {
+        } else {
             id = id_array[i++];
         }
 
-        // Getting agent-info data from global.db
-        j_agent_info = wdb_get_agent_info(id, &sock);
-        if (!j_agent_info) {
-            mdebug1("Failed to get agent '%d' information from Wazuh DB.", id);
-            goto next;
-        }
-
-        j_field = cJSON_GetObjectItem(j_agent_info->child, "node_name");
-        if(cJSON_IsString(j_field) && j_field->valuestring != NULL) {
-            if (0 != strcmp(j_field->valuestring, vuldet->node_name)) {
-                goto next;
-            }
-        }
-
-        j_field = cJSON_GetObjectItem(j_agent_info->child, "os_name");
-        char *agti_os_name = NULL;
-        if(cJSON_IsString(j_field) && j_field->valuestring != NULL) {
-            agti_os_name = j_field->valuestring;
-        }
-
-        j_field = cJSON_GetObjectItem(j_agent_info->child, "os_major");
-        char *agti_os_major = NULL;
-        if(cJSON_IsString(j_field) && j_field->valuestring != NULL) {
-            agti_os_major = j_field->valuestring;
-        }
-
-        j_field = cJSON_GetObjectItem(j_agent_info->child, "name");
-        char *agti_name = NULL;
-        if(cJSON_IsString(j_field) && j_field->valuestring != NULL) {
-            agti_name = j_field->valuestring;
-        }
-
-        j_field = cJSON_GetObjectItem(j_agent_info->child, "os_build");
-        int agti_build = 0;
-        if(cJSON_IsNumber(j_field)){
-            agti_build = j_field->valueint;
-        }
-
-        j_field = cJSON_GetObjectItem(j_agent_info->child, "version");
-        char *agti_version = NULL;
-        if (cJSON_IsString(j_field) && j_field->valuestring != NULL) {
-            agti_version = j_field->valuestring;
-        }
-
-        j_field = cJSON_GetObjectItem(j_agent_info->child, "os_platform");
-        char *agti_os_platform = NULL;
-        if (cJSON_IsString(j_field) && j_field->valuestring != NULL) {
-            agti_os_platform = j_field->valuestring;
-        }
-
-        if (!agti_os_name) {
-            if (agti_name) {
-                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_NEVER_CON, agti_name);
-            }
-            goto next;
-        } else if (!agti_os_platform) {
-            mtdebug1(WM_VULNDETECTOR_LOGTAG, "Failed to read platform from agent '%.3d'", id);
-            goto next;
-        } else if (!agti_os_major) {
-            int rolling_distros_len = array_size(vu_os_platform_rolling_distros);
-            for (int distro_it = 0; distro_it < rolling_distros_len; ++distro_it) {
-                if (!strcmp(agti_os_platform, vu_os_platform_rolling_distros[distro_it])) {
-                    is_rolling = TRUE;
-                }
-            }
-            if (!is_rolling) {
-                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UNS_OS_VERSION, id, agti_name?agti_name:"");
-                goto next;
-            } else {
-                agti_os_major = "";
-            }
-        }
-
-        if (strcasestr(agti_os_name, vu_feed_ext[FEED_UBUNTU])) {
-            if (strstr(agti_os_major, "20")) {
-                agent_dist_ver = FEED_FOCAL;
-            } else if (strstr(agti_os_major, "18")) {
-                agent_dist_ver = FEED_BIONIC;
-            } else if (strstr(agti_os_major, "16")) {
-                agent_dist_ver = FEED_XENIAL;
-            } else if (strstr(agti_os_major, "14")) {
-                agent_dist_ver = FEED_TRUSTY;
-            } else {
-                dist_error = FEED_UBUNTU;
-            }
-            agent_dist = FEED_UBUNTU;
-        } else if (strcasestr(agti_os_name, vu_feed_ext[FEED_DEBIAN])) {
-            if (strstr(agti_os_major, "9")) {
-                agent_dist_ver = FEED_STRETCH;
-            } else if (strstr(agti_os_major, "10")) {
-                agent_dist_ver = FEED_BUSTER;
-            } else if (strstr(agti_os_major, "11")) {
-                agent_dist_ver = FEED_BULLSEYE;
-            } else {
-                dist_error = FEED_DEBIAN;
-            }
-            agent_dist = FEED_DEBIAN;
-        }  else if (strcasestr(agti_os_name, vu_feed_ext[FEED_REDHAT])) {
-            if (strstr(agti_os_major, "8")) {
-                agent_dist_ver = FEED_RHEL8;
-            } else if (strstr(agti_os_major, "7")) {
-                agent_dist_ver = FEED_RHEL7;
-            } else if (strstr(agti_os_major, "6")) {
-                agent_dist_ver = FEED_RHEL6;
-            } else if (strstr(agti_os_major, "5")) {
-                agent_dist_ver = FEED_RHEL5;
-            } else {
-                dist_error = FEED_REDHAT;
-            }
-            agent_dist = FEED_REDHAT;
-        } else if (strcasestr(agti_os_name, vu_feed_ext[FEED_ALAS])) {
-        /*
-        * The versioning and naming standards differ in both Amazon Linux and Amazon Linux 2 systems. Currently, the
-        * most reliable sources to determine the exact distribution of Amazon Linux are the @os_major field for
-        * Amazon Linux 2 systems (always "2"), and the @os_name field for Amazon Linux 1 (always "Amazon Linux AMI").
-        * This behavior should be reconsidered when new Amazon Linux distributions are released.
-        */
-            if (!strcmp(agti_os_major, "2")) {
-                agent_dist_ver = FEED_ALAS2;
-            } else if (strstr(agti_os_name, "AMI")) {
-                agent_dist_ver = FEED_ALAS1;
-            } else {
-                dist_error = FEED_ALAS;
-            }
-            agent_dist = FEED_ALAS;
-        } else if (strcasestr(agti_os_name, vu_feed_ext[FEED_CENTOS])) {
-            if (strstr(agti_os_major, "8")) {
-                agent_dist_ver = FEED_RHEL8;
-            } else if (strstr(agti_os_major, "7")) {
-                agent_dist_ver = FEED_RHEL7;
-            } else if (strstr(agti_os_major, "6")) {
-                agent_dist_ver = FEED_RHEL6;
-            } else if (strstr(agti_os_major, "5")) {
-                agent_dist_ver = FEED_RHEL5;
-            } else {
-                dist_error = FEED_CENTOS;
-            }
-            agent_dist = FEED_REDHAT;
-            is_centos = TRUE;
-        } else if (strcasestr(agti_os_name, vu_feed_ext[FEED_ARCH])) {
-            agent_dist_ver = FEED_ARCH;
-            agent_dist= FEED_ARCH;
-        } else if (strcasestr(agti_os_name, vu_feed_ext[FEED_WIN])) {
-            agent_dist_ver = wm_vuldet_decode_win_os(agti_os_name);
-            agent_dist = FEED_WIN;
-        } else if (strcasestr(agti_os_platform, vu_feed_ext[FEED_MAC])) {
-            char *version = NULL;
-            char *save_ptr = NULL;
-            w_strdup(agti_version, version);
-
-            if (agti_version) {
-                strtok_r(agti_version, "v", &save_ptr);
-                char *tmp_major = strtok_r(NULL, ".", &save_ptr);
-                char *tmp_minor = strtok_r(NULL, ".", &save_ptr);
-                if (!tmp_major || !tmp_minor) {
-                    dist_error = -2;
-                    mterror(WM_VULNDETECTOR_LOGTAG, VU_VER_INVALID_FORMAT, id);
-                } else {
-                    if (atoi(tmp_major) > 4 || (atoi(tmp_major) == 4 && atoi(tmp_minor) > 0)) {
-                        agent_dist_ver = FEED_MAC;
-                        agent_dist = FEED_MAC;
-                    } else {
-                        dist_error = -2;
-                        mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AGENT_UNSOPPORTED, id, version);
-                    }
-                }
-            } else {
-                dist_error = -2;
-                mterror(WM_VULNDETECTOR_LOGTAG, VU_VER_READING_ERROR, id);
-            }
-
-            os_free(version);
-        } else {
-            // Operating system not supported in any of its versions
-            dist_error = -2;
-        }
-
-        if (dist_error != -1) {
-            // Check if the agent OS can be matched with a OVAL
-            if (agent_dist_ver = wm_vuldet_set_allowed_feed(agti_os_name, agti_os_major, vuldet->updates, &agent_dist), agent_dist_ver == FEED_UNKNOWN) {
-                if (dist_error == -2) {
-                    mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UNS_OS, id, agti_os_name);
-                } else {
-                    mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UNS_OS_VERSION, id, vu_feed_ext[dist_error]);
-                }
-                goto next;
-            }
-        }
-
-        j_field = cJSON_GetObjectItem(j_agent_info->child, "register_ip");
-        char *agti_register_ip = NULL;
-        if(cJSON_IsString(j_field) && j_field->valuestring != NULL){
-            agti_register_ip = j_field->valuestring;
-        }
-
-        if (!agti_register_ip) {
-            mterror(WM_VULNDETECTOR_LOGTAG, VU_NULL_AGENT_IP, id);
-            goto next;
-        }
-
-        j_field = cJSON_GetObjectItem(j_agent_info->child, "os_arch");
-        char *agti_arch = NULL;
-        if(cJSON_IsString(j_field) && j_field->valuestring != NULL){
-            agti_arch = j_field->valuestring;
-        }
-
-        // Getting sys_osinfo data from agent database
-        if (j_osinfo = wdb_get_agent_sys_osinfo(id, &sock), !j_osinfo) {
-            goto next;
-        }
-
-        j_field = cJSON_GetObjectItem(j_osinfo->child, "triaged");
-        int osinfo_triaged = 0;
-        if (cJSON_IsNumber(j_field))
-            osinfo_triaged = j_field->valueint;
-
-        j_field = cJSON_GetObjectItem(j_osinfo->child, "reference");
-        char *osinfo_reference = NULL;
-        if (cJSON_IsString(j_field))
-            osinfo_reference = j_field->valuestring;
-
-        j_field = cJSON_GetObjectItem(j_osinfo->child, "os_version");
-        char *osinfo_version = NULL;
-        if (cJSON_IsString(j_field))
-            osinfo_version = j_field->valuestring;
-
-        j_field = cJSON_GetObjectItem(j_osinfo->child, "os_major");
-        char *osinfo_major = NULL;
-        if (cJSON_IsString(j_field))
-            osinfo_major = j_field->valuestring;
-
-        j_field = cJSON_GetObjectItem(j_osinfo->child, "os_minor");
-        char *osinfo_minor = NULL;
-        if (cJSON_IsString(j_field))
-            osinfo_minor = j_field->valuestring;
-
-        j_field = cJSON_GetObjectItem(j_osinfo->child, "os_patch");
-        char *osinfo_patch = NULL;
-        if (cJSON_IsString(j_field))
-            osinfo_patch = j_field->valuestring;
-
-        j_field = cJSON_GetObjectItem(j_osinfo->child, "os_release");
-        char *osinfo_os_release = NULL;
-        if (cJSON_IsString(j_field))
-            osinfo_os_release = j_field->valuestring;
-
-        j_field = cJSON_GetObjectItem(j_osinfo->child, "os_display_version");
-        char *osinfo_os_display_version = NULL;
-        if (cJSON_IsString(j_field))
-            osinfo_os_display_version = j_field->valuestring;
-
-        j_field = cJSON_GetObjectItem(j_osinfo->child, "release");
-        char *osinfo_release = NULL;
-        if (cJSON_IsString(j_field))
-            osinfo_release = j_field->valuestring;
-
-        j_field = cJSON_GetObjectItem(j_osinfo->child, "architecture");
-        char *osinfo_arch = NULL;
-        if (cJSON_IsString(j_field))
-            osinfo_arch = j_field->valuestring;
-
-        // Writting results
+        // Prepare and fill structure.
         if (!agents) {
             os_calloc(1, sizeof(scan_agent), agents);
             f_agent = agents;
@@ -5477,55 +5553,12 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
             os_calloc(1, sizeof(scan_agent), agents->next);
             agents = agents->next;
         }
-
         agents->next = NULL;
-        os_strdup(agti_register_ip, agents->agent_ip);
 
-        agents->build = agti_build;
-
-        char str_id[OS_SIZE_128] = "";
-        snprintf(str_id, sizeof(str_id), "%d", id);
-        os_strdup(str_id, agents->agent_id);
-
-        if (agti_name) {
-            os_strdup(agti_name, agents->agent_name);
+        if (wm_vuldet_collect_agent_info(id, vuldet, agents, &sock)) {
+            os_free(id_array)
+            return OS_INVALID;
         }
-
-        if (osinfo_arch) {
-            os_strdup(osinfo_arch, agents->arch);
-        }
-        else if (agti_arch) {
-            os_strdup(agti_arch, agents->arch);
-        }
-
-        agents->dist = agent_dist;
-        agents->dist_ver = agent_dist_ver;
-        agents->flags.centos = is_centos;
-        agents->os_triaged = osinfo_triaged;
-        agents->pending_attempts = WM_VULNDETECTOR_MAX_AGENT_SCAN_ATTEMPS;
-        w_strdup(osinfo_reference, agents->os_reference);
-        w_strdup(osinfo_version, agents->os_version);
-        w_strdup(agti_os_name, agents->os_name);
-        if (agent_dist == FEED_WIN) {
-            w_strdup(osinfo_os_release, agents->os_release);
-            w_strdup(osinfo_os_display_version, agents->os_display_version);
-            // The windows agent requires the architecture in the NVD format
-            char* nvd_architecture = wm_vuldet_normalize_architecture_nvd(agents->arch);
-            if (nvd_architecture) {
-                os_free(agents->arch);
-                agents->arch = nvd_architecture;
-            }
-        }
-        else {
-            w_strdup(osinfo_release, agents->kernel_release);
-            if (!is_rolling) {
-                wm_vuldet_build_unix_os_release(agents, osinfo_major, osinfo_minor, osinfo_patch);
-            }
-        }
-
-next:
-        if (j_agent_info) cJSON_Delete(j_agent_info);
-        if (j_osinfo) cJSON_Delete(j_osinfo);
     }
 
     vuldet->scan_agents = f_agent;
@@ -7157,8 +7190,7 @@ int wm_vuldet_build_unix_os_release(scan_agent *agent,
         size_t ver_length = strlen(os_major) + strlen(minor) + strlen(os_patch) + 2; // Two dots
         os_calloc(ver_length + 1, sizeof(char), version);
         snprintf(version, ver_length + 1, "%s.%s.%s", os_major, minor, os_patch);
-    }
-    else {
+    } else {
         size_t ver_length = strlen(os_major) + strlen(minor) + 1; // One dot
         os_calloc(ver_length + 1, sizeof(char), version);
         snprintf(version, ver_length + 1, "%s.%s", os_major, minor);
@@ -7682,7 +7714,6 @@ cpe *wm_vuldet_generate_cpe(const char *part, const char *vendor, const char *pr
 }
 
 void wm_vuldet_run_scan(wm_vuldet_t *vuldet) {
-
     mtinfo(WM_VULNDETECTOR_LOGTAG, VU_START_SCAN);
 
     if (wm_vuldet_nvd_empty() == 0) {
@@ -7691,10 +7722,9 @@ void wm_vuldet_run_scan(wm_vuldet_t *vuldet) {
         return;
     }
 
-    if (wm_vuldet_collect_agents_to_scan(vuldet)) {
+    if (wm_vuldet_collect_agents_to_scan(vuldet, TRUE)) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR);
-    }
-    else {
+    } else {
         if (wm_vuldet_check_agent_vulnerabilities(vuldet)) {
             mterror(WM_VULNDETECTOR_LOGTAG, VU_AG_CHECK_ERR);
         } else {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -210,11 +210,11 @@ STATIC int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet, bool scan_by_in
  *
  * @param agent_id Agent identifier.
  * @param vuldet The vulnerability detector main data structure.
- * @param agents The agent main data structure.
+ * @param agent The agent main data structure.
  * @param sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return 0 on success, -1 otherwise.
  */
-STATIC int wm_vuldet_collect_agent_info(int agent_id, wm_vuldet_t *vuldet, scan_agent *agents, int *sock);
+STATIC int wm_vuldet_collect_agent_info(int agent_id, wm_vuldet_t *vuldet, scan_agent *agent, int *sock);
 
 /**
  * @brief Compare two packages structures (src_name, bin_name, version and arch).
@@ -5186,7 +5186,7 @@ void *wm_vuldet_main(wm_vuldet_t * vuldet) {
     return NULL;
 }
 
-int wm_vuldet_collect_agent_info(int agent_id, wm_vuldet_t *vuldet, scan_agent *agents, int *sock) {
+int wm_vuldet_collect_agent_info(int agent_id, wm_vuldet_t *vuldet, scan_agent *agent, int *sock) {
     cJSON *j_agent_info = NULL;
     cJSON *j_osinfo = NULL;
     cJSON *j_field = NULL;
@@ -5467,45 +5467,45 @@ int wm_vuldet_collect_agent_info(int agent_id, wm_vuldet_t *vuldet, scan_agent *
         osinfo_arch = j_field->valuestring;
 
     // Writing information.
-    os_strdup(agti_register_ip, agents->agent_ip);
+    os_strdup(agti_register_ip, agent->agent_ip);
 
-    agents->build = agti_build;
+    agent->build = agti_build;
 
     char str_id[OS_SIZE_128] = "";
     snprintf(str_id, sizeof(str_id), "%d", agent_id);
-    os_strdup(str_id, agents->agent_id);
+    os_strdup(str_id, agent->agent_id);
 
     if (agti_name) {
-        os_strdup(agti_name, agents->agent_name);
+        os_strdup(agti_name, agent->agent_name);
     }
 
     if (osinfo_arch) {
-        os_strdup(osinfo_arch, agents->arch);
+        os_strdup(osinfo_arch, agent->arch);
     } else if (agti_arch) {
-        os_strdup(agti_arch, agents->arch);
+        os_strdup(agti_arch, agent->arch);
     }
 
-    agents->dist = agent_dist;
-    agents->dist_ver = agent_dist_ver;
-    agents->flags.centos = is_centos;
-    agents->os_triaged = osinfo_triaged;
-    agents->pending_attempts = WM_VULNDETECTOR_MAX_AGENT_SCAN_ATTEMPS;
-    w_strdup(osinfo_reference, agents->os_reference);
-    w_strdup(osinfo_version, agents->os_version);
-    w_strdup(agti_os_name, agents->os_name);
+    agent->dist = agent_dist;
+    agent->dist_ver = agent_dist_ver;
+    agent->flags.centos = is_centos;
+    agent->os_triaged = osinfo_triaged;
+    agent->pending_attempts = WM_VULNDETECTOR_MAX_AGENT_SCAN_ATTEMPS;
+    w_strdup(osinfo_reference, agent->os_reference);
+    w_strdup(osinfo_version, agent->os_version);
+    w_strdup(agti_os_name, agent->os_name);
     if (agent_dist == FEED_WIN) {
-        w_strdup(osinfo_os_release, agents->os_release);
-        w_strdup(osinfo_os_display_version, agents->os_display_version);
+        w_strdup(osinfo_os_release, agent->os_release);
+        w_strdup(osinfo_os_display_version, agent->os_display_version);
         // The windows agent requires the architecture in the NVD format.
-        char* nvd_architecture = wm_vuldet_normalize_architecture_nvd(agents->arch);
+        char* nvd_architecture = wm_vuldet_normalize_architecture_nvd(agent->arch);
         if (nvd_architecture) {
-            os_free(agents->arch);
-            agents->arch = nvd_architecture;
+            os_free(agent->arch);
+            agent->arch = nvd_architecture;
         }
     } else {
-        w_strdup(osinfo_release, agents->kernel_release);
+        w_strdup(osinfo_release, agent->kernel_release);
         if (!is_rolling) {
-            wm_vuldet_build_unix_os_release(agents, osinfo_major, osinfo_minor, osinfo_patch);
+            wm_vuldet_build_unix_os_release(agent, osinfo_major, osinfo_minor, osinfo_patch);
         }
     }
 
@@ -5517,7 +5517,7 @@ next:
 }
 
 int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet, bool scan_by_interval) {
-    scan_agent *agents = NULL;
+    scan_agent *agent = NULL;
     scan_agent *f_agent = NULL;
     int set_manager = 1;
     int i = 0;
@@ -5546,16 +5546,16 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet, bool scan_by_interval)
         }
 
         // Prepare and fill structure.
-        if (!agents) {
-            os_calloc(1, sizeof(scan_agent), agents);
-            f_agent = agents;
+        if (!agent) {
+            os_calloc(1, sizeof(scan_agent), agent);
+            f_agent = agent;
         } else {
-            os_calloc(1, sizeof(scan_agent), agents->next);
-            agents = agents->next;
+            os_calloc(1, sizeof(scan_agent), agent->next);
+            agent = agent->next;
         }
-        agents->next = NULL;
+        agent->next = NULL;
 
-        if (wm_vuldet_collect_agent_info(id, vuldet, agents, &sock)) {
+        if (wm_vuldet_collect_agent_info(id, vuldet, agent, &sock)) {
             os_free(id_array)
             return OS_INVALID;
         }
@@ -7722,6 +7722,8 @@ void wm_vuldet_run_scan(wm_vuldet_t *vuldet) {
         return;
     }
 
+    // TODO: The value for the parameter scan_by_interval (hardcoded as TRUE)
+    // must be defined before calling the function.
     if (wm_vuldet_collect_agents_to_scan(vuldet, TRUE)) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR);
     } else {


### PR DESCRIPTION
|Related issue|
|---|
|#12795|

## Description

This PR moves the method in charge to get the agents' information from the Global database as well as the OS information from an agent outside the method that collects the active agents. Since as part of this epic, the vulnerability detector will scan a specific agent from the task in the task manager we need to get the information for active agents for a scan by interval, and for a unique agent in case of a scan on demand.

## Scan-build report

![image](https://user-images.githubusercontent.com/13010397/161315063-9e360a7c-6300-422d-974d-451f40cd9e15.png)

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)