### PR TITLE
Engine - Processing logic

### DIFF
--- a/src/engine/source/base/CMakeLists.txt
+++ b/src/engine/source/base/CMakeLists.txt
@@ -75,6 +75,7 @@ add_library(base STATIC
     utils/ipUtils.hpp
     utils/stringUtils.cpp
     utils/stringUtils.hpp
+    EventHandler.hpp
     )
 
 if(PROFILE_BUILD)

--- a/src/engine/source/base/CMakeLists.txt
+++ b/src/engine/source/base/CMakeLists.txt
@@ -75,7 +75,8 @@ add_library(base STATIC
     utils/ipUtils.hpp
     utils/stringUtils.cpp
     utils/stringUtils.hpp
-    EventHandler.hpp
+    eventHandler.hpp
+    baseTypes.hpp
     )
 
 if(PROFILE_BUILD)

--- a/src/engine/source/base/EventHandler.hpp
+++ b/src/engine/source/base/EventHandler.hpp
@@ -1,0 +1,42 @@
+#ifndef _H_EVENT_HANDLER
+#define _H_EVENT_HANDLER
+
+#include <json.hpp>
+
+namespace Base
+{
+
+class EventHandler
+{
+
+private:
+    bool is_decoded;
+    std::shared_ptr<json::Document> event;
+
+public:
+    /**
+     * @brief Construct a new Event Handler from event
+     *
+     * @param event
+     */
+    EventHandler(std::shared_ptr<json::Document> event)
+        : event {event}
+        , is_decoded {false}
+    {
+    }
+
+    /**
+     * @brief Get the Event
+     *
+     * @return std::shared_ptr<json::Document>
+     */
+    std::shared_ptr<json::Document> getEvent()
+    {
+        return event;
+    }
+};
+
+
+
+} // namespace Base
+#endif

--- a/src/engine/source/base/EventHandler.hpp
+++ b/src/engine/source/base/EventHandler.hpp
@@ -34,9 +34,25 @@ public:
     {
         return event;
     }
+
+    /**
+     * @brief Get the boolean that indicates if the event is decoded
+     *
+     * @return bool
+     */
+    bool getIsDecoded() {
+        return is_decoded;
+    }
+
+    /**
+     * @brief Set the boolean that indicates if the event is decoded
+     *
+     * @param is_decoded
+     */
+    void setIsDecoded(bool is_decoded) {
+        this->is_decoded = is_decoded;
+    }
 };
-
-
 
 } // namespace Base
 #endif

--- a/src/engine/source/base/baseTypes.hpp
+++ b/src/engine/source/base/baseTypes.hpp
@@ -1,15 +1,16 @@
 #ifndef _H_BASE_TYPES
 #define _H_BASE_TYPES
 
+#include "eventHandler.hpp"
+
 #include <rxcpp/rx.hpp>
 
-#include "eventHandler.hpp"
 
 namespace base
 {
     using Event = std::shared_ptr<EventHandler>;
     using Document = json::Document;
-    using DocumentValue = json::Value; // TODO Se usa??
+    using DocumentValue = json::Value;
     using Observable = rxcpp::observable<Event>;
     using Lifter = std::function<Observable(Observable)>;
 }

--- a/src/engine/source/base/baseTypes.hpp
+++ b/src/engine/source/base/baseTypes.hpp
@@ -1,0 +1,17 @@
+#ifndef _H_BASE_TYPES
+#define _H_BASE_TYPES
+
+#include <rxcpp/rx.hpp>
+
+#include "eventHandler.hpp"
+
+namespace base
+{
+    using Event = std::shared_ptr<EventHandler>;
+    using Document = json::Document;
+    using DocumentValue = json::Value; // TODO Se usa??
+    using Observable = rxcpp::observable<Event>;
+    using Lifter = std::function<Observable(Observable)>;
+}
+
+#endif //_H_BASE_TYPES

--- a/src/engine/source/base/eventHandler.hpp
+++ b/src/engine/source/base/eventHandler.hpp
@@ -11,9 +11,9 @@ class EventHandler
 
 private:
     // Control
-    bool is_decoded;
+    bool is_decoded; ///< True if it reached the end of the decoding stage
     // Data
-    std::shared_ptr<json::Document> event;
+    std::shared_ptr<json::Document> event; ///< Event
 
 public:
     /**
@@ -36,6 +36,24 @@ public:
     std::shared_ptr<json::Document> getEvent()
     {
         return event;
+    }
+
+    /**
+     * @brief Get the Decoded
+     *
+     * @return bool
+     */
+    bool getDecoded() {
+        return is_decoded;
+    }
+
+    /**
+     * @brief Set the Decoded
+     *
+     * @param decoded
+     */
+    void setDecoded(bool decoded) {
+        is_decoded = decoded;
     }
 };
 

--- a/src/engine/source/base/eventHandler.hpp
+++ b/src/engine/source/base/eventHandler.hpp
@@ -3,14 +3,16 @@
 
 #include <json.hpp>
 
-namespace Base
+namespace base
 {
 
 class EventHandler
 {
 
 private:
+    // Control
     bool is_decoded;
+    // Data
     std::shared_ptr<json::Document> event;
 
 public:
@@ -23,6 +25,7 @@ public:
         : event {event}
         , is_decoded {false}
     {
+        // TODO Throw exception if shared_ptr is empty
     }
 
     /**
@@ -34,25 +37,9 @@ public:
     {
         return event;
     }
-
-    /**
-     * @brief Get the boolean that indicates if the event is decoded
-     *
-     * @return bool
-     */
-    bool getIsDecoded() {
-        return is_decoded;
-    }
-
-    /**
-     * @brief Set the boolean that indicates if the event is decoded
-     *
-     * @param is_decoded
-     */
-    void setIsDecoded(bool is_decoded) {
-        this->is_decoded = is_decoded;
-    }
 };
+
+
 
 } // namespace Base
 #endif

--- a/src/engine/source/base/eventHandler.hpp
+++ b/src/engine/source/base/eventHandler.hpp
@@ -11,7 +11,7 @@ class EventHandler
 
 private:
     // Control
-    bool is_decoded; ///< True if it reached the end of the decoding stage
+    bool m_isDecoded; ///< True if it reached the end of the decoding stage
     // Data
     std::shared_ptr<json::Document> event; ///< Event
 
@@ -23,7 +23,7 @@ public:
      */
     EventHandler(std::shared_ptr<json::Document> event)
         : event {event}
-        , is_decoded {false}
+        , m_isDecoded {false}
     {
         // TODO Throw exception if shared_ptr is empty
     }
@@ -44,14 +44,14 @@ public:
      * @return return true if it reached the end of the decoding stage
      */
     bool isDecoded() {
-        return is_decoded;
+        return m_isDecoded;
     }
 
     /**
      * @brief Changes event status to decoded
      */
     void setDecoded() {
-        is_decoded = true;
+        m_isDecoded = true;
     }
 };
 

--- a/src/engine/source/base/eventHandler.hpp
+++ b/src/engine/source/base/eventHandler.hpp
@@ -39,21 +39,19 @@ public:
     }
 
     /**
-     * @brief Get the Decoded
+     * @brief Checks if the event was decoded
      *
-     * @return bool
+     * @return return true if it reached the end of the decoding stage
      */
-    bool getDecoded() {
+    bool isDecoded() {
         return is_decoded;
     }
 
     /**
-     * @brief Set the Decoded
-     *
-     * @param decoded
+     * @brief Changes event status to decoded
      */
-    void setDecoded(bool decoded) {
-        is_decoded = decoded;
+    void setDecoded() {
+        is_decoded = true;
     }
 };
 

--- a/src/engine/source/builder/builder.hpp
+++ b/src/engine/source/builder/builder.hpp
@@ -118,6 +118,17 @@ public:
                 std::get<internals::types::AssetBuilder>(
                     internals::Registry::getBuilder("decoder")));
 
+            // TODO This works, but make sure this decoder is always connected last
+            decoderGraph.addNode(internals::types::ConnectableT {
+                "zzz_ByPassDecoder",
+                std::vector<std::string> {},
+                [](base::Observable o) {
+                    return o.filter([](base::Event e) {
+                        return !e->isDecoded();
+                    });
+                },
+                internals::types::ConnectableT::Tracer {"zzz_ByPassDecoder"}}
+            );
             subGraphs.push_back(std::make_tuple(
                 "INPUT_DECODER", decoderGraph, "OUTPUT_DECODER"));
         }

--- a/src/engine/source/builder/builder.hpp
+++ b/src/engine/source/builder/builder.hpp
@@ -63,9 +63,9 @@ private:
     // TODO: only used by operator(), we could use an unnamed struct instead
     struct envBuilder
     {
-        internals::types::Lifter m_lifter;
+        base::Lifter m_lifter;
         std::map<std::string, rxcpp::observable<std::string>> m_traceSinks;
-        internals::types::Lifter getLifter() const
+        base::Lifter getLifter() const
         {
             return m_lifter;
         }
@@ -213,13 +213,13 @@ public:
 
         // Lifter
         ret.m_lifter =
-            [g](internals::types::Observable o) -> internals::types::Observable
+            [g](base::Observable o) -> base::Observable
         {
-            internals::types::Observable last;
+            base::Observable last;
 
             // Recursive visitor function to call all connectable lifters and
             // build the whole rxcpp pipeline
-            auto visit = [&g, &last](internals::types::Observable source,
+            auto visit = [&g, &last](base::Observable source,
                                      std::string root,
                                      auto &visit_ref) -> void
             {
@@ -231,7 +231,7 @@ public:
 
                 // Call connect.publish only if this connectable has more than
                 // one child
-                auto obs = [&g, root]() -> internals::types::Observable
+                auto obs = [&g, root]() -> base::Observable
                 {
                     if (g->m_edges[root].size() > 1)
                     {

--- a/src/engine/source/builder/builder.hpp
+++ b/src/engine/source/builder/builder.hpp
@@ -117,6 +117,7 @@ public:
                 asset.get("/decoders"),
                 std::get<internals::types::AssetBuilder>(
                     internals::Registry::getBuilder("decoder")));
+
             subGraphs.push_back(std::make_tuple(
                 "INPUT_DECODER", decoderGraph, "OUTPUT_DECODER"));
         }

--- a/src/engine/source/builder/builderTypes.hpp
+++ b/src/engine/source/builder/builderTypes.hpp
@@ -17,8 +17,8 @@
 
 #include <rxcpp/rx.hpp>
 
-//#include <eventHandler.hpp>
 #include <baseTypes.hpp>
+
 #include "connectable.hpp"
 
 /**

--- a/src/engine/source/builder/builderTypes.hpp
+++ b/src/engine/source/builder/builderTypes.hpp
@@ -17,8 +17,8 @@
 
 #include <rxcpp/rx.hpp>
 
-#include <EventHandler.hpp>
-
+//#include <eventHandler.hpp>
+#include <baseTypes.hpp>
 #include "connectable.hpp"
 
 /**
@@ -27,17 +27,11 @@
  */
 namespace builder::internals::types
 {
-
-using Event = std::shared_ptr<Base::EventHandler>;
-using Document = json::Document;
-using DocumentValue = json::Value;
-using Observable = rxcpp::observable<Event>;
-using Lifter = std::function<Observable(Observable)>;
-using ConnectableT = Connectable<Observable>;
-using AssetBuilder = std::function<ConnectableT(const Document &)>;
+using ConnectableT = Connectable<base::Observable>;
+using AssetBuilder = std::function<ConnectableT(const base::Document &)>;
 using TracerFn = std::function<void(std::string)>;
-using OpBuilder = std::function<Lifter(const DocumentValue &, TracerFn)>;
-using CombinatorBuilder = std::function<Lifter(std::vector<Lifter>)>;
+using OpBuilder = std::function<base::Lifter(const base::DocumentValue &, TracerFn)>;
+using CombinatorBuilder = std::function<base::Lifter(std::vector<base::Lifter>)>;
 using BuilderVariant = std::variant<AssetBuilder, OpBuilder, CombinatorBuilder>;
 
 } // namespace builder::internals::types

--- a/src/engine/source/builder/builderTypes.hpp
+++ b/src/engine/source/builder/builderTypes.hpp
@@ -17,8 +17,9 @@
 
 #include <rxcpp/rx.hpp>
 
+#include <EventHandler.hpp>
+
 #include "connectable.hpp"
-#include "json.hpp"
 
 /**
  * @brief Type definitions needed by builders
@@ -27,7 +28,7 @@
 namespace builder::internals::types
 {
 
-using Event = std::shared_ptr<json::Document>;
+using Event = std::shared_ptr<Base::EventHandler>;
 using Document = json::Document;
 using DocumentValue = json::Value;
 using Observable = rxcpp::observable<Event>;

--- a/src/engine/source/builder/builders/assetBuilderDecoder.cpp
+++ b/src/engine/source/builder/builders/assetBuilderDecoder.cpp
@@ -22,7 +22,7 @@
 namespace builder::internals::builders
 {
 
-types::ConnectableT assetBuilderDecoder(const types::Document &def)
+types::ConnectableT assetBuilderDecoder(const base::Document &def)
 {
     // Assert document is as expected
     if (!def.m_doc.IsObject())
@@ -34,10 +34,10 @@ types::ConnectableT assetBuilderDecoder(const types::Document &def)
         throw std::invalid_argument(msg);
     }
 
-    std::vector<types::Lifter> stages;
+    std::vector<base::Lifter> stages;
 
     // Needed to build stages in a for loop popping its attributes
-    std::map<std::string, const types::DocumentValue &> attributes;
+    std::map<std::string, const base::DocumentValue &> attributes;
     try
     {
         for (auto it = def.m_doc.MemberBegin(); it != def.m_doc.MemberEnd();
@@ -75,7 +75,7 @@ types::ConnectableT assetBuilderDecoder(const types::Document &def)
     {
         try
         {
-            for (const types::DocumentValue &parentName :
+            for (const base::DocumentValue &parentName :
                  attributes.at("parents").GetArray())
             {
                 parents.push_back(parentName.GetString());
@@ -144,7 +144,7 @@ types::ConnectableT assetBuilderDecoder(const types::Document &def)
 
     try
     {
-        types::Lifter decoder = std::get<types::CombinatorBuilder>(
+        base::Lifter decoder = std::get<types::CombinatorBuilder>(
             Registry::getBuilder("combinator.chain"))(stages);
         // Finally return connectable
         return types::ConnectableT {name, parents, decoder, tr};

--- a/src/engine/source/builder/builders/assetBuilderDecoder.cpp
+++ b/src/engine/source/builder/builders/assetBuilderDecoder.cpp
@@ -36,6 +36,12 @@ types::ConnectableT assetBuilderDecoder(const base::Document &def)
 
     std::vector<base::Lifter> stages;
 
+    // Implicit XOR condition in front
+    stages.push_back([](base::Observable o) {
+        return o.filter([](base::Event e) {
+            return !e->isDecoded(); });
+    });
+
     // Needed to build stages in a for loop popping its attributes
     std::map<std::string, const base::DocumentValue &> attributes;
     try
@@ -76,6 +82,7 @@ types::ConnectableT assetBuilderDecoder(const base::Document &def)
         try
         {
             for (const base::DocumentValue &parentName :
+                // TODO Check if this is an array
                  attributes.at("parents").GetArray())
             {
                 parents.push_back(parentName.GetString());

--- a/src/engine/source/builder/builders/assetBuilderDecoder.hpp
+++ b/src/engine/source/builder/builders/assetBuilderDecoder.hpp
@@ -20,7 +20,7 @@ namespace builder::internals::builders
  * @param def
  * @return types::ConnectableT
  */
-types::ConnectableT assetBuilderDecoder(const types::Document & def);
+types::ConnectableT assetBuilderDecoder(const base::Document & def);
 } // namespace builder::internals::builders
 
 #endif // _ASSET_BUILDER_DECODER_H

--- a/src/engine/source/builder/builders/assetBuilderFilter.cpp
+++ b/src/engine/source/builder/builders/assetBuilderFilter.cpp
@@ -22,7 +22,7 @@
 namespace builder::internals::builders
 {
 
-types::ConnectableT assetBuilderFilter(const types::Document & def)
+types::ConnectableT assetBuilderFilter(const base::Document & def)
 {
     // Assert document is as expected
     if (!def.m_doc.IsObject())
@@ -32,10 +32,10 @@ types::ConnectableT assetBuilderFilter(const types::Document & def)
         throw std::invalid_argument(msg);
     }
 
-    std::vector<types::Lifter> stages;
+    std::vector<base::Lifter> stages;
 
     // Needed to build stages in a for loop popping its attributes
-    std::map<std::string, const types::DocumentValue &> attributes;
+    std::map<std::string, const base::DocumentValue &> attributes;
     try
     {
         for (auto it = def.m_doc.MemberBegin(); it != def.m_doc.MemberEnd(); ++it)
@@ -68,7 +68,7 @@ types::ConnectableT assetBuilderFilter(const types::Document & def)
     std::vector<std::string> after;
     try
     {
-        for (const types::DocumentValue & parentName : attributes.at("after").GetArray())
+        for (const base::DocumentValue & parentName : attributes.at("after").GetArray())
         {
             after.push_back(parentName.GetString());
         }
@@ -131,7 +131,7 @@ types::ConnectableT assetBuilderFilter(const types::Document & def)
     // Combine all stages
     try
     {
-        types::Lifter filter = std::get<types::CombinatorBuilder>(
+        base::Lifter filter = std::get<types::CombinatorBuilder>(
             Registry::getBuilder("combinator.chain"))(stages);
 
         return types::ConnectableT {name, after, filter, tr};

--- a/src/engine/source/builder/builders/assetBuilderFilter.hpp
+++ b/src/engine/source/builder/builders/assetBuilderFilter.hpp
@@ -20,7 +20,7 @@ namespace builder::internals::builders
  * @param def
  * @return types::ConnectableT
  */
-types::ConnectableT assetBuilderFilter(const types::Document & def);
+types::ConnectableT assetBuilderFilter(const base::Document & def);
 } // namespace builder::internals::builders
 
 #endif // _ASSET_BUILDER_FILTER_H

--- a/src/engine/source/builder/builders/assetBuilderOutput.cpp
+++ b/src/engine/source/builder/builders/assetBuilderOutput.cpp
@@ -21,7 +21,7 @@
 namespace builder::internals::builders
 {
 
-types::ConnectableT assetBuilderOutput(const types::Document & def)
+types::ConnectableT assetBuilderOutput(const base::Document & def)
 {
     // Assert document is as expected
     if (!def.m_doc.IsObject())
@@ -31,10 +31,10 @@ types::ConnectableT assetBuilderOutput(const types::Document & def)
         throw std::invalid_argument(std::move(msg));
     }
 
-    std::vector<types::Lifter> stages;
+    std::vector<base::Lifter> stages;
 
     // Needed to build stages in a for loop popping its attributes
-    std::map<std::string, const types::DocumentValue &> attributes;
+    std::map<std::string, const base::DocumentValue &> attributes;
     try
     {
         for (auto it = def.m_doc.MemberBegin(); it != def.m_doc.MemberEnd(); ++it)
@@ -69,7 +69,7 @@ types::ConnectableT assetBuilderOutput(const types::Document & def)
     {
         try
         {
-            for (const types::DocumentValue & parentName : attributes.at("parents").GetArray())
+            for (const base::DocumentValue & parentName : attributes.at("parents").GetArray())
             {
                 parents.push_back(parentName.GetString());
             }
@@ -145,7 +145,7 @@ types::ConnectableT assetBuilderOutput(const types::Document & def)
     }
 
     // Combine all stages
-    types::Lifter output;
+    base::Lifter output;
     try
     {
         output = std::get<types::CombinatorBuilder>(Registry::getBuilder("combinator.chain"))(stages);

--- a/src/engine/source/builder/builders/assetBuilderOutput.hpp
+++ b/src/engine/source/builder/builders/assetBuilderOutput.hpp
@@ -20,7 +20,7 @@ namespace builder::internals::builders
  * @param def
  * @return types::ConnectableT
  */
-types::ConnectableT assetBuilderOutput(const types::Document & def);
+types::ConnectableT assetBuilderOutput(const base::Document & def);
 } // namespace builder::internals::builders
 
 #endif // _ASSET_BUILDER_OUTPUT_H

--- a/src/engine/source/builder/builders/assetBuilderRule.cpp
+++ b/src/engine/source/builder/builders/assetBuilderRule.cpp
@@ -22,7 +22,7 @@
 namespace builder::internals::builders
 {
 
-types::ConnectableT assetBuilderRule(const types::Document & def)
+types::ConnectableT assetBuilderRule(const base::Document & def)
 {
     // Assert document is as expected
     if (!def.m_doc.IsObject())
@@ -32,10 +32,10 @@ types::ConnectableT assetBuilderRule(const types::Document & def)
         throw std::invalid_argument(msg);
     }
 
-    std::vector<types::Lifter> stages;
+    std::vector<base::Lifter> stages;
 
     // Needed to build stages in a for loop popping its attributes
-    std::map<std::string, const types::DocumentValue &> attributes;
+    std::map<std::string, const base::DocumentValue &> attributes;
     try
     {
         for (auto it = def.m_doc.MemberBegin(); it != def.m_doc.MemberEnd(); ++it)
@@ -70,7 +70,7 @@ types::ConnectableT assetBuilderRule(const types::Document & def)
     {
         try
         {
-            for (const types::DocumentValue & parentName : attributes.at("parents").GetArray())
+            for (const base::DocumentValue & parentName : attributes.at("parents").GetArray())
             {
                 parents.push_back(parentName.GetString());
             }
@@ -133,7 +133,7 @@ types::ConnectableT assetBuilderRule(const types::Document & def)
     // Combine all stages
     try
     {
-        types::Lifter decoder = std::get<types::CombinatorBuilder>(
+        base::Lifter decoder = std::get<types::CombinatorBuilder>(
             Registry::getBuilder("combinator.chain"))(stages);
         // Finally return connectable
         return types::ConnectableT {name, parents, decoder, tr};

--- a/src/engine/source/builder/builders/assetBuilderRule.hpp
+++ b/src/engine/source/builder/builders/assetBuilderRule.hpp
@@ -20,7 +20,7 @@ namespace builder::internals::builders
  * @param def
  * @return types::ConnectableT
  */
-types::ConnectableT assetBuilderRule(const types::Document & def);
+types::ConnectableT assetBuilderRule(const base::Document & def);
 } // namespace builder::internals::builders
 
 #endif // _ASSET_BUILDER_RULE_H

--- a/src/engine/source/builder/builders/combinatorBuilderBroadcast.cpp
+++ b/src/engine/source/builder/builders/combinatorBuilderBroadcast.cpp
@@ -14,12 +14,12 @@
 namespace builder::internals::builders
 {
 
-types::Lifter combinatorBuilderBroadcast(const std::vector<types::Lifter> & lifters)
+base::Lifter combinatorBuilderBroadcast(const std::vector<base::Lifter> & lifters)
 {
-    return [=](types::Observable input) -> types::Observable
+    return [=](base::Observable input) -> base::Observable
     {
         input = input.publish().ref_count();
-        std::vector<types::Observable> inputs;
+        std::vector<base::Observable> inputs;
         for (auto op : lifters)
         {
             inputs.push_back(op(input));

--- a/src/engine/source/builder/builders/combinatorBuilderBroadcast.hpp
+++ b/src/engine/source/builder/builders/combinatorBuilderBroadcast.hpp
@@ -18,9 +18,9 @@ namespace builder::internals::builders
  * @brief Broadcast to multiple lifters
  *
  * @param lifters
- * @return types::Lifter
+ * @return base::Lifter
  */
-types::Lifter combinatorBuilderBroadcast(const std::vector<types::Lifter> & lifters);
+base::Lifter combinatorBuilderBroadcast(const std::vector<base::Lifter> & lifters);
 } // namespace builder::internals::builders
 
 #endif // _COMBINATOR_BUILDER_BROADCAST_H

--- a/src/engine/source/builder/builders/combinatorBuilderChain.cpp
+++ b/src/engine/source/builder/builders/combinatorBuilderChain.cpp
@@ -12,19 +12,19 @@
 namespace builder::internals::builders
 {
 
-types::Lifter combinatorBuilderChain(const std::vector<types::Lifter> & lifters)
+base::Lifter combinatorBuilderChain(const std::vector<base::Lifter> & lifters)
 {
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // this is way better than std::function for 3 reasons: it doesn't
         // require type erasure or memory allocation, it can be constexpr and
         // it works properly with auto (templated) parameters / return type
-        auto connect = [](types::Observable o, std::vector<types::Lifter> remaining,
-                          auto & connect_ref) -> types::Observable
+        auto connect = [](base::Observable o, std::vector<base::Lifter> remaining,
+                          auto & connect_ref) -> base::Observable
         {
-            types::Lifter current = remaining.front();
+            base::Lifter current = remaining.front();
             remaining.erase(remaining.begin());
-            types::Observable chain = current(o);
+            base::Observable chain = current(o);
             if (remaining.size() == 0)
             {
                 return chain;

--- a/src/engine/source/builder/builders/combinatorBuilderChain.hpp
+++ b/src/engine/source/builder/builders/combinatorBuilderChain.hpp
@@ -18,9 +18,9 @@ namespace builder::internals::builders
  * @brief Chains multiple lifters
  *
  * @param lifters
- * @return types::Lifter
+ * @return base::Lifter
  */
-types::Lifter combinatorBuilderChain(const std::vector<types::Lifter> & lifters);
+base::Lifter combinatorBuilderChain(const std::vector<base::Lifter> & lifters);
 } // namespace builder::internals::builders
 
 #endif // _COMBINATOR_BUILDER_CHAIN_H

--- a/src/engine/source/builder/builders/opBuilderCondition.cpp
+++ b/src/engine/source/builder/builders/opBuilderCondition.cpp
@@ -20,7 +20,7 @@
 namespace builder::internals::builders
 {
 
-types::Lifter opBuilderCondition(const types::DocumentValue & def, types::TracerFn tr)
+base::Lifter opBuilderCondition(const base::DocumentValue & def, types::TracerFn tr)
 {
     // Check that input is as expected and throw exception otherwise
     if (!def.IsObject())

--- a/src/engine/source/builder/builders/opBuilderCondition.hpp
+++ b/src/engine/source/builder/builders/opBuilderCondition.hpp
@@ -19,9 +19,9 @@ namespace builder::internals::builders
  * @brief Auxiliray builder to handle proper specific condition builder
  *
  * @param def Definition of the operation to be built
- * @return types::Lifter
+ * @return base::Lifter
  */
-types::Lifter opBuilderCondition(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderCondition(const base::DocumentValue & def, types::TracerFn tr);
 
 } // namespace builder::internals::builders
 

--- a/src/engine/source/builder/builders/opBuilderConditionReference.cpp
+++ b/src/engine/source/builder/builders/opBuilderConditionReference.cpp
@@ -58,7 +58,7 @@ types::Lifter opBuilderConditionReference(const types::DocumentValue &def,
         return o.filter(
             [=](types::Event e)
             {
-                if (e->equals(field, reference))
+                if (e->getEvent()->equals(field, reference))
                 {
                     tr(successTrace);
                     return true;

--- a/src/engine/source/builder/builders/opBuilderConditionReference.cpp
+++ b/src/engine/source/builder/builders/opBuilderConditionReference.cpp
@@ -19,7 +19,7 @@
 namespace builder::internals::builders
 {
 
-types::Lifter opBuilderConditionReference(const types::DocumentValue &def,
+base::Lifter opBuilderConditionReference(const base::DocumentValue &def,
                                           types::TracerFn tr)
 {
     if (!def.MemberBegin()->name.IsString())
@@ -52,11 +52,11 @@ types::Lifter opBuilderConditionReference(const types::DocumentValue &def,
                     def.MemberBegin()->value.GetString());
 
     // Return Lifter
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // Append rxcpp operation
         return o.filter(
-            [=](types::Event e)
+            [=](base::Event e)
             {
                 if (e->getEvent()->equals(field, reference))
                 {

--- a/src/engine/source/builder/builders/opBuilderConditionReference.hpp
+++ b/src/engine/source/builder/builders/opBuilderConditionReference.hpp
@@ -20,9 +20,9 @@ namespace builder::internals::builders
  * Checks that a tuple <field: value> is present in the event.
  *
  * @param def Definition of the operation to be built
- * @return types::Lifter
+ * @return base::Lifter
  */
-types::Lifter opBuilderConditionReference(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderConditionReference(const base::DocumentValue & def, types::TracerFn tr);
 
 } // namespace builder::internals::builders
 

--- a/src/engine/source/builder/builders/opBuilderConditionValue.cpp
+++ b/src/engine/source/builder/builders/opBuilderConditionValue.cpp
@@ -16,7 +16,7 @@ using namespace std;
 namespace builder::internals::builders
 {
 
-types::Lifter opBuilderConditionValue(const types::DocumentValue &def,
+base::Lifter opBuilderConditionValue(const base::DocumentValue &def,
                                       types::TracerFn tr)
 {
     if (!def.MemberBegin()->name.IsString())
@@ -28,16 +28,16 @@ types::Lifter opBuilderConditionValue(const types::DocumentValue &def,
     std::string field =
         json::formatJsonPath(def.MemberBegin()->name.GetString());
     // TODO: build document with value only
-    types::Document value {def};
+    base::Document value {def};
     std::string successTrace = fmt::format("{} Condition Success", value.str());
     std::string failureTrace = fmt::format("{} Condition Failure", value.str());
 
     // Return Lifter
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // Append rxcpp operation
         return o.filter(
-            [=](types::Event e)
+            [=](base::Event e)
             {
                 if (e->getEvent()->equals(field, value.begin()->value))
                 {

--- a/src/engine/source/builder/builders/opBuilderConditionValue.cpp
+++ b/src/engine/source/builder/builders/opBuilderConditionValue.cpp
@@ -39,7 +39,7 @@ types::Lifter opBuilderConditionValue(const types::DocumentValue &def,
         return o.filter(
             [=](types::Event e)
             {
-                if (e->equals(field, value.begin()->value))
+                if (e->getEvent()->equals(field, value.begin()->value))
                 {
                     tr(successTrace);
                     return true;

--- a/src/engine/source/builder/builders/opBuilderConditionValue.hpp
+++ b/src/engine/source/builder/builders/opBuilderConditionValue.hpp
@@ -20,9 +20,9 @@ namespace builder::internals::builders
  * Checks that a tuple <field: value> is present in the event.
  *
  * @param def Definition of the operation to be built
- * @return types::Lifter
+ * @return base::Lifter
  */
-types::Lifter opBuilderConditionValue(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderConditionValue(const base::DocumentValue & def, types::TracerFn tr);
 
 } // namespace builder::internals::builders
 

--- a/src/engine/source/builder/builders/opBuilderFileOutput.cpp
+++ b/src/engine/source/builder/builders/opBuilderFileOutput.cpp
@@ -21,7 +21,7 @@
 namespace builder::internals::builders
 {
 
-types::Lifter opBuilderFileOutput(const types::DocumentValue &def, types::TracerFn tr)
+base::Lifter opBuilderFileOutput(const base::DocumentValue &def, types::TracerFn tr)
 {
     // Check that input is as expected and throw exception otherwise
     if (!def.IsObject())
@@ -54,7 +54,7 @@ types::Lifter opBuilderFileOutput(const types::DocumentValue &def, types::Tracer
         std::throw_with_nested(std::runtime_error(msg));
     }
 
-    return [=](const types::Observable &input) -> types::Observable
+    return [=](const base::Observable &input) -> base::Observable
     {
         auto filePtr = std::make_shared<outputs::FileOutput>(path);
         input.subscribe([=](auto v) { filePtr->write(v); },

--- a/src/engine/source/builder/builders/opBuilderFileOutput.hpp
+++ b/src/engine/source/builder/builders/opBuilderFileOutput.hpp
@@ -19,9 +19,9 @@ namespace builder::internals::builders
  * @brief Builds file output operation.
  *
  * @param def Definition of the operation to be built
- * @return types::Lifter
+ * @return base::Lifter
  */
-types::Lifter opBuilderFileOutput(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderFileOutput(const base::DocumentValue & def, types::TracerFn tr);
 
 } // namespace builder::internals::builders
 

--- a/src/engine/source/builder/builders/opBuilderHelperFilter.cpp
+++ b/src/engine/source/builder/builders/opBuilderHelperFilter.cpp
@@ -105,7 +105,7 @@ types::Lifter opBuilderHelperExists(const types::DocumentValue &def,
         return o.filter(
             [=](types::Event e)
             {
-                if (e->exists(field))
+                if (e->getEvent()->exists(field))
                 {
                     tr(successTrace);
                     return true;
@@ -149,7 +149,7 @@ types::Lifter opBuilderHelperNotExists(const types::DocumentValue &def,
         return o.filter(
             [=](types::Event e)
             {
-                if (!e->exists(field))
+                if (!e->getEvent()->exists(field))
                 {
                     tr(successTrace);
                     return true;
@@ -186,7 +186,7 @@ bool opBuilderHelperStringComparison(const std::string key,
     const rapidjson::Value *fieldToCompare {};
     try
     {
-        fieldToCompare = &e->get(key);
+        fieldToCompare = &e->getEvent()->get(key);
     }
     catch (std::exception &ex)
     {
@@ -209,7 +209,7 @@ bool opBuilderHelperStringComparison(const std::string key,
         const rapidjson::Value *refValueToCheck {};
         try
         {
-            refValueToCheck = &e->get(refValue.value());
+            refValueToCheck = &e->getEvent()->get(refValue.value());
         }
         catch (std::exception &ex)
         {
@@ -480,7 +480,7 @@ bool opBuilderHelperIntComparison(const std::string field,
     const rapidjson::Value *fieldValue {};
     try
     {
-        fieldValue = &e->get(field);
+        fieldValue = &e->getEvent()->get(field);
     }
     catch (std::exception &ex)
     {
@@ -503,7 +503,7 @@ bool opBuilderHelperIntComparison(const std::string field,
         const rapidjson::Value *refValueToCheck {};
         try
         {
-            refValueToCheck = &e->get(refValue.value());
+            refValueToCheck = &e->getEvent()->get(refValue.value());
         }
         catch (std::exception &ex)
         {
@@ -826,7 +826,7 @@ types::Lifter opBuilderHelperRegexMatch(const types::DocumentValue &def,
                 const rapidjson::Value *field_str {};
                 try
                 {
-                    field_str = &e->get(field);
+                    field_str = &e->getEvent()->get(field);
                 }
                 catch (std::exception &ex)
                 {
@@ -885,7 +885,7 @@ types::Lifter opBuilderHelperRegexNotMatch(const types::DocumentValue &def,
                 const rapidjson::Value *field_str {};
                 try
                 {
-                    field_str = &e->get(field);
+                    field_str = &e->getEvent()->get(field);
                 }
                 catch (std::exception &ex)
                 {
@@ -983,7 +983,7 @@ types::Lifter opBuilderHelperIPCIDR(const types::DocumentValue &def,
                 const rapidjson::Value *field_str {};
                 try
                 {
-                    field_str = &e->get(field);
+                    field_str = &e->getEvent()->get(field);
                 }
                 catch (std::exception &ex)
                 {

--- a/src/engine/source/builder/builders/opBuilderHelperFilter.cpp
+++ b/src/engine/source/builder/builders/opBuilderHelperFilter.cpp
@@ -24,7 +24,6 @@ namespace
 
 using opString = std::optional<std::string>;
 using builder::internals::syntax::REFERENCE_ANCHOR;
-using builder::internals::types::DocumentValue;
 
 /**
  * @brief Get the Comparator operator, and the value to compare
@@ -38,7 +37,7 @@ using builder::internals::types::DocumentValue;
  * helper function
  */
 std::tuple<std::string, opString, opString>
-getCompOpParameter(const DocumentValue &def)
+getCompOpParameter(const base::DocumentValue &def)
 {
     // Get destination path
     std::string field {
@@ -77,7 +76,7 @@ namespace builder::internals::builders
 {
 
 // <field>: exists
-types::Lifter opBuilderHelperExists(const types::DocumentValue &def,
+base::Lifter opBuilderHelperExists(const base::DocumentValue &def,
                                     types::TracerFn tr)
 {
     // Get Field path to check
@@ -99,11 +98,11 @@ types::Lifter opBuilderHelperExists(const types::DocumentValue &def,
                                            def.MemberBegin()->name.GetString());
 
     // Return Lifter
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // Append rxcpp operation
         return o.filter(
-            [=](types::Event e)
+            [=](base::Event e)
             {
                 if (e->getEvent()->exists(field))
                 {
@@ -120,7 +119,7 @@ types::Lifter opBuilderHelperExists(const types::DocumentValue &def,
 }
 
 // <field>: not_exists
-types::Lifter opBuilderHelperNotExists(const types::DocumentValue &def,
+base::Lifter opBuilderHelperNotExists(const base::DocumentValue &def,
                                        types::TracerFn tr)
 {
     // Get Field path to check
@@ -143,11 +142,11 @@ types::Lifter opBuilderHelperNotExists(const types::DocumentValue &def,
                     def.MemberBegin()->name.GetString());
 
     // Return Lifter
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // Append rxcpp operation
         return o.filter(
-            [=](types::Event e)
+            [=](base::Event e)
             {
                 if (!e->getEvent()->exists(field))
                 {
@@ -169,7 +168,7 @@ types::Lifter opBuilderHelperNotExists(const types::DocumentValue &def,
 
 bool opBuilderHelperStringComparison(const std::string key,
                                      char op,
-                                     types::Event &e,
+                                     base::Event &e,
                                      std::optional<std::string> refValue,
                                      std::optional<std::string> value)
 {
@@ -251,24 +250,24 @@ bool opBuilderHelperStringComparison(const std::string key,
 }
 
 // <field>: s_eq/<value>
-types::Lifter opBuilderHelperStringEQ(const types::DocumentValue &def,
+base::Lifter opBuilderHelperStringEQ(const base::DocumentValue &def,
                                       types::TracerFn tr)
 {
     auto [key, refValue, value] {getCompOpParameter(def)};
 
     // Tracing
-    types::Document defTmp {def};
+    base::Document defTmp {def};
     std::string successTrace =
         fmt::format("{} Condition Success", defTmp.str());
     std::string failureTrace =
         fmt::format("{} Condition Failure", defTmp.str());
 
     // Return Lifter
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // Append rxcpp operation
         return o.filter(
-            [=](types::Event e)
+            [=](base::Event e)
             {
                 // try and catch, return false
                 if (opBuilderHelperStringComparison(
@@ -287,24 +286,24 @@ types::Lifter opBuilderHelperStringEQ(const types::DocumentValue &def,
 }
 
 // <field>: s_ne/<value>
-types::Lifter opBuilderHelperStringNE(const types::DocumentValue &def,
+base::Lifter opBuilderHelperStringNE(const base::DocumentValue &def,
                                       types::TracerFn tr)
 {
     auto [key, refValue, value] {getCompOpParameter(def)};
 
     // Tracing
-    types::Document defTmp {def};
+    base::Document defTmp {def};
     std::string successTrace =
         fmt::format("{} Condition Success", defTmp.str());
     std::string failureTrace =
         fmt::format("{} Condition Failure", defTmp.str());
 
     // Return Lifter
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // Append rxcpp operation
         return o.filter(
-            [=](types::Event e)
+            [=](base::Event e)
             {
                 if (opBuilderHelperStringComparison(
                         key, '!', e, refValue, value))
@@ -322,24 +321,24 @@ types::Lifter opBuilderHelperStringNE(const types::DocumentValue &def,
 }
 
 // <field>: s_gt/<value>|$<ref>
-types::Lifter opBuilderHelperStringGT(const types::DocumentValue &def,
+base::Lifter opBuilderHelperStringGT(const base::DocumentValue &def,
                                       types::TracerFn tr)
 {
     auto [key, refValue, value] {getCompOpParameter(def)};
 
     // Tracing
-    types::Document defTmp {def};
+    base::Document defTmp {def};
     std::string successTrace =
         fmt::format("{} Condition Success", defTmp.str());
     std::string failureTrace =
         fmt::format("{} Condition Failure", defTmp.str());
 
     // Return Lifter
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // Append rxcpp operation
         return o.filter(
-            [=](types::Event e)
+            [=](base::Event e)
             {
                 if (opBuilderHelperStringComparison(
                         key, '>', e, refValue, value))
@@ -357,24 +356,24 @@ types::Lifter opBuilderHelperStringGT(const types::DocumentValue &def,
 }
 
 // <field>: s_ge/<value>|$<ref>
-types::Lifter opBuilderHelperStringGE(const types::DocumentValue &def,
+base::Lifter opBuilderHelperStringGE(const base::DocumentValue &def,
                                       types::TracerFn tr)
 {
     auto [key, refValue, value] {getCompOpParameter(def)};
 
     // Tracing
-    types::Document defTmp {def};
+    base::Document defTmp {def};
     std::string successTrace =
         fmt::format("{} Condition Success", defTmp.str());
     std::string failureTrace =
         fmt::format("{} Condition Failure", defTmp.str());
 
     // Return Lifter
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // Append rxcpp operation
         return o.filter(
-            [=](types::Event e)
+            [=](base::Event e)
             {
                 if (opBuilderHelperStringComparison(
                         key, 'g', e, refValue, value))
@@ -392,24 +391,24 @@ types::Lifter opBuilderHelperStringGE(const types::DocumentValue &def,
 }
 
 // <field>: s_lt/<value>|$<ref>
-types::Lifter opBuilderHelperStringLT(const types::DocumentValue &def,
+base::Lifter opBuilderHelperStringLT(const base::DocumentValue &def,
                                       types::TracerFn tr)
 {
     auto [key, refValue, value] {getCompOpParameter(def)};
 
     // Tracing
-    types::Document defTmp {def};
+    base::Document defTmp {def};
     std::string successTrace =
         fmt::format("{} Condition Success", defTmp.str());
     std::string failureTrace =
         fmt::format("{} Condition Failure", defTmp.str());
 
     // Return Lifter
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // Append rxcpp operation
         return o.filter(
-            [=](types::Event e)
+            [=](base::Event e)
             {
                 if (opBuilderHelperStringComparison(
                         key, '<', e, refValue, value))
@@ -427,24 +426,24 @@ types::Lifter opBuilderHelperStringLT(const types::DocumentValue &def,
 }
 
 // <field>: s_le/<value>|$<ref>
-types::Lifter opBuilderHelperStringLE(const types::DocumentValue &def,
+base::Lifter opBuilderHelperStringLE(const base::DocumentValue &def,
                                       types::TracerFn tr)
 {
     auto [key, refValue, value] {getCompOpParameter(def)};
 
     // Tracing
-    types::Document defTmp {def};
+    base::Document defTmp {def};
     std::string successTrace =
         fmt::format("{} Condition Success", defTmp.str());
     std::string failureTrace =
         fmt::format("{} Condition Failure", defTmp.str());
 
     // Return Lifter
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // Append rxcpp operation
         return o.filter(
-            [=](types::Event e)
+            [=](base::Event e)
             {
                 if (opBuilderHelperStringComparison(
                         key, 'l', e, refValue, value))
@@ -467,7 +466,7 @@ types::Lifter opBuilderHelperStringLE(const types::DocumentValue &def,
 
 bool opBuilderHelperIntComparison(const std::string field,
                                   char op,
-                                  types::Event &e,
+                                  base::Event &e,
                                   std::optional<std::string> refValue,
                                   std::optional<int> value)
 {
@@ -542,7 +541,7 @@ bool opBuilderHelperIntComparison(const std::string field,
 }
 
 // field: +i_eq/int|$ref/
-types::Lifter opBuilderHelperIntEqual(const types::DocumentValue &def,
+base::Lifter opBuilderHelperIntEqual(const base::DocumentValue &def,
                                       types::TracerFn tr)
 {
 
@@ -553,18 +552,18 @@ types::Lifter opBuilderHelperIntEqual(const types::DocumentValue &def,
                              : std::nullopt;
 
     // Tracing
-    types::Document defTmp {def};
+    base::Document defTmp {def};
     std::string successTrace =
         fmt::format("{} Condition Success", defTmp.str());
     std::string failureTrace =
         fmt::format("{} Condition Failure", defTmp.str());
 
     // Return Lifter
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // Append rxcpp operation
         return o.filter(
-            [=](types::Event e)
+            [=](base::Event e)
             {
                 if (opBuilderHelperIntComparison(
                         field, '=', e, refValue, value))
@@ -582,7 +581,7 @@ types::Lifter opBuilderHelperIntEqual(const types::DocumentValue &def,
 }
 
 // field: +i_ne/int|$ref/
-types::Lifter opBuilderHelperIntNotEqual(const types::DocumentValue &def,
+base::Lifter opBuilderHelperIntNotEqual(const base::DocumentValue &def,
                                          types::TracerFn tr)
 {
 
@@ -593,18 +592,18 @@ types::Lifter opBuilderHelperIntNotEqual(const types::DocumentValue &def,
                              : std::nullopt;
 
     // Tracing
-    types::Document defTmp {def};
+    base::Document defTmp {def};
     std::string successTrace =
         fmt::format("{} Condition Success", defTmp.str());
     std::string failureTrace =
         fmt::format("{} Condition Failure", defTmp.str());
 
     // Return Lifter
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // Append rxcpp operation
         return o.filter(
-            [=](types::Event e)
+            [=](base::Event e)
             {
                 // try and catche, return false
                 if (opBuilderHelperIntComparison(
@@ -623,7 +622,7 @@ types::Lifter opBuilderHelperIntNotEqual(const types::DocumentValue &def,
 }
 
 // field: +i_lt/int|$ref/
-types::Lifter opBuilderHelperIntLessThan(const types::DocumentValue &def,
+base::Lifter opBuilderHelperIntLessThan(const base::DocumentValue &def,
                                          types::TracerFn tr)
 {
 
@@ -634,18 +633,18 @@ types::Lifter opBuilderHelperIntLessThan(const types::DocumentValue &def,
                              : std::nullopt;
 
     // Tracing
-    types::Document defTmp {def};
+    base::Document defTmp {def};
     std::string successTrace =
         fmt::format("{} Condition Success", defTmp.str());
     std::string failureTrace =
         fmt::format("{} Condition Failure", defTmp.str());
 
     // Return Lifter
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // Append rxcpp operation
         return o.filter(
-            [=](types::Event e)
+            [=](base::Event e)
             {
                 // try and catche, return false
                 if (opBuilderHelperIntComparison(
@@ -664,7 +663,7 @@ types::Lifter opBuilderHelperIntLessThan(const types::DocumentValue &def,
 }
 
 // field: +i_le/int|$ref/
-types::Lifter opBuilderHelperIntLessThanEqual(const types::DocumentValue &def,
+base::Lifter opBuilderHelperIntLessThanEqual(const base::DocumentValue &def,
                                               types::TracerFn tr)
 {
 
@@ -675,18 +674,18 @@ types::Lifter opBuilderHelperIntLessThanEqual(const types::DocumentValue &def,
                              : std::nullopt;
 
     // Tracing
-    types::Document defTmp {def};
+    base::Document defTmp {def};
     std::string successTrace =
         fmt::format("{} Condition Success", defTmp.str());
     std::string failureTrace =
         fmt::format("{} Condition Failure", defTmp.str());
 
     // Return Lifter
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // Append rxcpp operation
         return o.filter(
-            [=](types::Event e)
+            [=](base::Event e)
             {
                 // try and catche, return false
                 if (opBuilderHelperIntComparison(
@@ -705,7 +704,7 @@ types::Lifter opBuilderHelperIntLessThanEqual(const types::DocumentValue &def,
 }
 
 // field: +i_gt/int|$ref/
-types::Lifter opBuilderHelperIntGreaterThan(const types::DocumentValue &def,
+base::Lifter opBuilderHelperIntGreaterThan(const base::DocumentValue &def,
                                             types::TracerFn tr)
 {
 
@@ -716,18 +715,18 @@ types::Lifter opBuilderHelperIntGreaterThan(const types::DocumentValue &def,
                              : std::nullopt;
 
     // Tracing
-    types::Document defTmp {def};
+    base::Document defTmp {def};
     std::string successTrace =
         fmt::format("{} Condition Success", defTmp.str());
     std::string failureTrace =
         fmt::format("{} Condition Failure", defTmp.str());
 
     // Return Lifter
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // Append rxcpp operation
         return o.filter(
-            [=](types::Event e)
+            [=](base::Event e)
             {
                 // try and catche, return false
                 if (opBuilderHelperIntComparison(
@@ -746,8 +745,8 @@ types::Lifter opBuilderHelperIntGreaterThan(const types::DocumentValue &def,
 }
 
 // field: +i_ge/int|$ref/
-types::Lifter
-opBuilderHelperIntGreaterThanEqual(const types::DocumentValue &def,
+base::Lifter
+opBuilderHelperIntGreaterThanEqual(const base::DocumentValue &def,
                                    types::TracerFn tr)
 {
 
@@ -758,18 +757,18 @@ opBuilderHelperIntGreaterThanEqual(const types::DocumentValue &def,
                              : std::nullopt;
 
     // Tracing
-    types::Document defTmp {def};
+    base::Document defTmp {def};
     std::string successTrace =
         fmt::format("{} Condition Success", defTmp.str());
     std::string failureTrace =
         fmt::format("{} Condition Failure", defTmp.str());
 
     // Return Lifter
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // Append rxcpp operation
         return o.filter(
-            [=](types::Event e)
+            [=](base::Event e)
             {
                 // try and catche, return false
                 if (opBuilderHelperIntComparison(
@@ -792,7 +791,7 @@ opBuilderHelperIntGreaterThanEqual(const types::DocumentValue &def,
 //*************************************************
 
 // field: +r_match/regexp
-types::Lifter opBuilderHelperRegexMatch(const types::DocumentValue &def,
+base::Lifter opBuilderHelperRegexMatch(const base::DocumentValue &def,
                                         types::TracerFn tr)
 {
     // Get field
@@ -815,11 +814,11 @@ types::Lifter opBuilderHelperRegexMatch(const types::DocumentValue &def,
     }
 
     // Return Lifter
-    return [field, regex_ptr](types::Observable o)
+    return [field, regex_ptr](base::Observable o)
     {
         // Append rxcpp operations
         return o.filter(
-            [=](types::Event e)
+            [=](base::Event e)
             {
                 // TODO Remove try catch
                 // TODO Update to use proper reference
@@ -844,7 +843,7 @@ types::Lifter opBuilderHelperRegexMatch(const types::DocumentValue &def,
 }
 
 // field: +r_not_match/regexp
-types::Lifter opBuilderHelperRegexNotMatch(const types::DocumentValue &def,
+base::Lifter opBuilderHelperRegexNotMatch(const base::DocumentValue &def,
                                            types::TracerFn tr)
 {
     // Get field
@@ -867,18 +866,18 @@ types::Lifter opBuilderHelperRegexNotMatch(const types::DocumentValue &def,
     }
 
     // Tracing
-    types::Document defTmp {def};
+    base::Document defTmp {def};
     std::string successTrace =
         fmt::format("{} Condition Success", defTmp.str());
     std::string failureTrace =
         fmt::format("{} Condition Failure", defTmp.str());
 
     // Return Lifter
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // Append rxcpp operations
         return o.filter(
-            [=](types::Event e)
+            [=](base::Event e)
             {
                 // TODO Remove try catch
                 // TODO Update to use proper reference
@@ -918,7 +917,7 @@ types::Lifter opBuilderHelperRegexNotMatch(const types::DocumentValue &def,
 
 // path_to_ip: +ip_cidr/192.168.0.0/16
 // path_to_ip: +ip_cidr/192.168.0.0/255.255.0.0
-types::Lifter opBuilderHelperIPCIDR(const types::DocumentValue &def,
+base::Lifter opBuilderHelperIPCIDR(const base::DocumentValue &def,
                                     types::TracerFn tr)
 {
     // Get Field path to check
@@ -965,18 +964,18 @@ types::Lifter opBuilderHelperIPCIDR(const types::DocumentValue &def,
     uint32_t net_upper {net_lower | (~mask)};
 
     // Tracing
-    types::Document defTmp {def};
+    base::Document defTmp {def};
     std::string successTrace =
         fmt::format("{} Condition Success", defTmp.str());
     std::string failureTrace =
         fmt::format("{} Condition Failure", defTmp.str());
 
     // Return Lifter
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // Append rxcpp operations
         return o.filter(
-            [=](types::Event e)
+            [=](base::Event e)
             {
                 // TODO Remove try catch
                 // TODO Update to use proper reference

--- a/src/engine/source/builder/builders/opBuilderHelperFilter.hpp
+++ b/src/engine/source/builder/builders/opBuilderHelperFilter.hpp
@@ -32,18 +32,18 @@ namespace builder::internals::builders
  *
  * The filter checks if a field exists in the JSON event `e`.
  * @param def The filter definition.
- * @return types::Lifter The lifter with the `exists` filter.
+ * @return base::Lifter The lifter with the `exists` filter.
  */
-types::Lifter opBuilderHelperExists(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderHelperExists(const base::DocumentValue & def, types::TracerFn tr);
 
 /**
  * @brief Create `not_exists` helper function that filters events that not contains specified field.
  *
  * The filter checks if a field not exists in the JSON event `e`.
  * @param def The filter definition.
- * @return types::Lifter The lifter with the `not_exists` filter.
+ * @return base::Lifter The lifter with the `not_exists` filter.
  */
-types::Lifter opBuilderHelperNotExists(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderHelperNotExists(const base::DocumentValue & def, types::TracerFn tr);
 
 //*************************************************
 //*           String filters                      *
@@ -67,7 +67,7 @@ types::Lifter opBuilderHelperNotExists(const types::DocumentValue & def, types::
  * @return false in other case
  * @note If `refExpStr` is not provided, the comparison will be against the value of `expectedStr`
  */
-inline bool opBuilderHelperStringComparison(const std::string  key, char op, types::Event& e,
+inline bool opBuilderHelperStringComparison(const std::string  key, char op, base::Event& e,
                                                  std::optional<std::string> refValue,
                                                  std::optional<std::string> value);
 
@@ -78,10 +78,10 @@ inline bool opBuilderHelperStringComparison(const std::string  key, char op, typ
  * The filter checks if a field in the JSON event is equal to a value.
  * Only pass events if the fields are equal (case sensitive) and the values are a string.
  * @param def The filter definition.
- * @return types::Lifter The lifter with the `s_eq` filter.
+ * @return base::Lifter The lifter with the `s_eq` filter.
  * @throw std::runtime_error if the parameter is not a string.
  */
-types::Lifter opBuilderHelperStringEQ(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderHelperStringEQ(const base::DocumentValue & def, types::TracerFn tr);
 
 /**
  * @brief Create `s_ne` helper function that filters events with a string
@@ -90,10 +90,10 @@ types::Lifter opBuilderHelperStringEQ(const types::DocumentValue & def, types::T
  * The filter checks if a field in the JSON event is not  equal to a value.
  * Only do not pass events if the fields are equal (case sensitive) and the values are a string.
  * @param def The filter definition.
- * @return types::Lifter The lifter with the `s_ne` filter.
+ * @return base::Lifter The lifter with the `s_ne` filter.
  * @throw std::runtime_error if the parameter is not a string.
  */
-types::Lifter opBuilderHelperStringNE(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderHelperStringNE(const base::DocumentValue & def, types::TracerFn tr);
 
 /**
  * @brief Create `s_gt` helper function that filters events with a string
@@ -103,10 +103,10 @@ types::Lifter opBuilderHelperStringNE(const types::DocumentValue & def, types::T
  * or another field <$ref>. Only pass the filter if the event has both fields
  * of type string and passes the condition.
  * @param def The filter definition.
- * @return types::Lifter The lifter with the `s_gt` filter.
+ * @return base::Lifter The lifter with the `s_gt` filter.
  * @throw std::runtime_error if the parameter is not a string.
  */
-types::Lifter opBuilderHelperStringGT(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderHelperStringGT(const base::DocumentValue & def, types::TracerFn tr);
 
 /**
  * @brief Create `s_ge` helper function that filters events with a string
@@ -116,10 +116,10 @@ types::Lifter opBuilderHelperStringGT(const types::DocumentValue & def, types::T
  * or another field <$ref>. Only pass the filter if the event has both fields
  * of type string and passes the condition.
  * @param def The filter definition.
- * @return types::Lifter The lifter with the `s_ge` filter.
+ * @return base::Lifter The lifter with the `s_ge` filter.
  * @throw std::runtime_error if the parameter is not a string.
  */
-types::Lifter opBuilderHelperStringGE(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderHelperStringGE(const base::DocumentValue & def, types::TracerFn tr);
 
 /**
  * @brief Create `s_lt` helper function that filters events with a string
@@ -129,10 +129,10 @@ types::Lifter opBuilderHelperStringGE(const types::DocumentValue & def, types::T
  * or another field <$ref>. Only pass the filter if the event has both fields
  * of type string and passes the condition.
  * @param def The filter definition.
- * @return types::Lifter The lifter with the `s_lt` filter.
+ * @return base::Lifter The lifter with the `s_lt` filter.
  * @throw std::runtime_error if the parameter is not a string.
  */
-types::Lifter opBuilderHelperStringLT(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderHelperStringLT(const base::DocumentValue & def, types::TracerFn tr);
 
 /**
  * @brief Create `s_le` helper function that filters events with a string
@@ -142,10 +142,10 @@ types::Lifter opBuilderHelperStringLT(const types::DocumentValue & def, types::T
  * or another field <$ref>. Only pass the filter if the event has both fields
  * of type string and passes the condition.
  * @param def The filter definition.
- * @return types::Lifter The lifter with the `s_le` filter.
+ * @return base::Lifter The lifter with the `s_le` filter.
  * @throw std::runtime_error if the parameter is not a string.
  */
-types::Lifter opBuilderHelperStringLE(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderHelperStringLE(const base::DocumentValue & def, types::TracerFn tr);
 
 //*************************************************
 //*              Int filters                      *
@@ -172,7 +172,7 @@ types::Lifter opBuilderHelperStringLE(const types::DocumentValue & def, types::T
  * `value`
  */
 inline bool opBuilderHelperIntComparison(const std::string field, char op,
-                                         types::Event & e,
+                                         base::Event & e,
                                          std::optional<std::string> refValue,
                                          std::optional<int> value);
 
@@ -183,10 +183,10 @@ inline bool opBuilderHelperIntComparison(const std::string field, char op,
  * The filter checks if a field in the JSON event is equal to a value.
  * Only pass events if the fields are equal and the values are a integer.
  * @param def Definition of the operation to be built
- * @return types::Lifter The lifter with the `i_eq` filter.
+ * @return base::Lifter The lifter with the `i_eq` filter.
  * @throw std::runtime_error if the parameter is not a integer.
  */
-types::Lifter opBuilderHelperIntEqual(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderHelperIntEqual(const base::DocumentValue & def, types::TracerFn tr);
 
 /**
  * @brief Builds helper integer not equal operation.
@@ -195,10 +195,10 @@ types::Lifter opBuilderHelperIntEqual(const types::DocumentValue & def, types::T
  * The filter checks if a field in the JSON event is not equal to a value.
  * Only pass events if the fields are not equal and the values are a integer.
  * @param def Definition of the operation to be built
- * @return types::Lifter The lifter with the `i_ne` filter.
+ * @return base::Lifter The lifter with the `i_ne` filter.
  * @throw std::runtime_error if the parameter is not a integer.
  */
-types::Lifter opBuilderHelperIntNotEqual(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderHelperIntNotEqual(const base::DocumentValue & def, types::TracerFn tr);
 
 /**
  * @brief Builds helper integer less than operation.
@@ -207,10 +207,10 @@ types::Lifter opBuilderHelperIntNotEqual(const types::DocumentValue & def, types
  * The filter checks if a field in the JSON event is less than a value.
  * Only pass events if the fields are less than and the values are a integer.
  * @param def Definition of the operation to be built
- * @return types::Lifter The lifter with the `i_lt` filter.
+ * @return base::Lifter The lifter with the `i_lt` filter.
  * @throw std::runtime_error if the parameter is not a integer.
  */
-types::Lifter opBuilderHelperIntLessThan(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderHelperIntLessThan(const base::DocumentValue & def, types::TracerFn tr);
 
 /**
  * @brief Builds helper integer less than equal operation.
@@ -219,10 +219,10 @@ types::Lifter opBuilderHelperIntLessThan(const types::DocumentValue & def, types
  * The filter checks if a field in the JSON event is less than equal a value.
  * Only pass events if the fields are less than equal and the values are a integer.
  * @param def Definition of the operation to be built
- * @return types::Lifter The lifter with the `i_le` filter.
+ * @return base::Lifter The lifter with the `i_le` filter.
  * @throw std::runtime_error if the parameter is not a integer.
  */
-types::Lifter opBuilderHelperIntLessThanEqual(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderHelperIntLessThanEqual(const base::DocumentValue & def, types::TracerFn tr);
 
 /**
  * @brief Builds helper integer greater than operation.
@@ -231,11 +231,11 @@ types::Lifter opBuilderHelperIntLessThanEqual(const types::DocumentValue & def, 
  * The filter checks if a field in the JSON event is greater than a value.
  * Only pass events if the fields are greater than and the values are a integer.
  * @param def Definition of the operation to be built
- * @return types::Lifter The lifter with the `i_gt` filter.
+ * @return base::Lifter The lifter with the `i_gt` filter.
  * @throw std::runtime_error if the parameter is not a integer.
  */
 
-types::Lifter opBuilderHelperIntGreaterThan(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderHelperIntGreaterThan(const base::DocumentValue & def, types::TracerFn tr);
 
 /**
  * @brief Builds helper integer greater than equal operation.
@@ -244,38 +244,38 @@ types::Lifter opBuilderHelperIntGreaterThan(const types::DocumentValue & def, ty
  * The filter checks if a field in the JSON event is greater than equal a value.
  * Only pass events if the fields are greater than equal and the values are a integer.
  * @param def Definition of the operation to be built
- * @return types::Lifter The lifter with the `i_ge` filter.
+ * @return base::Lifter The lifter with the `i_ge` filter.
  * @throw std::runtime_error if the parameter is not a integer.
  */
-types::Lifter opBuilderHelperIntGreaterThanEqual(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderHelperIntGreaterThanEqual(const base::DocumentValue & def, types::TracerFn tr);
 
 /**
  * @brief Builds helper regex match operation.
  * Checks that the field value matches a regular expression
  *
  * @param def Definition of the operation to be built
- * @return types::Lifter The lifter with the `regex` filter.
+ * @return base::Lifter The lifter with the `regex` filter.
  */
-types::Lifter opBuilderHelperRegexMatch(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderHelperRegexMatch(const base::DocumentValue & def, types::TracerFn tr);
 
 /**
  * @brief Builds helper regex not match operation.
  * Checks that the field value doesn't match a regular expression
  *
  * @param def Definition of the operation to be built
- * @return types::Lifter The lifter with the `regex_not` filter.
+ * @return base::Lifter The lifter with the `regex_not` filter.
  */
-types::Lifter opBuilderHelperRegexNotMatch(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderHelperRegexNotMatch(const base::DocumentValue & def, types::TracerFn tr);
 
 /**
  * @brief Create `ip_cidr` helper function that filters events if the field
  * is in the specified CIDR range.
  *
  * @param def The filter definition.
- * @return types::Lifter The lifter with the `ip_cidr` filter.
+ * @return base::Lifter The lifter with the `ip_cidr` filter.
  * @throw  std::runtime_error if the parameter is not a cidr.
  */
-types::Lifter opBuilderHelperIPCIDR(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderHelperIPCIDR(const base::DocumentValue & def, types::TracerFn tr);
 
 } // namespace builder::internals::builders
 

--- a/src/engine/source/builder/builders/opBuilderHelperMap.cpp
+++ b/src/engine/source/builder/builders/opBuilderHelperMap.cpp
@@ -55,7 +55,7 @@ Event opBuilderHelperStringTransformation(const std::string field,
         const rapidjson::Value* refValueToCheck {};
         try
         {
-            refValueToCheck = &e->get(refValue.value());
+            refValueToCheck = &e->getEvent()->get(refValue.value());
         }
         catch (std::exception& ex)
         {
@@ -97,8 +97,8 @@ Event opBuilderHelperStringTransformation(const std::string field,
     // Create and add string to event
     try
     {
-        e->set(field,
-               rapidjson::Value(value.value().c_str(), e->m_doc.GetAllocator())
+        e->getEvent()->set(field,
+               rapidjson::Value(value.value().c_str(), e->getEvent()->m_doc.GetAllocator())
                    .Move());
     }
     catch (std::exception& ex)
@@ -138,7 +138,7 @@ Event opBuilderHelperIntTransformation(const std::string field,
     const rapidjson::Value* fieldValue {};
     try
     {
-        fieldValue = &e->get(field);
+        fieldValue = &e->getEvent()->get(field);
     }
     catch (std::exception& ex)
     {
@@ -159,7 +159,7 @@ Event opBuilderHelperIntTransformation(const std::string field,
         const rapidjson::Value* refValueToCheck {};
         try
         {
-            refValueToCheck = &e->get(refValue.value());
+            refValueToCheck = &e->getEvent()->get(refValue.value());
         }
         catch (std::exception& ex)
         {
@@ -204,7 +204,7 @@ Event opBuilderHelperIntTransformation(const std::string field,
     // Create and add string to event
     try
     {
-        e->set(field, rapidjson::Value(value.value()));
+        e->getEvent()->set(field, rapidjson::Value(value.value()));
     }
     catch (std::exception& ex)
     {
@@ -379,7 +379,7 @@ types::Lifter opBuilderHelperStringTrim(const types::DocumentValue& def,
                 const rapidjson::Value* fieldValue;
                 try
                 {
-                    fieldValue = &e->get(field);
+                    fieldValue = &e->getEvent()->get(field);
                 }
                 catch (std::exception& ex)
                 {
@@ -426,9 +426,9 @@ types::Lifter opBuilderHelperStringTrim(const types::DocumentValue& def,
                 // Update event
                 try
                 {
-                    e->set(field,
+                    e->getEvent()->set(field,
                            rapidjson::Value(strToTrim.c_str(),
-                                            e->m_doc.GetAllocator())
+                                            e->getEvent()->m_doc.GetAllocator())
                                .Move());
                 }
                 catch (std::exception& ex)
@@ -543,7 +543,7 @@ types::Lifter opBuilderHelperRegexExtract(const types::DocumentValue& def,
                 const rapidjson::Value* field_str {};
                 try
                 {
-                    field_str = &e->get(field);
+                    field_str = &e->getEvent()->get(field);
                 }
                 catch (std::exception& ex)
                 {
@@ -559,9 +559,9 @@ types::Lifter opBuilderHelperRegexExtract(const types::DocumentValue& def,
                         // Create and add string to event
                         try
                         {
-                            e->set(map_field,
+                            e->getEvent()->set(map_field,
                                    rapidjson::Value(match.c_str(),
-                                                    e->m_doc.GetAllocator())
+                                                    e->getEvent()->m_doc.GetAllocator())
                                        .Move());
                         }
                         catch (std::exception& ex)

--- a/src/engine/source/builder/builders/opBuilderHelperMap.cpp
+++ b/src/engine/source/builder/builders/opBuilderHelperMap.cpp
@@ -20,27 +20,24 @@
 namespace
 {
 
-using DocumentValue = builder::internals::types::DocumentValue;
-using Event = builder::internals::types::Event;
-
 /**
- * @brief Tranform the string in `field` path in the event `e` according to the
+ * @brief Tranform the string in `field` path in the base::Event `e` according to the
  * `op` definition and the `value` or the `refValue`
  *
  * @param field The field path to transform
  * @param op The operator to use:
  * - `u`: Upper case
  * - `l`: Lower case
- * @param e The event that contains the field to transform
+ * @param e The base::Event that contains the field to transform
  * @param refValue The reference to the value user as source of the
  * transformation
  * @param value The value to use as source of the transformation
- * @return types::Event The event with the field transformed
+ * @return base::Event The base::Event with the field transformed
  * @throw std::logic_error if the `op` is not valid
  */
-Event opBuilderHelperStringTransformation(const std::string field,
+base::Event opBuilderHelperStringTransformation(const std::string field,
                                           char op,
-                                          Event& e,
+                                          base::Event& e,
                                           std::optional<std::string> refValue,
                                           std::optional<std::string> value)
 {
@@ -48,7 +45,7 @@ Event opBuilderHelperStringTransformation(const std::string field,
     // Get src field
     if (refValue.has_value())
     {
-        // Get reference to json event
+        // Get reference to json base::Event
         // TODO Remove try catch or if nullptr after fix get method of document
         // class
         // TODO Update to use proper reference
@@ -94,7 +91,7 @@ Event opBuilderHelperStringTransformation(const std::string field,
             break;
     }
 
-    // Create and add string to event
+    // Create and add string to base::Event
     try
     {
         e->getEvent()->set(field,
@@ -111,7 +108,7 @@ Event opBuilderHelperStringTransformation(const std::string field,
 }
 
 /**
- * @brief Tranform the int in `field` path in the event `e` according to the
+ * @brief Tranform the int in `field` path in the base::Event `e` according to the
  * `op` definition and the `value` or the `refValue`
  *
  * @param field The field path to transform
@@ -120,16 +117,16 @@ Event opBuilderHelperStringTransformation(const std::string field,
  * - `sub`: Subtract
  * - `mul`: Multiply
  * - `div`: Divide
- * @param e The event that contains the field to transform
+ * @param e The base::Event that contains the field to transform
  * @param refValue The reference to the value user as source of the
  * transformation
  * @param value The value to use as source of the transformation
- * @return types::Event The event with the field transformed
+ * @return base::Event The base::Event with the field transformed
  * @throw std::logic_error if the `op` is not valid
  */
-Event opBuilderHelperIntTransformation(const std::string field,
+base::Event opBuilderHelperIntTransformation(const std::string field,
                                        std::string op,
-                                       Event& e,
+                                       base::Event& e,
                                        std::optional<std::string> refValue,
                                        std::optional<int> value)
 {
@@ -153,7 +150,7 @@ Event opBuilderHelperIntTransformation(const std::string field,
 
     if (refValue.has_value())
     {
-        // Get reference to json event
+        // Get reference to json base::Event
         // TODO Remove try catch or if nullptr after fix get method of document
         // class
         const rapidjson::Value* refValueToCheck {};
@@ -201,7 +198,7 @@ Event opBuilderHelperIntTransformation(const std::string field,
         return e;
     }
 
-    // Create and add string to event
+    // Create and add string to base::Event
     try
     {
         e->getEvent()->set(field, rapidjson::Value(value.value()));
@@ -225,7 +222,7 @@ using builder::internals::syntax::REFERENCE_ANCHOR;
 //*************************************************
 
 // <field>: +s_up/<str>|$<ref>
-types::Lifter opBuilderHelperStringUP(const types::DocumentValue& def,
+base::Lifter opBuilderHelperStringUP(const base::DocumentValue& def,
                                       types::TracerFn tr)
 {
     // Get field key to check
@@ -251,7 +248,7 @@ types::Lifter opBuilderHelperStringUP(const types::DocumentValue& def,
     std::optional<std::string> refExpStr {};
     std::optional<std::string> expectedStr {};
 
-    // Check if is a reference to json event
+    // Check if is a reference to json base::Event
     if (parametersArr[1][0] == REFERENCE_ANCHOR)
     {
         refExpStr = json::formatJsonPath(parametersArr[1].substr(1));
@@ -262,11 +259,11 @@ types::Lifter opBuilderHelperStringUP(const types::DocumentValue& def,
     }
 
     // Return Lifter
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // Append rxcpp operation
         return o.map(
-            [key, expectedStr, refExpStr](types::Event e)
+            [key, expectedStr, refExpStr](base::Event e)
             {
                 return opBuilderHelperStringTransformation(
                     key, 'u', e, refExpStr, expectedStr);
@@ -275,7 +272,7 @@ types::Lifter opBuilderHelperStringUP(const types::DocumentValue& def,
 }
 
 // <field>: +s_lo/<str>|$<ref>
-types::Lifter opBuilderHelperStringLO(const types::DocumentValue& def,
+base::Lifter opBuilderHelperStringLO(const base::DocumentValue& def,
                                       types::TracerFn tr)
 {
 
@@ -301,7 +298,7 @@ types::Lifter opBuilderHelperStringLO(const types::DocumentValue& def,
     std::optional<std::string> refExpStr {};
     std::optional<std::string> expectedStr {};
 
-    // Check if is a reference to json event
+    // Check if is a reference to json base::Event
     if (parametersArr[1][0] == REFERENCE_ANCHOR)
     {
         refExpStr = json::formatJsonPath(parametersArr[1].substr(1));
@@ -312,11 +309,11 @@ types::Lifter opBuilderHelperStringLO(const types::DocumentValue& def,
     }
 
     // Return Lifter
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // Append rxcpp operation
         return o.map(
-            [key, expectedStr, refExpStr](types::Event e)
+            [key, expectedStr, refExpStr](base::Event e)
             {
                 return opBuilderHelperStringTransformation(
                     key, 'l', e, refExpStr, expectedStr);
@@ -325,7 +322,7 @@ types::Lifter opBuilderHelperStringLO(const types::DocumentValue& def,
 }
 
 // <field>: +s_trim/[begin | end | both]/char
-types::Lifter opBuilderHelperStringTrim(const types::DocumentValue& def,
+base::Lifter opBuilderHelperStringTrim(const base::DocumentValue& def,
                                         types::TracerFn tr)
 {
 
@@ -368,11 +365,11 @@ types::Lifter opBuilderHelperStringTrim(const types::DocumentValue& def,
     }
 
     // Return Lifter
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // Append rxcpp operation
         return o.map(
-            [field, trimType, trimChar](types::Event e)
+            [field, trimType, trimChar](base::Event e)
             {
                 // Shoulbe short after refact, witout try catch
                 // Get field value
@@ -423,7 +420,7 @@ types::Lifter opBuilderHelperStringTrim(const types::DocumentValue& def,
                         break;
                 }
 
-                // Update event
+                // Update base::Event
                 try
                 {
                     e->getEvent()->set(field,
@@ -447,7 +444,7 @@ types::Lifter opBuilderHelperStringTrim(const types::DocumentValue& def,
 //*************************************************
 
 // field: +i_calc/[+|-|*|/]/val|$ref/
-types::Lifter opBuilderHelperIntCalc(const types::DocumentValue& def,
+base::Lifter opBuilderHelperIntCalc(const base::DocumentValue& def,
                                      types::TracerFn tr)
 {
     // Get field
@@ -492,11 +489,11 @@ types::Lifter opBuilderHelperIntCalc(const types::DocumentValue& def,
     }
 
     // Return Lifter
-    return [field, op, refValue, value](types::Observable o)
+    return [field, op, refValue, value](base::Observable o)
     {
         // Append rxcpp operation
         return o.map(
-            [=](types::Event e) {
+            [=](base::Event e) {
                 return opBuilderHelperIntTransformation(
                     field, op, e, refValue, value);
             });
@@ -508,7 +505,7 @@ types::Lifter opBuilderHelperIntCalc(const types::DocumentValue& def,
 //*************************************************
 
 // field: +r_ext/_field/regexp/
-types::Lifter opBuilderHelperRegexExtract(const types::DocumentValue& def,
+base::Lifter opBuilderHelperRegexExtract(const base::DocumentValue& def,
                                           types::TracerFn tr)
 {
     // Get fields
@@ -533,11 +530,11 @@ types::Lifter opBuilderHelperRegexExtract(const types::DocumentValue& def,
     }
 
     // Return Lifter
-    return [field, regex_ptr, map_field](types::Observable o)
+    return [field, regex_ptr, map_field](base::Observable o)
     {
         // Append rxcpp operation
         return o.map(
-            [=](types::Event e)
+            [=](base::Event e)
             {
                 // TODO Remove try catch
                 const rapidjson::Value* field_str {};
@@ -556,7 +553,7 @@ types::Lifter opBuilderHelperRegexExtract(const types::DocumentValue& def,
                     if (RE2::PartialMatch(
                             field_str->GetString(), *regex_ptr, &match))
                     {
-                        // Create and add string to event
+                        // Create and add string to base::Event
                         try
                         {
                             e->getEvent()->set(map_field,

--- a/src/engine/source/builder/builders/opBuilderHelperMap.hpp
+++ b/src/engine/source/builder/builders/opBuilderHelperMap.hpp
@@ -28,29 +28,29 @@ namespace builder::internals::builders
  * @brief Transforms a string to uppercase and append or remplace it in the event `e`
  *
  * @param def The transformation definition. i.e : `<field>: +s_up/<str>|$<ref>`
- * @return types::Lifter The lifter with the `uppercase` transformation.
+ * @return base::Lifter The lifter with the `uppercase` transformation.
  * @throw std::runtime_error if the parameter is not a string.
  */
-types::Lifter opBuilderHelperStringUP(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderHelperStringUP(const base::DocumentValue & def, types::TracerFn tr);
 
 /**
  * @brief Transforms a string to lowercase and append or remplace it in the event `e`
  *
  * @param def The transformation definition. i.e : `<field>: +s_lo/<str>|$<ref>`
- * @return types::Lifter The lifter with the `lowercase` transformation.
+ * @return base::Lifter The lifter with the `lowercase` transformation.
  * @throw std::runtime_error if the parameter is not a string.
  */
-types::Lifter opBuilderHelperStringLO(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderHelperStringLO(const base::DocumentValue & def, types::TracerFn tr);
 
 /**
  * @brief Transforms a string, trim it and append or remplace it in the event `e`
  *
  * @param def The transformation definition.
  * i.e : `<field>: +s_trim/[begin | end | both]/char`
- * @return types::Lifter The lifter with the `trim` transformation.
+ * @return base::Lifter The lifter with the `trim` transformation.
  * @throw std::runtime_error if the parameter is not a string.
  */
-types::Lifter opBuilderHelperStringTrim(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderHelperStringTrim(const base::DocumentValue & def, types::TracerFn tr);
 
 //*************************************************
 //*           Int tranform                        *
@@ -61,10 +61,10 @@ types::Lifter opBuilderHelperStringTrim(const types::DocumentValue & def, types:
  *
  * @param def The transformation definition.
  * i.e : `<field>: +icalcm/[sum|sub|mul|div]/[value|$<ref>]`
- * @return types::Lifter The lifter with the `mathematical operation` transformation.
+ * @return base::Lifter The lifter with the `mathematical operation` transformation.
  * @throw std::runtime_error if the parameter is not a integer.
  */
-types::Lifter opBuilderHelperIntCalc(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderHelperIntCalc(const base::DocumentValue & def, types::TracerFn tr);
 
 //*************************************************
 //*           Regex tranform                      *
@@ -75,10 +75,10 @@ types::Lifter opBuilderHelperIntCalc(const types::DocumentValue & def, types::Tr
  * Maps into an auxiliary field the part of the field value that matches a regexp
  *
  * @param def Definition of the operation to be built
- * @return types::Lifter The lifter with the `regex extract` transformation.
+ * @return base::Lifter The lifter with the `regex extract` transformation.
  * @throw std::runtime_error if the parameter is the regex is invalid.
  */
-types::Lifter opBuilderHelperRegexExtract(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderHelperRegexExtract(const base::DocumentValue & def, types::TracerFn tr);
 
 } // namespace builder::internals::builders
 

--- a/src/engine/source/builder/builders/opBuilderKVDB.cpp
+++ b/src/engine/source/builder/builders/opBuilderKVDB.cpp
@@ -83,7 +83,7 @@ types::Lifter opBuilderKVDBExtract(const types::DocumentValue& def,
                 {
                     try
                     {
-                        auto value = &e->get(key);
+                        auto value = &e->getEvent()->get(key);
                         if (value && value->IsString())
                         {
                             dbKey = value->GetString();
@@ -117,9 +117,9 @@ types::Lifter opBuilderKVDBExtract(const types::DocumentValue& def,
                 // Create and add string to event
                 try
                 {
-                    e->set(target,
+                    e->getEvent()->set(target,
                            rapidjson::Value(dbValue.c_str(),
-                                            e->m_doc.GetAllocator())
+                                            e->getEvent()->m_doc.GetAllocator())
                                .Move());
                     tr(successTrace);
                 }
@@ -185,7 +185,7 @@ types::Lifter opBuilderKVDBExistanceCheck(const types::DocumentValue& def,
                 try // TODO We are only using try for JSON::get. Is correct to
                     // wrap everything?
                 {
-                    auto value = &e->get(key);
+                    auto value = &e->getEvent()->get(key);
                     if (value && value->IsString())
                     {
                         if (kvdb->hasKey(value->GetString()))

--- a/src/engine/source/builder/builders/opBuilderKVDB.cpp
+++ b/src/engine/source/builder/builders/opBuilderKVDB.cpp
@@ -23,7 +23,7 @@ namespace builder::internals::builders
 using builder::internals::syntax::REFERENCE_ANCHOR;
 
 // <field>: +kvdb_extract/<DB>/<ref_key>
-types::Lifter opBuilderKVDBExtract(const types::DocumentValue& def,
+base::Lifter opBuilderKVDBExtract(const base::DocumentValue& def,
                                    types::TracerFn tr)
 {
     // Get target of the extraction
@@ -66,16 +66,16 @@ types::Lifter opBuilderKVDBExtract(const types::DocumentValue& def,
 
     // TODO this is not great
     // Make deep copy of value
-    types::Document doc {def};
+    base::Document doc {def};
     std::string successTrace = fmt::format("{} KVDBExtract Success", doc.str());
     std::string failureTrace = fmt::format("{} KVDBExtract Failure", doc.str());
 
     // Return Lifter
-    return [=, kvdb = std::move(kvdb), tr = std::move(tr)](types::Observable o)
+    return [=, kvdb = std::move(kvdb), tr = std::move(tr)](base::Observable o)
     {
         // Append rxcpp operation
         return o.map(
-            [=, kvdb = std::move(kvdb), tr = std::move(tr)](types::Event e)
+            [=, kvdb = std::move(kvdb), tr = std::move(tr)](base::Event e)
             {
                 // Get DB key
                 std::string dbKey;
@@ -135,7 +135,7 @@ types::Lifter opBuilderKVDBExtract(const types::DocumentValue& def,
     };
 }
 
-types::Lifter opBuilderKVDBExistanceCheck(const types::DocumentValue& def,
+base::Lifter opBuilderKVDBExistanceCheck(const base::DocumentValue& def,
                                           bool checkExist,
                                           types::TracerFn tr)
 {
@@ -168,18 +168,18 @@ types::Lifter opBuilderKVDBExistanceCheck(const types::DocumentValue& def,
 
     // TODO this is not great
     // Make deep copy of value
-    types::Document doc {def};
+    base::Document doc {def};
     std::string successTrace =
         fmt::format("{} KVDBExistanceCheck Found", doc.str());
     std::string failureTrace =
         fmt::format("{} KVDBExistanceCheck NotFound", doc.str());
 
     // Return Lifter
-    return [=, kvdb = std::move(kvdb), tr = std::move(tr)](types::Observable o)
+    return [=, kvdb = std::move(kvdb), tr = std::move(tr)](base::Observable o)
     {
         // Append rxcpp operations
         return o.filter(
-            [=, kvdb = std::move(kvdb), tr = std::move(tr)](types::Event e)
+            [=, kvdb = std::move(kvdb), tr = std::move(tr)](base::Event e)
             {
                 bool found = false;
                 try // TODO We are only using try for JSON::get. Is correct to
@@ -206,14 +206,14 @@ types::Lifter opBuilderKVDBExistanceCheck(const types::DocumentValue& def,
 }
 
 // <field>: +kvdb_match/<DB>
-types::Lifter opBuilderKVDBMatch(const types::DocumentValue& def,
+base::Lifter opBuilderKVDBMatch(const base::DocumentValue& def,
                                  types::TracerFn tr)
 {
     return opBuilderKVDBExistanceCheck(def, true, tr);
 }
 
 // <field>: +kvdb_not_match/<DB>
-types::Lifter opBuilderKVDBNotMatch(const types::DocumentValue& def,
+base::Lifter opBuilderKVDBNotMatch(const base::DocumentValue& def,
                                     types::TracerFn tr)
 {
     return opBuilderKVDBExistanceCheck(def, false, tr);

--- a/src/engine/source/builder/builders/opBuilderKVDB.hpp
+++ b/src/engine/source/builder/builders/opBuilderKVDB.hpp
@@ -18,27 +18,27 @@ namespace builder::internals::builders
  * @brief Builds KVDB extract function helper
  *
  * @param def
- * @return types::Lifter
+ * @return base::Lifter
  */
-types::Lifter opBuilderKVDBExtract(const types::DocumentValue& def,
+base::Lifter opBuilderKVDBExtract(const base::DocumentValue& def,
                                    types::TracerFn tr);
 
 /**
  * @brief Builds KVDB match function helper
  *
  * @param def
- * @return types::Lifter
+ * @return base::Lifter
  */
-types::Lifter opBuilderKVDBMatch(const types::DocumentValue& def,
+base::Lifter opBuilderKVDBMatch(const base::DocumentValue& def,
                                  types::TracerFn tr);
 
 /**
  * @brief Builds KVDB not-match function helper
  *
  * @param def
- * @return types::Lifter
+ * @return base::Lifter
  */
-types::Lifter opBuilderKVDBNotMatch(const types::DocumentValue& def,
+base::Lifter opBuilderKVDBNotMatch(const base::DocumentValue& def,
                                     types::TracerFn tr);
 } // namespace builder::internals::builders
 

--- a/src/engine/source/builder/builders/opBuilderMap.cpp
+++ b/src/engine/source/builder/builders/opBuilderMap.cpp
@@ -20,7 +20,7 @@
 namespace builder::internals::builders
 {
 
-types::Lifter opBuilderMap(const types::DocumentValue& def, types::TracerFn tr)
+base::Lifter opBuilderMap(const base::DocumentValue& def, types::TracerFn tr)
 {
     // Check that input is as expected and throw exception otherwise
     if (!def.IsObject())

--- a/src/engine/source/builder/builders/opBuilderMap.hpp
+++ b/src/engine/source/builder/builders/opBuilderMap.hpp
@@ -19,9 +19,9 @@ namespace builder::internals::builders
  * @brief Auxiliray builder to handle proper specific map builder
  *
  * @param def Definition of the operation to be built
- * @return types::Lifter
+ * @return base::Lifter
  */
-types::Lifter opBuilderMap(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderMap(const base::DocumentValue & def, types::TracerFn tr);
 
 } // namespace builder::internals::builders
 

--- a/src/engine/source/builder/builders/opBuilderMapReference.cpp
+++ b/src/engine/source/builder/builders/opBuilderMapReference.cpp
@@ -19,7 +19,7 @@ namespace builder::internals::builders
 {
 
 // TODO Add test for this
-types::Lifter opBuilderMapReference(const types::DocumentValue &def,
+base::Lifter opBuilderMapReference(const base::DocumentValue &def,
                                     types::TracerFn tr)
 {
     if (!def.MemberBegin()->name.IsString())
@@ -44,16 +44,16 @@ types::Lifter opBuilderMapReference(const types::DocumentValue &def,
     reference = json::formatJsonPath(reference);
 
     // Debug trace
-    types::Document value{def};
+    base::Document value{def};
     std::string successTrace = fmt::format("{} Mapping Success", value.str());
     std::string failureTrace = fmt::format("{} Mapping Failure", value.str());
 
     // Return Lifter
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // Append rxcpp operation
         return o.map(
-            [=](types::Event e)
+            [=](base::Event e)
             {
                 e->getEvent()->set(field, reference);
                 tr(successTrace);

--- a/src/engine/source/builder/builders/opBuilderMapReference.cpp
+++ b/src/engine/source/builder/builders/opBuilderMapReference.cpp
@@ -55,7 +55,7 @@ types::Lifter opBuilderMapReference(const types::DocumentValue &def,
         return o.map(
             [=](types::Event e)
             {
-                e->set(field, reference);
+                e->getEvent()->set(field, reference);
                 tr(successTrace);
                 return e;
             });

--- a/src/engine/source/builder/builders/opBuilderMapReference.hpp
+++ b/src/engine/source/builder/builders/opBuilderMapReference.hpp
@@ -19,9 +19,9 @@ namespace builder::internals::builders
  * @brief Builds map reference operation.
  *
  * @param def Definition of the operation to be built
- * @return types::Lifter
+ * @return base::Lifter
  */
-types::Lifter opBuilderMapReference(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderMapReference(const base::DocumentValue & def, types::TracerFn tr);
 
 } // namespace builder::internals::builders
 

--- a/src/engine/source/builder/builders/opBuilderMapValue.cpp
+++ b/src/engine/source/builder/builders/opBuilderMapValue.cpp
@@ -34,7 +34,7 @@ types::Lifter opBuilderMapValue(const types::DocumentValue &def,
         return o.map(
             [=](types::Event e)
             {
-                e->set(field, doc.m_doc.MemberBegin()->value);
+                e->getEvent()->set(field, doc.m_doc.MemberBegin()->value);
                 tr(successTrace);
                 return e;
             });

--- a/src/engine/source/builder/builders/opBuilderMapValue.cpp
+++ b/src/engine/source/builder/builders/opBuilderMapValue.cpp
@@ -14,11 +14,11 @@ using namespace std;
 namespace builder::internals::builders
 {
 // TODOL DOC and test this
-types::Lifter opBuilderMapValue(const types::DocumentValue &def,
+base::Lifter opBuilderMapValue(const base::DocumentValue &def,
                                 types::TracerFn tr)
 {
     // Make deep copy of value
-    types::Document doc {def};
+    base::Document doc {def};
     std::string field =
         json::formatJsonPath(def.MemberBegin()->name.GetString());
     std::string defstr {doc.str()};
@@ -28,11 +28,11 @@ types::Lifter opBuilderMapValue(const types::DocumentValue &def,
     std::string failureTrace = fmt::format("{} Mapping Failure", doc.str());
 
     // Return Lifter
-    return [=](types::Observable o)
+    return [=](base::Observable o)
     {
         // Append rxcpp operation
         return o.map(
-            [=](types::Event e)
+            [=](base::Event e)
             {
                 e->getEvent()->set(field, doc.m_doc.MemberBegin()->value);
                 tr(successTrace);

--- a/src/engine/source/builder/builders/opBuilderMapValue.hpp
+++ b/src/engine/source/builder/builders/opBuilderMapValue.hpp
@@ -19,9 +19,9 @@ namespace builder::internals::builders
  * @brief Builds map value operation.
  *
  * @param def Definition of the operation to be built
- * @return types::Lifter
+ * @return base::Lifter
  */
-types::Lifter opBuilderMapValue(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter opBuilderMapValue(const base::DocumentValue & def, types::TracerFn tr);
 
 } // namespace builder::internals::builders
 

--- a/src/engine/source/builder/builders/stageBuilderCheck.cpp
+++ b/src/engine/source/builder/builders/stageBuilderCheck.cpp
@@ -34,12 +34,7 @@ base::Lifter stageBuilderCheck(const base::DocumentValue &def, types::TracerFn t
 
     // Build all conditions
     std::vector<base::Lifter> conditions;
-    // Implicit XOR condition in front
-    conditions.push_back([](base::Observable o) {
-        return o.filter([](base::Event e) {
-            // Insert cout for check if the event was discarded
-            return e->getDecoded(); });
-    });
+
     for (auto it = def.Begin(); it != def.End(); ++it)
     {
         try

--- a/src/engine/source/builder/builders/stageBuilderCheck.cpp
+++ b/src/engine/source/builder/builders/stageBuilderCheck.cpp
@@ -21,7 +21,7 @@
 namespace builder::internals::builders
 {
 
-types::Lifter stageBuilderCheck(const types::DocumentValue &def, types::TracerFn tr)
+base::Lifter stageBuilderCheck(const base::DocumentValue &def, types::TracerFn tr)
 {
     // Assert value is as expected
     if (!def.IsArray())
@@ -33,7 +33,7 @@ types::Lifter stageBuilderCheck(const types::DocumentValue &def, types::TracerFn
     }
 
     // Build all conditions
-    std::vector<types::Lifter> conditions;
+    std::vector<base::Lifter> conditions;
     for (auto it = def.Begin(); it != def.End(); ++it)
     {
         try
@@ -54,7 +54,7 @@ types::Lifter stageBuilderCheck(const types::DocumentValue &def, types::TracerFn
     }
 
     // Chain all operations
-    types::Lifter check;
+    base::Lifter check;
     try
     {
         check = std::get<types::CombinatorBuilder>(

--- a/src/engine/source/builder/builders/stageBuilderCheck.cpp
+++ b/src/engine/source/builder/builders/stageBuilderCheck.cpp
@@ -34,6 +34,12 @@ base::Lifter stageBuilderCheck(const base::DocumentValue &def, types::TracerFn t
 
     // Build all conditions
     std::vector<base::Lifter> conditions;
+    // Implicit XOR condition in front
+    conditions.push_back([](base::Observable o) {
+        return o.filter([](base::Event e) {
+            // Insert cout for check if the event was discarded
+            return e->getDecoded(); });
+    });
     for (auto it = def.Begin(); it != def.End(); ++it)
     {
         try

--- a/src/engine/source/builder/builders/stageBuilderCheck.hpp
+++ b/src/engine/source/builder/builders/stageBuilderCheck.hpp
@@ -19,9 +19,9 @@ namespace builder::internals::builders
  * @brief Builds stage check
  *
  * @param def
- * @return types::Lifter
+ * @return base::Lifter
  */
-types::Lifter stageBuilderCheck(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter stageBuilderCheck(const base::DocumentValue & def, types::TracerFn tr);
 
 } // namespace builder::internals::builders
 

--- a/src/engine/source/builder/builders/stageBuilderNormalize.cpp
+++ b/src/engine/source/builder/builders/stageBuilderNormalize.cpp
@@ -20,7 +20,7 @@
 namespace builder::internals::builders
 {
 
-types::Lifter stageBuilderNormalize(const types::DocumentValue & def, types::TracerFn tr)
+base::Lifter stageBuilderNormalize(const base::DocumentValue & def, types::TracerFn tr)
 {
     // Assert value is as expected
     if (!def.IsArray())
@@ -31,7 +31,7 @@ types::Lifter stageBuilderNormalize(const types::DocumentValue & def, types::Tra
     }
 
     // Build all mappings
-    std::vector<types::Lifter> mappings;
+    std::vector<base::Lifter> mappings;
     for (auto it = def.Begin(); it != def.End(); ++it)
     {
         try

--- a/src/engine/source/builder/builders/stageBuilderNormalize.hpp
+++ b/src/engine/source/builder/builders/stageBuilderNormalize.hpp
@@ -19,9 +19,9 @@ namespace builder::internals::builders
  * @brief Builds stage check
  *
  * @param def
- * @return types::Lifter
+ * @return base::Lifter
  */
-types::Lifter stageBuilderNormalize(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter stageBuilderNormalize(const base::DocumentValue & def, types::TracerFn tr);
 
 } // namespace builder::internals::builders
 

--- a/src/engine/source/builder/builders/stageBuilderOutputs.cpp
+++ b/src/engine/source/builder/builders/stageBuilderOutputs.cpp
@@ -20,7 +20,7 @@
 namespace builder::internals::builders
 {
 
-types::Lifter stageBuilderOutputs(const types::DocumentValue & def, types::TracerFn tr)
+base::Lifter stageBuilderOutputs(const base::DocumentValue & def, types::TracerFn tr)
 {
     // Assert value is as expected
     if (!def.IsArray())
@@ -33,7 +33,7 @@ types::Lifter stageBuilderOutputs(const types::DocumentValue & def, types::Trace
     }
 
     // Build all outputs
-    std::vector<types::Lifter> outputs;
+    std::vector<base::Lifter> outputs;
     for (auto it = def.Begin(); it != def.End(); ++it)
     {
         try
@@ -49,7 +49,7 @@ types::Lifter stageBuilderOutputs(const types::DocumentValue & def, types::Trace
     }
 
     // Broadcast to all operations
-    types::Lifter output;
+    base::Lifter output;
     try
     {
         output = std::get<types::CombinatorBuilder>(Registry::getBuilder("combinator.broadcast"))(outputs);

--- a/src/engine/source/builder/builders/stageBuilderOutputs.hpp
+++ b/src/engine/source/builder/builders/stageBuilderOutputs.hpp
@@ -19,9 +19,9 @@ namespace builder::internals::builders
  * @brief Builds stage outputs
  *
  * @param def
- * @return types::Lifter
+ * @return base::Lifter
  */
-types::Lifter stageBuilderOutputs(const types::DocumentValue & def, types::TracerFn tr);
+base::Lifter stageBuilderOutputs(const base::DocumentValue & def, types::TracerFn tr);
 
 } // namespace builder::internals::builders
 

--- a/src/engine/source/builder/builders/stageParse.cpp
+++ b/src/engine/source/builder/builders/stageParse.cpp
@@ -84,7 +84,8 @@ types::Lifter stageBuilderParse(const types::DocumentValue &def, types::TracerFn
             return o.map(
                 [parserOp = std::move(parserOp)](types::Event e)
                 {
-                    const auto & ev = e->get("/message");
+                    // TODO: What is the /message field? Why is hard-coded?
+                    const auto & ev = e->getEvent()->get("/message");
                     if (!ev.IsString())
                     {
                         // TODO error
@@ -103,7 +104,7 @@ types::Lifter stageBuilderParse(const types::DocumentValue &def, types::TracerFn
                     {
                         auto name =
                             json::formatJsonPath(val.first.c_str());
-                        e->set(name, {val.second.c_str(), e->getAllocator()});
+                        e->getEvent()->set(name, {val.second.c_str(), e->getEvent()->getAllocator()});
                     }
 
                     return e;

--- a/src/engine/source/builder/builders/stageParse.cpp
+++ b/src/engine/source/builder/builders/stageParse.cpp
@@ -22,7 +22,7 @@
 namespace builder::internals::builders
 {
 
-types::Lifter stageBuilderParse(const types::DocumentValue &def, types::TracerFn tr)
+base::Lifter stageBuilderParse(const base::DocumentValue &def, types::TracerFn tr)
 {
     // Assert value is as expected
     if (!def.IsObject())
@@ -52,7 +52,7 @@ types::Lifter stageBuilderParse(const types::DocumentValue &def, types::TracerFn
             "[Stage parse]Must have some expressions configured.");
     }
 
-    std::vector<types::Lifter> parsers;
+    std::vector<base::Lifter> parsers;
     for (auto const &item : logqlArr.GetArray())
     {
         if (!item.IsObject())
@@ -79,10 +79,10 @@ types::Lifter stageBuilderParse(const types::DocumentValue &def, types::TracerFn
             std::throw_with_nested(std::runtime_error(msg));
         }
 
-        auto newOp = [parserOp = std::move(parseOp)](types::Observable o)
+        auto newOp = [parserOp = std::move(parseOp)](base::Observable o)
         {
             return o.map(
-                [parserOp = std::move(parserOp)](types::Event e)
+                [parserOp = std::move(parserOp)](base::Event e)
                 {
                     // TODO: What is the /message field? Why is hard-coded?
                     const auto & ev = e->getEvent()->get("/message");

--- a/src/engine/source/builder/builders/stageParse.hpp
+++ b/src/engine/source/builder/builders/stageParse.hpp
@@ -20,9 +20,9 @@ namespace builder::internals::builders
  * logged event
  *
  * @param def
- * @return types::Lifter
+ * @return base::Lifter
  */
-types::Lifter stageBuilderParse(const types::DocumentValue &def, types::TracerFn tr);
+base::Lifter stageBuilderParse(const base::DocumentValue &def, types::TracerFn tr);
 
 } // namespace builder::internals::builders
 

--- a/src/engine/source/builder/connectable.hpp
+++ b/src/engine/source/builder/connectable.hpp
@@ -187,7 +187,7 @@ struct Connectable
                         },
                         [](auto eptr) {},
                         []() {})
-                    .filter([](base::Event event){
+                    .filter([](auto event){
                         // TODO: This is not only executed in the OUTPUT_DECODER but in all subgraph ends.
                         event->setDecoded();
                         return true;

--- a/src/engine/source/builder/connectable.hpp
+++ b/src/engine/source/builder/connectable.hpp
@@ -187,7 +187,11 @@ struct Connectable
                         },
                         [](auto eptr) {},
                         []() {})
-                    .distinct_until_changed()
+                    .filter([](base::Event event){
+                        // TODO: This is not only executed in the OUTPUT_DECODER but in all subgraph ends.
+                        event->setDecoded();
+                        return true;
+                    })
                     .tap([=](auto event) { trFn(" sent event"); },
                          [](auto eptr) {},
                          []() {});

--- a/src/engine/source/builder/connectable.hpp
+++ b/src/engine/source/builder/connectable.hpp
@@ -93,7 +93,7 @@ struct Connectable
                 if (sbj.has_observers() && s.is_subscribed())
                 {
                     s.on_next(
-                        fmt::format("({}) {} {}", name, msg, event->str()));
+                        fmt::format("({}) {} {}", name, msg, event->getEvent()->str()));
                 }
             };
         }

--- a/src/engine/source/builder/outputs/file.hpp
+++ b/src/engine/source/builder/outputs/file.hpp
@@ -65,7 +65,7 @@ public:
      *
      * @param e
      */
-    void write(const types::Event & e)
+    void write(const base::Event & e)
     {
         this->m_os << e->getEvent()->str() << std::endl;
     }

--- a/src/engine/source/builder/outputs/file.hpp
+++ b/src/engine/source/builder/outputs/file.hpp
@@ -67,7 +67,7 @@ public:
      */
     void write(const types::Event & e)
     {
-        this->m_os << e->str() << std::endl;
+        this->m_os << e->getEvent()->str() << std::endl;
     }
 };
 

--- a/src/engine/source/router/router.hpp
+++ b/src/engine/source/router/router.hpp
@@ -18,7 +18,6 @@
 #include <fmt/format.h>
 #include <rxcpp/rx.hpp>
 
-//#include <eventHandler.hpp>
 #include <baseTypes.hpp>
 
 namespace router

--- a/src/engine/source/router/router.hpp
+++ b/src/engine/source/router/router.hpp
@@ -18,7 +18,8 @@
 #include <fmt/format.h>
 #include <rxcpp/rx.hpp>
 
-#include <EventHandler.hpp>
+//#include <eventHandler.hpp>
+#include <baseTypes.hpp>
 
 namespace router
 {
@@ -31,7 +32,7 @@ struct Route
 {
     std::string m_name;
     std::string m_to;
-    std::function<bool(std::shared_ptr<Base::EventHandler>)> m_from;
+    std::function<bool(base::Event)> m_from;
     rxcpp::composite_subscription m_subscription;
 
     Route() = default;
@@ -48,7 +49,7 @@ struct Route
      */
     Route(const std::string &name,
           const std::string &environment,
-          std::function<bool(std::shared_ptr<Base::EventHandler>)> filter_function,
+          std::function<bool(base::Event)> filter_function,
           rxcpp::composite_subscription subscription) noexcept
         : m_name(name)
         , m_to(environment)
@@ -103,7 +104,7 @@ struct Environment
 {
     // TODO: handle debug sink subscriptions lifetime
 
-    using Event = std::shared_ptr<Base::EventHandler>;
+    using Event = base::Event;
     using Observable = rxcpp::observable<Event>;
     using Lifter = std::function<Observable(Observable)>;
 
@@ -193,7 +194,7 @@ struct Environment
 template<class Builder>
 class Router
 {
-    using Observable = rxcpp::observable<std::shared_ptr<Base::EventHandler>>;
+    using Observable = rxcpp::observable<base::Event>;
     using Lifter = std::function<Observable(Observable)>;
 
     // Assert Builder satisfies expected interface/functionality
@@ -236,8 +237,8 @@ private:
 
     std::map<std::string, Environment> m_environments;
     std::map<std::string, Route> m_routes;
-    rxcpp::subjects::subject<std::shared_ptr<Base::EventHandler>> m_subj;
-    rxcpp::subscriber<std::shared_ptr<Base::EventHandler>> m_input;
+    rxcpp::subjects::subject<base::Event> m_subj;
+    rxcpp::subscriber<base::Event> m_input;
     Builder m_builder;
 
 public:
@@ -262,7 +263,7 @@ public:
     void add(
         const std::string &route,
         const std::string &environment,
-        const std::function<bool(std::shared_ptr<Base::EventHandler>)>
+        const std::function<bool(base::Event)>
             filterFunction = [](const auto) { return true; })
     {
         // Assert route with same name not exists
@@ -335,7 +336,7 @@ public:
      *
      * @return const rxcpp::subscriber<json::Document>&
      */
-    const rxcpp::subscriber<std::shared_ptr<Base::EventHandler>> &input() const
+    const rxcpp::subscriber<base::Event> &input() const
     {
         return this->m_input;
     }

--- a/src/engine/source/router/router.hpp
+++ b/src/engine/source/router/router.hpp
@@ -18,7 +18,7 @@
 #include <fmt/format.h>
 #include <rxcpp/rx.hpp>
 
-#include "json.hpp"
+#include <EventHandler.hpp>
 
 namespace router
 {
@@ -31,7 +31,7 @@ struct Route
 {
     std::string m_name;
     std::string m_to;
-    std::function<bool(std::shared_ptr<json::Document>)> m_from;
+    std::function<bool(std::shared_ptr<Base::EventHandler>)> m_from;
     rxcpp::composite_subscription m_subscription;
 
     Route() = default;
@@ -48,7 +48,7 @@ struct Route
      */
     Route(const std::string &name,
           const std::string &environment,
-          std::function<bool(std::shared_ptr<json::Document>)> filter_function,
+          std::function<bool(std::shared_ptr<Base::EventHandler>)> filter_function,
           rxcpp::composite_subscription subscription) noexcept
         : m_name(name)
         , m_to(environment)
@@ -103,7 +103,7 @@ struct Environment
 {
     // TODO: handle debug sink subscriptions lifetime
 
-    using Event = std::shared_ptr<json::Document>;
+    using Event = std::shared_ptr<Base::EventHandler>;
     using Observable = rxcpp::observable<Event>;
     using Lifter = std::function<Observable(Observable)>;
 
@@ -193,7 +193,7 @@ struct Environment
 template<class Builder>
 class Router
 {
-    using Observable = rxcpp::observable<std::shared_ptr<json::Document>>;
+    using Observable = rxcpp::observable<std::shared_ptr<Base::EventHandler>>;
     using Lifter = std::function<Observable(Observable)>;
 
     // Assert Builder satisfies expected interface/functionality
@@ -236,8 +236,8 @@ private:
 
     std::map<std::string, Environment> m_environments;
     std::map<std::string, Route> m_routes;
-    rxcpp::subjects::subject<std::shared_ptr<json::Document>> m_subj;
-    rxcpp::subscriber<std::shared_ptr<json::Document>> m_input;
+    rxcpp::subjects::subject<std::shared_ptr<Base::EventHandler>> m_subj;
+    rxcpp::subscriber<std::shared_ptr<Base::EventHandler>> m_input;
     Builder m_builder;
 
 public:
@@ -262,7 +262,7 @@ public:
     void add(
         const std::string &route,
         const std::string &environment,
-        const std::function<bool(std::shared_ptr<json::Document>)>
+        const std::function<bool(std::shared_ptr<Base::EventHandler>)>
             filterFunction = [](const auto) { return true; })
     {
         // Assert route with same name not exists
@@ -335,7 +335,7 @@ public:
      *
      * @return const rxcpp::subscriber<json::Document>&
      */
-    const rxcpp::subscriber<std::shared_ptr<json::Document>> &input() const
+    const rxcpp::subscriber<std::shared_ptr<Base::EventHandler>> &input() const
     {
         return this->m_input;
     }

--- a/src/engine/source/router/router.hpp
+++ b/src/engine/source/router/router.hpp
@@ -43,8 +43,8 @@ struct Route
      * @brief Construct a new Route object
      *
      * @param name Name of the route
-     * @param filter_function Filter events to send to environment
      * @param environment Environment name wich receives filtered events
+     * @param filter_function Filter events to send to environment
      * @param subscription Subscription to handle status
      */
     Route(const std::string &name,
@@ -194,8 +194,6 @@ struct Environment
 template<class Builder>
 class Router
 {
-    using Observable = rxcpp::observable<base::Event>;
-    using Lifter = std::function<Observable(Observable)>;
 
     // Assert Builder satisfies expected interface/functionality
     // First check if Builder is callable with a string as an argument
@@ -214,7 +212,7 @@ class Router
     // Assert getLifter returns a lifter
     static_assert(
         std::is_same_v<decltype(std::declval<builder_ret_type>().getLifter()),
-                       Lifter>,
+                       base::Lifter>,
         "Error, getLifter method does not return function with signature: "
         "std::function<Observable(Observable)>");
 

--- a/src/engine/source/server/protocolHandler.cpp
+++ b/src/engine/source/server/protocolHandler.cpp
@@ -35,7 +35,7 @@ bool ProtocolHandler::hasHeader()
     return false;
 }
 
-std::shared_ptr<Base::EventHandler> ProtocolHandler::parse(const std::string& event)
+base::Event ProtocolHandler::parse(const std::string& event)
 {
     auto doc = std::make_shared<json::Document>();
     doc->m_doc.SetObject();
@@ -80,7 +80,8 @@ std::shared_ptr<Base::EventHandler> ProtocolHandler::parse(const std::string& ev
             ("Error parsing location using token sep :" + event));
     }
 
-    return  std::shared_ptr<Base::EventHandler>(new Base::EventHandler(doc));
+    // TODO Create event here
+    return  std::shared_ptr<base::EventHandler>(new base::EventHandler(doc));
 }
 
 std::optional<std::vector<std::string>>

--- a/src/engine/source/server/protocolHandler.cpp
+++ b/src/engine/source/server/protocolHandler.cpp
@@ -35,7 +35,7 @@ bool ProtocolHandler::hasHeader()
     return false;
 }
 
-std::shared_ptr<json::Document> ProtocolHandler::parse(const std::string& event)
+std::shared_ptr<Base::EventHandler> ProtocolHandler::parse(const std::string& event)
 {
     auto doc = std::make_shared<json::Document>();
     doc->m_doc.SetObject();
@@ -80,7 +80,7 @@ std::shared_ptr<json::Document> ProtocolHandler::parse(const std::string& event)
             ("Error parsing location using token sep :" + event));
     }
 
-    return doc;
+    return  std::shared_ptr<Base::EventHandler>(new Base::EventHandler(doc));
 }
 
 std::optional<std::vector<std::string>>

--- a/src/engine/source/server/protocolHandler.hpp
+++ b/src/engine/source/server/protocolHandler.hpp
@@ -12,7 +12,7 @@
 
 #include <optional>
 
-#include "json.hpp"
+#include <EventHandler.hpp>
 
 namespace engineserver
 {
@@ -44,7 +44,7 @@ public:
      *
      * @return json::Document
      */
-    static std::shared_ptr<json::Document> parse(const std::string &event);
+    static std::shared_ptr<Base::EventHandler> parse(const std::string &event);
 
     /**
      * @brief process the chunk of data and send messages to dst when. Return

--- a/src/engine/source/server/protocolHandler.hpp
+++ b/src/engine/source/server/protocolHandler.hpp
@@ -12,7 +12,7 @@
 
 #include <optional>
 
-#include <EventHandler.hpp>
+#include <baseTypes.hpp>
 
 namespace engineserver
 {
@@ -44,7 +44,7 @@ public:
      *
      * @return json::Document
      */
-    static std::shared_ptr<Base::EventHandler> parse(const std::string &event);
+    static base::Event parse(const std::string &event);
 
     /**
      * @brief process the chunk of data and send messages to dst when. Return

--- a/src/engine/test/acceptance_test/utils/benchmark_tool.go
+++ b/src/engine/test/acceptance_test/utils/benchmark_tool.go
@@ -229,8 +229,7 @@ func connectToSock(protocol string, address string) net.Conn {
 func sendLogSock(conn net.Conn, header bool, message string) {
 	var payload []byte
 
-	ret := '\r'
-	payload = []byte("1:[123] (hostname_test_bench) any->/var/some_location:" + message + string(ret))
+	payload = []byte("1:[123] (hostname_test_bench) any->/var/some_location:" + message)
 
 	if header {
 		secMsg := new(bytes.Buffer)

--- a/src/engine/test/assets/decoders/decoder_test.yml
+++ b/src/engine/test/assets/decoders/decoder_test.yml
@@ -13,3 +13,5 @@ normalize:
   - decoded.queue: decoded_queue
   - decoded.location: decoded_location
   - decoded.message: decoded_message
+  - decoded.logline: $logLine
+  - decoded.index: $index

--- a/src/engine/test/assets/decoders/decoder_test_index_1.yml
+++ b/src/engine/test/assets/decoders/decoder_test_index_1.yml
@@ -1,0 +1,9 @@
+name: decoder_test_index_1
+parents:
+  - decoder_test
+
+check:
+  - index: +s_eq/one
+
+normalize:
+  - decoded.by: 1

--- a/src/engine/test/assets/decoders/decoder_test_index_2.yml
+++ b/src/engine/test/assets/decoders/decoder_test_index_2.yml
@@ -1,0 +1,9 @@
+name: decoder_test_index_2
+parents:
+  - decoder_test
+
+check:
+  - index: +s_eq/two
+
+normalize:
+  - decoded.by: 2

--- a/src/engine/test/assets/decoders/decoder_test_index_2_child_1.yml
+++ b/src/engine/test/assets/decoders/decoder_test_index_2_child_1.yml
@@ -1,0 +1,9 @@
+name: decoder_test_index_2_child_1
+parents:
+  - decoder_test_index_2
+
+check:
+  - logLine: +s_eq/user
+
+normalize:
+  - decoded.user_logline: true

--- a/src/engine/test/assets/environments/test_environment.yml
+++ b/src/engine/test/assets/environments/test_environment.yml
@@ -1,7 +1,8 @@
 decoders:
-  - decoder_test
-  - decoder_test_index_1
-  - decoder_test_index_2
+  - decoder_test                 # [Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: user#xxx
+  - decoder_test_index_1         # [Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: user#one
+  - decoder_test_index_2         # [Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: notuser#two
+  - decoder_test_index_2_child_1 # [Mon Jan 2 15:04:05 2006] host test_decoder_example[1234]: user#two
 rules:
   - rule_test
 filters:

--- a/src/engine/test/assets/environments/test_environment.yml
+++ b/src/engine/test/assets/environments/test_environment.yml
@@ -1,5 +1,7 @@
 decoders:
   - decoder_test
+  - decoder_test_index_1
+  - decoder_test_index_2
 rules:
   - rule_test
 filters:

--- a/src/engine/test/source/builder/CMakeLists.txt
+++ b/src/engine/test/source/builder/CMakeLists.txt
@@ -56,34 +56,38 @@ gtest_discover_tests(registerTest)
 add_executable(opBuilderTest
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderConditionReference_test.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderConditionValue_test.cpp
-  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperExists_test.cpp
-  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperNotExists_test.cpp
-  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperStringEq_test.cpp
-  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperStringGe_test.cpp
-  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperStringGt_test.cpp
-  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperStringLO_test.cpp
-  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperStringLe_test.cpp
-  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperStringLt_test.cpp
-  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperStringNe_test.cpp
-  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperStringUP_test.cpp
 )
 gtest_discover_tests(opBuilderTest)
 
-add_executable(opBuilderHelperTest
-  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIPCIDRCheck_test.cpp
-  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntCalc_test.cpp
+add_executable(opBuilderHelperCheckTest
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntEqual_test.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntNotEqual_test.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntGreaterThanEqual_test.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntGreaterThan_test.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntLessThanEqual_test.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntLessThan_test.cpp
-  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntNotEqual_test.cpp
-  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperRegexExtract_test.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperExists_test.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperNotExists_test.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperStringEq_test.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperStringNe_test.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperStringGe_test.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperStringGt_test.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperStringLe_test.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperStringLt_test.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperRegexMatch_test.cpp
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperRegexNotMatch_test.cpp
-  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperStringTrim_test.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIPCIDRCheck_test.cpp
 )
-gtest_discover_tests(opBuilderHelperTest)
+gtest_discover_tests(opBuilderHelperCheckTest)
+
+add_executable(opBuilderHelperMapTest
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperIntCalc_test.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperStringLO_test.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperStringUP_test.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperStringTrim_test.cpp
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperRegexExtract_test.cpp
+)
+gtest_discover_tests(opBuilderHelperMapTest)
 
 add_executable(opBuilderMapTest
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderMapValue_test.cpp

--- a/src/engine/test/source/builder/builder_test.cpp
+++ b/src/engine/test/source/builder/builder_test.cpp
@@ -15,7 +15,7 @@
 #define GTEST_COUT std::cerr << "[          ] [ INFO ] "
 using namespace base;
 
-auto createEvent = [](const char * json){
+auto createSharedEvent = [](const char * json){
     return std::make_shared<EventHandler>(std::make_shared<Document>(json));
 };
 
@@ -105,10 +105,10 @@ TEST(Builder, GraphRulesFilteredOut)
                           for (int i = 0; i < expected; i++)
                           {
                               if (i % 2 == 0)
-                                  s.on_next(createEvent(R"({"type": "int", "field": "odd",
+                                  s.on_next(createSharedEvent(R"({"type": "int", "field": "odd",
                                   "value": 0})"));
                               else
-                                  s.on_next(createEvent(R"({"type": "int", "field": "even",
+                                  s.on_next(createSharedEvent(R"({"type": "int", "field": "even",
                                   "value": 1})"));
                           }
                           s.on_completed();
@@ -161,10 +161,10 @@ TEST(Builder, GraphDuplicatedExample)
                           for (int i = 0; i < expected; i++)
                           {
                               if (i % 2 == 0)
-                                  s.on_next(createEvent(R"({"type": "int", "field": "odd",
+                                  s.on_next(createSharedEvent(R"({"type": "int", "field": "odd",
                                   "value": 0})"));
                               else
-                                  s.on_next(createEvent(R"({"type": "int", "field": "even",
+                                  s.on_next(createSharedEvent(R"({"type": "int", "field": "even",
                                   "value": 1})"));
                           }
                           s.on_completed();

--- a/src/engine/test/source/builder/builders/assetBuilderDecoder_test.cpp
+++ b/src/engine/test/source/builder/builders/assetBuilderDecoder_test.cpp
@@ -30,10 +30,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
-};
-
 TEST(AssetBuilderDecoder, BuildsAllNonRegistered)
 {
     Document doc{R"({
@@ -106,17 +102,17 @@ TEST(AssetBuilderDecoder, BuildsOperates)
         [=](auto s)
         {
             //TODO: fix json interface to not throw exception
-            s.on_next(createEvent(R"({
+            s.on_next(createSharedEvent(R"({
                 "field1": "value",
                 "field2": 2,
                 "field3": "value",
                 "field4": true,
                 "field5": "+exists"
             })"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(createEvent(R"({
+            s.on_next(createSharedEvent(R"({
                 "field":"value",
                 "field1": "value",
                 "field2": 2,
@@ -125,7 +121,7 @@ TEST(AssetBuilderDecoder, BuildsOperates)
                 "field5": "+exists",
                 "field6": "+exists"
             })"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();

--- a/src/engine/test/source/builder/builders/assetBuilderFilter_test.cpp
+++ b/src/engine/test/source/builder/builders/assetBuilderFilter_test.cpp
@@ -25,10 +25,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
-};
-
 TEST(AssetBuilderFilter, BuildsAllNonRegistered)
 {
     Document doc{R"({
@@ -85,17 +81,17 @@ TEST(AssetBuilderFilter, BuildsOperates)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"({
+            s.on_next(createSharedEvent(R"({
                 "field1": "value",
                 "field2": 2,
                 "field3": "value",
                 "field4": true,
                 "field5": "+exists"
             })"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(createEvent(R"({
+            s.on_next(createSharedEvent(R"({
                 "field":"value",
                 "field1": "value",
                 "field2": 2,
@@ -104,7 +100,7 @@ TEST(AssetBuilderFilter, BuildsOperates)
                 "field5": "+exists",
                 "field6": "+exists"
             })"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();

--- a/src/engine/test/source/builder/builders/assetBuilderOutput_test.cpp
+++ b/src/engine/test/source/builder/builders/assetBuilderOutput_test.cpp
@@ -32,10 +32,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
-};
-
 TEST(AssetBuilderOutput, BuildsAllNonRegistered)
 {
     Document doc{R"({
@@ -117,22 +113,22 @@ TEST(AssetBuilderOutput, BuildsOperates)
     auto input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field1":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"value1"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"value"}
             )"));
             s.on_completed();

--- a/src/engine/test/source/builder/builders/assetBuilderRule_test.cpp
+++ b/src/engine/test/source/builder/builders/assetBuilderRule_test.cpp
@@ -30,10 +30,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
-};
-
 TEST(AssetBuilderRule, BuildsAllNonRegistered)
 {
     Document doc{R"({
@@ -106,17 +102,17 @@ TEST(AssetBuilderRule, BuildsOperates)
         [=](auto s)
         {
             // TODO: fix json interface to not throw exception
-            s.on_next(createEvent(R"({
+            s.on_next(createSharedEvent(R"({
                 "field1": "value",
                 "field2": 2,
                 "field3": "value",
                 "field4": true,
                 "field5": "+exists"
             })"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(createEvent(R"({
+            s.on_next(createSharedEvent(R"({
                 "field":"value",
                 "field1": "value",
                 "field2": 2,
@@ -125,7 +121,7 @@ TEST(AssetBuilderRule, BuildsOperates)
                 "field5": "+exists",
                 "field6": "+exists"
             })"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();

--- a/src/engine/test/source/builder/builders/assetBuilderRule_test.cpp
+++ b/src/engine/test/source/builder/builders/assetBuilderRule_test.cpp
@@ -24,7 +24,15 @@
 #include "opBuilderMapValue.hpp"
 #include "stageBuilderNormalize.hpp"
 
-using namespace builder::internals::builders;
+using namespace base;
+namespace bld = builder::internals::builders;
+
+using FakeTrFn = std::function<void(std::string)>;
+static FakeTrFn tr = [](std::string msg){};
+
+auto createEvent = [](const char * json){
+    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
+};
 
 TEST(AssetBuilderRule, BuildsAllNonRegistered)
 {
@@ -38,33 +46,33 @@ TEST(AssetBuilderRule, BuildsAllNonRegistered)
         ]
     })"};
 
-    ASSERT_THROW(builders::assetBuilderRule(doc), std::_Nested_exception<std::runtime_error>);
+    ASSERT_THROW(bld::assetBuilderRule(doc), std::_Nested_exception<std::runtime_error>);
 }
 
 TEST(AssetBuilderRule, Builds)
 {
-    BuilderVariant c = opBuilderMapValue;
+    BuilderVariant c = bld::opBuilderMapValue;
     Registry::registerBuilder("map.value", c);
-    c = opBuilderMapReference;
+    c = bld::opBuilderMapReference;
     Registry::registerBuilder("map.reference", c);
-    c = opBuilderMap;
+    c = bld::opBuilderMap;
     Registry::registerBuilder("map", c);
-    c = combinatorBuilderChain;
+    c = bld::combinatorBuilderChain;
     Registry::registerBuilder("combinator.chain", c);
-    c = stageBuilderNormalize;
+    c = bld::stageBuilderNormalize;
     Registry::registerBuilder("normalize", c);
 
-    c = opBuilderConditionValue;
+    c = bld::opBuilderConditionValue;
     Registry::registerBuilder("condition.value", c);
-    c = opBuilderConditionReference;
+    c = bld::opBuilderConditionReference;
     Registry::registerBuilder("condition.reference", c);
-    c = opBuilderHelperExists;
+    c = bld::opBuilderHelperExists;
     Registry::registerBuilder("helper.exists", c);
-    c = opBuilderHelperNotExists;
+    c = bld::opBuilderHelperNotExists;
     Registry::registerBuilder("helper.not_exists", c);
-    c = opBuilderCondition;
+    c = bld::opBuilderCondition;
     Registry::registerBuilder("condition", c);
-    c = stageBuilderCheck;
+    c = bld::stageBuilderCheck;
     Registry::registerBuilder("check", c);
 
     Document doc{R"({
@@ -77,7 +85,7 @@ TEST(AssetBuilderRule, Builds)
         ]
     })"};
 
-    ASSERT_NO_THROW(builders::assetBuilderRule(doc));
+    ASSERT_NO_THROW(bld::assetBuilderRule(doc));
 }
 
 TEST(AssetBuilderRule, BuildsOperates)
@@ -92,23 +100,23 @@ TEST(AssetBuilderRule, BuildsOperates)
         ]
     })"};
 
-    auto rule = builders::assetBuilderRule(doc);
+    auto rule = bld::assetBuilderRule(doc);
 
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
             // TODO: fix json interface to not throw exception
-            s.on_next(std::make_shared<json::Document>(R"({
+            s.on_next(createEvent(R"({
                 "field1": "value",
                 "field2": 2,
                 "field3": "value",
                 "field4": true,
                 "field5": "+exists"
             })"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"({
+            s.on_next(createEvent(R"({
                 "field":"value",
                 "field1": "value",
                 "field2": 2,
@@ -117,7 +125,7 @@ TEST(AssetBuilderRule, BuildsOperates)
                 "field5": "+exists",
                 "field6": "+exists"
             })"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();
@@ -130,6 +138,6 @@ TEST(AssetBuilderRule, BuildsOperates)
     ASSERT_EQ(expected.size(), 2);
     for (auto e : expected)
     {
-        ASSERT_STREQ(e->get("/mapped/field").GetString(), "value");
+        ASSERT_STREQ(e->getEvent()->get("/mapped/field").GetString(), "value");
     }
 }

--- a/src/engine/test/source/builder/builders/opBuilderConditionReference_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderConditionReference_test.cpp
@@ -20,10 +20,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
-};
-
 TEST(opBuilderConditionReference, Builds)
 {
     Document doc{R"({
@@ -43,24 +39,24 @@ TEST(opBuilderConditionReference, BuildsOperatesString)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field":"value1",
                     "otherfield":"value1"
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field":"value1",
                     "otherfield":"value2"
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "otherfield":"value1"
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field":"value1"
                 }
@@ -86,24 +82,24 @@ TEST(opBuilderConditionReference, BuildsOperatesInt)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field":1,
                     "otherfield":1
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field":1,
                     "otherfield":2
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "otherfield":"value1"
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field":"value1"
                 }
@@ -129,24 +125,24 @@ TEST(opBuilderConditionReference, BuildsOperatesBool)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field":true,
                     "otherfield":true
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field":true,
                     "otherfield":false
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "otherfield":"value1"
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field":"value1"
                 }
@@ -172,24 +168,24 @@ TEST(opBuilderConditionReference, BuildsOperatesNull)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field":null,
                     "otherfield":null
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field":null,
                     "otherfield":false
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "otherfield":"value1"
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field":"value1"
                 }
@@ -214,24 +210,24 @@ TEST(opBuilderConditionReference, BuildsOperatesArray)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field":[1, 2],
                     "otherfield":[1, 2]
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field":[1, 2],
                     "otherfield":[1, 2, 3]
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "otherfield":"value1"
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field":"value1"
                 }
@@ -263,7 +259,7 @@ TEST(opBuilderConditionReference, BuildsOperatesObject)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
             {
                 "field": {
                     "int": 1,
@@ -279,7 +275,7 @@ TEST(opBuilderConditionReference, BuildsOperatesObject)
                 }
             }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
             {
                 "field": {
                     "int": 1,
@@ -295,19 +291,19 @@ TEST(opBuilderConditionReference, BuildsOperatesObject)
                 }
             }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":true}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":1}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"1"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();
@@ -338,24 +334,24 @@ TEST(opBuilderConditionReference, BuildsOperatesOneLevel)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":2}
             )"));
-            s.on_next(createEvent(R"({
+            s.on_next(createSharedEvent(R"({
                 "field":{"level": 1},
                 "otherfield":{"level": 1}
             })"));
-            s.on_next(createEvent(R"({
+            s.on_next(createSharedEvent(R"({
                 "field":{"level": 1},
                 "otherfield":{"level": 2}
             })"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":{"level": "1"}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();
@@ -378,24 +374,24 @@ TEST(opBuilderConditionReference, BuildsOperatesMultiLevel)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":2}
             )"));
-            s.on_next(createEvent(R"({
+            s.on_next(createSharedEvent(R"({
                 "field":{"multi": {"level": 1}},
                 "otherfield":{"multi": {"level": 1}}
             })"));
-            s.on_next(createEvent(R"({
+            s.on_next(createSharedEvent(R"({
                 "field":{"multi": {"level": 1}},
                 "otherfield":{"multi": {"level": 2}}
             })"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":{"level": "1"}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();

--- a/src/engine/test/source/builder/builders/opBuilderConditionReference_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderConditionReference_test.cpp
@@ -14,10 +14,15 @@
 
 #include "opBuilderConditionReference.hpp"
 
-using namespace builder::internals::builders;
+using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
+
+auto createEvent = [](const char * json){
+    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
+};
 
 TEST(opBuilderConditionReference, Builds)
 {
@@ -38,24 +43,24 @@ TEST(opBuilderConditionReference, BuildsOperatesString)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field":"value1",
                     "otherfield":"value1"
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field":"value1",
                     "otherfield":"value2"
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "otherfield":"value1"
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field":"value1"
                 }
@@ -67,8 +72,8 @@ TEST(opBuilderConditionReference, BuildsOperatesString)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_STREQ(expected[0]->get("/field").GetString(), "value1");
-    ASSERT_STREQ(expected[0]->get("/otherfield").GetString(), "value1");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/field").GetString(), "value1");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/otherfield").GetString(), "value1");
 }
 
 TEST(opBuilderConditionReference, BuildsOperatesInt)
@@ -81,24 +86,24 @@ TEST(opBuilderConditionReference, BuildsOperatesInt)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field":1,
                     "otherfield":1
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field":1,
                     "otherfield":2
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "otherfield":"value1"
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field":"value1"
                 }
@@ -110,8 +115,8 @@ TEST(opBuilderConditionReference, BuildsOperatesInt)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_EQ(expected[0]->get("/field").GetInt(), 1);
-    ASSERT_EQ(expected[0]->get("/otherfield").GetInt(), 1);
+    ASSERT_EQ(expected[0]->getEvent()->get("/field").GetInt(), 1);
+    ASSERT_EQ(expected[0]->getEvent()->get("/otherfield").GetInt(), 1);
 }
 
 TEST(opBuilderConditionReference, BuildsOperatesBool)
@@ -124,24 +129,24 @@ TEST(opBuilderConditionReference, BuildsOperatesBool)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field":true,
                     "otherfield":true
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field":true,
                     "otherfield":false
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "otherfield":"value1"
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field":"value1"
                 }
@@ -153,8 +158,8 @@ TEST(opBuilderConditionReference, BuildsOperatesBool)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_TRUE(expected[0]->get("/field").GetBool());
-    ASSERT_TRUE(expected[0]->get("/otherfield").GetBool());
+    ASSERT_TRUE(expected[0]->getEvent()->get("/field").GetBool());
+    ASSERT_TRUE(expected[0]->getEvent()->get("/otherfield").GetBool());
 }
 
 TEST(opBuilderConditionReference, BuildsOperatesNull)
@@ -167,24 +172,24 @@ TEST(opBuilderConditionReference, BuildsOperatesNull)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field":null,
                     "otherfield":null
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field":null,
                     "otherfield":false
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "otherfield":"value1"
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field":"value1"
                 }
@@ -196,7 +201,7 @@ TEST(opBuilderConditionReference, BuildsOperatesNull)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_EQ(expected[0]->get("/field"), rapidjson::Value{});
+    ASSERT_EQ(expected[0]->getEvent()->get("/field"), rapidjson::Value{});
 }
 
 TEST(opBuilderConditionReference, BuildsOperatesArray)
@@ -209,24 +214,24 @@ TEST(opBuilderConditionReference, BuildsOperatesArray)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field":[1, 2],
                     "otherfield":[1, 2]
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field":[1, 2],
                     "otherfield":[1, 2, 3]
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "otherfield":"value1"
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field":"value1"
                 }
@@ -238,11 +243,11 @@ TEST(opBuilderConditionReference, BuildsOperatesArray)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_TRUE(expected[0]->get("/field").IsArray());
-    ASSERT_EQ(expected[0]->get("/field").GetArray().Size(), expected[0]->get("/otherfield").GetArray().Size());
-    for (auto eIt = expected[0]->get("/field").GetArray().Begin(),
-              it = expected[0]->get("/otherfield").GetArray().Begin();
-         eIt != expected[0]->get("/field").GetArray().End(); ++eIt, ++it)
+    ASSERT_TRUE(expected[0]->getEvent()->get("/field").IsArray());
+    ASSERT_EQ(expected[0]->getEvent()->get("/field").GetArray().Size(), expected[0]->getEvent()->get("/otherfield").GetArray().Size());
+    for (auto eIt = expected[0]->getEvent()->get("/field").GetArray().Begin(),
+              it = expected[0]->getEvent()->get("/otherfield").GetArray().Begin();
+         eIt != expected[0]->getEvent()->get("/field").GetArray().End(); ++eIt, ++it)
     {
         ASSERT_EQ(*eIt, *it);
     }
@@ -258,7 +263,7 @@ TEST(opBuilderConditionReference, BuildsOperatesObject)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
             {
                 "field": {
                     "int": 1,
@@ -274,7 +279,7 @@ TEST(opBuilderConditionReference, BuildsOperatesObject)
                 }
             }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
             {
                 "field": {
                     "int": 1,
@@ -290,19 +295,19 @@ TEST(opBuilderConditionReference, BuildsOperatesObject)
                 }
             }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":true}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":1}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":"1"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();
@@ -312,11 +317,11 @@ TEST(opBuilderConditionReference, BuildsOperatesObject)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_TRUE(expected[0]->get("/field").IsObject());
-    ASSERT_TRUE(expected[0]->get("/otherfield").IsObject());
-    for (auto eIt = expected[0]->get("/field").GetObj().MemberBegin(),
-              it = expected[0]->get("/otherfield").GetObj().MemberBegin();
-         eIt != expected[0]->get("/field").GetObj().MemberEnd(); ++eIt, ++it)
+    ASSERT_TRUE(expected[0]->getEvent()->get("/field").IsObject());
+    ASSERT_TRUE(expected[0]->getEvent()->get("/otherfield").IsObject());
+    for (auto eIt = expected[0]->getEvent()->get("/field").GetObj().MemberBegin(),
+              it = expected[0]->getEvent()->get("/otherfield").GetObj().MemberBegin();
+         eIt != expected[0]->getEvent()->get("/field").GetObj().MemberEnd(); ++eIt, ++it)
     {
         ASSERT_EQ(eIt->name, it->name);
         ASSERT_EQ(eIt->value, it->value);
@@ -333,24 +338,24 @@ TEST(opBuilderConditionReference, BuildsOperatesOneLevel)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":2}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"({
+            s.on_next(createEvent(R"({
                 "field":{"level": 1},
                 "otherfield":{"level": 1}
             })"));
-            s.on_next(std::make_shared<json::Document>(R"({
+            s.on_next(createEvent(R"({
                 "field":{"level": 1},
                 "otherfield":{"level": 2}
             })"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":{"level": "1"}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();
@@ -360,7 +365,7 @@ TEST(opBuilderConditionReference, BuildsOperatesOneLevel)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_EQ(expected[0]->get("/field/level").GetInt(), expected[0]->get("/otherfield/level").GetInt());
+    ASSERT_EQ(expected[0]->getEvent()->get("/field/level").GetInt(), expected[0]->getEvent()->get("/otherfield/level").GetInt());
 }
 
 TEST(opBuilderConditionReference, BuildsOperatesMultiLevel)
@@ -373,24 +378,24 @@ TEST(opBuilderConditionReference, BuildsOperatesMultiLevel)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":2}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"({
+            s.on_next(createEvent(R"({
                 "field":{"multi": {"level": 1}},
                 "otherfield":{"multi": {"level": 1}}
             })"));
-            s.on_next(std::make_shared<json::Document>(R"({
+            s.on_next(createEvent(R"({
                 "field":{"multi": {"level": 1}},
                 "otherfield":{"multi": {"level": 2}}
             })"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":{"level": "1"}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();
@@ -400,5 +405,5 @@ TEST(opBuilderConditionReference, BuildsOperatesMultiLevel)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_EQ(expected[0]->get("/field/multi/level").GetInt(), expected[0]->get("/otherfield/multi/level").GetInt());
+    ASSERT_EQ(expected[0]->getEvent()->get("/field/multi/level").GetInt(), expected[0]->getEvent()->get("/otherfield/multi/level").GetInt());
 }

--- a/src/engine/test/source/builder/builders/opBuilderConditionReference_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderConditionReference_test.cpp
@@ -25,7 +25,7 @@ TEST(opBuilderConditionReference, Builds)
         "check":
             {"field": "$reference"}
     })"};
-    ASSERT_NO_THROW(opBuilderConditionReference(doc.get("/check"), tr));
+    ASSERT_NO_THROW(bld::opBuilderConditionReference(doc.get("/check"), tr));
 }
 
 TEST(opBuilderConditionReference, BuildsOperatesString)
@@ -62,7 +62,7 @@ TEST(opBuilderConditionReference, BuildsOperatesString)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderConditionReference(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderConditionReference(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -105,7 +105,7 @@ TEST(opBuilderConditionReference, BuildsOperatesInt)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderConditionReference(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderConditionReference(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -148,7 +148,7 @@ TEST(opBuilderConditionReference, BuildsOperatesBool)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderConditionReference(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderConditionReference(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -191,7 +191,7 @@ TEST(opBuilderConditionReference, BuildsOperatesNull)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderConditionReference(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderConditionReference(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -233,7 +233,7 @@ TEST(opBuilderConditionReference, BuildsOperatesArray)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderConditionReference(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderConditionReference(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -307,7 +307,7 @@ TEST(opBuilderConditionReference, BuildsOperatesObject)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderConditionReference(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderConditionReference(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -355,7 +355,7 @@ TEST(opBuilderConditionReference, BuildsOperatesOneLevel)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderConditionReference(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderConditionReference(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -395,7 +395,7 @@ TEST(opBuilderConditionReference, BuildsOperatesMultiLevel)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderConditionReference(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderConditionReference(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });

--- a/src/engine/test/source/builder/builders/opBuilderConditionValue_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderConditionValue_test.cpp
@@ -14,10 +14,15 @@
 
 #include "opBuilderConditionValue.hpp"
 
-using namespace builder::internals::builders;
+using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
+
+auto createEvent = [](const char * json){
+    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
+};
 
 TEST(opBuilderConditionValue, Builds)
 {
@@ -45,16 +50,16 @@ TEST(opBuilderConditionValue, BuildsOperatesString)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":"values"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();
@@ -64,7 +69,7 @@ TEST(opBuilderConditionValue, BuildsOperatesString)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_STREQ(expected[0]->get("/field").GetString(), doc.get("/check").MemberBegin()->value.GetString());
+    ASSERT_STREQ(expected[0]->getEvent()->get("/field").GetString(), doc.get("/check").MemberBegin()->value.GetString());
 }
 
 TEST(opBuilderConditionValue, BuildsOperatesInt)
@@ -77,19 +82,19 @@ TEST(opBuilderConditionValue, BuildsOperatesInt)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":2}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":1}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":"1"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();
@@ -99,7 +104,7 @@ TEST(opBuilderConditionValue, BuildsOperatesInt)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_EQ(expected[0]->get("/field").GetInt(), doc.get("/check").MemberBegin()->value.GetInt());
+    ASSERT_EQ(expected[0]->getEvent()->get("/field").GetInt(), doc.get("/check").MemberBegin()->value.GetInt());
 }
 
 TEST(opBuilderConditionValue, BuildsOperatesBool)
@@ -112,22 +117,22 @@ TEST(opBuilderConditionValue, BuildsOperatesBool)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":false}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":true}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":1}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":"1"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();
@@ -137,7 +142,7 @@ TEST(opBuilderConditionValue, BuildsOperatesBool)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_EQ(expected[0]->get("/field").GetBool(), doc.get("/check").MemberBegin()->value.GetBool());
+    ASSERT_EQ(expected[0]->getEvent()->get("/field").GetBool(), doc.get("/check").MemberBegin()->value.GetBool());
 }
 
 TEST(opBuilderConditionValue, BuildsOperatesNull)
@@ -150,22 +155,22 @@ TEST(opBuilderConditionValue, BuildsOperatesNull)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":null}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":true}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":1}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":"1"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();
@@ -175,7 +180,7 @@ TEST(opBuilderConditionValue, BuildsOperatesNull)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_EQ(expected[0]->get("/field"), rapidjson::Value{});
+    ASSERT_EQ(expected[0]->getEvent()->get("/field"), rapidjson::Value{});
 }
 
 TEST(opBuilderConditionValue, BuildsOperatesArray)
@@ -188,22 +193,22 @@ TEST(opBuilderConditionValue, BuildsOperatesArray)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":false}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":[1, 2]}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":1}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":"1"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();
@@ -213,11 +218,11 @@ TEST(opBuilderConditionValue, BuildsOperatesArray)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_TRUE(expected[0]->get("/field").IsArray());
-    ASSERT_EQ(expected[0]->get("/field").GetArray().Size(), doc.get("/check").MemberBegin()->value.GetArray().Size());
-    for (auto eIt = expected[0]->get("/field").GetArray().Begin(),
+    ASSERT_TRUE(expected[0]->getEvent()->get("/field").IsArray());
+    ASSERT_EQ(expected[0]->getEvent()->get("/field").GetArray().Size(), doc.get("/check").MemberBegin()->value.GetArray().Size());
+    for (auto eIt = expected[0]->getEvent()->get("/field").GetArray().Begin(),
               it = doc.get("/check").MemberBegin()->value.GetArray().Begin();
-         eIt != expected[0]->get("/field").GetArray().End(); ++eIt, ++it)
+         eIt != expected[0]->getEvent()->get("/field").GetArray().End(); ++eIt, ++it)
     {
         ASSERT_EQ(*eIt, *it);
     }
@@ -238,7 +243,7 @@ TEST(opBuilderConditionValue, BuildsOperatesObject)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field": {
                     "int": 1,
                     "bool": false,
@@ -247,19 +252,19 @@ TEST(opBuilderConditionValue, BuildsOperatesObject)
                 }
             }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":true}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":1}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":"1"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();
@@ -269,10 +274,10 @@ TEST(opBuilderConditionValue, BuildsOperatesObject)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_TRUE(expected[0]->get("/field").IsObject());
-    for (auto eIt = expected[0]->get("/field").GetObj().MemberBegin(),
+    ASSERT_TRUE(expected[0]->getEvent()->get("/field").IsObject());
+    for (auto eIt = expected[0]->getEvent()->get("/field").GetObj().MemberBegin(),
               it = doc.get("/check").MemberBegin()->value.GetObj().MemberBegin();
-         eIt != expected[0]->get("/field").GetObj().MemberEnd(); ++eIt, ++it)
+         eIt != expected[0]->getEvent()->get("/field").GetObj().MemberEnd(); ++eIt, ++it)
     {
         ASSERT_EQ(eIt->name, it->name);
         ASSERT_EQ(eIt->value, it->value);
@@ -289,19 +294,19 @@ TEST(opBuilderConditionValue, BuildsOperatesOneLevel)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":2}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":{"level": 1}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":{"level": "1"}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();
@@ -311,7 +316,7 @@ TEST(opBuilderConditionValue, BuildsOperatesOneLevel)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_EQ(expected[0]->get("/field/level").GetInt(), doc.get("/check").MemberBegin()->value.GetInt());
+    ASSERT_EQ(expected[0]->getEvent()->get("/field/level").GetInt(), doc.get("/check").MemberBegin()->value.GetInt());
 }
 
 TEST(opBuilderConditionValue, BuildsOperatesMultiLevel)
@@ -324,19 +329,19 @@ TEST(opBuilderConditionValue, BuildsOperatesMultiLevel)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":2}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field": {"multi": {"level": 1}}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field": {"multi": {"level": "1"}}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();
@@ -346,5 +351,5 @@ TEST(opBuilderConditionValue, BuildsOperatesMultiLevel)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_EQ(expected[0]->get("/field/multi/level").GetInt(), doc.get("/check").MemberBegin()->value.GetInt());
+    ASSERT_EQ(expected[0]->getEvent()->get("/field/multi/level").GetInt(), doc.get("/check").MemberBegin()->value.GetInt());
 }

--- a/src/engine/test/source/builder/builders/opBuilderConditionValue_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderConditionValue_test.cpp
@@ -31,7 +31,7 @@ TEST(opBuilderConditionValue, Builds)
     const auto & arr = doc.begin()->value.GetArray();
     for (auto it = arr.Begin(); it != arr.end(); ++it)
     {
-        ASSERT_NO_THROW(opBuilderConditionValue(*it, tr));
+        ASSERT_NO_THROW(bld::opBuilderConditionValue(*it, tr));
     }
 }
 
@@ -59,7 +59,7 @@ TEST(opBuilderConditionValue, BuildsOperatesString)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderConditionValue(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderConditionValue(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -94,7 +94,7 @@ TEST(opBuilderConditionValue, BuildsOperatesInt)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderConditionValue(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderConditionValue(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -132,7 +132,7 @@ TEST(opBuilderConditionValue, BuildsOperatesBool)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderConditionValue(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderConditionValue(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -170,7 +170,7 @@ TEST(opBuilderConditionValue, BuildsOperatesNull)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderConditionValue(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderConditionValue(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -208,7 +208,7 @@ TEST(opBuilderConditionValue, BuildsOperatesArray)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderConditionValue(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderConditionValue(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -264,7 +264,7 @@ TEST(opBuilderConditionValue, BuildsOperatesObject)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderConditionValue(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderConditionValue(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -306,7 +306,7 @@ TEST(opBuilderConditionValue, BuildsOperatesOneLevel)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderConditionValue(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderConditionValue(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -341,7 +341,7 @@ TEST(opBuilderConditionValue, BuildsOperatesMultiLevel)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderConditionValue(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderConditionValue(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });

--- a/src/engine/test/source/builder/builders/opBuilderConditionValue_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderConditionValue_test.cpp
@@ -8,9 +8,10 @@
  */
 
 #include "testUtils.hpp"
-#include <gtest/gtest.h>
 
 #include <vector>
+
+#include <gtest/gtest.h>
 
 #include "opBuilderConditionValue.hpp"
 
@@ -19,10 +20,6 @@ namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
-
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
-};
 
 TEST(opBuilderConditionValue, Builds)
 {
@@ -50,16 +47,16 @@ TEST(opBuilderConditionValue, BuildsOperatesString)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"values"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();
@@ -82,19 +79,19 @@ TEST(opBuilderConditionValue, BuildsOperatesInt)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":2}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":1}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"1"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();
@@ -117,22 +114,22 @@ TEST(opBuilderConditionValue, BuildsOperatesBool)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":false}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":true}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":1}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"1"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();
@@ -155,22 +152,22 @@ TEST(opBuilderConditionValue, BuildsOperatesNull)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":null}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":true}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":1}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"1"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();
@@ -193,22 +190,22 @@ TEST(opBuilderConditionValue, BuildsOperatesArray)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":false}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":[1, 2]}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":1}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"1"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();
@@ -243,7 +240,7 @@ TEST(opBuilderConditionValue, BuildsOperatesObject)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field": {
                     "int": 1,
                     "bool": false,
@@ -252,19 +249,19 @@ TEST(opBuilderConditionValue, BuildsOperatesObject)
                 }
             }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":true}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":1}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"1"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();
@@ -294,19 +291,19 @@ TEST(opBuilderConditionValue, BuildsOperatesOneLevel)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":2}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":{"level": 1}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":{"level": "1"}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();
@@ -329,19 +326,19 @@ TEST(opBuilderConditionValue, BuildsOperatesMultiLevel)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":2}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field": {"multi": {"level": 1}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field": {"multi": {"level": "1"}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();

--- a/src/engine/test/source/builder/builders/opBuilderCondition_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderCondition_test.cpp
@@ -15,10 +15,15 @@
 #include "opBuilderConditionValue.hpp"
 #include "opBuilderHelperFilter.hpp"
 
-using namespace builder::internals::builders;
+using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
+
+auto createEvent = [](const char * json){
+    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
+};
 
 TEST(opBuilderCondition, BuildsAllNonRegistered)
 {
@@ -35,13 +40,13 @@ TEST(opBuilderCondition, BuildsAllNonRegistered)
     const auto & arr = doc.begin()->value.GetArray();
     for (auto it = arr.Begin(); it != arr.end(); ++it)
     {
-        ASSERT_THROW(opBuilderCondition(*it, tr), invalid_argument);
+        ASSERT_THROW(bld::opBuilderCondition(*it, tr), invalid_argument);
     }
 }
 
 TEST(opBuilderCondition, BuildsValue)
 {
-    BuilderVariant c = opBuilderConditionValue;
+    BuilderVariant c = bld::opBuilderConditionValue;
     Registry::registerBuilder("condition.value", c);
     Document doc{R"({
         "check": [
@@ -53,30 +58,30 @@ TEST(opBuilderCondition, BuildsValue)
     const auto & arr = doc.begin()->value.GetArray();
     for (auto it = arr.Begin(); it != arr.end(); ++it)
     {
-        ASSERT_NO_THROW(opBuilderCondition(*it, tr));
+        ASSERT_NO_THROW(bld::opBuilderCondition(*it, tr));
     }
 }
 
 TEST(opBuilderCondition, BuildsReference)
 {
-    BuilderVariant c = opBuilderConditionReference;
+    BuilderVariant c = bld::opBuilderConditionReference;
     Registry::registerBuilder("condition.reference", c);
     Document doc{R"({"check": {"ref": "$ref"}})"};
-    ASSERT_NO_THROW(opBuilderCondition(doc.get("/check"), tr));
+    ASSERT_NO_THROW(bld::opBuilderCondition(doc.get("/check"), tr));
 }
 
 TEST(opBuilderCondition, BuildsHelperExists)
 {
-    BuilderVariant c = opBuilderHelperExists;
+    BuilderVariant c = bld::opBuilderHelperExists;
     Registry::registerBuilder("helper.exists", c);
     Document doc{R"({"check": {"ref": "+exists"}})"};
-    ASSERT_NO_THROW(opBuilderCondition(doc.get("/check"), tr));
+    ASSERT_NO_THROW(bld::opBuilderCondition(doc.get("/check"), tr));
 }
 
 TEST(opBuilderCondition, BuildsHelperNotExists)
 {
-    BuilderVariant c = opBuilderHelperNotExists;
+    BuilderVariant c = bld::opBuilderHelperNotExists;
     Registry::registerBuilder("helper.not_exists", c);
     Document doc{R"({"check": {"ref": "+not_exists"}})"};
-    ASSERT_NO_THROW(opBuilderCondition(doc.get("/check"), tr));
+    ASSERT_NO_THROW(bld::opBuilderCondition(doc.get("/check"), tr));
 }

--- a/src/engine/test/source/builder/builders/opBuilderCondition_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderCondition_test.cpp
@@ -21,10 +21,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
-};
-
 TEST(opBuilderCondition, BuildsAllNonRegistered)
 {
     Document doc{R"({

--- a/src/engine/test/source/builder/builders/opBuilderFileOutput_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderFileOutput_test.cpp
@@ -17,10 +17,15 @@
 
 #include "opBuilderFileOutput.hpp"
 
-using namespace builder::internals::builders;
+using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
+
+auto createEvent = [](const char * json){
+    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
+};
 
 TEST(opBuilderFileOutput, Builds)
 {
@@ -29,7 +34,7 @@ TEST(opBuilderFileOutput, Builds)
             {"path": "value"}
     })"};
 
-    ASSERT_NO_THROW(opBuilderFileOutput(doc.get("/file"), tr));
+    ASSERT_NO_THROW(bld::opBuilderFileOutput(doc.get("/file"), tr));
 }
 
 TEST(opBuilderFileOutput, BuildsOperates)
@@ -42,21 +47,21 @@ TEST(opBuilderFileOutput, BuildsOperates)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":"value"}
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderFileOutput(doc.get("/file"), tr);
+    Lifter lift = bld::opBuilderFileOutput(doc.get("/file"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });

--- a/src/engine/test/source/builder/builders/opBuilderFileOutput_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderFileOutput_test.cpp
@@ -23,9 +23,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
-};
 
 TEST(opBuilderFileOutput, Builds)
 {
@@ -47,16 +44,16 @@ TEST(opBuilderFileOutput, BuildsOperates)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"value"}
             )"));
             s.on_completed();

--- a/src/engine/test/source/builder/builders/opBuilderHelperExists_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperExists_test.cpp
@@ -21,9 +21,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
-};
 
 TEST(opBuilderHelperExists, Builds)
 {
@@ -55,19 +52,19 @@ TEST(opBuilderHelperExists, Exec_exists_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":11,
                     "ref_key":10
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":10
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":11
@@ -98,7 +95,7 @@ TEST(opBuilderHelperExists, Exec_multilevel_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -111,7 +108,7 @@ TEST(opBuilderHelperExists, Exec_multilevel_ok)
                 }
             )"));
 
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -125,7 +122,7 @@ TEST(opBuilderHelperExists, Exec_multilevel_ok)
             )"));
 
             // false
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -138,7 +135,7 @@ TEST(opBuilderHelperExists, Exec_multilevel_ok)
                 }
             )"));
 
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,

--- a/src/engine/test/source/builder/builders/opBuilderHelperExists_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperExists_test.cpp
@@ -12,14 +12,16 @@
 
 #include "testUtils.hpp"
 #include "opBuilderHelperFilter.hpp"
+#include "base/baseTypes.hpp"
 
 using namespace builder::internals::builders;
+using namespace base;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
 auto createEvent = [](const char * json){
-    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
 };
 
 TEST(opBuilderHelperExists, Builds)

--- a/src/engine/test/source/builder/builders/opBuilderHelperExists_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperExists_test.cpp
@@ -14,8 +14,8 @@
 #include "opBuilderHelperFilter.hpp"
 #include "base/baseTypes.hpp"
 
-using namespace builder::internals::builders;
 using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
@@ -31,7 +31,7 @@ TEST(opBuilderHelperExists, Builds)
             {"field": "+exists"}
     })"};
 
-    ASSERT_NO_THROW(opBuilderHelperExists(doc.get("/check"), tr));
+    ASSERT_NO_THROW(bld::opBuilderHelperExists(doc.get("/check"), tr));
 }
 
 TEST(opBuilderHelperExists, Builds_error_bad_parameter)
@@ -41,7 +41,7 @@ TEST(opBuilderHelperExists, Builds_error_bad_parameter)
             {"field_test": "+exists/test"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperIntEqual(doc.get("/check"), tr), std::invalid_argument);
+    ASSERT_THROW(bld::opBuilderHelperIntEqual(doc.get("/check"), tr), std::invalid_argument);
 }
 
 TEST(opBuilderHelperExists, Exec_exists_ok)
@@ -75,7 +75,7 @@ TEST(opBuilderHelperExists, Exec_exists_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperExists(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperExists(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -152,7 +152,7 @@ TEST(opBuilderHelperExists, Exec_multilevel_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperExists(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperExists(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperExists_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperExists_test.cpp
@@ -18,6 +18,10 @@ using namespace builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
+auto createEvent = [](const char * json){
+    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+};
+
 TEST(opBuilderHelperExists, Builds)
 {
     Document doc{R"({
@@ -48,19 +52,19 @@ TEST(opBuilderHelperExists, Exec_exists_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":11,
                     "ref_key":10
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":10
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":11
@@ -76,9 +80,9 @@ TEST(opBuilderHelperExists, Exec_exists_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_TRUE(expected[0]->exists("/field2check"));
-    ASSERT_TRUE(expected[1]->exists("/field2check"));
-    ASSERT_TRUE(expected[2]->exists("/field2check"));
+    ASSERT_TRUE(expected[0]->getEvent()->exists("/field2check"));
+    ASSERT_TRUE(expected[1]->getEvent()->exists("/field2check"));
+    ASSERT_TRUE(expected[2]->getEvent()->exists("/field2check"));
 }
 
 TEST(opBuilderHelperExists, Exec_multilevel_ok)
@@ -91,7 +95,7 @@ TEST(opBuilderHelperExists, Exec_multilevel_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -104,7 +108,7 @@ TEST(opBuilderHelperExists, Exec_multilevel_ok)
                 }
             )"));
 
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -118,7 +122,7 @@ TEST(opBuilderHelperExists, Exec_multilevel_ok)
             )"));
 
             // false
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -131,7 +135,7 @@ TEST(opBuilderHelperExists, Exec_multilevel_ok)
                 }
             )"));
 
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -153,7 +157,7 @@ TEST(opBuilderHelperExists, Exec_multilevel_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_TRUE(expected[0]->exists("/parentObjt_1/field2check"));
-    ASSERT_TRUE(expected[1]->exists("/parentObjt_1/field2check"));
-    ASSERT_TRUE(expected[2]->exists("/parentObjt_1/field2check"));
+    ASSERT_TRUE(expected[0]->getEvent()->exists("/parentObjt_1/field2check"));
+    ASSERT_TRUE(expected[1]->getEvent()->exists("/parentObjt_1/field2check"));
+    ASSERT_TRUE(expected[2]->getEvent()->exists("/parentObjt_1/field2check"));
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperExists_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperExists_test.cpp
@@ -10,9 +10,10 @@
 #include <gtest/gtest.h>
 #include <vector>
 
+#include <baseTypes.hpp>
+
 #include "testUtils.hpp"
 #include "opBuilderHelperFilter.hpp"
-#include "base/baseTypes.hpp"
 
 using namespace base;
 namespace bld = builder::internals::builders;

--- a/src/engine/test/source/builder/builders/opBuilderHelperIPCIDRCheck_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIPCIDRCheck_test.cpp
@@ -6,11 +6,13 @@
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
  */
+#include <gtest/gtest.h>
+
+#include <baseTypes.hpp>
 
 #include "opBuilderHelperFilter.hpp"
 #include "testUtils.hpp"
-#include <gtest/gtest.h>
-#include "base/baseTypes.hpp"
+
 
 using namespace base;
 namespace bld = builder::internals::builders;

--- a/src/engine/test/source/builder/builders/opBuilderHelperIPCIDRCheck_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIPCIDRCheck_test.cpp
@@ -21,10 +21,6 @@ using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg) {
 };
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
-
 TEST(opBuilderHelperIPCIDR, Builds)
 {
     Document doc {R"({
@@ -90,26 +86,26 @@ TEST(opBuilderHelperIPCIDR, chack_ip_range)
         [=](auto s)
         {
             // Network address
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"192.168.0.0"}
             )"));
             // First address
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"192.168.0.1"}
             )"));
             // Last address
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"192.168.255.254"}
             )"));
             // Broadcast address
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"192.168.255.255"}
             )"));
             // Address out of cidr range
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"10.0.0.1"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"127.0.0.1"}
             )"));
             s.on_completed();

--- a/src/engine/test/source/builder/builders/opBuilderHelperIPCIDRCheck_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIPCIDRCheck_test.cpp
@@ -10,11 +10,17 @@
 #include "opBuilderHelperFilter.hpp"
 #include "testUtils.hpp"
 #include <gtest/gtest.h>
+#include "base/baseTypes.hpp"
 
 using namespace builder::internals::builders;
+using namespace base;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg) {
+};
+
+auto createEvent = [](const char * json){
+    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
 };
 
 TEST(opBuilderHelperIPCIDR, Builds)
@@ -77,10 +83,6 @@ TEST(opBuilderHelperIPCIDR, chack_ip_range)
         "check":
             {"field2check": "+ip_cidr/192.168.0.0/16"}
     })"};
-
-    auto createEvent = [](const char * json){
-        return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
-    };
 
     Observable input = observable<>::create<Event>(
         [=](auto s)

--- a/src/engine/test/source/builder/builders/opBuilderHelperIPCIDRCheck_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIPCIDRCheck_test.cpp
@@ -12,8 +12,8 @@
 #include <gtest/gtest.h>
 #include "base/baseTypes.hpp"
 
-using namespace builder::internals::builders;
 using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg) {
@@ -34,8 +34,8 @@ TEST(opBuilderHelperIPCIDR, Builds)
             {"field2check": "+ip_cidr/192.168.0.0/255.255.0.0"}
     })"};
 
-    ASSERT_NO_THROW(opBuilderHelperIPCIDR(doc.get("/check"), tr));
-    ASSERT_NO_THROW(opBuilderHelperIPCIDR(doc2.get("/check"), tr));
+    ASSERT_NO_THROW(bld::opBuilderHelperIPCIDR(doc.get("/check"), tr));
+    ASSERT_NO_THROW(bld::opBuilderHelperIPCIDR(doc2.get("/check"), tr));
 }
 
 TEST(opBuilderHelperIPCIDR, Builds_incorrect_number_of_arguments)
@@ -45,7 +45,7 @@ TEST(opBuilderHelperIPCIDR, Builds_incorrect_number_of_arguments)
             {"field2check": "+ip_cidr/192.168.0.0/255.255.0.0/123"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperIPCIDR(doc.get("/check"), tr),
+    ASSERT_THROW(bld::opBuilderHelperIPCIDR(doc.get("/check"), tr),
                  std::runtime_error);
 }
 
@@ -56,7 +56,7 @@ TEST(opBuilderHelperIPCIDR, Builds_invalid_arguments)
             {"field2check": "+ip_cidr/192.168.0.0/256.255.0.0"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperIPCIDR(doc.get("/check"), tr),
+    ASSERT_THROW(bld::opBuilderHelperIPCIDR(doc.get("/check"), tr),
                  std::runtime_error);
 
     Document doc2 {R"({
@@ -64,7 +64,7 @@ TEST(opBuilderHelperIPCIDR, Builds_invalid_arguments)
             {"field2check": "+ip_cidr/192.168.0.-1/255.255.0.0.1"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperIPCIDR(doc2.get("/check"), tr),
+    ASSERT_THROW(bld::opBuilderHelperIPCIDR(doc2.get("/check"), tr),
                  std::runtime_error);
 
     Document doc3 {R"({
@@ -72,7 +72,7 @@ TEST(opBuilderHelperIPCIDR, Builds_invalid_arguments)
             {"field2check": "+ip_cidr/192.168.0.1/33"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperIPCIDR(doc3.get("/check"), tr),
+    ASSERT_THROW(bld::opBuilderHelperIPCIDR(doc3.get("/check"), tr),
                  std::runtime_error);
 }
 
@@ -113,7 +113,7 @@ TEST(opBuilderHelperIPCIDR, chack_ip_range)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperIPCIDR(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIPCIDR(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
@@ -10,9 +10,10 @@
 #include <gtest/gtest.h>
 #include <vector>
 
+#include <baseTypes.hpp>
+
 #include "testUtils.hpp"
 #include "opBuilderHelperMap.hpp"
-#include "base/baseTypes.hpp"
 
 using namespace base;
 namespace bld = builder::internals::builders;

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
@@ -12,14 +12,16 @@
 
 #include "testUtils.hpp"
 #include "opBuilderHelperMap.hpp"
+#include "base/baseTypes.hpp"
 
 using namespace builder::internals::builders;
+using namespace base;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
 auto createEvent = [](const char * json){
-    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
 };
 
 TEST(opBuilderHelperIntCalc, Builds)

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
@@ -18,6 +18,10 @@ using namespace builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
+auto createEvent = [](const char * json){
+    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+};
+
 TEST(opBuilderHelperIntCalc, Builds)
 {
     Document doc{R"({
@@ -89,16 +93,16 @@ TEST(opBuilderHelperIntCalc, Exec_equal_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -110,10 +114,10 @@ TEST(opBuilderHelperIntCalc, Exec_equal_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 4);
-    ASSERT_EQ(expected[0]->get("/field_test").GetInt(),19);
-    ASSERT_EQ(expected[1]->get("/field_test").GetInt(),20);
-    ASSERT_EQ(expected[2]->get("/field_test").GetInt(),20);
-    ASSERT_EQ(expected[3]->get("/field_test").GetInt(),21);
+    ASSERT_EQ(expected[0]->getEvent()->get("/field_test").GetInt(),19);
+    ASSERT_EQ(expected[1]->getEvent()->get("/field_test").GetInt(),20);
+    ASSERT_EQ(expected[2]->getEvent()->get("/field_test").GetInt(),20);
+    ASSERT_EQ(expected[3]->getEvent()->get("/field_test").GetInt(),21);
 
 }
 
@@ -127,22 +131,22 @@ TEST(opBuilderHelperIntCalc, Exec_sum_int)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":0}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":100}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":-100}
             )"));
             s.on_completed();
@@ -154,12 +158,12 @@ TEST(opBuilderHelperIntCalc, Exec_sum_int)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 6);
-    ASSERT_EQ(expected[0]->get("/field_test").GetInt(),10);
-    ASSERT_EQ(expected[1]->get("/field_test").GetInt(),19);
-    ASSERT_EQ(expected[2]->get("/field_test").GetInt(),20);
-    ASSERT_EQ(expected[3]->get("/field_test").GetInt(),21);
-    ASSERT_EQ(expected[4]->get("/field_test").GetInt(),110);
-    ASSERT_EQ(expected[5]->get("/field_test").GetInt(),-90);
+    ASSERT_EQ(expected[0]->getEvent()->get("/field_test").GetInt(),10);
+    ASSERT_EQ(expected[1]->getEvent()->get("/field_test").GetInt(),19);
+    ASSERT_EQ(expected[2]->getEvent()->get("/field_test").GetInt(),20);
+    ASSERT_EQ(expected[3]->getEvent()->get("/field_test").GetInt(),21);
+    ASSERT_EQ(expected[4]->getEvent()->get("/field_test").GetInt(),110);
+    ASSERT_EQ(expected[5]->getEvent()->get("/field_test").GetInt(),-90);
 
 }
 
@@ -173,22 +177,22 @@ TEST(opBuilderHelperIntCalc, Exec_sub_int)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":0}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":100}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":-100}
             )"));
             s.on_completed();
@@ -200,12 +204,12 @@ TEST(opBuilderHelperIntCalc, Exec_sub_int)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 6);
-    ASSERT_EQ(expected[0]->get("/field_test").GetInt(),-10);
-    ASSERT_EQ(expected[1]->get("/field_test").GetInt(),-1);
-    ASSERT_EQ(expected[2]->get("/field_test").GetInt(),0);
-    ASSERT_EQ(expected[3]->get("/field_test").GetInt(),1);
-    ASSERT_EQ(expected[4]->get("/field_test").GetInt(),90);
-    ASSERT_EQ(expected[5]->get("/field_test").GetInt(),-110);
+    ASSERT_EQ(expected[0]->getEvent()->get("/field_test").GetInt(),-10);
+    ASSERT_EQ(expected[1]->getEvent()->get("/field_test").GetInt(),-1);
+    ASSERT_EQ(expected[2]->getEvent()->get("/field_test").GetInt(),0);
+    ASSERT_EQ(expected[3]->getEvent()->get("/field_test").GetInt(),1);
+    ASSERT_EQ(expected[4]->getEvent()->get("/field_test").GetInt(),90);
+    ASSERT_EQ(expected[5]->getEvent()->get("/field_test").GetInt(),-110);
 
 }
 
@@ -219,22 +223,22 @@ TEST(opBuilderHelperIntCalc, Exec_mult_int)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":0}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":100}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":-100}
             )"));
             s.on_completed();
@@ -246,12 +250,12 @@ TEST(opBuilderHelperIntCalc, Exec_mult_int)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 6);
-    ASSERT_EQ(expected[0]->get("/field_test").GetInt(),0);
-    ASSERT_EQ(expected[1]->get("/field_test").GetInt(),90);
-    ASSERT_EQ(expected[2]->get("/field_test").GetInt(),100);
-    ASSERT_EQ(expected[3]->get("/field_test").GetInt(),110);
-    ASSERT_EQ(expected[4]->get("/field_test").GetInt(),1000);
-    ASSERT_EQ(expected[5]->get("/field_test").GetInt(),-1000);
+    ASSERT_EQ(expected[0]->getEvent()->get("/field_test").GetInt(),0);
+    ASSERT_EQ(expected[1]->getEvent()->get("/field_test").GetInt(),90);
+    ASSERT_EQ(expected[2]->getEvent()->get("/field_test").GetInt(),100);
+    ASSERT_EQ(expected[3]->getEvent()->get("/field_test").GetInt(),110);
+    ASSERT_EQ(expected[4]->getEvent()->get("/field_test").GetInt(),1000);
+    ASSERT_EQ(expected[5]->getEvent()->get("/field_test").GetInt(),-1000);
 
 }
 
@@ -265,22 +269,22 @@ TEST(opBuilderHelperIntCalc, Exec_div_int)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":0}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":100}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":-100}
             )"));
             s.on_completed();
@@ -292,12 +296,12 @@ TEST(opBuilderHelperIntCalc, Exec_div_int)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 6);
-    ASSERT_EQ(expected[0]->get("/field_test").GetInt(),0);
-    ASSERT_EQ(expected[1]->get("/field_test").GetInt(),0);
-    ASSERT_EQ(expected[2]->get("/field_test").GetInt(),1);
-    ASSERT_EQ(expected[3]->get("/field_test").GetInt(),1);
-    ASSERT_EQ(expected[4]->get("/field_test").GetInt(),10);
-    ASSERT_EQ(expected[5]->get("/field_test").GetInt(),-10);
+    ASSERT_EQ(expected[0]->getEvent()->get("/field_test").GetInt(),0);
+    ASSERT_EQ(expected[1]->getEvent()->get("/field_test").GetInt(),0);
+    ASSERT_EQ(expected[2]->getEvent()->get("/field_test").GetInt(),1);
+    ASSERT_EQ(expected[3]->getEvent()->get("/field_test").GetInt(),1);
+    ASSERT_EQ(expected[4]->getEvent()->get("/field_test").GetInt(),10);
+    ASSERT_EQ(expected[5]->getEvent()->get("/field_test").GetInt(),-10);
 
 }
 
@@ -311,28 +315,28 @@ TEST(opBuilderHelperIntCalc, Exec_sum_ref)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 0,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 10,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 0,"field_src":-10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src":-10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 10,"field_src":-10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src":-10}
             )"));
             s.on_completed();
@@ -344,14 +348,14 @@ TEST(opBuilderHelperIntCalc, Exec_sum_ref)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 8);
-    ASSERT_EQ(expected[0]->get("/field_test").GetInt(),10);
-    ASSERT_EQ(expected[1]->get("/field_test").GetInt(),19);
-    ASSERT_EQ(expected[2]->get("/field_test").GetInt(),20);
-    ASSERT_EQ(expected[3]->get("/field_test").GetInt(),21);
-    ASSERT_EQ(expected[4]->get("/field_test").GetInt(),-10);
-    ASSERT_EQ(expected[5]->get("/field_test").GetInt(),-1);
-    ASSERT_EQ(expected[6]->get("/field_test").GetInt(),0);
-    ASSERT_EQ(expected[7]->get("/field_test").GetInt(),1);
+    ASSERT_EQ(expected[0]->getEvent()->get("/field_test").GetInt(),10);
+    ASSERT_EQ(expected[1]->getEvent()->get("/field_test").GetInt(),19);
+    ASSERT_EQ(expected[2]->getEvent()->get("/field_test").GetInt(),20);
+    ASSERT_EQ(expected[3]->getEvent()->get("/field_test").GetInt(),21);
+    ASSERT_EQ(expected[4]->getEvent()->get("/field_test").GetInt(),-10);
+    ASSERT_EQ(expected[5]->getEvent()->get("/field_test").GetInt(),-1);
+    ASSERT_EQ(expected[6]->getEvent()->get("/field_test").GetInt(),0);
+    ASSERT_EQ(expected[7]->getEvent()->get("/field_test").GetInt(),1);
 
 }
 
@@ -365,28 +369,28 @@ TEST(opBuilderHelperIntCalc, Exec_sub_ref)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 0,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 10,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 0,"field_src":-10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src":-10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 10,"field_src":-10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src":-10}
             )"));
             s.on_completed();
@@ -398,14 +402,14 @@ TEST(opBuilderHelperIntCalc, Exec_sub_ref)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 8);
-    ASSERT_EQ(expected[0]->get("/field_test").GetInt(),-10);
-    ASSERT_EQ(expected[1]->get("/field_test").GetInt(),-1);
-    ASSERT_EQ(expected[2]->get("/field_test").GetInt(),0);
-    ASSERT_EQ(expected[3]->get("/field_test").GetInt(),1);
-    ASSERT_EQ(expected[4]->get("/field_test").GetInt(),10);
-    ASSERT_EQ(expected[5]->get("/field_test").GetInt(),19);
-    ASSERT_EQ(expected[6]->get("/field_test").GetInt(),20);
-    ASSERT_EQ(expected[7]->get("/field_test").GetInt(),21);
+    ASSERT_EQ(expected[0]->getEvent()->get("/field_test").GetInt(),-10);
+    ASSERT_EQ(expected[1]->getEvent()->get("/field_test").GetInt(),-1);
+    ASSERT_EQ(expected[2]->getEvent()->get("/field_test").GetInt(),0);
+    ASSERT_EQ(expected[3]->getEvent()->get("/field_test").GetInt(),1);
+    ASSERT_EQ(expected[4]->getEvent()->get("/field_test").GetInt(),10);
+    ASSERT_EQ(expected[5]->getEvent()->get("/field_test").GetInt(),19);
+    ASSERT_EQ(expected[6]->getEvent()->get("/field_test").GetInt(),20);
+    ASSERT_EQ(expected[7]->getEvent()->get("/field_test").GetInt(),21);
 
 }
 
@@ -419,28 +423,28 @@ TEST(opBuilderHelperIntCalc, Exec_mult_ref)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 0,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 10,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 0,"field_src":-10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src":-10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 10,"field_src":-10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src":-10}
             )"));
             s.on_completed();
@@ -452,14 +456,14 @@ TEST(opBuilderHelperIntCalc, Exec_mult_ref)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 8);
-    ASSERT_EQ(expected[0]->get("/field_test").GetInt(),0);
-    ASSERT_EQ(expected[1]->get("/field_test").GetInt(),90);
-    ASSERT_EQ(expected[2]->get("/field_test").GetInt(),100);
-    ASSERT_EQ(expected[3]->get("/field_test").GetInt(),110);
-    ASSERT_EQ(expected[4]->get("/field_test").GetInt(),0);
-    ASSERT_EQ(expected[5]->get("/field_test").GetInt(),-90);
-    ASSERT_EQ(expected[6]->get("/field_test").GetInt(),-100);
-    ASSERT_EQ(expected[7]->get("/field_test").GetInt(),-110);
+    ASSERT_EQ(expected[0]->getEvent()->get("/field_test").GetInt(),0);
+    ASSERT_EQ(expected[1]->getEvent()->get("/field_test").GetInt(),90);
+    ASSERT_EQ(expected[2]->getEvent()->get("/field_test").GetInt(),100);
+    ASSERT_EQ(expected[3]->getEvent()->get("/field_test").GetInt(),110);
+    ASSERT_EQ(expected[4]->getEvent()->get("/field_test").GetInt(),0);
+    ASSERT_EQ(expected[5]->getEvent()->get("/field_test").GetInt(),-90);
+    ASSERT_EQ(expected[6]->getEvent()->get("/field_test").GetInt(),-100);
+    ASSERT_EQ(expected[7]->getEvent()->get("/field_test").GetInt(),-110);
 
 }
 
@@ -473,28 +477,28 @@ TEST(opBuilderHelperIntCalc, Exec_div_ref)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 0,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 10,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 0,"field_src":-10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src":-10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 10,"field_src":-10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src":-10}
             )"));
             s.on_completed();
@@ -506,14 +510,14 @@ TEST(opBuilderHelperIntCalc, Exec_div_ref)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 8);
-    ASSERT_EQ(expected[0]->get("/field_test").GetInt(),0);
-    ASSERT_EQ(expected[1]->get("/field_test").GetInt(),0);
-    ASSERT_EQ(expected[2]->get("/field_test").GetInt(),1);
-    ASSERT_EQ(expected[3]->get("/field_test").GetInt(),1);
-    ASSERT_EQ(expected[4]->get("/field_test").GetInt(),0);
-    ASSERT_EQ(expected[5]->get("/field_test").GetInt(),0);
-    ASSERT_EQ(expected[6]->get("/field_test").GetInt(),-1);
-    ASSERT_EQ(expected[7]->get("/field_test").GetInt(),-1);
+    ASSERT_EQ(expected[0]->getEvent()->get("/field_test").GetInt(),0);
+    ASSERT_EQ(expected[1]->getEvent()->get("/field_test").GetInt(),0);
+    ASSERT_EQ(expected[2]->getEvent()->get("/field_test").GetInt(),1);
+    ASSERT_EQ(expected[3]->getEvent()->get("/field_test").GetInt(),1);
+    ASSERT_EQ(expected[4]->getEvent()->get("/field_test").GetInt(),0);
+    ASSERT_EQ(expected[5]->getEvent()->get("/field_test").GetInt(),0);
+    ASSERT_EQ(expected[6]->getEvent()->get("/field_test").GetInt(),-1);
+    ASSERT_EQ(expected[7]->getEvent()->get("/field_test").GetInt(),-1);
 
 }
 
@@ -527,28 +531,28 @@ TEST(opBuilderHelperIntCalc, Exec_div_ref_zero)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 0,"field_src":0}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src":0}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 10,"field_src":0}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src":0}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 0,"field_src":0}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src":0}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 10,"field_src":0}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src":0}
             )"));
             s.on_completed();
@@ -560,14 +564,14 @@ TEST(opBuilderHelperIntCalc, Exec_div_ref_zero)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 8);
-    ASSERT_EQ(expected[0]->get("/field_test").GetInt(),0);
-    ASSERT_EQ(expected[1]->get("/field_test").GetInt(),9);
-    ASSERT_EQ(expected[2]->get("/field_test").GetInt(),10);
-    ASSERT_EQ(expected[3]->get("/field_test").GetInt(),11);
-    ASSERT_EQ(expected[4]->get("/field_test").GetInt(),0);
-    ASSERT_EQ(expected[5]->get("/field_test").GetInt(),9);
-    ASSERT_EQ(expected[6]->get("/field_test").GetInt(),10);
-    ASSERT_EQ(expected[7]->get("/field_test").GetInt(),11);
+    ASSERT_EQ(expected[0]->getEvent()->get("/field_test").GetInt(),0);
+    ASSERT_EQ(expected[1]->getEvent()->get("/field_test").GetInt(),9);
+    ASSERT_EQ(expected[2]->getEvent()->get("/field_test").GetInt(),10);
+    ASSERT_EQ(expected[3]->getEvent()->get("/field_test").GetInt(),11);
+    ASSERT_EQ(expected[4]->getEvent()->get("/field_test").GetInt(),0);
+    ASSERT_EQ(expected[5]->getEvent()->get("/field_test").GetInt(),9);
+    ASSERT_EQ(expected[6]->getEvent()->get("/field_test").GetInt(),10);
+    ASSERT_EQ(expected[7]->getEvent()->get("/field_test").GetInt(),11);
 
 }
 
@@ -582,7 +586,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sum)
         [=](auto s)
         {
             // sorted
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_1": {
                         "field2check": 10,
@@ -595,7 +599,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sum)
                 }
             )"));
             // not sorted
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -617,8 +621,8 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sum)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_EQ(expected[0]->get("/parentObjt_1/field2check").GetInt(), 21);
-    ASSERT_EQ(expected[1]->get("/parentObjt_1/field2check").GetInt(), 20);
+    ASSERT_EQ(expected[0]->getEvent()->get("/parentObjt_1/field2check").GetInt(), 21);
+    ASSERT_EQ(expected[1]->getEvent()->get("/parentObjt_1/field2check").GetInt(), 20);
 }
 
 TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sub)
@@ -632,7 +636,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sub)
         [=](auto s)
         {
             // sorted
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_1": {
                         "field2check": 10,
@@ -645,7 +649,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sub)
                 }
             )"));
             // not sorted
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -667,8 +671,8 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sub)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_EQ(expected[0]->get("/parentObjt_1/field2check").GetInt(), -1);
-    ASSERT_EQ(expected[1]->get("/parentObjt_1/field2check").GetInt(), 0);
+    ASSERT_EQ(expected[0]->getEvent()->get("/parentObjt_1/field2check").GetInt(), -1);
+    ASSERT_EQ(expected[1]->getEvent()->get("/parentObjt_1/field2check").GetInt(), 0);
 }
 
 TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_mul)
@@ -682,7 +686,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_mul)
         [=](auto s)
         {
             // sorted
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_1": {
                         "field2check": 10,
@@ -695,7 +699,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_mul)
                 }
             )"));
             // not sorted
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -717,8 +721,8 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_mul)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_EQ(expected[0]->get("/parentObjt_1/field2check").GetInt(), 110);
-    ASSERT_EQ(expected[1]->get("/parentObjt_1/field2check").GetInt(), 100);
+    ASSERT_EQ(expected[0]->getEvent()->get("/parentObjt_1/field2check").GetInt(), 110);
+    ASSERT_EQ(expected[1]->getEvent()->get("/parentObjt_1/field2check").GetInt(), 100);
 }
 
 TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_div)
@@ -732,7 +736,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_div)
         [=](auto s)
         {
             // sorted
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_1": {
                         "field2check": 10,
@@ -745,7 +749,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_div)
                 }
             )"));
             // not sorted
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -767,6 +771,6 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_div)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_EQ(expected[0]->get("/parentObjt_1/field2check").GetInt(), 0);
-    ASSERT_EQ(expected[1]->get("/parentObjt_1/field2check").GetInt(), 1);
+    ASSERT_EQ(expected[0]->getEvent()->get("/parentObjt_1/field2check").GetInt(), 0);
+    ASSERT_EQ(expected[1]->getEvent()->get("/parentObjt_1/field2check").GetInt(), 1);
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
@@ -21,10 +21,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
-
 TEST(opBuilderHelperIntCalc, Builds)
 {
     Document doc{R"({
@@ -96,16 +92,16 @@ TEST(opBuilderHelperIntCalc, Exec_equal_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -134,22 +130,22 @@ TEST(opBuilderHelperIntCalc, Exec_sum_int)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":0}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":100}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":-100}
             )"));
             s.on_completed();
@@ -180,22 +176,22 @@ TEST(opBuilderHelperIntCalc, Exec_sub_int)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":0}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":100}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":-100}
             )"));
             s.on_completed();
@@ -226,22 +222,22 @@ TEST(opBuilderHelperIntCalc, Exec_mult_int)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":0}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":100}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":-100}
             )"));
             s.on_completed();
@@ -272,22 +268,22 @@ TEST(opBuilderHelperIntCalc, Exec_div_int)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":0}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":100}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":-100}
             )"));
             s.on_completed();
@@ -318,28 +314,28 @@ TEST(opBuilderHelperIntCalc, Exec_sum_ref)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 0,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 10,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 0,"field_src":-10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src":-10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 10,"field_src":-10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src":-10}
             )"));
             s.on_completed();
@@ -372,28 +368,28 @@ TEST(opBuilderHelperIntCalc, Exec_sub_ref)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 0,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 10,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 0,"field_src":-10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src":-10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 10,"field_src":-10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src":-10}
             )"));
             s.on_completed();
@@ -426,28 +422,28 @@ TEST(opBuilderHelperIntCalc, Exec_mult_ref)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 0,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 10,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 0,"field_src":-10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src":-10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 10,"field_src":-10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src":-10}
             )"));
             s.on_completed();
@@ -480,28 +476,28 @@ TEST(opBuilderHelperIntCalc, Exec_div_ref)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 0,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 10,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 0,"field_src":-10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src":-10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 10,"field_src":-10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src":-10}
             )"));
             s.on_completed();
@@ -534,28 +530,28 @@ TEST(opBuilderHelperIntCalc, Exec_div_ref_zero)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 0,"field_src":0}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src":0}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 10,"field_src":0}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src":0}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 0,"field_src":0}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src":0}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 10,"field_src":0}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src":0}
             )"));
             s.on_completed();
@@ -589,7 +585,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sum)
         [=](auto s)
         {
             // sorted
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_1": {
                         "field2check": 10,
@@ -602,7 +598,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sum)
                 }
             )"));
             // not sorted
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -639,7 +635,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sub)
         [=](auto s)
         {
             // sorted
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_1": {
                         "field2check": 10,
@@ -652,7 +648,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sub)
                 }
             )"));
             // not sorted
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -689,7 +685,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_mul)
         [=](auto s)
         {
             // sorted
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_1": {
                         "field2check": 10,
@@ -702,7 +698,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_mul)
                 }
             )"));
             // not sorted
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -739,7 +735,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_div)
         [=](auto s)
         {
             // sorted
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_1": {
                         "field2check": 10,
@@ -752,7 +748,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_div)
                 }
             )"));
             // not sorted
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntCalc_test.cpp
@@ -14,8 +14,8 @@
 #include "opBuilderHelperMap.hpp"
 #include "base/baseTypes.hpp"
 
-using namespace builder::internals::builders;
 using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
@@ -31,7 +31,7 @@ TEST(opBuilderHelperIntCalc, Builds)
             {"field_test": "+i_calc/sum/10"}
     })"};
 
-    ASSERT_NO_THROW(opBuilderHelperIntCalc(doc.get("/normalice"), tr));
+    ASSERT_NO_THROW(bld::opBuilderHelperIntCalc(doc.get("/normalice"), tr));
 }
 
 TEST(opBuilderHelperIntCalc, Builds_error_bad_parameter)
@@ -41,7 +41,7 @@ TEST(opBuilderHelperIntCalc, Builds_error_bad_parameter)
             {"field_test": "+i_calc/test/test"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperIntCalc(doc.get("/normalice"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperIntCalc(doc.get("/normalice"), tr), std::runtime_error);
 }
 
 TEST(opBuilderHelperIntCalc, Builds_error_less_parameters)
@@ -51,7 +51,7 @@ TEST(opBuilderHelperIntCalc, Builds_error_less_parameters)
             {"field_test": "+i_calc/10"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperIntCalc(doc.get("/normalice"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperIntCalc(doc.get("/normalice"), tr), std::runtime_error);
 }
 
 
@@ -62,7 +62,7 @@ TEST(opBuilderHelperIntCalc, Builds_error_more_parameters)
             {"field_test": "+i_calc/10/10/10"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperIntCalc(doc.get("/normalice"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperIntCalc(doc.get("/normalice"), tr), std::runtime_error);
 }
 
 TEST(opBuilderHelperIntCalc, Builds_error_bad_operator)
@@ -72,7 +72,7 @@ TEST(opBuilderHelperIntCalc, Builds_error_bad_operator)
             {"field_test": "+i_calc/^/10"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperIntCalc(doc.get("/normalice"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperIntCalc(doc.get("/normalice"), tr), std::runtime_error);
 }
 
 TEST(opBuilderHelperIntCalc, Builds_error_zero_division)
@@ -82,7 +82,7 @@ TEST(opBuilderHelperIntCalc, Builds_error_zero_division)
             {"field_test": "+i_calc/div/0"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperIntCalc(doc.get("/normalice"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperIntCalc(doc.get("/normalice"), tr), std::runtime_error);
 }
 
 TEST(opBuilderHelperIntCalc, Exec_equal_ok)
@@ -109,7 +109,7 @@ TEST(opBuilderHelperIntCalc, Exec_equal_ok)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntCalc(doc.get("/normalice"), tr);
+    Lifter lift = bld::opBuilderHelperIntCalc(doc.get("/normalice"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -153,7 +153,7 @@ TEST(opBuilderHelperIntCalc, Exec_sum_int)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntCalc(doc.get("/normalice"), tr);
+    Lifter lift = bld::opBuilderHelperIntCalc(doc.get("/normalice"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -199,7 +199,7 @@ TEST(opBuilderHelperIntCalc, Exec_sub_int)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntCalc(doc.get("/normalice"), tr);
+    Lifter lift = bld::opBuilderHelperIntCalc(doc.get("/normalice"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -245,7 +245,7 @@ TEST(opBuilderHelperIntCalc, Exec_mult_int)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntCalc(doc.get("/normalice"), tr);
+    Lifter lift = bld::opBuilderHelperIntCalc(doc.get("/normalice"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -291,7 +291,7 @@ TEST(opBuilderHelperIntCalc, Exec_div_int)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntCalc(doc.get("/normalice"), tr);
+    Lifter lift = bld::opBuilderHelperIntCalc(doc.get("/normalice"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -343,7 +343,7 @@ TEST(opBuilderHelperIntCalc, Exec_sum_ref)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntCalc(doc.get("/normalice"), tr);
+    Lifter lift = bld::opBuilderHelperIntCalc(doc.get("/normalice"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -397,7 +397,7 @@ TEST(opBuilderHelperIntCalc, Exec_sub_ref)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntCalc(doc.get("/normalice"), tr);
+    Lifter lift = bld::opBuilderHelperIntCalc(doc.get("/normalice"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -451,7 +451,7 @@ TEST(opBuilderHelperIntCalc, Exec_mult_ref)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntCalc(doc.get("/normalice"), tr);
+    Lifter lift = bld::opBuilderHelperIntCalc(doc.get("/normalice"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -505,7 +505,7 @@ TEST(opBuilderHelperIntCalc, Exec_div_ref)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntCalc(doc.get("/normalice"), tr);
+    Lifter lift = bld::opBuilderHelperIntCalc(doc.get("/normalice"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -559,7 +559,7 @@ TEST(opBuilderHelperIntCalc, Exec_div_ref_zero)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntCalc(doc.get("/normalice"), tr);
+    Lifter lift = bld::opBuilderHelperIntCalc(doc.get("/normalice"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -616,7 +616,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sum)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperIntCalc(doc.get("/normalice"), tr);
+    Lifter lift = bld::opBuilderHelperIntCalc(doc.get("/normalice"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -666,7 +666,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_sub)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperIntCalc(doc.get("/normalice"), tr);
+    Lifter lift = bld::opBuilderHelperIntCalc(doc.get("/normalice"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -716,7 +716,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_mul)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperIntCalc(doc.get("/normalice"), tr);
+    Lifter lift = bld::opBuilderHelperIntCalc(doc.get("/normalice"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -766,7 +766,7 @@ TEST(opBuilderHelperIntCalc, Exec_multilevel_dynamics_int_div)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperIntCalc(doc.get("/normalice"), tr);
+    Lifter lift = bld::opBuilderHelperIntCalc(doc.get("/normalice"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntEqual_test.cpp
@@ -18,6 +18,10 @@ using namespace builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
+auto createEvent = [](const char * json){
+    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+};
+
 TEST(opBuilderHelperIntEqual, Builds)
 {
     Document doc{R"({
@@ -58,16 +62,16 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -79,8 +83,8 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_EQ(expected[0]->get("/field_test").GetInt(), 10);
-    ASSERT_EQ(expected[1]->get("/field_test").GetInt(), 10);
+    ASSERT_EQ(expected[0]->getEvent()->get("/field_test").GetInt(), 10);
+    ASSERT_EQ(expected[1]->getEvent()->get("/field_test").GetInt(), 10);
 }
 
 TEST(opBuilderHelperIntEqual, Exec_equal_true)
@@ -93,16 +97,16 @@ TEST(opBuilderHelperIntEqual, Exec_equal_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -114,8 +118,8 @@ TEST(opBuilderHelperIntEqual, Exec_equal_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_EQ(expected[0]->get("/field_test").GetInt(), 10);
-    ASSERT_EQ(expected[1]->get("/field_test").GetInt(), 10);
+    ASSERT_EQ(expected[0]->getEvent()->get("/field_test").GetInt(), 10);
+    ASSERT_EQ(expected[1]->getEvent()->get("/field_test").GetInt(), 10);
 }
 
 TEST(opBuilderHelperIntEqual, Exec_equal_false)
@@ -128,16 +132,16 @@ TEST(opBuilderHelperIntEqual, Exec_equal_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test2":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test3":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -161,28 +165,28 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ref_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 9,"field_src": 10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10,"field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":"10","field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":"10","field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10,"field_src":"test"}
             )"));
             s.on_completed();
@@ -193,10 +197,10 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ref_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_EQ(expected[0]->get("/field_test").GetInt(),
-              expected[0]->get("/field_src").GetInt());
-    ASSERT_EQ(expected[1]->get("/field_test").GetInt(),
-              expected[0]->get("/field_src").GetInt());
+    ASSERT_EQ(expected[0]->getEvent()->get("/field_test").GetInt(),
+              expected[0]->getEvent()->get("/field_src").GetInt());
+    ASSERT_EQ(expected[1]->getEvent()->get("/field_test").GetInt(),
+              expected[0]->getEvent()->get("/field_src").GetInt());
 }
 
 TEST(opBuilderHelperIntEqual, Exec_equal_ref_false)
@@ -209,28 +213,28 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ref_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test2":9,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10,"field_src3":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10,"field_src4":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test5":10,"field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test6":"10","field_src2":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_":"10","field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src2":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test2":10,"field_src2":"test"}
             )"));
             s.on_completed();
@@ -254,21 +258,21 @@ TEST(opBuilderHelperIntEqual, Exec_dynamics_int_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":11,
                     "ref_key":10
                 }
             )"));
             // Equal
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":10
                 }
             )"));
             // Less
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":11
@@ -284,8 +288,8 @@ TEST(opBuilderHelperIntEqual, Exec_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_EQ(expected[0]->get("/field2check").GetInt(),
-              expected[0]->get("/ref_key").GetInt());
+    ASSERT_EQ(expected[0]->getEvent()->get("/field2check").GetInt(),
+              expected[0]->getEvent()->get("/ref_key").GetInt());
 }
 
 TEST(opBuilderHelperIntEqual, Exec_multilevel_dynamics_int_ok)
@@ -298,7 +302,7 @@ TEST(opBuilderHelperIntEqual, Exec_multilevel_dynamics_int_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -311,7 +315,7 @@ TEST(opBuilderHelperIntEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -324,7 +328,7 @@ TEST(opBuilderHelperIntEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -337,7 +341,7 @@ TEST(opBuilderHelperIntEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -359,6 +363,6 @@ TEST(opBuilderHelperIntEqual, Exec_multilevel_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_EQ(expected[0]->get("/parentObjt_1/field2check").GetInt(),
-              expected[0]->get("/parentObjt_2/ref_key").GetInt());
+    ASSERT_EQ(expected[0]->getEvent()->get("/parentObjt_1/field2check").GetInt(),
+              expected[0]->getEvent()->get("/parentObjt_2/ref_key").GetInt());
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntEqual_test.cpp
@@ -12,14 +12,16 @@
 
 #include "testUtils.hpp"
 #include "opBuilderHelperFilter.hpp"
+#include "base/baseTypes.hpp"
 
 using namespace builder::internals::builders;
+using namespace base;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
 auto createEvent = [](const char * json){
-    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
 };
 
 TEST(opBuilderHelperIntEqual, Builds)

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntEqual_test.cpp
@@ -14,8 +14,8 @@
 #include "opBuilderHelperFilter.hpp"
 #include "base/baseTypes.hpp"
 
-using namespace builder::internals::builders;
 using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
@@ -31,7 +31,7 @@ TEST(opBuilderHelperIntEqual, Builds)
             {"field_test": "+i_eq/10"}
     })"};
 
-    ASSERT_NO_THROW(opBuilderHelperIntEqual(doc.get("/check"), tr));
+    ASSERT_NO_THROW(bld::opBuilderHelperIntEqual(doc.get("/check"), tr));
 }
 
 TEST(opBuilderHelperIntEqual, Builds_error_bad_parameter)
@@ -41,7 +41,7 @@ TEST(opBuilderHelperIntEqual, Builds_error_bad_parameter)
             {"field_test": "+i_eq/test"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperIntEqual(doc.get("/check"), tr), std::invalid_argument);
+    ASSERT_THROW(bld::opBuilderHelperIntEqual(doc.get("/check"), tr), std::invalid_argument);
 }
 
 TEST(opBuilderHelperIntEqual, Builds_error_more_parameters)
@@ -51,7 +51,7 @@ TEST(opBuilderHelperIntEqual, Builds_error_more_parameters)
             {"field_test": "+i_eq/10/10"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperIntEqual(doc.get("/check"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperIntEqual(doc.get("/check"), tr), std::runtime_error);
 }
 
 TEST(opBuilderHelperIntEqual, Exec_equal_ok)
@@ -78,7 +78,7 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ok)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -113,7 +113,7 @@ TEST(opBuilderHelperIntEqual, Exec_equal_true)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -148,7 +148,7 @@ TEST(opBuilderHelperIntEqual, Exec_equal_false)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -193,7 +193,7 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ref_true)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -241,7 +241,7 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ref_false)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -283,7 +283,7 @@ TEST(opBuilderHelperIntEqual, Exec_dynamics_int_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperIntEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -358,7 +358,7 @@ TEST(opBuilderHelperIntEqual, Exec_multilevel_dynamics_int_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperIntEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntEqual_test.cpp
@@ -21,9 +21,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
 
 TEST(opBuilderHelperIntEqual, Builds)
 {
@@ -65,16 +62,16 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -100,16 +97,16 @@ TEST(opBuilderHelperIntEqual, Exec_equal_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -135,16 +132,16 @@ TEST(opBuilderHelperIntEqual, Exec_equal_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test2":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test3":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -168,28 +165,28 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ref_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 9,"field_src": 10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10,"field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":"10","field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":"10","field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10,"field_src":"test"}
             )"));
             s.on_completed();
@@ -216,28 +213,28 @@ TEST(opBuilderHelperIntEqual, Exec_equal_ref_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test2":9,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10,"field_src3":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10,"field_src4":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test5":10,"field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test6":"10","field_src2":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_":"10","field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src2":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test2":10,"field_src2":"test"}
             )"));
             s.on_completed();
@@ -261,21 +258,21 @@ TEST(opBuilderHelperIntEqual, Exec_dynamics_int_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":11,
                     "ref_key":10
                 }
             )"));
             // Equal
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":10
                 }
             )"));
             // Less
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":11
@@ -305,7 +302,7 @@ TEST(opBuilderHelperIntEqual, Exec_multilevel_dynamics_int_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -318,7 +315,7 @@ TEST(opBuilderHelperIntEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -331,7 +328,7 @@ TEST(opBuilderHelperIntEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -344,7 +341,7 @@ TEST(opBuilderHelperIntEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntEqual_test.cpp
@@ -10,9 +10,10 @@
 #include <gtest/gtest.h>
 #include <vector>
 
+#include <baseTypes.hpp>
+
 #include "testUtils.hpp"
 #include "opBuilderHelperFilter.hpp"
-#include "base/baseTypes.hpp"
 
 using namespace base;
 namespace bld = builder::internals::builders;

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThanEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThanEqual_test.cpp
@@ -14,10 +14,8 @@
 #include "opBuilderHelperFilter.hpp"
 #include "base/baseTypes.hpp"
 
-using namespace builder::internals::builders;
 using namespace base;
-
-using namespace builder::internals::builders;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
@@ -33,7 +31,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Builds)
             {"field_test": "+i_lt/10"}
     })"};
 
-    ASSERT_NO_THROW(opBuilderHelperIntGreaterThanEqual(doc.get("/check"), tr));
+    ASSERT_NO_THROW(bld::opBuilderHelperIntGreaterThanEqual(doc.get("/check"), tr));
 }
 
 TEST(opBuilderHelperIntGreaterThanEqual, Builds_error_bad_parameter)
@@ -43,7 +41,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Builds_error_bad_parameter)
             {"field_test": "+i_lt/test"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperIntGreaterThanEqual(doc.get("/check"), tr),
+    ASSERT_THROW(bld::opBuilderHelperIntGreaterThanEqual(doc.get("/check"), tr),
                  std::invalid_argument);
 }
 
@@ -54,7 +52,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Builds_error_more_parameters)
             {"field_test": "+i_lt/10/10"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperIntGreaterThanEqual(doc.get("/check"), tr),
+    ASSERT_THROW(bld::opBuilderHelperIntGreaterThanEqual(doc.get("/check"), tr),
                  std::runtime_error);
 }
 
@@ -82,7 +80,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ok)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntGreaterThanEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntGreaterThanEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -118,7 +116,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_true)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntGreaterThanEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntGreaterThanEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -154,7 +152,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_false)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntGreaterThanEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntGreaterThanEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -199,7 +197,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ref_true)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntGreaterThanEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntGreaterThanEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -248,7 +246,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ref_false)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntGreaterThanEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntGreaterThanEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -291,7 +289,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_dynamics_int_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperIntGreaterThanEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntGreaterThanEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -368,7 +366,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_multilevel_dynamics_int_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperIntGreaterThanEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntGreaterThanEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThanEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThanEqual_test.cpp
@@ -21,10 +21,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
-
 TEST(opBuilderHelperIntGreaterThanEqual, Builds)
 {
     Document doc{R"({
@@ -67,16 +63,16 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -103,16 +99,16 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -139,16 +135,16 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test2":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test3":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":8}
             )"));
             s.on_completed();
@@ -172,28 +168,28 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ref_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 10,"field_src": 10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":"11","field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":"11","field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src":"test"}
             )"));
             s.on_completed();
@@ -221,28 +217,28 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ref_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test2":11,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src3":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src4":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test5":11,"field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test6":"11","field_src2":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_":"11","field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src2":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test2":11,"field_src2":"test"}
             )"));
             s.on_completed();
@@ -267,21 +263,21 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_dynamics_int_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":11,
                     "ref_key":10
                 }
             )"));
             // Equal
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":10
                 }
             )"));
             // Less
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":11
@@ -313,7 +309,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_multilevel_dynamics_int_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -326,7 +322,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -339,7 +335,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -352,7 +348,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThanEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThanEqual_test.cpp
@@ -18,6 +18,10 @@ using namespace builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
+auto createEvent = [](const char * json){
+    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+};
+
 TEST(opBuilderHelperIntGreaterThanEqual, Builds)
 {
     Document doc{R"({
@@ -60,16 +64,16 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -81,9 +85,9 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_GE(expected[0]->get("/field_test").GetInt(), 10);
-    ASSERT_GE(expected[1]->get("/field_test").GetInt(), 10);
-    ASSERT_GE(expected[2]->get("/field_test").GetInt(), 10);
+    ASSERT_GE(expected[0]->getEvent()->get("/field_test").GetInt(), 10);
+    ASSERT_GE(expected[1]->getEvent()->get("/field_test").GetInt(), 10);
+    ASSERT_GE(expected[2]->getEvent()->get("/field_test").GetInt(), 10);
 }
 
 TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_true)
@@ -96,16 +100,16 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -117,9 +121,9 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_GE(expected[0]->get("/field_test").GetInt(), 10);
-    ASSERT_GE(expected[1]->get("/field_test").GetInt(), 10);
-    ASSERT_GE(expected[2]->get("/field_test").GetInt(), 11);
+    ASSERT_GE(expected[0]->getEvent()->get("/field_test").GetInt(), 10);
+    ASSERT_GE(expected[1]->getEvent()->get("/field_test").GetInt(), 10);
+    ASSERT_GE(expected[2]->getEvent()->get("/field_test").GetInt(), 11);
 }
 
 TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_false)
@@ -132,16 +136,16 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test2":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test3":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":8}
             )"));
             s.on_completed();
@@ -165,28 +169,28 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ref_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 10,"field_src": 10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":"11","field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":"11","field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src":"test"}
             )"));
             s.on_completed();
@@ -198,10 +202,10 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ref_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_GE(expected[0]->get("/field_test").GetInt(),
-              expected[0]->get("/field_src").GetInt());
-    ASSERT_GE(expected[1]->get("/field_test").GetInt(),
-              expected[1]->get("/field_src").GetInt());
+    ASSERT_GE(expected[0]->getEvent()->get("/field_test").GetInt(),
+              expected[0]->getEvent()->get("/field_src").GetInt());
+    ASSERT_GE(expected[1]->getEvent()->get("/field_test").GetInt(),
+              expected[1]->getEvent()->get("/field_src").GetInt());
 }
 
 TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ref_false)
@@ -214,28 +218,28 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_greater_than_equal_ref_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test2":11,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src3":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src4":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test5":11,"field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test6":"11","field_src2":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_":"11","field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src2":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test2":11,"field_src2":"test"}
             )"));
             s.on_completed();
@@ -260,21 +264,21 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_dynamics_int_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":11,
                     "ref_key":10
                 }
             )"));
             // Equal
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":10
                 }
             )"));
             // Less
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":11
@@ -290,10 +294,10 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_GE(expected[0]->get("/field2check").GetInt(),
-              expected[0]->get("/ref_key").GetInt());
-    ASSERT_GE(expected[1]->get("/field2check").GetInt(),
-              expected[1]->get("/ref_key").GetInt());
+    ASSERT_GE(expected[0]->getEvent()->get("/field2check").GetInt(),
+              expected[0]->getEvent()->get("/ref_key").GetInt());
+    ASSERT_GE(expected[1]->getEvent()->get("/field2check").GetInt(),
+              expected[1]->getEvent()->get("/ref_key").GetInt());
 }
 
 TEST(opBuilderHelperIntGreaterThanEqual, Exec_multilevel_dynamics_int_ok)
@@ -306,7 +310,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_multilevel_dynamics_int_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -319,7 +323,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -332,7 +336,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -345,7 +349,7 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -367,8 +371,8 @@ TEST(opBuilderHelperIntGreaterThanEqual, Exec_multilevel_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_GE(expected[0]->get("/parentObjt_1/field2check").GetInt(),
-              expected[0]->get("/parentObjt_2/ref_key").GetInt());
-    ASSERT_GE(expected[1]->get("/parentObjt_1/field2check").GetInt(),
-              expected[1]->get("/parentObjt_2/ref_key").GetInt());
+    ASSERT_GE(expected[0]->getEvent()->get("/parentObjt_1/field2check").GetInt(),
+              expected[0]->getEvent()->get("/parentObjt_2/ref_key").GetInt());
+    ASSERT_GE(expected[1]->getEvent()->get("/parentObjt_1/field2check").GetInt(),
+              expected[1]->getEvent()->get("/parentObjt_2/ref_key").GetInt());
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThanEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThanEqual_test.cpp
@@ -12,6 +12,10 @@
 
 #include "testUtils.hpp"
 #include "opBuilderHelperFilter.hpp"
+#include "base/baseTypes.hpp"
+
+using namespace builder::internals::builders;
+using namespace base;
 
 using namespace builder::internals::builders;
 
@@ -19,7 +23,7 @@ using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
 auto createEvent = [](const char * json){
-    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
 };
 
 TEST(opBuilderHelperIntGreaterThanEqual, Builds)

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThanEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThanEqual_test.cpp
@@ -10,9 +10,10 @@
 #include <gtest/gtest.h>
 #include <vector>
 
+#include <baseTypes.hpp>
+
 #include "testUtils.hpp"
 #include "opBuilderHelperFilter.hpp"
-#include "base/baseTypes.hpp"
 
 using namespace base;
 namespace bld = builder::internals::builders;

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThan_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThan_test.cpp
@@ -18,6 +18,10 @@ using namespace builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
+auto createEvent = [](const char * json){
+    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+};
+
 TEST(opBuilderHelperIntGreaterThan, Builds)
 {
     Document doc{R"({
@@ -59,16 +63,16 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -80,7 +84,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_GT(expected[0]->get("/field_test").GetInt(), 10);
+    ASSERT_GT(expected[0]->getEvent()->get("/field_test").GetInt(), 10);
 }
 
 TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_true)
@@ -93,16 +97,16 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -114,7 +118,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_GT(expected[0]->get("/field_test").GetInt(), 10);
+    ASSERT_GT(expected[0]->getEvent()->get("/field_test").GetInt(), 10);
 }
 
 TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_false)
@@ -127,16 +131,16 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test2":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test3":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":8}
             )"));
             s.on_completed();
@@ -160,28 +164,28 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ref_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 10,"field_src": 10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":"11","field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":"11","field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src":"test"}
             )"));
             s.on_completed();
@@ -193,10 +197,10 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ref_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_GT(expected[0]->get("/field_test").GetInt(),
-              expected[0]->get("/field_src").GetInt());
-    ASSERT_GT(expected[1]->get("/field_test").GetInt(),
-              expected[1]->get("/field_src").GetInt());
+    ASSERT_GT(expected[0]->getEvent()->get("/field_test").GetInt(),
+              expected[0]->getEvent()->get("/field_src").GetInt());
+    ASSERT_GT(expected[1]->getEvent()->get("/field_test").GetInt(),
+              expected[1]->getEvent()->get("/field_src").GetInt());
 }
 
 TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ref_false)
@@ -209,28 +213,28 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ref_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test2":11,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10,"field_src3":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10,"field_src4":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test5":10,"field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test6":"10","field_src2":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_":"10","field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src2":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test2":10,"field_src2":"test"}
             )"));
             s.on_completed();
@@ -255,21 +259,21 @@ TEST(opBuilderHelperIntGreaterThan, Exec_dynamics_int_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":11,
                     "ref_key":10
                 }
             )"));
             // Equal
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":10
                 }
             )"));
             // Less
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":11
@@ -285,8 +289,8 @@ TEST(opBuilderHelperIntGreaterThan, Exec_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_GT(expected[0]->get("/field2check").GetInt(),
-              expected[0]->get("/ref_key").GetInt());
+    ASSERT_GT(expected[0]->getEvent()->get("/field2check").GetInt(),
+              expected[0]->getEvent()->get("/ref_key").GetInt());
 }
 
 TEST(opBuilderHelperIntGreaterThan, Exec_multilevel_dynamics_int_ok)
@@ -299,7 +303,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_multilevel_dynamics_int_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -312,7 +316,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -325,7 +329,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -338,7 +342,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -360,6 +364,6 @@ TEST(opBuilderHelperIntGreaterThan, Exec_multilevel_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_GT(expected[0]->get("/parentObjt_1/field2check").GetInt(),
-              expected[0]->get("/parentObjt_2/ref_key").GetInt());
+    ASSERT_GT(expected[0]->getEvent()->get("/parentObjt_1/field2check").GetInt(),
+              expected[0]->getEvent()->get("/parentObjt_2/ref_key").GetInt());
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThan_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThan_test.cpp
@@ -12,14 +12,16 @@
 
 #include "testUtils.hpp"
 #include "opBuilderHelperFilter.hpp"
+#include "base/baseTypes.hpp"
 
 using namespace builder::internals::builders;
+using namespace base;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
 auto createEvent = [](const char * json){
-    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
 };
 
 TEST(opBuilderHelperIntGreaterThan, Builds)

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThan_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThan_test.cpp
@@ -10,9 +10,11 @@
 #include <gtest/gtest.h>
 #include <vector>
 
+#include <baseTypes.hpp>
+
 #include "testUtils.hpp"
 #include "opBuilderHelperFilter.hpp"
-#include "base/baseTypes.hpp"
+
 
 using namespace base;
 namespace bld = builder::internals::builders;

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThan_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThan_test.cpp
@@ -22,10 +22,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
-
 TEST(opBuilderHelperIntGreaterThan, Builds)
 {
     Document doc{R"({
@@ -67,16 +63,16 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -101,16 +97,16 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -135,16 +131,16 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test2":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test3":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":8}
             )"));
             s.on_completed();
@@ -168,28 +164,28 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ref_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 10,"field_src": 10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":"11","field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":"11","field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src":"test"}
             )"));
             s.on_completed();
@@ -217,28 +213,28 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ref_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test2":11,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10,"field_src3":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10,"field_src4":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test5":10,"field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test6":"10","field_src2":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_":"10","field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src2":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test2":10,"field_src2":"test"}
             )"));
             s.on_completed();
@@ -263,21 +259,21 @@ TEST(opBuilderHelperIntGreaterThan, Exec_dynamics_int_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":11,
                     "ref_key":10
                 }
             )"));
             // Equal
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":10
                 }
             )"));
             // Less
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":11
@@ -307,7 +303,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_multilevel_dynamics_int_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -320,7 +316,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -333,7 +329,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -346,7 +342,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThan_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntGreaterThan_test.cpp
@@ -14,8 +14,8 @@
 #include "opBuilderHelperFilter.hpp"
 #include "base/baseTypes.hpp"
 
-using namespace builder::internals::builders;
 using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
@@ -31,7 +31,7 @@ TEST(opBuilderHelperIntGreaterThan, Builds)
             {"field_test": "+i_lt/10"}
     })"};
 
-    ASSERT_NO_THROW(opBuilderHelperIntGreaterThan(doc.get("/check"), tr));
+    ASSERT_NO_THROW(bld::opBuilderHelperIntGreaterThan(doc.get("/check"), tr));
 }
 
 TEST(opBuilderHelperIntGreaterThan, Builds_error_bad_parameter)
@@ -41,7 +41,7 @@ TEST(opBuilderHelperIntGreaterThan, Builds_error_bad_parameter)
             {"field_test": "+i_lt/test"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperIntGreaterThan(doc.get("/check"), tr),
+    ASSERT_THROW(bld::opBuilderHelperIntGreaterThan(doc.get("/check"), tr),
                  std::invalid_argument);
 }
 
@@ -52,7 +52,7 @@ TEST(opBuilderHelperIntGreaterThan, Builds_error_more_parameters)
             {"field_test": "+i_lt/10/10"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperIntGreaterThan(doc.get("/check"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperIntGreaterThan(doc.get("/check"), tr), std::runtime_error);
 }
 
 TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ok)
@@ -79,7 +79,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ok)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntGreaterThan(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntGreaterThan(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -113,7 +113,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_true)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntGreaterThan(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntGreaterThan(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -147,7 +147,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_false)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntGreaterThan(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntGreaterThan(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -192,7 +192,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ref_true)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntGreaterThan(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntGreaterThan(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -241,7 +241,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_greater_than_ref_false)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntGreaterThan(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntGreaterThan(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -284,7 +284,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_dynamics_int_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperIntGreaterThan(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntGreaterThan(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -359,7 +359,7 @@ TEST(opBuilderHelperIntGreaterThan, Exec_multilevel_dynamics_int_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperIntGreaterThan(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntGreaterThan(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntLessThanEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntLessThanEqual_test.cpp
@@ -21,10 +21,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
-
 TEST(opBuilderHelperIntLessThanEqual, Builds)
 {
     Document doc{R"({
@@ -66,16 +62,16 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -102,16 +98,16 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -138,16 +134,16 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":20}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test2":100}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test3":100}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -171,28 +167,28 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ref_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 10,"field_src": 10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":"9","field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":"9","field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src":"test"}
             )"));
             s.on_completed();
@@ -222,28 +218,28 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ref_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test2":9,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src3":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src4":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test5":9,"field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test6":"9","field_src2":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_":"9","field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src2":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test2":9,"field_src2":"test"}
             )"));
             s.on_completed();
@@ -268,21 +264,21 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_dynamics_int_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":11,
                     "ref_key":10
                 }
             )"));
             // Equal
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":10
                 }
             )"));
             // Less
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":11
@@ -314,7 +310,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_multilevel_dynamics_int_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -327,7 +323,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 9,
@@ -340,7 +336,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -353,7 +349,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntLessThanEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntLessThanEqual_test.cpp
@@ -14,8 +14,8 @@
 #include "opBuilderHelperFilter.hpp"
 #include "base/baseTypes.hpp"
 
-namespace bl = builder::internals::builders;
 using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
@@ -31,7 +31,7 @@ TEST(opBuilderHelperIntLessThanEqual, Builds)
             {"field_test": "+i_lt/10"}
     })"};
 
-    ASSERT_NO_THROW(bl::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr));
+    ASSERT_NO_THROW(bld::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr));
 }
 
 TEST(opBuilderHelperIntLessThanEqual, Builds_error_bad_parameter)
@@ -41,7 +41,7 @@ TEST(opBuilderHelperIntLessThanEqual, Builds_error_bad_parameter)
             {"field_test": "+i_lt/test"}
     })"};
 
-    ASSERT_THROW(bl::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr),
+    ASSERT_THROW(bld::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr),
                  std::invalid_argument);
 }
 
@@ -52,7 +52,7 @@ TEST(opBuilderHelperIntLessThanEqual, Builds_error_more_parameters)
             {"field_test": "+i_lt/10/10"}
     })"};
 
-    ASSERT_THROW(bl::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr), std::runtime_error);
 }
 
 TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ok)
@@ -79,7 +79,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ok)
             )"));
             s.on_completed();
         });
-    Lifter lift = bl::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -115,7 +115,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_true)
             )"));
             s.on_completed();
         });
-    Lifter lift = bl::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -151,7 +151,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_false)
             )"));
             s.on_completed();
         });
-    Lifter lift = bl::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -196,7 +196,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ref_true)
             )"));
             s.on_completed();
         });
-    Lifter lift = bl::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -247,7 +247,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ref_false)
             )"));
             s.on_completed();
         });
-    Lifter lift = bl::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -290,7 +290,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_dynamics_int_ok)
             s.on_completed();
         });
 
-    Lifter lift = bl::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -367,7 +367,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_multilevel_dynamics_int_ok)
             s.on_completed();
         });
 
-    Lifter lift = bl::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntLessThanEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntLessThanEqual_test.cpp
@@ -12,14 +12,16 @@
 
 #include "testUtils.hpp"
 #include "opBuilderHelperFilter.hpp"
+#include "base/baseTypes.hpp"
 
-using namespace builder::internals::builders;
+namespace bl = builder::internals::builders;
+using namespace base;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
 auto createEvent = [](const char * json){
-    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
 };
 
 TEST(opBuilderHelperIntLessThanEqual, Builds)
@@ -29,7 +31,7 @@ TEST(opBuilderHelperIntLessThanEqual, Builds)
             {"field_test": "+i_lt/10"}
     })"};
 
-    ASSERT_NO_THROW(opBuilderHelperIntLessThanEqual(doc.get("/check"), tr));
+    ASSERT_NO_THROW(bl::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr));
 }
 
 TEST(opBuilderHelperIntLessThanEqual, Builds_error_bad_parameter)
@@ -39,7 +41,7 @@ TEST(opBuilderHelperIntLessThanEqual, Builds_error_bad_parameter)
             {"field_test": "+i_lt/test"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperIntLessThanEqual(doc.get("/check"), tr),
+    ASSERT_THROW(bl::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr),
                  std::invalid_argument);
 }
 
@@ -50,7 +52,7 @@ TEST(opBuilderHelperIntLessThanEqual, Builds_error_more_parameters)
             {"field_test": "+i_lt/10/10"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperIntLessThanEqual(doc.get("/check"), tr), std::runtime_error);
+    ASSERT_THROW(bl::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr), std::runtime_error);
 }
 
 TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ok)
@@ -77,7 +79,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ok)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
+    Lifter lift = bl::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -113,7 +115,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_true)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
+    Lifter lift = bl::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -149,7 +151,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_false)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
+    Lifter lift = bl::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -194,7 +196,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ref_true)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
+    Lifter lift = bl::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -245,7 +247,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ref_false)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
+    Lifter lift = bl::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -288,7 +290,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_dynamics_int_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
+    Lifter lift = bl::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -365,7 +367,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_multilevel_dynamics_int_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
+    Lifter lift = bl::opBuilderHelperIntLessThanEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntLessThanEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntLessThanEqual_test.cpp
@@ -18,6 +18,10 @@ using namespace builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
+auto createEvent = [](const char * json){
+    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+};
+
 TEST(opBuilderHelperIntLessThanEqual, Builds)
 {
     Document doc{R"({
@@ -59,16 +63,16 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -80,9 +84,9 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_LE(expected[0]->get("/field_test").GetInt(), 10);
-    ASSERT_LE(expected[1]->get("/field_test").GetInt(), 10);
-    ASSERT_LE(expected[2]->get("/field_test").GetInt(), 10);
+    ASSERT_LE(expected[0]->getEvent()->get("/field_test").GetInt(), 10);
+    ASSERT_LE(expected[1]->getEvent()->get("/field_test").GetInt(), 10);
+    ASSERT_LE(expected[2]->getEvent()->get("/field_test").GetInt(), 10);
 }
 
 TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_true)
@@ -95,16 +99,16 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -116,9 +120,9 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_LE(expected[0]->get("/field_test").GetInt(), 10);
-    ASSERT_LE(expected[1]->get("/field_test").GetInt(), 10);
-    ASSERT_LE(expected[2]->get("/field_test").GetInt(), 10);
+    ASSERT_LE(expected[0]->getEvent()->get("/field_test").GetInt(), 10);
+    ASSERT_LE(expected[1]->getEvent()->get("/field_test").GetInt(), 10);
+    ASSERT_LE(expected[2]->getEvent()->get("/field_test").GetInt(), 10);
 }
 
 TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_false)
@@ -131,16 +135,16 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":20}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test2":100}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test3":100}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -164,28 +168,28 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ref_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 10,"field_src": 10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":"9","field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":"9","field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src":"test"}
             )"));
             s.on_completed();
@@ -197,12 +201,12 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ref_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_LE(expected[0]->get("/field_test").GetInt(),
-              expected[0]->get("/field_src").GetInt());
-    ASSERT_LE(expected[1]->get("/field_test").GetInt(),
-              expected[1]->get("/field_src").GetInt());
-    ASSERT_LE(expected[2]->get("/field_test").GetInt(),
-              expected[2]->get("/field_src").GetInt());
+    ASSERT_LE(expected[0]->getEvent()->get("/field_test").GetInt(),
+              expected[0]->getEvent()->get("/field_src").GetInt());
+    ASSERT_LE(expected[1]->getEvent()->get("/field_test").GetInt(),
+              expected[1]->getEvent()->get("/field_src").GetInt());
+    ASSERT_LE(expected[2]->getEvent()->get("/field_test").GetInt(),
+              expected[2]->getEvent()->get("/field_src").GetInt());
 }
 
 TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ref_false)
@@ -215,28 +219,28 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_less_than_equal_ref_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test2":9,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src3":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src4":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test5":9,"field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test6":"9","field_src2":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_":"9","field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src2":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test2":9,"field_src2":"test"}
             )"));
             s.on_completed();
@@ -261,21 +265,21 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_dynamics_int_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":11,
                     "ref_key":10
                 }
             )"));
             // Equal
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":10
                 }
             )"));
             // Less
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":11
@@ -291,10 +295,10 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_LE(expected[0]->get("/field2check").GetInt(),
-              expected[0]->get("/ref_key").GetInt());
-    ASSERT_LE(expected[1]->get("/field2check").GetInt(),
-              expected[1]->get("/ref_key").GetInt());
+    ASSERT_LE(expected[0]->getEvent()->get("/field2check").GetInt(),
+              expected[0]->getEvent()->get("/ref_key").GetInt());
+    ASSERT_LE(expected[1]->getEvent()->get("/field2check").GetInt(),
+              expected[1]->getEvent()->get("/ref_key").GetInt());
 }
 
 TEST(opBuilderHelperIntLessThanEqual, Exec_multilevel_dynamics_int_ok)
@@ -307,7 +311,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_multilevel_dynamics_int_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -320,7 +324,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 9,
@@ -333,7 +337,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -346,7 +350,7 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -368,8 +372,8 @@ TEST(opBuilderHelperIntLessThanEqual, Exec_multilevel_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_LE(expected[0]->get("/parentObjt_1/field2check").GetInt(),
-              expected[0]->get("/parentObjt_2/ref_key").GetInt());
-    ASSERT_LE(expected[1]->get("/parentObjt_1/field2check").GetInt(),
-              expected[1]->get("/parentObjt_2/ref_key").GetInt());
+    ASSERT_LE(expected[0]->getEvent()->get("/parentObjt_1/field2check").GetInt(),
+              expected[0]->getEvent()->get("/parentObjt_2/ref_key").GetInt());
+    ASSERT_LE(expected[1]->getEvent()->get("/parentObjt_1/field2check").GetInt(),
+              expected[1]->getEvent()->get("/parentObjt_2/ref_key").GetInt());
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntLessThanEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntLessThanEqual_test.cpp
@@ -10,9 +10,10 @@
 #include <gtest/gtest.h>
 #include <vector>
 
+#include <baseTypes.hpp>
+
 #include "testUtils.hpp"
 #include "opBuilderHelperFilter.hpp"
-#include "base/baseTypes.hpp"
 
 using namespace base;
 namespace bld = builder::internals::builders;

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntLessThan_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntLessThan_test.cpp
@@ -18,6 +18,10 @@ using namespace builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
+auto createEvent = [](const char * json){
+    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+};
+
 TEST(opBuilderHelperIntLessThan, Builds)
 {
     Document doc{R"({
@@ -58,16 +62,16 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -79,7 +83,7 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_LT(expected[0]->get("/field_test").GetInt(), 10);
+    ASSERT_LT(expected[0]->getEvent()->get("/field_test").GetInt(), 10);
 }
 
 TEST(opBuilderHelperIntLessThan, Exec_less_than_true)
@@ -92,16 +96,16 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -113,7 +117,7 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_LT(expected[0]->get("/field_test").GetInt(), 10);
+    ASSERT_LT(expected[0]->getEvent()->get("/field_test").GetInt(), 10);
 }
 
 TEST(opBuilderHelperIntLessThan, Exec_less_than_false)
@@ -126,16 +130,16 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":20}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test2":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test3":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -159,28 +163,28 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_ref_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 10,"field_src": 10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":"9","field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":"9","field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src":"test"}
             )"));
             s.on_completed();
@@ -192,10 +196,10 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_ref_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_LT(expected[0]->get("/field_test").GetInt(),
-              expected[0]->get("/field_src").GetInt());
-    ASSERT_LT(expected[1]->get("/field_test").GetInt(),
-              expected[1]->get("/field_src").GetInt());
+    ASSERT_LT(expected[0]->getEvent()->get("/field_test").GetInt(),
+              expected[0]->getEvent()->get("/field_src").GetInt());
+    ASSERT_LT(expected[1]->getEvent()->get("/field_test").GetInt(),
+              expected[1]->getEvent()->get("/field_src").GetInt());
 }
 
 TEST(opBuilderHelperIntLessThan, Exec_less_than_ref_false)
@@ -208,28 +212,28 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_ref_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test2":9,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src3":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src4":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test5":9,"field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test6":"9","field_src2":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_":"9","field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9,"field_src2":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test2":9,"field_src2":"test"}
             )"));
             s.on_completed();
@@ -254,21 +258,21 @@ TEST(opBuilderHelperIntLessThan, Exec_dynamics_int_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":11,
                     "ref_key":10
                 }
             )"));
             // Equal
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":10
                 }
             )"));
             // Less
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":11
@@ -284,8 +288,8 @@ TEST(opBuilderHelperIntLessThan, Exec_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_LT(expected[0]->get("/field2check").GetInt(),
-              expected[0]->get("/ref_key").GetInt());
+    ASSERT_LT(expected[0]->getEvent()->get("/field2check").GetInt(),
+              expected[0]->getEvent()->get("/ref_key").GetInt());
 }
 
 TEST(opBuilderHelperIntLessThan, Exec_multilevel_dynamics_int_ok)
@@ -298,7 +302,7 @@ TEST(opBuilderHelperIntLessThan, Exec_multilevel_dynamics_int_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -311,7 +315,7 @@ TEST(opBuilderHelperIntLessThan, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 9,
@@ -324,7 +328,7 @@ TEST(opBuilderHelperIntLessThan, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -337,7 +341,7 @@ TEST(opBuilderHelperIntLessThan, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -359,6 +363,6 @@ TEST(opBuilderHelperIntLessThan, Exec_multilevel_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_LT(expected[0]->get("/parentObjt_1/field2check").GetInt(),
-              expected[0]->get("/parentObjt_2/ref_key").GetInt());
+    ASSERT_LT(expected[0]->getEvent()->get("/parentObjt_1/field2check").GetInt(),
+              expected[0]->getEvent()->get("/parentObjt_2/ref_key").GetInt());
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntLessThan_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntLessThan_test.cpp
@@ -12,14 +12,16 @@
 
 #include "testUtils.hpp"
 #include "opBuilderHelperFilter.hpp"
+#include "base/baseTypes.hpp"
 
 using namespace builder::internals::builders;
+using namespace base;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
 auto createEvent = [](const char * json){
-    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
 };
 
 TEST(opBuilderHelperIntLessThan, Builds)

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntLessThan_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntLessThan_test.cpp
@@ -14,8 +14,8 @@
 #include "opBuilderHelperFilter.hpp"
 #include "base/baseTypes.hpp"
 
-using namespace builder::internals::builders;
 using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
@@ -31,7 +31,7 @@ TEST(opBuilderHelperIntLessThan, Builds)
             {"field_test": "+i_lt/10"}
     })"};
 
-    ASSERT_NO_THROW(opBuilderHelperIntLessThan(doc.get("/check"), tr));
+    ASSERT_NO_THROW(bld::opBuilderHelperIntLessThan(doc.get("/check"), tr));
 }
 
 TEST(opBuilderHelperIntLessThan, Builds_error_bad_parameter)
@@ -41,7 +41,7 @@ TEST(opBuilderHelperIntLessThan, Builds_error_bad_parameter)
             {"field_test": "+i_lt/test"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperIntLessThan(doc.get("/check"), tr), std::invalid_argument);
+    ASSERT_THROW(bld::opBuilderHelperIntLessThan(doc.get("/check"), tr), std::invalid_argument);
 }
 
 TEST(opBuilderHelperIntLessThan, Builds_error_more_parameters)
@@ -51,7 +51,7 @@ TEST(opBuilderHelperIntLessThan, Builds_error_more_parameters)
             {"field_test": "+i_lt/10/10"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperIntLessThan(doc.get("/check"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperIntLessThan(doc.get("/check"), tr), std::runtime_error);
 }
 
 TEST(opBuilderHelperIntLessThan, Exec_less_than_ok)
@@ -78,7 +78,7 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_ok)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntLessThan(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntLessThan(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -112,7 +112,7 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_true)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntLessThan(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntLessThan(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -146,7 +146,7 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_false)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntLessThan(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntLessThan(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -191,7 +191,7 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_ref_true)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntLessThan(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntLessThan(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -240,7 +240,7 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_ref_false)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntLessThan(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntLessThan(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -283,7 +283,7 @@ TEST(opBuilderHelperIntLessThan, Exec_dynamics_int_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperIntLessThan(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntLessThan(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -358,7 +358,7 @@ TEST(opBuilderHelperIntLessThan, Exec_multilevel_dynamics_int_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperIntLessThan(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntLessThan(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntLessThan_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntLessThan_test.cpp
@@ -21,9 +21,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
 
 TEST(opBuilderHelperIntLessThan, Builds)
 {
@@ -65,16 +62,16 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -99,16 +96,16 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -133,16 +130,16 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":20}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test2":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test3":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -166,28 +163,28 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_ref_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 10,"field_src": 10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":"9","field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":"9","field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src":"test"}
             )"));
             s.on_completed();
@@ -215,28 +212,28 @@ TEST(opBuilderHelperIntLessThan, Exec_less_than_ref_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test2":9,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src3":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src4":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test5":9,"field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test6":"9","field_src2":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_":"9","field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9,"field_src2":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test2":9,"field_src2":"test"}
             )"));
             s.on_completed();
@@ -261,21 +258,21 @@ TEST(opBuilderHelperIntLessThan, Exec_dynamics_int_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":11,
                     "ref_key":10
                 }
             )"));
             // Equal
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":10
                 }
             )"));
             // Less
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":11
@@ -305,7 +302,7 @@ TEST(opBuilderHelperIntLessThan, Exec_multilevel_dynamics_int_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -318,7 +315,7 @@ TEST(opBuilderHelperIntLessThan, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 9,
@@ -331,7 +328,7 @@ TEST(opBuilderHelperIntLessThan, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -344,7 +341,7 @@ TEST(opBuilderHelperIntLessThan, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntLessThan_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntLessThan_test.cpp
@@ -10,9 +10,10 @@
 #include <gtest/gtest.h>
 #include <vector>
 
+#include <baseTypes.hpp>
+
 #include "testUtils.hpp"
 #include "opBuilderHelperFilter.hpp"
-#include "base/baseTypes.hpp"
 
 using namespace base;
 namespace bld = builder::internals::builders;

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntNotEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntNotEqual_test.cpp
@@ -14,8 +14,8 @@
 #include "opBuilderHelperFilter.hpp"
 #include "base/baseTypes.hpp"
 
-using namespace builder::internals::builders;
 using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
@@ -31,7 +31,7 @@ TEST(opBuilderHelperIntNotEqual, Builds)
             {"field_test": "+i_ne/10"}
     })"};
 
-    ASSERT_NO_THROW(opBuilderHelperIntNotEqual(doc.get("/check"), tr));
+    ASSERT_NO_THROW(bld::opBuilderHelperIntNotEqual(doc.get("/check"), tr));
 }
 
 TEST(opBuilderHelperIntNotEqual, Builds_error_bad_parameter)
@@ -41,7 +41,7 @@ TEST(opBuilderHelperIntNotEqual, Builds_error_bad_parameter)
             {"field_test": "+i_ne/test"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperIntNotEqual(doc.get("/check"), tr), std::invalid_argument);
+    ASSERT_THROW(bld::opBuilderHelperIntNotEqual(doc.get("/check"), tr), std::invalid_argument);
 }
 
 TEST(opBuilderHelperIntNotEqual, Builds_error_more_parameters)
@@ -51,7 +51,7 @@ TEST(opBuilderHelperIntNotEqual, Builds_error_more_parameters)
             {"field_test": "+i_ne/10/10"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperIntNotEqual(doc.get("/check"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperIntNotEqual(doc.get("/check"), tr), std::runtime_error);
 }
 
 TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ok)
@@ -78,7 +78,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ok)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntNotEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntNotEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -113,7 +113,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_true)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntNotEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntNotEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -148,7 +148,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_false)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntNotEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntNotEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -193,7 +193,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ref_true)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntNotEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntNotEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -242,7 +242,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ref_false)
             )"));
             s.on_completed();
         });
-    Lifter lift = opBuilderHelperIntNotEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntNotEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -285,7 +285,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_dynamics_int_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperIntNotEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntNotEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -362,7 +362,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_multilevel_dynamics_int_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperIntNotEqual(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperIntNotEqual(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntNotEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntNotEqual_test.cpp
@@ -18,6 +18,10 @@ using namespace builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
+auto createEvent = [](const char * json){
+    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+};
+
 TEST(opBuilderHelperIntNotEqual, Builds)
 {
     Document doc{R"({
@@ -58,16 +62,16 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -79,8 +83,8 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_EQ(expected[0]->get("/field_test").GetInt(), 9);
-    ASSERT_EQ(expected[1]->get("/field_test").GetInt(), 11);
+    ASSERT_EQ(expected[0]->getEvent()->get("/field_test").GetInt(), 9);
+    ASSERT_EQ(expected[1]->getEvent()->get("/field_test").GetInt(), 11);
 }
 
 TEST(opBuilderHelperIntNotEqual, Exec_not_equal_true)
@@ -93,16 +97,16 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -114,8 +118,8 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_EQ(expected[0]->get("/field_test").GetInt(), 9);
-    ASSERT_EQ(expected[1]->get("/field_test").GetInt(), 11);
+    ASSERT_EQ(expected[0]->getEvent()->get("/field_test").GetInt(), 9);
+    ASSERT_EQ(expected[1]->getEvent()->get("/field_test").GetInt(), 11);
 }
 
 TEST(opBuilderHelperIntNotEqual, Exec_not_equal_false)
@@ -128,16 +132,16 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test2":9}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test3":11}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10}
             )"));
             s.on_completed();
@@ -161,28 +165,28 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ref_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test": 9,"field_src": 10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10,"field_src":11}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10,"field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":"10","field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":"10","field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10,"field_src":"test"}
             )"));
             s.on_completed();
@@ -194,10 +198,10 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ref_true)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_NE(expected[0]->get("/field_test").GetInt(),
-              expected[0]->get("/field_src").GetInt());
-    ASSERT_NE(expected[1]->get("/field_test").GetInt(),
-              expected[1]->get("/field_src").GetInt());
+    ASSERT_NE(expected[0]->getEvent()->get("/field_test").GetInt(),
+              expected[0]->getEvent()->get("/field_src").GetInt());
+    ASSERT_NE(expected[1]->getEvent()->get("/field_test").GetInt(),
+              expected[1]->getEvent()->get("/field_src").GetInt());
 }
 
 TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ref_false)
@@ -210,28 +214,28 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ref_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test2":9,"field_src":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10,"field_src3":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":10,"field_src4":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test5":10,"field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test6":"10","field_src2":10}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_":"10","field_src":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test":11,"field_src2":"10"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field_test2":10,"field_src2":"test"}
             )"));
             s.on_completed();
@@ -256,21 +260,21 @@ TEST(opBuilderHelperIntNotEqual, Exec_dynamics_int_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":11,
                     "ref_key":10
                 }
             )"));
             // Equal
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":10
                 }
             )"));
             // Less
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":11
@@ -286,10 +290,10 @@ TEST(opBuilderHelperIntNotEqual, Exec_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_NE(expected[0]->get("/field2check").GetInt(),
-              expected[0]->get("/ref_key").GetInt());
-    ASSERT_NE(expected[1]->get("/field2check").GetInt(),
-              expected[1]->get("/ref_key").GetInt());
+    ASSERT_NE(expected[0]->getEvent()->get("/field2check").GetInt(),
+              expected[0]->getEvent()->get("/ref_key").GetInt());
+    ASSERT_NE(expected[1]->getEvent()->get("/field2check").GetInt(),
+              expected[1]->getEvent()->get("/ref_key").GetInt());
 }
 
 TEST(opBuilderHelperIntNotEqual, Exec_multilevel_dynamics_int_ok)
@@ -302,7 +306,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_multilevel_dynamics_int_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -315,7 +319,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -328,7 +332,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -341,7 +345,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -363,6 +367,6 @@ TEST(opBuilderHelperIntNotEqual, Exec_multilevel_dynamics_int_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_NE(expected[0]->get("/parentObjt_1/field2check").GetInt(),
-              expected[0]->get("/parentObjt_2/ref_key").GetInt());
+    ASSERT_NE(expected[0]->getEvent()->get("/parentObjt_1/field2check").GetInt(),
+              expected[0]->getEvent()->get("/parentObjt_2/ref_key").GetInt());
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntNotEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntNotEqual_test.cpp
@@ -21,10 +21,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
-
 TEST(opBuilderHelperIntNotEqual, Builds)
 {
     Document doc{R"({
@@ -65,16 +61,16 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -100,16 +96,16 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":9}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11}
             )"));
             s.on_completed();
@@ -135,16 +131,16 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test2":9}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test3":11}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10}
             )"));
             s.on_completed();
@@ -168,28 +164,28 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ref_true)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test": 9,"field_src": 10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10,"field_src":11}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10,"field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":"10","field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":"10","field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10,"field_src":"test"}
             )"));
             s.on_completed();
@@ -217,28 +213,28 @@ TEST(opBuilderHelperIntNotEqual, Exec_not_equal_ref_false)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test2":9,"field_src":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10,"field_src3":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":10,"field_src4":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test5":10,"field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test6":"10","field_src2":10}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_":"10","field_src":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test":11,"field_src2":"10"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field_test2":10,"field_src2":"test"}
             )"));
             s.on_completed();
@@ -263,21 +259,21 @@ TEST(opBuilderHelperIntNotEqual, Exec_dynamics_int_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":11,
                     "ref_key":10
                 }
             )"));
             // Equal
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":10
                 }
             )"));
             // Less
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":10,
                     "ref_key":11
@@ -309,7 +305,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_multilevel_dynamics_int_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -322,7 +318,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -335,7 +331,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -348,7 +344,7 @@ TEST(opBuilderHelperIntNotEqual, Exec_multilevel_dynamics_int_ok)
                 }
             )"));
 
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntNotEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntNotEqual_test.cpp
@@ -12,14 +12,16 @@
 
 #include "testUtils.hpp"
 #include "opBuilderHelperFilter.hpp"
+#include "base/baseTypes.hpp"
 
 using namespace builder::internals::builders;
+using namespace base;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
 auto createEvent = [](const char * json){
-    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
 };
 
 TEST(opBuilderHelperIntNotEqual, Builds)

--- a/src/engine/test/source/builder/builders/opBuilderHelperIntNotEqual_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperIntNotEqual_test.cpp
@@ -10,9 +10,10 @@
 #include <gtest/gtest.h>
 #include <vector>
 
+#include <baseTypes.hpp>
+
 #include "testUtils.hpp"
 #include "opBuilderHelperFilter.hpp"
-#include "base/baseTypes.hpp"
 
 using namespace base;
 namespace bld = builder::internals::builders;

--- a/src/engine/test/source/builder/builders/opBuilderHelperNotExists_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperNotExists_test.cpp
@@ -22,10 +22,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
-
 TEST(opBuilderHelperNotExists, Builds)
 {
     Document doc{R"({
@@ -57,21 +53,21 @@ TEST(opBuilderHelperNotExists, Exec_not_exists_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check2":11,
                     "ref_key":10
                 }
             )"));
             // Equal
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field":10,
                     "ref_key":10
                 }
             )"));
             // Less
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "fieldcheck":10,
                     "ref_key":11
@@ -102,7 +98,7 @@ TEST(opBuilderHelperNotExists, Exec_multilevel_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -115,7 +111,7 @@ TEST(opBuilderHelperNotExists, Exec_multilevel_ok)
                 }
             )"));
 
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -128,7 +124,7 @@ TEST(opBuilderHelperNotExists, Exec_multilevel_ok)
                 }
             )"));
 
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -142,7 +138,7 @@ TEST(opBuilderHelperNotExists, Exec_multilevel_ok)
             )"));
 
             // true
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,

--- a/src/engine/test/source/builder/builders/opBuilderHelperNotExists_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperNotExists_test.cpp
@@ -12,14 +12,16 @@
 
 #include "testUtils.hpp"
 #include "opBuilderHelperFilter.hpp"
+#include "base/baseTypes.hpp"
 
 using namespace builder::internals::builders;
+using namespace base;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
 auto createEvent = [](const char * json){
-    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
 };
 
 TEST(opBuilderHelperNotExists, Builds)

--- a/src/engine/test/source/builder/builders/opBuilderHelperNotExists_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperNotExists_test.cpp
@@ -10,9 +10,11 @@
 #include <gtest/gtest.h>
 #include <vector>
 
+#include <baseTypes.hpp>
+
 #include "testUtils.hpp"
 #include "opBuilderHelperFilter.hpp"
-#include "base/baseTypes.hpp"
+
 
 using namespace base;
 namespace bld = builder::internals::builders;

--- a/src/engine/test/source/builder/builders/opBuilderHelperNotExists_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperNotExists_test.cpp
@@ -18,6 +18,10 @@ using namespace builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
+auto createEvent = [](const char * json){
+    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+};
+
 TEST(opBuilderHelperNotExists, Builds)
 {
     Document doc{R"({
@@ -49,21 +53,21 @@ TEST(opBuilderHelperNotExists, Exec_not_exists_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check2":11,
                     "ref_key":10
                 }
             )"));
             // Equal
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field":10,
                     "ref_key":10
                 }
             )"));
             // Less
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "fieldcheck":10,
                     "ref_key":11
@@ -79,9 +83,9 @@ TEST(opBuilderHelperNotExists, Exec_not_exists_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_FALSE(expected[0]->exists("/field2check"));
-    ASSERT_FALSE(expected[1]->exists("/field2check"));
-    ASSERT_FALSE(expected[2]->exists("/field2check"));
+    ASSERT_FALSE(expected[0]->getEvent()->exists("/field2check"));
+    ASSERT_FALSE(expected[1]->getEvent()->exists("/field2check"));
+    ASSERT_FALSE(expected[2]->getEvent()->exists("/field2check"));
 }
 
 TEST(opBuilderHelperNotExists, Exec_multilevel_ok)
@@ -94,7 +98,7 @@ TEST(opBuilderHelperNotExists, Exec_multilevel_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 10,
@@ -107,7 +111,7 @@ TEST(opBuilderHelperNotExists, Exec_multilevel_ok)
                 }
             )"));
 
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": 11,
@@ -120,7 +124,7 @@ TEST(opBuilderHelperNotExists, Exec_multilevel_ok)
                 }
             )"));
 
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -134,7 +138,7 @@ TEST(opBuilderHelperNotExists, Exec_multilevel_ok)
             )"));
 
             // true
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":10,
@@ -156,7 +160,7 @@ TEST(opBuilderHelperNotExists, Exec_multilevel_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
 
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_FALSE(expected[0]->exists("/parentObjt_1/field2check"));
-    ASSERT_FALSE(expected[1]->exists("/parentObjt_1/field2check"));
-    ASSERT_FALSE(expected[2]->exists("/parentObjt_1/field2check"));
+    ASSERT_FALSE(expected[0]->getEvent()->exists("/parentObjt_1/field2check"));
+    ASSERT_FALSE(expected[1]->getEvent()->exists("/parentObjt_1/field2check"));
+    ASSERT_FALSE(expected[2]->getEvent()->exists("/parentObjt_1/field2check"));
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperNotExists_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperNotExists_test.cpp
@@ -14,8 +14,8 @@
 #include "opBuilderHelperFilter.hpp"
 #include "base/baseTypes.hpp"
 
-using namespace builder::internals::builders;
 using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
@@ -31,7 +31,7 @@ TEST(opBuilderHelperNotExists, Builds)
             {"field": "+not_exists"}
     })"};
 
-    ASSERT_NO_THROW(opBuilderHelperNotExists(doc.get("/check"), tr));
+    ASSERT_NO_THROW(bld::opBuilderHelperNotExists(doc.get("/check"), tr));
 }
 
 TEST(opBuilderHelperNotExists, Builds_error_bad_parameter)
@@ -41,7 +41,7 @@ TEST(opBuilderHelperNotExists, Builds_error_bad_parameter)
             {"field_test": "+exists/test"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperIntEqual(doc.get("/check"), tr), std::invalid_argument);
+    ASSERT_THROW(bld::opBuilderHelperIntEqual(doc.get("/check"), tr), std::invalid_argument);
 }
 
 TEST(opBuilderHelperNotExists, Exec_not_exists_ok)
@@ -78,7 +78,7 @@ TEST(opBuilderHelperNotExists, Exec_not_exists_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperNotExists(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperNotExists(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 
@@ -155,7 +155,7 @@ TEST(opBuilderHelperNotExists, Exec_multilevel_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperNotExists(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperNotExists(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
 

--- a/src/engine/test/source/builder/builders/opBuilderHelperRegexExtract_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperRegexExtract_test.cpp
@@ -8,12 +8,15 @@
  */
 
 #include <gtest/gtest.h>
-#include <vector>
 #include <re2/re2.h>
+
+#include <vector>
+
+#include <baseTypes.hpp>
+
 
 #include "opBuilderHelperMap.hpp"
 #include "testUtils.hpp"
-#include "base/baseTypes.hpp"
 
 using namespace base;
 namespace bld = builder::internals::builders;

--- a/src/engine/test/source/builder/builders/opBuilderHelperRegexExtract_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperRegexExtract_test.cpp
@@ -15,8 +15,8 @@
 #include "testUtils.hpp"
 #include "base/baseTypes.hpp"
 
-using namespace builder::internals::builders;
 using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
@@ -32,7 +32,7 @@ TEST(opBuilderHelperRegexExtract, Builds)
             {"field": "+r_ext/_field/regexp/"}
     })"};
 
-    ASSERT_NO_THROW(opBuilderHelperRegexExtract(doc.get("/map"), tr));
+    ASSERT_NO_THROW(bld::opBuilderHelperRegexExtract(doc.get("/map"), tr));
 }
 
 TEST(opBuilderHelperRegexExtract, Not_enough_arguments_error)
@@ -42,7 +42,7 @@ TEST(opBuilderHelperRegexExtract, Not_enough_arguments_error)
             {"field": "+r_ext/_field/"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperRegexExtract(doc.get("/map"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperRegexExtract(doc.get("/map"), tr), std::runtime_error);
 }
 
 TEST(opBuilderHelperRegexExtract, Too_many_arguments_error)
@@ -52,7 +52,7 @@ TEST(opBuilderHelperRegexExtract, Too_many_arguments_error)
             {"field": "+r_ext/_field/regexp/arg/"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperRegexExtract(doc.get("/map"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperRegexExtract(doc.get("/map"), tr), std::runtime_error);
 }
 
 TEST(opBuilderHelperRegexExtract, String_regex_extract)
@@ -77,7 +77,7 @@ TEST(opBuilderHelperRegexExtract, String_regex_extract)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperRegexExtract(doc.get("/map"), tr);
+    Lifter lift = bld::opBuilderHelperRegexExtract(doc.get("/map"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -110,7 +110,7 @@ TEST(opBuilderHelperRegexExtract, Numeric_regex_extract)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperRegexExtract(doc.get("/map"), tr);
+    Lifter lift = bld::opBuilderHelperRegexExtract(doc.get("/map"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -140,7 +140,7 @@ TEST(opBuilderHelperRegexExtract, Advanced_regex_extract)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperRegexExtract(doc.get("/map"), tr);
+    Lifter lift = bld::opBuilderHelperRegexExtract(doc.get("/map"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -173,7 +173,7 @@ TEST(opBuilderHelperRegexExtract, Nested_field_regex_extract)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperRegexExtract(doc.get("/map"), tr);
+    Lifter lift = bld::opBuilderHelperRegexExtract(doc.get("/map"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -205,7 +205,7 @@ TEST(opBuilderHelperRegexExtract, Field_not_exists_regex_extract)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperRegexExtract(doc.get("/map"), tr);
+    Lifter lift = bld::opBuilderHelperRegexExtract(doc.get("/map"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -237,7 +237,7 @@ TEST(opBuilderHelperRegexExtract, Multilevel_field_regex_extract)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperRegexExtract(doc.get("/map"), tr);
+    Lifter lift = bld::opBuilderHelperRegexExtract(doc.get("/map"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -268,7 +268,7 @@ TEST(opBuilderHelperRegexExtract, Multilevel_field_dst_regex_extract)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperRegexExtract(doc.get("/map"), tr);
+    Lifter lift = bld::opBuilderHelperRegexExtract(doc.get("/map"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });

--- a/src/engine/test/source/builder/builders/opBuilderHelperRegexExtract_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperRegexExtract_test.cpp
@@ -24,10 +24,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
-
 TEST(opBuilderHelperRegexExtract, Builds)
 {
     Document doc{R"({
@@ -68,13 +64,13 @@ TEST(opBuilderHelperRegexExtract, String_regex_extract)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"exp"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"expregex"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"this is a test exp"}
             )"));
             s.on_completed();
@@ -101,13 +97,13 @@ TEST(opBuilderHelperRegexExtract, Numeric_regex_extract)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"123"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"123"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"123"}
             )"));
             s.on_completed();
@@ -134,10 +130,10 @@ TEST(opBuilderHelperRegexExtract, Advanced_regex_extract)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"client@wazuh.com"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"engine@wazuh.com"}
             )"));
             s.on_completed();
@@ -165,11 +161,11 @@ TEST(opBuilderHelperRegexExtract, Nested_field_regex_extract)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"~~({
+            s.on_next(createSharedEvent(R"~~({
             "test":
                 {"field": "exp"}
             })~~"));
-            s.on_next(createEvent(R"~~({
+            s.on_next(createSharedEvent(R"~~({
             "test":
                 {"field": "this is a test exp"}
             })~~"));
@@ -196,13 +192,13 @@ TEST(opBuilderHelperRegexExtract, Field_not_exists_regex_extract)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"exp"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"expregex"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"this is a test exp"}
             )"));
             s.on_completed();
@@ -229,11 +225,11 @@ TEST(opBuilderHelperRegexExtract, Multilevel_field_regex_extract)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"~~({
+            s.on_next(createSharedEvent(R"~~({
             "test":
                 {"field": "exp"}
             })~~"));
-            s.on_next(createEvent(R"~~({
+            s.on_next(createSharedEvent(R"~~({
             "test":
                 {"field": "this is a test exp"}
             })~~"));
@@ -260,11 +256,11 @@ TEST(opBuilderHelperRegexExtract, Multilevel_field_dst_regex_extract)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"~~({
+            s.on_next(createSharedEvent(R"~~({
             "test":
                 {"field": "exp"}
             })~~"));
-            s.on_next(createEvent(R"~~({
+            s.on_next(createSharedEvent(R"~~({
             "test":
                 {"field": "this is a test exp"}
             })~~"));

--- a/src/engine/test/source/builder/builders/opBuilderHelperRegexExtract_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperRegexExtract_test.cpp
@@ -13,14 +13,16 @@
 
 #include "opBuilderHelperMap.hpp"
 #include "testUtils.hpp"
+#include "base/baseTypes.hpp"
 
 using namespace builder::internals::builders;
+using namespace base;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
 auto createEvent = [](const char * json){
-    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
 };
 
 TEST(opBuilderHelperRegexExtract, Builds)

--- a/src/engine/test/source/builder/builders/opBuilderHelperRegexMatch_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperRegexMatch_test.cpp
@@ -8,12 +8,15 @@
  */
 
 #include <gtest/gtest.h>
-#include <vector>
 #include <re2/re2.h>
+
+#include <vector>
+
+#include <baseTypes.hpp>
 
 #include "opBuilderHelperFilter.hpp"
 #include "testUtils.hpp"
-#include "base/baseTypes.hpp"
+
 
 using namespace base;
 namespace bld = builder::internals::builders;

--- a/src/engine/test/source/builder/builders/opBuilderHelperRegexMatch_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperRegexMatch_test.cpp
@@ -24,10 +24,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
-
 TEST(opBuilderHelperRegexMatch, Builds)
 {
     Document doc{R"({
@@ -76,19 +72,19 @@ TEST(opBuilderHelperRegexMatch, Invalid_src_type)
         [=](auto s)
         {
             // Object
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldSrc": { "fieldSrc" : "child value"} }
             )"));
             // Number
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldSrc":55}
             )"));
             // Array
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldSrc":[123]}
             )"));
             // Not existing field
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"fieldSrc not exist"}
             )"));
             s.on_completed();
@@ -112,16 +108,16 @@ TEST(opBuilderHelperRegexMatch, String_regex_match)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"exp"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"expregex"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"this is a test exp"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"value"}
             )"));
             s.on_completed();
@@ -148,16 +144,16 @@ TEST(opBuilderHelperRegexMatch, Numeric_regex_match)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"123"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"123.02"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"10123"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"234"}
             )"));
             s.on_completed();
@@ -184,13 +180,13 @@ TEST(opBuilderHelperRegexMatch, Advanced_regex_match)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"client@wazuh.com"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"engine@wazuh.com"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"wazuh.com"}
             )"));
             s.on_completed();
@@ -218,11 +214,11 @@ TEST(opBuilderHelperRegexMatch, Nested_field_regex_match)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"~~({
+            s.on_next(createSharedEvent(R"~~({
             "test":
                 {"field": "exp"}
             })~~"));
-            s.on_next(createEvent(R"~~({
+            s.on_next(createSharedEvent(R"~~({
             "test":
                 {"field": "this is a test exp"}
             })~~"));
@@ -249,10 +245,10 @@ TEST(opBuilderHelperRegexMatch, Field_not_exists_regex_match)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2":"exp"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"exp"}
             )"));
             s.on_completed();

--- a/src/engine/test/source/builder/builders/opBuilderHelperRegexMatch_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperRegexMatch_test.cpp
@@ -13,14 +13,16 @@
 
 #include "opBuilderHelperFilter.hpp"
 #include "testUtils.hpp"
+#include "base/baseTypes.hpp"
 
 using namespace builder::internals::builders;
+using namespace base;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
 auto createEvent = [](const char * json){
-    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
 };
 
 TEST(opBuilderHelperRegexMatch, Builds)

--- a/src/engine/test/source/builder/builders/opBuilderHelperRegexMatch_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperRegexMatch_test.cpp
@@ -15,8 +15,8 @@
 #include "testUtils.hpp"
 #include "base/baseTypes.hpp"
 
-using namespace builder::internals::builders;
 using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
@@ -31,7 +31,7 @@ TEST(opBuilderHelperRegexMatch, Builds)
         "check":
             {"field": "+r_match/regexp"}
     })"};
-    ASSERT_NO_THROW(opBuilderHelperRegexMatch(doc.get("/check"), tr));
+    ASSERT_NO_THROW(bld::opBuilderHelperRegexMatch(doc.get("/check"), tr));
 }
 
 TEST(opBuilderHelperRegexMatch, Not_enough_arguments_error)
@@ -40,7 +40,7 @@ TEST(opBuilderHelperRegexMatch, Not_enough_arguments_error)
         "check":
             {"field": "+r_match/"}
     })"};
-    ASSERT_THROW(opBuilderHelperRegexMatch(doc.get("/check"), tr), std::invalid_argument);
+    ASSERT_THROW(bld::opBuilderHelperRegexMatch(doc.get("/check"), tr), std::invalid_argument);
 }
 
 TEST(opBuilderHelperRegexMatch, Too_many_arguments_error)
@@ -49,7 +49,7 @@ TEST(opBuilderHelperRegexMatch, Too_many_arguments_error)
         "check":
             {"field": "+r_match/regexp/regexp2"}
     })"};
-    ASSERT_THROW(opBuilderHelperRegexMatch(doc.get("/check"), tr), std::invalid_argument);
+    ASSERT_THROW(bld::opBuilderHelperRegexMatch(doc.get("/check"), tr), std::invalid_argument);
 }
 
 TEST(opBuilderHelperRegexMatch, Invalid_regex)
@@ -59,7 +59,7 @@ TEST(opBuilderHelperRegexMatch, Invalid_regex)
             {"field": "+r_match/(\\w{"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperRegexMatch(doc.get("/check"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperRegexMatch(doc.get("/check"), tr), std::runtime_error);
 }
 
 TEST(opBuilderHelperRegexMatch, Invalid_src_type)
@@ -91,7 +91,7 @@ TEST(opBuilderHelperRegexMatch, Invalid_src_type)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperRegexMatch(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperRegexMatch(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -124,7 +124,7 @@ TEST(opBuilderHelperRegexMatch, String_regex_match)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperRegexMatch(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperRegexMatch(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -160,7 +160,7 @@ TEST(opBuilderHelperRegexMatch, Numeric_regex_match)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperRegexMatch(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperRegexMatch(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -193,7 +193,7 @@ TEST(opBuilderHelperRegexMatch, Advanced_regex_match)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperRegexMatch(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperRegexMatch(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -226,7 +226,7 @@ TEST(opBuilderHelperRegexMatch, Nested_field_regex_match)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperRegexMatch(doc.get("/map"), tr);
+    Lifter lift = bld::opBuilderHelperRegexMatch(doc.get("/map"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -255,7 +255,7 @@ TEST(opBuilderHelperRegexMatch, Field_not_exists_regex_match)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperRegexMatch(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperRegexMatch(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });

--- a/src/engine/test/source/builder/builders/opBuilderHelperRegexNotMatch_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperRegexNotMatch_test.cpp
@@ -15,8 +15,8 @@
 #include "testUtils.hpp"
 #include "base/baseTypes.hpp"
 
-using namespace builder::internals::builders;
 using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
@@ -32,7 +32,7 @@ TEST(opBuilderHelperRegexNotMatch, Builds)
             {"field": "+r_not_match/regexp"}
     })"};
 
-    ASSERT_NO_THROW(opBuilderHelperRegexNotMatch(doc.get("/check"), tr));
+    ASSERT_NO_THROW(bld::opBuilderHelperRegexNotMatch(doc.get("/check"), tr));
 }
 
 TEST(opBuilderHelperRegexNotMatch, NotEnoughArgumentsError)
@@ -42,7 +42,7 @@ TEST(opBuilderHelperRegexNotMatch, NotEnoughArgumentsError)
             {"field": "+r_not_match/"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperRegexNotMatch(doc.get("/check"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperRegexNotMatch(doc.get("/check"), tr), std::runtime_error);
 }
 
 TEST(opBuilderHelperRegexNotMatch, TooManyArgumentsError)
@@ -52,7 +52,7 @@ TEST(opBuilderHelperRegexNotMatch, TooManyArgumentsError)
             {"field": "+r_not_match/regexp/regexp2"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperRegexNotMatch(doc.get("/check"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperRegexNotMatch(doc.get("/check"), tr), std::runtime_error);
 }
 
 TEST(opBuilderHelperRegexMatch, InvalidRegex)
@@ -62,7 +62,7 @@ TEST(opBuilderHelperRegexMatch, InvalidRegex)
             {"field": "+r_match/(\\w{"}
     })"};
 
-    ASSERT_THROW(opBuilderHelperRegexMatch(doc.get("/check"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperRegexMatch(doc.get("/check"), tr), std::runtime_error);
 }
 
 
@@ -95,7 +95,7 @@ TEST(opBuilderHelperRegexNotMatch, InvalidSrcType)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperRegexNotMatch(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperRegexNotMatch(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -128,7 +128,7 @@ TEST(opBuilderHelperRegexNotMatch, StringRegexMatch)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperRegexNotMatch(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperRegexNotMatch(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -160,7 +160,7 @@ TEST(opBuilderHelperRegexNotMatch, NumericRegexMatch)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperRegexNotMatch(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperRegexNotMatch(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -189,7 +189,7 @@ TEST(opBuilderHelperRegexNotMatch, AdvancedRegexMatch)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperRegexNotMatch(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperRegexNotMatch(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -221,7 +221,7 @@ TEST(opBuilderHelperRegexNotMatch, NestedFieldRegexMatch)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperRegexNotMatch(doc.get("/map"), tr);
+    Lifter lift = bld::opBuilderHelperRegexNotMatch(doc.get("/map"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -250,7 +250,7 @@ TEST(opBuilderHelperRegexNotMatch, FieldNotExistsRegexNotMatch)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperRegexNotMatch(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperRegexNotMatch(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });

--- a/src/engine/test/source/builder/builders/opBuilderHelperRegexNotMatch_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperRegexNotMatch_test.cpp
@@ -8,12 +8,15 @@
  */
 
 #include <gtest/gtest.h>
-#include <re2/re2.h>
 #include <vector>
+
+#include <re2/re2.h>
+
+#include <baseTypes.hpp>
 
 #include "opBuilderHelperFilter.hpp"
 #include "testUtils.hpp"
-#include "base/baseTypes.hpp"
+
 
 using namespace base;
 namespace bld = builder::internals::builders;

--- a/src/engine/test/source/builder/builders/opBuilderHelperRegexNotMatch_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperRegexNotMatch_test.cpp
@@ -24,10 +24,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
-
 TEST(opBuilderHelperRegexNotMatch, Builds)
 {
     Document doc{R"({
@@ -80,19 +76,19 @@ TEST(opBuilderHelperRegexNotMatch, InvalidSrcType)
         [=](auto s)
         {
             // Object
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldSrc": { "fieldSrc" : "child value"} }
             )"));
             // Number
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldSrc":55}
             )"));
             // Array
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldSrc":[123]}
             )"));
             // Not existing field
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"fieldSrc not exist"}
             )"));
             s.on_completed();
@@ -116,16 +112,16 @@ TEST(opBuilderHelperRegexNotMatch, StringRegexMatch)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"ex-president"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"this is a test exp"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"exp"}
             )"));
             s.on_completed();
@@ -151,13 +147,13 @@ TEST(opBuilderHelperRegexNotMatch, NumericRegexMatch)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"1023"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"19"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"0.123"}
             )"));
             s.on_completed();
@@ -183,10 +179,10 @@ TEST(opBuilderHelperRegexNotMatch, AdvancedRegexMatch)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"wazuh.com"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"client@wazuh.com"}
             )"));
             s.on_completed();
@@ -213,11 +209,11 @@ TEST(opBuilderHelperRegexNotMatch, NestedFieldRegexMatch)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"~~({
+            s.on_next(createSharedEvent(R"~~({
             "test":
                 {"field": "value"}
             })~~"));
-            s.on_next(createEvent(R"~~({
+            s.on_next(createSharedEvent(R"~~({
             "test":
                 {"field": "ex-president"}
             })~~"));
@@ -244,10 +240,10 @@ TEST(opBuilderHelperRegexNotMatch, FieldNotExistsRegexNotMatch)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"value"}
             )"));
             s.on_completed();

--- a/src/engine/test/source/builder/builders/opBuilderHelperRegexNotMatch_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperRegexNotMatch_test.cpp
@@ -13,14 +13,16 @@
 
 #include "opBuilderHelperFilter.hpp"
 #include "testUtils.hpp"
+#include "base/baseTypes.hpp"
 
 using namespace builder::internals::builders;
+using namespace base;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
 auto createEvent = [](const char * json){
-    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
 };
 
 TEST(opBuilderHelperRegexNotMatch, Builds)

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringEq_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringEq_test.cpp
@@ -22,10 +22,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
-
 // Build ok
 TEST(opBuilderHelperStringEQ, Builds)
 {
@@ -57,19 +53,19 @@ TEST(opBuilderHelperStringEQ, Static_string_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"not_test_value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"test_value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"test_value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"test_value"}
             )"));
             s.on_completed();
@@ -95,19 +91,19 @@ TEST(opBuilderHelperStringEQ, Static_number_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"not_11"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"11"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"11"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":11}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"11"}
             )"));
             s.on_completed();
@@ -133,31 +129,31 @@ TEST(opBuilderHelperStringEQ, Dynamics_string_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":"not_test_value",
                     "ref_key":"test_value"
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":"test_value",
                     "ref_key":"test_value"
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "otherfield":"value",
                     "ref_key":"test_value"
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "otherfield":"test_value",
                     "ref_key":"test_value"
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":"test_value",
                     "ref_key":"test_value"
@@ -187,7 +183,7 @@ TEST(opBuilderHelperStringEQ, MultiLevel_dynamics_string_ok)
         [=](auto s)
         {
             // no
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": "test_value",
@@ -200,7 +196,7 @@ TEST(opBuilderHelperStringEQ, MultiLevel_dynamics_string_ok)
                 }
             )"));
             // yes
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": "not_test_value",
@@ -213,7 +209,7 @@ TEST(opBuilderHelperStringEQ, MultiLevel_dynamics_string_ok)
                 }
             )"));
             // no
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":"test_value",
@@ -252,37 +248,37 @@ TEST(opBuilderHelperStringEQ, Dynamics_number_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":11,
                     "ref_key":11
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":"11",
                     "ref_key":11
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "otherfield":11,
                     "ref_key":11
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "otherfield":11,
                     "ref_key":11
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":11,
                     "ref_key":"11"
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":"11",
                     "not_ref_key":"11"

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringEq_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringEq_test.cpp
@@ -18,6 +18,10 @@ using namespace builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
+auto createEvent = [](const char * json){
+    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+};
+
 // Build ok
 TEST(opBuilderHelperStringEQ, Builds)
 {
@@ -49,19 +53,19 @@ TEST(opBuilderHelperStringEQ, Static_string_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"not_test_value"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"test_value"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"test_value"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"test_value"}
             )"));
             s.on_completed();
@@ -72,8 +76,8 @@ TEST(opBuilderHelperStringEQ, Static_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_STREQ(expected[0]->get("/field2check").GetString(), "test_value");
-    ASSERT_STREQ(expected[1]->get("/field2check").GetString(), "test_value");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/field2check").GetString(), "test_value");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/field2check").GetString(), "test_value");
 }
 
 // Test ok: static values (numbers, compare as string)
@@ -87,19 +91,19 @@ TEST(opBuilderHelperStringEQ, Static_number_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"not_11"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"11"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"11"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":11}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"11"}
             )"));
             s.on_completed();
@@ -110,8 +114,8 @@ TEST(opBuilderHelperStringEQ, Static_number_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_STREQ(expected[0]->get("/field2check").GetString(), "11");
-    ASSERT_STREQ(expected[1]->get("/field2check").GetString(), "11");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/field2check").GetString(), "11");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/field2check").GetString(), "11");
 }
 
 // Test ok: dynamic values (string)
@@ -125,31 +129,31 @@ TEST(opBuilderHelperStringEQ, Dynamics_string_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":"not_test_value",
                     "ref_key":"test_value"
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":"test_value",
                     "ref_key":"test_value"
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "otherfield":"value",
                     "ref_key":"test_value"
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "otherfield":"test_value",
                     "ref_key":"test_value"
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":"test_value",
                     "ref_key":"test_value"
@@ -163,8 +167,8 @@ TEST(opBuilderHelperStringEQ, Dynamics_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_STREQ(expected[0]->get("/field2check").GetString(), "test_value");
-    ASSERT_STREQ(expected[1]->get("/field2check").GetString(), "test_value");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/field2check").GetString(), "test_value");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/field2check").GetString(), "test_value");
 }
 
 // Test ok: multilevel dynamic values (string)
@@ -179,7 +183,7 @@ TEST(opBuilderHelperStringEQ, MultiLevel_dynamics_string_ok)
         [=](auto s)
         {
             // no
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": "test_value",
@@ -192,7 +196,7 @@ TEST(opBuilderHelperStringEQ, MultiLevel_dynamics_string_ok)
                 }
             )"));
             // yes
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": "not_test_value",
@@ -205,7 +209,7 @@ TEST(opBuilderHelperStringEQ, MultiLevel_dynamics_string_ok)
                 }
             )"));
             // no
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":"test_value",
@@ -226,11 +230,11 @@ TEST(opBuilderHelperStringEQ, MultiLevel_dynamics_string_ok)
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
 
-    ASSERT_STREQ(expected[0]->get("/parentObjt_1/field2check").GetString(),
-                 expected[0]->get("/parentObjt_2/ref_key").GetString());
+    ASSERT_STREQ(expected[0]->getEvent()->get("/parentObjt_1/field2check").GetString(),
+                 expected[0]->getEvent()->get("/parentObjt_2/ref_key").GetString());
 
-    ASSERT_STRNE(expected[0]->get("/parentObjt_2/field2check").GetString(), "test_value");
-    ASSERT_STRNE(expected[0]->get("/parentObjt_1/ref_key").GetString(), "test_value");
+    ASSERT_STRNE(expected[0]->getEvent()->get("/parentObjt_2/field2check").GetString(), "test_value");
+    ASSERT_STRNE(expected[0]->getEvent()->get("/parentObjt_1/ref_key").GetString(), "test_value");
 }
 
 // Test ok: dynamic values (number)
@@ -244,37 +248,37 @@ TEST(opBuilderHelperStringEQ, Dynamics_number_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":11,
                     "ref_key":11
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":"11",
                     "ref_key":11
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "otherfield":11,
                     "ref_key":11
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "otherfield":11,
                     "ref_key":11
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":11,
                     "ref_key":"11"
                 }
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":"11",
                     "not_ref_key":"11"

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringEq_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringEq_test.cpp
@@ -12,14 +12,16 @@
 
 #include "testUtils.hpp"
 #include "opBuilderHelperFilter.hpp"
+#include "base/baseTypes.hpp"
 
 using namespace builder::internals::builders;
+using namespace base;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
 auto createEvent = [](const char * json){
-    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
 };
 
 // Build ok

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringEq_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringEq_test.cpp
@@ -14,8 +14,8 @@
 #include "opBuilderHelperFilter.hpp"
 #include "base/baseTypes.hpp"
 
-using namespace builder::internals::builders;
 using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
@@ -31,7 +31,7 @@ TEST(opBuilderHelperStringEQ, Builds)
         "check":
             {"field2check": "+s_eq/test_value"}
     })"};
-    ASSERT_NO_THROW(opBuilderHelperStringEQ(doc.get("/check"), tr));
+    ASSERT_NO_THROW(bld::opBuilderHelperStringEQ(doc.get("/check"), tr));
 }
 
 // Build incorrect number of arguments
@@ -41,7 +41,7 @@ TEST(opBuilderHelperStringEQ, Builds_incorrect_number_of_arguments)
         "check":
             {"field2check": "+s_eq/test_value/test_value2"}
     })"};
-    ASSERT_THROW(opBuilderHelperStringEQ(doc.get("/check"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperStringEQ(doc.get("/check"), tr), std::runtime_error);
 }
 
 // Test ok: static values
@@ -73,7 +73,7 @@ TEST(opBuilderHelperStringEQ, Static_string_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringEQ(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperStringEQ(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -111,7 +111,7 @@ TEST(opBuilderHelperStringEQ, Static_number_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringEQ(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperStringEQ(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -164,7 +164,7 @@ TEST(opBuilderHelperStringEQ, Dynamics_string_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringEQ(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperStringEQ(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -226,7 +226,7 @@ TEST(opBuilderHelperStringEQ, MultiLevel_dynamics_string_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringEQ(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperStringEQ(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -289,7 +289,7 @@ TEST(opBuilderHelperStringEQ, Dynamics_number_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringEQ(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperStringEQ(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringEq_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringEq_test.cpp
@@ -8,11 +8,13 @@
  */
 
 #include <gtest/gtest.h>
+
 #include <vector>
+
+#include <baseTypes.hpp>
 
 #include "testUtils.hpp"
 #include "opBuilderHelperFilter.hpp"
-#include "base/baseTypes.hpp"
 
 using namespace base;
 namespace bld = builder::internals::builders;

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringGe_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringGe_test.cpp
@@ -18,6 +18,10 @@ using namespace builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
+auto createEvent = [](const char * json){
+    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+};
+
 // Build ok
 TEST(opBuilderHelperStringGE, Builds)
 {
@@ -50,40 +54,40 @@ TEST(opBuilderHelperStringGE, Static_string_ok)
         [=](auto s)
         {
             // less
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"ABC"}
             )"));
             // Equal
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"ABCD"}
             )"));
             // Greater
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"ABCDE"}
             )"));
             // Greater with different case
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"BBBB"}
             )"));
             // Less with different case
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"AABCD"}
             )"));
             // lower case are greater
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"abc"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"abcd"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"abcde"}
             )"));
             // Other fields will be ignored
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"abcd"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"abcd"}
             )"));
             s.on_completed();
@@ -94,12 +98,12 @@ TEST(opBuilderHelperStringGE, Static_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 6);
-    ASSERT_STREQ(expected[0]->get("/field2check").GetString(), "ABCD");
-    ASSERT_STREQ(expected[1]->get("/field2check").GetString(), "ABCDE");
-    ASSERT_STREQ(expected[2]->get("/field2check").GetString(), "BBBB");
-    ASSERT_STREQ(expected[3]->get("/field2check").GetString(), "abc");
-    ASSERT_STREQ(expected[4]->get("/field2check").GetString(), "abcd");
-    ASSERT_STREQ(expected[5]->get("/field2check").GetString(), "abcde");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/field2check").GetString(), "ABCD");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/field2check").GetString(), "ABCDE");
+    ASSERT_STREQ(expected[2]->getEvent()->get("/field2check").GetString(), "BBBB");
+    ASSERT_STREQ(expected[3]->getEvent()->get("/field2check").GetString(), "abc");
+    ASSERT_STREQ(expected[4]->getEvent()->get("/field2check").GetString(), "abcd");
+    ASSERT_STREQ(expected[5]->getEvent()->get("/field2check").GetString(), "abcde");
 }
 
 // Test ok: static values (numbers, compare as string)
@@ -114,17 +118,17 @@ TEST(opBuilderHelperStringGE, Static_number_ok)
         [=](auto s)
         {
             // Equal
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"AA"}
             )"));
             // Greater
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"BB"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"aa"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield": "bb"}
             )"));
             s.on_completed();
@@ -135,8 +139,8 @@ TEST(opBuilderHelperStringGE, Static_number_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_STREQ(expected[0]->get("/field2check").GetString(), "AA");
-    ASSERT_STREQ(expected[1]->get("/field2check").GetString(), "BB");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/field2check").GetString(), "AA");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/field2check").GetString(), "BB");
 }
 
 // Test ok: dynamic values (string)
@@ -151,21 +155,21 @@ TEST(opBuilderHelperStringGE, Dynamics_string_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":"abcd",
                     "ref_key":"ABCD"
                 }
             )"));
             // Equal
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":"ABCD",
                     "ref_key":"ABCD"
                 }
             )"));
             // Less
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "otherfield":"AABCD",
                     "ref_key":"ABCD"
@@ -179,6 +183,6 @@ TEST(opBuilderHelperStringGE, Dynamics_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_STREQ(expected[0]->get("/field2check").GetString(), "abcd");
-    ASSERT_STREQ(expected[1]->get("/field2check").GetString(), "ABCD");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/field2check").GetString(), "abcd");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/field2check").GetString(), "ABCD");
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringGe_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringGe_test.cpp
@@ -14,8 +14,8 @@
 #include "opBuilderHelperFilter.hpp"
 #include "base/baseTypes.hpp"
 
-using namespace builder::internals::builders;
 using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
@@ -31,7 +31,7 @@ TEST(opBuilderHelperStringGE, Builds)
         "check":
             {"field2check": "+s_ge/abcd"}
     })"};
-    ASSERT_NO_THROW(opBuilderHelperStringGE(doc.get("/check"), tr));
+    ASSERT_NO_THROW(bld::opBuilderHelperStringGE(doc.get("/check"), tr));
 }
 
 // Build incorrect number of arguments
@@ -41,7 +41,7 @@ TEST(opBuilderHelperStringGE, Builds_incorrect_number_of_arguments)
         "check":
             {"field2check": "+s_ge/test_value/test_value2"}
     })"};
-    ASSERT_THROW(opBuilderHelperStringGE(doc.get("/check"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperStringGE(doc.get("/check"), tr), std::runtime_error);
 }
 
 // Test ok: static values
@@ -95,7 +95,7 @@ TEST(opBuilderHelperStringGE, Static_string_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringGE(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperStringGE(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -136,7 +136,7 @@ TEST(opBuilderHelperStringGE, Static_number_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringGE(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperStringGE(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -180,7 +180,7 @@ TEST(opBuilderHelperStringGE, Dynamics_string_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringGE(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperStringGE(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringGe_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringGe_test.cpp
@@ -8,11 +8,13 @@
  */
 
 #include <gtest/gtest.h>
-#include "testUtils.hpp"
 #include <vector>
 
+#include <baseTypes.hpp>
+
+#include "testUtils.hpp"
 #include "opBuilderHelperFilter.hpp"
-#include "base/baseTypes.hpp"
+
 
 using namespace base;
 namespace bld = builder::internals::builders;

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringGe_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringGe_test.cpp
@@ -22,10 +22,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
-
 // Build ok
 TEST(opBuilderHelperStringGE, Builds)
 {
@@ -58,40 +54,40 @@ TEST(opBuilderHelperStringGE, Static_string_ok)
         [=](auto s)
         {
             // less
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"ABC"}
             )"));
             // Equal
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"ABCD"}
             )"));
             // Greater
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"ABCDE"}
             )"));
             // Greater with different case
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"BBBB"}
             )"));
             // Less with different case
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"AABCD"}
             )"));
             // lower case are greater
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"abc"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"abcd"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"abcde"}
             )"));
             // Other fields will be ignored
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"abcd"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"abcd"}
             )"));
             s.on_completed();
@@ -122,17 +118,17 @@ TEST(opBuilderHelperStringGE, Static_number_ok)
         [=](auto s)
         {
             // Equal
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"AA"}
             )"));
             // Greater
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"BB"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"aa"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield": "bb"}
             )"));
             s.on_completed();
@@ -159,21 +155,21 @@ TEST(opBuilderHelperStringGE, Dynamics_string_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":"abcd",
                     "ref_key":"ABCD"
                 }
             )"));
             // Equal
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":"ABCD",
                     "ref_key":"ABCD"
                 }
             )"));
             // Less
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "otherfield":"AABCD",
                     "ref_key":"ABCD"

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringGe_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringGe_test.cpp
@@ -12,14 +12,16 @@
 #include <vector>
 
 #include "opBuilderHelperFilter.hpp"
+#include "base/baseTypes.hpp"
 
 using namespace builder::internals::builders;
+using namespace base;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
 auto createEvent = [](const char * json){
-    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
 };
 
 // Build ok

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringGt_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringGt_test.cpp
@@ -18,6 +18,10 @@ using namespace builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
+auto createEvent = [](const char * json){
+    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+};
+
 // Build ok
 TEST(opBuilderHelperStringGT, Builds)
 {
@@ -50,40 +54,40 @@ TEST(opBuilderHelperStringGT, Static_string_ok)
         [=](auto s)
         {
             // less
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"ABC"}
             )"));
             // Equal
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"ABCD"}
             )"));
             // Greater
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"ABCDE"}
             )"));
             // Greater with different case
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"BBBB"}
             )"));
             // Less with different case
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"AABCD"}
             )"));
             // lower case are greater
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"abc"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"abcd"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"abcde"}
             )"));
             // Other fields will be ignored
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"abcd"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"abcd"}
             )"));
             s.on_completed();
@@ -94,11 +98,11 @@ TEST(opBuilderHelperStringGT, Static_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 5);
-    ASSERT_STREQ(expected[0]->get("/field2check").GetString(), "ABCDE");
-    ASSERT_STREQ(expected[1]->get("/field2check").GetString(), "BBBB");
-    ASSERT_STREQ(expected[2]->get("/field2check").GetString(), "abc");
-    ASSERT_STREQ(expected[3]->get("/field2check").GetString(), "abcd");
-    ASSERT_STREQ(expected[4]->get("/field2check").GetString(), "abcde");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/field2check").GetString(), "ABCDE");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/field2check").GetString(), "BBBB");
+    ASSERT_STREQ(expected[2]->getEvent()->get("/field2check").GetString(), "abc");
+    ASSERT_STREQ(expected[3]->getEvent()->get("/field2check").GetString(), "abcd");
+    ASSERT_STREQ(expected[4]->getEvent()->get("/field2check").GetString(), "abcde");
 }
 
 // Test ok: static values (numbers, compare as string)
@@ -113,17 +117,17 @@ TEST(opBuilderHelperStringGT, Static_number_ok)
         [=](auto s)
         {
             // Equal
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"AA"}
             )"));
             // Greater
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"BB"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"aa"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield": "bb"}
             )"));
             s.on_completed();
@@ -134,7 +138,7 @@ TEST(opBuilderHelperStringGT, Static_number_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_STREQ(expected[0]->get("/field2check").GetString(), "BB");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/field2check").GetString(), "BB");
 }
 
 // Test ok: dynamic values (string)
@@ -149,21 +153,21 @@ TEST(opBuilderHelperStringGT, Dynamics_string_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":"abcd",
                     "ref_key":"ABCD"
                 }
             )"));
             // Equal
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":"ABCD",
                     "ref_key":"ABCD"
                 }
             )"));
             // Less
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "otherfield":"AABCD",
                     "ref_key":"ABCD"
@@ -177,5 +181,5 @@ TEST(opBuilderHelperStringGT, Dynamics_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_STREQ(expected[0]->get("/field2check").GetString(), "abcd");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/field2check").GetString(), "abcd");
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringGt_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringGt_test.cpp
@@ -8,11 +8,14 @@
  */
 
 #include <gtest/gtest.h>
-#include "testUtils.hpp"
+
 #include <vector>
 
+#include <baseTypes.hpp>
+
+#include "testUtils.hpp"
 #include "opBuilderHelperFilter.hpp"
-#include "base/baseTypes.hpp"
+
 
 using namespace base;
 namespace bld = builder::internals::builders;

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringGt_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringGt_test.cpp
@@ -23,10 +23,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
-
 // Build ok
 TEST(opBuilderHelperStringGT, Builds)
 {
@@ -59,40 +55,40 @@ TEST(opBuilderHelperStringGT, Static_string_ok)
         [=](auto s)
         {
             // less
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"ABC"}
             )"));
             // Equal
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"ABCD"}
             )"));
             // Greater
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"ABCDE"}
             )"));
             // Greater with different case
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"BBBB"}
             )"));
             // Less with different case
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"AABCD"}
             )"));
             // lower case are greater
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"abc"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"abcd"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"abcde"}
             )"));
             // Other fields will be ignored
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"abcd"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"abcd"}
             )"));
             s.on_completed();
@@ -122,17 +118,17 @@ TEST(opBuilderHelperStringGT, Static_number_ok)
         [=](auto s)
         {
             // Equal
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"AA"}
             )"));
             // Greater
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"BB"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"aa"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield": "bb"}
             )"));
             s.on_completed();
@@ -158,21 +154,21 @@ TEST(opBuilderHelperStringGT, Dynamics_string_ok)
         [=](auto s)
         {
             // Greater
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":"abcd",
                     "ref_key":"ABCD"
                 }
             )"));
             // Equal
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":"ABCD",
                     "ref_key":"ABCD"
                 }
             )"));
             // Less
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "otherfield":"AABCD",
                     "ref_key":"ABCD"

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringGt_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringGt_test.cpp
@@ -14,8 +14,8 @@
 #include "opBuilderHelperFilter.hpp"
 #include "base/baseTypes.hpp"
 
-using namespace builder::internals::builders;
 using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
@@ -31,7 +31,7 @@ TEST(opBuilderHelperStringGT, Builds)
         "check":
             {"field2check": "+s_gt/abcd"}
     })"};
-    ASSERT_NO_THROW(opBuilderHelperStringGT(doc.get("/check"), tr));
+    ASSERT_NO_THROW(bld::opBuilderHelperStringGT(doc.get("/check"), tr));
 }
 
 // Build incorrect number of arguments
@@ -41,7 +41,7 @@ TEST(opBuilderHelperStringGT, Builds_incorrect_number_of_arguments)
         "check":
             {"field2check": "+s_gt/test_value/test_value2"}
     })"};
-    ASSERT_THROW(opBuilderHelperStringGT(doc.get("/check"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperStringGT(doc.get("/check"), tr), std::runtime_error);
 }
 
 // Test ok: static values
@@ -95,7 +95,7 @@ TEST(opBuilderHelperStringGT, Static_string_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringGT(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperStringGT(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -135,7 +135,7 @@ TEST(opBuilderHelperStringGT, Static_number_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringGT(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperStringGT(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -178,7 +178,7 @@ TEST(opBuilderHelperStringGT, Dynamics_string_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringGT(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperStringGT(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringGt_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringGt_test.cpp
@@ -12,14 +12,16 @@
 #include <vector>
 
 #include "opBuilderHelperFilter.hpp"
+#include "base/baseTypes.hpp"
 
 using namespace builder::internals::builders;
+using namespace base;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
 auto createEvent = [](const char * json){
-    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
 };
 
 // Build ok

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringLO_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringLO_test.cpp
@@ -12,14 +12,16 @@
 
 #include "testUtils.hpp"
 #include "opBuilderHelperMap.hpp"
+#include "base/baseTypes.hpp"
 
 using namespace builder::internals::builders;
+using namespace base;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
 auto createEvent = [](const char * json){
-    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
 };
 
 // Build ok

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringLO_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringLO_test.cpp
@@ -8,11 +8,13 @@
  */
 
 #include <gtest/gtest.h>
+
 #include <vector>
+
+#include <baseTypes.hpp>
 
 #include "testUtils.hpp"
 #include "opBuilderHelperMap.hpp"
-#include "base/baseTypes.hpp"
 
 using namespace base;
 namespace bld = builder::internals::builders;

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringLO_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringLO_test.cpp
@@ -18,6 +18,10 @@ using namespace builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
+auto createEvent = [](const char * json){
+    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+};
+
 // Build ok
 TEST(opBuilderHelperStringLO, Builds)
 {
@@ -49,13 +53,13 @@ TEST(opBuilderHelperStringLO, Static_string_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"not_fieltToCreate": "qwe"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"not_fieltToCreate": "ASD123asd"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"not_fieltToCreate": "ASD"}
             )"));
             s.on_completed();
@@ -66,9 +70,9 @@ TEST(opBuilderHelperStringLO, Static_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0]->get("/fieltToCreate").GetString(), "asd123asd");
-    ASSERT_STREQ(expected[1]->get("/fieltToCreate").GetString(), "asd123asd");
-    ASSERT_STREQ(expected[2]->get("/fieltToCreate").GetString(), "asd123asd");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/fieltToCreate").GetString(), "asd123asd");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/fieltToCreate").GetString(), "asd123asd");
+    ASSERT_STREQ(expected[2]->getEvent()->get("/fieltToCreate").GetString(), "asd123asd");
 }
 
 // Test ok: dynamic values (string)
@@ -82,13 +86,13 @@ TEST(opBuilderHelperStringLO, Dynamics_string_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"srcField": "qwe"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"srcField": "ASD123asd"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"srcField": "ASD"}
             )"));
             s.on_completed();
@@ -99,9 +103,9 @@ TEST(opBuilderHelperStringLO, Dynamics_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0]->get("/fieltToCreate").GetString(), "qwe");
-    ASSERT_STREQ(expected[1]->get("/fieltToCreate").GetString(), "asd123asd");
-    ASSERT_STREQ(expected[2]->get("/fieltToCreate").GetString(), "asd");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/fieltToCreate").GetString(), "qwe");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/fieltToCreate").GetString(), "asd123asd");
+    ASSERT_STREQ(expected[2]->getEvent()->get("/fieltToCreate").GetString(), "asd");
 }
 
 TEST(opBuilderHelperStringLO, Multilevel_dst)
@@ -114,13 +118,13 @@ TEST(opBuilderHelperStringLO, Multilevel_dst)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"a": {"b": {"c": {"srcField": "qwe"}}}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD123asd"}}}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD"}}}}
             )"));
             s.on_completed();
@@ -131,9 +135,9 @@ TEST(opBuilderHelperStringLO, Multilevel_dst)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0]->get("/a/b/fieltToCreate/2").GetString(), "qwe");
-    ASSERT_STREQ(expected[1]->get("/a/b/fieltToCreate/2").GetString(), "asd123asd");
-    ASSERT_STREQ(expected[2]->get("/a/b/fieltToCreate/2").GetString(), "asd");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/a/b/fieltToCreate/2").GetString(), "qwe");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/a/b/fieltToCreate/2").GetString(), "asd123asd");
+    ASSERT_STREQ(expected[2]->getEvent()->get("/a/b/fieltToCreate/2").GetString(), "asd");
 }
 
 TEST(opBuilderHelperStringLO, Exist_dst)
@@ -146,13 +150,13 @@ TEST(opBuilderHelperStringLO, Exist_dst)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"a": {"b": {"c": {"srcField": "qwe"}}}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD123asd"}}}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD"}}}}
             )"));
             s.on_completed();
@@ -163,9 +167,9 @@ TEST(opBuilderHelperStringLO, Exist_dst)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0]->get("/a/b").GetString(), "qwe");
-    ASSERT_STREQ(expected[1]->get("/a/b").GetString(), "asd123asd");
-    ASSERT_STREQ(expected[2]->get("/a/b").GetString(), "asd");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/a/b").GetString(), "qwe");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/a/b").GetString(), "asd123asd");
+    ASSERT_STREQ(expected[2]->getEvent()->get("/a/b").GetString(), "asd");
 }
 
 TEST(opBuilderHelperStringLO, Not_exist_src)
@@ -178,10 +182,10 @@ TEST(opBuilderHelperStringLO, Not_exist_src)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"a": {"b": "QWE"}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"c": {"d": "QWE123"}}
             )"));
             s.on_completed();
@@ -192,8 +196,8 @@ TEST(opBuilderHelperStringLO, Not_exist_src)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_STREQ(expected[0]->get("/a/b").GetString(), "QWE");
-    ASSERT_FALSE(expected[1]->exists("/a/b"));
+    ASSERT_STREQ(expected[0]->getEvent()->get("/a/b").GetString(), "QWE");
+    ASSERT_FALSE(expected[1]->getEvent()->exists("/a/b"));
 }
 
 TEST(opBuilderHelperStringLO, Src_not_string)
@@ -206,13 +210,13 @@ TEST(opBuilderHelperStringLO, Src_not_string)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"srcField": "qwe"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"srcField": "ASD123asd"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"srcField": "ASD"}
             )"));
             s.on_completed();
@@ -223,9 +227,9 @@ TEST(opBuilderHelperStringLO, Src_not_string)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_FALSE(expected[0]->exists("/fieltToCreate"));
-    ASSERT_FALSE(expected[1]->exists("/fieltToCreate"));
-    ASSERT_FALSE(expected[2]->exists("/fieltToCreate"));
+    ASSERT_FALSE(expected[0]->getEvent()->exists("/fieltToCreate"));
+    ASSERT_FALSE(expected[1]->getEvent()->exists("/fieltToCreate"));
+    ASSERT_FALSE(expected[2]->getEvent()->exists("/fieltToCreate"));
 }
 
 TEST(opBuilderHelperStringLO, Multilevel_src)
@@ -238,13 +242,13 @@ TEST(opBuilderHelperStringLO, Multilevel_src)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"a": {"b": {"c": {"srcField": "qwe"}}}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD123asd"}}}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD"}}}}
             )"));
             s.on_completed();
@@ -255,9 +259,9 @@ TEST(opBuilderHelperStringLO, Multilevel_src)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0]->get("/fieltToCreate").GetString(), "qwe");
-    ASSERT_STREQ(expected[1]->get("/fieltToCreate").GetString(), "asd123asd");
-    ASSERT_STREQ(expected[2]->get("/fieltToCreate").GetString(), "asd");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/fieltToCreate").GetString(), "qwe");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/fieltToCreate").GetString(), "asd123asd");
+    ASSERT_STREQ(expected[2]->getEvent()->get("/fieltToCreate").GetString(), "asd");
 }
 
 TEST(opBuilderHelperStringLO, MultiLevel_dst)
@@ -270,13 +274,13 @@ TEST(opBuilderHelperStringLO, MultiLevel_dst)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"a": {"b": {"c": {"srcField": "qwe"}}}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD123asd"}}}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD"}}}}
             )"));
             s.on_completed();
@@ -287,7 +291,7 @@ TEST(opBuilderHelperStringLO, MultiLevel_dst)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0]->get("/a/b").GetString(), "qwe");
-    ASSERT_STREQ(expected[1]->get("/a/b").GetString(), "asd123asd");
-    ASSERT_STREQ(expected[2]->get("/a/b").GetString(), "asd");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/a/b").GetString(), "qwe");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/a/b").GetString(), "asd123asd");
+    ASSERT_STREQ(expected[2]->getEvent()->get("/a/b").GetString(), "asd");
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringLO_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringLO_test.cpp
@@ -22,10 +22,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
-
 // Build ok
 TEST(opBuilderHelperStringLO, Builds)
 {
@@ -57,13 +53,13 @@ TEST(opBuilderHelperStringLO, Static_string_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"not_fieltToCreate": "qwe"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"not_fieltToCreate": "ASD123asd"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"not_fieltToCreate": "ASD"}
             )"));
             s.on_completed();
@@ -90,13 +86,13 @@ TEST(opBuilderHelperStringLO, Dynamics_string_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"srcField": "qwe"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"srcField": "ASD123asd"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"srcField": "ASD"}
             )"));
             s.on_completed();
@@ -122,13 +118,13 @@ TEST(opBuilderHelperStringLO, Multilevel_dst)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b": {"c": {"srcField": "qwe"}}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD123asd"}}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD"}}}}
             )"));
             s.on_completed();
@@ -154,13 +150,13 @@ TEST(opBuilderHelperStringLO, Exist_dst)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b": {"c": {"srcField": "qwe"}}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD123asd"}}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD"}}}}
             )"));
             s.on_completed();
@@ -186,10 +182,10 @@ TEST(opBuilderHelperStringLO, Not_exist_src)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b": "QWE"}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"c": {"d": "QWE123"}}
             )"));
             s.on_completed();
@@ -214,13 +210,13 @@ TEST(opBuilderHelperStringLO, Src_not_string)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"srcField": "qwe"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"srcField": "ASD123asd"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"srcField": "ASD"}
             )"));
             s.on_completed();
@@ -246,13 +242,13 @@ TEST(opBuilderHelperStringLO, Multilevel_src)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b": {"c": {"srcField": "qwe"}}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD123asd"}}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD"}}}}
             )"));
             s.on_completed();
@@ -278,13 +274,13 @@ TEST(opBuilderHelperStringLO, MultiLevel_dst)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b": {"c": {"srcField": "qwe"}}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD123asd"}}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD"}}}}
             )"));
             s.on_completed();

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringLO_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringLO_test.cpp
@@ -14,8 +14,8 @@
 #include "opBuilderHelperMap.hpp"
 #include "base/baseTypes.hpp"
 
-using namespace builder::internals::builders;
 using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
@@ -31,7 +31,7 @@ TEST(opBuilderHelperStringLO, Builds)
         "normalize":
             {"field2normalize": "+s_lo/abcd"}
     })"};
-    ASSERT_NO_THROW(opBuilderHelperStringLO(doc.get("/normalize"), tr));
+    ASSERT_NO_THROW(bld::opBuilderHelperStringLO(doc.get("/normalize"), tr));
 }
 
 // Build incorrect number of arguments
@@ -41,7 +41,7 @@ TEST(opBuilderHelperStringLO, Builds_incorrect_number_of_arguments)
         "normalize":
             {"field2normalize": "+s_lo/test_value/test_value2"}
     })"};
-    ASSERT_THROW(opBuilderHelperStringLO(doc.get("/normalize"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperStringLO(doc.get("/normalize"), tr), std::runtime_error);
 }
 
 // Test ok: static values
@@ -67,7 +67,7 @@ TEST(opBuilderHelperStringLO, Static_string_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringLO(doc.get("/normalize"), tr);
+    Lifter lift = bld::opBuilderHelperStringLO(doc.get("/normalize"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -100,7 +100,7 @@ TEST(opBuilderHelperStringLO, Dynamics_string_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringLO(doc.get("/normalize"), tr);
+    Lifter lift = bld::opBuilderHelperStringLO(doc.get("/normalize"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -132,7 +132,7 @@ TEST(opBuilderHelperStringLO, Multilevel_dst)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringLO(doc.get("/normalize"), tr);
+    Lifter lift = bld::opBuilderHelperStringLO(doc.get("/normalize"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -164,7 +164,7 @@ TEST(opBuilderHelperStringLO, Exist_dst)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringLO(doc.get("/normalize"), tr);
+    Lifter lift = bld::opBuilderHelperStringLO(doc.get("/normalize"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -193,7 +193,7 @@ TEST(opBuilderHelperStringLO, Not_exist_src)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringLO(doc.get("/normalize"), tr);
+    Lifter lift = bld::opBuilderHelperStringLO(doc.get("/normalize"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -224,7 +224,7 @@ TEST(opBuilderHelperStringLO, Src_not_string)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringLO(doc.get("/normalize"), tr);
+    Lifter lift = bld::opBuilderHelperStringLO(doc.get("/normalize"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -256,7 +256,7 @@ TEST(opBuilderHelperStringLO, Multilevel_src)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringLO(doc.get("/normalize"), tr);
+    Lifter lift = bld::opBuilderHelperStringLO(doc.get("/normalize"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -288,7 +288,7 @@ TEST(opBuilderHelperStringLO, MultiLevel_dst)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringLO(doc.get("/normalize"), tr);
+    Lifter lift = bld::opBuilderHelperStringLO(doc.get("/normalize"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringLe_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringLe_test.cpp
@@ -14,10 +14,8 @@
 #include "opBuilderHelperFilter.hpp"
 #include "base/baseTypes.hpp"
 
-using namespace builder::internals::builders;
 using namespace base;
-
-using namespace builder::internals::builders;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
@@ -33,7 +31,7 @@ TEST(opBuilderHelperStringLE, Builds)
         "check":
             {"field2check": "+s_le/abcd"}
     })"};
-    ASSERT_NO_THROW(opBuilderHelperStringLE(doc.get("/check"), tr));
+    ASSERT_NO_THROW(bld::opBuilderHelperStringLE(doc.get("/check"), tr));
 }
 
 // Build incorrect number of arguments
@@ -43,7 +41,7 @@ TEST(opBuilderHelperStringLE, Builds_incorrect_number_of_arguments)
         "check":
             {"field2check": "+s_le/test_value/test_value2"}
     })"};
-    ASSERT_THROW(opBuilderHelperStringLE(doc.get("/check"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperStringLE(doc.get("/check"), tr), std::runtime_error);
 }
 
 // Test ok: static values
@@ -97,7 +95,7 @@ TEST(opBuilderHelperStringLE, Static_string_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringLE(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperStringLE(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -133,7 +131,7 @@ TEST(opBuilderHelperStringLE, Static_number_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringLE(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperStringLE(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -177,7 +175,7 @@ TEST(opBuilderHelperStringLE, Dynamics_string_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringLE(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperStringLE(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringLe_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringLe_test.cpp
@@ -8,11 +8,13 @@
  */
 
 #include <gtest/gtest.h>
-#include "testUtils.hpp"
+
 #include <vector>
 
+#include <baseTypes.hpp>
+
+#include "testUtils.hpp"
 #include "opBuilderHelperFilter.hpp"
-#include "base/baseTypes.hpp"
 
 using namespace base;
 namespace bld = builder::internals::builders;

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringLe_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringLe_test.cpp
@@ -22,10 +22,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
-
 // Build ok
 TEST(opBuilderHelperStringLE, Builds)
 {
@@ -58,40 +54,40 @@ TEST(opBuilderHelperStringLE, Static_string_ok)
         [=](auto s)
         {
             // less
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"ABC"}
             )"));
             // Equal
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"ABCD"}
             )"));
             // Greater
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"ABCDE"}
             )"));
             // Greater with different case
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"BBBB"}
             )"));
             // Less with different case
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"AABCD"}
             )"));
             // lower case are greater
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"abc"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"abcd"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"abcde"}
             )"));
             // Other fields will be ignored
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"abcd"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"abcd"}
             )"));
             s.on_completed();
@@ -119,15 +115,15 @@ TEST(opBuilderHelperStringLE, Static_number_ok)
         [=](auto s)
         {
             // Less
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"499"}
             )"));
             // Equal
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"50"}
             )"));
             // Greater
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"51"}
             )"));
             s.on_completed();
@@ -154,21 +150,21 @@ TEST(opBuilderHelperStringLE, Dynamics_string_ok)
         [=](auto s)
         {
             // Less
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":"ABCD",
                     "ref_key":"abcd"
                 }
             )"));
             // Equal
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":"ABCD",
                     "ref_key":"ABCD"
                 }
             )"));
             // GREATER
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "otherfield":"abcd",
                     "ref_key":"ABCD"

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringLe_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringLe_test.cpp
@@ -18,6 +18,10 @@ using namespace builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
+auto createEvent = [](const char * json){
+    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+};
+
 // Build ok
 TEST(opBuilderHelperStringLE, Builds)
 {
@@ -50,40 +54,40 @@ TEST(opBuilderHelperStringLE, Static_string_ok)
         [=](auto s)
         {
             // less
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"ABC"}
             )"));
             // Equal
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"ABCD"}
             )"));
             // Greater
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"ABCDE"}
             )"));
             // Greater with different case
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"BBBB"}
             )"));
             // Less with different case
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"AABCD"}
             )"));
             // lower case are greater
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"abc"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"abcd"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"abcde"}
             )"));
             // Other fields will be ignored
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"abcd"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"abcd"}
             )"));
             s.on_completed();
@@ -94,9 +98,9 @@ TEST(opBuilderHelperStringLE, Static_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0]->get("/field2check").GetString(), "ABC");
-    ASSERT_STREQ(expected[1]->get("/field2check").GetString(), "ABCD");
-    ASSERT_STREQ(expected[2]->get("/field2check").GetString(), "AABCD");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/field2check").GetString(), "ABC");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/field2check").GetString(), "ABCD");
+    ASSERT_STREQ(expected[2]->getEvent()->get("/field2check").GetString(), "AABCD");
 }
 
 // Test ok: static values (numbers, compare as string)
@@ -111,15 +115,15 @@ TEST(opBuilderHelperStringLE, Static_number_ok)
         [=](auto s)
         {
             // Less
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"499"}
             )"));
             // Equal
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"50"}
             )"));
             // Greater
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"51"}
             )"));
             s.on_completed();
@@ -130,8 +134,8 @@ TEST(opBuilderHelperStringLE, Static_number_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_STREQ(expected[0]->get("/field2check").GetString(), "499");
-    ASSERT_STREQ(expected[1]->get("/field2check").GetString(), "50");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/field2check").GetString(), "499");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/field2check").GetString(), "50");
 }
 
 // Test ok: dynamic values (string)
@@ -146,21 +150,21 @@ TEST(opBuilderHelperStringLE, Dynamics_string_ok)
         [=](auto s)
         {
             // Less
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":"ABCD",
                     "ref_key":"abcd"
                 }
             )"));
             // Equal
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":"ABCD",
                     "ref_key":"ABCD"
                 }
             )"));
             // GREATER
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "otherfield":"abcd",
                     "ref_key":"ABCD"
@@ -174,6 +178,6 @@ TEST(opBuilderHelperStringLE, Dynamics_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_STREQ(expected[0]->get("/field2check").GetString(), "ABCD");
-    ASSERT_STREQ(expected[1]->get("/field2check").GetString(), "ABCD");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/field2check").GetString(), "ABCD");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/field2check").GetString(), "ABCD");
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringLe_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringLe_test.cpp
@@ -12,6 +12,10 @@
 #include <vector>
 
 #include "opBuilderHelperFilter.hpp"
+#include "base/baseTypes.hpp"
+
+using namespace builder::internals::builders;
+using namespace base;
 
 using namespace builder::internals::builders;
 
@@ -19,7 +23,7 @@ using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
 auto createEvent = [](const char * json){
-    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
 };
 
 // Build ok

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringLt_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringLt_test.cpp
@@ -18,6 +18,10 @@ using namespace builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
+auto createEvent = [](const char * json){
+    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+};
+
 // Build ok
 TEST(opBuilderHelperStringLT, Builds)
 {
@@ -50,40 +54,40 @@ TEST(opBuilderHelperStringLT, Static_string_ok)
         [=](auto s)
         {
             // less
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"ABC"}
             )"));
             // Equal
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"ABCD"}
             )"));
             // Greater
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"ABCDE"}
             )"));
             // Greater with different case
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"BBBB"}
             )"));
             // Less with different case
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"AABCD"}
             )"));
             // lower case are greater
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"abc"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"abcd"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"abcde"}
             )"));
             // Other fields will be ignored
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"abcd"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"abcd"}
             )"));
             s.on_completed();
@@ -94,8 +98,8 @@ TEST(opBuilderHelperStringLT, Static_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_STREQ(expected[0]->get("/field2check").GetString(), "ABC");
-    ASSERT_STREQ(expected[1]->get("/field2check").GetString(), "AABCD");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/field2check").GetString(), "ABC");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/field2check").GetString(), "AABCD");
 }
 
 // Test ok: static values (numbers, compare as string)
@@ -110,15 +114,15 @@ TEST(opBuilderHelperStringLT, Static_number_ok)
         [=](auto s)
         {
             // Less
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"499"}
             )"));
             // Equal
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field2check":"50"}
             )"));
             // Greater
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":"51"}
             )"));
             s.on_completed();
@@ -129,7 +133,7 @@ TEST(opBuilderHelperStringLT, Static_number_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_STREQ(expected[0]->get("/field2check").GetString(), "499");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/field2check").GetString(), "499");
 }
 
 // Test ok: dynamic values (string)
@@ -144,21 +148,21 @@ TEST(opBuilderHelperStringLT, Dynamics_string_ok)
         [=](auto s)
         {
             // Less
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":"ABCD",
                     "ref_key":"abcd"
                 }
             )"));
             // Equal
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "field2check":"ABCD",
                     "ref_key":"ABCD"
                 }
             )"));
             // GREATER
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {
                     "otherfield":"abcd",
                     "ref_key":"ABCD"
@@ -172,5 +176,5 @@ TEST(opBuilderHelperStringLT, Dynamics_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_STREQ(expected[0]->get("/field2check").GetString(), "ABCD");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/field2check").GetString(), "ABCD");
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringLt_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringLt_test.cpp
@@ -22,10 +22,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
-
 // Build ok
 TEST(opBuilderHelperStringLT, Builds)
 {
@@ -58,40 +54,40 @@ TEST(opBuilderHelperStringLT, Static_string_ok)
         [=](auto s)
         {
             // less
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"ABC"}
             )"));
             // Equal
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"ABCD"}
             )"));
             // Greater
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"ABCDE"}
             )"));
             // Greater with different case
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"BBBB"}
             )"));
             // Less with different case
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"AABCD"}
             )"));
             // lower case are greater
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"abc"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"abcd"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"abcde"}
             )"));
             // Other fields will be ignored
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"abcd"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"abcd"}
             )"));
             s.on_completed();
@@ -118,15 +114,15 @@ TEST(opBuilderHelperStringLT, Static_number_ok)
         [=](auto s)
         {
             // Less
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"499"}
             )"));
             // Equal
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"50"}
             )"));
             // Greater
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"51"}
             )"));
             s.on_completed();
@@ -152,21 +148,21 @@ TEST(opBuilderHelperStringLT, Dynamics_string_ok)
         [=](auto s)
         {
             // Less
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":"ABCD",
                     "ref_key":"abcd"
                 }
             )"));
             // Equal
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":"ABCD",
                     "ref_key":"ABCD"
                 }
             )"));
             // GREATER
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "otherfield":"abcd",
                     "ref_key":"ABCD"

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringLt_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringLt_test.cpp
@@ -8,11 +8,13 @@
  */
 
 #include <gtest/gtest.h>
-#include "testUtils.hpp"
+
 #include <vector>
 
+#include <baseTypes.hpp>
+
+#include "testUtils.hpp"
 #include "opBuilderHelperFilter.hpp"
-#include "base/baseTypes.hpp"
 
 using namespace base;
 namespace bld = builder::internals::builders;

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringLt_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringLt_test.cpp
@@ -14,8 +14,8 @@
 #include "opBuilderHelperFilter.hpp"
 #include "base/baseTypes.hpp"
 
-using namespace builder::internals::builders;
 using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
@@ -31,7 +31,7 @@ TEST(opBuilderHelperStringLT, Builds)
         "check":
             {"field2check": "+s_lt/abcd"}
     })"};
-    ASSERT_NO_THROW(opBuilderHelperStringLT(doc.get("/check"), tr));
+    ASSERT_NO_THROW(bld::opBuilderHelperStringLT(doc.get("/check"), tr));
 }
 
 // Build incorrect number of arguments
@@ -41,7 +41,7 @@ TEST(opBuilderHelperStringLT, Builds_incorrect_number_of_arguments)
         "check":
             {"field2check": "+s_lt/test_value/test_value2"}
     })"};
-    ASSERT_THROW(opBuilderHelperStringLT(doc.get("/check"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperStringLT(doc.get("/check"), tr), std::runtime_error);
 }
 
 // Test ok: static values
@@ -95,7 +95,7 @@ TEST(opBuilderHelperStringLT, Static_string_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringLT(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperStringLT(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -130,7 +130,7 @@ TEST(opBuilderHelperStringLT, Static_number_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringLT(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperStringLT(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -173,7 +173,7 @@ TEST(opBuilderHelperStringLT, Dynamics_string_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringLT(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperStringLT(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringLt_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringLt_test.cpp
@@ -12,14 +12,16 @@
 #include <vector>
 
 #include "opBuilderHelperFilter.hpp"
+#include "base/baseTypes.hpp"
 
 using namespace builder::internals::builders;
+using namespace base;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
 auto createEvent = [](const char * json){
-    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
 };
 
 // Build ok

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringNe_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringNe_test.cpp
@@ -22,10 +22,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
-
 // Build ok
 TEST(opBuilderHelperStringNE, Builds)
 {
@@ -57,19 +53,19 @@ TEST(opBuilderHelperStringNE, Static_string_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"not_test_value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"test_value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"test_value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"test_value_2"}
             )"));
             s.on_completed();
@@ -96,23 +92,23 @@ TEST(opBuilderHelperStringNE, Static_number_ok)
         [=](auto s)
         {
             // yes
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"not_11"}
             )"));
             // no
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"11"}
             )"));
             // yes
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"11"}
             )"));
             // yes
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":11}
             )"));
             // no
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2check":"11"}
             )"));
             s.on_completed();
@@ -137,31 +133,31 @@ TEST(opBuilderHelperStringNE, Dynamics_string_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":"not_test_value",
                     "ref_key":"test_value"
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":"test_value",
                     "ref_key":"test_value"
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "otherfield":"value",
                     "ref_key":"test_value"
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "otherfield":"test_value",
                     "ref_key":"test_value"
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":"test_value",
                     "ref_key":"test_value"
@@ -191,7 +187,7 @@ TEST(opBuilderHelperStringNE, Multilevel_dynamics_string_ok)
         [=](auto s)
         {
             // yes
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": "test_value",
@@ -204,7 +200,7 @@ TEST(opBuilderHelperStringNE, Multilevel_dynamics_string_ok)
                 }
             )"));
             // no
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check": "not_test_value",
@@ -217,7 +213,7 @@ TEST(opBuilderHelperStringNE, Multilevel_dynamics_string_ok)
                 }
             )"));
             // yes
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":"test_value",
@@ -230,7 +226,7 @@ TEST(opBuilderHelperStringNE, Multilevel_dynamics_string_ok)
                 }
             )"));
             // yes
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "parentObjt_2": {
                         "field2check":"test_value",
@@ -265,31 +261,31 @@ TEST(opBuilderHelperStringNE, Dynamics_number_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":11,
                     "ref_key":11
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":"11",
                     "ref_key":11
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "otherfield":11,
                     "ref_key":11
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":11,
                     "ref_key":"11"
                 }
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {
                     "field2check":"11",
                     "not_ref_key":"11"

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringNe_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringNe_test.cpp
@@ -8,11 +8,13 @@
  */
 
 #include <gtest/gtest.h>
-#include "testUtils.hpp"
+
 #include <vector>
 
+#include <baseTypes.hpp>
+
+#include "testUtils.hpp"
 #include "opBuilderHelperFilter.hpp"
-#include "base/baseTypes.hpp"
 
 using namespace base;
 namespace bld = builder::internals::builders;

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringNe_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringNe_test.cpp
@@ -14,8 +14,8 @@
 #include "opBuilderHelperFilter.hpp"
 #include "base/baseTypes.hpp"
 
-using namespace builder::internals::builders;
 using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
@@ -31,7 +31,7 @@ TEST(opBuilderHelperStringNE, Builds)
         "check":
             {"field2check": "+s_ne/test_value"}
     })"};
-    ASSERT_NO_THROW(opBuilderHelperStringNE(doc.get("/check"), tr));
+    ASSERT_NO_THROW(bld::opBuilderHelperStringNE(doc.get("/check"), tr));
 }
 
 // Build incorrect number of arguments
@@ -41,7 +41,7 @@ TEST(opBuilderHelperStringNE, Builds_incorrect_number_of_arguments)
         "check":
             {"field2check": "+s_ne/test_value/test_value2"}
     })"};
-    ASSERT_THROW(opBuilderHelperStringNE(doc.get("/check"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperStringNE(doc.get("/check"), tr), std::runtime_error);
 }
 
 // Test ok: static values
@@ -73,7 +73,7 @@ TEST(opBuilderHelperStringNE, Static_string_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringNE(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperStringNE(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -116,7 +116,7 @@ TEST(opBuilderHelperStringNE, Static_number_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringNE(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperStringNE(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -168,7 +168,7 @@ TEST(opBuilderHelperStringNE, Dynamics_string_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringNE(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperStringNE(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -243,7 +243,7 @@ TEST(opBuilderHelperStringNE, Multilevel_dynamics_string_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringNE(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperStringNE(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -296,7 +296,7 @@ TEST(opBuilderHelperStringNE, Dynamics_number_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringNE(doc.get("/check"), tr);
+    Lifter lift = bld::opBuilderHelperStringNE(doc.get("/check"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringNe_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringNe_test.cpp
@@ -12,14 +12,16 @@
 #include <vector>
 
 #include "opBuilderHelperFilter.hpp"
+#include "base/baseTypes.hpp"
 
 using namespace builder::internals::builders;
+using namespace base;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
 auto createEvent = [](const char * json){
-    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
 };
 
 // Build ok

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringTrim_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringTrim_test.cpp
@@ -8,11 +8,13 @@
  */
 
 #include <gtest/gtest.h>
-#include "testUtils.hpp"
+
 #include <vector>
 
+#include <baseTypes.hpp>
+
+#include "testUtils.hpp"
 #include "opBuilderHelperMap.hpp"
-#include "base/baseTypes.hpp"
 
 using namespace base;
 namespace bld = builder::internals::builders;

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringTrim_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringTrim_test.cpp
@@ -18,6 +18,10 @@ using namespace builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
+auto createEvent = [](const char * json){
+    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+};
+
 // Build ok
 TEST(opBuilderHelperStringTrim, Builds)
 {
@@ -49,16 +53,16 @@ TEST(opBuilderHelperStringTrim, BothOk)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"fieldToTranf": "---hi---"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"fieldToTranf": "hi---"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"fieldToTranf": "---hi"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"fieldToTranf": "hi"}
             )"));
             s.on_completed();
@@ -69,9 +73,9 @@ TEST(opBuilderHelperStringTrim, BothOk)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 4);
-    ASSERT_STREQ(expected[0]->get("/fieldToTranf").GetString(), "hi");
-    ASSERT_STREQ(expected[1]->get("/fieldToTranf").GetString(), "hi");
-    ASSERT_STREQ(expected[2]->get("/fieldToTranf").GetString(), "hi");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/fieldToTranf").GetString(), "hi");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/fieldToTranf").GetString(), "hi");
+    ASSERT_STREQ(expected[2]->getEvent()->get("/fieldToTranf").GetString(), "hi");
 }
 
 TEST(opBuilderHelperStringTrim, Start_ok)
@@ -84,16 +88,16 @@ TEST(opBuilderHelperStringTrim, Start_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"fieldToTranf": "---hi---"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"fieldToTranf": "hi---"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"fieldToTranf": "---hi"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"fieldToTranf": "hi"}
             )"));
             s.on_completed();
@@ -104,10 +108,10 @@ TEST(opBuilderHelperStringTrim, Start_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 4);
-    ASSERT_STREQ(expected[0]->get("/fieldToTranf").GetString(), "hi---");
-    ASSERT_STREQ(expected[1]->get("/fieldToTranf").GetString(), "hi---");
-    ASSERT_STREQ(expected[2]->get("/fieldToTranf").GetString(), "hi");
-    ASSERT_STREQ(expected[3]->get("/fieldToTranf").GetString(), "hi");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/fieldToTranf").GetString(), "hi---");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/fieldToTranf").GetString(), "hi---");
+    ASSERT_STREQ(expected[2]->getEvent()->get("/fieldToTranf").GetString(), "hi");
+    ASSERT_STREQ(expected[3]->getEvent()->get("/fieldToTranf").GetString(), "hi");
 }
 
 // Test ok: dynamic values (string)
@@ -121,16 +125,16 @@ TEST(opBuilderHelperStringTrim, End_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"fieldToTranf": "---hi---"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"fieldToTranf": "hi---"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"fieldToTranf": "---hi"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"fieldToTranf": "hi"}
             )"));
             s.on_completed();
@@ -141,10 +145,10 @@ TEST(opBuilderHelperStringTrim, End_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 4);
-    ASSERT_STREQ(expected[0]->get("/fieldToTranf").GetString(), "---hi");
-    ASSERT_STREQ(expected[1]->get("/fieldToTranf").GetString(), "hi");
-    ASSERT_STREQ(expected[2]->get("/fieldToTranf").GetString(), "---hi");
-    ASSERT_STREQ(expected[3]->get("/fieldToTranf").GetString(), "hi");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/fieldToTranf").GetString(), "---hi");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/fieldToTranf").GetString(), "hi");
+    ASSERT_STREQ(expected[2]->getEvent()->get("/fieldToTranf").GetString(), "---hi");
+    ASSERT_STREQ(expected[3]->getEvent()->get("/fieldToTranf").GetString(), "hi");
 }
 
 TEST(opBuilderHelperStringTrim, Multilevel_src)
@@ -157,16 +161,16 @@ TEST(opBuilderHelperStringTrim, Multilevel_src)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"fieldToTranf": {"a": {"b": "---hi---"}}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"fieldToTranf": {"a": {"b": "hi---"}}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"fieldToTranf": {"a": {"b": "---hi"}}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"fieldToTranf": {"a": {"b": "hi"}}}
             )"));
             s.on_completed();
@@ -177,10 +181,10 @@ TEST(opBuilderHelperStringTrim, Multilevel_src)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 4);
-    ASSERT_STREQ(expected[0]->get("/fieldToTranf/a/b").GetString(), "---hi");
-    ASSERT_STREQ(expected[1]->get("/fieldToTranf/a/b").GetString(), "hi");
-    ASSERT_STREQ(expected[2]->get("/fieldToTranf/a/b").GetString(), "---hi");
-    ASSERT_STREQ(expected[3]->get("/fieldToTranf/a/b").GetString(), "hi");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/fieldToTranf/a/b").GetString(), "---hi");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/fieldToTranf/a/b").GetString(), "hi");
+    ASSERT_STREQ(expected[2]->getEvent()->get("/fieldToTranf/a/b").GetString(), "---hi");
+    ASSERT_STREQ(expected[3]->getEvent()->get("/fieldToTranf/a/b").GetString(), "hi");
 }
 
 TEST(opBuilderHelperStringTrim, Not_exist_src)
@@ -193,7 +197,7 @@ TEST(opBuilderHelperStringTrim, Not_exist_src)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"not_ext": "---hi---"}
             )"));
             s.on_completed();
@@ -204,7 +208,7 @@ TEST(opBuilderHelperStringTrim, Not_exist_src)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_FALSE(expected[0]->exists("/fieldToTranf"));
+    ASSERT_FALSE(expected[0]->getEvent()->exists("/fieldToTranf"));
 }
 
 TEST(opBuilderHelperStringTrim, Src_not_string)
@@ -217,7 +221,7 @@ TEST(opBuilderHelperStringTrim, Src_not_string)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"fieldToTranf": 15}
             )"));
             s.on_completed();
@@ -228,8 +232,8 @@ TEST(opBuilderHelperStringTrim, Src_not_string)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_TRUE(expected[0]->exists("/fieldToTranf"));
-    ASSERT_EQ(expected[0]->get("/fieldToTranf").GetInt(), 15);
+    ASSERT_TRUE(expected[0]->getEvent()->exists("/fieldToTranf"));
+    ASSERT_EQ(expected[0]->getEvent()->get("/fieldToTranf").GetInt(), 15);
 }
 
 TEST(opBuilderHelperStringTrim, Multilevel)
@@ -242,16 +246,16 @@ TEST(opBuilderHelperStringTrim, Multilevel)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"fieldToTranf": {"a": {"b": "---hi---"}}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"fieldToTranf": {"a": {"b": "hi---"}}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"fieldToTranf": {"a": {"b": "---hi"}}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"fieldToTranf": {"a": {"b": "hi"}}}
             )"));
             s.on_completed();
@@ -262,8 +266,8 @@ TEST(opBuilderHelperStringTrim, Multilevel)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 4);
-    ASSERT_STREQ(expected[0]->get("/fieldToTranf/a/b").GetString(), "---hi");
-    ASSERT_STREQ(expected[1]->get("/fieldToTranf/a/b").GetString(), "hi");
-    ASSERT_STREQ(expected[2]->get("/fieldToTranf/a/b").GetString(), "---hi");
-    ASSERT_STREQ(expected[3]->get("/fieldToTranf/a/b").GetString(), "hi");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/fieldToTranf/a/b").GetString(), "---hi");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/fieldToTranf/a/b").GetString(), "hi");
+    ASSERT_STREQ(expected[2]->getEvent()->get("/fieldToTranf/a/b").GetString(), "---hi");
+    ASSERT_STREQ(expected[3]->getEvent()->get("/fieldToTranf/a/b").GetString(), "hi");
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringTrim_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringTrim_test.cpp
@@ -14,8 +14,8 @@
 #include "opBuilderHelperMap.hpp"
 #include "base/baseTypes.hpp"
 
-using namespace builder::internals::builders;
 using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
@@ -31,7 +31,7 @@ TEST(opBuilderHelperStringTrim, Builds)
         "normalize":
             {"fieldToTranf": "+s_trim/both/t"}
     })"};
-    ASSERT_NO_THROW(opBuilderHelperStringTrim(doc.get("/normalize"), tr));
+    ASSERT_NO_THROW(bld::opBuilderHelperStringTrim(doc.get("/normalize"), tr));
 }
 
 // Build incorrect number of arguments
@@ -41,7 +41,7 @@ TEST(opBuilderHelperStringTrim, Builds_incorrect_number_of_arguments)
         "normalize":
             {"fieldToTranf": "+s_trim/both/t/t"}
     })"};
-    ASSERT_THROW(opBuilderHelperStringTrim(doc.get("/normalize"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperStringTrim(doc.get("/normalize"), tr), std::runtime_error);
 }
 
 // Test ok: both trim
@@ -70,7 +70,7 @@ TEST(opBuilderHelperStringTrim, BothOk)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringTrim(doc.get("/normalize"), tr);
+    Lifter lift = bld::opBuilderHelperStringTrim(doc.get("/normalize"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -105,7 +105,7 @@ TEST(opBuilderHelperStringTrim, Start_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringTrim(doc.get("/normalize"), tr);
+    Lifter lift = bld::opBuilderHelperStringTrim(doc.get("/normalize"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -142,7 +142,7 @@ TEST(opBuilderHelperStringTrim, End_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringTrim(doc.get("/normalize"), tr);
+    Lifter lift = bld::opBuilderHelperStringTrim(doc.get("/normalize"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -178,7 +178,7 @@ TEST(opBuilderHelperStringTrim, Multilevel_src)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringTrim(doc.get("/normalize"), tr);
+    Lifter lift = bld::opBuilderHelperStringTrim(doc.get("/normalize"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -205,7 +205,7 @@ TEST(opBuilderHelperStringTrim, Not_exist_src)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringTrim(doc.get("/normalize"), tr);
+    Lifter lift = bld::opBuilderHelperStringTrim(doc.get("/normalize"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -229,7 +229,7 @@ TEST(opBuilderHelperStringTrim, Src_not_string)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringTrim(doc.get("/normalize"), tr);
+    Lifter lift = bld::opBuilderHelperStringTrim(doc.get("/normalize"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -263,7 +263,7 @@ TEST(opBuilderHelperStringTrim, Multilevel)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringTrim(doc.get("/normalize"), tr);
+    Lifter lift = bld::opBuilderHelperStringTrim(doc.get("/normalize"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringTrim_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringTrim_test.cpp
@@ -21,11 +21,6 @@ namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
-
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
-
 // Build ok
 TEST(opBuilderHelperStringTrim, Builds)
 {
@@ -57,16 +52,16 @@ TEST(opBuilderHelperStringTrim, BothOk)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldToTranf": "---hi---"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldToTranf": "hi---"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldToTranf": "---hi"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldToTranf": "hi"}
             )"));
             s.on_completed();
@@ -92,16 +87,16 @@ TEST(opBuilderHelperStringTrim, Start_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldToTranf": "---hi---"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldToTranf": "hi---"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldToTranf": "---hi"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldToTranf": "hi"}
             )"));
             s.on_completed();
@@ -129,16 +124,16 @@ TEST(opBuilderHelperStringTrim, End_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldToTranf": "---hi---"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldToTranf": "hi---"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldToTranf": "---hi"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldToTranf": "hi"}
             )"));
             s.on_completed();
@@ -165,16 +160,16 @@ TEST(opBuilderHelperStringTrim, Multilevel_src)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldToTranf": {"a": {"b": "---hi---"}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldToTranf": {"a": {"b": "hi---"}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldToTranf": {"a": {"b": "---hi"}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldToTranf": {"a": {"b": "hi"}}}
             )"));
             s.on_completed();
@@ -201,7 +196,7 @@ TEST(opBuilderHelperStringTrim, Not_exist_src)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"not_ext": "---hi---"}
             )"));
             s.on_completed();
@@ -225,7 +220,7 @@ TEST(opBuilderHelperStringTrim, Src_not_string)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldToTranf": 15}
             )"));
             s.on_completed();
@@ -250,16 +245,16 @@ TEST(opBuilderHelperStringTrim, Multilevel)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldToTranf": {"a": {"b": "---hi---"}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldToTranf": {"a": {"b": "hi---"}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldToTranf": {"a": {"b": "---hi"}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"fieldToTranf": {"a": {"b": "hi"}}}
             )"));
             s.on_completed();

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringTrim_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringTrim_test.cpp
@@ -12,14 +12,16 @@
 #include <vector>
 
 #include "opBuilderHelperMap.hpp"
+#include "base/baseTypes.hpp"
 
 using namespace builder::internals::builders;
+using namespace base;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
 auto createEvent = [](const char * json){
-    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
 };
 
 // Build ok

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringUP_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringUP_test.cpp
@@ -8,11 +8,13 @@
  */
 
 #include <gtest/gtest.h>
-#include "testUtils.hpp"
+
 #include <vector>
 
+#include <baseTypes.hpp>
+
+#include "testUtils.hpp"
 #include "opBuilderHelperMap.hpp"
-#include "base/baseTypes.hpp"
 
 using namespace base;
 namespace bld = builder::internals::builders;

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringUP_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringUP_test.cpp
@@ -18,6 +18,10 @@ using namespace builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
+auto createEvent = [](const char * json){
+    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+};
+
 // Build ok
 TEST(opBuilderHelperStringUP, Builds)
 {
@@ -49,13 +53,13 @@ TEST(opBuilderHelperStringUP, Static_string_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"not_fieltToCreate": "qwe"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"not_fieltToCreate": "ASD123asd"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"not_fieltToCreate": "ASD"}
             )"));
             s.on_completed();
@@ -66,9 +70,9 @@ TEST(opBuilderHelperStringUP, Static_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0]->get("/fieltToCreate").GetString(), "ASD123ASD");
-    ASSERT_STREQ(expected[1]->get("/fieltToCreate").GetString(), "ASD123ASD");
-    ASSERT_STREQ(expected[2]->get("/fieltToCreate").GetString(), "ASD123ASD");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/fieltToCreate").GetString(), "ASD123ASD");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/fieltToCreate").GetString(), "ASD123ASD");
+    ASSERT_STREQ(expected[2]->getEvent()->get("/fieltToCreate").GetString(), "ASD123ASD");
 }
 
 // Test ok: dynamic values (string)
@@ -83,13 +87,13 @@ TEST(opBuilderHelperStringUP, Dynamics_string_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"srcField": "qwe"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"srcField": "ASD123asd"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"srcField": "ASD"}
             )"));
             s.on_completed();
@@ -100,9 +104,9 @@ TEST(opBuilderHelperStringUP, Dynamics_string_ok)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0]->get("/fieltToCreate").GetString(), "QWE");
-    ASSERT_STREQ(expected[1]->get("/fieltToCreate").GetString(), "ASD123ASD");
-    ASSERT_STREQ(expected[2]->get("/fieltToCreate").GetString(), "ASD");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/fieltToCreate").GetString(), "QWE");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/fieltToCreate").GetString(), "ASD123ASD");
+    ASSERT_STREQ(expected[2]->getEvent()->get("/fieltToCreate").GetString(), "ASD");
 }
 
 TEST(opBuilderHelperStringUP, Multilevel_src)
@@ -115,13 +119,13 @@ TEST(opBuilderHelperStringUP, Multilevel_src)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"a": {"b": {"c": {"srcField": "qwe"}}}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD123asd"}}}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD"}}}}
             )"));
             s.on_completed();
@@ -132,9 +136,9 @@ TEST(opBuilderHelperStringUP, Multilevel_src)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0]->get("/fieltToCreate").GetString(), "qwe");
-    ASSERT_STREQ(expected[1]->get("/fieltToCreate").GetString(), "asd123asd");
-    ASSERT_STREQ(expected[2]->get("/fieltToCreate").GetString(), "asd");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/fieltToCreate").GetString(), "qwe");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/fieltToCreate").GetString(), "asd123asd");
+    ASSERT_STREQ(expected[2]->getEvent()->get("/fieltToCreate").GetString(), "asd");
 }
 
 TEST(opBuilderHelperStringUP, Multilevel_dst)
@@ -147,13 +151,13 @@ TEST(opBuilderHelperStringUP, Multilevel_dst)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"a": {"b": {"c": {"srcField": "qwe"}}}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD123asd"}}}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD"}}}}
             )"));
             s.on_completed();
@@ -164,9 +168,9 @@ TEST(opBuilderHelperStringUP, Multilevel_dst)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0]->get("/a/b/fieltToCreate/2").GetString(), "QWE");
-    ASSERT_STREQ(expected[1]->get("/a/b/fieltToCreate/2").GetString(), "ASD123ASD");
-    ASSERT_STREQ(expected[2]->get("/a/b/fieltToCreate/2").GetString(), "ASD");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/a/b/fieltToCreate/2").GetString(), "QWE");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/a/b/fieltToCreate/2").GetString(), "ASD123ASD");
+    ASSERT_STREQ(expected[2]->getEvent()->get("/a/b/fieltToCreate/2").GetString(), "ASD");
 }
 
 TEST(opBuilderHelperStringUP, Exist_dst)
@@ -179,13 +183,13 @@ TEST(opBuilderHelperStringUP, Exist_dst)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"a": {"b": {"c": {"srcField": "qwe"}}}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD123asd"}}}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD"}}}}
             )"));
             s.on_completed();
@@ -196,9 +200,9 @@ TEST(opBuilderHelperStringUP, Exist_dst)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_STREQ(expected[0]->get("/a/b").GetString(), "QWE");
-    ASSERT_STREQ(expected[1]->get("/a/b").GetString(), "ASD123ASD");
-    ASSERT_STREQ(expected[2]->get("/a/b").GetString(), "ASD");
+    ASSERT_STREQ(expected[0]->getEvent()->get("/a/b").GetString(), "QWE");
+    ASSERT_STREQ(expected[1]->getEvent()->get("/a/b").GetString(), "ASD123ASD");
+    ASSERT_STREQ(expected[2]->getEvent()->get("/a/b").GetString(), "ASD");
 }
 
 TEST(opBuilderHelperStringUP, Not_exist_src)
@@ -211,10 +215,10 @@ TEST(opBuilderHelperStringUP, Not_exist_src)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"a": {"b": "QWE"}}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"c": {"d": "QWE123"}}
             )"));
             s.on_completed();
@@ -225,8 +229,8 @@ TEST(opBuilderHelperStringUP, Not_exist_src)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 2);
-    ASSERT_STREQ(expected[0]->get("/a/b").GetString(), "QWE");
-    ASSERT_FALSE(expected[1]->exists("/a/b"));
+    ASSERT_STREQ(expected[0]->getEvent()->get("/a/b").GetString(), "QWE");
+    ASSERT_FALSE(expected[1]->getEvent()->exists("/a/b"));
 }
 
 TEST(opBuilderHelperStringUP, Src_not_string)
@@ -239,13 +243,13 @@ TEST(opBuilderHelperStringUP, Src_not_string)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"srcField": "qwe"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"srcField": "ASD123asd"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"srcField": "ASD"}
             )"));
             s.on_completed();
@@ -256,7 +260,7 @@ TEST(opBuilderHelperStringUP, Src_not_string)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 3);
-    ASSERT_FALSE(expected[0]->exists("/fieltToCreate"));
-    ASSERT_FALSE(expected[1]->exists("/fieltToCreate"));
-    ASSERT_FALSE(expected[2]->exists("/fieltToCreate"));
+    ASSERT_FALSE(expected[0]->getEvent()->exists("/fieltToCreate"));
+    ASSERT_FALSE(expected[1]->getEvent()->exists("/fieltToCreate"));
+    ASSERT_FALSE(expected[2]->getEvent()->exists("/fieltToCreate"));
 }

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringUP_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringUP_test.cpp
@@ -22,10 +22,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
-
 // Build ok
 TEST(opBuilderHelperStringUP, Builds)
 {
@@ -57,13 +53,13 @@ TEST(opBuilderHelperStringUP, Static_string_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"not_fieltToCreate": "qwe"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"not_fieltToCreate": "ASD123asd"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"not_fieltToCreate": "ASD"}
             )"));
             s.on_completed();
@@ -91,13 +87,13 @@ TEST(opBuilderHelperStringUP, Dynamics_string_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"srcField": "qwe"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"srcField": "ASD123asd"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"srcField": "ASD"}
             )"));
             s.on_completed();
@@ -123,13 +119,13 @@ TEST(opBuilderHelperStringUP, Multilevel_src)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b": {"c": {"srcField": "qwe"}}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD123asd"}}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD"}}}}
             )"));
             s.on_completed();
@@ -155,13 +151,13 @@ TEST(opBuilderHelperStringUP, Multilevel_dst)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b": {"c": {"srcField": "qwe"}}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD123asd"}}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD"}}}}
             )"));
             s.on_completed();
@@ -187,13 +183,13 @@ TEST(opBuilderHelperStringUP, Exist_dst)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b": {"c": {"srcField": "qwe"}}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD123asd"}}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b": {"c": {"srcField": "ASD"}}}}
             )"));
             s.on_completed();
@@ -219,10 +215,10 @@ TEST(opBuilderHelperStringUP, Not_exist_src)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b": "QWE"}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"c": {"d": "QWE123"}}
             )"));
             s.on_completed();
@@ -247,13 +243,13 @@ TEST(opBuilderHelperStringUP, Src_not_string)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"srcField": "qwe"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"srcField": "ASD123asd"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"srcField": "ASD"}
             )"));
             s.on_completed();

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringUP_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringUP_test.cpp
@@ -12,14 +12,16 @@
 #include <vector>
 
 #include "opBuilderHelperMap.hpp"
+#include "base/baseTypes.hpp"
 
 using namespace builder::internals::builders;
+using namespace base;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
 auto createEvent = [](const char * json){
-    return std::make_shared<Base::EventHandler>(std::make_shared<json::Document>(json));
+    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
 };
 
 // Build ok

--- a/src/engine/test/source/builder/builders/opBuilderHelperStringUP_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperStringUP_test.cpp
@@ -14,8 +14,8 @@
 #include "opBuilderHelperMap.hpp"
 #include "base/baseTypes.hpp"
 
-using namespace builder::internals::builders;
 using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
@@ -31,7 +31,7 @@ TEST(opBuilderHelperStringUP, Builds)
         "normalize":
             {"field2normalize": "+s_up/abcd"}
     })"};
-    ASSERT_NO_THROW(opBuilderHelperStringUP(doc.get("/normalize"), tr));
+    ASSERT_NO_THROW(bld::opBuilderHelperStringUP(doc.get("/normalize"), tr));
 }
 
 // Build incorrect number of arguments
@@ -41,7 +41,7 @@ TEST(opBuilderHelperStringUP, Builds_incorrect_number_of_arguments)
         "normalize":
             {"field2normalize": "+s_up/test_value/test_value2"}
     })"};
-    ASSERT_THROW(opBuilderHelperStringUP(doc.get("/normalize"), tr), std::runtime_error);
+    ASSERT_THROW(bld::opBuilderHelperStringUP(doc.get("/normalize"), tr), std::runtime_error);
 }
 
 // Test ok: static values
@@ -67,7 +67,7 @@ TEST(opBuilderHelperStringUP, Static_string_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringUP(doc.get("/normalize"), tr);
+    Lifter lift = bld::opBuilderHelperStringUP(doc.get("/normalize"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -101,7 +101,7 @@ TEST(opBuilderHelperStringUP, Dynamics_string_ok)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringUP(doc.get("/normalize"), tr);
+    Lifter lift = bld::opBuilderHelperStringUP(doc.get("/normalize"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -133,7 +133,7 @@ TEST(opBuilderHelperStringUP, Multilevel_src)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringLO(doc.get("/normalize"), tr);
+    Lifter lift = bld::opBuilderHelperStringLO(doc.get("/normalize"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -165,7 +165,7 @@ TEST(opBuilderHelperStringUP, Multilevel_dst)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringUP(doc.get("/normalize"), tr);
+    Lifter lift = bld::opBuilderHelperStringUP(doc.get("/normalize"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -197,7 +197,7 @@ TEST(opBuilderHelperStringUP, Exist_dst)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringUP(doc.get("/normalize"), tr);
+    Lifter lift = bld::opBuilderHelperStringUP(doc.get("/normalize"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -226,7 +226,7 @@ TEST(opBuilderHelperStringUP, Not_exist_src)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringUP(doc.get("/normalize"), tr);
+    Lifter lift = bld::opBuilderHelperStringUP(doc.get("/normalize"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
@@ -257,7 +257,7 @@ TEST(opBuilderHelperStringUP, Src_not_string)
             s.on_completed();
         });
 
-    Lifter lift = opBuilderHelperStringUP(doc.get("/normalize"), tr);
+    Lifter lift = bld::opBuilderHelperStringUP(doc.get("/normalize"), tr);
     Observable output = lift(input);
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });

--- a/src/engine/test/source/builder/builders/opBuilderKVDBExtract_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderKVDBExtract_test.cpp
@@ -23,10 +23,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
-
 class opBuilderKVDBExtractTest : public ::testing::Test
 {
 
@@ -90,13 +86,13 @@ TEST_F(opBuilderKVDBExtractTest, Static_key)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"dummy_field": "qwe"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"dummy_field": "ASD123asd"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"dummy_field": "ASD"}
             )"));
             s.on_completed();
@@ -126,16 +122,16 @@ TEST_F(opBuilderKVDBExtractTest, Dynamic)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"key": "KEY"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"inexistent_key": "KEY"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"invalid_string": 123}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"invalid_key": "INVALID_KEY"}
             )"));
             s.on_completed();
@@ -166,13 +162,13 @@ TEST_F(opBuilderKVDBExtractTest, Multi_level_key)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                  {"a":{"b":{"key":"KEY"}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                  {"a":{"b":{"inexistent_key":"KEY"}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                  {"a":{"b":{"invalid_key":"INVALID_KEY"}}}
             )"));
             s.on_completed();
@@ -202,13 +198,13 @@ TEST_F(opBuilderKVDBExtractTest, Multi_level_target)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"not_fieldToCreate": "qwe"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"not_fieldToCreate": "ASD123asd"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"not_fieldToCreate": "ASD"}
             )"));
             s.on_completed();
@@ -238,10 +234,10 @@ TEST_F(opBuilderKVDBExtractTest, Existent_target)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"dummy_data": "dummy_value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2extract": "PRE_VALUE"}
             )"));
             s.on_completed();

--- a/src/engine/test/source/builder/builders/opBuilderKVDBMatch_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderKVDBMatch_test.cpp
@@ -21,9 +21,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
 
 namespace
 {
@@ -88,11 +85,11 @@ TEST_F(opBuilderKVDBMatchTest, Single_level_target_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2match":"KEY"}
             )"));
             // Other fields will be ignored
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"KEY"}
             )"));
             s.on_completed();
@@ -121,11 +118,11 @@ TEST_F(opBuilderKVDBMatchTest, Multilevel_target_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a":{"b":{"field2match":"KEY"}}}
             )"));
             // Other fields will be ignored
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a":{"b":{"otherfield":"KEY"}}}
             )"));
             s.on_completed();

--- a/src/engine/test/source/builder/builders/opBuilderKVDBNotMatch_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderKVDBNotMatch_test.cpp
@@ -21,10 +21,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
-};
-
 namespace
 {
 class opBuilderKVDBNotMatchTest : public ::testing::Test
@@ -91,14 +87,14 @@ TEST_F(opBuilderKVDBNotMatchTest, Static_string_ok)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2match":"KEY"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field2match":"INEXISTENT_KEY"}
             )"));
             // Other fields will be ignored
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"KEY"}
             )"));
             s.on_completed();
@@ -128,14 +124,14 @@ TEST_F(opBuilderKVDBNotMatchTest, Multilevel_target)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b":{"field2match":"KEY"}}}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b":{"field2match":"INEXISTENT_KEY"}}}
             )"));
             // Other fields will continue
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"a": {"b":{"otherfield":"KEY"}}}
             )"));
             s.on_completed();

--- a/src/engine/test/source/builder/builders/opBuilderMapReference_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderMapReference_test.cpp
@@ -20,9 +20,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
-};
 
 TEST(opBuilderMapReference, Builds)
 {
@@ -44,13 +41,13 @@ TEST(opBuilderMapReference, BuildsOperates)
         [=](auto s)
         {
             // TODO: Fix json to return false instead of throw
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"other_field":"referenced"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"values"}
             )"));
             s.on_completed();

--- a/src/engine/test/source/builder/builders/opBuilderMapValue_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderMapValue_test.cpp
@@ -20,10 +20,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
-};
-
 TEST(opBuilderMapValue, Builds)
 {
     Document doc{R"({
@@ -53,16 +49,16 @@ TEST(opBuilderMapValue, BuildsOperates)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"values"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();

--- a/src/engine/test/source/builder/builders/opBuilderMap_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderMap_test.cpp
@@ -15,10 +15,15 @@
 #include "opBuilderMapValue.hpp"
 #include "opBuilderHelperFilter.hpp"
 
-using namespace builder::internals::builders;
+using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
+
+auto createEvent = [](const char * json){
+    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
+};
 
 TEST(opBuilderMap, BuildsAllNonRegistered)
 {
@@ -33,13 +38,13 @@ TEST(opBuilderMap, BuildsAllNonRegistered)
     const auto & arr = doc.begin()->value.GetArray();
     for (auto it = arr.Begin(); it != arr.end(); ++it)
     {
-        ASSERT_THROW(opBuilderMap(*it, tr), invalid_argument);
+        ASSERT_THROW(bld::opBuilderMap(*it, tr), invalid_argument);
     }
 }
 
 TEST(opBuilderMap, BuildsValue)
 {
-    BuilderVariant c = opBuilderMapValue;
+    BuilderVariant c = bld::opBuilderMapValue;
     Registry::registerBuilder("map.value", c);
     Document doc{R"({
         "normalize": [
@@ -51,14 +56,14 @@ TEST(opBuilderMap, BuildsValue)
     const auto & arr = doc.begin()->value.GetArray();
     for (auto it = arr.Begin(); it != arr.end(); ++it)
     {
-        ASSERT_NO_THROW(opBuilderMap(*it, tr));
+        ASSERT_NO_THROW(bld::opBuilderMap(*it, tr));
     }
 }
 
 TEST(opBuilderMap, BuildsReference)
 {
-    BuilderVariant c = opBuilderMapReference;
+    BuilderVariant c = bld::opBuilderMapReference;
     Registry::registerBuilder("map.reference", c);
     Document doc{R"({"normalize": {"ref": "$ref"}})"};
-    ASSERT_NO_THROW(opBuilderMap(doc.get("/normalize"), tr));
+    ASSERT_NO_THROW(bld::opBuilderMap(doc.get("/normalize"), tr));
 }

--- a/src/engine/test/source/builder/builders/opBuilderMap_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderMap_test.cpp
@@ -21,10 +21,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
-};
-
 TEST(opBuilderMap, BuildsAllNonRegistered)
 {
     Document doc{R"({

--- a/src/engine/test/source/builder/builders/stageBuilderCheck_test.cpp
+++ b/src/engine/test/source/builder/builders/stageBuilderCheck_test.cpp
@@ -114,10 +114,10 @@ TEST(StageBuilderCheck, BuildsOperates)
     vector<Event> expected;
     output.subscribe([&](Event e) { expected.push_back(e); });
     ASSERT_EQ(expected.size(), 1);
-    ASSERT_STREQ(expected[0]->get("/field1").GetString(), "value");
-    ASSERT_EQ(expected[0]->get("/field2").GetInt(), 2);
-    ASSERT_STREQ(expected[0]->get("/field3").GetString(), "value");
-    ASSERT_TRUE(expected[0]->get("/field4").GetBool());
-    ASSERT_NO_THROW(expected[0]->get("/field5"));
-    ASSERT_FALSE(expected[0]->exists("/field6"));
+    ASSERT_STREQ(expected[0]->getEvent()->get("/field1").GetString(), "value");
+    ASSERT_EQ(expected[0]->getEvent()->get("/field2").GetInt(), 2);
+    ASSERT_STREQ(expected[0]->getEvent()->get("/field3").GetString(), "value");
+    ASSERT_TRUE(expected[0]->getEvent()->get("/field4").GetBool());
+    ASSERT_NO_THROW(expected[0]->getEvent()->get("/field5"));
+    ASSERT_FALSE(expected[0]->getEvent()->exists("/field6"));
 }

--- a/src/engine/test/source/builder/builders/stageBuilderCheck_test.cpp
+++ b/src/engine/test/source/builder/builders/stageBuilderCheck_test.cpp
@@ -23,10 +23,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
-};
-
 TEST(StageBuilderCheck, BuildsAllNonRegistered)
 {
     Document doc{R"({
@@ -90,17 +86,17 @@ TEST(StageBuilderCheck, BuildsOperates)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"({
+            s.on_next(createSharedEvent(R"({
                 "field1": "value",
                 "field2": 2,
                 "field3": "value",
                 "field4": true,
                 "field5": "+exists"
             })"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"values"}
             )"));
-            s.on_next(createEvent(R"({
+            s.on_next(createSharedEvent(R"({
                 "field1": "value",
                 "field2": 2,
                 "field3": "value",
@@ -108,7 +104,7 @@ TEST(StageBuilderCheck, BuildsOperates)
                 "field5": "+exists",
                 "field6": "+exists"
             })"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();

--- a/src/engine/test/source/builder/builders/stageBuilderCheck_test.cpp
+++ b/src/engine/test/source/builder/builders/stageBuilderCheck_test.cpp
@@ -17,10 +17,15 @@
 #include "opBuilderHelperFilter.hpp"
 #include "stageBuilderCheck.hpp"
 
-using namespace builder::internals::builders;
+using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
+
+auto createEvent = [](const char * json){
+    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
+};
 
 TEST(StageBuilderCheck, BuildsAllNonRegistered)
 {
@@ -40,15 +45,15 @@ TEST(StageBuilderCheck, BuildsAllNonRegistered)
 
 TEST(StageBuilderCheck, Builds)
 {
-    BuilderVariant c = opBuilderConditionValue;
+    BuilderVariant c = bld::opBuilderConditionValue;
     Registry::registerBuilder("condition.value", c);
-    c = opBuilderConditionReference;
+    c = bld::opBuilderConditionReference;
     Registry::registerBuilder("condition.reference", c);
-    c = opBuilderHelperExists;
+    c = bld::opBuilderHelperExists;
     Registry::registerBuilder("helper.exists", c);
-    c = opBuilderHelperNotExists;
+    c = bld::opBuilderHelperNotExists;
     Registry::registerBuilder("helper.not_exists", c);
-    c = opBuilderCondition;
+    c = bld::opBuilderCondition;
     Registry::registerBuilder("condition", c);
     c = combinatorBuilderChain;
     Registry::registerBuilder("combinator.chain", c);

--- a/src/engine/test/source/builder/builders/stageBuilderCheck_test.cpp
+++ b/src/engine/test/source/builder/builders/stageBuilderCheck_test.cpp
@@ -24,7 +24,7 @@ using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
 auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<json::Document>(json));
+    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
 };
 
 TEST(StageBuilderCheck, BuildsAllNonRegistered)
@@ -55,7 +55,7 @@ TEST(StageBuilderCheck, Builds)
     Registry::registerBuilder("helper.not_exists", c);
     c = bld::opBuilderCondition;
     Registry::registerBuilder("condition", c);
-    c = combinatorBuilderChain;
+    c = bld::combinatorBuilderChain;
     Registry::registerBuilder("combinator.chain", c);
 
     Document doc{R"({
@@ -90,17 +90,17 @@ TEST(StageBuilderCheck, BuildsOperates)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"({
+            s.on_next(createEvent(R"({
                 "field1": "value",
                 "field2": 2,
                 "field3": "value",
                 "field4": true,
                 "field5": "+exists"
             })"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":"values"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"({
+            s.on_next(createEvent(R"({
                 "field1": "value",
                 "field2": 2,
                 "field3": "value",
@@ -108,7 +108,7 @@ TEST(StageBuilderCheck, BuildsOperates)
                 "field5": "+exists",
                 "field6": "+exists"
             })"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"otherfield":1}
             )"));
             s.on_completed();

--- a/src/engine/test/source/builder/builders/stageBuilderNormalize_test.cpp
+++ b/src/engine/test/source/builder/builders/stageBuilderNormalize_test.cpp
@@ -22,10 +22,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
-};
-
 TEST(StageBuilderNormalize, BuildsAllNonRegistered)
 {
     Document doc{R"({
@@ -79,7 +75,7 @@ TEST(StageBuilderNormalize, BuildsOperates)
     Observable input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"({
+            s.on_next(createSharedEvent(R"({
                 "field1": "value",
                 "field2": 2,
                 "field3": "value",
@@ -87,10 +83,10 @@ TEST(StageBuilderNormalize, BuildsOperates)
                 "field5": "+exists"
             })"));
             // TODO: fix json interfaces to dont throw
-            // s.on_next(createEvent(R"(
+            // s.on_next(createSharedEvent(R"(
             //     {"field":"values"}
             // )"));
-            s.on_next(createEvent(R"({
+            s.on_next(createSharedEvent(R"({
                 "field1": "value",
                 "field2": 2,
                 "field3": "value",
@@ -98,7 +94,7 @@ TEST(StageBuilderNormalize, BuildsOperates)
                 "field5": "+exists",
                 "field6": "+exists"
             })"));
-            // s.on_next(createEvent(R"(
+            // s.on_next(createSharedEvent(R"(
             //     {"otherfield":1}
             // )"));
             s.on_completed();

--- a/src/engine/test/source/builder/builders/stageBuilderOutputs_test.cpp
+++ b/src/engine/test/source/builder/builders/stageBuilderOutputs_test.cpp
@@ -25,10 +25,6 @@ namespace bld = builder::internals::builders;
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
-};
-
 TEST(StageBuilderOutputs, BuildsAllNonRegistered)
 {
     Document doc{R"({
@@ -82,16 +78,16 @@ TEST(StageBuilderOutputs, BuildsOperates)
     auto input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(createEvent(R"(
+            s.on_next(createSharedEvent(R"(
                 {"field":"value"}
             )"));
             s.on_completed();

--- a/src/engine/test/source/builder/builders/stageBuilderOutputs_test.cpp
+++ b/src/engine/test/source/builder/builders/stageBuilderOutputs_test.cpp
@@ -19,10 +19,15 @@
 #include "opBuilderFileOutput.hpp"
 #include "stageBuilderOutputs.hpp"
 
-using namespace builder::internals::builders;
+using namespace base;
+namespace bld = builder::internals::builders;
 
 using FakeTrFn = std::function<void(std::string)>;
 static FakeTrFn tr = [](std::string msg){};
+
+auto createEvent = [](const char * json){
+    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
+};
 
 TEST(StageBuilderOutputs, BuildsAllNonRegistered)
 {
@@ -42,9 +47,9 @@ TEST(StageBuilderOutputs, BuildsAllNonRegistered)
 
 TEST(StageBuilderOutputs, Builds)
 {
-    BuilderVariant c = opBuilderFileOutput;
+    BuilderVariant c = bld::opBuilderFileOutput;
     Registry::registerBuilder("file", c);
-    c = combinatorBuilderBroadcast;
+    c = bld::combinatorBuilderBroadcast;
     Registry::registerBuilder("combinator.broadcast", c);
 
     Document doc{R"({
@@ -77,16 +82,16 @@ TEST(StageBuilderOutputs, BuildsOperates)
     auto input = observable<>::create<Event>(
         [=](auto s)
         {
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":"value"}
             )"));
-            s.on_next(std::make_shared<json::Document>(R"(
+            s.on_next(createEvent(R"(
                 {"field":"value"}
             )"));
             s.on_completed();

--- a/src/engine/test/source/builder/outputs/fileOutput_test.cpp
+++ b/src/engine/test/source/builder/outputs/fileOutput_test.cpp
@@ -15,7 +15,12 @@
 
 #include "test_utils.hpp"
 
-using namespace builder::internals;
+using namespace base;
+namespace bld = builder::internals;
+
+auto createEvent = [](const char * json){
+    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
+};
 
 auto messageStr = R"({
     "event": {
@@ -58,20 +63,20 @@ auto compact_message =
 
 TEST(FileOutput, Create)
 {
-    auto output = outputs::FileOutput("/tmp/file");
+    auto output = bld::outputs::FileOutput("/tmp/file");
     std::filesystem::remove("/tmp/file");
 }
 
 TEST(FileOutput, Unknown_path)
 {
-    ASSERT_THROW(outputs::FileOutput("/tmp45/file"), std::invalid_argument);
+    ASSERT_THROW(bld::outputs::FileOutput("/tmp45/file"), std::invalid_argument);
 }
 
 TEST(FileOutput, Write)
 {
     auto filepath = "/tmp/file";
-    auto msg = std::make_shared<json::Document>(messageStr);
-    auto output = outputs::FileOutput(filepath);
+    auto msg = createEvent(messageStr);
+    auto output = bld::outputs::FileOutput(filepath);
     output.write(msg);
 
     std::ifstream ifs(filepath);

--- a/src/engine/test/source/builder/outputs/fileOutput_test.cpp
+++ b/src/engine/test/source/builder/outputs/fileOutput_test.cpp
@@ -1,3 +1,6 @@
+#include <rxcpp/rx.hpp>
+#include <gtest/gtest.h>
+
 #include <algorithm>
 #include <chrono>
 #include <iostream>
@@ -8,19 +11,17 @@
 #include <fstream>
 #include <iostream>
 
-#include "outputs/file.hpp"
-#include "rxcpp/rx.hpp"
-#include "gtest/gtest.h"
 #include "json/json.hpp"
-
 #include "test_utils.hpp"
 
-using namespace base;
+#include "outputs/file.hpp"
+
 namespace bld = builder::internals;
 
-auto createEvent = [](const char * json){
-    return std::make_shared<EventHandler>(std::make_shared<Document>(json));
+auto createSharedEvent = [](const char * json){
+    return std::make_shared<base::EventHandler>(std::make_shared<base::Document>(json));
 };
+
 
 auto messageStr = R"({
     "event": {
@@ -75,7 +76,7 @@ TEST(FileOutput, Unknown_path)
 TEST(FileOutput, Write)
 {
     auto filepath = "/tmp/file";
-    auto msg = createEvent(messageStr);
+    auto msg = createSharedEvent(messageStr);
     auto output = bld::outputs::FileOutput(filepath);
     output.write(msg);
 

--- a/src/engine/test/source/builder/registry_test.cpp
+++ b/src/engine/test/source/builder/registry_test.cpp
@@ -40,7 +40,7 @@ TEST(Registry_test, GetNonExistentBuilder)
 TEST(Registry_test, GetBuilderAndBuilds)
 {
     auto buildB = std::get<types::OpBuilder>(Registry::getBuilder("test"));
-    types::Observable o = rxcpp::observable<>::empty<types::Event>();
-    types::Observable expected = buildB(Document(R"({"test":1})").get("/test"), tr)(o);
+    base::Observable o = rxcpp::observable<>::empty<base::Event>();
+    base::Observable expected = buildB(Document(R"({"test":1})").get("/test"), tr)(o);
     ASSERT_EQ(o, expected);
 }

--- a/src/engine/test/source/builder/registry_test.cpp
+++ b/src/engine/test/source/builder/registry_test.cpp
@@ -5,6 +5,8 @@
 #include "testUtils.hpp"
 #include <json.hpp>
 
+using namespace base;
+
 using FakeTrFn = std::function<void(std::string)>;
 FakeTrFn tr = [](std::string msg){};
 

--- a/src/engine/test/source/builder/testUtils.hpp
+++ b/src/engine/test/source/builder/testUtils.hpp
@@ -13,9 +13,10 @@
 // Shared dependencies for Builder module
 #include <rxcpp/rx.hpp>
 
+#include <baseTypes.hpp>
+
 #include "builderTypes.hpp"
 #include "registry.hpp"
-#include "json.hpp"
 
 #define GTEST_COUT std::cout << std::boolalpha << "[          ] [ INFO ] "
 
@@ -23,5 +24,9 @@ using namespace std;
 using namespace rxcpp;
 using namespace builder::internals;
 using namespace builder::internals::types;
+
+auto createSharedEvent = [](const char * json){
+    return std::make_shared<base::EventHandler>(std::make_shared<base::Document>(json));
+};
 
 #endif // _TEST_UTILS_H

--- a/src/engine/test/source/router/router_test.cpp
+++ b/src/engine/test/source/router/router_test.cpp
@@ -23,9 +23,6 @@ using namespace router;
 using document_t = base::Event;
 using documents_t = vector<document_t>;
 
-auto createEvent = [](const char * json){
-    return std::make_shared<base::EventHandler>(std::make_shared<base::Document>(json));
-};
 struct FakeServer
 {
     explicit FakeServer(const documents_t &documents, bool verbose = false)
@@ -136,14 +133,20 @@ TEST(RouterTest, RemoveNonExistentRoute)
 
 TEST(RouterTest, PassThroughSingleRoute)
 {
+
+    auto createSharedEvent = [](const char* json) {
+        return std::make_shared<base::EventHandler>(
+            std::make_shared<base::Document>(json));
+    };
+
     documents_t input {
-        createEvent(R"({
+        createSharedEvent(R"({
         "event": 1
     })"),
-        createEvent(R"({
+        createSharedEvent(R"({
         "event": 2
     })"),
-        createEvent(R"({
+        createSharedEvent(R"({
         "event": 3
     })"),
     };


### PR DESCRIPTION
|Related issue|
|---|
|#12633|

We need to align the semantics defined in our design document with the software we've created. Also, this software must be able to fit in the place of analysisd. Because of that, we've identified some friction points which we must address in order to operate within the rest of the Wazuh platform.

### Processing logic

Each graph node and each set of operations should behave as stated in the functional document. We need to implement some
logical combinations at the graph and operation levels. At least we need an exclusive or (XOR) ideally with a sorted list by the number of times an option has been selected.

We can implement this without own code, instead of using RXCPP primitives or combinators.