### PR TITLE
Fix regex to correctly translate the new `Firefox ESR` product name in CPE Helper

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/cpe_helper.json
+++ b/src/wazuh_modules/vulnerability_detector/cpe_helper.json
@@ -99,7 +99,7 @@
                     "^Mozilla"
                 ],
                 "product": [
-                    "^Mozilla Firefox ([0-9]+\\.*[0-9]*\\.*[0-9]*) ESR",
+                    "^Mozilla Firefox ([0-9]+\\.*[0-9]*\\.*[0-9]* )*ESR",
                     "^Mozilla Firefox",
                     "^Mozilla Thunderbird",
                     "^SeaMonkey"


### PR DESCRIPTION
|Related issue|
|---|
|#12983|

## Description

With this PR, we avoided the false positives encountered due to mistranslation because of the new product name change applied to the new versions of `Firefox ESR` (causing them to match `Firefox` packages, which have a different CPE).

To fix the problem, it was only necessary to modify the regex, as explained in the **_Workaround_** section in issue #12983.

With the new modification, both old and new _Firefox ESR_ versions are translated correctly:
- Format old versions: `Mozilla Firefox <version> ESR`
- Format new versions: `Mozilla Firefox ESR`

## Configuration options

```xml
  <vulnerability-detector>
    <enabled>yes</enabled>
    <interval>5m</interval>
    <min_full_scan_interval>6h</min_full_scan_interval>
    <run_on_start>yes</run_on_start>

    <!-- Windows OS vulnerabilities -->
    <provider name="msu">
      <enabled>yes</enabled>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Aggregate vulnerabilities -->
    <provider name="nvd">
      <enabled>yes</enabled>
      <update_from_year>2010</update_from_year>
      <update_interval>1h</update_interval>
    </provider>

  </vulnerability-detector>
```

## Logs/Alerts example

#### Mozilla Firefox ESR 91.7.1

**`sqlite3 /var/ossec/queue/db/001.db "select * from sys_programs where name like '%firefox%';"`**
```
0|2022/04/06 10:50:32|win|Mozilla Firefox ESR (x64 es-ES)|||0|Mozilla||91.7.1|x86_64||||C:\Program Files\Mozilla Firefox|1|||5e410db0a2dccbd724999eb349aa7d03bb9b7a72|111e57266a8b2b86f9aff006107ea8b7d56122e0
```
**CPE created (log):**
```
wazuh-modulesd:vulnerability-detector[7352] wm_vuln_detector_nvd.c:3185 at wm_vuldet_add_dic_cpe(): DEBUG: (5446): The CPE 'a:mozilla:firefox_esr:91.7.1::::::x64:' from the agent '001' was indexed.
```

#### Mozilla Firefox ESR 78.0

**`sqlite3 /var/ossec/queue/db/001.db "select * from sys_programs where name like '%firefox%';"`**

```
0|2022/04/06 11:25:09|win|Mozilla Firefox 78.0 ESR (x64 en-US)|||0|Mozilla||78.0|x86_64||||C:\Program Files\Mozilla Firefox|0|||230b6adf6801753ce081fef04ee4db8e37ff3e50|0979ac9b53d83f2e27d5600fd1cb9699e95c2968```
```
**CPE created (log):**
```
wazuh-modulesd:vulnerability-detector[8917] wm_vuln_detector_nvd.c:3185 at wm_vuldet_add_dic_cpe(): DEBUG: (5446): The CPE 'a:mozilla:firefox_esr:78.0::::::x64:' from the agent '001' was indexed.
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities
