### PR TITLE
Add windows resource information capability

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -113,6 +113,7 @@ endif
 
 ifeq (${TARGET},winagent)
 CMAKE_OPTS=-DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=${MING_BASE}${CC} -DCMAKE_CXX_COMPILER=${MING_BASE}${CXX}
+WIN_RESOURCE_OBJ=-DRESOURCE_OBJ=win32/version-dll.o
 WIN_CMAKE_RULES+=win32/sysinfo
 WIN_CMAKE_RULES+=win32/shared_modules
 ifeq (,$(filter ${DISABLE_SYSC},YES yes y Y 1))
@@ -633,6 +634,7 @@ help: failtarget
 	@echo "   make DEBUG=yes                   Build with symbols and without optimization. Allowed values are 1, yes, YES, y and Y, otherwise, the flag is ignored"
 	@echo "   make DEBUGAD=yes                 Enables extra debugging logging in wazuh-analysisd. Allowed values are 1, yes, YES, y and Y, otherwise, the flag is ignored"
 	@echo "   make INSTALLDIR=/path            Wazuh's installation path. Mandatory when compiling the python interpreter from sources using PYTHON_SOURCE."
+	@echo "   make BUILD_VERSION=version       Windows detailed build version. If ommited, VERSION file content will be used."
 	@echo "   make ONEWAY=yes                  Disables manager's ACK towards agent. It allows connecting agents without backward connection from manager. Allowed values are 1, yes, YES, y and Y, otherwise, the flag is ignored"
 	@echo "   make CLEANFULL=yes               Makes the alert mailing subject clear in the format: '<location> - <level> - <description>'. Allowed values are 1, yes, YES, y and Y, otherwise, the flag is ignored"
 	@echo "   make RESOURCES_URL               Set the Wazuh resources URL"
@@ -677,6 +679,7 @@ settings:
 	@echo "    DEBUG:                   ${DEBUG}"
 	@echo "    DEBUGAD                  ${DEBUGAD}"
 	@echo "    INSTALLDIR:              ${INSTALLDIR}"
+	@echo "    BUILD_VERSION            ${BUILD_VERSION}"
 	@echo "    DATABASE:                ${DATABASE}"
 	@echo "    ONEWAY:                  ${ONEWAY}"
 	@echo "    CLEANFULL:               ${CLEANFULL}"
@@ -854,9 +857,9 @@ winagent: external win32/libwinpthread-1.dll win32/libgcc_s_sjlj-1.dll
 	cd win32/ && ./unix2dos.pl ../REVISION > REVISION
 	cd win32/ && makensis wazuh-installer.nsi
 
-win32/shared_modules: $(WAZUHEXT_LIB)
-	cd ${DBSYNC} && mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${DBSYNC_TEST} ${SHARED_MODULES_RELEASE_TYPE} .. && ${MAKE}
-	cd ${RSYNC} &&  mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${RSYNC_TEST} ${SHARED_MODULES_RELEASE_TYPE} .. && ${MAKE}
+win32/shared_modules: $(WAZUHEXT_LIB) win32/version-dll.o
+	cd ${DBSYNC} && mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${DBSYNC_TEST} ${SHARED_MODULES_RELEASE_TYPE} ${WIN_RESOURCE_OBJ} .. && ${MAKE}
+	cd ${RSYNC} &&  mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${RSYNC_TEST} ${SHARED_MODULES_RELEASE_TYPE} ${WIN_RESOURCE_OBJ} .. && ${MAKE}
 ifneq (,$(filter ${TEST},YES yes y Y 1))
 ifneq (,$(filter ${DEBUG},YES yes y Y 1))
 	cd ${SHARED_UTILS_TEST} &&  mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SHARED_MODULES_RELEASE_TYPE} .. && ${MAKE}
@@ -865,12 +868,12 @@ endif
 
 #### Sysinfo ##
 
-win32/sysinfo: $(WAZUHEXT_LIB)
-	cd ${SYSINFO} && mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SYSINFO_OS} ${SYSINFO_TEST} ${SYSINFO_RELEASE_TYPE} .. && ${MAKE}
+win32/sysinfo: $(WAZUHEXT_LIB) win32/version-dll.o
+	cd ${SYSINFO} && mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SYSINFO_OS} ${SYSINFO_TEST} ${SYSINFO_RELEASE_TYPE} ${WIN_RESOURCE_OBJ} .. && ${MAKE}
 
 #### Syscollector ##
-win32/syscollector: win32/shared_modules win32/sysinfo
-	cd ${SYSCOLLECTOR} && mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SYSCOLLECTOR_TEST} ${SYSCOLLECTOR_RELEASE_TYPE} .. && ${MAKE}
+win32/syscollector: win32/shared_modules win32/sysinfo win32/version-dll.o
+	cd ${SYSCOLLECTOR} && mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SYSCOLLECTOR_TEST} ${SYSCOLLECTOR_RELEASE_TYPE} ${WIN_RESOURCE_OBJ} .. && ${MAKE}
 
 win32/libwinpthread-1.dll: ${WIN_PTHREAD_LIB}
 	cp $< $@
@@ -1771,7 +1774,7 @@ $(WAZUHEXT_LIB): $(EXTERNAL_LIBS)
 	$(OSSEC_SHARED) $(OSSEC_CFLAGS) $(WAZUH_SHFLAGS) -o $@ -Wl,-all_load $^ -Wl,-noall_load $(OSSEC_LIBS)
 else
 ifeq (${TARGET}, winagent)
-$(WAZUHEXT_LIB): $(EXTERNAL_LIBS)
+$(WAZUHEXT_LIB): $(EXTERNAL_LIBS) win32/version-dll.o
 	$(OSSEC_SHARED) $(OSSEC_CFLAGS) -o $@ -static-libgcc -Wl,--export-all-symbols -Wl,--whole-archive $^ -Wl,--no-whole-archive ${OSSEC_LIBS}
 else
 ifeq (${uname_S},SunOS)
@@ -1999,7 +2002,7 @@ $(WAZUH_LIB): $(WAZUHEXT_LIB) $(AR_PROGRAMS_DEPS)
 	$(OSSEC_SHARED) $(OSSEC_CFLAGS) $(WAZUH_SHARED_SHFLAGS) -o $@ -Wl,-all_load $^ -Wl,-noall_load $(OSSEC_LIBS)
 else
 ifeq (${TARGET}, winagent)
-$(WAZUH_LIB): $(WAZUHEXT_LIB) $(AR_PROGRAMS_DEPS)
+$(WAZUH_LIB): $(WAZUHEXT_LIB) $(AR_PROGRAMS_DEPS) win32/version-dll.o
 	$(OSSEC_SHARED) $(OSSEC_CFLAGS) -UOSSECHIDS -o $@ -static-libgcc -Wl,--export-all-symbols -Wl,--whole-archive $^ -Wl,--no-whole-archive ${OSSEC_LIBS}
 else
 ifeq (${uname_S},SunOS)
@@ -2432,6 +2435,19 @@ test-rules:
 #### windows #######
 ####################
 
+ifneq (,${BUILD_VERSION})
+WIN_BUILD_VERSION=-DVER_PRODUCTVERSION_STR=${BUILD_VERSION}
+endif
+ifneq (,$(filter ${DISABLE_STRIP_SYMBOLS},YES yes y Y 1))
+WIN_BUILD_TYPE=-DVER_FILEFLAGS=VS_FF_DEBUG
+endif
+
+win32/version-dll.o: win32/version.rc
+	${OSSEC_WINDRES} ${WIN_BUILD_VERSION} ${WIN_BUILD_TYPE} -DVER_TYPE=VFT_DLL -i $< -o $@
+
+win32/version-app.o: win32/version.rc
+	${OSSEC_WINDRES} ${WIN_BUILD_VERSION} ${WIN_BUILD_TYPE} -DVER_TYPE=VFT_APP -i $< -o $@
+
 win32/icon.o: win32/icofile.rc
 	${OSSEC_WINDRES} -i $< -o $@
 
@@ -2450,22 +2466,22 @@ win32_ui_o := $(win32_ui_c:.c=.o)
 win32/ui/%.o: win32/ui/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -UOSSECHIDS -DARGV0=\"wazuh-win32ui\" -c $^ -o $@
 
-win32/wazuh-agent.exe: win32/icon.o win32/win_agent.o win32/win_service.o win32/win_utils.o ${syscheck_o} ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main.o, ${os_logcollector_o}) ${os_execd_o} active-response/active_responses.o monitord/rotate_log.o monitord/compress_log.o
+win32/wazuh-agent.exe: win32/version-app.o win32/icon.o win32/win_agent.o win32/win_service.o win32/win_utils.o ${syscheck_o} ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main.o, ${os_logcollector_o}) ${os_execd_o} active-response/active_responses.o monitord/rotate_log.o monitord/compress_log.o
 	${OSSEC_CCBIN} -DARGV0=\"wazuh-agent\" -DOSSECHIDS ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-win32/wazuh-agent-eventchannel.exe: win32/icon.o win32/win_agent.o win32/win_service.o win32/win_utils.o $(filter-out syscheckd/main-event.o, ${syscheck_eventchannel_o}) ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main-event.o, ${os_logcollector_eventchannel_o}) ${os_execd_o} active-response/active_responses.o monitord/rotate_log.o monitord/compress_log.o
+win32/wazuh-agent-eventchannel.exe: win32/version-app.o win32/icon.o win32/win_agent.o win32/win_service.o win32/win_utils.o $(filter-out syscheckd/main-event.o, ${syscheck_eventchannel_o}) ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main-event.o, ${os_logcollector_eventchannel_o}) ${os_execd_o} active-response/active_responses.o monitord/rotate_log.o monitord/compress_log.o
 	${OSSEC_CCBIN} -DARGV0=\"wazuh-agent\" -DOSSECHIDS -DEVENTCHANNEL_SUPPORT ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-win32/manage_agents.exe: win32/win_service_rk.o ${addagent_o}
+win32/manage_agents.exe: win32/version-app.o win32/win_service_rk.o ${addagent_o}
 	${OSSEC_CCBIN} -DARGV0=\"manage-agents\" -DMA ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-win32/setup-windows.exe: win32/win_service_rk.o win32/setup-win.o win32/setup-shared.o
+win32/setup-windows.exe: win32/version-app.o win32/win_service_rk.o win32/setup-win.o win32/setup-shared.o
 	${OSSEC_CCBIN} -DARGV0=\"setup-windows\" ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-win32/setup-syscheck.exe: win32/setup-syscheck.o win32/setup-shared.o
+win32/setup-syscheck.exe: win32/version-app.o win32/setup-syscheck.o win32/setup-shared.o
 	${OSSEC_CCBIN} -DARGV0=\"setup-syscheck\" ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
-win32/setup-iis.exe: win32/setup-iis.o
+win32/setup-iis.exe: win32/version-app.o win32/setup-iis.o
 	${OSSEC_CCBIN} -DARGV0=\"setup-iis\" ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 win32/ui_resource.o: win32/ui/win32ui.rc
@@ -2474,19 +2490,19 @@ win32/ui_resource.o: win32/ui/win32ui.rc
 win32/auth_resource.o: win32/agent-auth.rc
 	${OSSEC_WINDRES} -i $< -o $@
 
-win32/os_win32ui.exe: win32/ui_resource.o win32/win_service_rk.o ${win32_ui_o}
+win32/os_win32ui.exe: win32/ui_resource.o win32/win_service_rk.o ${win32_ui_o} win32/version-app.o
 	${OSSEC_CCBIN} -DARGV0=\"wazuh-win32ui\" ${AR_CFLAGS} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -mwindows -o $@
 
-win32/agent-auth.exe: win32/auth_resource.o win32/win_service_rk.o os_auth/main-client.o os_auth/ssl.o os_auth/main-client.o os_auth/check_cert.o addagent/validate.o
+win32/agent-auth.exe: win32/auth_resource.o win32/win_service_rk.o os_auth/main-client.o os_auth/ssl.o os_auth/main-client.o os_auth/check_cert.o addagent/validate.o win32/version-app.o
 	${OSSEC_CCBIN} -DARGV0=\"agent-auth\" -DOSSECHIDS ${AR_CFLAGS} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -lshlwapi -lwsock32 -lsecur32 -lws2_32 -flto -o $@
 
-win32/restart-wazuh.exe: ${WAZUH_LIB} ${WAZUHEXT_LIB} active-response/restart-wazuh.o active-response/active_responses.o
+win32/restart-wazuh.exe: ${WAZUH_LIB} ${WAZUHEXT_LIB} active-response/restart-wazuh.o active-response/active_responses.o win32/version-app.o
 	${OSSEC_CCBIN} -DARGV0=\"restart-wazuh\" ${AR_CFLAGS} ${AR_LDFLAGS} $^ -o $@
 
-win32/route-null.exe: ${WAZUH_LIB} ${WAZUHEXT_LIB} active-response/route-null.o active-response/active_responses.o
+win32/route-null.exe: ${WAZUH_LIB} ${WAZUHEXT_LIB} active-response/route-null.o active-response/active_responses.o win32/version-app.o
 	${OSSEC_CCBIN} -DARGV0=\"route-null\" ${AR_CFLAGS} ${AR_LDFLAGS} $^ -o $@
 
-win32/netsh.exe: ${WAZUH_LIB} ${WAZUHEXT_LIB} active-response/netsh.o active-response/active_responses.o
+win32/netsh.exe: ${WAZUH_LIB} ${WAZUHEXT_LIB} active-response/netsh.o active-response/active_responses.o win32/version-app.o
 	${OSSEC_CCBIN} -DARGV0=\"netsh\" ${AR_CFLAGS} ${AR_LDFLAGS} $^ -o $@
 
 ####################
@@ -2660,6 +2676,7 @@ clean-windows:
 	rm -f ${WINDOWS_BINS}
 	rm -f win32/wazuh-agent-*.exe
 	rm -f win32/libwinpthread-1.dll
+	rm -f win32/version-*.o
 	rm -f win32/VERSION
 	rm -f win32/REVISION
 

--- a/src/data_provider/CMakeLists.txt
+++ b/src/data_provider/CMakeLists.txt
@@ -129,7 +129,8 @@ endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 
 add_library(sysinfo SHARED
     ${SYSINFO_SRC}
-    ${CMAKE_SOURCE_DIR}/src/sysInfo.cpp )
+    ${CMAKE_SOURCE_DIR}/src/sysInfo.cpp
+    ${SRC_FOLDER}/${RESOURCE_OBJ} )
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   target_link_libraries(sysinfo psapi iphlpapi ws2_32)

--- a/src/shared_modules/dbsync/CMakeLists.txt
+++ b/src/shared_modules/dbsync/CMakeLists.txt
@@ -53,7 +53,8 @@ file(GLOB DBSYNC_SRC
     "${CMAKE_SOURCE_DIR}/src/sqlite/*.cpp")
 
 add_library(dbsync SHARED
-    ${DBSYNC_SRC} )
+    ${DBSYNC_SRC}
+    ${SRC_FOLDER}/${RESOURCE_OBJ} )
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   add_definitions(-DWIN_EXPORT)

--- a/src/shared_modules/rsync/CMakeLists.txt
+++ b/src/shared_modules/rsync/CMakeLists.txt
@@ -55,7 +55,8 @@ file(GLOB RSYNC_SRC
     "${CMAKE_SOURCE_DIR}/src/*.cpp")
 
 add_library(rsync SHARED
-    ${RSYNC_SRC} )
+    ${RSYNC_SRC}
+    ${SRC_FOLDER}/${RESOURCE_OBJ} )
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   add_definitions(-DWIN_EXPORT)

--- a/src/wazuh_modules/syscollector/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/CMakeLists.txt
@@ -74,7 +74,7 @@ file(GLOB SYSCOLLECTOR_SRC
 
 add_library(syscollector SHARED
     ${SYSCOLLECTOR_SRC}
-    )
+    ${SRC_FOLDER}/${RESOURCE_OBJ} )
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   set_target_properties(syscollector PROPERTIES

--- a/src/win32/version.rc
+++ b/src/win32/version.rc
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <winver.h>
+#include <ntdef.h>
+
+#ifdef RC_INVOKED
+
+#define Q(x) #x
+#define QUOTE(x) Q(x)
+
+#ifndef VER_PRODUCTVERSION
+#define VER_PRODUCTVERSION 4,4,0,0
+#endif
+
+#ifndef VER_PRODUCTVERSION_STR
+#define VER_PRODUCTVERSION_STR v4.4.0
+#endif
+
+#ifndef VER_FILEFLAGS
+#define VER_FILEFLAGS 0
+#endif
+
+#ifndef VER_TYPE
+#define VER_TYPE VFT_UNKNOWN
+#endif
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION             VER_PRODUCTVERSION
+PRODUCTVERSION          VER_PRODUCTVERSION
+FILEFLAGSMASK           VS_FFI_FILEFLAGSMASK
+FILEFLAGS               VER_FILEFLAGS
+FILEOS                  VOS_NT
+FILETYPE                VER_TYPE
+BEGIN
+	BLOCK "StringFileInfo"
+	BEGIN
+		BLOCK "040904b0"
+        BEGIN
+		VALUE "CompanyName",        "Wazuh Inc."
+		VALUE "FileDescription",    "Wazuh Windows Agent internal file"
+		VALUE "FileVersion",        QUOTE(VER_PRODUCTVERSION_STR)
+		VALUE "LegalCopyright",     "Copyright (C) 2015, Wazuh Inc."
+		VALUE "ProductName",        "Wazuh Windows Agent"
+		VALUE "ProductVersion",     QUOTE(VER_PRODUCTVERSION_STR)
+        VALUE "Info",               "https://www.wazuh.com"
+        VALUE "Licence",            "GPLv2"
+        END
+	END
+     BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END
+#endif

--- a/src/win32/version.rc
+++ b/src/win32/version.rc
@@ -49,8 +49,8 @@ BEGIN
 		VALUE "LegalCopyright",     "Copyright (C) 2015, Wazuh Inc."
 		VALUE "ProductName",        "Wazuh Windows Agent"
 		VALUE "ProductVersion",     QUOTE(VER_PRODUCTVERSION_STR)
-        VALUE "Info",               "https://www.wazuh.com"
-        VALUE "Licence",            "GPLv2"
+         VALUE "Info",               "https://www.wazuh.com"
+         VALUE "Licence",            "GPLv2"
         END
 	END
      BLOCK "VarFileInfo"

--- a/tools/bump_version.sh
+++ b/tools/bump_version.sh
@@ -70,6 +70,7 @@ CLUSTER_INIT="../framework/wazuh/core/cluster/__init__.py"
 API_SETUP="../api/setup.py"
 API_SPEC="../api/api/spec/spec.yaml"
 VERSION_DOCU="../src/Doxyfile"
+WIN_RESOURCE="../src/win32/version.rc"
 
 if [ -n "$version" ]
 then
@@ -137,6 +138,18 @@ then
     # Documentation config file
 
     sed -E -i'' -e "s/PROJECT_NUMBER         = \".+\"/PROJECT_NUMBER         = \"$version\"/g" $VERSION_DOCU
+
+     # version.rc
+
+    egrep "^#define VER_PRODUCTVERSION_STR v.+" $WIN_RESOURCE > /dev/null
+
+    if [ $? != 0 ]
+    then
+        echo "Error: no suitable version definition found at file $WIN_RESOURCE"
+        exit 1
+    fi
+
+    sed -E -i'' -e "s/^(#define VER_PRODUCTVERSION_STR +)v.+/\1$version/" $WIN_RESOURCE
 fi
 
 if [ -n "$revision" ]
@@ -192,4 +205,17 @@ then
     fi
 
     sed -E -i'' -e "s/^(VIProductVersion \").+\"/\1$product\"/g" $NSIS_FILE
+
+    # version.rc
+
+    egrep "^#define VER_PRODUCTVERSION [[:digit:]]+,[[:digit:]]+,[[:digit:]]+,[[:digit:]]+" $WIN_RESOURCE > /dev/null
+
+    if [ $? != 0 ]
+    then
+        echo "Error: no suitable version definition found at file $WIN_RESOURCE"
+        exit 1
+    fi
+
+    product_commas=`echo $product | tr '.' ','`
+    sed -E -i'' -e "s/^(#define VER_PRODUCTVERSION +).+/\1$product_commas/" $WIN_RESOURCE
 fi


### PR DESCRIPTION
|Related issue|
|---|
|#12660|


- Add detailed information for Windows agent binaries and libraries.
- Add version.rc file with default values and allowing to set some of
them by defines
- Add version.rc customization by bump_version.sh

## Description

This PR allows setting common detailed information for windows agent's binaries and libraries, and at the same time enabling custom build version

## Use examples
### Default compilation
```
make -C src TARGET=winagent
```
![Capture](https://user-images.githubusercontent.com/1791430/161338249-e74c2cff-0b72-4c95-9c68-3b51a6924835.PNG)

### Custom compilation
```
make -C src BUILD_VERSION="v4.4.0-commit123" TARGET=winagent
```
![Capture2](https://user-images.githubusercontent.com/1791430/161338265-20a3acdd-dcc6-42f3-97c2-0d47bde146cb.PNG)


### Compilation after bump to 4.5.0
```
./bump_version.sh v4.5.0 -r 40500 -p 4.5.0.0
make -C src TARGET=winagent
```
![Capture3](https://user-images.githubusercontent.com/1791430/161338276-6cebd179-3501-4a2d-a241-5b3647b9c8e0.PNG)


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors