### PR TITLE
DBSync commit strategy changes.

### DIFF
--- a/src/shared_modules/dbsync/cppcheckSuppress.txt
+++ b/src/shared_modules/dbsync/cppcheckSuppress.txt
@@ -1,3 +1,3 @@
 *:*src/sqlite/sqlite_dbengine.cpp:73
-*:*src/sqlite/sqlite_dbengine.cpp:184
+*:*src/sqlite/sqlite_dbengine.cpp:182
 *:*testtool/action.h:625

--- a/src/shared_modules/dbsync/cppcheckSuppress.txt
+++ b/src/shared_modules/dbsync/cppcheckSuppress.txt
@@ -1,2 +1,3 @@
-*:*src/sqlite/sqlite_dbengine.cpp:67
+*:*src/sqlite/sqlite_dbengine.cpp:73
+*:*src/sqlite/sqlite_dbengine.cpp:184
 *:*testtool/action.h:625

--- a/src/shared_modules/dbsync/include/db_exception.h
+++ b/src/shared_modules/dbsync/include/db_exception.h
@@ -36,6 +36,8 @@ DBSyncExceptionType STEP_ERROR_ADD_STATUS_FIELD    { std::make_pair(17, "Error a
 DBSyncExceptionType STEP_ERROR_UPDATE_STATUS_FIELD { std::make_pair(18, "Error updating status field.")                         };
 DBSyncExceptionType STEP_ERROR_DELETE_STATUS_FIELD { std::make_pair(19, "Error deleting status field.")                         };
 DBSyncExceptionType DELETE_OLD_DB_ERROR            { std::make_pair(20, "Error deleting old db.")                               };
+DBSyncExceptionType MIN_ROW_LIMIT_BELOW_ZERO       { std::make_pair(21, "Invalid row limit, values below 0 not allowed.")       };
+DBSyncExceptionType ERROR_COUNT_MAX_ROWS           { std::make_pair(22, "Count is less than 0.")                                };
 
 namespace DbSync
 {

--- a/src/shared_modules/dbsync/include/dbsync.h
+++ b/src/shared_modules/dbsync/include/dbsync.h
@@ -140,9 +140,9 @@ EXPORTED int dbsync_insert_data(const DBSYNC_HANDLE handle,
  *
  * @details The table will work as a queue if the limit is exceeded.
  */
-EXPORTED int dbsync_set_table_max_rows(const DBSYNC_HANDLE      handle,
-                                       const char*              table,
-                                       const unsigned long long max_rows);
+EXPORTED int dbsync_set_table_max_rows(const DBSYNC_HANDLE handle,
+                                       const char*         table,
+                                       const long long     max_rows);
 
 /**
  * @brief Inserts (or modifies) a database record.

--- a/src/shared_modules/dbsync/include/dbsync.h
+++ b/src/shared_modules/dbsync/include/dbsync.h
@@ -72,8 +72,6 @@ EXPORTED void dbsync_teardown(void);
  *                       and user data space returned in each callback call.
  *
  * @return Handle instance to be used in transacted operations.
- *
- * @details If the max queue size is reached then this will be processed synchronously.
  */
 EXPORTED TXN_HANDLE dbsync_create_txn(const DBSYNC_HANDLE handle,
                                       const cJSON*        tables,
@@ -137,8 +135,6 @@ EXPORTED int dbsync_insert_data(const DBSYNC_HANDLE handle,
  *
  * @return 0 if succeeded,
  *         specific error code (OS dependent) otherwise.
- *
- * @details The table will work as a queue if the limit is exceeded.
  */
 EXPORTED int dbsync_set_table_max_rows(const DBSYNC_HANDLE handle,
                                        const char*         table,

--- a/src/shared_modules/dbsync/include/dbsync.hpp
+++ b/src/shared_modules/dbsync/include/dbsync.hpp
@@ -93,8 +93,8 @@ public:
      *
      * @details The table will work as a queue if the limit is exceeded.
      */
-    virtual void setTableMaxRow(const std::string&       table,
-                                const unsigned long long maxRows);
+    virtual void setTableMaxRow(const std::string& table,
+                                const long long    maxRows);
 
     /**
      * @brief Inserts (or modifies) a database record.

--- a/src/shared_modules/dbsync/src/dbengine.h
+++ b/src/shared_modules/dbsync/src/dbengine.h
@@ -42,7 +42,7 @@ namespace DbSync
             virtual void syncTableRowData(const nlohmann::json& jsInput,
                                           const ResultCallback callback,
                                           const bool inTransaction,
-                                          Utils::AbstractLocking& mutex) = 0;
+                                          Utils::ILocking& mutex) = 0;
 
             virtual void setMaxRows(const std::string& table,
                                     const int64_t maxRows) = 0;

--- a/src/shared_modules/dbsync/src/dbengine.h
+++ b/src/shared_modules/dbsync/src/dbengine.h
@@ -19,6 +19,7 @@
 #include <shared_mutex>
 #include "json.hpp"
 #include "commonDefs.h"
+#include "abstractLocking.hpp"
 
 namespace DbSync
 {
@@ -32,8 +33,7 @@ namespace DbSync
             // LCOV_EXCL_STOP
 
             virtual void bulkInsert(const std::string& table,
-                                    const nlohmann::json& data,
-                                    const bool inTransaction = true) = 0;
+                                    const nlohmann::json& data) = 0;
 
             virtual void refreshTableData(const nlohmann::json& data,
                                           const ResultCallback callback,
@@ -42,10 +42,10 @@ namespace DbSync
             virtual void syncTableRowData(const nlohmann::json& jsInput,
                                           const ResultCallback callback,
                                           const bool inTransaction,
-                                          std::function<void()> unlockMutex) = 0;
+                                          Utils::AbstractLocking& mutex) = 0;
 
             virtual void setMaxRows(const std::string& table,
-                                    const unsigned long long maxRows) = 0;
+                                    const int64_t maxRows) = 0;
 
             virtual void initializeStatusField(const nlohmann::json& tableNames) = 0;
 

--- a/src/shared_modules/dbsync/src/dbsync.cpp
+++ b/src/shared_modules/dbsync/src/dbsync.cpp
@@ -294,9 +294,9 @@ int dbsync_insert_data(const DBSYNC_HANDLE handle,
     return retVal;
 }
 
-int dbsync_set_table_max_rows(const DBSYNC_HANDLE      handle,
-                              const char*              table,
-                              const unsigned long long max_rows)
+int dbsync_set_table_max_rows(const DBSYNC_HANDLE handle,
+                              const char*         table,
+                              const long long     max_rows)
 {
     auto retVal { -1 };
     std::string errorMessage;
@@ -692,8 +692,8 @@ void DBSync::insertData(const nlohmann::json& jsInsert)
     DBSyncImplementation::instance().insertBulkData(m_dbsyncHandle, jsInsert);
 }
 
-void DBSync::setTableMaxRow(const std::string&       table,
-                            const unsigned long long maxRows)
+void DBSync::setTableMaxRow(const std::string& table,
+                            const long long    maxRows)
 {
     DBSyncImplementation::instance().setMaxRows(m_dbsyncHandle, table, maxRows);
 }

--- a/src/shared_modules/dbsync/src/dbsync_implementation.cpp
+++ b/src/shared_modules/dbsync/src/dbsync_implementation.cpp
@@ -119,7 +119,7 @@ std::shared_ptr<DBSyncImplementation::DbEngineContext> DBSyncImplementation::dbE
 
 void DBSyncImplementation::setMaxRows(const DBSYNC_HANDLE handle,
                                       const std::string& table,
-                                      const int64_t maxRows)
+                                      const long long maxRows)
 {
     const auto ctx{ dbEngineContext(handle) };
 

--- a/src/shared_modules/dbsync/src/dbsync_implementation.h
+++ b/src/shared_modules/dbsync/src/dbsync_implementation.h
@@ -57,7 +57,7 @@ namespace DbSync
 
             void setMaxRows(const DBSYNC_HANDLE handle,
                             const std::string& table,
-                            const unsigned long long maxRows);
+                            const int64_t maxRows);
 
             TXN_HANDLE createTransaction(const DBSYNC_HANDLE    handle,
                                          const nlohmann::json&  json);

--- a/src/shared_modules/dbsync/src/dbsync_implementation.h
+++ b/src/shared_modules/dbsync/src/dbsync_implementation.h
@@ -57,7 +57,7 @@ namespace DbSync
 
             void setMaxRows(const DBSYNC_HANDLE handle,
                             const std::string& table,
-                            const int64_t maxRows);
+                            const long long maxRows);
 
             TXN_HANDLE createTransaction(const DBSYNC_HANDLE    handle,
                                          const nlohmann::json&  json);

--- a/src/shared_modules/dbsync/src/sqlite/isqlite_wrapper.h
+++ b/src/shared_modules/dbsync/src/sqlite/isqlite_wrapper.h
@@ -39,6 +39,7 @@ namespace SQLite
             // LCOV_EXCL_STOP
             virtual void close() = 0;
             virtual void execute(const std::string& query) = 0;
+            virtual int64_t changes() const = 0;
             virtual const std::shared_ptr<sqlite3>& db() const = 0;
     };
 

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -2066,7 +2066,7 @@ std::string SQLiteDBEngine::buildUpdateRelationTrigger(const nlohmann::json&    
     return sqlUpdate;
 }
 
-void SQLiteDBEngine::updateTableRowCounter(const std::string& table, const int64_t rowModifyCount)
+void SQLiteDBEngine::updateTableRowCounter(const std::string& table, const long long rowModifyCount)
 {
     std::lock_guard<std::mutex> lock(m_maxRowsMutex);
     auto it { m_maxRows.find(table) };

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -9,9 +9,7 @@
  * Foundation.
  */
 
-#include <climits>
 #include <fstream>
-#include <limits>
 #include <thread>
 #include "db_exception.h"
 #include "mapWrapperSafe.h"
@@ -146,7 +144,7 @@ void SQLiteDBEngine::refreshTableData(const nlohmann::json& data,
 void SQLiteDBEngine::syncTableRowData(const nlohmann::json& jsInput,
                                       const DbSync::ResultCallback callback,
                                       const bool inTransaction,
-                                      Utils::AbstractLocking& lock)
+                                      Utils::ILocking& lock)
 {
     const auto& table { jsInput.at("table") };
     const auto& data { jsInput.at("data") };

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.h
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.h
@@ -131,7 +131,7 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
         void syncTableRowData(const nlohmann::json& jsInput,
                               const DbSync::ResultCallback callback,
                               const bool inTransaction,
-                              Utils::AbstractLocking& mutex) override;
+                              Utils::ILocking& mutex) override;
 
         void setMaxRows(const std::string& table,
                         const int64_t maxRows) override;

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.h
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.h
@@ -107,7 +107,7 @@ class dbengine_error : public DbSync::dbsync_error
         {}
 };
 
-struct MaxRows
+struct MaxRows final
 {
     int64_t maxRows;
     int64_t currentRows;
@@ -303,7 +303,7 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
                                                const std::vector<std::string>&  primaryKeys);
 
         void updateTableRowCounter(const std::string& table,
-                                   const int64_t      rowModifyCount);
+                                   const long long    rowModifyCount);
 
         void insertElement(const std::string& table,
                            const TableColumns& tableColumns,

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.h
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.h
@@ -107,6 +107,11 @@ class dbengine_error : public DbSync::dbsync_error
         {}
 };
 
+struct MaxRows
+{
+    int64_t maxRows;
+    int64_t currentRows;
+};
 
 class SQLiteDBEngine final : public DbSync::IDbEngine
 {
@@ -117,8 +122,7 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
         ~SQLiteDBEngine();
 
         void bulkInsert(const std::string& table,
-                        const nlohmann::json& data,
-                        const bool inTransaction = true) override;
+                        const nlohmann::json& data) override;
 
         void refreshTableData(const nlohmann::json& data,
                               const DbSync::ResultCallback callback,
@@ -127,10 +131,10 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
         void syncTableRowData(const nlohmann::json& jsInput,
                               const DbSync::ResultCallback callback,
                               const bool inTransaction,
-                              std::function<void()> unlockMutex) override;
+                              Utils::AbstractLocking& mutex) override;
 
         void setMaxRows(const std::string& table,
-                        const unsigned long long maxRows) override;
+                        const int64_t maxRows) override;
 
         void initializeStatusField(const nlohmann::json& tableNames) override;
 
@@ -161,8 +165,8 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
 
         bool loadFieldData(const std::string& table);
 
-        std::string buildInsertBulkDataSqlQuery(const std::string& table,
-                                                const nlohmann::json& data = {});
+        std::string buildInsertDataSqlQuery(const std::string& table,
+                                            const nlohmann::json& data = {});
 
         std::string buildDeleteBulkDataSqlQuery(const std::string& table,
                                                 const std::vector<std::string>& primaryKeyList);
@@ -298,12 +302,22 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
                                                const std::string&               baseTable,
                                                const std::vector<std::string>&  primaryKeys);
 
+        void updateTableRowCounter(const std::string& table,
+                                   const int64_t      rowModifyCount);
+
+        void insertElement(const std::string& table,
+                           const TableColumns& tableColumns,
+                           const nlohmann::json& element,
+                           const std::function<void()> callback = {});
+
         Utils::MapWrapperSafe<std::string, TableColumns> m_tableFields;
         std::deque<std::pair<std::string, std::shared_ptr<SQLite::IStatement>>> m_statementsCache;
         const std::shared_ptr<ISQLiteFactory> m_sqliteFactory;
         std::shared_ptr<SQLite::IConnection> m_sqliteConnection;
         std::mutex m_stmtMutex;
-
+        std::unique_ptr<SQLite::ITransaction> m_transaction;
+        std::mutex m_maxRowsMutex;
+        std::map<std::string, MaxRows> m_maxRows;
 };
 
 #endif // _SQLITE_DBENGINE_H

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_wrapper.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_wrapper.cpp
@@ -38,7 +38,6 @@ static sqlite3* openSQLiteDb(const std::string& path)
     {
         sqlite3_open_v2(path.c_str(), &pDb, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nullptr)
     };
-    sqlite3_extended_result_codes(pDb, 1);
     checkSqliteResult(result, "Unspecified type during initialization of SQLite.");
     return pDb;
 }

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_wrapper.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_wrapper.cpp
@@ -24,20 +24,10 @@ static void checkSqliteResult(const int result,
 {
     if (SQLITE_OK != result)
     {
-        if (SQLITE_CONSTRAINT == result && exceptionString.find(MAX_ROWS_ERROR_STRING) != std::string::npos)
+        throw sqlite_error
         {
-            throw DbSync::max_rows_error
-            {
-                exceptionString
-            };
-        }
-        else
-        {
-            throw sqlite_error
-            {
-                std::make_pair(result, exceptionString)
-            };
-        }
+            std::make_pair(result, exceptionString)
+        };
     }
 }
 
@@ -48,6 +38,7 @@ static sqlite3* openSQLiteDb(const std::string& path)
     {
         sqlite3_open_v2(path.c_str(), &pDb, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nullptr)
     };
+    sqlite3_extended_result_codes(pDb, 1);
     checkSqliteResult(result, "Unspecified type during initialization of SQLite.");
     return pDb;
 }
@@ -87,7 +78,13 @@ void Connection::execute(const std::string& query)
     {
         sqlite3_exec(m_db.get(), query.c_str(), 0, 0, nullptr)
     };
+
     checkSqliteResult(result, query + ". " + sqlite3_errmsg(m_db.get()));
+}
+
+int64_t Connection::changes() const
+{
+    return sqlite3_changes(m_db.get());
 }
 
 Transaction::~Transaction()
@@ -100,8 +97,11 @@ Transaction::~Transaction()
         }
     }
     //dtor should never throw
+    // LCOV_EXCL_START
     catch (...)
     {}
+
+    // LCOV_EXCL_STOP
 }
 
 Transaction::Transaction(std::shared_ptr<IConnection>& connection)
@@ -132,8 +132,11 @@ void Transaction::rollback()
         }
     }
     //rollback can be called in a catch statement to unwind things so it shouldn't throw
+    // LCOV_EXCL_START
     catch (...)
     {}
+
+    // LCOV_EXCL_STOP
 }
 
 bool Transaction::isCommited() const
@@ -230,10 +233,12 @@ void Statement::bind(const int32_t index, const double_t value)
     ++m_bindParametersIndex;
 }
 
+// LCOV_EXCL_START
 std::string Statement::expand()
 {
-    return sqlite3_sql(m_stmt.get());
+    return sqlite3_expanded_sql(m_stmt.get());
 }
+// LCOV_EXCL_STOP
 
 std::unique_ptr<IColumn> Statement::column(const int32_t index)
 {

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_wrapper.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_wrapper.cpp
@@ -82,7 +82,7 @@ void Connection::execute(const std::string& query)
     checkSqliteResult(result, query + ". " + sqlite3_errmsg(m_db.get()));
 }
 
-int64_t Connection::changes() const
+long long Connection::changes() const
 {
     return sqlite3_changes(m_db.get());
 }

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_wrapper.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_wrapper.cpp
@@ -82,7 +82,7 @@ void Connection::execute(const std::string& query)
     checkSqliteResult(result, query + ". " + sqlite3_errmsg(m_db.get()));
 }
 
-long long Connection::changes() const
+int64_t Connection::changes() const
 {
     return sqlite3_changes(m_db.get());
 }

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_wrapper.h
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_wrapper.h
@@ -29,6 +29,7 @@ namespace SQLite
             void execute(const std::string& query) override;
             void close() override;
             const std::shared_ptr<sqlite3>& db() const override;
+            int64_t changes() const override;
         private:
             std::shared_ptr<sqlite3> m_db;
     };

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_wrapper_factory.h
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_wrapper_factory.h
@@ -17,7 +17,9 @@
 class ISQLiteFactory
 {
     public:
+        // LCOV_EXCL_START
         virtual ~ISQLiteFactory() = default;
+        // LCOV_EXCL_STOP
         virtual std::shared_ptr<SQLite::IConnection> createConnection(const std::string& path) = 0;
         virtual std::unique_ptr<SQLite::ITransaction> createTransaction(std::shared_ptr<SQLite::IConnection>& connection) = 0;
         virtual std::unique_ptr<SQLite::IStatement> createStatement(std::shared_ptr<SQLite::IConnection>& connection,
@@ -28,7 +30,9 @@ class SQLiteFactory : public ISQLiteFactory
 {
     public:
         SQLiteFactory() = default;
+        // LCOV_EXCL_START
         ~SQLiteFactory() = default;
+        // LCOV_EXCL_STOP
         SQLiteFactory(const SQLiteFactory&) = delete;
         SQLiteFactory& operator=(const SQLiteFactory&) = delete;
 

--- a/src/shared_modules/dbsync/tests/dbengine/dbengine_test.cpp
+++ b/src/shared_modules/dbsync/tests/dbengine/dbengine_test.cpp
@@ -11,6 +11,7 @@
 
 #include <iostream>
 #include <string>
+#include "abstractLocking.hpp"
 #include "dbengine_test.h"
 #include "sqlite_dbengine.h"
 #include "../mocks/sqlitewrapper_mock.h"
@@ -28,6 +29,9 @@ static void initNoMetaDataMocks(std::unique_ptr<SQLiteDBEngine>& spEngine)
 
     auto mockTransaction { std::make_unique<MockTransaction>() };
 
+    EXPECT_CALL(*mockFactory, createTransaction(_))
+    .WillOnce(Return(ByMove(std::move(mockTransaction))));
+
     EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
 
     auto mockStatement_1 { std::make_unique<MockStatement>() };
@@ -37,7 +41,7 @@ static void initNoMetaDataMocks(std::unique_ptr<SQLiteDBEngine>& spEngine)
     .WillOnce(Return(ByMove(std::move(mockStatement_1))));
 
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
-    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(
@@ -58,12 +62,18 @@ TEST_F(DBEngineTest, Initialization)
     const auto& mockFactory { std::make_shared<MockSQLiteFactory>() };
     const auto& mockConnection { std::make_shared<MockConnection>() };
     auto mockStatement { std::make_unique<MockStatement>() };
+    auto mockTransaction { std::make_unique<MockTransaction>() };
 
-    EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
-    EXPECT_CALL(*mockStatement, step()).WillOnce(Return(SQLITE_DONE));
-    EXPECT_CALL(*mockFactory, createStatement(_, _)).WillOnce(Return(ByMove(std::move(mockStatement))));
+    EXPECT_CALL(*mockFactory, createTransaction(_))
+    .WillOnce(Return(ByMove(std::move(mockTransaction))));
+    EXPECT_CALL(*mockFactory, createConnection(_))
+    .WillOnce(Return(mockConnection));
+    EXPECT_CALL(*mockStatement, step())
+    .WillOnce(Return(SQLITE_DONE));
+    EXPECT_CALL(*mockFactory, createStatement(_, _))
+    .WillOnce(Return(ByMove(std::move(mockStatement))));
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
-    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     EXPECT_NO_THROW(std::make_unique<SQLiteDBEngine>(
@@ -78,11 +88,14 @@ TEST_F(DBEngineTest, InitializationSQLError)
     const auto& mockConnection { std::make_shared<MockConnection>() };
     auto mockStatement { std::make_unique<MockStatement>() };
 
-    EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
-    EXPECT_CALL(*mockStatement, step()).WillOnce(Return(SQLITE_ERROR));
-    EXPECT_CALL(*mockFactory, createStatement(_, _)).WillOnce(Return(ByMove(std::move(mockStatement))));
+    EXPECT_CALL(*mockFactory, createConnection(_))
+    .WillOnce(Return(mockConnection));
+    EXPECT_CALL(*mockStatement, step())
+    .WillOnce(Return(SQLITE_ERROR));
+    EXPECT_CALL(*mockFactory, createStatement(_, _))
+    .WillOnce(Return(ByMove(std::move(mockStatement))));
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
-    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     EXPECT_THROW(std::make_unique<SQLiteDBEngine>(
@@ -95,10 +108,14 @@ TEST_F(DBEngineTest, InitializationEmptyQuery)
 {
     const auto& mockFactory { std::make_shared<MockSQLiteFactory>() };
     const auto& mockConnection { std::make_shared<MockConnection>() };
+    auto mockTransaction { std::make_unique<MockTransaction>() };
 
-    EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
+    EXPECT_CALL(*mockFactory, createTransaction(_))
+    .WillOnce(Return(ByMove(std::move(mockTransaction))));
+    EXPECT_CALL(*mockFactory, createConnection(_))
+    .WillOnce(Return(mockConnection));
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
-    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     EXPECT_NO_THROW(std::make_unique<SQLiteDBEngine>(
@@ -122,9 +139,10 @@ TEST_F(DBEngineTest, InitializeStatusField)
 
     auto mockTransaction { std::make_unique<MockTransaction>() };
 
-    EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
-    EXPECT_CALL(*mockTransaction, commit()).Times(1);
-    EXPECT_CALL(*mockFactory, createTransaction(_)).WillOnce(Return(ByMove(std::move(mockTransaction))));
+    EXPECT_CALL(*mockFactory, createConnection(_))
+    .WillOnce(Return(mockConnection));
+    EXPECT_CALL(*mockFactory, createTransaction(_))
+    .WillOnce(Return(ByMove(std::move(mockTransaction))));
 
     auto mockStatement_1 { std::make_unique<MockStatement>() };
     EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
@@ -134,7 +152,7 @@ TEST_F(DBEngineTest, InitializeStatusField)
 
 
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
-    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
@@ -200,18 +218,21 @@ TEST_F(DBEngineTest, InitializeStatusFieldNoMetadata)
 
     auto mockTransaction { std::make_unique<MockTransaction>() };
 
-    EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
-    EXPECT_CALL(*mockFactory, createTransaction(_)).WillOnce(Return(ByMove(std::move(mockTransaction))));
+    EXPECT_CALL(*mockFactory, createConnection(_))
+    .WillOnce(Return(mockConnection));
+    EXPECT_CALL(*mockFactory, createTransaction(_))
+    .WillOnce(Return(ByMove(std::move(mockTransaction))));
 
     auto mockStatement_1 { std::make_unique<MockStatement>() };
-    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
+    EXPECT_CALL(*mockStatement_1, step())
+    .WillOnce(Return(SQLITE_DONE));
     EXPECT_CALL(*mockFactory,
                 createStatement(_, "NNN"))
     .WillOnce(Return(ByMove(std::move(mockStatement_1))));
 
 
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
-    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
@@ -237,19 +258,21 @@ TEST_F(DBEngineTest, InitializeStatusFieldPreExistent)
 
     auto mockTransaction { std::make_unique<MockTransaction>() };
 
-    EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
-    EXPECT_CALL(*mockTransaction, commit()).Times(1);
-    EXPECT_CALL(*mockFactory, createTransaction(_)).WillOnce(Return(ByMove(std::move(mockTransaction))));
+    EXPECT_CALL(*mockFactory, createConnection(_))
+    .WillOnce(Return(mockConnection));
+    EXPECT_CALL(*mockFactory, createTransaction(_))
+    .WillOnce(Return(ByMove(std::move(mockTransaction))));
 
     auto mockStatement_1 { std::make_unique<MockStatement>() };
-    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
+    EXPECT_CALL(*mockStatement_1, step())
+    .WillOnce(Return(SQLITE_DONE));
     EXPECT_CALL(*mockFactory,
                 createStatement(_, "NNN"))
     .WillOnce(Return(ByMove(std::move(mockStatement_1))));
 
 
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
-    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
@@ -324,19 +347,23 @@ TEST_F(DBEngineTest, DeleteRowsByStatusField)
 
     auto mockTransaction { std::make_unique<MockTransaction>() };
 
-    EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
-    EXPECT_CALL(*mockTransaction, commit()).Times(1);
-    EXPECT_CALL(*mockFactory, createTransaction(_)).WillOnce(Return(ByMove(std::move(mockTransaction))));
+    EXPECT_CALL(*mockFactory, createConnection(_))
+    .WillOnce(Return(mockConnection));
+    EXPECT_CALL(*mockFactory, createTransaction(_))
+    .WillOnce(Return(ByMove(std::move(mockTransaction))));
 
     auto mockStatement_1 { std::make_unique<MockStatement>() };
-    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
+    EXPECT_CALL(*mockStatement_1, step())
+    .WillOnce(Return(SQLITE_DONE));
     EXPECT_CALL(*mockFactory,
                 createStatement(_, "NNN"))
     .WillOnce(Return(ByMove(std::move(mockStatement_1))));
 
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
-    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
+    EXPECT_CALL(*mockConnection, changes()).Times(1)
+    .WillOnce(Return(1));
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
     EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(
@@ -410,8 +437,10 @@ TEST_F(DBEngineTest, DeleteRowsByStatusFieldNoMetadata)
 
     auto mockTransaction { std::make_unique<MockTransaction>() };
 
-    EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
-    EXPECT_CALL(*mockFactory, createTransaction(_)).WillOnce(Return(ByMove(std::move(mockTransaction))));
+    EXPECT_CALL(*mockFactory, createConnection(_))
+    .WillOnce(Return(mockConnection));
+    EXPECT_CALL(*mockFactory, createTransaction(_))
+    .WillOnce(Return(ByMove(std::move(mockTransaction))));
 
     auto mockStatement_1 { std::make_unique<MockStatement>() };
     EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
@@ -420,7 +449,7 @@ TEST_F(DBEngineTest, DeleteRowsByStatusFieldNoMetadata)
     .WillOnce(Return(ByMove(std::move(mockStatement_1))));
 
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
-    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
@@ -443,17 +472,23 @@ TEST_F(DBEngineTest, GetRowsToBeDeletedByStatusFieldNoMetadata)
 {
     const auto& mockFactory { std::make_shared<MockSQLiteFactory>() };
     const auto& mockConnection { std::make_shared<MockConnection>() };
+    auto mockTransaction1 { std::make_unique<MockTransaction>() };
+    auto mockTransaction2 { std::make_unique<MockTransaction>() };
 
-    EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
+    EXPECT_CALL(*mockFactory, createConnection(_))
+    .WillOnce(Return(mockConnection));
+    EXPECT_CALL(*mockTransaction1, commit()).Times(1);
+    EXPECT_CALL(*mockFactory, createTransaction(_)).Times(2)
+    .WillOnce(Return(ByMove(std::move(mockTransaction1))))
+    .WillOnce(Return(ByMove(std::move(mockTransaction2))));
 
     auto mockStatement_1 { std::make_unique<MockStatement>() };
     EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
-    EXPECT_CALL(*mockFactory,
-                createStatement(_, "NNN"))
+    EXPECT_CALL(*mockFactory, createStatement(_, "NNN"))
     .WillOnce(Return(ByMove(std::move(mockStatement_1))));
 
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
-    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
@@ -465,8 +500,7 @@ TEST_F(DBEngineTest, GetRowsToBeDeletedByStatusFieldNoMetadata)
     auto mockStatement_2 { std::make_unique<MockStatement>() };
     EXPECT_CALL(*mockStatement_2, step())
     .WillOnce(Return(SQLITE_DONE));
-    EXPECT_CALL(*mockFactory,
-                createStatement(_, "PRAGMA table_info(dummy);"))
+    EXPECT_CALL(*mockFactory, createStatement(_, "PRAGMA table_info(dummy);"))
     .WillOnce(Return(ByMove(std::move(mockStatement_2))));
 
     std::shared_timed_mutex mutex;
@@ -479,7 +513,17 @@ TEST_F(DBEngineTest, GetRowsToBeDeletedByStatusField)
     const auto& mockFactory { std::make_shared<MockSQLiteFactory>() };
     const auto& mockConnection { std::make_shared<MockConnection>() };
 
+    // First transaction, during the initialization of the engine.
+    auto mockTransaction1 { std::make_unique<MockTransaction>() };
+    // Second transaction, created after the getDeletedRows call.
+    auto mockTransaction2 { std::make_unique<MockTransaction>() };
+
     EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
+    EXPECT_CALL(*mockTransaction1, commit()).Times(1);
+    EXPECT_CALL(*mockFactory, createTransaction(_))
+    .Times(2)
+    .WillOnce(Return(ByMove(std::move(mockTransaction1))))
+    .WillOnce(Return(ByMove(std::move(mockTransaction2))));
 
     auto mockStatement_1 { std::make_unique<MockStatement>() };
     EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
@@ -489,7 +533,7 @@ TEST_F(DBEngineTest, GetRowsToBeDeletedByStatusField)
 
 
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
-    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
@@ -570,10 +614,12 @@ TEST_F(DBEngineTest, GetRowsToBeDeletedByStatusField)
 TEST_F(DBEngineTest, syncTableRowDataWithoutMetadataShouldThrow)
 {
     std::unique_ptr<SQLiteDBEngine> spEngine;
-    initNoMetaDataMocks(spEngine);
+    std::shared_timed_mutex mutex;
+    Utils::ExclusiveLocking lock(mutex);
 
+    initNoMetaDataMocks(spEngine);
     // Due to the no metadata this should throw
-    EXPECT_THROW(spEngine->syncTableRowData({{"table", "dummy"}, {"data", {}}}, nullptr, false, [] {}), dbengine_error);
+    EXPECT_THROW(spEngine->syncTableRowData({{"table", "dummy"}, {"data", {}}}, nullptr, false, lock), dbengine_error);
 }
 
 TEST_F(DBEngineTest, deleteTableRowsDataWithoutMetadataShouldThrow)
@@ -634,7 +680,10 @@ TEST_F(DBEngineTest, AddTableRelationship)
             }
         )"
                                    )};
+    auto mockTransaction { std::make_unique<MockTransaction>() };
 
+    EXPECT_CALL(*mockFactory, createTransaction(_))
+    .WillOnce(Return(ByMove(std::move(mockTransaction))));
     EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
 
     auto mockStatement_1 { std::make_unique<MockStatement>() };
@@ -645,7 +694,7 @@ TEST_F(DBEngineTest, AddTableRelationship)
 
 
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
-    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
@@ -759,18 +808,23 @@ TEST_F(DBEngineTest, AddTableRelationshipNoMetadata)
             }
         )"
                                    )};
+    auto mockTransaction { std::make_unique<MockTransaction>() };
 
-    EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
+    EXPECT_CALL(*mockFactory, createTransaction(_))
+    .WillOnce(Return(ByMove(std::move(mockTransaction))));
+    EXPECT_CALL(*mockFactory, createConnection(_))
+    .WillOnce(Return(mockConnection));
 
     auto mockStatement_1 { std::make_unique<MockStatement>() };
-    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
+    EXPECT_CALL(*mockStatement_1, step())
+    .WillOnce(Return(SQLITE_DONE));
     EXPECT_CALL(*mockFactory,
                 createStatement(_, "NNN"))
     .WillOnce(Return(ByMove(std::move(mockStatement_1))));
 
 
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
-    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = truncate;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;

--- a/src/shared_modules/dbsync/tests/mocks/sqlitewrapper_mock.h
+++ b/src/shared_modules/dbsync/tests/mocks/sqlitewrapper_mock.h
@@ -29,6 +29,10 @@ class MockConnection : public SQLite::IConnection
                     execute,
                     (const std::string& query),
                     (override));
+        MOCK_METHOD(int64_t,
+                    changes,
+                    (),
+                    (const override));
         MOCK_METHOD(const std::shared_ptr<sqlite3>&,
                     db,
                     (),

--- a/src/shared_modules/dbsync/tests/mocks/sqlitewrapper_mock.h
+++ b/src/shared_modules/dbsync/tests/mocks/sqlitewrapper_mock.h
@@ -29,7 +29,7 @@ class MockConnection : public SQLite::IConnection
                     execute,
                     (const std::string& query),
                     (override));
-        MOCK_METHOD(int64_t,
+        MOCK_METHOD(long long,
                     changes,
                     (),
                     (const override));

--- a/src/shared_modules/dbsync/tests/mocks/sqlitewrapper_mock.h
+++ b/src/shared_modules/dbsync/tests/mocks/sqlitewrapper_mock.h
@@ -29,7 +29,7 @@ class MockConnection : public SQLite::IConnection
                     execute,
                     (const std::string& query),
                     (override));
-        MOCK_METHOD(long long,
+        MOCK_METHOD(int64_t,
                     changes,
                     (),
                     (const override));

--- a/src/shared_modules/dbsync/tests/pipelineFactory/dbsyncPipelineFactory_test.cpp
+++ b/src/shared_modules/dbsync/tests/pipelineFactory/dbsyncPipelineFactory_test.cpp
@@ -161,9 +161,9 @@ TEST_F(DBSyncPipelineFactoryTest, PipelineSyncRow)
     };
     ASSERT_NE(nullptr, pipeHandle);
     const auto pipeline{ m_pipelineFactory.pipeline(pipeHandle) };
-    EXPECT_CALL(wrapper, callback(INSERTED, nlohmann::json::parse(R"([{"pid":4,"name":"System","tid":100}])"))).Times(1);
-    EXPECT_CALL(wrapper, callback(MODIFIED, nlohmann::json::parse(R"([{"pid":4,"name":"System1","tid":101}])"))).Times(1);
-    EXPECT_CALL(wrapper, callback(MODIFIED, nlohmann::json::parse(R"([{"pid":4,"tid":102}])"))).Times(1);
+    EXPECT_CALL(wrapper, callback(INSERTED, nlohmann::json::parse(R"({"pid":4,"name":"System","tid":100})"))).Times(1);
+    EXPECT_CALL(wrapper, callback(MODIFIED, nlohmann::json::parse(R"({"pid":4,"name":"System1","tid":101})"))).Times(1);
+    EXPECT_CALL(wrapper, callback(MODIFIED, nlohmann::json::parse(R"({"pid":4,"tid":102})"))).Times(1);
     pipeline->syncRow(nlohmann::json::parse(jsonInput));
     pipeline->syncRow(nlohmann::json::parse(jsonInput));
     pipeline->syncRow(nlohmann::json::parse(jsonInput1));
@@ -198,7 +198,7 @@ TEST_F(DBSyncPipelineFactoryTest, PipelineSyncRowMaxQueueSize)
     };
     ASSERT_NE(nullptr, pipeHandle);
     const auto pipeline{ m_pipelineFactory.pipeline(pipeHandle) };
-    EXPECT_CALL(wrapper, callback(INSERTED, nlohmann::json::parse(R"([{"pid":4,"name":"System","tid":100}])"))).Times(1);
+    EXPECT_CALL(wrapper, callback(INSERTED, nlohmann::json::parse(R"({"pid":4,"name":"System","tid":100})"))).Times(1);
     pipeline->syncRow(nlohmann::json::parse(jsonInput));
     pipeline->getDeleted(nullptr);
     m_pipelineFactory.destroy(pipeHandle);
@@ -217,8 +217,8 @@ TEST_F(DBSyncPipelineFactoryTest, PipelineSyncRowAndGetDeleted)
             wrapper.callback(resultType, result);
         }
     };
-    EXPECT_CALL(wrapper, callback(MODIFIED, nlohmann::json::parse(R"([{"pid":4,"tid":101}])"))).Times(1);
-    EXPECT_CALL(wrapper, callback(INSERTED, nlohmann::json::parse(R"([{"pid":6,"name":"System2","tid":105}])"))).Times(1);
+    EXPECT_CALL(wrapper, callback(MODIFIED, nlohmann::json::parse(R"({"pid":4,"tid":101})"))).Times(1);
+    EXPECT_CALL(wrapper, callback(INSERTED, nlohmann::json::parse(R"({"pid":6,"name":"System2","tid":105})"))).Times(1);
     EXPECT_CALL(wrapper, callback(DELETED, nlohmann::json::parse(R"({"pid":5})"))).Times(1);
     EXPECT_CALL(wrapper, callback(DELETED, nlohmann::json::parse(R"({"pid":7})"))).Times(1);
     DBSyncImplementation::instance().syncRowData(m_dbHandle, nlohmann::json::parse(jsonInputNoTxn), nullptr);
@@ -255,8 +255,8 @@ TEST_F(DBSyncPipelineFactoryTest, PipelineSyncRowAndGetDeletedSameData)
             wrapper.callback(resultType, result);
         }
     };
-    EXPECT_CALL(wrapper, callback(MODIFIED, nlohmann::json::parse(R"([{"pid":4,"tid":101}])"))).Times(1);
-    EXPECT_CALL(wrapper, callback(INSERTED, nlohmann::json::parse(R"([{"pid":6,"name":"System2","tid":105}])"))).Times(1);
+    EXPECT_CALL(wrapper, callback(MODIFIED, nlohmann::json::parse(R"({"pid":4,"tid":101})"))).Times(1);
+    EXPECT_CALL(wrapper, callback(INSERTED, nlohmann::json::parse(R"({"pid":6,"name":"System2","tid":105})"))).Times(1);
     EXPECT_CALL(wrapper, callback(DELETED, nlohmann::json::parse(R"({"pid":7})"))).Times(1);
     DBSyncImplementation::instance().syncRowData(m_dbHandle, nlohmann::json::parse(jsonInputNoTxn), nullptr);
     const auto& json{ nlohmann::json::parse(R"({"tables": ["processes"]})") };

--- a/src/shared_modules/dbsync/tests/sqlite/sqlite_test.cpp
+++ b/src/shared_modules/dbsync/tests/sqlite/sqlite_test.cpp
@@ -34,6 +34,7 @@ class ConnectionWrapper: public IConnection
         ~ConnectionWrapper() = default;
         MOCK_METHOD(void, execute, (const std::string&), (override));
         MOCK_METHOD(void, close, (), (override));
+        MOCK_METHOD(int64_t, changes, (), (const override));
         MOCK_METHOD((const std::shared_ptr<sqlite3>&), db, (), (const override));
 };
 

--- a/src/shared_modules/utils/abstractLocking.hpp
+++ b/src/shared_modules/utils/abstractLocking.hpp
@@ -1,0 +1,68 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015, Wazuh Inc.
+ * April 18, 2022.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _ABSTRACT_LOCKING_HPP
+#define _ABSTRACT_LOCKING_HPP
+
+#include <mutex>
+#include <shared_mutex>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+namespace Utils
+{
+    class AbstractLocking
+    {
+        public:
+            virtual ~AbstractLocking() = default;
+            virtual void lock() = 0;
+            virtual void unlock() = 0;
+    };
+
+    class SharedLocking final : public AbstractLocking
+    {
+        std::shared_lock<std::shared_timed_mutex> m_lock;
+        public:
+            explicit SharedLocking(std::shared_timed_mutex &mutex)
+                : m_lock(std::shared_lock<std::shared_timed_mutex>(mutex)) {};
+
+            virtual ~SharedLocking() = default;
+            virtual void lock() override
+            {
+                m_lock.lock();
+            }
+            virtual void unlock() override
+            {
+                m_lock.unlock();
+            }
+    };
+
+    class ExclusiveLocking final : public AbstractLocking
+    {
+        std::unique_lock<std::shared_timed_mutex> m_lock;
+        public:
+            explicit ExclusiveLocking(std::shared_timed_mutex &mutex)
+                : m_lock(std::unique_lock<std::shared_timed_mutex>(mutex)) {};
+
+            virtual ~ExclusiveLocking() = default;
+            virtual void lock() override
+            {
+                m_lock.lock();
+            }
+            virtual void unlock() override
+            {
+                m_lock.unlock();
+            }
+    };
+};
+
+#endif /* _ABSTRACT_LOCKING_HPP */

--- a/src/shared_modules/utils/abstractLocking.hpp
+++ b/src/shared_modules/utils/abstractLocking.hpp
@@ -20,15 +20,15 @@
 
 namespace Utils
 {
-    class AbstractLocking
+    class ILocking
     {
         public:
-            virtual ~AbstractLocking() = default;
+            virtual ~ILocking() = default;
             virtual void lock() = 0;
             virtual void unlock() = 0;
     };
 
-    class SharedLocking final : public AbstractLocking
+    class SharedLocking final : public ILocking
     {
         std::shared_lock<std::shared_timed_mutex> m_lock;
         public:
@@ -46,7 +46,7 @@ namespace Utils
             }
     };
 
-    class ExclusiveLocking final : public AbstractLocking
+    class ExclusiveLocking final : public ILocking
     {
         std::unique_lock<std::shared_timed_mutex> m_lock;
         public:

--- a/src/syscheckd/src/db/include/db.h
+++ b/src/syscheckd/src/db/include/db.h
@@ -38,14 +38,16 @@ extern "C" {
  * @param file_limit Maximum number of files to be monitored
  * @param value_limit Maximum number of registry values to be monitored.
  * @param sync_registry_enable Flag to enable the registry synchronization.
+ *
+ * @return FIMDB_OK on success, FIMDB_ERROR on error.
  */
-void fim_db_init(int storage,
-                 int sync_interval,
-                 fim_sync_callback_t sync_callback,
-                 logging_callback_t log_callback,
-                 int file_limit,
-                 int value_limit,
-                 bool sync_registry_enabled);
+FIMDBErrorCode fim_db_init(int storage,
+                           int sync_interval,
+                           fim_sync_callback_t sync_callback,
+                           logging_callback_t log_callback,
+                           int file_limit,
+                           int value_limit,
+                           bool sync_registry_enabled);
 
 /**
  * @brief Get entry data using path.

--- a/src/syscheckd/src/db/include/db.h
+++ b/src/syscheckd/src/db/include/db.h
@@ -102,7 +102,7 @@ int fim_db_get_count_file_entry();
  * @param data The information linked to the path to be created or updated.
  * @param callback Callback to send the fim message.
  */
-void fim_db_file_update(fim_entry* data, callback_context_t callback);
+FIMDBErrorCode fim_db_file_update(fim_entry* data, callback_context_t callback);
 
 /**
  * @brief Find entries using the inode.
@@ -110,6 +110,8 @@ void fim_db_file_update(fim_entry* data, callback_context_t callback);
  * @param inode Inode.
  * @param dev Device.
  * @param data Pointer to the data structure where the callback context will be stored.
+ *
+ * @return FIMDB_OK on success.
  */
 FIMDBErrorCode fim_db_file_inode_search(unsigned long long int inode, unsigned long int dev, callback_context_t data);
 

--- a/src/syscheckd/src/db/src/db.cpp
+++ b/src/syscheckd/src/db/src/db.cpp
@@ -123,14 +123,16 @@ int DB::countEntries(const std::string& tableName, const COUNT_SELECT_TYPE selec
 #ifdef __cplusplus
 extern "C" {
 #endif
-void fim_db_init(int storage,
-                 int sync_interval,
-                 fim_sync_callback_t sync_callback,
-                 logging_callback_t log_callback,
-                 int file_limit,
-                 int value_limit,
-                 bool sync_registry_enabled)
+FIMDBErrorCode fim_db_init(int storage,
+                           int sync_interval,
+                           fim_sync_callback_t sync_callback,
+                           logging_callback_t log_callback,
+                           int file_limit,
+                           int value_limit,
+                           bool sync_registry_enabled)
 {
+    auto retVal { FIMDBErrorCode::FIMDB_ERR };
+
     try
     {
         // LCOV_EXCL_START
@@ -232,6 +234,7 @@ void fim_db_init(int storage,
                             file_limit,
                             value_limit,
                             sync_registry_enabled);
+        retVal = FIMDBErrorCode::FIMDB_OK;
 
     }
     // LCOV_EXCL_START
@@ -242,6 +245,7 @@ void fim_db_init(int storage,
     }
 
     // LCOV_EXCL_STOP
+    return retVal;
 }
 
 void fim_run_integrity()

--- a/src/syscheckd/src/db/src/file.cpp
+++ b/src/syscheckd/src/db/src/file.cpp
@@ -145,9 +145,9 @@ nlohmann::json DB::createJsonEvent(const nlohmann::json& fileJson, const nlohman
     }
 
     // Last event
-    if (resultJson[0].contains("last_event"))
+    if (resultJson.contains("last_event"))
     {
-        jsonEvent["data"]["timestamp"] = resultJson[0].at("last_event");
+        jsonEvent["data"]["timestamp"] = resultJson.at("last_event");
     }
     else
     {
@@ -155,10 +155,10 @@ nlohmann::json DB::createJsonEvent(const nlohmann::json& fileJson, const nlohman
     }
 
     // Old data attributes
-    if (resultJson[0].contains("old"))
+    if (resultJson.contains("old"))
     {
 
-        nlohmann::json old_data = resultJson[0].at("old");
+        nlohmann::json old_data = resultJson.at("old");
         nlohmann::json changed_attributes = nlohmann::json::array();
 
         jsonEvent["data"]["old_attributes"]["type"] = "file";
@@ -572,8 +572,9 @@ int fim_db_get_count_file_entry()
     return count;
 }
 
-void fim_db_file_update(fim_entry* data, callback_context_t callback)
+FIMDBErrorCode fim_db_file_update(fim_entry* data, callback_context_t callback)
 {
+    auto retVal { FIMDB_ERR };
 
     if (!data || !callback.callback)
     {
@@ -590,6 +591,7 @@ void fim_db_file_update(fim_entry* data, callback_context_t callback)
                 const std::unique_ptr<cJSON, CJsonDeleter> spJson{ cJSON_Parse(jsonResult.dump().c_str()) };
                 callback.callback(spJson.get(), callback.context);
             });
+            retVal = FIMDB_OK;
         }
         // LCOV_EXCL_START
         catch (DbSync::max_rows_error& max_row)
@@ -603,6 +605,8 @@ void fim_db_file_update(fim_entry* data, callback_context_t callback)
 
         // LCOV_EXCL_STOP
     }
+
+    return retVal;
 }
 
 FIMDBErrorCode fim_db_file_inode_search(const unsigned long long int inode,

--- a/src/syscheckd/src/db/src/fimDB.cpp
+++ b/src/syscheckd/src/db/src/fimDB.cpp
@@ -50,9 +50,9 @@ void FIMDB::init(unsigned int syncInterval,
                  std::function<void(modules_log_level_t, const std::string&)> callbackLogWrapper,
                  std::shared_ptr<DBSync> dbsyncHandler,
                  std::shared_ptr<RemoteSync> rsyncHandler,
-                 unsigned int fileLimit,
-                 unsigned int registryLimit,
-                 bool syncRegistryEnabled)
+                 const int fileLimit,
+                 const int registryLimit,
+                 const bool syncRegistryEnabled)
 {
     m_syncInterval = syncInterval;
     m_dbsyncHandler = dbsyncHandler;

--- a/src/syscheckd/src/db/src/fimDB.hpp
+++ b/src/syscheckd/src/db/src/fimDB.hpp
@@ -56,7 +56,9 @@ constexpr auto CREATE_FILE_DB_STATEMENT
     hash_sha1 TEXT,
     hash_sha256 TEXT,
     mtime INTEGER,
-    PRIMARY KEY(path)) WITHOUT ROWID;)"
+    PRIMARY KEY(path)) WITHOUT ROWID;
+    CREATE INDEX IF NOT EXISTS path_index ON file_entry (path);
+    CREATE INDEX IF NOT EXISTS inode_index ON file_entry (dev, inode);)"
 };
 
 constexpr auto CREATE_REGISTRY_KEY_DB_STATEMENT
@@ -73,7 +75,8 @@ constexpr auto CREATE_REGISTRY_KEY_DB_STATEMENT
     scanned INTEGER,
     last_event INTEGER,
     checksum TEXT NOT NULL,
-    PRIMARY KEY (arch, path)) WITHOUT ROWID;)"
+    PRIMARY KEY (arch, path)) WITHOUT ROWID;
+    CREATE INDEX IF NOT EXISTS path_index ON registry_key (path);)"
 };
 
 constexpr auto CREATE_REGISTRY_VALUE_DB_STATEMENT
@@ -92,7 +95,8 @@ constexpr auto CREATE_REGISTRY_VALUE_DB_STATEMENT
     checksum TEXT NOT NULL,
     PRIMARY KEY(path, arch, name)
     FOREIGN KEY (path) REFERENCES registry_key(path)
-    FOREIGN KEY (arch) REFERENCES registry_key(arch)) WITHOUT ROWID;)"
+    FOREIGN KEY (arch) REFERENCES registry_key(arch)) WITHOUT ROWID;
+    CREATE INDEX IF NOT EXISTS key_name_index ON registry_data (path, name);)"
 };
 
 constexpr auto CREATE_REGISTRY_VIEW_STATEMENT
@@ -161,8 +165,8 @@ class FIMDB
                   std::function<void(modules_log_level_t, const std::string&)> callbackLogWrapper,
                   std::shared_ptr<DBSync> dbsyncHandler,
                   std::shared_ptr<RemoteSync> rsyncHandler,
-                  unsigned int fileLimit,
-                  unsigned int registryLimit = 0,
+                  int fileLimit,
+                  int registryLimit = 0,
                   bool syncRegistryEnabled = true);
 
         /**

--- a/src/syscheckd/src/db/src/fimDBSpecialization.h
+++ b/src/syscheckd/src/db/src/fimDBSpecialization.h
@@ -225,8 +225,8 @@ class FIMDBCreator<OSType::WINDOWS> final
 {
     public:
         static void setLimits(std::shared_ptr<DBSync> DBSyncHandler,
-                              const unsigned int& fileLimit,
-                              const unsigned int& registryLimit)
+                              const int fileLimit,
+                              const int registryLimit)
         {
             if (fileLimit > 0)
             {
@@ -302,8 +302,8 @@ class FIMDBCreator<OSType::OTHERS> final
 {
     public:
         static void setLimits(std::shared_ptr<DBSync> DBSyncHandler,
-                              const unsigned int& fileLimit,
-                              __attribute__((unused)) const unsigned int& registryLimit)
+                              const int fileLimit,
+                              __attribute__((unused)) const int registryLimit)
         {
             if (fileLimit > 0)
             {

--- a/src/syscheckd/src/db/src/fimDBSpecialization.h
+++ b/src/syscheckd/src/db/src/fimDBSpecialization.h
@@ -228,16 +228,9 @@ class FIMDBCreator<OSType::WINDOWS> final
                               const int fileLimit,
                               const int registryLimit)
         {
-            if (fileLimit > 0)
-            {
-                DBSyncHandler->setTableMaxRow("file_entry", fileLimit);
-
-            }
-            if (registryLimit > 0)
-            {
-                DBSyncHandler->setTableMaxRow("registry_key", registryLimit);
-                DBSyncHandler->setTableMaxRow("registry_data", registryLimit);
-            }
+            DBSyncHandler->setTableMaxRow("file_entry", fileLimit);
+            DBSyncHandler->setTableMaxRow("registry_key", registryLimit);
+            DBSyncHandler->setTableMaxRow("registry_data", registryLimit);
 
         }
 
@@ -305,10 +298,7 @@ class FIMDBCreator<OSType::OTHERS> final
                               const int fileLimit,
                               __attribute__((unused)) const int registryLimit)
         {
-            if (fileLimit > 0)
-            {
-                DBSyncHandler->setTableMaxRow("file_entry", fileLimit);
-            }
+            DBSyncHandler->setTableMaxRow("file_entry", fileLimit);
         }
 
         static std::string CreateStatement()

--- a/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
@@ -195,3 +195,49 @@ TEST_F(DBTestFixture, TestSyncDeletedRowsTransactionWithInvalidParameters)
     auto result = fim_db_transaction_deleted_rows(nullptr, nullptr, nullptr);
     ASSERT_EQ(result, FIMDB_ERR);
 }
+
+TEST(DBTest, TestInvalidFimLimit)
+{
+    mockLog = new MockLoggingCall();
+    mockSync = new MockSyncMsg();
+
+    EXPECT_CALL(*mockLog,
+                loggingFunction(LOG_ERROR_EXIT,
+                                "Error, id: dbEngine: Invalid row limit, values below 0 not allowed.")).Times(1);
+    auto result
+    {
+        fim_db_init(FIM_DB_MEMORY,
+                    300,
+                    mockSyncMessage,
+                    mockLoggingFunction,
+                    -1,
+                    100000,
+                    true)
+    };
+    ASSERT_EQ(result, FIMDB_ERR);
+
+    delete mockLog;
+    delete mockSync;
+}
+
+TEST(DBTest, TestValidFimLimit)
+{
+    mockLog = new MockLoggingCall();
+    mockSync = new MockSyncMsg();
+
+    auto result
+    {
+        fim_db_init(FIM_DB_MEMORY,
+                    300,
+                    mockSyncMessage,
+                    mockLoggingFunction,
+                    100,
+                    100000,
+                    true)
+    };
+    ASSERT_EQ(result, FIMDB_OK);
+
+    delete mockLog;
+    delete mockSync;
+}
+

--- a/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
@@ -77,7 +77,7 @@ TEST_F(DBTestFixture, TestFimDBInit)
     EXPECT_NO_THROW(
     {
         const auto fileFIMTest { std::make_unique<FileItem>(insertFileStatement) };
-        fim_db_file_update(fileFIMTest->toFimEntry(), callback_data_added);
+        ASSERT_EQ(fim_db_file_update(fileFIMTest->toFimEntry(), callback_data_added), FIMDB_OK);
     });
 }
 
@@ -85,7 +85,7 @@ TEST_F(DBTestFixture, TestFimSyncPushMsg)
 {
     const auto test{R"(fim_file no_data {"begin":"a2fbef8f81af27155dcee5e3927ff6243593b91a","end":"a2fbef8f81af27155dcee5e3927ff6243593b91b","id":1})"};
     const auto fileFIMTest { std::make_unique<FileItem>(insertFileStatement) };
-    fim_db_file_update(fileFIMTest->toFimEntry(), callback_data_added);
+    ASSERT_EQ(fim_db_file_update(fileFIMTest->toFimEntry(), callback_data_added), FIMDB_OK);
     EXPECT_CALL(*mockLog, loggingFunction(LOG_DEBUG_VERBOSE, std::string("Message pushed: ") + test)).Times(1);
     EXPECT_CALL(*mockLog, loggingFunction(LOG_INFO, "FIM sync module started.")).Times(1);
     EXPECT_CALL(*mockLog, loggingFunction(LOG_DEBUG, "Executing FIM sync.")).Times(1);

--- a/src/syscheckd/src/db/tests/db/FIMDB/fimDBTests/fimDBImpTests.hpp
+++ b/src/syscheckd/src/db/tests/db/FIMDB/fimDBTests/fimDBImpTests.hpp
@@ -27,7 +27,7 @@ class MockDBSyncHandler: public DBSync
                           const std::string& path,
                           const std::string& sqlStatement): DBSync(hostType, dbType, path, sqlStatement) {};
         ~MockDBSyncHandler() {};
-        MOCK_METHOD(void, setTableMaxRow, (const std::string&, const unsigned long long), (override));
+        MOCK_METHOD(void, setTableMaxRow, (const std::string&, const long long), (override));
         MOCK_METHOD(void, insertData, (const nlohmann::json&), (override));
         MOCK_METHOD(void, deleteRows, (const nlohmann::json&), (override));
         MOCK_METHOD(void, syncRow, (const nlohmann::json&, ResultCallbackData), (override));

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -78,22 +78,26 @@ void read_internal(int debug_level)
 void fim_initialize() {
     // Create store data
 #ifndef WIN32
-    fim_db_init(syscheck.database_store,
-                syscheck.sync_interval,
-                fim_send_sync_state,
-                loggingFunction,
-                syscheck.db_entry_file_limit,
-                0,
-                false);
+    FIMDBErrorCode ret_val = fim_db_init(syscheck.database_store,
+                                         syscheck.sync_interval,
+                                         fim_send_sync_state,
+                                         loggingFunction,
+                                         syscheck.db_entry_file_limit,
+                                         0,
+                                         false);
 #else
-    fim_db_init(syscheck.database_store,
-                syscheck.sync_interval,
-                fim_send_sync_state,
-                loggingFunction,
-                syscheck.db_entry_file_limit,
-                syscheck.db_entry_registry_limit,
-                syscheck.enable_registry_synchronization);
+    FIMDBErrorCode ret_val = fim_db_init(syscheck.database_store,
+                                         syscheck.sync_interval,
+                                         fim_send_sync_state,
+                                         loggingFunction,
+                                         syscheck.db_entry_file_limit,
+                                         syscheck.db_entry_registry_limit,
+                                         syscheck.enable_registry_synchronization);
 #endif
+
+    if (ret_val != FIMDB_OK) {
+        merror_exit("Unable to initialize database.");
+    }
 
     w_rwlock_init(&syscheck.directories_lock, NULL);
     w_mutex_init(&syscheck.fim_scan_mutex, NULL);

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -1308,7 +1308,7 @@ static void test_fim_file_add(void **state) {
 
     expect_get_data(strdup("user"), strdup("group"), file_path, 1);
 
-    expect_function_call(__wrap_fim_db_file_update);
+    will_return(__wrap_fim_db_file_update, 0);
 
     fim_file(file_path, &configuration, &evt_data, NULL, NULL);
 }
@@ -1426,7 +1426,7 @@ static void test_fim_file_modify(void **state) {
                                         "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", OS_BINARY,
                                         0x400, 0);
 
-    expect_function_call(__wrap_fim_db_file_update);;
+    will_return(__wrap_fim_db_file_update, 0);
 
     fim_file(file_path, &configuration, &evt_data, NULL, NULL);
 }
@@ -1532,7 +1532,7 @@ static void test_fim_file_error_on_insert(void **state) {
     expect_value(__wrap_OS_MD5_SHA1_SHA256_File, max_size, 0x400);
     will_return(__wrap_OS_MD5_SHA1_SHA256_File, 0);
 
-    expect_function_call(__wrap_fim_db_file_update);;
+    will_return(__wrap_fim_db_file_update, 0);
 
     fim_file(file_path, &configuration, &evt_data, NULL, NULL);
 }
@@ -1723,7 +1723,7 @@ static void test_fim_checker_fim_regular(void **state) {
     will_return(__wrap_get_user, strdup("user"));
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, strdup("group"));
-    expect_function_call(__wrap_fim_db_file_update);;
+    will_return(__wrap_fim_db_file_update, 0);
 
     fim_checker(path, &evt_data, NULL, NULL, NULL);
 }
@@ -1758,7 +1758,7 @@ static void test_fim_checker_fim_regular_warning(void **state) {
 
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, strdup("group"));
-    expect_function_call(__wrap_fim_db_file_update);;
+    will_return(__wrap_fim_db_file_update, 0);
 
     fim_checker(path, &evt_data, NULL, NULL, NULL);
 }
@@ -1938,7 +1938,7 @@ static void test_fim_checker_root_file_within_recursion_level(void **state) {
 
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, strdup("group"));
-    expect_function_call(__wrap_fim_db_file_update);;
+    will_return(__wrap_fim_db_file_update, 0);
 
     fim_checker(path, &evt_data, NULL, NULL, NULL);
 }
@@ -2352,7 +2352,7 @@ static void test_fim_checker_fim_regular(void **state) {
     will_return(__wrap_HasFilesystem, 0);
     // Inside fim_file
     expect_get_data(strdup("user"), "group", expanded_path, 0);
-    expect_function_call(__wrap_fim_db_file_update);
+    will_return(__wrap_fim_db_file_update, 0);
     expect_string(__wrap_w_get_file_attrs, file_path, expanded_path);
     will_return(__wrap_w_get_file_attrs, 123456);
     fim_checker(expanded_path, &evt_data, NULL, NULL, NULL);
@@ -2447,7 +2447,7 @@ static void test_fim_checker_fim_regular_warning(void **state) {
     expect_string(__wrap_w_get_file_attrs, file_path, expanded_path);
     will_return(__wrap_w_get_file_attrs, 123456);
 
-    expect_function_call(__wrap_fim_db_file_update);
+    will_return(__wrap_fim_db_file_update, 0);
 
     fim_checker(expanded_path, &evt_data, NULL, NULL, NULL);
 }

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -1308,7 +1308,7 @@ static void test_fim_file_add(void **state) {
 
     expect_get_data(strdup("user"), strdup("group"), file_path, 1);
 
-    will_return(__wrap_fim_db_file_update, 0);
+    will_return(__wrap_fim_db_file_update, FIMDB_OK);
 
     fim_file(file_path, &configuration, &evt_data, NULL, NULL);
 }
@@ -1426,7 +1426,7 @@ static void test_fim_file_modify(void **state) {
                                         "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", OS_BINARY,
                                         0x400, 0);
 
-    will_return(__wrap_fim_db_file_update, 0);
+    will_return(__wrap_fim_db_file_update, FIMDB_OK);
 
     fim_file(file_path, &configuration, &evt_data, NULL, NULL);
 }
@@ -1532,7 +1532,7 @@ static void test_fim_file_error_on_insert(void **state) {
     expect_value(__wrap_OS_MD5_SHA1_SHA256_File, max_size, 0x400);
     will_return(__wrap_OS_MD5_SHA1_SHA256_File, 0);
 
-    will_return(__wrap_fim_db_file_update, 0);
+    will_return(__wrap_fim_db_file_update, FIMDB_OK);
 
     fim_file(file_path, &configuration, &evt_data, NULL, NULL);
 }
@@ -1723,7 +1723,7 @@ static void test_fim_checker_fim_regular(void **state) {
     will_return(__wrap_get_user, strdup("user"));
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, strdup("group"));
-    will_return(__wrap_fim_db_file_update, 0);
+    will_return(__wrap_fim_db_file_update, FIMDB_OK);
 
     fim_checker(path, &evt_data, NULL, NULL, NULL);
 }
@@ -1758,7 +1758,7 @@ static void test_fim_checker_fim_regular_warning(void **state) {
 
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, strdup("group"));
-    will_return(__wrap_fim_db_file_update, 0);
+    will_return(__wrap_fim_db_file_update, FIMDB_OK);
 
     fim_checker(path, &evt_data, NULL, NULL, NULL);
 }
@@ -1938,7 +1938,7 @@ static void test_fim_checker_root_file_within_recursion_level(void **state) {
 
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, strdup("group"));
-    will_return(__wrap_fim_db_file_update, 0);
+    will_return(__wrap_fim_db_file_update, FIMDB_OK);
 
     fim_checker(path, &evt_data, NULL, NULL, NULL);
 }
@@ -2352,7 +2352,7 @@ static void test_fim_checker_fim_regular(void **state) {
     will_return(__wrap_HasFilesystem, 0);
     // Inside fim_file
     expect_get_data(strdup("user"), "group", expanded_path, 0);
-    will_return(__wrap_fim_db_file_update, 0);
+    will_return(__wrap_fim_db_file_update, FIMDB_OK);
     expect_string(__wrap_w_get_file_attrs, file_path, expanded_path);
     will_return(__wrap_w_get_file_attrs, 123456);
     fim_checker(expanded_path, &evt_data, NULL, NULL, NULL);
@@ -2447,7 +2447,7 @@ static void test_fim_checker_fim_regular_warning(void **state) {
     expect_string(__wrap_w_get_file_attrs, file_path, expanded_path);
     will_return(__wrap_w_get_file_attrs, 123456);
 
-    will_return(__wrap_fim_db_file_update, 0);
+    will_return(__wrap_fim_db_file_update, FIMDB_OK);
 
     fim_checker(expanded_path, &evt_data, NULL, NULL, NULL);
 }

--- a/src/unit_tests/syscheckd/test_syscheck.c
+++ b/src/unit_tests/syscheckd/test_syscheck.c
@@ -195,7 +195,6 @@ void test_Start_win32_Syscheck_corrupted_config_file(void **state) {
     will_return(__wrap_rootcheck_init, 1);
 
     expect_wrapper_fim_db_init(0, 300, 100000, 100000, 1);
-
     expect_function_call(__wrap_os_wait);
     expect_function_call(__wrap_start_daemon);
     assert_int_equal(Start_win32_Syscheck(), 0);
@@ -222,7 +221,6 @@ void test_Start_win32_Syscheck_syscheck_disabled_1(void **state) {
     will_return(__wrap_rootcheck_init, 0);
 
     expect_wrapper_fim_db_init(0, 300, 100000, 100000, 1);
-
     expect_string(__wrap__minfo, formatted_msg, FIM_FILE_SIZE_LIMIT_DISABLED);
 
     expect_string(__wrap__minfo, formatted_msg, FIM_DISK_QUOTA_LIMIT_DISABLED);
@@ -253,7 +251,6 @@ void test_Start_win32_Syscheck_syscheck_disabled_2(void **state) {
     will_return(__wrap_rootcheck_init, 0);
 
     expect_wrapper_fim_db_init(0, 300, 100000, 100000, 1);
-
     expect_string(__wrap__minfo, formatted_msg, FIM_FILE_SIZE_LIMIT_DISABLED);
 
     expect_string(__wrap__minfo, formatted_msg, FIM_DISK_QUOTA_LIMIT_DISABLED);
@@ -324,7 +321,6 @@ void test_Start_win32_Syscheck_dirs_and_registry(void **state) {
     expect_string(__wrap__minfo, formatted_msg, "(6004): No diff for file: 'Diff'");
 
     expect_wrapper_fim_db_init(0, 300, 100000, 100000, 1);
-
     snprintf(info_msg, OS_MAXSTR, "Started (pid: %d).", getpid());
     expect_string(__wrap__minfo, formatted_msg, info_msg);
 
@@ -373,7 +369,6 @@ void test_Start_win32_Syscheck_whodata_active(void **state) {
     expect_string(__wrap__minfo, formatted_msg, "(6003): Monitoring path: 'c:\\dir1', with options 'whodata'.");
 
     expect_wrapper_fim_db_init(0, 300, 100000, 100000, 1);
-
     expect_string(__wrap__minfo, formatted_msg, FIM_FILE_SIZE_LIMIT_DISABLED);
 
     expect_string(__wrap__minfo, formatted_msg, FIM_DISK_QUOTA_LIMIT_DISABLED);

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
@@ -94,10 +94,10 @@ void expect_fim_db_remove_path(const char *path, int ret_val) {
     will_return(__wrap_fim_db_remove_path, ret_val);
 }
 
-void __wrap_fim_db_file_update(__attribute__((unused)) fim_entry* new,
+int __wrap_fim_db_file_update(__attribute__((unused)) fim_entry* new,
                               __attribute__((unused)) callback_context_t callback)
 {
-    function_called();
+    return mock_type(int);
 }
 
 int __wrap_fim_db_file_pattern_search(const char* pattern,

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
@@ -37,19 +37,20 @@ void expect_fim_db_get_path(const char* path, int ret_val) {
     will_return(__wrap_fim_db_get_path, ret_val);
 }
 
-void __wrap_fim_db_init(int storage,
-                        int sync_interval,
-                        __attribute__((unused)) fim_sync_callback_t sync_callback,
-                        __attribute__((unused)) logging_callback_t log_callback,
-                        int file_limit,
-                        int value_limit,
-                        int sync_registry_enable
-                        ) {
+FIMDBErrorCode __wrap_fim_db_init(int storage,
+                                  int sync_interval,
+                                  __attribute__((unused)) fim_sync_callback_t sync_callback,
+                                  __attribute__((unused)) logging_callback_t log_callback,
+                                  int file_limit,
+                                  int value_limit,
+                                  int sync_registry_enable) {
     check_expected(storage);
     check_expected(sync_interval);
     check_expected(file_limit);
     check_expected(value_limit);
     check_expected(sync_registry_enable);
+
+    return mock_type(int);
 }
 
 void expect_wrapper_fim_db_init(int storage,
@@ -62,9 +63,11 @@ void expect_wrapper_fim_db_init(int storage,
     expect_value(__wrap_fim_db_init, file_limit, file_limit);
     expect_value(__wrap_fim_db_init, value_limit, value_limit);
     expect_value(__wrap_fim_db_init, sync_registry_enable, sync_registry_enable);
+
+    will_return(__wrap_fim_db_init, FIMDB_OK);
 }
 
-int __wrap_fim_db_remove_path(const char *path) {
+FIMDBErrorCode __wrap_fim_db_remove_path(const char *path) {
     check_expected(path);
 
     return mock_type(int);
@@ -94,13 +97,13 @@ void expect_fim_db_remove_path(const char *path, int ret_val) {
     will_return(__wrap_fim_db_remove_path, ret_val);
 }
 
-int __wrap_fim_db_file_update(__attribute__((unused)) fim_entry* new,
+FIMDBErrorCode __wrap_fim_db_file_update(__attribute__((unused)) fim_entry* new,
                               __attribute__((unused)) callback_context_t callback)
 {
     return mock_type(int);
 }
 
-int __wrap_fim_db_file_pattern_search(const char* pattern,
+FIMDBErrorCode __wrap_fim_db_file_pattern_search(const char* pattern,
                                       __attribute__((unused)) callback_context_t callback) {
     check_expected(pattern);
 
@@ -112,7 +115,7 @@ void expect_fim_db_file_pattern_search(const char* pattern, int ret_val) {
     will_return(__wrap_fim_db_file_pattern_search, ret_val);
 }
 
-int __wrap_fim_db_file_inode_search(const unsigned long inode,
+FIMDBErrorCode __wrap_fim_db_file_inode_search(const unsigned long inode,
                                     const unsigned long dev,
                                     __attribute__((unused)) callback_context_t callback) {
     check_expected(inode);

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
@@ -69,7 +69,7 @@ void expect_wrapper_fim_db_get_count_file_entry(int ret);
  */
 void expect_fim_db_remove_path(const char *path, int ret_val);
 
-void __wrap_fim_db_file_update(fim_entry* new, callback_context_t callback);
+int __wrap_fim_db_file_update(fim_entry* new, callback_context_t callback);
 
 int __wrap_fim_db_file_pattern_search(const char* pattern,
                                       __attribute__((unused)) callback_context_t callback);

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
@@ -39,13 +39,13 @@ int __wrap_fim_db_get_count_range(fdb_t *fim_sql,
 FIMDBErrorCode __wrap_fim_db_get_path(const char *file_path, callback_context_t callback);
 void expect_fim_db_get_path(const char* path, int ret_val);
 
-void __wrap_fim_db_init(int storage,
-                        int sync_interval,
-                        fim_sync_callback_t sync_callback,
-                        logging_callback_t log_callback,
-                        int file_limit,
-                        int value_limit,
-                        int sync_registry_enable);
+FIMDBErrorCode __wrap_fim_db_init(int storage,
+                                  int sync_interval,
+                                  fim_sync_callback_t sync_callback,
+                                  logging_callback_t log_callback,
+                                  int file_limit,
+                                  int value_limit,
+                                  int sync_registry_enable);
 
 void expect_wrapper_fim_db_init(int storage,
                                 int sync_interval,
@@ -53,7 +53,7 @@ void expect_wrapper_fim_db_init(int storage,
                                 int value_limit,
                                 int sync_registry_enable);
 
-int __wrap_fim_db_remove_path(const char *path);
+FIMDBErrorCode __wrap_fim_db_remove_path(const char *path);
 
 int __wrap_fim_db_read_line_from_file(fim_tmp_file *file, int storage, int it, char **buffer);
 
@@ -69,14 +69,14 @@ void expect_wrapper_fim_db_get_count_file_entry(int ret);
  */
 void expect_fim_db_remove_path(const char *path, int ret_val);
 
-int __wrap_fim_db_file_update(fim_entry* new, callback_context_t callback);
+FIMDBErrorCode __wrap_fim_db_file_update(fim_entry* new, callback_context_t callback);
 
-int __wrap_fim_db_file_pattern_search(const char* pattern,
+FIMDBErrorCode __wrap_fim_db_file_pattern_search(const char* pattern,
                                       __attribute__((unused)) callback_context_t callback);
 
 void expect_fim_db_file_pattern_search(const char* pattern, int ret_val);
 
-int __wrap_fim_db_file_inode_search(const unsigned long inode,
+FIMDBErrorCode __wrap_fim_db_file_inode_search(const unsigned long inode,
                                     const unsigned long dev,
                                     __attribute__((unused)) callback_context_t callback);
 void expect_fim_db_file_inode_search(const unsigned long inode,


### PR DESCRIPTION
|Related issue|
|---|
|Closes #13043 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR aims to solve performance issues, basically disk usage and therefore improve scan times.

The work is surrounded around changing the strategy of commits in transactions, managing the maximum number of registers at the memory level of the process, removing the trigger, to avoid a select with an aggregation function for each element inserted.


