### PR TITLE
Creating a working thread for vulnerability detector

### DIFF
--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -41,7 +41,7 @@
 #define VU_UPDATE_VU_INFO     "(5426): Inserting '%s' vulnerabilities information."
 #define VU_STOP_REFRESH_DB    "(5427): Refresh of '%s' database finished."
 #define VU_DOWNLOAD_PAGE_SUC  "(5428): Page '%d' successfully downloaded."
-#define VU_NVD_UPD_CANCEL     "(5429): The '%s' update has failed, so the NVD feed will not be updated."
+#define VU_CPEW_UPD_CANCEL     "(5429): The '%s' update has failed, so this feed will not be updated any more."
 #define VU_ENDING_UPDATE      "(5430): The update of the '%s' feed finished successfully."
 #define VU_START_SCAN         "(5431): Starting vulnerability scan."
 #define VU_AG_NEVER_CON       "(5432): Agent '%s' never connected."
@@ -98,6 +98,8 @@
 #define VU_DISCARD_DU         "(5489): '%s' vulnerability information discarded for agent '%.3d' ('KB%s'): Dynamic Updates (DU) are only available when upgrading to new Windows 10 versions."
 #define VU_REMOVED_VULN       "(5490): The vulnerability '%s' affecting '%s' was eliminated"
 #define VU_AG_BASELINE_SCAN   "(5491): A baseline scan will be run on agent '%.3d'"
+#define VU_FAILED_UPDATE      "(5492): The update of the '%s' feed failed."
+
 
 /* File integrity monitoring debug messages */
 #define FIM_DIFF_SKIPPED                    "(6200): Diff execution skipped for containing insecure characters."

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -355,7 +355,6 @@
 #define VU_SYSC_SCAN_REQUEST_ERROR  "(5518): Last software scan from the agent '%.3d' could not be requested."
 #define VU_NO_SYSC_SCANS            "(5519): No package inventory found for agent '%.3d', so their vulnerabilities will not be checked."
 #define VU_REPORT_ERROR             "(5520): The agent '%.3d' vulnerabilities could not be reported. Error: '%s'"
-#define VU_UPDATE_RETRY             "(5521): Failed when updating '%s %s' database. Retrying in '%lu' seconds."
 #define VU_API_REQ_INV              "(5522): There was no valid response to '%s' after '%d' attempts."
 #define VU_CONTENT_FEED_ERROR       "(5523): Couldn't get the content of the '%s' feed from '%s' file."
 #define VU_PARSED_FEED_ERROR        "(5524): The '%s' feed couldn't be parsed from '%s' file."

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -326,7 +326,7 @@ STATIC void wm_vuldet_set_subversion(char *version, char **os_minor);
 STATIC cJSON *wm_vuldet_json_fread(char *json_file);
 STATIC cJSON *wm_vuldet_get_cvss(const char *scoring_vector);
 STATIC int wm_vuldet_get_term_condition(char *i_term, char **term, char **comp_field, char **condition);
-STATIC void wm_vuldet_run_scan(wm_vuldet_t *vuldet);
+STATIC int wm_vuldet_run_scan(wm_vuldet_t *vuldet);
 STATIC void wm_vuldet_init(wm_vuldet_t *vuldet);
 STATIC void wm_vuldet_update_last_scan(scan_ctx_t* scan_ctx);
 STATIC char *wm_vuldet_normalize_date(char **date);
@@ -417,7 +417,6 @@ int usec;
 
 w_linked_queue_t *vu_messages_queue = NULL;
 w_linked_queue_t* vu_tasks_queue = NULL;
-w_linked_queue_t* vu_messages_queue = NULL;
 
 const wm_context WM_VULNDETECTOR_CONTEXT = {
     "vulnerability-detector",
@@ -633,6 +632,7 @@ const char *vu_cpe_dic_option[] = {
 
 // Task flags for vu_tasks_queue
 bool VU_TASKS_QUEUE_FLAGS[VU_TASK_TYPES_SIZE] = {0};
+bool VU_TASKS_QUEUE_FEED_UPDATE_FLAGS[FEED_UNKNOWN] = {0};
 
 void vu_tasks_queue_push_callback (void* data) {
     if (data) {
@@ -663,14 +663,14 @@ vu_task_ctx_t *create_task(const int task_id,
     return task;
 }
 
-void task_message_free(vu_task_message_ctx_t *msg) {
+void vu_task_msg_ctx_free(vu_task_msg_ctx_t *msg) {
     if (msg->status_message) {
         os_free(msg->status_message);
     }
     os_free(msg);
 }
 
-void vu_tasks_task_context_free (vu_task_ctx_t* task) {
+void vu_task_ctx_free (vu_task_ctx_t* task) {
     os_free(task);
 }
 
@@ -707,7 +707,17 @@ vu_feed wm_vuldet_set_allowed_feed(const char *os_name, const char *os_version, 
 }
 
 int wm_vuldet_check_update_period(update_node *upd) {
-    return upd && (!upd->last_sync || (upd->interval != WM_VULNDETECTOR_ONLY_ONE_UPD && (upd->last_sync + (time_t) upd->interval) < time(NULL)));
+    if (!upd) {
+        return 0;
+    }
+
+    bool time_to_update = !upd->last_sync || (upd->interval != WM_VULNDETECTOR_ONLY_ONE_UPD && (upd->last_sync + (time_t) upd->interval) < time(NULL));
+
+    if (time_to_update) {
+        upd->last_sync = time(NULL);
+    }
+
+    return time_to_update;
 }
 int wm_vuldet_sync_feed(update_node *upd, int8_t *need_update) {
     return wm_vuldet_fetch_feed(upd, need_update) == OS_INVALID || (*need_update && wm_vuldet_index_feed(upd));
@@ -4583,19 +4593,15 @@ int wm_vuldet_check_feed(update_node *upd, int8_t *updated) {
         mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_STARTING_UPDATE, vu_feed_ext[upd->dist_tag_ref]);
     }
     if (wm_vuldet_update_feed(upd, updated)) {
-        if (!upd->attempted) {
-            upd->last_sync = time(NULL) - upd->interval + WM_VULNDETECTOR_RETRY_UPDATE;
-            upd->attempted = 1;
-            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UPDATE_RETRY, upd->dist, upd->version ? upd->version : "provider", (long unsigned)WM_VULNDETECTOR_RETRY_UPDATE);
-        } else {
-            upd->last_sync = time(NULL);
-            upd->attempted = 0;
-            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UPDATE_RETRY, upd->dist, upd->version ? upd->version : "provider", upd->interval);
+        if (upd->dist_tag_ref == FEED_CPEW) {
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_CPEW_UPD_CANCEL, "Wazuh CPE Helper");
+            *updated = -1;
         }
 
-        if (upd->dist_tag_ref == FEED_CPEW) {
-            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_NVD_UPD_CANCEL, "Wazuh CPE Helper");
-            *updated = -1;
+        if (!wm_vuldet_silent_feed(upd->dist_tag_ref)) {
+            mtinfo(WM_VULNDETECTOR_LOGTAG, VU_FAILED_UPDATE, upd->dist_ext);
+        } else {
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_FAILED_UPDATE, vu_feed_ext[upd->dist_tag_ref]);
         }
 
         return OS_INVALID;
@@ -4605,7 +4611,7 @@ int wm_vuldet_check_feed(update_node *upd, int8_t *updated) {
         } else {
             mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_ENDING_UPDATE, vu_feed_ext[upd->dist_tag_ref]);
         }
-        upd->last_sync = time(NULL);
+
         time_t last_feed_upd = wm_vuldet_get_last_feed_update(upd->dist_tag_ref);
         if (last_feed_upd != -1) {
             upd->last_update = last_feed_upd;
@@ -4670,6 +4676,25 @@ void wm_vuldet_clean_after_run_update() {
     }
 }
 
+void wm_vuldet_schedule_updates(update_node **updates) {
+    if (!updates) {
+        return;
+    }
+
+    // Check updates for all the feeds
+    for (int os = 0; os < OS_SUPP_SIZE; os++) {
+        if (updates[os] && wm_vuldet_check_update_period(updates[os]) && !VU_TASKS_QUEUE_FEED_UPDATE_FLAGS[updates[os]->dist_ref]) {
+            // TODO modify the flags with the proper callback
+            VU_TASKS_QUEUE_FEED_UPDATE_FLAGS[updates[os]->dist_ref] = 1;
+            vu_task_ctx_t *task = create_task(OS_INVALID, VU_INTERVAL_FEED_UPDATE, WM_TASK_PENDING, updates[os]->dist_ref, OS_INVALID);
+            if (OS_INVALID == register_task(task)) {
+                mwarn("Couldn't establish communication with task manager. There's no ID for task");
+            }
+            linked_queue_push_ex(vu_tasks_queue, task);
+        }
+    }
+}
+
 int wm_vuldet_run_update(update_node **updates) {
     int ret = 0;
     int8_t updated = 1;
@@ -4681,13 +4706,7 @@ int wm_vuldet_run_update(update_node **updates) {
 
     // Check updates for all the feeds
     for (int os = 0; os < OS_SUPP_SIZE; os++) {
-        if (updates[os] && wm_vuldet_check_update_period(updates[os])) {
-            vu_task_ctx_t *task = create_task(OS_INVALID, VU_INTERVAL_FEED_UPDATE, WM_TASK_PENDING, updates[os]->dist_ref, OS_INVALID);
-            if (OS_INVALID == register_task(task)) {
-                mwarn("Couldn't establish communication with task manager. There's no ID for task");
-            }
-            linked_queue_push_ex(vu_tasks_queue, task);
-
+        if (updates[os]) {
             // If none of RedHat's OVALs have been updated,
             // we can deduce that the JSON is already up to date.
             if (updates[os]->dist_ref == FEED_JREDHAT && up_status == 1) {
@@ -5211,24 +5230,23 @@ end:
 }
 
 w_err_t register_task(vu_task_ctx_t *task) {
-    srand(time(NULL));
+    static int id = 0;
 
     // TODO: Interaction with task manager to set information in the database
     // and obtain a task ID.
-    // Generating a dummy task IDs from 1 to 10.
-    int id = rand() % 10 + 1;
-    task->task_id = id;
+    // Generating a dummy task ID.
+    task->task_id = ++id;
 
     return OS_SUCCESS;
 }
 
 void wm_vuldet_create_and_send_message(vu_task_ctx_t* task, task_status TASK_STATUS, char* details) {
-    wm_vuldet_task_msg_ctx* message = NULL;
+    vu_task_msg_ctx_t* message = NULL;
     char status_message[OS_SIZE_128] = {0};
 
-    if (task && task->taskID != OS_INVALID) {
-        os_calloc(1, sizeof(wm_vuldet_task_msg_ctx), message);
-        message->task_id = task->taskID;
+    if (task && task->task_id != OS_INVALID) {
+        os_calloc(1, sizeof(vu_task_msg_ctx_t), message);
+        message->task_id = task->task_id;
         message->task_status = TASK_STATUS;
 
         switch (TASK_STATUS) {
@@ -5285,7 +5303,7 @@ void wm_vuldet_on_demand_feed_update(vu_task_ctx_t* current_task, wm_vuldet_t* v
 }
 
 void wm_vuldet_feed_update_by_interval(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet) {
-    int8_t feed_updated = 0;     // Unused variable
+    int8_t feed_updated = 0;
     char status_message[OS_SIZE_64] = {0};
     bool result = 0;
 
@@ -5301,8 +5319,12 @@ void wm_vuldet_feed_update_by_interval(vu_task_ctx_t* current_task, wm_vuldet_t*
         if ((vuldet->updates[os])->dist_ref == current_task->feed_to_update) {
             snprintf(status_message, OS_SIZE_64, " Updating OS: %s.", vu_feed_tag[(vuldet->updates[os])->dist_tag_ref]);
             wm_vuldet_create_and_send_message(current_task, WM_TASK_IN_PROGRESS, status_message);
-            if (wm_vuldet_update_feed((vuldet->updates)[os], &feed_updated)) {
+            if (wm_vuldet_check_feed((vuldet->updates)[os], &feed_updated)) {
                 result = 1;
+                if (feed_updated == -1) {
+                    // The CPE helper update failed (updated is only set to -1 when evaluating the CPE helper)
+                    wm_vuldet_release_update_node(vuldet->updates, CPE_WDIC);
+                }
             }
         }
     }
@@ -5371,6 +5393,8 @@ void wm_vuldet_working_thread(void* vuldet_data) {
                     break;
                 case VU_INTERVAL_FEED_UPDATE:
                     wm_vuldet_feed_update_by_interval(current_task, vuldet);
+                    // TODO modify the flags with the proper callback
+                    VU_TASKS_QUEUE_FEED_UPDATE_FLAGS[current_task->feed_to_update] = 0;
                     break;
                 case VU_INTERVAL_SCAN:
                     wm_vuldet_scan_by_interval(current_task, vuldet);
@@ -5380,7 +5404,7 @@ void wm_vuldet_working_thread(void* vuldet_data) {
                     break;
             }
             // Removing task from queue
-            vu_tasks_task_context_free((vu_task_ctx_t*) linked_queue_pop_ex(vu_tasks_queue));
+            vu_task_ctx_free((vu_task_ctx_t*) linked_queue_pop_ex(vu_tasks_queue));
         } else {
             sleep(1);
         }
@@ -5405,56 +5429,46 @@ void *wm_vuldet_main(wm_vuldet_t* vuldet) {
 
     wm_vuldet_init_queues();
 
-    while (true) {
-        curr_time = time(NULL);
-        // Update CVE databases
-        if (vuldet->flags.update && wm_vuldet_run_update(vuldet->updates)) {
-            mterror(WM_VULNDETECTOR_LOGTAG, VU_OVAL_UPDATE_ERROR);
-        }
+    // TODO split the structures for the working and the sheduler threads
+    wm_vuldet_t vuldet_cpy = {0};
+    vuldet_cpy = *vuldet;
 
-        pthread_t working_thread;
-        if (OS_SUCCESS == wm_vuldet_run_working_thread(&working_thread, vuldet)) {
-            while (true) {
-                curr_time = time(NULL);
-                // Update CVE databases
-                if (vuldet->flags.update && wm_vuldet_run_update(vuldet->updates)) {
-                    mterror(WM_VULNDETECTOR_LOGTAG, VU_OVAL_UPDATE_ERROR);
-                }
-
-                if ((curr_time - vuldet->last_scan >= vuldet->scan_interval)) {
-                    // Scaning the manager
-                    if (wm_vuldet_collect_agent_info(000, vuldet)) {
-                        mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR);
-                    } else {
-                        if (wm_vuldet_run_scan(vuldet)) {
-                            mterror(WM_VULNDETECTOR_LOGTAG, VU_AG_CHECK_ERR);
-                        }
-                    }
-                    // Scanning agents
-                    int sock = wm_vuldet_get_wdb_socket();
-                    int* agents_array = wdb_get_agents_by_connection_status(AGENT_CS_ACTIVE, &sock);
-                    int i = 0;
-                    while(agents_array && agents_array[i] != OS_INVALID) {
-                        if (wm_vuldet_collect_agent_info(agents_array[i], vuldet)) {
-                            mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR);
-                        } else {
-                            if (wm_vuldet_run_scan(vuldet)) {
-                                mterror(WM_VULNDETECTOR_LOGTAG, VU_AG_CHECK_ERR);
-                            }
-                        }
-                        i++;
-                    }
-                    mtinfo(WM_VULNDETECTOR_LOGTAG, VU_END_SCAN);
-                    os_free(agents_array);
-                }
-
-                wm_vuldet_run_sleep(vuldet);
+    pthread_t working_thread;
+    if (OS_SUCCESS == wm_vuldet_run_working_thread(&working_thread, &vuldet_cpy)) {
+        while (true) {
+            curr_time = time(NULL);
+            // Schedule CVE databases
+            if (vuldet->flags.update) {
+                wm_vuldet_schedule_updates(vuldet->updates);
             }
-            wm_vuldet_working_thread_active = 0;
-            // Join threads
-            pthread_join(working_thread, NULL);
+
+            if ((curr_time - vuldet->last_scan >= vuldet->scan_interval)) {
+                if (!VU_TASKS_QUEUE_FLAGS[VU_INTERVAL_SCAN]) {
+                    vu_task_ctx_t *task = create_task(OS_INVALID, VU_INTERVAL_SCAN, WM_TASK_PENDING, FEED_UNKNOWN, OS_INVALID);
+                    if (OS_INVALID == register_task(task)) {
+                        mwarn("Couldn't establish communication with task manager. There's no ID for task");
+                    }
+                    linked_queue_push_ex(vu_tasks_queue, task);
+                }
+
+                vuldet->last_scan = curr_time;
+            }
+            /* Checks for messages in the queue */
+            vu_task_msg_ctx_t *msg = (vu_task_msg_ctx_t *)linked_queue_pop_ex_no_cond_wait(vu_messages_queue);
+            while(msg) {
+                /* TODO: Dummy message that represents the interaction with the task manager */
+                minfo("Task ID: '%d' status: '%s' message: '%s'", msg->task_id, task_statuses[msg->task_status], msg->status_message);
+                vu_task_msg_ctx_free(msg);
+                msg = (vu_task_msg_ctx_t *)linked_queue_pop_ex_no_cond_wait(vu_messages_queue);
+            }
         }
+        wm_vuldet_working_thread_active = 0;
+        // Join threads
+        pthread_join(working_thread, NULL);
     }
+
+    linked_queue_free(vu_tasks_queue);
+    linked_queue_free(vu_messages_queue);
 
     return NULL;
 }
@@ -7972,7 +7986,6 @@ int wm_vuldet_run_scan(wm_vuldet_t *vuldet) {
     }
 
     vuldet->scan_agents = NULL;
-    vuldet->last_scan = time(NULL);
 
     return result;
 }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4675,6 +4675,10 @@ int wm_vuldet_run_update(update_node **updates) {
     int8_t updated = 1;
     int up_status = 0;
 
+    if (!updates) {
+        return ret;
+    }
+
     // Check updates for all the feeds
     for (int os = 0; os < OS_SUPP_SIZE; os++) {
         if (updates[os] && wm_vuldet_check_update_period(updates[os])) {
@@ -5218,13 +5222,13 @@ w_err_t register_task(vu_task_ctx_t *task) {
     return OS_SUCCESS;
 }
 
-void wm_vuldet_create_and_send_message(vu_task_context_t task, task_status TASK_STATUS, char* details) {
+void wm_vuldet_create_and_send_message(vu_task_context_t* task, task_status TASK_STATUS, char* details) {
     wm_vuldet_task_msg_ctx* message = NULL;
     char status_message[OS_SIZE_128] = {0};
 
-    if (task.taskID != (size_t)OS_INVALID) {
+    if (task && task->taskID != (size_t)OS_INVALID) {
         os_calloc(1, sizeof(wm_vuldet_task_msg_ctx), message);
-        message->task_id = task.taskID;
+        message->task_id = task->taskID;
         message->task_status = TASK_STATUS;
 
         switch (TASK_STATUS) {
@@ -5256,39 +5260,39 @@ void wm_vuldet_create_and_send_message(vu_task_context_t task, task_status TASK_
 }
 
 void wm_vuldet_on_demand_scan(vu_task_context_t* current_task, wm_vuldet_t* vuldet) {
-    wm_vuldet_create_and_send_message(*current_task, WM_TASK_IN_PROGRESS, NULL);
+    wm_vuldet_create_and_send_message(current_task, WM_TASK_IN_PROGRESS, NULL);
     if (wm_vuldet_collect_agent_info(current_task->agent_to_scan, vuldet)) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR);
-        wm_vuldet_create_and_send_message(*current_task, WM_TASK_FAILED, NULL);
+        wm_vuldet_create_and_send_message(current_task, WM_TASK_FAILED, NULL);
     } else {
         if (wm_vuldet_run_scan(vuldet)) {
-            wm_vuldet_create_and_send_message(*current_task, WM_TASK_DONE, NULL);
-        } else {
-            wm_vuldet_create_and_send_message(*current_task, WM_TASK_FAILED, NULL);
+            wm_vuldet_create_and_send_message(current_task, WM_TASK_FAILED, NULL);
             mterror(WM_VULNDETECTOR_LOGTAG, VU_AG_CHECK_ERR);
+        } else {
+            wm_vuldet_create_and_send_message(current_task, WM_TASK_DONE, NULL);
         }
     }
 }
 
 void wm_vuldet_on_demand_feed_update(vu_task_context_t* current_task, wm_vuldet_t* vuldet) {
-    wm_vuldet_create_and_send_message(*current_task, WM_TASK_IN_PROGRESS, NULL);
+    wm_vuldet_create_and_send_message(current_task, WM_TASK_IN_PROGRESS, NULL);
     if (wm_vuldet_run_update(vuldet->updates)) {
-        wm_vuldet_create_and_send_message(*current_task, WM_TASK_FAILED, NULL);
+        wm_vuldet_create_and_send_message(current_task, WM_TASK_FAILED, NULL);
         mterror(WM_VULNDETECTOR_LOGTAG, VU_OVAL_UPDATE_ERROR);
     } else {
-        wm_vuldet_create_and_send_message(*current_task, WM_TASK_DONE, NULL);
+        wm_vuldet_create_and_send_message(current_task, WM_TASK_DONE, NULL);
     }
 }
 
 void wm_vuldet_feed_update_by_interval(vu_task_context_t* current_task, wm_vuldet_t* vuldet) {
     int8_t feed_updated = 0;
 
-    wm_vuldet_create_and_send_message(*current_task, WM_TASK_IN_PROGRESS, NULL);
+    wm_vuldet_create_and_send_message(current_task, WM_TASK_IN_PROGRESS, NULL);
     if (!vuldet->updates || wm_vuldet_update_feed((vuldet->updates)[current_task->feed_to_update], &feed_updated)) {
-        wm_vuldet_create_and_send_message(*current_task, WM_TASK_FAILED, NULL);
+        wm_vuldet_create_and_send_message(current_task, WM_TASK_FAILED, NULL);
         mterror(WM_VULNDETECTOR_LOGTAG, VU_OVAL_UPDATE_ERROR);
     } else {
-        wm_vuldet_create_and_send_message(*current_task, WM_TASK_DONE, NULL);
+        wm_vuldet_create_and_send_message(current_task, WM_TASK_DONE, NULL);
     }
     wm_vuldet_clean_after_run_update();
 }
@@ -5304,7 +5308,7 @@ void wm_vuldet_scan_by_interval(vu_task_context_t* current_task, wm_vuldet_t* vu
         mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR);
     } else {
         snprintf(status_message, OS_SIZE_64, "Agent: manager.");
-        wm_vuldet_create_and_send_message(*current_task, WM_TASK_IN_PROGRESS, status_message);
+        wm_vuldet_create_and_send_message(current_task, WM_TASK_IN_PROGRESS, status_message);
         if (wm_vuldet_run_scan(vuldet)) {
             mterror(WM_VULNDETECTOR_LOGTAG, VU_AG_CHECK_ERR);
         }
@@ -5317,7 +5321,7 @@ void wm_vuldet_scan_by_interval(vu_task_context_t* current_task, wm_vuldet_t* vu
             mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR);
         } else {
             snprintf(status_message, OS_SIZE_64, "Agent: %.3d.", agents_array[i]);
-            wm_vuldet_create_and_send_message(*current_task, WM_TASK_IN_PROGRESS, status_message);
+            wm_vuldet_create_and_send_message(current_task, WM_TASK_IN_PROGRESS, status_message);
             if (wm_vuldet_run_scan(vuldet)) {
                 mterror(WM_VULNDETECTOR_LOGTAG, VU_AG_CHECK_ERR);
             }
@@ -5327,7 +5331,7 @@ void wm_vuldet_scan_by_interval(vu_task_context_t* current_task, wm_vuldet_t* vu
     }
     mtinfo(WM_VULNDETECTOR_LOGTAG, VU_END_SCAN);
 
-    wm_vuldet_create_and_send_message(*current_task, WM_TASK_DONE, NULL);
+    wm_vuldet_create_and_send_message(current_task, WM_TASK_DONE, NULL);
     os_free(agents_array);
 }
 
@@ -5398,7 +5402,30 @@ void *wm_vuldet_main(wm_vuldet_t* vuldet) {
                 }
 
                 if ((curr_time - vuldet->last_scan >= vuldet->scan_interval)) {
-                    wm_vuldet_run_scan(vuldet);
+                    // Scaning the manager
+                    if (wm_vuldet_collect_agent_info(000, vuldet)) {
+                        mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR);
+                    } else {
+                        if (wm_vuldet_run_scan(vuldet)) {
+                            mterror(WM_VULNDETECTOR_LOGTAG, VU_AG_CHECK_ERR);
+                        }
+                    }
+                    // Scanning agents
+                    int sock = wm_vuldet_get_wdb_socket();
+                    int* agents_array = wdb_get_agents_by_connection_status(AGENT_CS_ACTIVE, &sock);
+                    int i = 0;
+                    while(agents_array && agents_array[i] != OS_INVALID) {
+                        if (wm_vuldet_collect_agent_info(agents_array[i], vuldet)) {
+                            mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR);
+                        } else {
+                            if (wm_vuldet_run_scan(vuldet)) {
+                                mterror(WM_VULNDETECTOR_LOGTAG, VU_AG_CHECK_ERR);
+                            }
+                        }
+                        i++;
+                    }
+                    mtinfo(WM_VULNDETECTOR_LOGTAG, VU_END_SCAN);
+                    os_free(agents_array);
                 }
 
                 wm_vuldet_run_sleep(vuldet);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -670,7 +670,7 @@ void task_message_free(vu_task_message_ctx_t *msg) {
     os_free(msg);
 }
 
-void vu_tasks_task_context_free (vu_task_context_t* task) {
+void vu_tasks_task_context_free (vu_task_ctx_t* task) {
     os_free(task);
 }
 
@@ -5222,11 +5222,11 @@ w_err_t register_task(vu_task_ctx_t *task) {
     return OS_SUCCESS;
 }
 
-void wm_vuldet_create_and_send_message(vu_task_context_t* task, task_status TASK_STATUS, char* details) {
+void wm_vuldet_create_and_send_message(vu_task_ctx_t* task, task_status TASK_STATUS, char* details) {
     wm_vuldet_task_msg_ctx* message = NULL;
     char status_message[OS_SIZE_128] = {0};
 
-    if (task && task->taskID != (size_t)OS_INVALID) {
+    if (task && task->taskID != OS_INVALID) {
         os_calloc(1, sizeof(wm_vuldet_task_msg_ctx), message);
         message->task_id = task->taskID;
         message->task_status = TASK_STATUS;
@@ -5259,7 +5259,7 @@ void wm_vuldet_create_and_send_message(vu_task_context_t* task, task_status TASK
     }
 }
 
-void wm_vuldet_on_demand_scan(vu_task_context_t* current_task, wm_vuldet_t* vuldet) {
+void wm_vuldet_on_demand_scan(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet) {
     wm_vuldet_create_and_send_message(current_task, WM_TASK_IN_PROGRESS, NULL);
     if (wm_vuldet_collect_agent_info(current_task->agent_to_scan, vuldet)) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR);
@@ -5274,7 +5274,7 @@ void wm_vuldet_on_demand_scan(vu_task_context_t* current_task, wm_vuldet_t* vuld
     }
 }
 
-void wm_vuldet_on_demand_feed_update(vu_task_context_t* current_task, wm_vuldet_t* vuldet) {
+void wm_vuldet_on_demand_feed_update(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet) {
     wm_vuldet_create_and_send_message(current_task, WM_TASK_IN_PROGRESS, NULL);
     if (wm_vuldet_run_update(vuldet->updates)) {
         wm_vuldet_create_and_send_message(current_task, WM_TASK_FAILED, NULL);
@@ -5284,7 +5284,7 @@ void wm_vuldet_on_demand_feed_update(vu_task_context_t* current_task, wm_vuldet_
     }
 }
 
-void wm_vuldet_feed_update_by_interval(vu_task_context_t* current_task, wm_vuldet_t* vuldet) {
+void wm_vuldet_feed_update_by_interval(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet) {
     int8_t feed_updated = 0;     // Unused variable
     char status_message[OS_SIZE_64] = {0};
     bool result = 0;
@@ -5317,7 +5317,7 @@ void wm_vuldet_feed_update_by_interval(vu_task_context_t* current_task, wm_vulde
     wm_vuldet_clean_after_run_update();
 }
 
-void wm_vuldet_scan_by_interval(vu_task_context_t* current_task, wm_vuldet_t* vuldet) {
+void wm_vuldet_scan_by_interval(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet) {
     int* agents_array = NULL;
     int i = 0;
     int sock = wm_vuldet_get_wdb_socket();
@@ -5347,7 +5347,7 @@ void wm_vuldet_scan_by_interval(vu_task_context_t* current_task, wm_vuldet_t* vu
             }
         }
         i++;
-        current_task = (vu_task_context_t*) linked_queue_read_ex(vu_tasks_queue);
+        current_task = (vu_task_ctx_t*) linked_queue_read_ex(vu_tasks_queue);
     }
     mtinfo(WM_VULNDETECTOR_LOGTAG, VU_END_SCAN);
 
@@ -5357,10 +5357,10 @@ void wm_vuldet_scan_by_interval(vu_task_context_t* current_task, wm_vuldet_t* vu
 
 void wm_vuldet_working_thread(void* vuldet_data) {
     wm_vuldet_t* vuldet = (wm_vuldet_t*) vuldet_data;
-    vu_task_context_t* current_task = NULL;
+    vu_task_ctx_t* current_task = NULL;
 
     while (wm_vuldet_working_thread_active) {
-        current_task = (vu_task_context_t*) linked_queue_read_ex(vu_tasks_queue);
+        current_task = (vu_task_ctx_t*) linked_queue_read_ex(vu_tasks_queue);
         if (current_task) {
             switch (current_task->task_type) {
                 case VU_ON_DEMAND_SCAN:
@@ -5380,7 +5380,7 @@ void wm_vuldet_working_thread(void* vuldet_data) {
                     break;
             }
             // Removing task from queue
-            vu_tasks_task_context_free((vu_task_context_t*) linked_queue_pop_ex(vu_tasks_queue));
+            vu_tasks_task_context_free((vu_task_ctx_t*) linked_queue_pop_ex(vu_tasks_queue));
         } else {
             sleep(1);
         }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4710,7 +4710,6 @@ int wm_vuldet_run_update(update_node **updates) {
             // If none of RedHat's OVALs have been updated,
             // we can deduce that the JSON is already up to date.
             if (updates[os]->dist_ref == FEED_JREDHAT && up_status == 1) {
-                updates[os]->last_sync = time(NULL);
                 mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UPDATE_DATE, vu_feed_ext[FEED_JREDHAT]);
                 continue;
             }
@@ -7967,7 +7966,6 @@ int wm_vuldet_run_scan(wm_vuldet_t *vuldet) {
 
     if (wm_vuldet_nvd_empty() == 0) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_NVD_EMPTY);
-        vuldet->last_scan = time(NULL);
         return result;
     }
 
@@ -7988,36 +7986,6 @@ int wm_vuldet_run_scan(wm_vuldet_t *vuldet) {
     vuldet->scan_agents = NULL;
 
     return result;
-}
-
-void wm_vuldet_run_sleep(wm_vuldet_t * vuldet) {
-    time_t t_now = time(NULL);
-    time_t time_sleep = (vuldet->last_scan + vuldet->scan_interval) - t_now;
-    int i;
-
-    if (time_sleep <= 0) {
-        time_sleep = 1;
-        i = OS_SUPP_SIZE;
-    } else {
-        i = 0;
-    }
-
-    // Check the remaining time for all updates and adjust the sleep time
-    for (; i < OS_SUPP_SIZE; i++) {
-        if (vuldet->updates[i]) {
-            time_t t_diff = (vuldet->updates[i]->last_sync + vuldet->updates[i]->interval) - t_now;
-            // Stop checking if we have any pending updates
-            if (t_diff <= 0) {
-                time_sleep = 1;
-                break;
-            } else if (t_diff < time_sleep) {
-                time_sleep = t_diff;
-            }
-        }
-    }
-
-    mtdebug2(WM_VULNDETECTOR_LOGTAG, "Sleeping for %lu seconds...", time_sleep);
-    sleep(time_sleep);
 }
 
 void wm_vuldet_init(wm_vuldet_t * vuldet) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5285,15 +5285,35 @@ void wm_vuldet_on_demand_feed_update(vu_task_context_t* current_task, wm_vuldet_
 }
 
 void wm_vuldet_feed_update_by_interval(vu_task_context_t* current_task, wm_vuldet_t* vuldet) {
-    int8_t feed_updated = 0;
+    int8_t feed_updated = 0;     // Unused variable
+    char status_message[OS_SIZE_64] = {0};
+    bool result = 0;
 
-    wm_vuldet_create_and_send_message(current_task, WM_TASK_IN_PROGRESS, NULL);
-    if (!vuldet->updates || wm_vuldet_update_feed((vuldet->updates)[current_task->feed_to_update], &feed_updated)) {
+    if (!vuldet->updates) {
+        return;
+    }
+
+    for (int os = 0; os < OS_SUPP_SIZE; os++) {
+        if (!(vuldet->updates)[os]) {
+            continue;
+        }
+
+        if ((vuldet->updates[os])->dist_ref == current_task->feed_to_update) {
+            snprintf(status_message, OS_SIZE_64, " Updating OS: %s.", vu_feed_tag[(vuldet->updates[os])->dist_tag_ref]);
+            wm_vuldet_create_and_send_message(current_task, WM_TASK_IN_PROGRESS, status_message);
+            if (wm_vuldet_update_feed((vuldet->updates)[os], &feed_updated)) {
+                result = 1;
+            }
+        }
+    }
+
+    if (result) {
         wm_vuldet_create_and_send_message(current_task, WM_TASK_FAILED, NULL);
         mterror(WM_VULNDETECTOR_LOGTAG, VU_OVAL_UPDATE_ERROR);
     } else {
         wm_vuldet_create_and_send_message(current_task, WM_TASK_DONE, NULL);
     }
+
     wm_vuldet_clean_after_run_update();
 }
 
@@ -5307,7 +5327,7 @@ void wm_vuldet_scan_by_interval(vu_task_context_t* current_task, wm_vuldet_t* vu
     if (wm_vuldet_collect_agent_info(000, vuldet)) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR);
     } else {
-        snprintf(status_message, OS_SIZE_64, "Agent: manager.");
+        snprintf(status_message, OS_SIZE_64, " Agent: manager.");
         wm_vuldet_create_and_send_message(current_task, WM_TASK_IN_PROGRESS, status_message);
         if (wm_vuldet_run_scan(vuldet)) {
             mterror(WM_VULNDETECTOR_LOGTAG, VU_AG_CHECK_ERR);
@@ -5320,14 +5340,14 @@ void wm_vuldet_scan_by_interval(vu_task_context_t* current_task, wm_vuldet_t* vu
         if (wm_vuldet_collect_agent_info(agents_array[i], vuldet)) {
             mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR);
         } else {
-            snprintf(status_message, OS_SIZE_64, "Agent: %.3d.", agents_array[i]);
+            snprintf(status_message, OS_SIZE_64, " Agent: %.3d.", agents_array[i]);
             wm_vuldet_create_and_send_message(current_task, WM_TASK_IN_PROGRESS, status_message);
             if (wm_vuldet_run_scan(vuldet)) {
                 mterror(WM_VULNDETECTOR_LOGTAG, VU_AG_CHECK_ERR);
             }
         }
         i++;
-        current_task = linked_queue_read_ex(vu_tasks_queue);
+        current_task = (vu_task_context_t*) linked_queue_read_ex(vu_tasks_queue);
     }
     mtinfo(WM_VULNDETECTOR_LOGTAG, VU_END_SCAN);
 
@@ -5336,11 +5356,11 @@ void wm_vuldet_scan_by_interval(vu_task_context_t* current_task, wm_vuldet_t* vu
 }
 
 void wm_vuldet_working_thread(void* vuldet_data) {
-    wm_vuldet_t* vuldet = vuldet_data;
+    wm_vuldet_t* vuldet = (wm_vuldet_t*) vuldet_data;
     vu_task_context_t* current_task = NULL;
 
     while (wm_vuldet_working_thread_active) {
-        current_task = linked_queue_read_ex(vu_tasks_queue);
+        current_task = (vu_task_context_t*) linked_queue_read_ex(vu_tasks_queue);
         if (current_task) {
             switch (current_task->task_type) {
                 case VU_ON_DEMAND_SCAN:
@@ -5360,7 +5380,7 @@ void wm_vuldet_working_thread(void* vuldet_data) {
                     break;
             }
             // Removing task from queue
-            vu_tasks_task_context_free(linked_queue_pop_ex(vu_tasks_queue));
+            vu_tasks_task_context_free((vu_task_context_t*) linked_queue_pop_ex(vu_tasks_queue));
         } else {
             sleep(1);
         }
@@ -5430,6 +5450,9 @@ void *wm_vuldet_main(wm_vuldet_t* vuldet) {
 
                 wm_vuldet_run_sleep(vuldet);
             }
+            wm_vuldet_working_thread_active = 0;
+            // Join threads
+            pthread_join(working_thread, NULL);
         }
     }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -197,24 +197,13 @@ STATIC vu_feed wm_vuldet_set_allowed_feed(const char *os_name, const char *os_ve
 time_t wm_vuldet_get_last_feed_update(vu_feed feed);
 
 /**
- * @brief Initialize the main structure linked list of agents for later analysis.
- *
- * @param vuldet The vulnerability detector main data structure.
- * @param scan_by_interval Flag if set, specifies that only connected agents will be collected.
- * @return 0 on success, -1 otherwise.
- */
-STATIC int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet, bool scan_by_interval);
-
-/**
  * @brief Collects information from a given agent ID.
  *
  * @param agent_id Agent identifier.
  * @param vuldet The vulnerability detector main data structure.
- * @param agent The agent main data structure.
- * @param sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return 0 on success, -1 otherwise.
  */
-STATIC int wm_vuldet_collect_agent_info(int agent_id, wm_vuldet_t *vuldet, scan_agent *agent, int *sock);
+STATIC int wm_vuldet_collect_agent_info(int agent_id, wm_vuldet_t *vuldet);
 
 /**
  * @brief Compare two packages structures (src_name, bin_name, version and arch).
@@ -428,6 +417,7 @@ int usec;
 
 w_linked_queue_t *vu_messages_queue = NULL;
 w_linked_queue_t* vu_tasks_queue = NULL;
+w_linked_queue_t* vu_messages_queue = NULL;
 
 const wm_context WM_VULNDETECTOR_CONTEXT = {
     "vulnerability-detector",
@@ -679,6 +669,13 @@ void task_message_free(vu_task_message_ctx_t *msg) {
     }
     os_free(msg);
 }
+
+void vu_tasks_task_context_free (vu_task_context_t* task) {
+    os_free(task);
+}
+
+// Vulnerability detector threads flags
+static volatile int wm_vuldet_working_thread_active = 1;
 
 vu_feed wm_vuldet_set_allowed_feed(const char *os_name, const char *os_version, update_node **updates, vu_feed *agent_dist) {
     vu_feed retval = FEED_UNKNOWN;
@@ -4606,7 +4603,7 @@ int wm_vuldet_check_feed(update_node *upd, int8_t *updated) {
         if (!wm_vuldet_silent_feed(upd->dist_tag_ref)) {
             mtinfo(WM_VULNDETECTOR_LOGTAG, VU_ENDING_UPDATE, upd->dist_ext);
         } else {
-            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_STARTING_UPDATE, vu_feed_ext[upd->dist_tag_ref]);
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_ENDING_UPDATE, vu_feed_ext[upd->dist_tag_ref]);
         }
         upd->last_sync = time(NULL);
         time_t last_feed_upd = wm_vuldet_get_last_feed_update(upd->dist_tag_ref);
@@ -4666,6 +4663,13 @@ cJSON *wm_vuldet_get_debian_status_feed(update_node *update) {
     return wm_vuldet_json_fread(VU_DEB_TEMP_FILE);
 }
 
+void wm_vuldet_clean_after_run_update() {
+    // Remove Debian status feed
+    if (remove(VU_DEB_TEMP_FILE) < 0 && errno != ENOENT) {
+        mtdebug2(WM_VULNDETECTOR_LOGTAG, "remove(%s): %s", VU_DEB_TEMP_FILE, strerror(errno));
+    }
+}
+
 int wm_vuldet_run_update(update_node **updates) {
     int ret = 0;
     int8_t updated = 1;
@@ -4693,7 +4697,6 @@ int wm_vuldet_run_update(update_node **updates) {
                 if (updated == -1) {
                     // The CPE helper update failed (updated is only set to -1 when evaluating the CPE helper)
                     wm_vuldet_release_update_node(updates, CPE_WDIC);
-                    wm_vuldet_release_update_node(updates, CVE_NVD);
                     continue;
                 }
             }
@@ -4707,10 +4710,7 @@ int wm_vuldet_run_update(update_node **updates) {
         }
     }
 
-    // Remove Debian status feed
-    if (remove(VU_DEB_TEMP_FILE) < 0 && errno != ENOENT) {
-        mtdebug2(WM_VULNDETECTOR_LOGTAG, "remove(%s): %s", VU_DEB_TEMP_FILE, strerror(errno));
-    }
+    wm_vuldet_clean_after_run_update();
 
     return ret;
 }
@@ -5218,7 +5218,163 @@ w_err_t register_task(vu_task_ctx_t *task) {
     return OS_SUCCESS;
 }
 
-void *wm_vuldet_main(wm_vuldet_t * vuldet) {
+void wm_vuldet_create_and_send_message(vu_task_context_t task, task_status TASK_STATUS, char* details) {
+    wm_vuldet_task_msg_ctx* message = NULL;
+    char status_message[OS_SIZE_128] = {0};
+
+    if (task.taskID != (size_t)OS_INVALID) {
+        os_calloc(1, sizeof(wm_vuldet_task_msg_ctx), message);
+        message->task_id = task.taskID;
+        message->task_status = TASK_STATUS;
+
+        switch (TASK_STATUS) {
+            case WM_TASK_IN_PROGRESS:
+                snprintf(status_message, OS_SIZE_128, "Task in progress.%s", details ? details : "");
+                os_strdup(status_message, message->status_message);
+                break;
+            case WM_TASK_CANCELLED:
+                snprintf(status_message, OS_SIZE_128, "Task cancelled by the user.%s", details ? details : "");
+                os_strdup(status_message, message->status_message);
+                break;
+            case WM_TASK_DONE:
+                snprintf(status_message, OS_SIZE_128, "Task completed.%s", details ? details : "");
+                os_strdup(status_message, message->status_message);
+                break;
+            case WM_TASK_FAILED:
+                snprintf(status_message, OS_SIZE_128, "Task failed.%s", details ? details : "");
+                os_strdup(status_message, message->status_message);
+                break;
+            default:
+                os_free(message);
+                message = NULL;
+                break;
+        }
+        if (message) {
+            linked_queue_push_ex(vu_messages_queue, (void*) message);
+        }
+    }
+}
+
+void wm_vuldet_on_demand_scan(vu_task_context_t* current_task, wm_vuldet_t* vuldet) {
+    wm_vuldet_create_and_send_message(*current_task, WM_TASK_IN_PROGRESS, NULL);
+    if (wm_vuldet_collect_agent_info(current_task->agent_to_scan, vuldet)) {
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR);
+        wm_vuldet_create_and_send_message(*current_task, WM_TASK_FAILED, NULL);
+    } else {
+        if (wm_vuldet_run_scan(vuldet)) {
+            wm_vuldet_create_and_send_message(*current_task, WM_TASK_DONE, NULL);
+        } else {
+            wm_vuldet_create_and_send_message(*current_task, WM_TASK_FAILED, NULL);
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_AG_CHECK_ERR);
+        }
+    }
+}
+
+void wm_vuldet_on_demand_feed_update(vu_task_context_t* current_task, wm_vuldet_t* vuldet) {
+    wm_vuldet_create_and_send_message(*current_task, WM_TASK_IN_PROGRESS, NULL);
+    if (wm_vuldet_run_update(vuldet->updates)) {
+        wm_vuldet_create_and_send_message(*current_task, WM_TASK_FAILED, NULL);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_OVAL_UPDATE_ERROR);
+    } else {
+        wm_vuldet_create_and_send_message(*current_task, WM_TASK_DONE, NULL);
+    }
+}
+
+void wm_vuldet_feed_update_by_interval(vu_task_context_t* current_task, wm_vuldet_t* vuldet) {
+    int8_t feed_updated = 0;
+
+    wm_vuldet_create_and_send_message(*current_task, WM_TASK_IN_PROGRESS, NULL);
+    if (!vuldet->updates || wm_vuldet_update_feed((vuldet->updates)[current_task->feed_to_update], &feed_updated)) {
+        wm_vuldet_create_and_send_message(*current_task, WM_TASK_FAILED, NULL);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_OVAL_UPDATE_ERROR);
+    } else {
+        wm_vuldet_create_and_send_message(*current_task, WM_TASK_DONE, NULL);
+    }
+    wm_vuldet_clean_after_run_update();
+}
+
+void wm_vuldet_scan_by_interval(vu_task_context_t* current_task, wm_vuldet_t* vuldet) {
+    int* agents_array = NULL;
+    int i = 0;
+    int sock = wm_vuldet_get_wdb_socket();
+    char status_message[OS_SIZE_64] = {0};
+
+    // Scaning the manager
+    if (wm_vuldet_collect_agent_info(000, vuldet)) {
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR);
+    } else {
+        snprintf(status_message, OS_SIZE_64, "Agent: manager.");
+        wm_vuldet_create_and_send_message(*current_task, WM_TASK_IN_PROGRESS, status_message);
+        if (wm_vuldet_run_scan(vuldet)) {
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_AG_CHECK_ERR);
+        }
+    }
+
+    // Scanning agents
+    agents_array = wdb_get_agents_by_connection_status(AGENT_CS_ACTIVE, &sock);
+    while(agents_array && agents_array[i] != OS_INVALID && current_task && WM_TASK_CANCELLED != current_task->task_status) {
+        if (wm_vuldet_collect_agent_info(agents_array[i], vuldet)) {
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR);
+        } else {
+            snprintf(status_message, OS_SIZE_64, "Agent: %.3d.", agents_array[i]);
+            wm_vuldet_create_and_send_message(*current_task, WM_TASK_IN_PROGRESS, status_message);
+            if (wm_vuldet_run_scan(vuldet)) {
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_AG_CHECK_ERR);
+            }
+        }
+        i++;
+        current_task = linked_queue_read_ex(vu_tasks_queue);
+    }
+    mtinfo(WM_VULNDETECTOR_LOGTAG, VU_END_SCAN);
+
+    wm_vuldet_create_and_send_message(*current_task, WM_TASK_DONE, NULL);
+    os_free(agents_array);
+}
+
+void wm_vuldet_working_thread(void* vuldet_data) {
+    wm_vuldet_t* vuldet = vuldet_data;
+    vu_task_context_t* current_task = NULL;
+
+    while (wm_vuldet_working_thread_active) {
+        current_task = linked_queue_read_ex(vu_tasks_queue);
+        if (current_task) {
+            switch (current_task->task_type) {
+                case VU_ON_DEMAND_SCAN:
+                    wm_vuldet_on_demand_scan(current_task, vuldet);
+                    break;
+                case VU_ON_DEMAND_FEED_UPDATE:
+                    wm_vuldet_on_demand_feed_update(current_task, vuldet);
+                    break;
+                case VU_INTERVAL_FEED_UPDATE:
+                    wm_vuldet_feed_update_by_interval(current_task, vuldet);
+                    break;
+                case VU_INTERVAL_SCAN:
+                    wm_vuldet_scan_by_interval(current_task, vuldet);
+                    break;
+                default:
+                    mdebug1("Invalid task type for vulnerability detector.");
+                    break;
+            }
+            // Removing task from queue
+            vu_tasks_task_context_free(linked_queue_pop_ex(vu_tasks_queue));
+        } else {
+            sleep(1);
+        }
+    }
+}
+
+int wm_vuldet_run_working_thread(pthread_t* working_thread, wm_vuldet_t* vuldet) {
+    int status;
+
+    if (status = pthread_create(working_thread, NULL, (void*)&wm_vuldet_working_thread, (void*) vuldet), status != 0) {
+        mwarn("Couldn't create vulnerability detector working thread: %s", strerror(status));
+        return OS_INVALID;
+    }
+
+    return OS_SUCCESS;
+}
+
+void *wm_vuldet_main(wm_vuldet_t* vuldet) {
     wm_vuldet_init(vuldet);
 
     wm_vuldet_check_db();
@@ -5232,33 +5388,28 @@ void *wm_vuldet_main(wm_vuldet_t * vuldet) {
             mterror(WM_VULNDETECTOR_LOGTAG, VU_OVAL_UPDATE_ERROR);
         }
 
-        if ((curr_time - vuldet->last_scan >= vuldet->scan_interval)) {
-            if (!VU_TASKS_QUEUE_FLAGS[VU_INTERVAL_SCAN]) {
-                vu_task_ctx_t *task = create_task(OS_INVALID, VU_INTERVAL_SCAN, WM_TASK_PENDING, FEED_UNKNOWN, OS_INVALID);
-                if (OS_INVALID == register_task(task)) {
-                    mwarn("Couldn't establish communication with task manager. There's no ID for task");
+        pthread_t working_thread;
+        if (OS_SUCCESS == wm_vuldet_run_working_thread(&working_thread, vuldet)) {
+            while (true) {
+                curr_time = time(NULL);
+                // Update CVE databases
+                if (vuldet->flags.update && wm_vuldet_run_update(vuldet->updates)) {
+                    mterror(WM_VULNDETECTOR_LOGTAG, VU_OVAL_UPDATE_ERROR);
                 }
-                linked_queue_push_ex(vu_tasks_queue, task);
-            } else {
-                vuldet->last_scan = curr_time;
-            }
-            wm_vuldet_run_scan(vuldet);
-        }
 
-        /* Checks for messages in the queue */
-        vu_task_message_ctx_t *msg = (vu_task_message_ctx_t *)linked_queue_pop_ex_no_cond_wait(vu_messages_queue);
-        while(msg) {
-            /* TODO: Dummy message that represents the interaction with the task manager */
-            minfo("Task ID: '%d' status: '%s' message: '%s'", msg->task_id, task_statuses[msg->task_status], msg->status_message);
-            task_message_free(msg);
-            msg = (vu_task_message_ctx_t *)linked_queue_pop_ex_no_cond_wait(vu_messages_queue);
+                if ((curr_time - vuldet->last_scan >= vuldet->scan_interval)) {
+                    wm_vuldet_run_scan(vuldet);
+                }
+
+                wm_vuldet_run_sleep(vuldet);
+            }
         }
     }
 
     return NULL;
 }
 
-int wm_vuldet_collect_agent_info(int agent_id, wm_vuldet_t *vuldet, scan_agent *agent, int *sock) {
+int wm_vuldet_collect_agent_info(int agent_id, wm_vuldet_t *vuldet) {
     cJSON *j_agent_info = NULL;
     cJSON *j_osinfo = NULL;
     cJSON *j_field = NULL;
@@ -5268,9 +5419,16 @@ int wm_vuldet_collect_agent_info(int agent_id, wm_vuldet_t *vuldet, scan_agent *
     int dist_error = -1;
     bool is_rolling = FALSE;
     w_err_t ret = OS_SUCCESS;
+    scan_agent *agent = NULL;
+    int sock = wm_vuldet_get_wdb_socket();
+
+    // Prepare and fill structure.
+    os_calloc(1, sizeof(scan_agent), agent);
+    agent->next = NULL;
+    vuldet->scan_agents = agent;
 
     // Getting agent-info data from global.db.
-    j_agent_info = wdb_get_agent_info(agent_id, sock);
+    j_agent_info = wdb_get_agent_info(agent_id, &sock);
     if (!j_agent_info) {
         mdebug1("Failed to get agent '%.3d' information from Wazuh DB.", agent_id);
         ret = OS_INVALID;
@@ -5482,7 +5640,7 @@ int wm_vuldet_collect_agent_info(int agent_id, wm_vuldet_t *vuldet, scan_agent *
     }
 
     // Getting sys_osinfo data from agent database.
-    if (j_osinfo = wdb_get_agent_sys_osinfo(agent_id, sock), !j_osinfo) {
+    if (j_osinfo = wdb_get_agent_sys_osinfo(agent_id, &sock), !j_osinfo) {
         mdebug1("Failed to get agent '%.3d' OS information from Wazuh DB.", agent_id);
         ret = OS_INVALID;
         goto next;
@@ -5584,58 +5742,12 @@ int wm_vuldet_collect_agent_info(int agent_id, wm_vuldet_t *vuldet, scan_agent *
 next:
     if (j_agent_info) cJSON_Delete(j_agent_info);
     if (j_osinfo) cJSON_Delete(j_osinfo);
+    if (OS_INVALID == ret) {
+        wm_vuldet_free_scan_agent(agent);
+        vuldet->scan_agents = NULL;
+    }
 
     return ret;
-}
-
-int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet, bool scan_by_interval) {
-    scan_agent *agent = NULL;
-    scan_agent *f_agent = NULL;
-    int set_manager = 1;
-    int i = 0;
-    int *id_array = NULL;
-    int sock = wm_vuldet_get_wdb_socket();
-
-    if (sock < 0) {
-        mdebug1("Failed getting Wazuh DB socket connection.");
-        return OS_INVALID;
-    }
-
-    if (scan_by_interval) {
-        id_array = wdb_get_agents_by_connection_status(AGENT_CS_ACTIVE, &sock);
-    } else {
-        //id_array = TODO: Scan on demand;
-        set_manager = 0;
-    }
-
-    while (set_manager || (id_array && id_array[i] != -1)) {
-        int id = 0;
-
-        if (set_manager) {
-            id = --set_manager;
-        } else {
-            id = id_array[i++];
-        }
-
-        // Prepare and fill structure.
-        if (!agent) {
-            os_calloc(1, sizeof(scan_agent), agent);
-            f_agent = agent;
-        } else {
-            os_calloc(1, sizeof(scan_agent), agent->next);
-            agent = agent->next;
-        }
-        agent->next = NULL;
-
-        if (wm_vuldet_collect_agent_info(id, vuldet, agent, &sock)) {
-            os_free(id_array)
-            return OS_INVALID;
-        }
-    }
-
-    vuldet->scan_agents = f_agent;
-    os_free(id_array);
-    return OS_SUCCESS;
 }
 
 void wm_vuldet_destroy(wm_vuldet_t * vuldet) {
@@ -7785,26 +7897,17 @@ cpe *wm_vuldet_generate_cpe(const char *part, const char *vendor, const char *pr
     return new_cpe;
 }
 
-void wm_vuldet_run_scan(wm_vuldet_t *vuldet) {
+int wm_vuldet_run_scan(wm_vuldet_t *vuldet) {
+    int result = OS_INVALID;
     mtinfo(WM_VULNDETECTOR_LOGTAG, VU_START_SCAN);
 
     if (wm_vuldet_nvd_empty() == 0) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_NVD_EMPTY);
         vuldet->last_scan = time(NULL);
-        return;
+        return result;
     }
 
-    // TODO: The value for the parameter scan_by_interval (hardcoded as TRUE)
-    // must be defined before calling the function.
-    if (wm_vuldet_collect_agents_to_scan(vuldet, TRUE)) {
-        mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR);
-    } else {
-        if (wm_vuldet_check_agent_vulnerabilities(vuldet)) {
-            mterror(WM_VULNDETECTOR_LOGTAG, VU_AG_CHECK_ERR);
-        } else {
-            mtinfo(WM_VULNDETECTOR_LOGTAG, VU_END_SCAN);
-        }
-    }
+    result = wm_vuldet_check_agent_vulnerabilities(vuldet);
 
     scan_agent *agent;
     for (agent = vuldet->scan_agents; agent;) {
@@ -7820,6 +7923,38 @@ void wm_vuldet_run_scan(wm_vuldet_t *vuldet) {
 
     vuldet->scan_agents = NULL;
     vuldet->last_scan = time(NULL);
+
+    return result;
+}
+
+void wm_vuldet_run_sleep(wm_vuldet_t * vuldet) {
+    time_t t_now = time(NULL);
+    time_t time_sleep = (vuldet->last_scan + vuldet->scan_interval) - t_now;
+    int i;
+
+    if (time_sleep <= 0) {
+        time_sleep = 1;
+        i = OS_SUPP_SIZE;
+    } else {
+        i = 0;
+    }
+
+    // Check the remaining time for all updates and adjust the sleep time
+    for (; i < OS_SUPP_SIZE; i++) {
+        if (vuldet->updates[i]) {
+            time_t t_diff = (vuldet->updates[i]->last_sync + vuldet->updates[i]->interval) - t_now;
+            // Stop checking if we have any pending updates
+            if (t_diff <= 0) {
+                time_sleep = 1;
+                break;
+            } else if (t_diff < time_sleep) {
+                time_sleep = t_diff;
+            }
+        }
+    }
+
+    mtdebug2(WM_VULNDETECTOR_LOGTAG, "Sleeping for %lu seconds...", time_sleep);
+    sleep(time_sleep);
 }
 
 void wm_vuldet_init(wm_vuldet_t * vuldet) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -881,13 +881,13 @@ typedef struct scan_ctx_t {
 } scan_ctx_t;
 
 // Task context for vu_tasks_queue
-typedef struct vu_task_context_t {
-    size_t taskID;
+typedef struct vu_task_ctx_t {
+    int taskID;
     vu_task_type_t task_type;
     task_status task_status;
     vu_feed feed_to_update;
-    size_t agent_to_scan;
-} vu_task_context_t;
+    int agent_to_scan;
+} vu_task_ctx_t;
 
 // Macros
 #define wm_vuldet_is_single_provider(x) (x == FEED_UBUNTU || x == FEED_DEBIAN || x == FEED_REDHAT || x == FEED_ALAS)
@@ -988,7 +988,7 @@ void wm_vuldet_working_thread(void* vuldet_data);
  * @param TASK_STATUS The status of the task to be written in the message.
  * @param details Optional parameter to add more details to the message.
  */
-void wm_vuldet_create_and_send_message(vu_task_context_t* task, task_status TASK_STATUS, char* details);
+void wm_vuldet_create_and_send_message(vu_task_ctx_t* task, task_status TASK_STATUS, char* details);
 
 /**
  * @brief Method to run all the required steps for a scan on demand for a specific agent.
@@ -996,7 +996,7 @@ void wm_vuldet_create_and_send_message(vu_task_context_t* task, task_status TASK
  * @param current_task The task containing the data of the agent to scan.
  * @param vuldet The vulnerability detector structure.
  */
-void wm_vuldet_on_demand_scan(vu_task_context_t* current_task, wm_vuldet_t* vuldet);
+void wm_vuldet_on_demand_scan(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet);
 
 /**
  * @brief Method to run all the required steps for a feed update on demand. All the feeds will be updated.
@@ -1004,7 +1004,7 @@ void wm_vuldet_on_demand_scan(vu_task_context_t* current_task, wm_vuldet_t* vuld
  * @param current_task The task containing the data of the agent to scan.
  * @param vuldet The vulnerability detector structure.
  */
-void wm_vuldet_on_demand_feed_update(vu_task_context_t* current_task, wm_vuldet_t* vuldet);
+void wm_vuldet_on_demand_feed_update(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet);
 
 /**
  * @brief Method to run all the required steps for a feed update by interval. Only the specified feed will be updated.
@@ -1012,7 +1012,7 @@ void wm_vuldet_on_demand_feed_update(vu_task_context_t* current_task, wm_vuldet_
  * @param current_task The task containing the data of the agent to scan.
  * @param vuldet The vulnerability detector structure.
  */
-void wm_vuldet_feed_update_by_interval(vu_task_context_t* current_task, wm_vuldet_t* vuldet);
+void wm_vuldet_feed_update_by_interval(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet);
 
 /**
  * @brief Method to run all the required steps for a scan by interval. All the connected agents and the manager
@@ -1021,7 +1021,7 @@ void wm_vuldet_feed_update_by_interval(vu_task_context_t* current_task, wm_vulde
  * @param current_task The task containing the data of the agent to scan.
  * @param vuldet The vulnerability detector structure.
  */
-void wm_vuldet_scan_by_interval(vu_task_context_t* current_task, wm_vuldet_t* vuldet);
+void wm_vuldet_scan_by_interval(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet);
 
 /**
  * @brief Performs all the required cleaning actions after a feed update.

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -885,8 +885,8 @@ typedef struct vu_task_context_t {
     size_t taskID;
     vu_task_type_t task_type;
     task_status task_status;
-    cve_db feed_to_update;
-    int agent_to_scan;
+    vu_feed feed_to_update;
+    size_t agent_to_scan;
 } vu_task_context_t;
 
 // Macros

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -988,7 +988,7 @@ void wm_vuldet_working_thread(void* vuldet_data);
  * @param TASK_STATUS The status of the task to be written in the message.
  * @param details Optional parameter to add more details to the message.
  */
-void wm_vuldet_create_and_send_message(vu_task_context_t task, task_status TASK_STATUS, char* details);
+void wm_vuldet_create_and_send_message(vu_task_context_t* task, task_status TASK_STATUS, char* details);
 
 /**
  * @brief Method to run all the required steps for a scan on demand for a specific agent.
@@ -1022,6 +1022,12 @@ void wm_vuldet_feed_update_by_interval(vu_task_context_t* current_task, wm_vulde
  * @param vuldet The vulnerability detector structure.
  */
 void wm_vuldet_scan_by_interval(vu_task_context_t* current_task, wm_vuldet_t* vuldet);
+
+/**
+ * @brief Performs all the required cleaning actions after a feed update.
+ *
+ */
+void wm_vuldet_clean_after_run_update();
 
 /**
  * @brief Correlate OVAL and NVD feeds for a more fine tuned result.

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -27,7 +27,6 @@
 #define WM_VULNDETECTOR_DEFAULT_TIMEOUT 300 // 5 minutes
 #define WM_VULNDETECTOR_NVD_UPDATE_INTERVAL 86400 // 1 day
 #define WM_VULNDETECTOR_DEFAULT_CPE_UPDATE_INTERVAL 86400 // 1 day
-#define WM_VULNDETECTOR_RETRY_UPDATE  300 // 5 minutes
 #define WM_VULNDETECTOR_ONLY_ONE_UPD UINT_MAX
 #define WM_VULNDETECTOR_MAX_AGENT_SCAN_ATTEMPS 5
 #define WM_VULNDETECTOR_DOWN_ATTEMPTS  5
@@ -308,7 +307,7 @@ typedef enum vu_feed {
     FEED_CPEW,
     FEED_MSU,
     FEED_MAC,
-    FEED_UNKNOWN
+    FEED_UNKNOWN   // This must be the last one
 } vu_feed;
 
 typedef enum vu_ver_comp {
@@ -352,11 +351,11 @@ typedef struct vu_task_ctx_t {
 } vu_task_ctx_t;
 
 // Message task context for vu_messages_queue
-typedef struct vu_task_message_ctx_t {
+typedef struct vu_task_msg_ctx_t {
     int task_id;
     task_status task_status;
     char *status_message;
-} vu_task_message_ctx_t;
+} vu_task_msg_ctx_t;
 
 typedef struct cve_vuln_cond_NVD {
     int id;
@@ -486,7 +485,6 @@ typedef struct update_node {
         char **allowed_os_name;
         char **allowed_os_ver;
     };
-    unsigned int attempted:1;
     unsigned int json_format:1;
     unsigned int custom_location:1;
 } update_node;
@@ -880,15 +878,6 @@ typedef struct scan_ctx_t {
     bool            package_scan;
 } scan_ctx_t;
 
-// Task context for vu_tasks_queue
-typedef struct vu_task_ctx_t {
-    int taskID;
-    vu_task_type_t task_type;
-    task_status task_status;
-    vu_feed feed_to_update;
-    int agent_to_scan;
-} vu_task_ctx_t;
-
 // Macros
 #define wm_vuldet_is_single_provider(x) (x == FEED_UBUNTU || x == FEED_DEBIAN || x == FEED_REDHAT || x == FEED_ALAS)
 #define wm_vuldet_silent_feed(x) (x == FEED_CPEW)
@@ -954,7 +943,7 @@ vu_task_ctx_t *create_task(const int task_id,
  *
  * @param msg Struct to be freed.
  */
-void task_message_free(vu_task_message_ctx_t *msg);
+void vu_task_msg_ctx_free(vu_task_msg_ctx_t *msg);
 
 /**
  * @brief Sends information to the task manager and receives a task ID.
@@ -1028,6 +1017,13 @@ void wm_vuldet_scan_by_interval(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet
  *
  */
 void wm_vuldet_clean_after_run_update();
+
+/**
+ * @brief Creates a new task for every vendor to update.
+ *
+ * @param updates The update nodes array.
+ */
+void wm_vuldet_schedule_updates(update_node **updates);
 
 /**
  * @brief Correlate OVAL and NVD feeds for a more fine tuned result.

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -880,6 +880,15 @@ typedef struct scan_ctx_t {
     bool            package_scan;
 } scan_ctx_t;
 
+// Task context for vu_tasks_queue
+typedef struct vu_task_context_t {
+    size_t taskID;
+    vu_task_type_t task_type;
+    task_status task_status;
+    cve_db feed_to_update;
+    int agent_to_scan;
+} vu_task_context_t;
+
 // Macros
 #define wm_vuldet_is_single_provider(x) (x == FEED_UBUNTU || x == FEED_DEBIAN || x == FEED_REDHAT || x == FEED_ALAS)
 #define wm_vuldet_silent_feed(x) (x == FEED_CPEW)
@@ -954,6 +963,65 @@ void task_message_free(vu_task_message_ctx_t *msg);
  * @return w_err_t OS_SUCCESS if the communication was successfully established. OS_INVALID otherwise.
  */
 w_err_t register_task(vu_task_ctx_t *task);
+
+/**
+ * @brief Launches the vulnerability detector working thread.
+ *
+ * @param working_thread The thread identifier.
+ * @param vuldet The vulnerability detector structure.
+ * @return int OS_SUCCESS if the thread was launched, OS_INVALID otherwise.
+ */
+int wm_vuldet_run_working_thread(pthread_t* working_thread, wm_vuldet_t* vuldet);
+
+/**
+ * @brief Main loop to read and execute vulnerability detector scheduled tasks.
+ *
+ * @param vuldet_data Vulnerability detector data structure.
+ */
+void wm_vuldet_working_thread(void* vuldet_data);
+
+/**
+ * @brief Method to create a message from a task and a status and push it to the messages queue.
+ *        If the task has an invalid task ID, the message is discarded.
+ *
+ * @param task The task to create the message from.
+ * @param TASK_STATUS The status of the task to be written in the message.
+ * @param details Optional parameter to add more details to the message.
+ */
+void wm_vuldet_create_and_send_message(vu_task_context_t task, task_status TASK_STATUS, char* details);
+
+/**
+ * @brief Method to run all the required steps for a scan on demand for a specific agent.
+ *
+ * @param current_task The task containing the data of the agent to scan.
+ * @param vuldet The vulnerability detector structure.
+ */
+void wm_vuldet_on_demand_scan(vu_task_context_t* current_task, wm_vuldet_t* vuldet);
+
+/**
+ * @brief Method to run all the required steps for a feed update on demand. All the feeds will be updated.
+ *
+ * @param current_task The task containing the data of the agent to scan.
+ * @param vuldet The vulnerability detector structure.
+ */
+void wm_vuldet_on_demand_feed_update(vu_task_context_t* current_task, wm_vuldet_t* vuldet);
+
+/**
+ * @brief Method to run all the required steps for a feed update by interval. Only the specified feed will be updated.
+ *
+ * @param current_task The task containing the data of the agent to scan.
+ * @param vuldet The vulnerability detector structure.
+ */
+void wm_vuldet_feed_update_by_interval(vu_task_context_t* current_task, wm_vuldet_t* vuldet);
+
+/**
+ * @brief Method to run all the required steps for a scan by interval. All the connected agents and the manager
+ *        will be scanned.
+ *
+ * @param current_task The task containing the data of the agent to scan.
+ * @param vuldet The vulnerability detector structure.
+ */
+void wm_vuldet_scan_by_interval(vu_task_context_t* current_task, wm_vuldet_t* vuldet);
 
 /**
  * @brief Correlate OVAL and NVD feeds for a more fine tuned result.


### PR DESCRIPTION
|Related issue|
|---|
|#13129|

## Description

This PR creates and launches a working thread for vulnerability detector. It will:
- Read the tasks queue and execute
- Push frequent messages to the queue regarding the task state

For these tasks, it was necessary to modify the current vulnerability detector scan structure. Now every consists of a single agent.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report

<!-- Checks for huge PRs that affect the product more generally -->
