### PR TITLE
Fix condition to assign 'default' group when 'guess_agent_group' option is enabled

### DIFF
--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -1410,7 +1410,7 @@ STATIC int lookfor_agent_group(const char *agent_id, char *msg, char **r_group)
 
             w_mutex_lock(&files_mutex);
 
-            if (!guess_agent_group || !find_group_from_file(file, md5, group) || !find_multi_group_from_file(file, md5, group)) {
+            if (!guess_agent_group || (!find_group_from_file(file, md5, group) && !find_multi_group_from_file(file, md5, group))) {
                 // If the group could not be guessed, set to "default"
                 // or if the user requested not to guess the group, through the internal
                 // option 'guess_agent_group', set to "default"


### PR DESCRIPTION
|Related issue|
|---|
|#13071|

## Description

This PR closes #13071. This PR fixes a condition in the `lookfor_agent_group` function to assign the `default `group when the `guess_agent_group` mechanism is enabled.

After the changes made and when reproducing the steps marked in the issue #13071, the agent maintains the previously assigned group.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
