### PR TITLE
Add UTC conversion to `WazuhDBQueryGroupByVulnerability` format data function and fix SDK unittest

### DIFF
--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -67,6 +67,7 @@ async def test_response_init():
         assert response.content is None
 
 
+@pytest.mark.asyncio
 async def test_response_read():
     """Test for the 'read' method that belongs to the Response class. This method waits until a response is received."""
 
@@ -77,6 +78,7 @@ async def test_response_read():
         wait_mock.assert_called_once()
 
 
+@pytest.mark.asyncio
 async def test_response_write():
     """Test for the 'write' method that belongs to the Response class. It sets the content of a response and its
     availability."""

--- a/framework/wazuh/core/vulnerability.py
+++ b/framework/wazuh/core/vulnerability.py
@@ -71,7 +71,7 @@ class WazuhDBQueryGroupByVulnerability(WazuhDBQueryGroupBy, WazuhDBQueryVulnerab
             if field_name in self.date_fields:
                 try:
                     # These values will be the keys of the result. They cannot be datetime objects
-                    return str(datetime.utcfromtimestamp(int(value)))
+                    return str(get_date_from_timestamp(int(value)))
                 except (ValueError, TypeError):
                     pass
 

--- a/framework/wazuh/tests/test_vulnerability.py
+++ b/framework/wazuh/tests/test_vulnerability.py
@@ -114,9 +114,10 @@ def test_get_agent_cve_select(socket_mock, send_mock, exists_mock, params, expec
             item.keys()) == set(), '"select" param did not return expected fields.'
 
 
+@patch('wazuh.core.utils.path.exists', return_value=True)
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
-def test_vulnerability_get_inventory_summary(socket_mock, send_mock):
+def test_vulnerability_get_inventory_summary(socket_mock, send_mock, exists_mock):
     """Check if `get_inventory_summary` function returns the expected data placed in the testing database."""
     agent_id = '001'
     field = 'severity'


### PR DESCRIPTION
## Description

This PR closes #13230 

After merging 4.3 into master, the new `WazuhDBQueryGroupByVulnerability` class was using the old timestamp to date conversion.
In this PR, I have added the new UTC conversion to this timestamp. Also, I have fixed a vulnerability unit test failing after the 4.3 merge (SDK).

### Test results

SDK:

```
============================= test session starts ==============================
collecting ... collected 36 items

test_vulnerability.py::test_get_agent_cve[params0-cve-expected_items0] PASSED [  2%]
test_vulnerability.py::test_get_agent_cve[params1-cve-expected_items1] PASSED [  5%]
test_vulnerability.py::test_get_agent_cve[params2-cve-expected_items2] PASSED [  8%]
test_vulnerability.py::test_get_agent_cve[params3-name-expected_items3] PASSED [ 11%]
test_vulnerability.py::test_get_agent_cve[params4-name-expected_items4] PASSED [ 13%]
test_vulnerability.py::test_get_agent_cve[params5-cve-expected_items5] PASSED [ 16%]
test_vulnerability.py::test_get_agent_cve[params6-cve-expected_items6] PASSED [ 19%]
test_vulnerability.py::test_get_agent_cve[params7-cve-expected_items7] PASSED [ 22%]
test_vulnerability.py::test_get_agent_cve[params8-cve-expected_items8] PASSED [ 25%]
test_vulnerability.py::test_get_agent_cve[params9-cve-expected_items9] PASSED [ 27%]
test_vulnerability.py::test_get_agent_cve[params10-cve-expected_items10] PASSED [ 30%]
test_vulnerability.py::test_get_agent_cve[params11-cve-expected_items11] PASSED [ 33%]
test_vulnerability.py::test_get_agent_cve[params12-cve-expected_items12] PASSED [ 36%]
test_vulnerability.py::test_get_agent_cve[params13-cve-expected_items13] PASSED [ 38%]
test_vulnerability.py::test_get_agent_cve[params14-cve-expected_items14] PASSED [ 41%]
test_vulnerability.py::test_get_agent_cve[params15-cve-expected_items15] PASSED [ 44%]
test_vulnerability.py::test_get_agent_cve[params16-cve-expected_items16] PASSED [ 47%]
test_vulnerability.py::test_get_agent_cve[params17-cve-expected_items17] PASSED [ 50%]
test_vulnerability.py::test_get_agent_cve[params18-cve-expected_items18] PASSED [ 52%]
test_vulnerability.py::test_get_agent_cve[params19-cve-expected_items19] PASSED [ 55%]
test_vulnerability.py::test_get_agent_cve[params20-cve-expected_items20] PASSED [ 58%]
test_vulnerability.py::test_get_agent_cve[params21-cve-expected_items21] PASSED [ 61%]
test_vulnerability.py::test_get_agent_cve[params22-cve-expected_items22] PASSED [ 63%]
test_vulnerability.py::test_get_agent_cve[params23-cve-expected_items23] PASSED [ 66%]
test_vulnerability.py::test_get_agent_cve[params24-cve-expected_items24] PASSED [ 69%]
test_vulnerability.py::test_get_agent_cve[params25-cve-expected_items25] PASSED [ 72%]
test_vulnerability.py::test_get_agent_cve[params26-cve-expected_items26] PASSED [ 75%]
test_vulnerability.py::test_get_agent_cve[params27-cve-expected_items27] PASSED [ 77%]
test_vulnerability.py::test_get_agent_cve[params28-cve-expected_items28] PASSED [ 80%]
test_vulnerability.py::test_get_agent_cve[params29-cve-expected_items29] PASSED [ 83%]
test_vulnerability.py::test_get_agent_cve[params30-architecture-expected_items30] PASSED [ 86%]
test_vulnerability.py::test_get_agent_cve[params31-architecture-expected_items31] PASSED [ 88%]
test_vulnerability.py::test_get_agent_cve_select[params0-expected_fields0] PASSED [ 91%]
test_vulnerability.py::test_get_agent_cve_select[params1-expected_fields1] PASSED [ 94%]
test_vulnerability.py::test_get_agent_cve_select[params2-expected_fields2] PASSED [ 97%]
test_vulnerability.py::test_vulnerability_get_inventory_summary PASSED   [100%]

======================= 36 passed, 10 warnings in 0.72s ========================
```

Core:

```
============================= test session starts ==============================
collecting ... collected 2 items

test_vulnerability.py::test_WazuhDBQueryVulnerability__init__ PASSED     [ 50%]
test_vulnerability.py::test_WazuhDBQueryVulnerability_format_data_into_dictionary PASSED [100%]

======================== 2 passed, 10 warnings in 0.50s ========================
```