### PR TITLE
Fix agent_groups typo

### DIFF
--- a/framework/scripts/agent_groups.py
+++ b/framework/scripts/agent_groups.py
@@ -57,7 +57,7 @@ async def show_groups():
     for items in groups.affected_items:
         print(f"  {items['name']} ({items['count']})")
 
-    print(f"Unassigned agens: {unassigned_agents.total_affected_items}.")
+    print(f"Unassigned agents: {unassigned_agents.total_affected_items}.")
 
 
 async def show_group(agent_id):


### PR DESCRIPTION
|Related issue|
|---|
|#13011|

## Description

This PR closes #13011. In this PR we have fixed the typo detected in the agent_groups tool. The unittests for this tool (https://github.com/wazuh/wazuh/issues/12812) are pending to be added once we close #10771. 

```
root@wazuh-master:/# /var/ossec/bin/agent_groups -l
Groups (1):
  default (0)
Unassigned agents: 0.
```