### PR TITLE
Rework for checks 20553 and 20592 on SCA CIS Benchmark for Amazon Linux 2

### DIFF
--- a/ruleset/sca/amazon/cis_amazon_linux_2.yml
+++ b/ruleset/sca/amazon/cis_amazon_linux_2.yml
@@ -986,7 +986,7 @@ checks:
       - tsc: ["CC5.2"]
     references:
       - More detailed documentation on OpenLDAP is available at https://www.openldap.org
-    condition: none
+    condition: any
     rules:
       - 'c:rpm -q openldap-servers -> r:package openldap-servers is not installed'
 
@@ -1742,7 +1742,7 @@ checks:
       - cis_csc: ["9.4"]
       - pci_dss: ["1.1"]
       - tsc: ["CC8.1"]
-    condition: all
+    condition: any
     rules:
       - 'c:rpm -q firewalld -> r:^package firewalld is not installed'
       - 'c:systemctl is-enabled firewalld -> r:masked'


### PR DESCRIPTION
|Related issue|
|---|
|  #13030 |

## Description 

This PR solves conditions for checks 20553 and 20592

The affected changes were:
- Check 20553 condition should be ANY/ALL instead of NONE.
- Check 20592 condition should be ANY instead of ALL. 

## SCA Checks
### Syntax and semantic

- [x] a) ID of each policy must be contiguous.
- [x] b) The order and format set in [Documentation](https://documentation.wazuh.com/current/user-manual/capabilities/sec-config-assessment/creating-custom-policies.html) must be respected.
- [x] c) YML must be valid to avoid errors.

### Content

- [x] a) Compare each check with its analogue from CIS Benchmark.
- [x] b) Try to maintain each rule as similar as possible with the `Audit` section from the CIS check.
- [x] c) Check that the commands provide the expected output.
- [x] d) When a failure is discovered, check similar policies to avoid repetition of the issue.

### Unit testing

- [x] a) Output from `agent.log` after the SCA scan and a raw output of the result of the checks.
<details><summary>Tests results</summary>
<p>

#### Analysisd (server or local)
analysisd.debug=2

#### Auth daemon debug (server)
authd.debug=0

#### Exec daemon debug (server, local, or Unix agent)
execd.debug=0

#### Monitor daemon debug (server, local, or Unix agent)
monitord.debug=0

#### Log collector (server, local or Unix agent)
logcollector.debug=0

#### Integrator daemon debug (server, local or Unix agent)
integrator.debug=0

#### Unix agentd
agent.debug=2

</p>
</details>

### Deployment

- [x] a) If the policy it's new, it must be added to the `sca.files` templates.
- [x] b) If the OS has many supported SCA policies, a policy must be set as default policy. ([as example](https://github.com/wazuh/wazuh/blob/master/etc/templates/config/centos/sca.files))
