### PR TITLE
Prevent the agent from delaying for a negative timespan

### DIFF
--- a/src/client-agent/buffer.c
+++ b/src/client-agent/buffer.c
@@ -240,7 +240,10 @@ void delay(struct timespec * ts_loop) {
     long interval_ns = 1000000000 / agt->events_persec;
     struct timespec ts_timeout = { interval_ns / 1000000000, interval_ns % 1000000000 };
     time_sub(&ts_timeout, ts_loop);
-    nanosleep(&ts_timeout, NULL);
+
+    if (ts_timeout.tv_sec >= 0) {
+        nanosleep(&ts_timeout, NULL);
+    }
 }
 
 int w_agentd_get_buffer_lenght() {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #12923|

This PR simply adds a guard to the agent to let it call `nanosleep` only if the parameter is positive.

## Rationale

### Platforms

I checked that Linux refuses to sleep with a negative value.

<details><summary>PoC</summary>

#### Code

```c
#include <time.h>
#include <errno.h>
#include <stdio.h>
​
int main() {
    struct timespec ts = { -1, 0 };
    nanosleep(&ts, NULL);
    perror("nanosleep");
    return 0;
}
```

#### Program error

```
nanosleep: Invalid argument
```
</details>

This makes me conclude that **this issue cannot happen on Linux**.

### `timespec` signedness

On Windows, `timespec` is implemented this way:

```c
struct timespec {
    long int tv_sec;
    long int tv_nsec;
};
```

<details><summary>PoC</summary>

#### Code

```c
#include <time.h>
#include <stdio.h>

int main() {
    unsigned m_uint = 0;
    struct timespec ts = { 0 };

    if (m_uint < ts.tv_sec) printf("uint is lower.\n");
    if (m_uint < ts.tv_nsec) printf("uint is lower.\n");
}
```

### Compiler warning

```
time-sign.c:8:16: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘time_t’ {aka
long int’} [-Wsign-compare]
    8 |     if (m_uint < ts.tv_sec) printf("uint is lower.\n");
      |                ^
time-sign.c:9:16: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘long int’ [-Wsign-compare]
    9 |     if (m_uint < ts.tv_nsec) printf("uint is lower.\n");
      |                ^
```

</details>

## Possible fixes

### Use the monotonic counter

Using a monotonic clock would not fix this issue completely: We could use [`GetTickCount64`](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-gettickcount64) to get the system uptime, but then we need to calculate the effective delay as the desired interval minus the time spent handling each message:

> _t_delay_ = _EPS⁻¹_ - _t_handle_

Which may also run into a negative result.

### Check signedness prior to calling `nanosleep`

Since this is the guard that we miss in the Windows library implementation, we decided to apply it. In addition, that is the simplest change with the minimum collateral changes.

We only need to check `tv_sec` because function `time_sub()` takes care of the nanosecond carry.

## Tests

In order to validate this PR, I added a temporary log (which is not included) to warn when the agent is skipping the call to `nanosleep`:

```
2022/04/08 11:22:51 wazuh-agent: WARNING: Skipping delay of -124 s. and 945187800 ns.
```