### PR TITLE
Fix errors in sshd decoders

### DIFF
--- a/ruleset/decoders/0310-ssh_decoders.xml
+++ b/ruleset/decoders/0310-ssh_decoders.xml
@@ -165,10 +165,11 @@
   <order>srcip</order>
 </decoder>
 
+<!-- Apr 14 19:28:21 gorilla sshd[31274]: Connection closed by 192.168.1.33 port 883 -->
 <decoder name="ssh-closed">
   <parent>sshd</parent>
-  <prematch>^Connection closed </prematch>
-  <regex offset="after_prematch">^by (\S+)$ port (\S+)</regex>
+  <prematch>^Connection closed by (\S+) port (\S+)$</prematch>
+  <regex>by (\S+) port (\S+)$</regex>
   <order>srcip, srcport</order>
 </decoder>
 
@@ -234,9 +235,10 @@
   <order>srcuser,srcip,srcport</order>
 </decoder>
 
-<!-- user from, added last to avoid confilicts with ssh-error and ssh-failed -->
+<!-- user from, added last to avoid conflicts with ssh-error and ssh-failed -->
 <decoder name="sshd-from">
   <parent>sshd</parent>
+  <prematch>for (\S+) from (\S+)</prematch>
   <regex>for (\S+) from (\S+)</regex>
   <order>srcuser, srcip</order>
 </decoder>

--- a/ruleset/decoders/0310-ssh_decoders.xml
+++ b/ruleset/decoders/0310-ssh_decoders.xml
@@ -169,7 +169,7 @@
 <decoder name="ssh-closed">
   <parent>sshd</parent>
   <prematch>^Connection closed by \S+ port \S+</prematch>
-  <regex>by (\S+) port (\S+)$</regex>
+  <regex>by (\S+) port (\S+)</regex>
   <order>srcip, srcport</order>
 </decoder>
 

--- a/ruleset/decoders/0310-ssh_decoders.xml
+++ b/ruleset/decoders/0310-ssh_decoders.xml
@@ -168,7 +168,7 @@
 <!-- Apr 14 19:28:21 gorilla sshd[31274]: Connection closed by 192.168.1.33 port 883 -->
 <decoder name="ssh-closed">
   <parent>sshd</parent>
-  <prematch>^Connection closed by (\S+) port (\S+)$</prematch>
+  <prematch>^Connection closed by \S+ port \S+</prematch>
   <regex>by (\S+) port (\S+)$</regex>
   <order>srcip, srcport</order>
 </decoder>
@@ -238,7 +238,7 @@
 <!-- user from, added last to avoid conflicts with ssh-error and ssh-failed -->
 <decoder name="sshd-from">
   <parent>sshd</parent>
-  <prematch>for (\S+) from (\S+)</prematch>
+  <prematch>for \S+ from \S+</prematch>
   <regex>for (\S+) from (\S+)</regex>
   <order>srcuser, srcip</order>
 </decoder>

--- a/ruleset/decoders/0310-ssh_decoders.xml
+++ b/ruleset/decoders/0310-ssh_decoders.xml
@@ -234,11 +234,3 @@
   <regex offset="after_prematch">^(\S+) (\S+) port (\d+)</regex>
   <order>srcuser,srcip,srcport</order>
 </decoder>
-
-<!-- user from, added last to avoid conflicts with ssh-error and ssh-failed -->
-<decoder name="sshd-from">
-  <parent>sshd</parent>
-  <prematch>for \S+ from \S+</prematch>
-  <regex>for (\S+) from (\S+)</regex>
-  <order>srcuser, srcip</order>
-</decoder>


### PR DESCRIPTION
|Related issue|
|---|
|closes #13120|



## Description

Fix for SSHD decoders: 

- ssh-closed: fixed prematch and regex. 
- sshd-from: added prematch.

As explained in #13120 the errors in these decoders were hindering development of custom decoders.


## Logs/Alerts example

Using wazuh-logtest:

```
**Phase 1: Completed pre-decoding.
        full event: 'Apr 12 14:21:00 jumphost sshd[21684]: Connection closed by authenticating user ubuntu 10.0.0.100 port 54114 [preauth]'
        timestamp: 'Apr 12 14:21:00'
        hostname: 'jumphost'
        program_name: 'sshd'

**Phase 2: Completed decoding.
        name: 'sshd'
        parent: 'sshd'
        dstuser: 'ubuntu'
        srcip: '10.0.0.100'
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors