### PR TITLE
KVDB improvements

### DIFF
--- a/src/engine/source/kvdb/include/kvdb/kvdb.hpp
+++ b/src/engine/source/kvdb/include/kvdb/kvdb.hpp
@@ -52,7 +52,7 @@ public:
                const std::string &columnName = DEFAULT_CF_NAME);
 
     bool writeToTransaction(
-        const std::vector<std::pair<std::string, std::string>> pairsVector,
+        const std::vector<std::pair<std::string, std::string>>& pairsVector,
         const std::string &columnName = DEFAULT_CF_NAME);
 
     bool hasKey(const std::string &key,

--- a/src/engine/source/kvdb/include/kvdb/kvdb.hpp
+++ b/src/engine/source/kvdb/include/kvdb/kvdb.hpp
@@ -71,11 +71,13 @@ public:
     bool deleteKey(const std::string &key,
                    const std::string &columnName = DEFAULT_CF_NAME);
     bool close();
-    bool destroy();
+    bool m_destroyOnClose = false;
+    void markToDestroy() {m_destroyOnClose = true;}
 
     constexpr static const char* DEFAULT_CF_NAME {"default"};
 
 private:
+    bool destroy();
     std::string m_name = "Invalid";
     std::string m_path;
     State m_state = State::Invalid;

--- a/src/engine/source/kvdb/include/kvdb/kvdb.hpp
+++ b/src/engine/source/kvdb/include/kvdb/kvdb.hpp
@@ -43,7 +43,7 @@ public:
     // TODO: all the default column names should be changed, one option is to
     // define a KVDB default CF in order to avoid using a deleteColumn or
     // cleanColumn without any argument
-    bool deleteColumn(const std::string &columnName = DEFAULT_CF_NAME);
+    bool deleteColumn(const std::string &columnName);
 
     bool cleanColumn(const std::string &columnName = DEFAULT_CF_NAME);
 
@@ -55,7 +55,7 @@ public:
                       const std::string &columnName = DEFAULT_CF_NAME);
 
     bool writeToTransaction(
-        const std::vector<std::pair<std::string, std::string>>& pairsVector,
+        const std::vector<std::pair<std::string, std::string>> &pairsVector,
         const std::string &columnName = DEFAULT_CF_NAME);
 
     bool hasKey(const std::string &key,
@@ -71,13 +71,16 @@ public:
     bool deleteKey(const std::string &key,
                    const std::string &columnName = DEFAULT_CF_NAME);
     bool close();
-    bool m_destroyOnClose = false;
-    void markToDestroy() {m_destroyOnClose = true;}
+    bool m_deleteOnClose = false;
+    void markToDelete()
+    {
+        m_deleteOnClose = true;
+    }
 
     constexpr static const char* DEFAULT_CF_NAME {"default"};
 
 private:
-    bool destroy();
+    bool deleteFile();
     std::string m_name = "Invalid";
     std::string m_path;
     State m_state = State::Invalid;

--- a/src/engine/source/kvdb/include/kvdb/kvdb.hpp
+++ b/src/engine/source/kvdb/include/kvdb/kvdb.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <shared_mutex>
 
 #include "rocksdb/db.h"
 #include "rocksdb/utilities/transaction_db.h"
@@ -37,6 +38,7 @@ public:
     }
 
     bool isReady();
+    bool isValid();
 
     bool createColumn(const std::string &columnName);
 
@@ -84,6 +86,7 @@ private:
     std::string m_name = "Invalid";
     std::string m_path;
     State m_state = State::Invalid;
+    std::shared_mutex m_mtx;
 
     rocksdb::DB *m_db;
     rocksdb::TransactionDB *m_txndb;

--- a/src/engine/source/kvdb/include/kvdb/kvdb.hpp
+++ b/src/engine/source/kvdb/include/kvdb/kvdb.hpp
@@ -51,6 +51,9 @@ public:
                const std::string &value,
                const std::string &columnName = DEFAULT_CF_NAME);
 
+    bool writeKeyOnly(const std::string &key,
+                      const std::string &columnName = DEFAULT_CF_NAME);
+
     bool writeToTransaction(
         const std::vector<std::pair<std::string, std::string>>& pairsVector,
         const std::string &columnName = DEFAULT_CF_NAME);

--- a/src/engine/source/kvdb/include/kvdb/kvdbManager.hpp
+++ b/src/engine/source/kvdb/include/kvdb/kvdbManager.hpp
@@ -9,22 +9,24 @@
 
 class KVDBManager
 {
-    KVDBManager();
+    KVDBManager(const std::string& DbFolder);
     ~KVDBManager();
-    // TODO: this will be moved to an init method and folder path will be
-    // modifiable
-    const std::string FOLDER = "/var/ossec/queue/db/kvdb/";
-    using DBMap = std::unordered_map<std::string, std::unique_ptr<KVDB>>;
-    DBMap m_availableKVDBs;
-    bool addDB(const std::string &name,const std::string &folder);
+    static KVDBManager* mInstance;
+    std::string mDbFolder;
+    using DBMap = std::unordered_map<std::string, KVDB *>;
+    DBMap available_kvdbs;
+    bool addDB(KVDB *DB);
+    KVDB invalidDB = KVDB(); // TODO: Make this static?
 
 public:
+    static bool init(const std::string& DbFolder);
     static KVDBManager &get()
     {
         static KVDBManager instance;
         return instance;
     }
     KVDBManager(KVDBManager const &) = delete;
+    KVDBManager() = delete;
     void operator=(KVDBManager const &) = delete;
     KVDB &createDB(const std::string &Name, bool overwrite = true);
     bool createDBfromCDB(const std::filesystem::path &path,

--- a/src/engine/source/kvdb/include/kvdb/kvdbManager.hpp
+++ b/src/engine/source/kvdb/include/kvdb/kvdbManager.hpp
@@ -13,22 +13,18 @@ class KVDBManager
     ~KVDBManager();
     static KVDBManager* mInstance;
     std::string mDbFolder;
-    using DBMap = std::unordered_map<std::string, KVDB *>;
-    DBMap available_kvdbs;
-    bool addDB(KVDB *DB);
-    KVDB invalidDB = KVDB(); // TODO: Make this static?
+    using DBMap = std::unordered_map<std::string, std::unique_ptr<KVDB>>;
+    DBMap m_availableKVDBs;
+    bool addDB(const std::string &name,const std::string &folder);
 
 public:
     static bool init(const std::string& DbFolder);
-    static KVDBManager &get()
-    {
-        static KVDBManager instance;
-        return instance;
-    }
+    static KVDBManager &get();
     KVDBManager(KVDBManager const &) = delete;
     KVDBManager() = delete;
     void operator=(KVDBManager const &) = delete;
-    KVDB &createDB(const std::string &Name, bool overwrite = true);
+    bool createDB(const std::string &Name,
+                  bool overwrite = true);
     bool createDBfromCDB(const std::filesystem::path &path,
                          bool overwrite = true);
     bool deleteDB(const std::string &name);

--- a/src/engine/source/kvdb/include/kvdb/kvdbManager.hpp
+++ b/src/engine/source/kvdb/include/kvdb/kvdbManager.hpp
@@ -13,7 +13,7 @@ class KVDBManager
     ~KVDBManager();
     static KVDBManager* mInstance;
     std::string mDbFolder;
-    using DBMap = std::unordered_map<std::string, std::unique_ptr<KVDB>>;
+    using DBMap = std::unordered_map<std::string, std::shared_ptr<KVDB>>;
     DBMap m_availableKVDBs;
     bool addDB(const std::string &name,const std::string &folder);
 
@@ -28,7 +28,7 @@ public:
     bool createDBfromCDB(const std::filesystem::path &path,
                          bool overwrite = true);
     bool deleteDB(const std::string &name);
-    KVDB &getDB(const std::string &name);
+    std::shared_ptr<KVDB> getDB(const std::string &name);
 };
 
 #endif // _KVDBMANAGER_H

--- a/src/engine/source/kvdb/include/kvdb/kvdbManager.hpp
+++ b/src/engine/source/kvdb/include/kvdb/kvdbManager.hpp
@@ -9,22 +9,22 @@
 
 class KVDBManager
 {
-    KVDBManager(const std::string& DbFolder);
+    KVDBManager(const std::string &DbFolder);
     ~KVDBManager();
-    static KVDBManager* mInstance;
+    static KVDBManager *mInstance;
     std::string mDbFolder;
     using DBMap = std::unordered_map<std::string, std::shared_ptr<KVDB>>;
     DBMap m_availableKVDBs;
-    bool addDB(const std::string &name,const std::string &folder);
+    bool addDB(const std::string &name, const std::string &folder);
+    bool popDB(const std::string &name);
 
 public:
-    static bool init(const std::string& DbFolder);
+    static bool init(const std::string &DbFolder);
     static KVDBManager &get();
     KVDBManager(KVDBManager const &) = delete;
     KVDBManager() = delete;
     void operator=(KVDBManager const &) = delete;
-    bool createDB(const std::string &Name,
-                  bool overwrite = true);
+    bool createDB(const std::string &Name, bool overwrite = true);
     bool createDBfromCDB(const std::filesystem::path &path,
                          bool overwrite = true);
     bool deleteDB(const std::string &name);

--- a/src/engine/source/kvdb/include/kvdb/kvdbManager.hpp
+++ b/src/engine/source/kvdb/include/kvdb/kvdbManager.hpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <string>
 #include <vector>
+#include <shared_mutex>
 
 #include "kvdb.hpp"
 
@@ -17,6 +18,7 @@ class KVDBManager
     DBMap m_availableKVDBs;
     bool addDB(const std::string &name, const std::string &folder);
     bool popDB(const std::string &name);
+    std::mutex mMtx;
 
 public:
     static bool init(const std::string &DbFolder);

--- a/src/engine/source/kvdb/src/kvdb.cpp
+++ b/src/engine/source/kvdb/src/kvdb.cpp
@@ -425,7 +425,7 @@ bool KVDB::writeToTransaction(
         return false;
     }
 
-    ROCKSDB::Transaction *txn = m_txndb->BeginTransaction(m_options.write);
+    rocksdb::Transaction *txn = m_txndb->BeginTransaction(kOptions.write);
     if (!txn)
     {
         WAZUH_LOG_ERROR("Couldn't begin in transaction");
@@ -444,7 +444,7 @@ bool KVDB::writeToTransaction(
             continue;
         }
         // Write a key-value in this transaction
-        ROCKSDB::Status s = txn->Put(cfh->second, key, value);
+        rocksdb::Status s = txn->Put(cfh->second, key, value);
         if (!s.ok())
         {
             txnOk = false;
@@ -452,7 +452,7 @@ bool KVDB::writeToTransaction(
                             s.ToString());
         }
     }
-    ROCKSDB::Status s = txn->Commit();
+    rocksdb::Status s = txn->Commit();
     if (!s.ok())
     {
         txnOk = false;
@@ -486,7 +486,7 @@ bool KVDB::hasKey(const std::string &key, const std::string &columnName)
         WAZUH_LOG_ERROR("DB should be open for execution");
     }
     std::string value;
-    return m_db->KeyMayExist(m_options.read, cfh->second, ROCKSDB::Slice(key), &value);
+    return m_db->KeyMayExist(kOptions.read, cfh->second, rocksdb::Slice(key), &value);
 }
 
 /**

--- a/src/engine/source/kvdb/src/kvdb.cpp
+++ b/src/engine/source/kvdb/src/kvdb.cpp
@@ -73,7 +73,7 @@ KVDB::KVDB(const std::string &dbName, const std::string &folder)
                         s.ToString());
         m_state = State::Error;
         // TODO: Investigate the reason of this:
-        // RocksDB creates a DB even if the option is create_if_missing is false.
+        // RocksDB creates a DB even if the option create_if_missing is false.
         // The open operation fails, but the DB is created anyway.
         rocksdb::DestroyDB(m_path, rocksdb::Options(), CFDescriptors);
     }
@@ -425,6 +425,7 @@ bool KVDB::cleanColumn(const std::string &columnName)
             deleteKey(iter->key().ToString());
             iter->Next();
         };
+        delete iter;
         return true;
     }
     else if (deleteColumn(columnName))

--- a/src/engine/source/kvdb/src/kvdb.cpp
+++ b/src/engine/source/kvdb/src/kvdb.cpp
@@ -117,18 +117,22 @@ bool KVDB::close()
     }
     m_txndb = nullptr;
     m_db = nullptr;
+
+    if (m_destroyOnClose && !destroy()) {
+        ret = false;
+    }
+
     return ret;
 }
 
 /**
  * @brief Db destruction cleaning all files and data related to it
  *
- * @return true succesfully destructed
- * @return false unsuccesfully destructed
+ * @return true successfully destructed
+ * @return false unsuccessfully destructed
  */
 bool KVDB::destroy()
 {
-    close();
     rocksdb::Status s =
         rocksdb::DestroyDB(m_path, rocksdb::Options(), CFDescriptors);
     if (!s.ok())

--- a/src/engine/source/kvdb/src/kvdb.cpp
+++ b/src/engine/source/kvdb/src/kvdb.cpp
@@ -51,13 +51,13 @@ KVDB::KVDB(const std::string &dbName, const std::string &folder)
             rocksdb::ColumnFamilyDescriptor(DEFAULT_CF_NAME, kOptions.CF));
     }
 
-    rocksdb::Status st = rocksdb::TransactionDB::Open(kOptions.open,
-                                                      kOptions.TX,
-                                                      m_path,
-                                                      CFDescriptors,
-                                                      &CFHandles,
-                                                      &m_txndb);
-    if (st.ok())
+    s = rocksdb::TransactionDB::Open(kOptions.open,
+                                     kOptions.TX,
+                                     m_path,
+                                     CFDescriptors,
+                                     &CFHandles,
+                                     &m_txndb);
+    if (s.ok())
     {
         m_db = m_txndb->GetBaseDB();
         for (auto CFHandle : CFHandles)
@@ -75,7 +75,10 @@ KVDB::KVDB(const std::string &dbName, const std::string &folder)
         // TODO: Investigate the reason of this:
         // RocksDB creates a DB even if the option create_if_missing is false.
         // The open operation fails, but the DB is created anyway.
-        rocksdb::DestroyDB(m_path, rocksdb::Options(), CFDescriptors);
+        // A possibility is to first open the DB and after that open the transaction.
+        if (s.IsInvalidArgument()) {
+            rocksdb::DestroyDB(m_path, rocksdb::Options(), CFDescriptors);
+        }
     }
 }
 

--- a/src/engine/source/kvdb/src/kvdb.cpp
+++ b/src/engine/source/kvdb/src/kvdb.cpp
@@ -72,6 +72,10 @@ KVDB::KVDB(const std::string &dbName, const std::string &folder)
                         m_name,
                         s.ToString());
         m_state = State::Error;
+        // TODO: Investigate the reason of this:
+        // RocksDB creates a DB even if the option is create_if_missing is false.
+        // The open operation fails, but the DB is created anyway.
+        rocksdb::DestroyDB(m_path, rocksdb::Options(), CFDescriptors);
     }
 }
 

--- a/src/engine/source/kvdb/src/kvdbManager.cpp
+++ b/src/engine/source/kvdb/src/kvdbManager.cpp
@@ -14,21 +14,16 @@
 
 #include <kvdb/kvdb.hpp>
 
-// TODO Change Function Helpers tests initialization too.
-KVDBManager *KVDBManager::mInstance = nullptr;
-bool KVDBManager::init(const std::string &DbFolder)
+KVDBManager* KVDBManager::mInstance = nullptr;
+bool KVDBManager::init(const std::string& DbFolder)
 {
-    if (mInstance)
-    {
+    if (mInstance) {
         return false;
     }
-    if (DbFolder.empty())
-    {
+    if (DbFolder.empty()) {
         return false;
     }
-    std::filesystem::create_directories(
-        DbFolder); // TODO Remove this whe Engine is integrated in Wazuh
-                   // installation
+    std::filesystem::create_directories(DbFolder); // TODO Remove this when Engine is integrated in Wazuh installation
     mInstance = new KVDBManager(DbFolder);
     return true;
 }
@@ -81,7 +76,9 @@ bool KVDBManager::createDB(const std::string &name, bool overwrite)
     rocksdb::Status s = rocksdb::DB::Open(createOptions, mDbFolder + name, &db);
     if (!s.ok())
     {
-        WAZUH_LOG_ERROR("couldn't open db file, error: [{}]", s.ToString());
+        WAZUH_LOG_ERROR("Couldn't create DB [{}] file, error: [{}]",
+                        name,
+                        s.ToString());
         return false;
     }
     s = db->Close(); // TODO: We can avoid this unnecessary close making a more
@@ -89,7 +86,7 @@ bool KVDBManager::createDB(const std::string &name, bool overwrite)
                      // or if receives a CFHandler and a CFDescriptor vector.
     if (!s.ok())
     {
-        WAZUH_LOG_ERROR("couldn't close db file, error: [{}]", s.ToString());
+        WAZUH_LOG_ERROR("Couldn't close db file, error: [{}]", s.ToString());
         return false;
     }
 
@@ -102,13 +99,13 @@ bool KVDBManager::createDBfromCDB(const std::filesystem::path &path,
     std::ifstream CDBfile(path);
     if (!CDBfile.is_open())
     {
-        WAZUH_LOG_ERROR("Can't open CDB already open");
+        WAZUH_LOG_ERROR("Can't open CDB file [{}]",
+                        path.c_str());
         return false;
     }
 
     if (!createDB(path.stem(), overwrite))
     {
-        WAZUH_LOG_ERROR("Couldn't create DB [{}]", path.stem().c_str());
         return false;
     }
     auto kvdb = getDB(path.stem());
@@ -125,7 +122,8 @@ bool KVDBManager::createDBfromCDB(const std::filesystem::path &path,
         auto KV = utils::string::split(line, ':');
         if (!KV.empty() && !KV.at(0).empty() && !KV.at(0).empty())
         {
-            WAZUH_LOG_ERROR("Error while reading CDBfile");
+            WAZUH_LOG_ERROR("Error while reading CDBfile [{}]",
+                            path.c_str());
             return false;
         }
         kvdb->write(KV.at(0), KV.at(1));

--- a/src/engine/test/source/builder/builders/opBuilderKVDBExtract_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderKVDBExtract_test.cpp
@@ -10,10 +10,11 @@
 #include <vector>
 
 #include <gtest/gtest.h>
-#include <kvdb/kvdbManager.hpp>
+#include <logging/logging.hpp>
 
 #include "testUtils.hpp"
 #include "opBuilderKVDB.hpp"
+#include <kvdb/kvdbManager.hpp>
 
 using namespace builder::internals::builders;
 
@@ -25,6 +26,9 @@ protected:
     KVDBManager& kvdbManager = KVDBManager::get();
 
     opBuilderKVDBExtractTest() {
+        logging::LoggingConfig logConfig;
+        logConfig.logLevel = logging::LogLevel::Off;
+        logging::loggingInit(logConfig);
     }
 
     virtual ~opBuilderKVDBExtractTest() {

--- a/src/engine/test/source/builder/builders/opBuilderKVDBExtract_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderKVDBExtract_test.cpp
@@ -21,6 +21,7 @@ namespace {
 class opBuilderKVDBExtractTest : public ::testing::Test {
 
 protected:
+    bool initialized = KVDBManager::init("/var/ossec/queue/db/kvdb/");
     KVDBManager& kvdbManager = KVDBManager::get();
 
     opBuilderKVDBExtractTest() {
@@ -71,8 +72,8 @@ TEST_F(opBuilderKVDBExtractTest, Builds_incorrect_invalid_db)
 // Static key
 TEST_F(opBuilderKVDBExtractTest, Static_key)
 {
-    KVDB& kvdb = kvdbManager.getDB("TEST_DB");
-    kvdb.write("KEY", "VALUE");
+    auto kvdb = kvdbManager.getDB("TEST_DB");
+    kvdb->write("KEY", "VALUE");
 
     Document doc{R"({
         "map":
@@ -107,8 +108,8 @@ TEST_F(opBuilderKVDBExtractTest, Static_key)
 // Dynamic key
 TEST_F(opBuilderKVDBExtractTest, Dynamic)
 {
-    KVDB& kvdb = kvdbManager.getDB("TEST_DB");
-    kvdb.write("KEY", "VALUE");
+    auto kvdb = kvdbManager.getDB("TEST_DB");
+    kvdb->write("KEY", "VALUE");
 
     Document doc{R"({
         "map":
@@ -147,8 +148,8 @@ TEST_F(opBuilderKVDBExtractTest, Dynamic)
 // Multi level key
 TEST_F(opBuilderKVDBExtractTest, Multi_level_key)
 {
-    KVDB& kvdb = kvdbManager.getDB("TEST_DB");
-    kvdb.write("KEY", "VALUE");
+    auto kvdb = kvdbManager.getDB("TEST_DB");
+    kvdb->write("KEY", "VALUE");
 
     Document doc{R"({
         "map":
@@ -183,8 +184,8 @@ TEST_F(opBuilderKVDBExtractTest, Multi_level_key)
 // Multi level target
 TEST_F(opBuilderKVDBExtractTest, Multi_level_target)
 {
-    KVDB& kvdb = kvdbManager.getDB("TEST_DB");
-    kvdb.write("KEY", "VALUE");
+    auto kvdb = kvdbManager.getDB("TEST_DB");
+    kvdb->write("KEY", "VALUE");
 
     Document doc{R"({
         "map":
@@ -219,8 +220,8 @@ TEST_F(opBuilderKVDBExtractTest, Multi_level_target)
 // Existent target
 TEST_F(opBuilderKVDBExtractTest, Existent_target)
 {
-    KVDB& kvdb = kvdbManager.getDB("TEST_DB");
-    kvdb.write("KEY", "VALUE");
+    auto kvdb = kvdbManager.getDB("TEST_DB");
+    kvdb->write("KEY", "VALUE");
 
     Document doc{R"({
         "map":

--- a/src/engine/test/source/builder/builders/opBuilderKVDBMatch_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderKVDBMatch_test.cpp
@@ -21,6 +21,7 @@ namespace {
 class opBuilderKVDBMatchTest : public ::testing::Test {
 
 protected:
+    bool initialized = KVDBManager::init("/var/ossec/queue/db/kvdb/");
     KVDBManager& kvdbManager = KVDBManager::get();
 
     opBuilderKVDBMatchTest() {
@@ -71,8 +72,8 @@ TEST_F(opBuilderKVDBMatchTest, Builds_incorrect_invalid_db)
 // Single level
 TEST_F(opBuilderKVDBMatchTest, Single_level_target_ok)
 {
-    KVDB& kvdb = kvdbManager.getDB("TEST_DB");
-    kvdb.write("KEY", "DUMMY"); // TODO: Remove DUMMY Use non-value overload
+    auto kvdb = kvdbManager.getDB("TEST_DB");
+    kvdb->write("KEY", "DUMMY"); // TODO: Remove DUMMY Use non-value overload
 
     Document doc{R"({
         "check":
@@ -104,8 +105,8 @@ TEST_F(opBuilderKVDBMatchTest, Single_level_target_ok)
 // Multi level
 TEST_F(opBuilderKVDBMatchTest, Multilevel_target_ok)
 {
-    KVDB& kvdb = kvdbManager.getDB("TEST_DB");
-    kvdb.write("KEY", "DUMMY"); // TODO: Remove DUMMY Use non-value overload
+    auto kvdb = kvdbManager.getDB("TEST_DB");
+    kvdb->write("KEY", "DUMMY"); // TODO: Remove DUMMY Use non-value overload
 
     Document doc{R"({
         "check":

--- a/src/engine/test/source/builder/builders/opBuilderKVDBMatch_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderKVDBMatch_test.cpp
@@ -8,12 +8,13 @@
  */
 
 #include <vector>
-#include <gtest/gtest.h>
 
-#include <kvdb/kvdbManager.hpp>
+#include <gtest/gtest.h>
+#include <logging/logging.hpp>
 
 #include "testUtils.hpp"
 #include "opBuilderKVDB.hpp"
+#include <kvdb/kvdbManager.hpp>
 
 using namespace builder::internals::builders;
 
@@ -25,6 +26,9 @@ protected:
     KVDBManager& kvdbManager = KVDBManager::get();
 
     opBuilderKVDBMatchTest() {
+        logging::LoggingConfig logConfig;
+        logConfig.logLevel = logging::LogLevel::Off;
+        logging::loggingInit(logConfig);
     }
 
     virtual ~opBuilderKVDBMatchTest() {

--- a/src/engine/test/source/builder/builders/opBuilderKVDBNotMatch_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderKVDBNotMatch_test.cpp
@@ -21,6 +21,7 @@ namespace {
 class opBuilderKVDBNotMatchTest : public ::testing::Test {
 
 protected:
+    bool initialized = KVDBManager::init("/var/ossec/queue/db/kvdb/");
     KVDBManager& kvdbManager = KVDBManager::get();
 
     opBuilderKVDBNotMatchTest() {
@@ -72,8 +73,8 @@ TEST_F(opBuilderKVDBNotMatchTest, Builds_incorrect_invalid_db)
 TEST_F(opBuilderKVDBNotMatchTest, Static_string_ok)
 {
     // Set Up KVDB
-    KVDB& kvdb = kvdbManager.getDB("TEST_DB");
-    kvdb.write("KEY", "DUMMY"); // TODO: Remove DUMMY Use non-value overload
+    auto kvdb = kvdbManager.getDB("TEST_DB");
+    kvdb->writeKeyOnly("KEY");
 
     Document doc{R"({
         "check":
@@ -108,8 +109,8 @@ TEST_F(opBuilderKVDBNotMatchTest, Static_string_ok)
 
 TEST_F(opBuilderKVDBNotMatchTest, Multilevel_target)
 {
-    KVDB& kvdb = kvdbManager.getDB("TEST_DB");
-    kvdb.write("KEY", "DUMMY"); // TODO: Remove DUMMY Use non-value overload
+    auto kvdb = kvdbManager.getDB("TEST_DB");
+    kvdb->writeKeyOnly("KEY");
 
     Document doc{R"({
         "check":

--- a/src/engine/test/source/builder/builders/opBuilderKVDBNotMatch_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderKVDBNotMatch_test.cpp
@@ -8,12 +8,13 @@
  */
 
 #include <vector>
-#include <gtest/gtest.h>
 
-#include <kvdb/kvdbManager.hpp>
+#include <gtest/gtest.h>
+#include <logging/logging.hpp>
 
 #include "testUtils.hpp"
 #include "opBuilderKVDB.hpp"
+#include <kvdb/kvdbManager.hpp>
 
 using namespace builder::internals::builders;
 
@@ -25,6 +26,9 @@ protected:
     KVDBManager& kvdbManager = KVDBManager::get();
 
     opBuilderKVDBNotMatchTest() {
+        logging::LoggingConfig logConfig;
+        logConfig.logLevel = logging::LogLevel::Off;
+        logging::loggingInit(logConfig);
     }
 
     virtual ~opBuilderKVDBNotMatchTest() {

--- a/src/engine/test/source/kvdb/kvdb_test.cpp
+++ b/src/engine/test/source/kvdb/kvdb_test.cpp
@@ -64,7 +64,9 @@ protected:
 
 TEST_F(KVDBTest, CreateDeleteKvdFile)
 {
-    KVDB &newKvdb = kvdbManager.createDB("NEW_DB");
+    bool ret = kvdbManager.createDB("NEW_DB");
+    ASSERT_TRUE(ret);
+    KVDB &newKvdb = kvdbManager.getDB("NEW_DB");
     ASSERT_EQ(newKvdb.getName(), "NEW_DB");
     ASSERT_EQ(newKvdb.getState(), KVDB::State::Open);
 
@@ -133,15 +135,12 @@ TEST_F(KVDBTest, KeyOnlyWrite)
     bool ret;
     KVDB &kvdb = kvdbManager.getDB("TEST_DB");
 
-    ret = kvdb.exist(KEY);
+    ret = kvdb.hasKey(KEY);
     ASSERT_FALSE(ret);
     ret = kvdb.writeKeyOnly(KEY);
     ASSERT_TRUE(ret);
-    ret = kvdb.exist(KEY);
+    ret = kvdb.hasKey(KEY);
     ASSERT_TRUE(ret);
-
-    KVDBManager &kvdbManager1 = KVDBManager::getInstance();
-    KVDBManager &kvdbManager2 = KVDBManager::getInstance();
 }
 
 TEST_F(KVDBTest, ReadWriteColumn)

--- a/src/engine/test/source/kvdb/kvdb_test.cpp
+++ b/src/engine/test/source/kvdb/kvdb_test.cpp
@@ -35,6 +35,7 @@ class KVDBTest : public ::testing::Test
 {
 
 protected:
+    bool initialized = KVDBManager::init("/var/ossec/queue/db/kvdb/");
     KVDBManager &kvdbManager = KVDBManager::get();
 
     KVDBTest()
@@ -119,13 +120,13 @@ TEST_F(KVDBTest, ReadWrite)
     valueRead = kvdb.read(KEY);
     ASSERT_TRUE(valueRead.empty());
 
-    ret = kvdb.readPinned(KEY, valueRead); // Check this...
+    ret = kvdb.readPinned(KEY, valueRead);
     ASSERT_FALSE(ret);
     ASSERT_TRUE(valueRead.empty());
 }
 
 // Key-only write
-TEST_F(KVDBTest, Key_only_write)
+TEST_F(KVDBTest, KeyOnlyWrite)
 {
     // TODO Update FH tests too
     const std::string KEY = "dummy_key";
@@ -138,6 +139,9 @@ TEST_F(KVDBTest, Key_only_write)
     ASSERT_TRUE(ret);
     ret = kvdb.exist(KEY);
     ASSERT_TRUE(ret);
+
+    KVDBManager &kvdbManager1 = KVDBManager::getInstance();
+    KVDBManager &kvdbManager2 = KVDBManager::getInstance();
 }
 
 TEST_F(KVDBTest, ReadWriteColumn)

--- a/src/engine/test/source/kvdb/kvdb_test.cpp
+++ b/src/engine/test/source/kvdb/kvdb_test.cpp
@@ -124,6 +124,22 @@ TEST_F(KVDBTest, ReadWrite)
     ASSERT_TRUE(valueRead.empty());
 }
 
+// Key-only write
+TEST_F(KVDBTest, Key_only_write)
+{
+    // TODO Update FH tests too
+    const std::string KEY = "dummy_key";
+    bool ret;
+    KVDB &kvdb = kvdbManager.getDB("TEST_DB");
+
+    ret = kvdb.exist(KEY);
+    ASSERT_FALSE(ret);
+    ret = kvdb.writeKeyOnly(KEY);
+    ASSERT_TRUE(ret);
+    ret = kvdb.exist(KEY);
+    ASSERT_TRUE(ret);
+}
+
 TEST_F(KVDBTest, ReadWriteColumn)
 {
     const std::string COLUMN_NAME = "NEW_COLUMN";

--- a/src/engine/test/source/kvdb/kvdb_test.cpp
+++ b/src/engine/test/source/kvdb/kvdb_test.cpp
@@ -83,9 +83,6 @@ TEST_F(KVDBTest, CreateDeleteColumns)
     ASSERT_TRUE(ret);
     ret = kvdb->deleteColumn(COLUMN_NAME);
     ASSERT_FALSE(ret);
-
-    ret = kvdb->deleteColumn(); // TODO "default" can be deleted? I dont think
-                               // so...
 }
 
 TEST_F(KVDBTest, ReadWrite)

--- a/src/engine/test/source/kvdb/kvdb_test.cpp
+++ b/src/engine/test/source/kvdb/kvdb_test.cpp
@@ -39,11 +39,9 @@ protected:
     KVDBManager &kvdbManager = KVDBManager::get();
 
     KVDBTest()
-    { // = default;
-        // TODO: this init is done in order to receive the logs at the right
-        // moment, insted we should be mocking these logs in each test
+    {
         logging::LoggingConfig logConfig;
-        logConfig.logLevel = logging::LogLevel::Debug;
+        logConfig.logLevel = logging::LogLevel::Off;
         logging::loggingInit(logConfig);
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|#12935|

This PR implements the following improvements to KVDB:
- [x] Move KVDB open to the getDB() method. Doing this, we will avoid opening unused DBs.
- [x] Support key-only values.
- [x] Fix for KVDB::deleteColumn() with "default" column. 
- [x] Improve LOG messages:
- [x] Fix memory leaks and open transaction kept in KVDB::writeToTransaction()
- [x] Make KVDBManager thead safe when manipulating the available DB map and the columns maps.
- [x] Remove the default KVDB folder by adding an initilizer method to KVDBManager.