### PR TITLE
Implement a tasks queue in the Vulnerability Detector module - Implementation

### DIFF
--- a/src/headers/queue_linked_op.h
+++ b/src/headers/queue_linked_op.h
@@ -43,9 +43,11 @@ typedef struct linked_queue_t
 /**
  * @brief Initializes a new queue structure
  *
- * @param push_callback Optional callback to run every time a push is called
- * @param pop_callback Optional callback to run every time a pop is called
- * @return w_linked_queue_t* Initialized queue structure
+ * @param push_callback Optional callback to run every time a push is called. It receives the (void* data) node as parameter.
+ *                      This parameter may be NULL so the method should perform the corresponding sanity checks.
+ * @param pop_callback Optional callback to run every time a pop is called. It receives the (void* data) node as parameter.
+ *                     This parameter may be NULL so the method should perform the corresponding sanity checks.
+ * @return w_linked_queue_t* Initialized queue structure.
  * */
 w_linked_queue_t * linked_queue_init(void (*push_callback)(void *), void (*pop_callback)(void *));
 
@@ -88,25 +90,25 @@ void *linked_queue_pop(w_linked_queue_t *queue);
  * @brief Same as queue_pop but with mutual exclusion
  * for multithreaded applications.
  *
- * @param queue the queue
- * @return next element in the queue
+ * @param queue The queue
+ * @return The front element in the queue
  * */
 void *linked_queue_pop_ex(w_linked_queue_t *queue);
 
 /**
- * @brief Retrieves next item in the queue without conditional wait
+ * @brief Retrieves the front item in the queue without conditional wait
  *
  * @param queue the queue
- * @return next element in the queue
+ * @return The front element in the queue
  *
  * */
 void *linked_queue_pop_ex_no_cond_wait(w_linked_queue_t *queue);
 
 /**
- * @brief Reads the next item in the queue with mutual exclusion but doesn't remove it
+ * @brief Reads the front item in the queue with mutual exclusion but doesn't remove it
  *
  * @param queue The queue used
- * @return void* The next element in the queue
+ * @return void* The front element in the queue
  */
 void *linked_queue_read_ex(w_linked_queue_t *queue);
 

--- a/src/headers/queue_linked_op.h
+++ b/src/headers/queue_linked_op.h
@@ -21,26 +21,33 @@
 
 #include <pthread.h>
 
-typedef struct linked_queue_node_t {
+typedef struct linked_queue_node_t
+{
     void *data;                       ///< pointer to the node data
     struct linked_queue_node_t *next; ///< pointer to next node
     struct linked_queue_node_t *prev; ///< pointer to prev node
 } w_linked_queue_node_t;
 
-typedef struct linked_queue_t {
-    pthread_mutex_t mutex;        ///< mutex for mutual exclusion
-    pthread_cond_t available;     ///< condition variable when queue is empty
-    unsigned int elements;        ///< counts the number of elements stored in the queue
-    w_linked_queue_node_t *first; ///< points to the first node that would go out the queue
-    w_linked_queue_node_t *last;  ///< pointer to the last node in the queue
+typedef struct linked_queue_t
+{
+    pthread_mutex_t mutex;         ///< mutex for mutual exclusion
+    pthread_cond_t available;      ///< condition variable when queue is empty
+    unsigned int elements;         ///< counts the number of elements stored in the queue
+    w_linked_queue_node_t *first;  ///< points to the first node that would go out the queue
+    w_linked_queue_node_t *last;   ///< pointer to the last node in the queue
+    void (*push_callback)(void *); ///< function pointer to an optional callback for push operation
+    void (*pop_callback)(void *);  ///< function pointer to an optional callback for pop operation
+
 } w_linked_queue_t;
 
 /**
  * @brief Initializes a new queue structure
  *
- * @return initialize queue structure
+ * @param push_callback Optional callback to run every time a push is called
+ * @param pop_callback Optional callback to run every time a pop is called
+ * @return w_linked_queue_t* Initialized queue structure
  * */
-w_linked_queue_t *linked_queue_init();
+w_linked_queue_t * linked_queue_init(void (*push_callback)(void *), void (*pop_callback)(void *));
 
 /**
  * @brief Frees an existent queue
@@ -56,7 +63,7 @@ void linked_queue_free(w_linked_queue_t *queue);
  * @param data data to be inserted
  * @return node structure pushed to the queue
  * */
-w_linked_queue_node_t * linked_queue_push(w_linked_queue_t * queue, void * data);
+w_linked_queue_node_t *linked_queue_push(w_linked_queue_t *queue, void *data);
 
 /**
  * @brief Same as queue_push but with mutual exclusion
@@ -66,7 +73,7 @@ w_linked_queue_node_t * linked_queue_push(w_linked_queue_t * queue, void * data)
  * @param data data to be inserted
  * @return node structure pushed to the queue
  * */
-w_linked_queue_node_t * linked_queue_push_ex(w_linked_queue_t * queue, void * data);
+w_linked_queue_node_t *linked_queue_push_ex(w_linked_queue_t *queue, void *data);
 
 /**
  * @brief Retrieves next item in the queue
@@ -75,7 +82,7 @@ w_linked_queue_node_t * linked_queue_push_ex(w_linked_queue_t * queue, void * da
  * @return element if queue has a next
  *         NULL if queue is empty
  * */
-void * linked_queue_pop(w_linked_queue_t * queue);
+void *linked_queue_pop(w_linked_queue_t *queue);
 
 /**
  * @brief Same as queue_pop but with mutual exclusion
@@ -84,7 +91,7 @@ void * linked_queue_pop(w_linked_queue_t * queue);
  * @param queue the queue
  * @return next element in the queue
  * */
-void * linked_queue_pop_ex(w_linked_queue_t * queue);
+void *linked_queue_pop_ex(w_linked_queue_t *queue);
 
 /**
  * @brief Retrieves next item in the queue without conditional wait
@@ -93,7 +100,15 @@ void * linked_queue_pop_ex(w_linked_queue_t * queue);
  * @return next element in the queue
  *
  * */
-void * linked_queue_pop_ex_no_cond_wait(w_linked_queue_t * queue);
+void *linked_queue_pop_ex_no_cond_wait(w_linked_queue_t *queue);
+
+/**
+ * @brief Reads the next item in the queue with mutual exclusion but doesn't remove it
+ *
+ * @param queue The queue used
+ * @return void* The next element in the queue
+ */
+void *linked_queue_read_ex(w_linked_queue_t *queue);
 
 /**
  * @brief Unlinks an existent node from the queue and pushes it again to the end
@@ -101,6 +116,6 @@ void * linked_queue_pop_ex_no_cond_wait(w_linked_queue_t * queue);
  * @param queue the queue
  * @param node node to be unlinked from the queue
  * */
-void linked_queue_unlink_and_push_node(w_linked_queue_t * queue, w_linked_queue_node_t *node);
+void linked_queue_unlink_and_push_node(w_linked_queue_t *queue, w_linked_queue_node_t *node);
 
 #endif

--- a/src/os_crypto/shared/msgs.c
+++ b/src/os_crypto/shared/msgs.c
@@ -138,7 +138,7 @@ void OS_StartCounter(keystore *keys)
     }
 
     mdebug2("Stored counter.");
-    keys->opened_fp_queue = linked_queue_init();
+    keys->opened_fp_queue = linked_queue_init(NULL, NULL);
 
     /* Get counter values */
     if (_s_recv_flush == 0) {

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -1699,7 +1699,7 @@ void manager_init()
 
     w_yaml_create_groups();
 
-    pending_queue = linked_queue_init();
+    pending_queue = linked_queue_init(NULL, NULL);
     pending_data = OSHash_Create();
 
     if (!m_hash || !pending_data) merror_exit("At manager_init(): OSHash_Create() failed");

--- a/src/unit_tests/os_crypto/shared/test_msgs.c
+++ b/src/unit_tests/os_crypto/shared/test_msgs.c
@@ -55,7 +55,7 @@ void test_StoreCounter_updating_rids(void **state)
     os_calloc(1, sizeof(keyentry*), keyentries);
     keys.keyentries = keyentries;
     w_linked_queue_t *queue;
-    queue = linked_queue_init();
+    queue = linked_queue_init(NULL, NULL);
     keys.keysize = 0;
     keys.id_counter = 0;
     keys.opened_fp_queue = queue;
@@ -103,7 +103,7 @@ void test_StoreCounter_pushing_rids(void **state)
     os_calloc(1, sizeof(keyentry*), keyentries);
     keys.keyentries = keyentries;
     w_linked_queue_t *queue;
-    queue = linked_queue_init();
+    queue = linked_queue_init(NULL, NULL);
     keys.keysize = 0;
     keys.id_counter = 0;
     keys.opened_fp_queue = queue;
@@ -156,7 +156,7 @@ void test_StoreCounter_pushing_rids_fp_null(void **state)
     os_calloc(1, sizeof(keyentry*), keyentries);
     keys.keyentries = keyentries;
     w_linked_queue_t *queue;
-    queue = linked_queue_init();
+    queue = linked_queue_init(NULL, NULL);
     keys.keysize = 0;
     keys.id_counter = 0;
     keys.opened_fp_queue = queue;
@@ -214,7 +214,7 @@ void test_StoreCounter_fail_first_open(void **state)
     os_calloc(1, sizeof(keyentry*), keyentries);
     keys.keyentries = keyentries;
     w_linked_queue_t *queue;
-    queue = linked_queue_init();
+    queue = linked_queue_init(NULL, NULL);
     keys.keysize = 0;
     keys.id_counter = 0;
     keys.opened_fp_queue = queue;

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -42,7 +42,7 @@ void HandleSecureMessage(char *buffer, int recv_b, struct sockaddr_storage *peer
 /* Setup/teardown */
 
 static int setup_config(void **state) {
-    w_linked_queue_t *queue = linked_queue_init();
+    w_linked_queue_t *queue = linked_queue_init(NULL, NULL);
     keys.opened_fp_queue = queue;
     test_mode = 1;
     return 0;

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_upgrades.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_upgrades.c
@@ -58,7 +58,7 @@ static int setup_config(void **state) {
     wm_manager_configs *config = NULL;
     os_calloc(1, sizeof(wm_manager_configs), config);
     *state = config;
-    upgrade_queue = linked_queue_init();
+    upgrade_queue = linked_queue_init(NULL, NULL);
     return 0;
 }
 
@@ -82,7 +82,7 @@ static int setup_upgrade_args(void **state) {
     args->config = config;
     state[0] = (void *)args;
     state[1] = (void *)config;
-    upgrade_queue = linked_queue_init();
+    upgrade_queue = linked_queue_init(NULL, NULL);
     sem_init(&upgrade_semaphore, 0, 5);
     return 0;
 }
@@ -109,7 +109,7 @@ static int setup_nodes(void **state) {
     node_next->data = agent_task_next;
     node->next = node_next;
     *state = (void *)node;
-    upgrade_queue = linked_queue_init();
+    upgrade_queue = linked_queue_init(NULL, NULL);
     return 0;
 }
 

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_upgrades.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_upgrades.c
@@ -127,7 +127,7 @@ STATIC int wm_agent_upgrade_send_sha1(int agent_id, int wpk_message_format, cons
 STATIC int wm_agent_upgrade_send_upgrade(int agent_id, int wpk_message_format, const char *wpk_file, const char *installer) __attribute__((nonnull));
 
 void wm_agent_upgrade_init_upgrade_queue() {
-    upgrade_queue = linked_queue_init();
+    upgrade_queue = linked_queue_init(NULL, NULL);
 }
 
 void wm_agent_upgrade_destroy_upgrade_queue() {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -641,6 +641,7 @@ const char *vu_cpe_dic_option[] = {
     "set_targethw_only_if_product_matches"
 };
 
+// Task flags for vu_tasks_queue
 bool VU_TASKS_QUEUE_FLAGS[VU_TASK_TYPES_SIZE] = {0};
 
 void vu_tasks_queue_push_callback (void* data) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -427,6 +427,8 @@ int *vu_queue;
 // Define time to sleep between messages sent
 int usec;
 
+w_linked_queue_t* vu_tasks_queue = NULL;
+
 const wm_context WM_VULNDETECTOR_CONTEXT = {
     "vulnerability-detector",
     (wm_routine)wm_vuldet_main,
@@ -638,6 +640,20 @@ const char *vu_cpe_dic_option[] = {
     "set_version_only_if_product_matches",
     "set_targethw_only_if_product_matches"
 };
+
+bool VU_TASKS_QUEUE_FLAGS[VU_TASK_TYPES_SIZE] = {0};
+
+void vu_tasks_queue_push_callback (void* data) {
+    if (data) {
+        VU_TASKS_QUEUE_FLAGS[((vu_task_context_t*)data)->task_type] = true;
+    }
+}
+
+void vu_tasks_queue_pop_callback (void* data) {
+    if (data) {
+        VU_TASKS_QUEUE_FLAGS[((vu_task_context_t*)data)->task_type] = false;
+    }
+}
 
 vu_feed wm_vuldet_set_allowed_feed(const char *os_name, const char *os_version, update_node **updates, vu_feed *agent_dist) {
     vu_feed retval = FEED_UNKNOWN;
@@ -5163,13 +5179,14 @@ end:
     return retval;
 }
 
-
 void *wm_vuldet_main(wm_vuldet_t * vuldet) {
     wm_vuldet_init(vuldet);
 
     wm_vuldet_check_db();
 
-    while (1) {
+    wm_vuldet_init_queue();
+
+    while (TRUE) {
         curr_time = time(NULL);
         // Update CVE databases
         if (vuldet->flags.update && wm_vuldet_run_update(vuldet->updates)) {
@@ -8618,6 +8635,17 @@ int wm_vuldet_get_software(int agent_id, bool not_triaged, cJSON** requested_ite
     }
 
     return result;
+}
+
+int wm_vuldet_init_queue() {
+    vu_tasks_queue = linked_queue_init(vu_tasks_queue_push_callback, vu_tasks_queue_pop_callback);
+
+    if (!vu_tasks_queue) {
+        mwarn("Unable to create the tasks queue for vulnerability detector.");
+        return OS_INVALID;
+    }
+
+    return OS_SUCCESS;
 }
 
 #endif

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -124,6 +124,36 @@
 // Types of scans
 typedef enum vu_scan_type_t { VU_BASELINE_SCAN , VU_FULL_SCAN, VU_PARTIAL_SCAN } vu_scan_type_t;
 
+// Type of tasks in vu_tasks_queue
+typedef enum vu_task_type_t {
+    VU_ON_DEMAND_SCAN,
+    VU_ON_DEMAND_FEED_UPDATE,
+    VU_INTERVAL_FEED_UPDATE,
+    VU_INTERVAL_SCAN,
+    VU_TASK_TYPES_SIZE // This should be the last constant
+} vu_task_type_t;
+
+// Status of tasks in vu_tasks_queue
+typedef enum vu_task_status_t {
+    VU_TASK_STATUS_VALID,
+    VU_TASK_STATUS_CANCELLED
+} vu_task_status_t;
+
+// Task context for vu_tasks_queue
+typedef struct vu_task_context_t {
+    size_t taskID;
+    vu_task_type_t task_type;
+    vu_task_status_t task_status;
+    char* feed_to_update;
+    int agent_to_scan;
+} vu_task_context_t;
+
+// Task flags for vu_tasks_queue
+extern bool VU_TASKS_QUEUE_FLAGS[VU_TASK_TYPES_SIZE];
+
+void vu_tasks_queue_push_callback (void* data);
+void vu_tasks_queue_pop_callback (void* data);
+
 extern const wm_context WM_VULNDETECTOR_CONTEXT;
 extern const char *vu_feed_tag[];
 extern const char *vu_os_product_name_list[];
@@ -894,6 +924,9 @@ int wm_vuldet_insert_nvd_cve(sqlite3 *db, nvd_vulnerability *nvd_data, int year)
 void wm_vuldet_free_nvd_node(nvd_vulnerability *data);
 void wm_vuldet_free_nvd_list(nvd_vulnerability *nvd_it);
 const char *wm_vuldet_get_unified_severity(char *severity);
+
+// Initialize tasks queue
+int wm_vuldet_init_queue();
 
 /**
  * @brief Correlate OVAL and NVD feeds for a more fine tuned result.

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -148,9 +148,6 @@ typedef struct vu_task_context_t {
     int agent_to_scan;
 } vu_task_context_t;
 
-// Task flags for vu_tasks_queue
-extern bool VU_TASKS_QUEUE_FLAGS[VU_TASK_TYPES_SIZE];
-
 void vu_tasks_queue_push_callback (void* data);
 void vu_tasks_queue_pop_callback (void* data);
 


### PR DESCRIPTION
|Related issue|
|---|
|#13107|


## Description

This PR adds a new tasks queue for vulnerability detector and the corresponding callbacks, variables and method required to work with it.

Like the initialization method for the linked queue `linked_queue_init` was modified, all the calls to this function were also updated.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report

- [x] Added unit tests (for new features)
