### PR TITLE
Remove unittest leftovers

### DIFF
--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -255,8 +255,9 @@ async def test_sync_files_sync_ok(compress_files_mock, unlink_mock, relpath_mock
 
 
 @pytest.mark.asyncio
+@patch("wazuh.core.cluster.cluster.compress_files", return_value="files/path/")
 @patch("wazuh.core.cluster.worker.WorkerHandler.send_request", return_value=Exception())
-async def test_sync_files_sync_ko(send_request_mock):
+async def test_sync_files_sync_ko(send_request_mock, compress_files_mock):
     """Test if the right exceptions are being risen when necessary."""
     files_to_sync = {"path1": "metadata1"}
     files_metadata = {"path2": "metadata2"}
@@ -268,6 +269,8 @@ async def test_sync_files_sync_ko(send_request_mock):
         await sync_files.sync(files_to_sync, files_metadata)
 
     send_request_mock.assert_called_once()
+    compress_files_mock.assert_called_once_with(name='Testing', list_path=files_to_sync,
+                                                cluster_control_json=files_metadata)
 
 
 # Test SyncWazuhdb class


### PR DESCRIPTION
|Related issue|
|---|
|#13070|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This closes #13070. The aim of this pull is to stop creating a residual file after running the [test_worker.py](https://github.com/wazuh/wazuh/blob/master/framework/wazuh/core/cluster/tests/test_worker.py) test:
```
(wazuh_env) yanazaeva@pop-os:~/git/wazuh$ pytest framework/wazuh/core/cluster/tests/test_worker.py --disable-warnings
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.5, pytest-5.4.3, py-1.11.0, pluggy-0.13.1
rootdir: /home/yanazaeva/git/wazuh/framework
plugins: asyncio-0.15.1, metadata-1.11.0, trio-0.7.0, testinfra-6.3.0, cov-2.12.0, anyio-3.5.0, aiohttp-0.3.0, html-3.1.1
collected 7 items                                                                                                                                                                                                 

framework/wazuh/core/cluster/tests/test_worker.py .......                                                                                                                                                   [100%]

========================================================================================== 7 passed, 3 warnings in 0.16s ==========================================================================================
sys:1: RuntimeWarning: coroutine 'WorkerHandler.process_files_from_master' was never awaited
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
(wazuh_env) yanazaeva@pop-os:~/git/wazuh$ git status
On branch fix/13070-unittest-leftovers
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   framework/wazuh/core/cluster/tests/test_worker.py

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	queue/

no changes added to commit (use "git add" and/or "git commit -a")
```
After the change, we can verify that this file is not being created anymore:
```
(wazuh_env) yanazaeva@pop-os:~/git/wazuh$ pytest framework/wazuh/core/cluster/tests/test_worker.py --disable-warnings
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.5, pytest-5.4.3, py-1.11.0, pluggy-0.13.1
rootdir: /home/yanazaeva/git/wazuh/framework
plugins: asyncio-0.15.1, metadata-1.11.0, trio-0.7.0, testinfra-6.3.0, cov-2.12.0, anyio-3.5.0, aiohttp-0.3.0, html-3.1.1
collected 7 items                                                                                                                                                                                                 

framework/wazuh/core/cluster/tests/test_worker.py .......                                                                                                                                                   [100%]

========================================================================================== 7 passed, 4 warnings in 0.16s ==========================================================================================
(wazuh_env) yanazaeva@pop-os:~/git/wazuh$ git status
On branch fix/13070-unittest-leftovers
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   framework/wazuh/core/cluster/tests/test_worker.py

no changes added to commit (use "git add" and/or "git commit -a")
```