### PR TITLE
Install debugging symbols for macOS and Linux

### DIFF
--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -926,12 +926,10 @@ InstallCommon()
   # Install debugging symbols if available
   # The symbols directory should always exist, if debugging symbols
   # are not supported for this platform, it will simply be empty.
-  if find symbols ! -path symbols ! -name .gitignore | grep . > /dev/null ;then
-    rm -rf ${INSTALLDIR}/.symbols
-    cp -r symbols ${INSTALLDIR}/.symbols
-    chown -R 0:0 ${INSTALLDIR}/.symbols
-    chmod -R 750 ${INSTALLDIR}/.symbols
-  fi
+  rm -rf ${INSTALLDIR}/.symbols
+  cp -r symbols ${INSTALLDIR}/.symbols
+  chown -R 0:0 ${INSTALLDIR}/.symbols
+  chmod -R 750 ${INSTALLDIR}/.symbols
 }
 
 InstallLocal()

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -923,6 +923,15 @@ InstallCommon()
 
   ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/backup
 
+  # Install debugging symbols if available
+  # The symbols directory should always exist, if debugging symbols
+  # are not supported for this platform, it will simply be empty.
+  if find symbols ! -path symbols ! -name .gitignore | grep . > /dev/null ;then
+    rm -rf ${INSTALLDIR}/.symbols
+    cp -r symbols ${INSTALLDIR}/.symbols
+    chown -R 0:0 ${INSTALLDIR}/.symbols
+    chmod -R 750 ${INSTALLDIR}/.symbols
+  fi
 }
 
 InstallLocal()
@@ -1159,15 +1168,6 @@ InstallAgent()
     ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/wodles/azure
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/azure/azure-logs.py ${INSTALLDIR}/wodles/azure/azure-logs
 
-    # Install debugging symbols if available
-    # The symbols directory should always exist, if debugging symbols
-    # are not supported for this platform, it will simply be empty.
-    if find symbols ! -path symbols ! -name .gitignore | grep . > /dev/null ;then
-      rm -rf ${INSTALLDIR}/.symbols
-      cp -r symbols ${INSTALLDIR}/.symbols
-      chown -R 0:0 ${INSTALLDIR}/.symbols
-      chmod -R 750 ${INSTALLDIR}/.symbols
-    fi
 }
 
 InstallWazuh()

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -924,12 +924,14 @@ InstallCommon()
   ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/backup
 
   # Install debugging symbols if available
-  # The symbols directory should always exist, if debugging symbols
+  # The symbols directory in the repo should always exist, if debugging symbols
   # are not supported for this platform, it will simply be empty.
   rm -rf ${INSTALLDIR}/.symbols
-  cp -r symbols ${INSTALLDIR}/.symbols
-  chown -R 0:0 ${INSTALLDIR}/.symbols
-  chmod -R 750 ${INSTALLDIR}/.symbols
+  if find symbols ! -path symbols ! -name .gitignore | grep . > /dev/null ;then
+    cp -r symbols ${INSTALLDIR}/.symbols
+    chown -R 0:0 ${INSTALLDIR}/.symbols
+    chmod -R 750 ${INSTALLDIR}/.symbols
+  fi
 }
 
 InstallLocal()

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1162,9 +1162,12 @@ InstallAgent()
     # Install debugging symbols if available
     # The symbols directory should always exist, if debugging symbols
     # are not supported for this platform, it will simply be empty.
-    cp -r symbols ${INSTALLDIR}/.symbols
-    chown -R 0:0 ${INSTALLDIR}/.symbols
-    chmod -R 750 ${INSTALLDIR}/.symbols
+    if find symbols ! -path symbols ! -name .gitignore | grep . > /dev/null ;then
+      rm -rf ${INSTALLDIR}/.symbols
+      cp -r symbols ${INSTALLDIR}/.symbols
+      chown -R 0:0 ${INSTALLDIR}/.symbols
+      chmod -R 750 ${INSTALLDIR}/.symbols
+    fi
 }
 
 InstallWazuh()

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1158,6 +1158,13 @@ InstallAgent()
 
     ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/wodles/azure
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/azure/azure-logs.py ${INSTALLDIR}/wodles/azure/azure-logs
+
+    # Install debugging symbols if available
+    if [ ${NUNAME} = 'Darwin' ]; then
+      cp .symbols/* ${INSTALLDIR}/.symbols/
+      chown -R 0:0 ${INSTALLDIR}/.symbols
+      chmod -R 750 ${INSTALLDIR}/.symbols
+    fi
 }
 
 InstallWazuh()

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1160,12 +1160,12 @@ InstallAgent()
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/azure/azure-logs.py ${INSTALLDIR}/wodles/azure/azure-logs
 
     # Install debugging symbols if available
-    if [ ${NUNAME} = 'Darwin' ]; then
-      mkdir -p 
-      cp -r symbols/* ${INSTALLDIR}/.symbols/
-      chown -R 0:0 ${INSTALLDIR}/.symbols
-      chmod -R 750 ${INSTALLDIR}/.symbols
-    fi
+    mkdir -p 
+    # The symbols directory should always exist, if debugging symbols
+    # are not supported for this platform, it will simply be empty.
+    cp -r symbols ${INSTALLDIR}/.symbols
+    chown -R 0:0 ${INSTALLDIR}/.symbols
+    chmod -R 750 ${INSTALLDIR}/.symbols
 }
 
 InstallWazuh()

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1160,7 +1160,6 @@ InstallAgent()
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/azure/azure-logs.py ${INSTALLDIR}/wodles/azure/azure-logs
 
     # Install debugging symbols if available
-    mkdir -p 
     # The symbols directory should always exist, if debugging symbols
     # are not supported for this platform, it will simply be empty.
     cp -r symbols ${INSTALLDIR}/.symbols

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1167,7 +1167,6 @@ InstallAgent()
 
     ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/wodles/azure
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/azure/azure-logs.py ${INSTALLDIR}/wodles/azure/azure-logs
-
 }
 
 InstallWazuh()

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1161,7 +1161,8 @@ InstallAgent()
 
     # Install debugging symbols if available
     if [ ${NUNAME} = 'Darwin' ]; then
-      cp .symbols/* ${INSTALLDIR}/.symbols/
+      mkdir -p 
+      cp -r symbols/* ${INSTALLDIR}/.symbols/
       chown -R 0:0 ${INSTALLDIR}/.symbols
       chmod -R 750 ${INSTALLDIR}/.symbols
     fi


### PR DESCRIPTION
|Related issue|
|---|
|#12712|

## Description
This PR modifies the installation script so that the debugging symbols for macOS (the .dSYM bundle fodlers) are copied to `/var/ossec/.symbols`.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [x] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors