### PR TITLE
Sort `PUT /agents/upgrade`, `PUT /agents/upgrade_custom` and `GET /agents/upgrade_result` responses

### DIFF
--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -187,7 +187,7 @@ def test_sort_response(response, key=None, reverse=False):
 
 
 def test_validate_data_dict_field(response, fields_dict):
-    assert fields_dict, f'Fields dict is empty'
+    assert fields_dict, "Fields dict is empty"
     for field, dikt in fields_dict.items():
         field_list = response.json()['data'][field]
 

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -983,7 +983,7 @@ def upgrade_agents(agent_list: list = None, wpk_repo: str = None, version: str =
                 else:
                     raise WazuhInternalError(error_code, cmd_error=True, extra_message=agent_result['message'])
 
-    result.affected_items.sort(key=lambda x: x['agent'])
+    result.affected_items.sort(key=operator.itemgetter('agent'))
 
     return result
 
@@ -1077,7 +1077,7 @@ def get_upgrade_result(agent_list: list = None, filters: dict = None, q: str = N
                 else:
                     raise WazuhInternalError(error_code, cmd_error=True, extra_message=task_result['message'])
 
-    result.affected_items.sort(key=lambda x: x['agent'])
+    result.affected_items.sort(key=operator.itemgetter('agent'))
 
     return result
 

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -931,8 +931,7 @@ def upgrade_agents(agent_list: list = None, wpk_repo: str = None, version: str =
 
         # Add non active agents to failed_items
         non_active_agents = [agent['id'] for agent in data['items'] if agent['status'] != 'active']
-        [result.add_failed_item(id_=agent, error=WazuhError(1707))
-         for agent in non_active_agents]
+        [result.add_failed_item(id_=agent, error=WazuhError(1707)) for agent in non_active_agents]
         non_active_agents = set(non_active_agents)
 
         # Add non eligible agents to failed_items
@@ -948,7 +947,7 @@ def upgrade_agents(agent_list: list = None, wpk_repo: str = None, version: str =
         eligible_agents = agent_list - not_found_agents - non_active_agents - non_eligible_agents
 
         # Transform the format of the agent ids to the general format
-        eligible_agents = sorted([int(agent) for agent in eligible_agents])
+        eligible_agents = [int(agent) for agent in eligible_agents]
 
         agents_result_chunks = [eligible_agents[x:x + 500] for x in range(0, len(eligible_agents), 500)]
 
@@ -1036,8 +1035,7 @@ def get_upgrade_result(agent_list: list = None, filters: dict = None, q: str = N
 
         # Add non active agents to failed_items
         non_active_agents = [agent['id'] for agent in data['items'] if agent['status'] != 'active']
-        [result.add_failed_item(id_=agent, error=WazuhError(1707))
-         for agent in non_active_agents]
+        [result.add_failed_item(id_=agent, error=WazuhError(1707)) for agent in non_active_agents]
         non_active_agents = set(non_active_agents)
 
         # Add non eligible agents to failed_items
@@ -1053,7 +1051,7 @@ def get_upgrade_result(agent_list: list = None, filters: dict = None, q: str = N
         eligible_agents = agent_list - not_found_agents - non_active_agents - non_eligible_agents
 
         # Transform the format of the agent ids to the general format
-        eligible_agents = sorted([int(agent) for agent in eligible_agents])
+        eligible_agents = [int(agent) for agent in eligible_agents]
 
         agents_result_chunks = [eligible_agents[x:x + 500] for x in range(0, len(eligible_agents), 500)]
 

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -984,6 +984,8 @@ def upgrade_agents(agent_list: list = None, wpk_repo: str = None, version: str =
                 else:
                     raise WazuhInternalError(error_code, cmd_error=True, extra_message=agent_result['message'])
 
+    result.affected_items.sort(key=lambda x: x['agent'])
+
     return result
 
 
@@ -1076,6 +1078,8 @@ def get_upgrade_result(agent_list: list = None, filters: dict = None, q: str = N
                 # Upgrade error for all agents, internal server error
                 else:
                     raise WazuhInternalError(error_code, cmd_error=True, extra_message=task_result['message'])
+
+    result.affected_items.sort(key=lambda x: x['agent'])
 
     return result
 


### PR DESCRIPTION
|Related issue|
|---|
|#13069|

This pull request closes #13069.

With this PR, we ensure that all the responses of endpoints `PUT /agents/upgrade`, `PUT /agents/upgrade_custom` and `GET /agents/upgrade_result` are sorted by the `agent` key. This sorting was needed due to the fact that the response obtained from the socket was not always sorted, as the petitions were not responded sequentially.

As we can see in https://github.com/wazuh/wazuh/issues/13069#issuecomment-1102856916, times are slightly higher, but this little difference will not truly affect the endpoint performance.

No changes are needed on the API integration tests as the test cases failing are now always expected to pass.

### Test results

```
test_agent_PUT_endpoints.tavern.yaml - Cluster environment 
	 10 passed, 11 warnings

test_agent_GET_endpoints.tavern.yaml - Cluster environment 
	 92 passed, 93 warnings

test_rbac_black_agent_endpoints.tavern.yaml 
	 41 passed, 42 warnings

test_rbac_white_agent_endpoints.tavern.yaml 
	 41 passed, 42 warnings
```
