### PR TITLE
Fix failing UT after merge.

### DIFF
--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -1421,7 +1421,7 @@ static void test_fim_file_modify(void **state) {
     expect_value(__wrap_decode_win_acl_json, perms, permissions);
 #endif
 
-    expect_OS_MD5_SHA1_SHA256_File_call(file_path, file_path, "d41d8cd98f00b204e9800998ecf8427e",
+    expect_OS_MD5_SHA1_SHA256_File_call(file_path, syscheck.prefilter_cmd, "d41d8cd98f00b204e9800998ecf8427e",
                                         "da39a3ee5e6b4b0d3255bfef95601890afd80709",
                                         "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", OS_BINARY,
                                         0x400, 0);


### PR DESCRIPTION
|Related issue|
|---|
|#13169|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Hi team! 

We have seen that there are UT that are failing after the merge of the master branch. This PR aims to fix them
Closes #9103
## Tests
Linux
```
est project /home/antoniomanuelfr/vagrant/share/wazuh/src/unit_tests/build/syscheckd
      Start  1: test_syscom
      Start  2: test_fim_diff_changes
      Start  3: test_run_realtime
      Start  4: test_config
      Start  5: test_syscheck
      Start  6: test_run_check
      Start  7: test_create_db
      Start  8: test_audit_healthcheck
 1/11 Test  #1: test_syscom ......................   Passed    0.03 sec
      Start  9: test_audit_rule_handling
 2/11 Test  #2: test_fim_diff_changes ............   Passed    0.03 sec
      Start 10: test_syscheck_audit
 3/11 Test  #5: test_syscheck ....................   Passed    0.03 sec
      Start 11: test_audit_parse
 4/11 Test  #3: test_run_realtime ................   Passed    0.04 sec
 5/11 Test  #6: test_run_check ...................   Passed    0.04 sec
 6/11 Test  #4: test_config ......................   Passed    0.05 sec
 7/11 Test  #9: test_audit_rule_handling .........   Passed    0.03 sec
 8/11 Test  #8: test_audit_healthcheck ...........   Passed    0.05 sec
 9/11 Test  #7: test_create_db ...................   Passed    0.06 sec
10/11 Test #11: test_audit_parse .................   Passed    0.03 sec
11/11 Test #10: test_syscheck_audit ..............   Passed    0.04 sec

100% tests passed, 0 tests failed out of 11

Total Test time (real) =   0.08 sec
```
Windows 
```
oot@16e0e6502691:/share/wazuh/src/unit_tests/build# ctest -j8 
Test project /share/wazuh/src/unit_tests/build
      Start  1: test_start_agent
      Start  2: test_notify
      Start  3: test_agentd_state
      Start  4: test_buffer
      Start  5: test_wm_github
      Start  6: test_wm_office365
      Start  7: test_win_execd
      Start  8: test_win_utils
 1/44 Test  #4: test_buffer .........................   Passed    0.61 sec
      Start  9: test_syscom
 2/44 Test  #7: test_win_execd ......................   Passed    0.61 sec
      Start 10: test_fim_diff_changes
 3/44 Test  #3: test_agentd_state ...................   Passed    0.62 sec
      Start 11: test_run_realtime
 4/44 Test  #1: test_start_agent ....................   Passed    0.62 sec
      Start 12: test_config
 5/44 Test  #5: test_wm_github ......................   Passed    0.62 sec
      Start 13: test_syscheck
 6/44 Test  #6: test_wm_office365 ...................   Passed    0.62 sec
      Start 14: test_run_check
 7/44 Test  #9: test_syscom .........................   Passed    0.11 sec
      Start 15: test_run_realtime_event
 8/44 Test #11: test_run_realtime ...................   Passed    0.12 sec
      Start 16: test_run_check_event
 9/44 Test #13: test_syscheck .......................   Passed    0.12 sec
      Start 17: test_create_db
10/44 Test #10: test_fim_diff_changes ...............   Passed    0.12 sec
      Start 18: test_registry
11/44 Test #14: test_run_check ......................   Passed    0.12 sec
      Start 19: test_events
12/44 Test #12: test_config .........................   Passed    0.13 sec
      Start 20: test_win_whodata
13/44 Test #19: test_events .........................   Passed    0.06 sec
      Start 21: test_list_op
14/44 Test #15: test_run_realtime_event .............   Passed    0.11 sec
      Start 22: test_file_op
15/44 Test #16: test_run_check_event ................   Passed    0.11 sec
      Start 23: test_integrity_op
16/44 Test #18: test_registry .......................   Passed    0.12 sec
      Start 24: test_rbtree_op
17/44 Test #17: test_create_db ......................   Passed    0.13 sec
      Start 25: test_validate_op
18/44 Test #20: test_win_whodata ....................   Passed    0.12 sec
      Start 26: test_string_op
19/44 Test #24: test_rbtree_op ......................   Passed    0.03 sec
      Start 27: test_expression
20/44 Test #21: test_list_op ........................   Passed    0.10 sec
      Start 28: test_version_op
21/44 Test #23: test_integrity_op ...................   Passed    0.06 sec
      Start 29: test_queue_op
22/44 Test #22: test_file_op ........................   Passed    0.10 sec
      Start 30: test_queue_linked_op
23/44 Test #26: test_string_op ......................   Passed    0.07 sec
      Start 31: test_agent_op
24/44 Test #25: test_validate_op ....................   Passed    0.10 sec
      Start 32: test_enrollment_op
25/44 Test #28: test_version_op .....................   Passed    0.03 sec
      Start 33: test_time_op
26/44 Test #27: test_expression .....................   Passed    0.10 sec
      Start 34: test_buffer_op
27/44 Test #29: test_queue_op .......................   Passed    0.10 sec
      Start 35: test_utf8_op
28/44 Test #30: test_queue_linked_op ................   Passed    0.10 sec
      Start 36: test_log_builder
29/44 Test #33: test_time_op ........................   Passed    0.03 sec
      Start 37: test_custom_output_search_replace
30/44 Test #31: test_agent_op .......................   Passed    0.10 sec
      Start 38: test_syscheck_op
31/44 Test #32: test_enrollment_op ..................   Passed    0.11 sec
      Start 39: test_atomic
32/44 Test #34: test_buffer_op ......................   Passed    0.03 sec
      Start 40: test_url
33/44 Test #37: test_custom_output_search_replace ...   Passed    0.03 sec
      Start 41: test_sysinfo_utils
34/44 Test #35: test_utf8_op ........................   Passed    0.10 sec
      Start 42: test_os_xml
35/44 Test #38: test_syscheck_op ....................   Passed    0.07 sec
      Start 43: test_os_regex
36/44 Test #36: test_log_builder ....................   Passed    0.10 sec
      Start 44: test_os_zlib
37/44 Test #40: test_url ............................   Passed    0.06 sec
38/44 Test #39: test_atomic .........................   Passed    0.10 sec
39/44 Test #41: test_sysinfo_utils ..................   Passed    0.10 sec
40/44 Test #44: test_os_zlib ........................   Passed    0.06 sec
41/44 Test #43: test_os_regex .......................   Passed    0.09 sec
42/44 Test #42: test_os_xml .........................   Passed    0.12 sec
43/44 Test  #8: test_win_utils ......................   Passed    0.61 sec
44/44 Test  #2: test_notify .........................   Passed    0.62 sec

100% tests passed, 0 tests failed out of 44

Total Test time (real) =   5.31 sec
```
<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
