### PR TITLE
Vuldet task msg context for queue data

### DIFF
--- a/src/headers/queue_linked_op.h
+++ b/src/headers/queue_linked_op.h
@@ -37,31 +37,31 @@ typedef struct linked_queue_t {
 
 /**
  * @brief Initializes a new queue structure
- * 
+ *
  * @return initialize queue structure
  * */
 w_linked_queue_t *linked_queue_init();
 
 /**
  * @brief Frees an existent queue
- * 
- * @param queue 
+ *
+ * @param queue
  * */
 void linked_queue_free(w_linked_queue_t *queue);
 
-/** 
+/**
  * @brief Inserts an element into the queue
- * 
+ *
  * @param queue the queue
  * @param data data to be inserted
  * @return node structure pushed to the queue
  * */
 w_linked_queue_node_t * linked_queue_push(w_linked_queue_t * queue, void * data);
 
-/** 
- * @brief Same as queue_push but with mutual exclusion 
+/**
+ * @brief Same as queue_push but with mutual exclusion
  * for multithreaded applications
- * 
+ *
  * @param queue the queue
  * @param data data to be inserted
  * @return node structure pushed to the queue
@@ -70,7 +70,7 @@ w_linked_queue_node_t * linked_queue_push_ex(w_linked_queue_t * queue, void * da
 
 /**
  * @brief Retrieves next item in the queue
- * 
+ *
  * @param queue the queue
  * @return element if queue has a next
  *         NULL if queue is empty
@@ -78,17 +78,26 @@ w_linked_queue_node_t * linked_queue_push_ex(w_linked_queue_t * queue, void * da
 void * linked_queue_pop(w_linked_queue_t * queue);
 
 /**
- * @brief Same as queue_pop but with mutual exclusion 
+ * @brief Same as queue_pop but with mutual exclusion
  * for multithreaded applications.
- * 
+ *
  * @param queue the queue
  * @return next element in the queue
  * */
 void * linked_queue_pop_ex(w_linked_queue_t * queue);
 
 /**
+ * @brief Retrieves next item in the queue without conditional wait
+ *
+ * @param queue the queue
+ * @return next element in the queue
+ *
+ * */
+void * linked_queue_pop_ex_no_cond_wait(w_linked_queue_t * queue);
+
+/**
  * @brief Unlinks an existent node from the queue and pushes it again to the end
- * 
+ *
  * @param queue the queue
  * @param node node to be unlinked from the queue
  * */

--- a/src/shared/queue_linked_op.c
+++ b/src/shared/queue_linked_op.c
@@ -70,7 +70,7 @@ void linked_queue_unlink_and_push_node(w_linked_queue_t * queue, w_linked_queue_
         node->next->prev = node->prev;
     } else {
         // Already at the correct spot
-        w_mutex_unlock(&queue->mutex); 
+        w_mutex_unlock(&queue->mutex);
         return;
     }
     if (node->prev) {
@@ -82,7 +82,7 @@ void linked_queue_unlink_and_push_node(w_linked_queue_t * queue, w_linked_queue_
     node->next = NULL;
     queue->elements--;
     linked_queue_append_node(queue, node);
-    w_mutex_unlock(&queue->mutex); 
+    w_mutex_unlock(&queue->mutex);
 }
 
 void * linked_queue_pop(w_linked_queue_t * queue) {
@@ -104,6 +104,16 @@ void * linked_queue_pop_ex(w_linked_queue_t * queue) {
     while (data = linked_queue_pop(queue), !data) {
         w_cond_wait(&queue->available, &queue->mutex);
     }
+    w_mutex_unlock(&queue->mutex);
+
+    return data;
+}
+
+void * linked_queue_pop_ex_no_cond_wait(w_linked_queue_t * queue) {
+    void * data;
+
+    w_mutex_lock(&queue->mutex);
+    data = linked_queue_pop(queue);
     w_mutex_unlock(&queue->mutex);
 
     return data;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -18,6 +18,7 @@
 
 #include "external/sqlite/sqlite3.h"
 #include "wm_vuln_detector_evr.h"
+#include "../wm_task_general.h"
 #include "cJSON.h"
 
 #define WM_VULNDETECTOR_LOGTAG ARGV0 ":" VU_WM_NAME
@@ -474,6 +475,12 @@ typedef struct wm_vuldet_t {
     wm_vuldet_state state;
     wm_vuldet_flags flags;
 } wm_vuldet_t;
+
+typedef struct wm_vuldet_task_msg_ctx {
+    int task_id;
+    task_status task_status;
+    char *status_message;
+} wm_vuldet_task_msg_ctx;
 
 typedef enum {
     V_START,


### PR DESCRIPTION
|Related issue|
|---|
|#13108|

## Description

This PR defines a context msg structure as node data for a queue. A simple method was added to operate the queue without a conditional wait if the queue is empty. 

## Scan-build

![2](https://user-images.githubusercontent.com/13010397/163000839-8d61bc8a-1e8e-40c4-b8f2-3d3c210ca654.png)

## Coverage

![1](https://user-images.githubusercontent.com/13010397/163000919-6fc99dc0-d101-4c77-a8bb-0418f3002fd1.png)

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] Added unit tests (for new features)