### PR TITLE
Update SDK vulnerability unit tests

### DIFF
--- a/framework/wazuh/tests/test_vulnerability.py
+++ b/framework/wazuh/tests/test_vulnerability.py
@@ -24,7 +24,6 @@ with patch('wazuh.core.common.wazuh_uid'):
         from api.util import remove_nones_to_dict, parse_api_param
         from wazuh.vulnerability import get_agent_cve, get_inventory_summary
         from wazuh.core.tests.test_agent import InitAgent
-        from wazuh.core.results import WazuhResult
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 test_data = InitAgent(data_path=test_data_path)
@@ -113,20 +112,22 @@ def test_get_agent_cve_select(socket_mock, send_mock, params, expected_fields):
             item.keys()) == set(), '"select" param did not return expected fields.'
 
 
-@pytest.mark.parametrize('limit', [1, 3])
-@pytest.mark.parametrize('field, expected_result', [
-    ('severity', {'High': 2, 'Medium': 1, 'Low': 1, 'Critical': 1}),
-    ('name', {'Ash-aio': 1, 'Credential Helpers': 1, 'Discourse': 1, 'Invenio-previewer': 1, 'Smokedetector': 1})
-])
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
-def test_vulnerability_get_inventory_summary(socket_mock, send_mock, field, expected_result, limit):
-    """Check if `get_inventory_summary` function returns the exact number of fields placed in the testing
-    database."""
-    # Expected severities from test DB
+def test_vulnerability_get_inventory_summary(socket_mock, send_mock):
+    """Check if `get_inventory_summary` function returns the expected data placed in the testing database."""
+    agent_id = '001'
+    field = 'severity'
+    limit = 1
 
-    result = get_inventory_summary(agent_list=['001'], field=field, limit=limit)
-    assert isinstance(result, WazuhResult), 'Unexpected result type'
-    assert result['data'][field] == {dict_tuple[0]: dict_tuple[1]
-                                     for i, dict_tuple in enumerate(expected_result.items()) if i < limit}, \
-        'Expected result does not match'
+    with patch('wazuh.vulnerability.WazuhDBQueryGroupByVulnerability', side_effect=MagicMock()) as wdbqgroup_mock:
+        get_inventory_summary(agent_list=[agent_id], field=field, limit=limit)
+        # Check that static parameters are set
+        wdbqgroup_mock.assert_called_once_with(**{'agent_id': agent_id, 'limit': limit, 'select': [field],
+                                                  'sort': {'fields': ['count'], 'order': 'desc'},
+                                                  'filter_fields': [field]})
+
+    # Check that result is sorted by count values
+    result = get_inventory_summary(agent_list=[agent_id], field=field, limit=limit)
+    assert result['data'][field] == {'High': 2}, f'Expected "High" to be the severity with the most entries based on ' \
+                                                 'our testing database'


### PR DESCRIPTION
|Related issue|
|---|
|closes #13068 |

## Description

In this PR, the SDK vulnerability unit tests were reworked to be more precise, avoiding the take of python dictionary keys order for granted. This was causing tests to fail on the new CI images.

## Tests performed

_Using the new CI image._

```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-5.4.3, py-1.11.0, pluggy-0.13.1 -- /usr/local/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.9.2', 'Platform': 'Linux-5.14.18-100.fc33.x86_64-x86_64-with-glibc2.28', 'Packages': {'pytest': '5.4.3', 'py': '1.11.0', 'pluggy': '0.13.1'}, 'Plugins': {'aiohttp': '0.3.0', 'asyncio': '0.15.1', 'html': '2.1.1', 'metadata': '2.0.1', 'trio': '0.7.0'}}
rootdir: /tmp/build/wazuh/framework
plugins: aiohttp-0.3.0, asyncio-0.15.1, html-2.1.1, metadata-2.0.1, trio-0.7.0
collecting ... collected 1640 items

wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI[kwargs0] PASSED [  0%]
wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI[kwargs1] PASSED [  0%]
wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function[get_agents_summary_status-local_master-master-local-True] PASSED [  0%]
wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function[restart_agents-distributed_master-master-forward-True] PASSED [  0%]
wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function[get_node_wrapper-local_any-worker-local-True] PASSED [  0%]
wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function[get_ciscat_results-distributed_master-worker-remote-True] PASSED [  0%]
wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function[status-local_master-worker-local-False] PASSED [  0%]
wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function_mock_solver[restart_agents-distributed_master-master-local] PASSED [  0%]
wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function_exception PASSED [  0%]
wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_invalid_json PASSED [  0%]

(...)

================ 1640 passed, 13 warnings in 346.79s (0:05:46) =================

```

Regards,
Víctor