### PR TITLE
Remove useless `set_user_name` function

### DIFF
--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -4,7 +4,6 @@
 
 from json import JSONDecodeError
 from logging import getLogger
-from datetime import datetime
 
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPException
@@ -25,13 +24,6 @@ logger = getLogger('wazuh-api')
 
 def _cleanup_detail_field(detail):
     return ' '.join(str(detail).replace("\n\n", ". ").replace("\n", "").split())
-
-
-@web.middleware
-async def set_user_name(request, handler):
-    if 'token_info' in request:
-        request['user'] = request['token_info']['sub']
-    return await handler(request)
 
 
 @web.middleware

--- a/api/api/test/test_middlewares.py
+++ b/api/api/test/test_middlewares.py
@@ -7,8 +7,8 @@ from unittest.mock import AsyncMock, patch
 from freezegun import freeze_time
 import pytest
 
-from api.middlewares import set_user_name, unlock_ip, _cleanup_detail_field, prevent_bruteforce_attack, \
-    prevent_denial_of_service, security_middleware
+from api.middlewares import unlock_ip, _cleanup_detail_field, prevent_bruteforce_attack, prevent_denial_of_service, \
+    security_middleware
 from wazuh.core.exception import WazuhPermissionError, WazuhTooManyRequests
 
 
@@ -44,20 +44,6 @@ def test_cleanup_detail_field():
     """
 
     assert _cleanup_detail_field(detail) == "Testing. Details field."
-
-
-@pytest.mark.parametrize("req", [
-    DummyRequest({'token_info': {'sub': 'test'},
-                  'user': None}),
-    DummyRequest({'user': None}),
-])
-@pytest.mark.asyncio
-async def test_middlewares_set_user_name(req):
-    """Test `set_user_name` updates user when there is `token_info`."""
-    await set_user_name(req, handler_mock)
-    processed_request = handler_mock.call_args.args[-1]
-
-    assert processed_request['user'] if "token_info" in req else processed_request['user'] is None
 
 
 @patch("api.middlewares.ip_stats", new={'ip': {'timestamp': 5}})

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -72,7 +72,7 @@ def start():
                 strict_validation=True,
                 validate_responses=False,
                 pass_context_arg_name='request',
-                options={"middlewares": [response_postprocessing, set_user_name, security_middleware, request_logging,
+                options={"middlewares": [response_postprocessing, security_middleware, request_logging,
                                          set_secure_headers]})
 
     # Maximum body size that the API can accept (bytes)
@@ -211,8 +211,7 @@ if __name__ == '__main__':
     from api import validator
     from api.api_exception import APIError
     from api.constants import CONFIG_FILE_PATH
-    from api.middlewares import set_user_name, security_middleware, response_postprocessing, request_logging, \
-        set_secure_headers
+    from api.middlewares import security_middleware, response_postprocessing, request_logging, set_secure_headers
     from api.signals import modify_response_headers
     from api.uri_parser import APIUriParser
     from api.util import to_relative_path


### PR DESCRIPTION
|Related issue|
|---|
|#12144|

## Description

This closes #12144. The goal of this pull is to remove the unused `set_user_function` from the `middlewares.py` file, as this function is no longer useful:
https://github.com/wazuh/wazuh/blob/245f82fc7561fb2920cd7b058ddf755c318d5f9e/api/api/middlewares.py#L30-L34