### PR TITLE
Add unittests for wazuh_clusterd.py

### DIFF
--- a/framework/scripts/tests/test_wazuh_clusterd.py
+++ b/framework/scripts/tests/test_wazuh_clusterd.py
@@ -1,0 +1,362 @@
+# Copyright (C) 2015, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+import asyncio
+import sys
+from unittest.mock import call, patch
+
+import pytest
+import scripts.wazuh_clusterd as wazuh_clusterd
+
+
+def test_set_logging():
+    """Check and set the behavior of set_logging function."""
+    import wazuh.core.cluster.utils as cluster_utils
+
+    wazuh_clusterd.cluster_utils = cluster_utils
+    with patch.object(cluster_utils, 'ClusterLogger') as clusterlogger_mock:
+        assert wazuh_clusterd.set_logging(foreground_mode=False, debug_mode=0)
+        clusterlogger_mock.assert_called_once_with(
+            foreground_mode=False, log_path='logs/cluster.log', debug_level=0,
+            tag='{asctime} {levelname}: [{tag}] [{subtag}] {message}')
+
+
+@patch('builtins.print')
+def test_print_version(print_mock):
+    """Set the scheme to be printed."""
+    with patch('wazuh.core.cluster.__version__', 'TEST'):
+        wazuh_clusterd.print_version()
+        print_mock.assert_called_once_with(
+            '\nWazuh TEST - Wazuh Inc\n\nThis program is free software; you can redistribute it and/or modify\n'
+            'it under the terms of the GNU General Public License (version 2) as \npublished by the '
+            'Free Software Foundation. For more details, go to \nhttps://www.gnu.org/licenses/gpl.html\n')
+
+
+@patch('scripts.wazuh_clusterd.os.kill')
+@patch('scripts.wazuh_clusterd.os.getpid', return_value=1001)
+def test_exit_handler(os_getpid_mock, os_kill_mock):
+    """Set the behavior when exiting the script."""
+    from wazuh.core import pyDaemonModule
+
+    class SignalMock:
+        SIG_DFL = 1
+
+        class Signals:
+            def __init__(self, signum):
+                self.name = signum
+
+        @staticmethod
+        def signal(signalnum, handler):
+            assert signalnum == 9
+            assert handler == SignalMock.SIG_DFL
+
+    class LoggerMock:
+        def __init__(self):
+            pass
+
+        def info(self, msg):
+            pass
+
+    def original_sig_handler(signum, frame):
+        pass
+
+    original_sig_handler_not_callable = 1
+
+    wazuh_clusterd.main_logger = LoggerMock()
+    wazuh_clusterd.pyDaemonModule = pyDaemonModule
+    wazuh_clusterd.original_sig_handler = original_sig_handler
+    with patch('scripts.wazuh_clusterd.signal', SignalMock):
+        with patch.object(wazuh_clusterd, 'main_logger') as main_logger_mock:
+            with patch.object(wazuh_clusterd.pyDaemonModule, 'delete_child_pids') as delete_child_pids_mock:
+                with patch.object(wazuh_clusterd.pyDaemonModule, 'delete_pid') as delete_pid_mock:
+                    with patch.object(wazuh_clusterd, 'original_sig_handler') as original_sig_handler_mock:
+                        wazuh_clusterd.exit_handler(9, 99)
+                        main_logger_mock.assert_has_calls([call.info('SIGNAL [(9)-(9)] received. Exit...')])
+                        delete_child_pids_mock.assert_called_once_with('wazuh-clusterd', 1001, main_logger_mock)
+                        delete_pid_mock.assert_called_once_with('wazuh-clusterd', 1001)
+                        original_sig_handler_mock.assert_called_once_with(9, 99)
+                        main_logger_mock.reset_mock()
+                        delete_child_pids_mock.reset_mock()
+                        delete_pid_mock.reset_mock()
+                        original_sig_handler_mock.reset_mock()
+
+                        wazuh_clusterd.original_sig_handler = original_sig_handler_not_callable
+                        wazuh_clusterd.exit_handler(9, 99)
+                        main_logger_mock.assert_has_calls([call.info('SIGNAL [(9)-(9)] received. Exit...')])
+                        delete_child_pids_mock.assert_called_once_with('wazuh-clusterd', 1001, main_logger_mock)
+                        delete_pid_mock.assert_called_once_with('wazuh-clusterd', 1001)
+                        original_sig_handler_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_master_main():
+    """Check and set the behavior of master_main function."""
+    import wazuh.core.cluster.utils as cluster_utils
+
+    class Arguments:
+        def __init__(self, performance_test, concurrency_test, ssl):
+            self.performance_test = performance_test
+            self.concurrency_test = concurrency_test
+            self.ssl = ssl
+
+    class TaskPoolMock:
+        def __init__(self):
+            self._max_workers = 1
+
+        def map(self, first, second):
+            assert first == cluster_utils.process_spawn_sleep
+            assert second == range(0, 1)
+
+    class MasterMock:
+        def __init__(self, performance_test, concurrency_test, configuration, enable_ssl, logger, cluster_items):
+            assert performance_test == 'test_performance'
+            assert concurrency_test == 'concurrency_test'
+            assert configuration == {'test': 'config'}
+            assert enable_ssl == True
+            assert logger == 'test_logger'
+            assert cluster_items == {'node': 'item'}
+            self.task_pool = TaskPoolMock()
+
+        def start(self):
+            return 'MASTER_START'
+
+    class LocalServerMasterMock:
+        def __init__(self, performance_test, logger, concurrency_test, node, configuration, enable_ssl, cluster_items):
+            pass
+
+        def start(self):
+            return 'LOCALSERVER_START'
+
+    async def gather(first, second):
+        assert first == 'MASTER_START'
+        assert second == 'LOCALSERVER_START'
+
+    wazuh_clusterd.cluster_utils = cluster_utils
+    args = Arguments(performance_test='test_performance', concurrency_test='concurrency_test', ssl=True)
+    with patch('scripts.wazuh_clusterd.asyncio.gather', gather):
+        with patch('wazuh.core.cluster.master.Master', MasterMock):
+            with patch('wazuh.core.cluster.local_server.LocalServerMaster', LocalServerMasterMock):
+                await wazuh_clusterd.master_main(args=args, cluster_config={'test': 'config'},
+                                                 cluster_items={'node': 'item'}, logger='test_logger')
+
+
+@pytest.mark.asyncio
+@patch("asyncio.sleep", side_effect=IndexError)
+async def test_worker_main(asyncio_sleep_mock):
+    """Check and set the behavior of worker_main function."""
+    import wazuh.core.cluster.utils as cluster_utils
+
+    class Arguments:
+        def __init__(self, performance_test, concurrency_test, ssl, send_file, send_string):
+            self.performance_test = performance_test
+            self.concurrency_test = concurrency_test
+            self.ssl = ssl
+            self.send_file = send_file
+            self.send_string = send_string
+
+    class LoggerMock:
+        def __init__(self):
+            pass
+
+        def warning(self, msg):
+            pass
+
+    class WorkerMock:
+        def __init__(self, performance_test, concurrency_test, configuration,
+                     enable_ssl, logger, cluster_items, file, string, task_pool):
+            assert performance_test == 'test_performance'
+            assert concurrency_test == 'concurrency_test'
+            assert configuration == {'test': 'config'}
+            assert enable_ssl == True
+            assert file == True
+            assert string == True
+            assert logger == 'test_logger'
+            assert cluster_items == {'intervals': {'worker': {'connection_retry': 34}}}
+            assert task_pool is None
+
+        def start(self):
+            return 'WORKER_START'
+
+    class LocalServerWorkerMock:
+        def __init__(self, performance_test, logger, concurrency_test, node, configuration, enable_ssl, cluster_items):
+            pass
+
+        def start(self):
+            return 'LOCALSERVER_START'
+
+    async def gather(first, second):
+        assert first == 'WORKER_START'
+        assert second == 'LOCALSERVER_START'
+        raise asyncio.CancelledError()
+
+    wazuh_clusterd.cluster_utils = cluster_utils
+    wazuh_clusterd.main_logger = LoggerMock
+    args = Arguments(performance_test='test_performance', concurrency_test='concurrency_test', ssl=True,
+                     send_file=True, send_string=True)
+
+    with patch.object(wazuh_clusterd, 'main_logger') as main_logger_mock:
+        with patch('concurrent.futures.ProcessPoolExecutor', side_effect=FileNotFoundError) as processpoolexecutor_mock:
+            with patch('scripts.wazuh_clusterd.asyncio.gather', gather):
+                with patch('scripts.wazuh_clusterd.logging.info') as logging_info_mock:
+                    with patch('wazuh.core.cluster.worker.Worker', WorkerMock):
+                        with patch('wazuh.core.cluster.local_server.LocalServerWorker', LocalServerWorkerMock):
+                            with pytest.raises(IndexError):
+                                await wazuh_clusterd.worker_main(
+                                    args=args, cluster_config={'test': 'config'},
+                                    cluster_items={'intervals': {'worker': {'connection_retry': 34}}},
+                                    logger='test_logger')
+                            processpoolexecutor_mock.assert_called_once_with(max_workers=1)
+                            main_logger_mock.assert_has_calls([
+                                call.warning(
+                                    "In order to take advantage of Wazuh 4.3.0 cluster improvements, the directory "
+                                    "'/dev/shm' must be accessible by the 'wazuh' user. Check that this file has "
+                                    "permissions to be accessed by all users. Changing the file permissions to 777 "
+                                    "will solve this issue."),
+                                call.warning(
+                                    'The Wazuh cluster will be run without the improvements added in Wazuh 4.3.0 and '
+                                    'higher versions.')
+                            ])
+                            logging_info_mock.assert_called_once_with('Connection with server has been lost. '
+                                                                      'Reconnecting in 10 seconds.')
+                            asyncio_sleep_mock.assert_called_once_with(34)
+
+
+@patch('scripts.wazuh_clusterd.argparse.ArgumentParser')
+def test_get_script_arguments(mock_ArgumentParser):
+    """Set the wazuh_clusterd script parameters."""
+    from wazuh.core import common
+
+    wazuh_clusterd.common = common
+    with patch.object(wazuh_clusterd.common, 'OSSEC_CONF', 'testing/path'):
+        wazuh_clusterd.get_script_arguments()
+        mock_ArgumentParser.assert_called_once_with()
+        mock_ArgumentParser.return_value.add_argument.assert_has_calls(
+            [call('--performance_test', type=int, dest='performance_test', help='==SUPPRESS=='),
+             call('--concurrency_test', type=int, dest='concurrency_test', help='==SUPPRESS=='),
+             call('--string', help='==SUPPRESS==', type=int, dest='send_string'),
+             call('--file', help='==SUPPRESS==', type=str, dest='send_file'),
+             call('--ssl', help='Enable communication over SSL', action='store_true', dest='ssl', default=False),
+             call('-f', help='Run in foreground', action='store_true', dest='foreground'),
+             call('-d', help='Enable debug messages. Use twice to increase verbosity.', action='count',
+                  dest='debug_level'),
+             call('-V', help='Print version', action='store_true', dest='version'),
+             call('-r', help='Run as root', action='store_true', dest='root'),
+             call('-t', help='Test configuration', action='store_true', dest='test_config'),
+             call('-c', help='Configuration file to use', type=str, metavar='config', dest='config_file',
+                  default=common.OSSEC_CONF)])
+
+
+@patch('scripts.wazuh_clusterd.sys.exit', side_effect=sys.exit)
+@patch('scripts.wazuh_clusterd.os.getpid', return_value=543)
+@patch('scripts.wazuh_clusterd.os.setgid')
+@patch('scripts.wazuh_clusterd.os.setuid')
+@patch('scripts.wazuh_clusterd.os.chmod')
+@patch('scripts.wazuh_clusterd.os.chown')
+@patch('scripts.wazuh_clusterd.os.path.exists', return_value=True)
+@patch('builtins.print')
+def test_main(print_mock, path_exists_mock, chown_mock, chmod_mock, setuid_mock, setgid_mock, getpid_mock, exit_mock):
+    """Check and set the behavior of wazuh_clusterd main function."""
+    import wazuh.core.cluster.utils as cluster_utils
+    from wazuh.core import common, pyDaemonModule
+
+    class Arguments:
+        def __init__(self, config_file, test_config, foreground, root):
+            self.config_file = config_file
+            self.test_config = test_config
+            self.foreground = foreground
+            self.root = root
+
+    class LoggerMock:
+        def __init__(self):
+            pass
+
+        def info(self, msg):
+            pass
+
+        def error(self, msg):
+            pass
+
+    args = Arguments(config_file='test', test_config=True, foreground=False, root=False)
+    wazuh_clusterd.main_logger = LoggerMock()
+    wazuh_clusterd.args = args
+    wazuh_clusterd.common = common
+    wazuh_clusterd.pyDaemonModule = pyDaemonModule
+    wazuh_clusterd.cluster_utils = cluster_utils
+    with patch.object(common, 'wazuh_uid', return_value='uid_test'):
+        with patch.object(common, 'wazuh_gid', return_value='gid_test'):
+            with patch.object(wazuh_clusterd.cluster_utils, 'read_config', return_value={'disabled': True}):
+                with pytest.raises(SystemExit):
+                    wazuh_clusterd.main()
+                path_exists_mock.assert_any_call(f'{common.WAZUH_PATH}/logs/cluster.log')
+                chown_mock.assert_called_with(f'{common.WAZUH_PATH}/logs/cluster.log', 'uid_test', 'gid_test')
+                chmod_mock.assert_called_with(f'{common.WAZUH_PATH}/logs/cluster.log', 432)
+                exit_mock.assert_called_once_with(0)
+                exit_mock.reset_mock()
+
+            with patch.object(wazuh_clusterd.cluster_utils, 'read_config',
+                              return_value={'disabled': False, 'node_type': 'master'}):
+                with patch.object(wazuh_clusterd.main_logger, 'error') as main_logger_mock:
+                    with patch.object(wazuh_clusterd.main_logger, 'info') as main_logger_info_mock:
+                        with patch('wazuh.core.cluster.cluster.check_cluster_config', side_effect=IndexError):
+                            with pytest.raises(SystemExit):
+                                wazuh_clusterd.main()
+                            main_logger_mock.assert_called_once()
+                            exit_mock.assert_called_once_with(1)
+                            exit_mock.reset_mock()
+
+                        with patch('wazuh.core.cluster.cluster.check_cluster_config', return_value=None):
+                            with pytest.raises(SystemExit):
+                                wazuh_clusterd.main()
+                            main_logger_mock.assert_called_once()
+                            exit_mock.assert_called_once_with(0)
+                            main_logger_mock.reset_mock()
+                            exit_mock.reset_mock()
+
+                            args.test_config = False
+                            wazuh_clusterd.args = args
+                            with patch('wazuh.core.cluster.utils.get_cluster_status', return_value={'running': 'yes'}):
+                                with pytest.raises(SystemExit):
+                                    wazuh_clusterd.main()
+                                main_logger_mock.assert_called_once_with('Cluster is already running.', exc_info=False)
+                                exit_mock.assert_called_once_with(1)
+                                main_logger_mock.reset_mock()
+
+                            with patch('wazuh.core.cluster.utils.get_cluster_status', return_value={'running': 'no'}):
+                                with patch('wazuh.core.cluster.cluster.clean_up') as clean_up_mock:
+                                    with patch('scripts.wazuh_clusterd.clean_pid_files') as clean_pid_files_mock:
+                                        with patch.object(wazuh_clusterd.pyDaemonModule, 'pyDaemon') as pyDaemon_mock:
+                                            with patch.object(wazuh_clusterd.pyDaemonModule,
+                                                              'create_pid') as create_pid_mock:
+                                                with patch.object(wazuh_clusterd.pyDaemonModule, 'delete_child_pids'):
+                                                    with patch.object(wazuh_clusterd.pyDaemonModule,
+                                                                      'delete_pid') as delete_pid_mock:
+                                                        wazuh_clusterd.main()
+                                                        main_logger_mock.assert_any_call(
+                                                            "Unhandled exception: name 'cluster_items' is not defined")
+                                                        clean_up_mock.assert_called_once()
+                                                        clean_pid_files_mock.assert_called_once_with('wazuh-clusterd')
+                                                        pyDaemon_mock.assert_called_once()
+                                                        setuid_mock.assert_called_once_with('uid_test')
+                                                        setgid_mock.assert_called_once_with('gid_test')
+                                                        getpid_mock.assert_called()
+                                                        create_pid_mock.assert_called_once_with('wazuh-clusterd', 543)
+                                                        delete_pid_mock.assert_called_once_with('wazuh-clusterd', 543)
+
+                                                        args.foreground = True
+                                                        wazuh_clusterd.main()
+                                                        print_mock.assert_called_once_with(
+                                                            'Starting cluster in foreground (pid: 543)')
+
+                                                        wazuh_clusterd.cluster_items = {}
+                                                        with patch('scripts.wazuh_clusterd.master_main',
+                                                                   side_effect=KeyboardInterrupt('TESTING')):
+                                                            wazuh_clusterd.main()
+                                                            main_logger_info_mock.assert_any_call(
+                                                                'SIGINT received. Bye!')
+
+                                                        with patch('scripts.wazuh_clusterd.master_main',
+                                                                   side_effect=MemoryError('TESTING')):
+                                                            wazuh_clusterd.main()
+                                                            main_logger_mock.assert_any_call(
+                                                                "Directory '/tmp' needs read, write & execution "
+                                                                "permission for 'wazuh' user")

--- a/framework/scripts/wazuh_clusterd.py
+++ b/framework/scripts/wazuh_clusterd.py
@@ -145,7 +145,7 @@ def get_script_arguments():
 
 
 def main():
-    """TODO"""
+    """Main function of the wazuh_clusterd script in charge of starting the cluster process."""
     import wazuh.core.cluster.cluster
 
     # Set correct permissions on cluster.log file

--- a/framework/scripts/wazuh_clusterd.py
+++ b/framework/scripts/wazuh_clusterd.py
@@ -27,7 +27,7 @@ def set_logging(foreground_mode=False, debug_mode=0):
 
 def print_version():
     from wazuh.core.cluster import __version__, __author__, __wazuh_name__, __licence__
-    print("\n{} {} - {}\n\n{}".format(__wazuh_name__, __version__, __author__, __licence__))
+    print(f"\n{__wazuh_name__} {__version__} - {__author__}\n\n{__licence__}")
 
 
 def exit_handler(signum, frame):
@@ -105,13 +105,14 @@ async def worker_main(args, cluster_config, cluster_items, logger):
             await asyncio.sleep(cluster_items['intervals']['worker']['connection_retry'])
 
 
-#
-# Main
-#
-if __name__ == '__main__':
-    import wazuh.core.cluster.cluster
-    import wazuh.core.cluster.utils as cluster_utils
-    from wazuh.core import pyDaemonModule, common, configuration
+def get_script_arguments():
+    """Get script arguments.
+
+    Returns
+    -------
+    ArgumentParser object
+        Arguments passed to the script.
+    """
 
     parser = argparse.ArgumentParser()
     ####################################################################################################################
@@ -139,29 +140,22 @@ if __name__ == '__main__':
     parser.add_argument('-t', help="Test configuration", action='store_true', dest='test_config')
     parser.add_argument('-c', help="Configuration file to use", type=str, metavar='config', dest='config_file',
                         default=common.OSSEC_CONF)
-    args = parser.parse_args()
 
-    if args.version:
-        print_version()
-        sys.exit(0)
+    return parser
 
-    # Set logger
-    try:
-        debug_mode = configuration.get_internal_options_value('wazuh_clusterd', 'debug', 2, 0) or args.debug_level
-    except Exception:
-        debug_mode = 0
 
-    # set correct permissions on cluster.log file
-    if os.path.exists('{0}/logs/cluster.log'.format(common.WAZUH_PATH)):
-        os.chown('{0}/logs/cluster.log'.format(common.WAZUH_PATH), common.wazuh_uid(), common.wazuh_gid())
-        os.chmod('{0}/logs/cluster.log'.format(common.WAZUH_PATH), 0o660)
+def main():
+    """TODO"""
+    import wazuh.core.cluster.cluster
 
-    main_logger = set_logging(foreground_mode=args.foreground, debug_mode=debug_mode)
+    # Set correct permissions on cluster.log file
+    if os.path.exists(f'{common.WAZUH_PATH}/logs/cluster.log'):
+        os.chown(f'{common.WAZUH_PATH}/logs/cluster.log', common.wazuh_uid(), common.wazuh_gid())
+        os.chmod(f'{common.WAZUH_PATH}/logs/cluster.log', 0o660)
 
     cluster_configuration = cluster_utils.read_config(config_file=args.config_file)
     if cluster_configuration['disabled']:
         sys.exit(0)
-    cluster_items = cluster_utils.get_cluster_items()
     try:
         wazuh.core.cluster.cluster.check_cluster_config(cluster_configuration)
     except Exception as e:
@@ -196,8 +190,6 @@ if __name__ == '__main__':
     if args.foreground:
         print(f"Starting cluster in foreground (pid: {pid})")
 
-    original_sig_handler = signal.signal(signal.SIGTERM, exit_handler)
-
     main_function = master_main if cluster_configuration['node_type'] == 'master' else worker_main
     try:
         asyncio.run(main_function(args, cluster_configuration, cluster_items, main_logger))
@@ -211,3 +203,25 @@ if __name__ == '__main__':
     finally:
         pyDaemonModule.delete_child_pids('wazuh-clusterd', pid, main_logger)
         pyDaemonModule.delete_pid('wazuh-clusterd', pid)
+
+
+if __name__ == '__main__':
+    import wazuh.core.cluster.utils as cluster_utils
+    from wazuh.core import pyDaemonModule, common, configuration
+
+    cluster_items = cluster_utils.get_cluster_items()
+    original_sig_handler = signal.signal(signal.SIGTERM, exit_handler)
+
+    args = get_script_arguments().parse_args()
+    if args.version:
+        print_version()
+        sys.exit(0)
+
+    # Set logger
+    try:
+        debug_mode_ = configuration.get_internal_options_value('wazuh_clusterd', 'debug', 2, 0) or args.debug_level
+    except Exception:
+        debug_mode_ = 0
+
+    main_logger = set_logging(foreground_mode=args.foreground, debug_mode=debug_mode_)
+    main()

--- a/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
@@ -491,13 +491,14 @@ def test_DistributedAPI_check_wazuh_status_exception(node_info_mock, status_valu
             assert e._extra_message['not_ready_daemons'] == extra_message
 
 
-@patch("asyncio.get_event_loop")
-def test_APIRequestQueue_init(loop_mock):
+@patch("asyncio.Queue")
+def test_APIRequestQueue_init(queue_mock):
     """Test `APIRequestQueue` constructor."""
     server = DistributedAPI(f=agent.get_agents_summary_status, logger=logger)
     api_request_queue = APIRequestQueue(server=server)
     api_request_queue.add_request(b'testing')
     assert api_request_queue.server == server
+    queue_mock.assert_called_once()
 
 
 @patch("wazuh.core.cluster.common.import_module", return_value="os.path")


### PR DESCRIPTION
|Related issue|
|---|
|#12815|

## Description

This PR closes #12815. In this PR we have refactored the wazuh_clusterd.py file to cover the major part of the code. We have added unit tests to check the functionality of each of the functions of the script. These are the results of running the tests:

```
============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.5, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
rootdir: /mnt/c/Users/adr_i/git/wazuh/framework
plugins: asyncio-0.15.1, trio-0.7.0, cov-2.12.0, metadata-1.11.0, tavern-1.19.0, testinfra-6.4.0, html-3.1.1, aiohttp-0.3.0
collected 7 items

framework/scripts/tests/test_wazuh_clusterd.py .......                                                                                                                                                     [100%]

========================================================================================= 7 passed, 2 warnings in 2.51s ==========================================================================================
```

```
Name                                  Stmts   Miss  Cover   Missing
-------------------------------------------------------------------
framework/scripts/wazuh_clusterd.py     119     14    88%   209-227
-------------------------------------------------------------------
TOTAL                                   119     14    88%
```