### PR TITLE
src/config/wmodules-vuln-detector.c: add the allow_package_vendors configuration in order to add an array of package vendors  to the vu_vendor_list_redhat

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -516,6 +516,8 @@ static int setup_cve_report(void **state) {
     state[REPORT_CVE_REPORT_POS] = report;
     wm_max_eps = 1000000;
 
+    free_vul_redhat_vendor_list();
+
     return OS_SUCCESS;
 }
 
@@ -1107,6 +1109,11 @@ void test_wm_vuldet_linux_rm_nvd_not_affected_packages_vendor_RedHat(void **stat
     const char *cve = "CVE-000-000";
     cve_vuln_pkg *first = NULL;
     int *vuln_discarded = NULL;
+    wm_vuldet_t * vuldet = NULL;
+
+    // init the vu_vendor_list_redhat[] list
+    int ret = init_vul_redhat_vendor_list(vuldet);
+    assert_int_equal(ret, 0);
 
     os_calloc(1, sizeof(cve_vuln_pkg), first);
     os_calloc(1, sizeof(int), vuln_discarded);
@@ -1119,9 +1126,10 @@ void test_wm_vuldet_linux_rm_nvd_not_affected_packages_vendor_RedHat(void **stat
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5462): Package 'test-wazuh' not vulnerable to 'CVE-000-000' since it is not affected (feed 'OVAL').");
 
-    int ret = wm_vuldet_linux_rm_nvd_not_affected_packages(db, agent, cve, first, vuln_discarded);
+    ret = wm_vuldet_linux_rm_nvd_not_affected_packages(db, agent, cve, first, vuln_discarded);
     assert_int_equal(ret, 0);
 
+    free_vul_redhat_vendor_list();
     os_free(first);
     os_free(vuln_discarded);
 }
@@ -2522,8 +2530,16 @@ void test_wm_vuldet_compare_vendors_external_vendor(void **state)
     int ret;
     char * vendor = "External";
 
+    wm_vuldet_t * vuldet = NULL;
+
+    // init the vu_vendor_list_redhat[] list
+    ret = init_vul_redhat_vendor_list(vuldet);
+    assert_int_equal(ret, 0);
+
     ret = wm_vuldet_compare_vendors(vendor);
     assert_int_equal(ret, 1);
+
+    free_vul_redhat_vendor_list();
 }
 
 void test_wm_vuldet_compare_vendors_official_vendor(void **state)
@@ -2536,10 +2552,18 @@ void test_wm_vuldet_compare_vendors_official_vendor(void **state)
     };
     int array_size = array_size(official_vendors);
 
+    wm_vuldet_t * vuldet = NULL;
+
+    // init the vu_vendor_list_redhat[] list
+    ret = init_vul_redhat_vendor_list(vuldet);
+    assert_int_equal(ret, 0);
+
     for (i = 0; i < array_size; i++) {
         ret = wm_vuldet_compare_vendors(official_vendors[i]);
         assert_int_equal(ret, 0);
     }
+
+    free_vul_redhat_vendor_list();
 }
 
 /* wm_checks_package_vulnerability */
@@ -3061,9 +3085,16 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_step(void **state)
 
     will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
-    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
+    wm_vuldet_t * vuldet = NULL;
+
+    // init the vu_vendor_list_redhat[] list
+    int ret = init_vul_redhat_vendor_list(vuldet);
+    assert_int_equal(ret, 0);
+
+    ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
     assert_int_equal(OS_INVALID, ret);
+    free_vul_redhat_vendor_list();
 }
 
 void test_wm_vuldet_linux_oval_vulnerabilities_step_done(void **state)
@@ -3516,10 +3547,17 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_centos_not_vulnerable(voi
     will_return(__wrap_time, (time_t)1);
     expect_string(__wrap__mtdebug1, formatted_msg, "(5470): It took '0' seconds to 'find OVAL' vulnerabilities in agent '000'");
 
-    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
+    wm_vuldet_t * vuldet = NULL;
+
+    // init the vu_vendor_list_redhat[] list
+    int ret = init_vul_redhat_vendor_list(vuldet);
+    assert_int_equal(ret, 0);
+
+    ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
     assert_int_equal(OS_SUCCESS, ret);
 
+    free_vul_redhat_vendor_list();
     wm_vuldet_free_cve_node(Pkg);
 }
 
@@ -4190,9 +4228,17 @@ void test_wm_vuldet_linux_oval_vulnerabilities_external_vendor(void **state)
     will_return(__wrap_time, (time_t)1);
     expect_string(__wrap__mtdebug1, formatted_msg, "(5470): It took '0' seconds to 'find OVAL' vulnerabilities in agent '000'");
 
-    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
+    wm_vuldet_t * vuldet = NULL;
+
+    // init the vu_vendor_list_redhat[] list
+    int ret = init_vul_redhat_vendor_list(vuldet);
+    assert_int_equal(ret, 0);
+
+    ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
     assert_int_equal(OS_SUCCESS, ret);
+
+    free_vul_redhat_vendor_list();
 }
 
 /* wm_vuldet_oval_discard_mismatching_cve_entries */
@@ -6753,6 +6799,7 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors
     os_free(node->key);
     os_free(node);
     os_free(vuldet);
+    free_vul_redhat_vendor_list();
     __real_cJSON_Delete(j_action);
     __real_cJSON_Delete(j_status);
 }
@@ -7108,6 +7155,7 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors
     os_free(node->key);
     os_free(node);
     os_free(vuldet);
+    free_vul_redhat_vendor_list();
     __real_cJSON_Delete(j_action);
     __real_cJSON_Delete(j_status);
 }
@@ -19460,6 +19508,7 @@ void test_wm_vuldet_init_success(void **state)
 
     wm_vuldet_init(vuldet);
 
+    free_vul_redhat_vendor_list();
     os_free(vuldet);
 }
 
@@ -20153,6 +20202,7 @@ void test_wm_vuldet_send_removed_cve_report_ip_assigned_success() {
     __real_cJSON_Delete(j_cvss3_score);
     __real_cJSON_Delete(j_references);
     os_free(vuldet);
+    free_vul_redhat_vendor_list();
 }
 
 void test_wm_vuldet_send_removed_cve_report_no_ip_success() {
@@ -20260,6 +20310,7 @@ void test_wm_vuldet_send_removed_cve_report_no_ip_success() {
     __real_cJSON_Delete(j_cvss2_score);
     __real_cJSON_Delete(j_cvss3_score);
     __real_cJSON_Delete(j_references);
+    free_vul_redhat_vendor_list();
     os_free(vuldet);
 }
 
@@ -20657,6 +20708,49 @@ void test_wm_vuldet_get_software_success() {
     __real_cJSON_Delete(j_object);
     __real_cJSON_Delete(j_object2);
     assert_int_equal(result, OS_SUCCESS);
+}
+
+// Tests init_vul_redhat_vendor_list
+
+void test_init_vul_redhat_vendor_list_success(void **state)
+{
+    wm_vuldet_t *vuldet = calloc(1, sizeof(wm_vuldet_t));
+    if(!vuldet) {
+        return;
+    }
+
+    os_calloc(1, sizeof(update_node), vuldet->updates[CVE_REDHAT7]);
+    if(!vuldet->updates[CVE_REDHAT7]) {
+        return;
+    }
+
+    os_calloc(2, sizeof(char*), vuldet->updates[CVE_REDHAT7]->allowed_package_vendors);
+    if(!vuldet->updates[CVE_REDHAT7]->allowed_package_vendors) {
+        return;
+    }
+
+    char * allowed_vendor = "Alibaba";
+    int len = strlen(allowed_vendor) + 1;
+    os_calloc(len, sizeof(char), vuldet->updates[CVE_REDHAT7]->allowed_package_vendors[0]);
+    if(!vuldet->updates[CVE_REDHAT7]->allowed_package_vendors[0]) {
+        return;
+    }
+
+    strcpy(vuldet->updates[CVE_REDHAT7]->allowed_package_vendors[0], allowed_vendor);
+    vuldet->updates[CVE_REDHAT7]->allowed_package_vendors[1] = NULL;
+
+    int result = init_vul_redhat_vendor_list(vuldet);
+
+    int vu_redhat_vendor_list_size = get_vul_redhat_vendor_list_size();
+
+    assert_int_equal(result, OS_SUCCESS);
+    assert_int_equal(vu_redhat_vendor_list_size, 3);
+
+    free_vul_redhat_vendor_list();
+    free(vuldet->updates[CVE_REDHAT7]->allowed_package_vendors[0]);
+    free(vuldet->updates[CVE_REDHAT7]->allowed_package_vendors);
+    free(vuldet->updates[CVE_REDHAT7]);
+    free(vuldet);
 }
 
 int main(void)
@@ -21220,6 +21314,8 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_get_software_send_error, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_get_software_not_triaged_send_error, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_get_software_success, setup_group, teardown_group),
+        // Tests init_vul_redhat_vendor_list
+        cmocka_unit_test_setup_teardown(test_init_vul_redhat_vendor_list_success, setup_group, teardown_group),
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -457,10 +457,8 @@ const char *vu_vendor_list_ubuntu_debian[] = {
     "debian"
 };
 
-const char *vu_vendor_list_redhat[] = {
-    "Red Hat, Inc.",
-    "CentOS"
-};
+char **vu_vendor_list_redhat;
+int vu_vendor_list_redhat_size = 2;
 
 const char *vu_vendor_list_amazon[] = {
     "Amazon Linux",
@@ -1833,7 +1831,7 @@ int wm_vuldet_linux_rm_nvd_not_affected_packages(sqlite3 *db, scan_agent *agent,
                         }
                     }
                 } else if (agent->dist == FEED_REDHAT) {
-                    vendor_len = array_size(vu_vendor_list_redhat);
+                    vendor_len = vu_vendor_list_redhat_size;
                     for(vendor_it = 0; vendor_it < vendor_len; ++vendor_it) {
                         if(!strcmp(pkg->vendor, vu_vendor_list_redhat[vendor_it])) {
                             // This is a RedHat package, so the OVAL said that it is not affected
@@ -5595,8 +5593,17 @@ void wm_vuldet_destroy(wm_vuldet_t * vuldet) {
         }
     }
     free(vuldet);
-}
 
+    // free vu_vendor_list_redhat
+    for(i = 0; i < vu_vendor_list_redhat_size; i++){
+        if (vu_vendor_list_redhat[i]) {
+            free(vu_vendor_list_redhat[i]);
+        }
+    }
+    if(vu_vendor_list_redhat) {
+        free(vu_vendor_list_redhat);
+    }
+}
 
 cJSON *wm_vuldet_dump(const wm_vuldet_t * vuldet){
     cJSON *root = cJSON_CreateObject();
@@ -7794,6 +7801,11 @@ void wm_vuldet_init(wm_vuldet_t * vuldet) {
 
     vu_queue = &vuldet->queue_fd;
 
+    if(init_vul_redhat_vendor_list()) {
+        mterror(WM_VULNDETECTOR_LOGTAG, "Can't initialize vulnerability vendors lists.");
+        pthread_exit(NULL);
+    }
+
     SSL_library_init();
     SSL_load_error_strings();
     OpenSSL_add_all_algorithms();
@@ -8213,7 +8225,7 @@ int wm_vuldet_compare_vendors(char * vendor) {
     int vendor_it = 0;
     int external_vendor = 1;
 
-    vendor_len = array_size(vu_vendor_list_redhat);
+    vendor_len = vu_vendor_list_redhat_size;
     for (vendor_it = 0; vendor_it < vendor_len; ++vendor_it) {
         if (!strcmp(vendor, vu_vendor_list_redhat[vendor_it])) {
             external_vendor = 0;
@@ -8632,6 +8644,46 @@ void wm_vuldet_give_report_format(vu_report *report) {
     const char* severity = wm_vuldet_get_unified_severity(report->severity);
     os_free(report->severity);
     w_strdup(severity, report->severity);
+}
+
+int init_vul_redhat_vendor_list() {
+    int i;
+
+    // init vu_vendor_list_redhat
+    if (vu_vendor_list_redhat_size < 2) {
+        merror("Invalid vu_vendor_list_redhat_size %d", vu_vendor_list_redhat_size);
+        goto end;
+    }
+    vu_vendor_list_redhat = (char**)malloc(vu_vendor_list_redhat_size * sizeof(char*));
+    if(!vu_vendor_list_redhat) {
+        merror("Error to malloc memory for vu_vendor_list_redhat");
+        goto end;
+    }
+    for(i = 0; i < vu_vendor_list_redhat_size; i++){
+        vu_vendor_list_redhat[i] = (char*)malloc(OS_MAXSTR * sizeof(char));
+        if (!vu_vendor_list_redhat[i]) {
+            merror("Error to malloc memory for vu_vendor_list_redhat[%d]",i);
+            goto end;
+        }
+    }
+
+    strcpy(vu_vendor_list_redhat[0], "Red Hat, Inc.");
+    strcpy(vu_vendor_list_redhat[1], "CentOS");
+
+    return OS_SUCCESS;
+
+end:
+    // free vu_vendor_list_redhat
+    for(i = 0; i < vu_vendor_list_redhat_size; i++){
+        if (vu_vendor_list_redhat[i]) {
+            free(vu_vendor_list_redhat[i]);
+        }
+    }
+    if(vu_vendor_list_redhat) {
+        free(vu_vendor_list_redhat);
+    }
+
+    return OS_INVALID;
 }
 
 #endif

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5578,6 +5578,12 @@ void wm_vuldet_destroy(wm_vuldet_t * vuldet) {
                     free(update[i]->allowed_os_name);
                     free(update[i]->allowed_os_ver);
                 }
+                if (update[i]->allowed_package_vendors) {
+                    for (j = 0; update[i]->allowed_package_vendors[j]; j++) {
+                         free(update[i]->allowed_package_vendors[j]);
+                    }
+                    free(update[i]->allowed_package_vendors);
+                }
             }
             os_free(update[i]);
         }
@@ -5594,15 +5600,7 @@ void wm_vuldet_destroy(wm_vuldet_t * vuldet) {
     }
     free(vuldet);
 
-    // free vu_vendor_list_redhat
-    for(i = 0; i < vu_vendor_list_redhat_size; i++){
-        if (vu_vendor_list_redhat[i]) {
-            free(vu_vendor_list_redhat[i]);
-        }
-    }
-    if(vu_vendor_list_redhat) {
-        free(vu_vendor_list_redhat);
-    }
+    free_vul_redhat_vendor_list();
 }
 
 cJSON *wm_vuldet_dump(const wm_vuldet_t * vuldet){
@@ -7801,7 +7799,7 @@ void wm_vuldet_init(wm_vuldet_t * vuldet) {
 
     vu_queue = &vuldet->queue_fd;
 
-    if(init_vul_redhat_vendor_list()) {
+    if(init_vul_redhat_vendor_list(vuldet)) {
         mterror(WM_VULNDETECTOR_LOGTAG, "Can't initialize vulnerability vendors lists.");
         pthread_exit(NULL);
     }
@@ -8646,8 +8644,8 @@ void wm_vuldet_give_report_format(vu_report *report) {
     w_strdup(severity, report->severity);
 }
 
-int init_vul_redhat_vendor_list() {
-    int i;
+int init_vul_redhat_vendor_list(wm_vuldet_t * vuldet) {
+    int i, len;
 
     // init vu_vendor_list_redhat
     if (vu_vendor_list_redhat_size < 2) {
@@ -8670,11 +8668,34 @@ int init_vul_redhat_vendor_list() {
     strcpy(vu_vendor_list_redhat[0], "Red Hat, Inc.");
     strcpy(vu_vendor_list_redhat[1], "CentOS");
 
+    if(!vuldet) {
+        return OS_SUCCESS;
+    }
+
+    // add allowed package vendors in vu vendor lists
+    for (int os = CVE_REDHAT5; os <= CVE_REDHAT8; os++) {
+        if (vuldet->updates[os] && vuldet->updates[os]->allowed_package_vendors) {
+            for (i = 0; vuldet->updates[os]->allowed_package_vendors[i]; i++) {
+                    os_realloc(vu_vendor_list_redhat, (vu_vendor_list_redhat_size + 1)*sizeof(char *), vu_vendor_list_redhat);
+                    len = strlen(vuldet->updates[os]->allowed_package_vendors[i]) + 1;
+                    os_calloc(len, sizeof(char), vu_vendor_list_redhat[vu_vendor_list_redhat_size]);
+                    strcpy(vu_vendor_list_redhat[vu_vendor_list_redhat_size], vuldet->updates[os]->allowed_package_vendors[i]);
+                    vu_vendor_list_redhat_size++;
+            }
+        }
+    }
+
     return OS_SUCCESS;
 
 end:
+    free_vul_redhat_vendor_list();
+
+    return OS_INVALID;
+}
+
+int free_vul_redhat_vendor_list() {
     // free vu_vendor_list_redhat
-    for(i = 0; i < vu_vendor_list_redhat_size; i++){
+    for(int i = 0; i < vu_vendor_list_redhat_size; i++){
         if (vu_vendor_list_redhat[i]) {
             free(vu_vendor_list_redhat[i]);
         }
@@ -8683,7 +8704,12 @@ end:
         free(vu_vendor_list_redhat);
     }
 
-    return OS_INVALID;
+    return OS_SUCCESS;
+}
+
+// Used for unit tests
+int get_vul_redhat_vendor_list_size() {
+    return vu_vendor_list_redhat_size;
 }
 
 #endif

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -455,6 +455,7 @@ typedef struct update_node {
     struct { // Supported operating systems
         char **allowed_os_name;
         char **allowed_os_ver;
+        char **allowed_package_vendors;
     };
     unsigned int attempted:1;
     unsigned int json_format:1;
@@ -1151,10 +1152,23 @@ char* wm_vuldet_normalize_architecture_nvd(char* architecture);
 void wm_vuldet_give_report_format(vu_report *report);
 
 /**
- * @brief initialize vulnerability Redhat vendors lists
+ * @brief initialize vulnerability Redhat vendors lists.
+ * @param vuldet The vulnearibility detector main data structure.
  * @return OS_SUCCESS if the request could be completed, OS_INVALID otherwise
  **/
-int init_vul_redhat_vendor_list();
+int init_vul_redhat_vendor_list(wm_vuldet_t * vuldet);
+
+/**
+ * @brief free vulnerability Redhat vendors lists.
+ * @return OS_SUCCESS if the request could be completed, OS_INVALID otherwise
+ **/
+int free_vul_redhat_vendor_list();
+
+/**
+ * @brief get vulnerability Redhat vendors list size.
+ * @return vulnerability Redhat vendors list size
+ **/
+int get_vul_redhat_vendor_list_size();
 
 #endif
 #endif

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -1150,6 +1150,12 @@ char* wm_vuldet_normalize_architecture_nvd(char* architecture);
  */
 void wm_vuldet_give_report_format(vu_report *report);
 
+/**
+ * @brief initialize vulnerability Redhat vendors lists
+ * @return OS_SUCCESS if the request could be completed, OS_INVALID otherwise
+ **/
+int init_vul_redhat_vendor_list();
+
 #endif
 #endif
 #endif


### PR DESCRIPTION
|Related issue|
|---|
| #12437 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

My configuration in `ossec.conf` is the following,

```XML
    <!-- RedHat OS vulnerabilities -->
    <provider name="redhat">
      <enabled>yes</enabled>
      <os path="/root/Redhat-cve-feeds/com.redhat.rhsa-RHEL5.xml.bz2">5</os>
      <os path="/root/Redhat-cve-feeds/rhel-6-including-unpatched.oval.xml.bz2">6</os>
      <os allow="Alibaba Cloud Linux-2,Anolis OS-7" path="/root/Redhat-cve-feeds/rhel-7-including-unpatched.oval.xml.bz2">7</os>
      <os allow="Alibaba Cloud Linux-3,Anolis OS-8" path="/root/Redhat-cve-feeds/rhel-8-including-unpatched.oval.xml.bz2" allow_package_vendors="Alibaba,Alibaba Cloud,Koji,OpenAnolis">8</os>
      <path>/root/Redhat-cve-feeds/redhat-feed.*json$</path>
      <update_interval>1h</update_interval>
    </provider>
```

I test OK in my OS(`Alibaba Cloud Linux 3`). 

<img width="396" alt="1649217665979_19763C6B-D0D2-486a-8552-86F54F559F76" src="https://user-images.githubusercontent.com/6824093/161893242-00226673-00fc-453e-81dd-89e223dd6b8f.png">



## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors