### PR TITLE
Update psutil version

### DIFF
--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -58,7 +58,7 @@ packaging==20.9
 pathlib==1.0.1
 protobuf==3.17.3
 proto-plus==1.19.0
-psutil==5.7.0
+psutil==5.8.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycparser==2.20


### PR DESCRIPTION
|Related issue|
|---|
|#11514|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR closes #11514. In this PR we have updated the version of Psutil used by Wazuh. We have moved from version 5.7.0 to 5.8.0. 

This change is due to an error in CentOS 6 when installing this dependency. 

With version 5.8.0 this should not happen. More details in the issue comments.