### PR TITLE
Adding sanity check for negative values in alternative parameters of `sync-agent-groups-get` command

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -2078,11 +2078,11 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_last_id_data_type(void 
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: sync-agent-groups-get {\"condition\":\"sync_status\",\"last_id\":\"1_string\"}");
-    expect_string(__wrap__mdebug1, formatted_msg, "Invalid alternative fields data type in sync-agent-groups-get command.");
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid alternative fields data in sync-agent-groups-get command.");
 
     ret = wdb_parse(query, data->output, 0);
 
-    assert_string_equal(data->output, "err Invalid JSON data, invalid alternative fields data type");
+    assert_string_equal(data->output, "err Invalid JSON data, invalid alternative fields data");
     assert_int_equal(ret, OS_INVALID);
 }
 
@@ -2094,11 +2094,11 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_set_synced_data_type(vo
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: sync-agent-groups-get {\"condition\":\"sync_status\",\"set_synced\":\"true_string\"}");
-    expect_string(__wrap__mdebug1, formatted_msg, "Invalid alternative fields data type in sync-agent-groups-get command.");
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid alternative fields data in sync-agent-groups-get command.");
 
     ret = wdb_parse(query, data->output, 0);
 
-    assert_string_equal(data->output, "err Invalid JSON data, invalid alternative fields data type");
+    assert_string_equal(data->output, "err Invalid JSON data, invalid alternative fields data");
     assert_int_equal(ret, OS_INVALID);
 }
 
@@ -2110,11 +2110,11 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_get_hash_data_type(void
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: sync-agent-groups-get {\"condition\":\"sync_status\",\"get_global_hash\":\"true_string\"}");
-    expect_string(__wrap__mdebug1, formatted_msg, "Invalid alternative fields data type in sync-agent-groups-get command.");
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid alternative fields data in sync-agent-groups-get command.");
 
     ret = wdb_parse(query, data->output, 0);
 
-    assert_string_equal(data->output, "err Invalid JSON data, invalid alternative fields data type");
+    assert_string_equal(data->output, "err Invalid JSON data, invalid alternative fields data");
     assert_int_equal(ret, OS_INVALID);
 }
 
@@ -2126,11 +2126,11 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_agent_registration_delt
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: sync-agent-groups-get {\"condition\":\"sync_status\",\"agent_registration_delta\":\"0_string\"}");
-    expect_string(__wrap__mdebug1, formatted_msg, "Invalid alternative fields data type in sync-agent-groups-get command.");
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid alternative fields data in sync-agent-groups-get command.");
 
     ret = wdb_parse(query, data->output, 0);
 
-    assert_string_equal(data->output, "err Invalid JSON data, invalid alternative fields data type");
+    assert_string_equal(data->output, "err Invalid JSON data, invalid alternative fields data");
     assert_int_equal(ret, OS_INVALID);
 }
 

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -2086,6 +2086,22 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_last_id_data_type(void 
     assert_int_equal(ret, OS_INVALID);
 }
 
+void test_wdb_parse_global_sync_agent_groups_get_invalid_last_id_negative(void **state)
+{
+    int ret = 0;
+    test_struct_t *data = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global sync-agent-groups-get {\"condition\":\"sync_status\",\"last_id\":-1}";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: sync-agent-groups-get {\"condition\":\"sync_status\",\"last_id\":-1}");
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid alternative fields data in sync-agent-groups-get command.");
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Invalid JSON data, invalid alternative fields data");
+    assert_int_equal(ret, OS_INVALID);
+}
+
 void test_wdb_parse_global_sync_agent_groups_get_invalid_set_synced_data_type(void **state)
 {
     int ret = 0;
@@ -2126,6 +2142,22 @@ void test_wdb_parse_global_sync_agent_groups_get_invalid_agent_registration_delt
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: sync-agent-groups-get {\"condition\":\"sync_status\",\"agent_registration_delta\":\"0_string\"}");
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid alternative fields data in sync-agent-groups-get command.");
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Invalid JSON data, invalid alternative fields data");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_sync_agent_groups_get_invalid_agent_registration_delta_negative(void **state)
+{
+    int ret = 0;
+    test_struct_t *data = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global sync-agent-groups-get {\"condition\":\"sync_status\",\"agent_registration_delta\":-1}";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: sync-agent-groups-get {\"condition\":\"sync_status\",\"agent_registration_delta\":-1}");
     expect_string(__wrap__mdebug1, formatted_msg, "Invalid alternative fields data in sync-agent-groups-get command.");
 
     ret = wdb_parse(query, data->output, 0);
@@ -2961,9 +2993,11 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_invalid_json, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_missing_condition_field, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_invalid_last_id_data_type, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_invalid_last_id_negative, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_invalid_set_synced_data_type, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_invalid_get_hash_data_type, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_invalid_agent_registration_delta_data_type, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_invalid_agent_registration_delta_negative, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_null_response, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_invalid_response, test_setup, test_teardown),

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5367,12 +5367,12 @@ int wdb_parse_global_sync_agent_groups_get(wdb_t* wdb, char* input, char* output
             ret = OS_INVALID;
         }
         // Checking data types of alternative parameters in case they would have been sent in the input JSON.
-        else if ((j_last_id && !cJSON_IsNumber(j_last_id)) ||
+        else if ((j_last_id && (!cJSON_IsNumber(j_last_id) || j_last_id->valueint < 0)) ||
             (j_set_synced && !cJSON_IsBool(j_set_synced)) ||
             (j_get_hash && !cJSON_IsBool(j_get_hash)) ||
-            (j_agent_registration_delta && !cJSON_IsNumber(j_agent_registration_delta))) {
-            mdebug1("Invalid alternative fields data type in sync-agent-groups-get command.");
-            snprintf(output, OS_MAXSTR + 1, "err Invalid JSON data, invalid alternative fields data type");
+            (j_agent_registration_delta && (!cJSON_IsNumber(j_agent_registration_delta) || j_agent_registration_delta->valueint < 0))) {
+            mdebug1("Invalid alternative fields data in sync-agent-groups-get command.");
+            snprintf(output, OS_MAXSTR + 1, "err Invalid JSON data, invalid alternative fields data");
             ret = OS_INVALID;
         } else {
             wdb_groups_sync_condition_t condition = WDB_GROUP_INVALID_CONDITION;


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/13039 |

## Description

This pull request adds sanity checks to return an error in case of receiving negative values for the `last_id` and `agent_registration_delta` alternative parameters in the `sync-agent-groups-get` command.

In this case, now the log that is written will be:

```
Invalid alternative fields data in sync-agent-groups-get command.
```

And the error returned by **wazuh-db** will be:

```
err Invalid JSON data, invalid alternative fields data
```

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

- Memory tests for Linux
  - [x] Scan-build report
          ![image](https://user-images.githubusercontent.com/5703274/161855712-d8318f7a-d6a7-4799-8411-4968daea80c1.png)