### PR TITLE
Fix verify-agent-conf for MacOS ULS

### DIFF
--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -23,12 +23,14 @@ int maximum_files;
 int current_files;
 int total_files;
 
+#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
 /**
  * @brief gets the type filter from the type attribute
  * @param content type attribute string
  * @return returns the configuration flags: activity, trace and/or log
  */
 STATIC int w_logcollector_get_macos_log_type(const char * content);
+#endif
 
 int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
 {
@@ -45,8 +47,10 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     const char *xml_localfile_future = "only-future-events";
     const char *xml_localfile_max_size_attr = "max-size";
     const char *xml_localfile_query = "query";
+#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
     const char *xml_localfile_query_type_attr = "type";
     const char *xml_localfile_query_level_attr = "level";
+#endif
     const char *xml_localfile_label = "label";
     const char *xml_localfile_target = "target";
     const char *xml_localfile_outformat = "out_format";
@@ -135,6 +139,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             }
         } else if (strcmp(node[i]->element, xml_localfile_query) == 0) {
+#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
             const char * type_attr = w_get_attr_val_by_name(node[i], xml_localfile_query_type_attr);
             if (type_attr) {
                 logf[pl].query_type = w_logcollector_get_macos_log_type(type_attr);
@@ -152,6 +157,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                     os_strdup(level_attr, logf[pl].query_level);
                 }
             }
+#endif
             os_strdup(node[i]->content, logf[pl].query);
         } else if (strcmp(node[i]->element, xml_localfile_target) == 0) {
             // Count number of targets
@@ -354,7 +360,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
             } else if (strcmp(logf[pl].logformat, EVENTLOG) == 0) {
             } else if (strcmp(logf[pl].logformat, EVENTCHANNEL) == 0) {
             } else if (strcmp(logf[pl].logformat, MACOS) == 0) {
-                log_config->macos_blocks_count++;
+#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
                 os_calloc(1, sizeof(w_macos_log_config_t), logf[pl].macos_log);
                 w_calloc_expression_t(&logf[pl].macos_log->log_start_regex, EXP_TYPE_OSREGEX);
                 if (!w_expression_compile(logf[pl].macos_log->log_start_regex, MACOS_LOG_START_REGEX, 0)) {
@@ -363,6 +369,10 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                     os_free(logf[pl].macos_log);
                     return (OS_INVALID);
                 }
+#endif
+#ifndef Darwin
+                mwarn(MACOS_NOT_SUPPORTED);
+#endif
 
             } else {
                 merror(XML_VALUEERR, node[i]->element, node[i]->content);
@@ -478,10 +488,6 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     }
 
     /* Verify macos log config*/
-    if (log_config->macos_blocks_count > 1) {
-        merror(DUP_MACOS);
-        return (OS_INVALID);
-    }
     if (strcmp(logf[pl].logformat, MACOS) == 0) {
 
         if (strcmp(logf[pl].file, MACOS) != 0) {
@@ -899,7 +905,7 @@ const char * multiline_attr_match_str(w_multiline_match_type_t match_type) {
     return match_str[match_type];
 }
 
-
+#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
 STATIC int w_logcollector_get_macos_log_type(const char * content) {
 
     const size_t MAX_ARRAY_SIZE = 64;
@@ -939,4 +945,4 @@ STATIC int w_logcollector_get_macos_log_type(const char * content) {
 
     return retval;
 }
-
+#endif

--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -23,14 +23,12 @@ int maximum_files;
 int current_files;
 int total_files;
 
-#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
 /**
  * @brief gets the type filter from the type attribute
  * @param content type attribute string
  * @return returns the configuration flags: activity, trace and/or log
  */
 STATIC int w_logcollector_get_macos_log_type(const char * content);
-#endif
 
 int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
 {
@@ -47,10 +45,8 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     const char *xml_localfile_future = "only-future-events";
     const char *xml_localfile_max_size_attr = "max-size";
     const char *xml_localfile_query = "query";
-#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
     const char *xml_localfile_query_type_attr = "type";
     const char *xml_localfile_query_level_attr = "level";
-#endif
     const char *xml_localfile_label = "label";
     const char *xml_localfile_target = "target";
     const char *xml_localfile_outformat = "out_format";
@@ -139,7 +135,6 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             }
         } else if (strcmp(node[i]->element, xml_localfile_query) == 0) {
-#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
             const char * type_attr = w_get_attr_val_by_name(node[i], xml_localfile_query_type_attr);
             if (type_attr) {
                 logf[pl].query_type = w_logcollector_get_macos_log_type(type_attr);
@@ -157,7 +152,6 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                     os_strdup(level_attr, logf[pl].query_level);
                 }
             }
-#endif
             os_strdup(node[i]->content, logf[pl].query);
         } else if (strcmp(node[i]->element, xml_localfile_target) == 0) {
             // Count number of targets
@@ -369,9 +363,8 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                     os_free(logf[pl].macos_log);
                     return (OS_INVALID);
                 }
-#endif
-#ifndef Darwin
-                mwarn(MACOS_NOT_SUPPORTED);
+#else
+                mwarn(LOGCOLLECTOR_ONLY_MACOS);
 #endif
 
             } else {
@@ -479,6 +472,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     if (logf[pl].file == NULL) {
         if (strcmp(logf[pl].logformat, MACOS) == 0) {
             mwarn(LOGCOLLECTOR_MISSING_LOCATION_MACOS);
+            // Neceesary to check duplicated blocks
             os_strdup(MACOS, logf[pl].file);
         } else {
             merror(MISS_FILE);
@@ -494,6 +488,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
             /* Invalid macos log configuration */
             mwarn(LOGCOLLECTOR_INV_MACOS, logf[pl].file);
             os_free(logf[pl].file);
+            // Neceesary to check duplicated blocks
             w_strdup(MACOS, logf[pl].file);
         }
 
@@ -743,13 +738,14 @@ void Free_Logreader(logreader * logf) {
     int i;
 
     if (logf) {
-        free(logf->ffile);
-        free(logf->file);
-        free(logf->logformat);
-        free(logf->djb_program_name);
-        free(logf->alias);
-        free(logf->query);
-        free(logf->exclude);
+        os_free(logf->ffile);
+        os_free(logf->file);
+        os_free(logf->logformat);
+        os_free(logf->djb_program_name);
+        os_free(logf->alias);
+        os_free(logf->query);
+        os_free(logf->exclude);
+        os_free(logf->query_level);
 
         if (logf->target) {
             for (i = 0; logf->target[i]; i++) {
@@ -759,7 +755,7 @@ void Free_Logreader(logreader * logf) {
             free(logf->target);
         }
 
-        free(logf->log_target);
+        os_free(logf->log_target);
 
         labels_free(logf->labels);
 
@@ -905,7 +901,6 @@ const char * multiline_attr_match_str(w_multiline_match_type_t match_type) {
     return match_str[match_type];
 }
 
-#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
 STATIC int w_logcollector_get_macos_log_type(const char * content) {
 
     const size_t MAX_ARRAY_SIZE = 64;
@@ -945,4 +940,3 @@ STATIC int w_logcollector_get_macos_log_type(const char * content) {
 
     return retval;
 }
-#endif

--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -23,14 +23,12 @@ int maximum_files;
 int current_files;
 int total_files;
 
-#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
 /**
  * @brief gets the type filter from the type attribute
  * @param content type attribute string
  * @return returns the configuration flags: activity, trace and/or log
  */
 STATIC int w_logcollector_get_macos_log_type(const char * content);
-#endif
 
 int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
 {
@@ -47,10 +45,8 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     const char *xml_localfile_future = "only-future-events";
     const char *xml_localfile_max_size_attr = "max-size";
     const char *xml_localfile_query = "query";
-#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
     const char *xml_localfile_query_type_attr = "type";
     const char *xml_localfile_query_level_attr = "level";
-#endif
     const char *xml_localfile_label = "label";
     const char *xml_localfile_target = "target";
     const char *xml_localfile_outformat = "out_format";
@@ -139,7 +135,6 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             }
         } else if (strcmp(node[i]->element, xml_localfile_query) == 0) {
-#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
             const char * type_attr = w_get_attr_val_by_name(node[i], xml_localfile_query_type_attr);
             if (type_attr) {
                 logf[pl].query_type = w_logcollector_get_macos_log_type(type_attr);
@@ -157,7 +152,6 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                     os_strdup(level_attr, logf[pl].query_level);
                 }
             }
-#endif
             os_strdup(node[i]->content, logf[pl].query);
         } else if (strcmp(node[i]->element, xml_localfile_target) == 0) {
             // Count number of targets
@@ -359,7 +353,6 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
 
             } else if (strcmp(logf[pl].logformat, EVENTLOG) == 0) {
             } else if (strcmp(logf[pl].logformat, EVENTCHANNEL) == 0) {
-#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
             } else if (strcmp(logf[pl].logformat, MACOS) == 0) {
                 log_config->macos_blocks_count++;
                 os_calloc(1, sizeof(w_macos_log_config_t), logf[pl].macos_log);
@@ -371,7 +364,6 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                     return (OS_INVALID);
                 }
 
-#endif
             } else {
                 merror(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
@@ -475,27 +467,21 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
 
     /* Missing file */
     if (logf[pl].file == NULL) {
-#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
         if (strcmp(logf[pl].logformat, MACOS) == 0) {
             mwarn(LOGCOLLECTOR_MISSING_LOCATION_MACOS);
             os_strdup(MACOS, logf[pl].file);
         } else {
-#endif
             merror(MISS_FILE);
             os_strdup("", logf[pl].file);
             return (OS_INVALID);
-#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
         }
-#endif
     }
 
-#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
     /* Verify macos log config*/
     if (log_config->macos_blocks_count > 1) {
         merror(DUP_MACOS);
         return (OS_INVALID);
     }
-    
     if (strcmp(logf[pl].logformat, MACOS) == 0) {
 
         if (strcmp(logf[pl].file, MACOS) != 0) {
@@ -530,7 +516,6 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
             mwarn(LOGCOLLECTOR_OPTION_IGNORED, MACOS, xml_localfile_alias);
         }
     }
-#endif
     /* Verify Multiline Regex Config */
     if (strcmp(logf[pl].logformat, MULTI_LINE_REGEX) == 0) {
 
@@ -914,7 +899,6 @@ const char * multiline_attr_match_str(w_multiline_match_type_t match_type) {
     return match_str[match_type];
 }
 
-#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
 
 STATIC int w_logcollector_get_macos_log_type(const char * content) {
 
@@ -956,4 +940,3 @@ STATIC int w_logcollector_get_macos_log_type(const char * content) {
     return retval;
 }
 
-#endif

--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -363,8 +363,6 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                     os_free(logf[pl].macos_log);
                     return (OS_INVALID);
                 }
-#else
-                mwarn(LOGCOLLECTOR_ONLY_MACOS);
 #endif
 
             } else {

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -227,7 +227,6 @@ typedef struct _logreader_glob {
 typedef struct _logreader_config {
     int agent_cfg;
     int accept_remote;
-    unsigned int macos_blocks_count;
     logreader_glob *globs;
     logreader *config;
     logsocket *socket_list;
@@ -243,7 +242,7 @@ void Free_Logreader(logreader * config);
 int Remove_Localfile(logreader **logf, int i, int gl, int fr, logreader_glob *globf);
 
 /**
- * @brief Get match attribute for multiline regex 
+ * @brief Get match attribute for multiline regex
  * @param node node to find match value
  * @retval ML_MATCH_START if match is "start" or if the attribute is not present
  * @retval ML_MATCH_ALL if match is "all"
@@ -252,7 +251,7 @@ int Remove_Localfile(logreader **logf, int i, int gl, int fr, logreader_glob *gl
 w_multiline_match_type_t w_get_attr_match(xml_node * node);
 
 /**
- * @brief Get replace attribute for multiline regex 
+ * @brief Get replace attribute for multiline regex
  * @param node node to find match value
  * @retval ML_REPLACE_NO_REPLACE if replace is "no-replace" or if the attribute is not present
  * @retval ML_REPLACE_WSPACE if replace is "wspace"

--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -71,6 +71,6 @@
 
 /* Logcollector info messages */
 #define LOGCOLLECTOR_INVALID_HANDLE_VALUE   "(9200): File '%s' can not be handled."
-#define LOGCOLLECTOR_ONLY_MACOS             "(9201): 'macos' log_format is only supported in macOS."
+#define LOGCOLLECTOR_ONLY_MACOS             "(9201): 'macos' log format is only supported on macOS."
 
 #endif /* INFO_MESSAGES_H */

--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -71,5 +71,6 @@
 
 /* Logcollector info messages */
 #define LOGCOLLECTOR_INVALID_HANDLE_VALUE   "(9200): File '%s' can not be handled."
+#define LOGCOLLECTOR_ONLY_MACOS             "(9201): 'macos' log_format is only supported in macOS."
 
 #endif /* INFO_MESSAGES_H */

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -129,7 +129,7 @@
                                                 "'log_format'. Default value will be used."
 #define LOGCOLLECTOR_MISSING_LOCATION_MACOS     "(8006): Missing 'location' element when using 'macos' as " \
                                                 "'log_format'. Default value will be used."
-#define MACOS_NOT_SUPPORTED                     "(8007): 'macos' log_format is only supported in macOS."
+#define LOGCOLLECTOR_ONLY_MACOS                 "(8007): 'macos' log_format is only supported in macOS."
 
 /* Remoted */
 #define REMOTED_NET_PROTOCOL_ERROR              "(9000): Error getting protocol. Default value (%s) will be used."

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -129,7 +129,6 @@
                                                 "'log_format'. Default value will be used."
 #define LOGCOLLECTOR_MISSING_LOCATION_MACOS     "(8006): Missing 'location' element when using 'macos' as " \
                                                 "'log_format'. Default value will be used."
-#define LOGCOLLECTOR_ONLY_MACOS                 "(8007): 'macos' log_format is only supported in macOS."
 
 /* Remoted */
 #define REMOTED_NET_PROTOCOL_ERROR              "(9000): Error getting protocol. Default value (%s) will be used."

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -129,6 +129,7 @@
                                                 "'log_format'. Default value will be used."
 #define LOGCOLLECTOR_MISSING_LOCATION_MACOS     "(8006): Missing 'location' element when using 'macos' as " \
                                                 "'log_format'. Default value will be used."
+#define MACOS_NOT_SUPPORTED                     "(8007): 'macos' log_format is only supported in macOS."
 
 /* Remoted */
 #define REMOTED_NET_PROTOCOL_ERROR              "(9000): Error getting protocol. Default value (%s) will be used."

--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -35,7 +35,6 @@ int LogCollectorConfig(const char *cfgfile)
     log_config.globs = NULL;
     log_config.socket_list = NULL;
     log_config.agent_cfg = 0;
-    log_config.macos_blocks_count = 0;
     accept_remote = getDefine_Int("logcollector", "remote_commands", 0, 1);
     log_config.accept_remote = accept_remote;
 

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -366,9 +366,9 @@ void LogCollectorStart()
                 }
             }
 #endif
-            current->file = NULL;
-            current->command = NULL;
-            current->fp = NULL;
+            os_free(current->file);
+            os_free(current->command);
+            os_free(current->fp);
         }
 
         else if (j < 0) {

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -365,6 +365,8 @@ void LogCollectorStart()
                     w_logcollector_state_add_target(MACOS_LOG_NAME, current->target[tg_idx]);
                 }
             }
+#else
+            minfo(LOGCOLLECTOR_ONLY_MACOS);
 #endif
             os_free(current->file);
             os_free(current->command);

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -347,8 +347,9 @@ void LogCollectorStart()
                 merror("Missing command argument. Ignoring it.");
             }
         }
-#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
+
         else if (strcmp(current->logformat, MACOS) == 0) {
+#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
             /* Get macOS version */
             w_macos_create_log_env(current, sysinfo);
             current->read = read_macos;
@@ -364,8 +365,12 @@ void LogCollectorStart()
                     w_logcollector_state_add_target(MACOS_LOG_NAME, current->target[tg_idx]);
                 }
             }
-        }
 #endif
+            current->file = NULL;
+            current->command = NULL;
+            current->fp = NULL;
+        }
+
         else if (j < 0) {
             set_read(current, i, j);
             if (current->file) {

--- a/src/unit_tests/wrappers/wazuh/os_xml/os_xml_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/os_xml/os_xml_wrappers.c
@@ -27,7 +27,8 @@ const char * __wrap_w_get_attr_val_by_name(xml_node * node, const char * name) {
     return __real_w_get_attr_val_by_name(node, name);
 }
 
-xml_node ** __wrap_OS_GetElementsbyNode(const OS_XML * _lxml, const xml_node * node) {
+xml_node ** __wrap_OS_GetElementsbyNode(__attribute__ ((__unused__)) const OS_XML * _lxml,
+                                        __attribute__ ((__unused__)) const xml_node * node) {
      return mock_type(xml_node **);
 }
 
@@ -45,7 +46,7 @@ void __wrap_OS_ClearNode(xml_node ** node) {
     }
 }
 
-int __wrap_OS_ReadXML(const char * file, OS_XML * _lxml) {
+int __wrap_OS_ReadXML(__attribute__ ((__unused__)) const char * file, OS_XML * _lxml) {
     int retval = mock_type(int);
     if (retval < 0) {
         char * buffer = mock_type(char *);
@@ -55,4 +56,4 @@ int __wrap_OS_ReadXML(const char * file, OS_XML * _lxml) {
     return retval;
 }
 
-void __wrap_OS_ClearXML(OS_XML * _lxml) { return; }
+void __wrap_OS_ClearXML(__attribute__ ((__unused__)) OS_XML * _lxml) { return; }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #12903|
|Closes #12904|
|Closes https://github.com/wazuh/wazuh-kibana-app/issues/3921|

# Description

Currently, Logcollector's `localfile` blocks with `macos` as log_format were ONLY allowed in macOS systems because is an OS-dependant feature.

```
<localfile>
  <location>macos</location>
  <log_format>macos</log_format>
  <query type="activity,trace" level="info">process == "sshd" OR message CONTAINS "invalid"</query>
</localfile>
```

The problem appears during Centralized Configuration deployment, validating those `localfile`s blocks in the Manager (Linux) before sharing it to configured agents, failing due previously mentioned OS restriction. `verify-agent-conf` tool shows the next error 
```
# /var/ossec/bin/verify-agent-conf 

verify-agent-conf: Verifying [etc/shared/default/agent.conf]
2022/03/29 12:29:22 verify-agent-conf: ERROR: (1235): Invalid value for element 'log_format': macos.
2022/03/29 12:29:22 verify-agent-conf: ERROR: (1202): Configuration error at 'etc/shared/default/agent.conf'.
2022/03/29 12:29:22 verify-agent-conf: ERROR: (1207): Localfile remote configuration in 'etc/shared/default/agent.conf' is corrupted
```
# Proposal

To solve this the configuration is accepted during the load configuration step but ignored during operation step. The same approach was taken with Evenchannel and Eventlog localfiles, 

As with eventchannel, it will be accepted in the configuration and will be returned by the API.

## Manager:

```xml
# cat /var/ossec/etc/shared/default/agent.conf
<agent_config>

  <!-- Shared agent configuration here -->
    <localfile>
    <location>macos</location>
    <log_format>macos</log_format>
    <query type="activity,trace" level="info">process == "sshd" OR message CONTAINS "third"</query>
    </localfile>

</agent_config>
```

#### verify-agent-conf
```
# /var/ossec/bin/verify-agent-conf

verify-agent-conf: Verifying [etc/shared/default/agent.conf]
verify-agent-conf: OK
```

## Agent config

```xml
<localfile>
    <log_format>syslog</log_format>
    <location>/var/log/kern.log</location>
</localfile>

<localfile>
  <location>macos</location>
  <log_format>macos</log_format>
  <query type="activity,trace" level="info">process == "sshd" OR message CONTAINS "first"</query>
</localfile>

<localfile>
  <location>macos</location>
  <log_format>macos</log_format>
  <query type="activity,trace" level="info">process == "sshd" OR message CONTAINS "second"</query>
</localfile>

<localfile>
    <location>Microsoft-Windows-PrintService/Operational</location>
    <log_format>eventchannel</log_format>
</localfile>

```
### Linux 
#### Logcollector logs:
```
# /var/ossec/bin/wazuh-logcollector -f
2022/04/05 14:46:04 wazuh-logcollector: INFO: (9201): 'macos' log_format is only supported in macOS.
2022/04/05 14:46:05 wazuh-logcollector: INFO: (9201): 'macos' log_format is only supported in macOS.
2022/04/05 14:46:05 wazuh-logcollector: INFO: (1950): Analyzing file: '/var/log/kern.log'.
2022/04/05 14:46:05 wazuh-logcollector: WARNING: (1958): Log file 'macos' is duplicated.
2022/04/05 14:46:05 wazuh-logcollector: WARNING: (1958): Log file 'macos' is duplicated.
2022/04/05 14:46:05 wazuh-logcollector: INFO: Started (pid: 192005).

```

#### API response:

```json
╰─# go run /_shared/go_scripts/wazuh_sock.go -f /var/ossec/queue/sockets/logcollector -m "getconfig localfile"
Response: ok {
    "localfile": [
        {
            "file": "/var/log/kern.log",
            "logformat": "syslog",
            "ignore_binaries": "no",
            "only-future-events": "yes",
            "target": [
                "agent"
            ]
        },
        {
            "logformat": "eventchannel",
            "ignore_binaries": "no",
            "only-future-events": "yes",
            "target": [
                "agent"
            ],
            "reconnect_time": 5
        },
        {
            "logformat": "macos",
            "query": {
                "value": "process == \"sshd\" OR message CONTAINS \"third\"",
                "level": "info",
                "type": [
                    "activity",
                    "trace"
                ]
            },
            "ignore_binaries": "no",
            "only-future-events": "yes",
            "target": [
                "agent"
            ]
        }
    ]
}
```

### Windows

#### API response:
```json
# go run /_shared/go_scripts/wazuh_sock.go -f /var/ossec/queue/sockets/request  -m "005 logcollector getconfig localfile"
Response: ok {
    "localfile": [
        {
            "channel": "Application",
            "logformat": "eventchannel",
            "ignore_binaries": "no",
            "only-future-events": "yes",
            "target": [
                "agent"
            ],
            "reconnect_time": 5
        },
        {
            "channel": "Security",
            "logformat": "eventchannel",
            "query": {
                "value": "Event/System[EventID != 5145 and EventID != 5156 and EventID != 5447 and\n      EventID != 4656 and EventID != 4658 and EventID != 4663 and EventID != 4660 and\n      EventID != 4670 and EventID != 4690 and EventID != 4703 and EventID != 4907 and\n      EventID != 5152 and EventID != 5157]"
            },
            "ignore_binaries": "no",
            "only-future-events": "yes",
            "target": [
                "agent"
            ],
            "reconnect_time": 5
        },
        {
            "channel": "System",
            "logformat": "eventchannel",
            "ignore_binaries": "no",
            "only-future-events": "yes",
            "target": [
                "agent"
            ],
            "reconnect_time": 5
        },
        {
            "file": "active-response\\active-responses.log",
            "logformat": "syslog",
            "ignore_binaries": "no",
            "only-future-events": "yes",
            "target": [
                "agent"
            ]
        },
        {
            "logformat": "macos",
            "query": {
                "value": "process == \"sshd\" OR message CONTAINS \"thrid\"",
                "level": "info",
                "type": [
                    "activity",
                    "trace"
                ]
            },
            "ignore_binaries": "no",
            "only-future-events": "yes",
            "target": [
                "agent"
            ]
        }
    ]
}
```

#### Logs:
```
...
2022/04/05 22:56:31 wazuh-agent: INFO: (9201): 'macos' log_format is only supported in macOS.
2022/04/05 22:56:31 wazuh-agent: INFO: (9201): 'macos' log_format is only supported in macOS.
....
2022/04/05 22:56:31 wazuh-agent: WARNING: (1958): Log file 'macos' is duplicated.
```

### MacOS

#### API response:
```json
# go run /_shared/go_scripts/wazuh_sock.go -f /var/ossec/queue/sockets/request  -m "007 logcollector getconfig localfile"                            Response: ok {
    "localfile": [
        {
            "logformat": "full_command",
            "command": "netstat -an | grep -e \"tcp\" -e \"udp\" | sed -E 's/([[:alnum:]]*)\\ *[[:digit:]]*\\ *[[:digit:]]*\\ *(.*)\\.([0-9\\*]*)\\ +([0-9\\.\\*]+).+/\\1 \\2 == \\3 == \\4/' | sort -k 4 -g | sed 's/ == \\(.*\\) ==/.\\1/'| uniq",
            "alias": "netstat listening ports",
            "ignore_binaries": "no",
            "target": [
                "agent"
            ],
            "frequency": 360
        },
        {
            "logformat": "macos",
            "query": {
                "value": "process == \"sshd\" OR message CONTAINS \"thrid\"",
                "level": "info",
                "type": [
                    "activity",
                    "trace"
                ]
            },
            "ignore_binaries": "no",
            "only-future-events": "yes",
            "target": [
                "agent"
            ]
        }
    ]
}
```

#### Logcollector logs
```
sh-3.2# tail -f /Library/Ossec/logs/ossec.log | grep logcollector
2022/04/05 16:23:58 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2022/04/05 16:24:02 wazuh-logcollector: INFO: Monitoring full output of command(360): netstat -an | grep -e "tcp" -e "udp" | sed -E 's/([[:alnum:]]*)\ *[[:digit:]]*\ *[[:digit:]]*\ *(.*)\.([0-9\*]*)\ +([0-9\.\*]+).+/\1 \2 == \3 == \4/' | sort -k 4 -g | sed 's/ == \(.*\) ==/.\1/'| uniq
2022/04/05 16:24:02 wazuh-logcollector: WARNING: (1958): Log file 'macos' is duplicated.
2022/04/05 16:24:02 wazuh-logcollector: WARNING: (1958): Log file 'macos' is duplicated.
2022/04/05 16:24:02 wazuh-logcollector: INFO: (1604): Monitoring macOS logs with: /usr/bin/log stream --style syslog --type activity --type trace --level info --predicate process == "sshd" OR message CONTAINS "thrid".
2022/04/05 16:24:02 wazuh-logcollector: INFO: Started (pid: 11082).

```


## Tests
#### Linux
[Scanbuild report](https://github.com/wazuh/wazuh/files/8421926/scan-build-2022-04-05-211333-91472-1.zip)
[Valgrind report](https://github.com/wazuh/wazuh/files/8421927/ValgrindPRs.log)
#### Macos





<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [x] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors