### PR TITLE
Add broadcasting system for the cluster

### DIFF
--- a/framework/wazuh/core/cluster/tests/test_server.py
+++ b/framework/wazuh/core/cluster/tests/test_server.py
@@ -5,7 +5,7 @@
 from asyncio import Transport
 from contextvars import ContextVar
 from logging import Logger
-from unittest.mock import call, patch, ANY, MagicMock
+from unittest.mock import call, patch, ANY, Mock
 
 import pytest
 from freezegun import freeze_time
@@ -45,6 +45,7 @@ def test_AbstractServerHandler_init():
         assert isinstance(abstract_server_handler.last_keepalive, float)
         assert abstract_server_handler.tag == "NoClient"
         assert mock_contextvar.get() == "NoClient"
+        assert abstract_server_handler.handler_tasks == []
         assert isinstance(abstract_server_handler.broadcast_queue, asyncio.Queue)
 
 
@@ -106,7 +107,8 @@ def test_AbstractServerHandler_echo_master():
     assert abstract_server_handler.last_keepalive == 0.0
 
 
-def test_AbstractServerHandler_hello():
+@patch("asyncio.create_task")
+def test_AbstractServerHandler_hello(create_task_mock):
     """Check that the information of the new client invoking this function is stored correctly."""
 
     class ServerMock:
@@ -114,10 +116,12 @@ def test_AbstractServerHandler_hello():
             self.clients = {}
             self.configuration = {"node_name": "elif_test"}
 
+    loop.create_task = Mock()
     abstract_server_handler = AbstractServerHandler(server="Test", loop=loop, fernet_key=fernet_key,
                                                     cluster_items={"test": "server"})
     abstract_server_handler.server = ServerMock()
     abstract_server_handler.tag = "FixBehaviour"
+    abstract_server_handler.broadcast_reader = Mock()
 
     with patch("wazuh.core.cluster.server.context_tag", ContextVar("tag", default="")) as mock_contextvar:
         assert abstract_server_handler.hello(b"else_test") == (b"ok",
@@ -126,6 +130,7 @@ def test_AbstractServerHandler_hello():
         assert abstract_server_handler.server.clients["else_test"] == abstract_server_handler
         assert abstract_server_handler.tag == f"FixBehaviour {abstract_server_handler.name}"
         assert mock_contextvar.get() == abstract_server_handler.tag
+        loop.create_task.assert_called_once()
 
     with pytest.raises(WazuhClusterError, match=".* 3029 .*"):
         abstract_server_handler.hello(b"elif_test")
@@ -179,8 +184,11 @@ def test_AbstractServerHandler_connection_lost():
             assert "unit" not in abstract_server_handler.server.clients.keys()
 
         with patch.object(logger, "debug") as mock_debug_logger:
+            task_mock = Mock()
+            abstract_server_handler.handler_tasks = [task_mock]
             abstract_server_handler.connection_lost(exc=None)
             mock_debug_logger.assert_called_once_with("Disconnected unit.")
+            task_mock.cancel.assert_called_once()
 
 
 @patch("asyncio.Queue")
@@ -203,8 +211,8 @@ async def test_AbstractServerHandler_broadcast_reader():
     def sync_mock_func():
         return 'Result'
 
-    server_mock = MagicMock()
-    logger_mock = MagicMock()
+    server_mock = Mock()
+    logger_mock = Mock()
     server_mock.broadcast_results = {'test1': {'worker1': {}}, 'test2': {'worker1': {}}, 'test3': {'worker1': {}}}
     abstract_server_handler = AbstractServerHandler(server=server_mock, loop=loop, fernet_key=fernet_key,
                                                     cluster_items={"test": "server"}, logger=logger_mock)
@@ -223,8 +231,10 @@ async def test_AbstractServerHandler_broadcast_reader():
                                                   " is not callable.")
 
 
-@patch("asyncio.get_running_loop", return_value=loop)
-def test_AbstractServer_init(loop_mock):
+@patch("asyncio.get_running_loop", new=Mock())
+@patch('wazuh.core.cluster.server.AbstractServer.check_clients_keepalive')
+@patch('wazuh.core.cluster.server.AbstractServerHandler')
+def test_AbstractServer_init(AbstractServerHandler_mock, keepalive_mock):
     """Check the correct initialization of the AbstractServer object."""
     with patch("wazuh.core.cluster.server.context_tag", ContextVar("tag", default="")) as mock_contextvar:
         abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
@@ -249,15 +259,17 @@ def test_AbstractServer_init(loop_mock):
         assert abstract_server.broadcast_results == {}
 
 
-@patch("asyncio.get_running_loop", return_value=loop)
-def test_AbstractServer_broadcast(loop_mock):
+@patch("asyncio.get_running_loop", new=Mock())
+@patch('wazuh.core.cluster.server.AbstractServer.check_clients_keepalive')
+@patch('wazuh.core.cluster.server.AbstractServerHandler')
+def test_AbstractServer_broadcast(AbstractServerHandler_mock, asynckeepalive_mock):
     """Check that add_request is called with expected parameters."""
     def test_func():
         pass
 
-    logger_mock = MagicMock()
-    worker1_instance = MagicMock()
-    worker2_instance = MagicMock()
+    logger_mock = Mock()
+    worker1_instance = Mock()
+    worker2_instance = Mock()
     abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
                                      cluster_items={"test4": 4}, enable_ssl=True, logger=logger_mock)
     abstract_server.clients = {"worker1": worker1_instance, "worker2": worker2_instance}
@@ -269,10 +281,10 @@ def test_AbstractServer_broadcast(loop_mock):
                                           call('Added broadcast request to execute "test_func" in worker2.')]
 
 
-@patch("asyncio.get_running_loop", return_value=loop)
-def test_AbstractServer_broadcast_ko(loop_mock):
+@patch("asyncio.get_running_loop", new=Mock())
+def test_AbstractServer_broadcast_ko():
     """Verify that expected error log is printed when an exception is raised."""
-    logger_mock = MagicMock()
+    logger_mock = Mock()
     abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
                                      cluster_items={"test4": 4}, enable_ssl=True, logger=logger_mock)
     abstract_server.clients = {"worker1": "test"}
@@ -281,16 +293,17 @@ def test_AbstractServer_broadcast_ko(loop_mock):
     logger_mock.error.assert_called_once_with("Error while adding broadcast request in worker1: 'str' object "
                                               "has no attribute 'add_request'", exc_info=False)
 
+
 @patch("wazuh.core.cluster.server.uuid4", return_value="abc123")
-@patch("asyncio.get_running_loop", return_value=loop)
-def test_AbstractServer_broadcast_add(loop_mock, uuid_mock):
+@patch("asyncio.get_running_loop", new=Mock())
+def test_AbstractServer_broadcast_add(uuid_mock):
     """Check that add_request is called with expected parameters."""
     def test_func():
         pass
 
-    logger_mock = MagicMock()
-    worker1_instance = MagicMock()
-    worker2_instance = MagicMock()
+    logger_mock = Mock()
+    worker1_instance = Mock()
+    worker2_instance = Mock()
     abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
                                      cluster_items={"test4": 4}, enable_ssl=True, logger=logger_mock)
     abstract_server.broadcast_results = {}
@@ -303,10 +316,10 @@ def test_AbstractServer_broadcast_add(loop_mock, uuid_mock):
 
 
 @patch("wazuh.core.cluster.server.uuid4", return_value="abc123")
-@patch("asyncio.get_running_loop", return_value=loop)
-def test_AbstractServer_broadcast_add_ko(loop_mock, uuid_mock):
+@patch("asyncio.get_running_loop", new=Mock())
+def test_AbstractServer_broadcast_add_ko(uuid_mock):
     """Check that expected error log is printed and that broadcast_results is deleted."""
-    logger_mock = MagicMock()
+    logger_mock = Mock()
     abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
                                      cluster_items={"test4": 4}, enable_ssl=True, logger=logger_mock)
     abstract_server.broadcast_results = {}
@@ -326,10 +339,10 @@ def test_AbstractServer_broadcast_add_ko(loop_mock, uuid_mock):
     ({"abc123": {"worker1": "Response", "worker2": "Response", "worker3": "Response"}},
      {"worker1": "Response", "worker2": "Response", "worker3": "Response"}),
 ])
-@patch("asyncio.get_running_loop", return_value=loop)
-def test_AbstractServer_broadcast_pop(loop_mock, broadcast_results, expected_response):
+@patch("asyncio.get_running_loop", new=Mock())
+def test_AbstractServer_broadcast_pop(broadcast_results, expected_response):
     """Check that expected response is returned for each case."""
-    logger_mock = MagicMock()
+    logger_mock = Mock()
     abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
                                      cluster_items={"test4": 4}, enable_ssl=True, logger=logger_mock)
     abstract_server.broadcast_results = broadcast_results
@@ -338,8 +351,8 @@ def test_AbstractServer_broadcast_pop(loop_mock, broadcast_results, expected_res
     assert abstract_server.broadcast_pop("abc123") == expected_response
 
 
-@patch("asyncio.get_running_loop", return_value=loop)
-def test_AbstractServer_to_dict(loop_mock):
+@patch("asyncio.get_running_loop", new=Mock())
+def test_AbstractServer_to_dict():
     """Check the correct transformation of an AbstractServer to a dict."""
     configuration = {"test_to_dict": 0,
                      "nodes": [0, 1],
@@ -349,8 +362,8 @@ def test_AbstractServer_to_dict(loop_mock):
     assert abstract_server.to_dict() == {"info": {"ip": configuration["nodes"][0], "name": configuration['node_name']}}
 
 
-@patch("asyncio.get_running_loop", return_value=loop)
-def test_AbstractServer_setup_task_logger(loop_mock):
+@patch("asyncio.get_running_loop", new=Mock())
+def test_AbstractServer_setup_task_logger():
     """Check that a logger is created with a specific tag."""
     logger = Logger("setup_task_logger")
     abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
@@ -363,8 +376,8 @@ def test_AbstractServer_setup_task_logger(loop_mock):
 
 
 @patch("wazuh.core.cluster.server.utils.process_array")
-@patch("asyncio.get_running_loop", return_value=loop)
-def test_AbstractServer_get_connected_nodes(loop_mock, mock_process_array):
+@patch("asyncio.get_running_loop", new=Mock())
+def test_AbstractServer_get_connected_nodes(mock_process_array):
     """Check that all the necessary data is sent to the utils.process_array
     function to return all the information of the connected nodes."""
     abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
@@ -381,8 +394,8 @@ def test_AbstractServer_get_connected_nodes(loop_mock, mock_process_array):
 
 
 @patch("wazuh.core.cluster.server.utils.process_array")
-@patch("asyncio.get_running_loop", return_value=loop)
-def test_AbstractServer_get_connected_nodes_ko(loop_mock, mock_process_array):
+@patch("asyncio.get_running_loop", new=Mock())
+def test_AbstractServer_get_connected_nodes_ko(mock_process_array):
     """Check all exceptions that can be returned by the get_connected_nodes function."""
     abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
                                      cluster_items={"test4": 4}, enable_ssl=True)
@@ -408,8 +421,8 @@ def test_AbstractServer_get_connected_nodes_ko(loop_mock, mock_process_array):
 
 @pytest.mark.asyncio
 @patch("asyncio.sleep", side_effect=IndexError)
-@patch("asyncio.get_running_loop", return_value=loop)
-async def test_AbstractServer_check_clients_keepalive(loop_mock, sleep_mock):
+@patch("asyncio.get_running_loop", new=Mock())
+async def test_AbstractServer_check_clients_keepalive(sleep_mock):
     """Check that the function check_clients_keepalive checks the date of the
     last last_keepalive of the clients to verify if they are connected or not."""
 
@@ -451,8 +464,8 @@ async def test_AbstractServer_check_clients_keepalive(loop_mock, sleep_mock):
 
 @pytest.mark.asyncio
 @patch("asyncio.sleep", side_effect=IndexError)
-@patch("asyncio.get_running_loop", return_value=loop)
-async def test_AbstractServer_echo(loop_mock, sleep_mock):
+@patch("asyncio.get_running_loop", new=Mock())
+async def test_AbstractServer_echo(sleep_mock):
     """Check that the echo function sends a message to all clients and that the information is written to the log."""
 
     class ClientMock:
@@ -476,9 +489,9 @@ async def test_AbstractServer_echo(loop_mock, sleep_mock):
 @pytest.mark.asyncio
 @freeze_time("2022-01-01")
 @patch("asyncio.sleep", side_effect=IndexError)
-@patch("asyncio.get_running_loop", return_value=loop)
+@patch("asyncio.get_running_loop", new=Mock())
 @patch('wazuh.core.cluster.server.perf_counter', return_value=0)
-async def test_AbstractServer_performance_test(perf_counter_mock, loop_mock, sleep_mock):
+async def test_AbstractServer_performance_test(perf_counter_mock, sleep_mock):
     """Check that the function performance_test sends a big message to all clients
      and then get the time it took to send them."""
 
@@ -502,9 +515,9 @@ async def test_AbstractServer_performance_test(perf_counter_mock, loop_mock, sle
 @pytest.mark.asyncio
 @freeze_time("2022-01-01")
 @patch("asyncio.sleep", side_effect=IndexError)
-@patch("asyncio.get_running_loop", return_value=loop)
+@patch("asyncio.get_running_loop", new=Mock())
 @patch('wazuh.core.cluster.server.perf_counter', return_value=0)
-async def test_AbstractServer_concurrency_test(perf_counter_mock, loop_mock, sleep_mock):
+async def test_AbstractServer_concurrency_test(perf_counter_mock, sleep_mock):
     """Check that the function concurrency_test sends messages to all clients
      and then get the time it took to send them."""
 
@@ -529,8 +542,8 @@ async def test_AbstractServer_concurrency_test(perf_counter_mock, loop_mock, sle
 @patch("os.path.join", return_value="testing_path")
 @patch("uvloop.EventLoopPolicy")
 @patch("asyncio.set_event_loop_policy")
-@patch("asyncio.sleep", side_effect=IndexError)
-async def test_AbstractServer_start(sleep_mock, set_event_loop_policy_mock, eventlooppolicy_mock, mock_path_join):
+@patch('wazuh.core.cluster.server.AbstractServer.check_clients_keepalive')
+async def test_AbstractServer_start(keepalive_mock, set_event_loop_policy_mock, eventlooppolicy_mock, mock_path_join):
     """Check that the start function starts infinite asynchronous tasks according
     to the parameters with which the AbstractServer object has been created."""
 
@@ -590,8 +603,8 @@ async def test_AbstractServer_start(sleep_mock, set_event_loop_policy_mock, even
 @patch("wazuh.core.cluster.server.AbstractServerHandler")
 @patch("uvloop.EventLoopPolicy")
 @patch("asyncio.set_event_loop_policy")
-@patch("asyncio.sleep", side_effect=IndexError)
-async def test_AbstractServer_start_ko(sleep_mock, set_event_loop_policy_mock, eventlooppolicy_mock,
+@patch('wazuh.core.cluster.server.AbstractServer.check_clients_keepalive')
+async def test_AbstractServer_start_ko(keepalive_mock, set_event_loop_policy_mock, eventlooppolicy_mock,
                                        mock_AbstractServerHandler):
     """Check for exceptions that may arise inside the start function."""
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #12912 |

## Description

This PR adds a new broadcasting system for the master node of the Wazuh cluster, as requested at #12912. 

To do this, an asynchronous queue is created for each AbstractServerHandler (there is one for each connected client), to which the functions to be executed are added. Thus, the functions will be executed as soon as the AbstractServerHandler is free, in the most resource-efficient way possible.

![schema_1](https://user-images.githubusercontent.com/23361101/162743472-c5963435-aded-4a82-a556-8240ba7a599b.png)

## Broadcast methods
This broadcasting system adds three new methods to make use of it. They are defined inside the [AbstractServer class](https://github.com/wazuh/wazuh/blob/5ce9cd8e2ab79e147cfbeb33d911668a6be83903/framework/wazuh/core/cluster/server.py#L245-L248). Therefore, they can be used there or in any inheriting class (such as `Master` or `LocalServer`):
- <b>broadcast(f, *args, **kwargs):</b>  Run a function in all server handlers. There is one server handler for each connected client. Nothing is returned and it is not possible to check if the function was run in every server handler or the result.
- <b>broadcast_add(f, *args, **kwargs):</b> It works as the method above (broadcast) but it does return an identifier (`broadcast_id`). When this function is used, the result of each server handler is stored and it can be queried with its `broadcast_id`.
- <b>broadcast_pop(broadcast_id):</b> Receive `broadcast_id` as a parameter. It returns False if the request has not yet been run in all expected server handlers. Otherwise, a dict with the response for each one is returned (or True if the `broadcast_id` is unknown).

## Usage example

An example of use could be this development of agent-groups (#10771). Until now, due to the lack of a broadcasting method, a function was called from which each MasterHandler obtained the info:
https://github.com/wazuh/wazuh/blob/813c85f70612bfbbdba340d90c003408763fb65c/framework/wazuh/core/cluster/master.py#L1194-L1206

Now, it could just call `broadcast()`, specifying a reference to the `MasterHandler.send_agent_groups_information` method and the info as a keyword:
```PYTHON
        while True:
            try:
                before = perf_counter()
                sync_object.logger.info("Starting.")

                if len(self.clients.keys()) > 0:
                    if info := await sync_object.retrieve_information():
                        self.broadcast(MasterHandler.send_agent_groups_information, info)
                    after = perf_counter()
                    logger.info(f"Finished in {(after - before):.3f}s.")
                elif len(self.clients.keys()) == 0:
                    logger.info("No clients connected. Skipping.")
            except Exception as e:
                sync_object.logger.error(f"Error getting agent-groups from WDB: {e}")
```

There is no way to verify if the function has been run in all MasterHandlers. If that is required, `broadcast_add()` and `broadcast_pop()` could be used instead. `broadcast_pop` would return False until all handlers run the function:
```PYTHON
        bc_id = None
        bc_sent = False
        while True:
            try:
                before = perf_counter()
                sync_object.logger.info("Starting.")

                bc_sent = self.broadcast_pop(bc_id)
                if bc_sent and len(self.clients.keys()) > 0:
                    if info := await sync_object.retrieve_information():
                        bc_id = self.broadcast_add(MasterHandler.send_agent_groups_information, info)
                    after = perf_counter()
                    logger.info(f"Finished in {(after - before):.3f}s.")
                elif len(self.clients.keys()) == 0:
                    logger.info("No clients connected. Skipping.")
            except Exception as e:
                sync_object.logger.error(f"Error getting agent-groups from WDB: {e}")
```

## Tests results
As it can be seen below, the coverage for the `server.py` module is still 100% after this development:

```
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.9.5, pytest-7.0.1, pluggy-1.0.0 -- /home/selu/venv/3.9-unittest-env/bin/python3.9
cachedir: .pytest_cache
rootdir: /home/selu/Git/wazuh/framework
plugins: anyio-3.5.0, asyncio-0.18.1, aiohttp-1.0.4, cov-3.0.0
asyncio: mode=auto
collected 30 items                                                                                                                                                                                          

framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServerHandler_init PASSED                                                                                                             [  3%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServerHandler_to_dict PASSED                                                                                                          [  6%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServerHandler_connection_made PASSED                                                                                                  [ 10%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServerHandler_process_request PASSED                                                                                                  [ 13%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServerHandler_echo_master PASSED                                                                                                      [ 16%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServerHandler_hello PASSED                                                                                                            [ 20%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServerHandler_process_response PASSED                                                                                                 [ 23%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServerHandler_connection_lost PASSED                                                                                                  [ 26%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServerHandler_add_request PASSED                                                                                                      [ 30%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServerHandler_broadcast_reader PASSED                                                                                                 [ 33%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_init PASSED                                                                                                                    [ 36%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_broadcast PASSED                                                                                                               [ 40%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_broadcast_ko PASSED                                                                                                            [ 43%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_broadcast_add PASSED                                                                                                           [ 46%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_broadcast_add_ko PASSED                                                                                                        [ 50%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_broadcast_pop[broadcast_results0-False] PASSED                                                                                 [ 53%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_broadcast_pop[broadcast_results1-False] PASSED                                                                                 [ 56%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_broadcast_pop[broadcast_results2-True] PASSED                                                                                  [ 60%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_broadcast_pop[broadcast_results3-expected_response3] PASSED                                                                    [ 63%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_broadcast_pop[broadcast_results4-expected_response4] PASSED                                                                    [ 66%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_to_dict PASSED                                                                                                                 [ 70%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_setup_task_logger PASSED                                                                                                       [ 73%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_get_connected_nodes PASSED                                                                                                     [ 76%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_get_connected_nodes_ko PASSED                                                                                                  [ 80%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_check_clients_keepalive PASSED                                                                                                 [ 83%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_echo PASSED                                                                                                                    [ 86%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_performance_test PASSED                                                                                                        [ 90%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_concurrency_test PASSED                                                                                                        [ 93%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_start PASSED                                                                                                                   [ 96%]
framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_start_ko PASSED                                                                                                                [100%]


============================================================================================= warnings summary ==============================================================================================
../../venv/3.9-unittest-env/lib/python3.9/site-packages/pytest_aiohttp/plugin.py:28
  /home/selu/venv/3.9-unittest-env/lib/python3.9/site-packages/pytest_aiohttp/plugin.py:28: DeprecationWarning: The 'asyncio_mode' is 'legacy', switching to 'auto' for the sake of pytest-aiohttp backward compatibility. Please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
    config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

----------- coverage: platform linux, python 3.9.5-final-0 -----------
Name                                                Stmts   Miss  Cover
-----------------------------------------------------------------------
api/api/__init__.py                                     0      0   100%
api/api/api_exception.py                               11      5    55%
api/api/configuration.py                               87     42    52%
api/api/constants.py                                   11      0   100%
api/api/validator.py                                  149     50    66%
framework/__init__.py                                   0      0   100%
framework/wazuh/__init__.py                            56     36    36%
framework/wazuh/core/__init__.py                        0      0   100%
framework/wazuh/core/cluster/__init__.py                5      0   100%
framework/wazuh/core/cluster/common.py                445    342    23%
framework/wazuh/core/cluster/server.py                196      0   100%
framework/wazuh/core/cluster/tests/__init__.py          0      0   100%
framework/wazuh/core/cluster/tests/test_server.py     395      5    99%
framework/wazuh/core/cluster/utils.py                 141     98    30%
framework/wazuh/core/common.py                        130     19    85%
framework/wazuh/core/configuration.py                 418    378    10%
framework/wazuh/core/database.py                       55     36    35%
framework/wazuh/core/exception.py                     113     36    68%
framework/wazuh/core/pyDaemonModule.py                 63     52    17%
framework/wazuh/core/results.py                       334    240    28%
framework/wazuh/core/utils.py                         932    779    16%
framework/wazuh/core/wazuh_socket.py                  151    112    26%
framework/wazuh/core/wdb.py                           174    148    15%
framework/wazuh/core/wlogging.py                       66     50    24%
-----------------------------------------------------------------------
TOTAL                                                3932   2428    38%

======================================================================================= 30 passed, 1 warning in 1.00s =======================================================================================
```