### PR TITLE
Fix race condition while checking max_eps in FIM synchro messages

### DIFF
--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -1049,9 +1049,30 @@ void test_send_sync_state(void **state) {
     char *event = "{\"data\":\"random_string\"}";
 
     snprintf(debug_msg, OS_SIZE_256, FIM_DBSYNC_SEND, event);
+    syscheck.sync_max_eps = 1;
 
-    expect_string(__wrap__mdebug2, formatted_msg, debug_msg);
+    expect_function_call(__wrap_pthread_mutex_lock);
     expect_w_send_sync_msg(event, "fim_file", DBSYNC_MQ, fim_shutdown_process_on, 0);
+#ifdef TEST_WINAGENT
+    expect_value(wrap_Sleep, dwMilliseconds, 1 * 1000);
+#else
+    expect_value(__wrap_sleep, seconds, 1);
+#endif
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    fim_send_sync_state("fim_file", event);
+}
+
+void test_send_sync_state_without_max_eps(void **state) {
+    char debug_msg[OS_SIZE_256] = {0};
+    char *event = "{\"data\":\"random_string\"}";
+
+    snprintf(debug_msg, OS_SIZE_256, FIM_DBSYNC_SEND, event);
+    syscheck.sync_max_eps = 0;
+
+    expect_w_send_sync_msg(event, "fim_file", DBSYNC_MQ, fim_shutdown_process_on, 0);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg);
 
     fim_send_sync_state("fim_file", event);
 }
@@ -1109,6 +1130,7 @@ int main(void) {
         cmocka_unit_test(test_fim_run_realtime_w_sleep),
 #endif
         cmocka_unit_test(test_send_sync_state),
+        cmocka_unit_test(test_send_sync_state_without_max_eps),
     };
 
     return cmocka_run_group_tests(tests, setup_group, teardown_group);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/13189|


## Description
This PR fixes some bugs found in the integration tests related to the `sync_max_eps` of the FIM sync. They were due to a race condition related to the use of the `fim_send_sync_state` function by rsync. The max eps check was being done without thread control. I have added a mutex to fix it.

## Configuration options
```
<syscheck>
    <directories>/testdir1</directories>
    <synchronization>
        <enabled>yes</enabled>
        <max_eps>1</max_eps>
    </synchronization>
</syscheck>
```
## Logs/Alerts example

Created 6 files while agent is off, then start the agent:
```
2022/04/21 10:22:02 wazuh-syscheckd[66820] run_check.c:113 at fim_send_sync_state(): DEBUG: (6317): Sending integrity control message: {"component":"fim_file","data":{"begin":"/testdir1/file0_to_max_eps_1_scheduled_mode1650536519.0831883","checksum":"c6bbc60ac2b761f933d725fe481fa7071a4073eb","end":"/testdir1/file2_to_max_eps_1_scheduled_mode1650536519.0832648","id":1650536521,"tail":"/testdir1/file3_to_max_eps_1_scheduled_mode1650536519.0832875"},"type":"integrity_check_left"}
2022/04/21 10:22:03 wazuh-syscheckd[66820] run_check.c:113 at fim_send_sync_state(): DEBUG: (6317): Sending integrity control message: {"component":"fim_file","data":{"begin":"/testdir1/file0_to_max_eps_1_scheduled_mode1650536519.0831883","checksum":"03b6711cf121551b9e3bcb5b0d221d200c8c66d2","end":"/testdir1/file0_to_max_eps_1_scheduled_mode1650536519.0831883","id":1650536521,"tail":"/testdir1/file1_to_max_eps_1_scheduled_mode1650536519.083238"},"type":"integrity_check_left"}
2022/04/21 10:22:04 wazuh-syscheckd[66820] run_check.c:113 at fim_send_sync_state(): DEBUG: (6317): Sending integrity control message: {"component":"fim_file","data":{"begin":"/testdir1/file3_to_max_eps_1_scheduled_mode1650536519.0832875","checksum":"91b1771599aa130b78d26d9f3b4e2f0fe2e6e2c2","end":"/testdir1/file5_to_max_eps_1_scheduled_mode1650536519.0833426","id":1650536521},"type":"integrity_check_right"}
2022/04/21 10:22:05 wazuh-syscheckd[66820] run_check.c:113 at fim_send_sync_state(): DEBUG: (6317): Sending integrity control message: {"component":"fim_file","data":{"attributes":{"attributes":"","checksum":"7510c7b5b00e0584aafdcb136a4c090f4f708e3c","gid":"0","group_name":"root","hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","inode":2228226,"mtime":1650536519,"perm":"rw-r--r--","size":0,"type":"file","uid":"0","user_name":"root"},"index":"/testdir1/file0_to_max_eps_1_scheduled_mode1650536519.0831883","timestamp":1650536521},"type":"state"}
2022/04/21 10:22:06 wazuh-syscheckd[66820] run_check.c:113 at fim_send_sync_state(): DEBUG: (6317): Sending integrity control message: {"component":"fim_file","data":{"begin":"/testdir1/file1_to_max_eps_1_scheduled_mode1650536519.083238","checksum":"55cfb0a842c211592a7e67e61d558f279646c7eb","end":"/testdir1/file2_to_max_eps_1_scheduled_mode1650536519.0832648","id":1650536521},"type":"integrity_check_right"}
2022/04/21 10:22:07 wazuh-syscheckd[66820] run_check.c:113 at fim_send_sync_state(): DEBUG: (6317): Sending integrity control message: {"component":"fim_file","data":{"begin":"/testdir1/file3_to_max_eps_1_scheduled_mode1650536519.0832875","checksum":"945bb38abc239bc38986a1cc862dc03bde9f9645","end":"/testdir1/file3_to_max_eps_1_scheduled_mode1650536519.0832875","id":1650536521,"tail":"/testdir1/file4_to_max_eps_1_scheduled_mode1650536519.08331"},"type":"integrity_check_left"}
2022/04/21 10:22:08 wazuh-syscheckd[66820] run_check.c:113 at fim_send_sync_state(): DEBUG: (6317): Sending integrity control message: {"component":"fim_file","data":{"begin":"/testdir1/file1_to_max_eps_1_scheduled_mode1650536519.083238","checksum":"0ae7601dfb2a6df7d614a0ed5b06a05e2b9895c8","end":"/testdir1/file1_to_max_eps_1_scheduled_mode1650536519.083238","id":1650536521,"tail":"/testdir1/file2_to_max_eps_1_scheduled_mode1650536519.0832648"},"type":"integrity_check_left"}

```

## Tests



<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
- Memory tests for Windows
  - [x] Scan-build report