### PR TITLE
Modify Python unit tests

### DIFF
--- a/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
@@ -534,8 +534,8 @@ async def test_APIRequestQueue_run(loop_mock, import_module_mock):
         apirequest.request_queue = RequestQueueMock()
         with pytest.raises(Exception, match=".*break while true.*"):
             await apirequest.run()
-            logger_mock.assert_called_once_with("Error in DAPI. The destination node is "
-                                                "not connected or does not exist: break while true.")
+        logger_mock.assert_called_once_with("Error in DAPI request. The destination node is "
+                                            "not connected or does not exist: 'wazuh'.")
 
         node = NodeMock()
         with patch.object(node, "send_string", return_value=b"noerror"):
@@ -589,11 +589,11 @@ async def test_SendSyncRequestQueue_run(loop_mock):
         sendsync.request_queue = RequestQueueMock()
         with pytest.raises(Exception, match=".*break while true.*"):
             await sendsync.run()
-            logger_mock.assert_called_with("Error in Sendsync. The destination node is "
-                                           "not connected or does not exist: break while true.")
+        logger_mock.assert_called_once_with("Error in Sendsync. The destination node is "
+                                            "not connected or does not exist: 'wazuh'.")
 
         node = NodeMock()
-        with patch.object(node, "send_request", Exception("break while true")) as node_mock:
+        with patch.object(node, "send_request", Exception("break while true")):
             with patch("wazuh.core.cluster.dapi.dapi.wazuh_sendsync", side_effect=Exception("break while true")):
                 server.clients = {"wazuh": node}
                 sendsync.logger = logging.getLogger("sendsync")
@@ -603,7 +603,6 @@ async def test_SendSyncRequestQueue_run(loop_mock):
             with patch("wazuh.core.cluster.dapi.dapi.wazuh_sendsync", side_effect="noerror"):
                 with pytest.raises(Exception):
                     await sendsync.run()
-                    node_mock.assert_called_with(b"sendsyn_res", "request_queue*test ")
 
         with patch.object(node, "send_request", return_value=WazuhError(1000)):
             with patch("wazuh.core.cluster.dapi.dapi.wazuh_sendsync", return_value="valid"):

--- a/framework/wazuh/core/cluster/tests/test_client.py
+++ b/framework/wazuh/core/cluster/tests/test_client.py
@@ -5,13 +5,11 @@
 import asyncio
 import logging
 import sys
-import threading
-import _thread
 import time
 from unittest.mock import MagicMock, patch, call
-from freezegun import freeze_time
 
 import pytest
+from freezegun import freeze_time
 
 with patch('wazuh.common.wazuh_uid'):
     with patch('wazuh.common.wazuh_gid'):
@@ -124,9 +122,10 @@ def test_acm_add_tasks():
 
 
 @pytest.mark.asyncio
+@patch('asyncio.sleep')
 @patch('itertools.starmap', return_value="")
 @patch('wazuh.core.cluster.client.AbstractClientManager.add_tasks', return_value=[])
-async def test_acm_start(add_tasks_mock, starmap_mock):
+async def test_acm_start(add_tasks_mock, starmap_mock, asyncio_sleep_mock):
     """Check that the 'start' method allow a connection to the server and wait until this connection is closed."""
 
     class ClientMock:
@@ -137,15 +136,10 @@ async def test_acm_start(add_tasks_mock, starmap_mock):
         def close(self):
             pass
 
-    async def middle_method():
-        await abstract_client_manager.start()
+    async def sleep_mock(connection_retry):
+        raise Exception()
 
-    def between_callback():
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-
-        loop.run_until_complete(middle_method())
-        loop.close()
+    asyncio_sleep_mock.side_effect = sleep_mock
 
     with patch.object(LoopMock, "create_connection",
                       return_value=(TransportMock(), ClientMock())) as create_connection_mock:
@@ -155,33 +149,26 @@ async def test_acm_start(add_tasks_mock, starmap_mock):
         with patch.object(logging.getLogger("wazuh"), "info") as logger_info_mock:
             with patch.object(logging.getLogger("wazuh"), "error") as logger_error_mock:
                 # Test the try
-                stop_while_thread = threading.Thread(target=between_callback)
-                # stop_while_thread.daemon = True
-                stop_while_thread.start()
-                time.sleep(5)
-                logger_info_mock.assert_called_with("The connection has been closed. Reconnecting in 10 seconds.")
+                try:
+                    await abstract_client_manager.start()
+                except Exception:
+                    logger_info_mock.assert_called_with("The connection has been closed. Reconnecting in 10 seconds.")
 
                 # Test the first exception
                 create_connection_mock.side_effect = ConnectionRefusedError
-                time.sleep(5)
-                logger_error_mock.assert_called_with("Could not connect to master. Trying again in 10 seconds.")
+                try:
+                    await abstract_client_manager.start()
+                except Exception:
+                    logger_error_mock.assert_called_with("Could not connect to master. Trying again in 10 seconds.")
 
                 # Test the second exception
                 create_connection_mock.side_effect = OSError
-                time.sleep(5)
-                logger_error_mock.assert_called_with("Could not connect to master: . Trying again in 10 seconds.")
-                add_tasks_mock.assert_called_with()
-                starmap_mock.assert_called()
-
-                # Stop the thread
-                print("The thread is about to be stopped, so an expected Exception will be raised.")
-                create_connection_mock.side_effect = Exception
-                time.sleep(5)
-
-                if not stop_while_thread.is_alive():
-                    print("The thread was correctly terminated.")
-                else:
-                    raise Exception("The thread could not be properly terminated.")
+                try:
+                    await abstract_client_manager.start()
+                except Exception:
+                    logger_error_mock.assert_called_with("Could not connect to master: . Trying again in 10 seconds.")
+                    add_tasks_mock.assert_called_with()
+                    starmap_mock.assert_called()
 
 
 # Test AbstractClient methods
@@ -331,9 +318,10 @@ def test_ac_echo_client():
 
 
 @pytest.mark.asyncio
+@patch('asyncio.sleep')
 @patch.object(FutureMock, "done", return_value=False)
 @patch('wazuh.core.cluster.client.AbstractClient.send_request', return_value=b"ok")
-async def test_ac_client_echo_ok(send_request_mock, done_mock):
+async def test_ac_client_echo_ok(send_request_mock, done_mock, asyncio_sleep_mock):
     """Test if a keepalive is being send to the server every couple of seconds until the connection is lost."""
 
     class TransportMock:
@@ -344,39 +332,42 @@ async def test_ac_client_echo_ok(send_request_mock, done_mock):
         def close(self):
             pass
 
+    async def sleep_mock(connection_retry):
+        raise Exception()
+
     def set_assignment():
         time.sleep(0.4)
         done_mock.return_value = True
 
     abstract_client.connected = True
+    asyncio_sleep_mock.side_effect = sleep_mock
 
     # Test try
     with patch.object(logging.getLogger("wazuh"), "info") as logger_mock:
         with patch('wazuh.core.cluster.common.Handler.setup_task_logger',
                    return_value=logging.getLogger("wazuh")) as setup_logger_mock:
-            stop_while_thread = threading.Thread(target=set_assignment)
-            stop_while_thread.start()
-            await abstract_client.client_echo()
-            send_request_mock.assert_called_once_with(b'echo-c', b'keepalive')
-            setup_logger_mock.assert_called_once_with("Keep Alive")
-            logger_mock.assert_called_with("ok")
+            try:
+                await abstract_client.client_echo()
+            except Exception:
+                send_request_mock.assert_called_once_with(b'echo-c', b'keepalive')
+                setup_logger_mock.assert_called_once_with("Keep Alive")
+                logger_mock.assert_called_with("ok")
 
     # Test except
     with patch.object(logging.getLogger("wazuh"), "error") as logger_mock:
         with patch('wazuh.core.cluster.common.Handler.setup_task_logger',
                    return_value=logging.getLogger("wazuh")) as setup_logger_mock:
-            abstract_client.transport = TransportMock()
-            done_mock.return_value = False
-            send_request_mock.side_effect = Exception()
-            stop_while_thread = threading.Thread(target=set_assignment)
-            stop_while_thread.start()
-
             with patch.object(TransportMock, "close") as close_mock:
-                await abstract_client.client_echo()
-                setup_logger_mock.assert_called_once_with("Keep Alive")
-                close_mock.assert_called_once()
-                logger_mock.assert_any_call("Error sending keep alive: ")
-                logger_mock.assert_called_with("Maximum number of failed keep alives reached. Disconnecting.")
+                abstract_client.transport = TransportMock()
+                done_mock.return_value = False
+                send_request_mock.side_effect = Exception()
+                try:
+                    await abstract_client.client_echo()
+                except Exception:
+                    setup_logger_mock.assert_called_once_with("Keep Alive")
+                    close_mock.assert_called_once()
+                    logger_mock.assert_any_call("Error sending keep alive: ")
+                    logger_mock.assert_called_with("Maximum number of failed keep alives reached. Disconnecting.")
 
 
 @pytest.mark.asyncio

--- a/framework/wazuh/core/cluster/tests/test_cluster.py
+++ b/framework/wazuh/core/cluster/tests/test_cluster.py
@@ -86,7 +86,6 @@ def test_check_cluster_config_ko(read_config, message):
     with patch('wazuh.core.cluster.utils.get_ossec_conf', return_value=read_config) as m:
         with pytest.raises(WazuhException, match=rf'.* 3004 .* {message}'):
             configuration = wazuh.core.cluster.utils.read_config()
-
             for key in m.return_value["cluster"]:
                 if key in configuration:
                     configuration[key] = m.return_value["cluster"][key]

--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -1035,7 +1035,7 @@ def test_wazuh_common_end_receiving_file_ko(path_exists_mock, os_remove_mock):
         with pytest.raises(exception.WazuhClusterError, match=r'.* 3027 .*'):
             os_remove_mock.side_effect = Exception
             wazuh_common.end_receiving_file("not_task_ID filepath")
-            os_remove_mock.assert_called_once_with(Exception)
+    assert os_remove_mock.call_count == 2
 
 
 @patch('json.loads')

--- a/framework/wazuh/core/cluster/tests/test_server.py
+++ b/framework/wazuh/core/cluster/tests/test_server.py
@@ -342,6 +342,7 @@ async def test_AbstractServer_echo(loop_mock, sleep_mock):
             mock_info.assert_called_once_with("keepalive worker_test mock")
 
 
+@pytest.mark.asyncio
 @freeze_time("2022-01-01")
 @patch("asyncio.sleep", side_effect=IndexError)
 @patch("asyncio.get_running_loop", return_value=loop)
@@ -367,6 +368,7 @@ async def test_AbstractServer_performance_test(perf_counter_mock, loop_mock, sle
         mock_info.assert_called_once_with("Received size: 20 // Time: 0")
 
 
+@pytest.mark.asyncio
 @freeze_time("2022-01-01")
 @patch("asyncio.sleep", side_effect=IndexError)
 @patch("asyncio.get_running_loop", return_value=loop)

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -340,8 +340,8 @@ async def test_sync_wazuh_db_sync_ko(send_string_mock, logger_debug_mock, json_d
     # Test try and if
     with pytest.raises(exception.WazuhClusterError, match=r".* 3016 .*"):
         await sync_wazuh_db.sync(start_time=10)
-        json_dumps_mock.assert_called_with({"set_data_command": "set_command", "chunks": ["get_command"]})
-        logger_debug_mock.assert_called_once_with(f"Obtained {1} chunks of data in 0.000s.")
+    json_dumps_mock.assert_called_with({"set_data_command": "set_command", "chunks": ["get_command"]})
+    logger_debug_mock.assert_called_once_with(f"Obtained {1} chunks of data in 0.000s.")
 
     send_string_mock.assert_called_with(b"")
 

--- a/framework/wazuh/tests/test_ciscat.py
+++ b/framework/wazuh/tests/test_ciscat.py
@@ -101,7 +101,7 @@ def test_get_ciscat_results_select_ko(agents_info_mock, socket_mock):
     with patch('wazuh.core.utils.WazuhDBConnection') as mock_wdb:
         mock_wdb.return_value = InitWDBSocketMock(sql_schema_file=db_file)
         with pytest.raises(WazuhError, match=r'\b1724\b'):
-            result = get_ciscat_results(agent_list=['001'], select=['random']).render()['data']
+            get_ciscat_results(agent_list=['001'], select=['random']).render()['data']
 
 
 @pytest.mark.parametrize('search, total_expected_items', [


### PR DESCRIPTION
|Related issue|
|---|
|#12086|

## Description

This closes #12086. The aim of this pull is to remove all the declarations that were established after a `pytest.raises` method, as they do not have any effect. Also, we modified some functions in the `test_client.py` and `test_master.py` files, as they were using threading. 

The current coverage of both functions is the following:
```
Name                                     Stmts   Miss  Cover   Missing
----------------------------------------------------------------------
framework/wazuh/core/cluster/master.py     429      0   100%
----------------------------------------------------------------------
TOTAL                                      429      0   100%

Name                                     Stmts   Miss  Cover   Missing
----------------------------------------------------------------------
framework/wazuh/core/cluster/client.py     146      1    99%   111
----------------------------------------------------------------------
TOTAL                                      146      1    99%
```

Lastly, we created a test for the `proces_spawn_child` present in the `utils.py` file. 