### PR TITLE
Prevent the leaky bucket from sleeping more than 1 / EPS

### DIFF
--- a/src/client-agent/buffer.c
+++ b/src/client-agent/buffer.c
@@ -232,7 +232,10 @@ void *dispatch_buffer(__attribute__((unused)) void * arg){
 
         gettime(&ts1);
         time_sub(&ts1, &ts0);
-        delay(&ts1);
+
+        if (ts1.tv_sec >= 0) {
+            delay(&ts1);
+        }
     }
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #12923|

This PR aims to apply the double guard proposed at #12923.

## Tests

- [x] Change the time to one hour earlier as soon as the agent starts. The agent keeps reporting data.
- [x] Change the time to one hour earlier after the agent scans end. The agent keeps reporting data.
- [x] Reset the time. The agent keeps reporting data.