### PR TITLE
Add the capability to the main thread to push and pop structures from queues.

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -420,6 +420,7 @@ STATIC int wm_vuldet_compare_vendors(char * vendor);
  */
 STATIC void wm_vuldel_truncate_revision(char * revision);
 
+w_linked_queue_t *vu_msg_queue = NULL;
 time_t curr_time;
 int wdb_vuldet_sock = -1;
 int *vu_queue;
@@ -5196,6 +5197,15 @@ void *wm_vuldet_main(wm_vuldet_t * vuldet) {
         if ((curr_time - vuldet->last_scan >= vuldet->scan_interval)) {
             wm_vuldet_run_scan(vuldet);
         }
+
+        /* Checks for messages in the queue */
+        wm_vuldet_task_msg_ctx *data = (wm_vuldet_task_msg_ctx *)linked_queue_pop_ex_no_cond_wait(vu_msg_queue);
+        while(data) {
+            /* TODO: Dummy message that represent interaction with task manager */
+            minfo("Update status '%s' for task ID '%d'", task_statuses[data->task_status], data->task_id);
+            os_free(data);
+            data = (wm_vuldet_task_msg_ctx *)linked_queue_pop_ex_no_cond_wait(vu_msg_queue);
+        }
     }
 
     return NULL;
@@ -7807,6 +7817,8 @@ void wm_vuldet_init(wm_vuldet_t * vuldet) {
 
     /* Get node name of this manager in cluster */
     vuldet->node_name = get_node_name();
+
+    vu_msg_queue = linked_queue_init();
 }
 
 void wm_vuldet_update_last_scan(scan_ctx_t* scan_ctx) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -656,30 +656,19 @@ void vu_tasks_queue_pop_callback (void* data) {
     }
 }
 
-vu_task_ctx_t *create_task(const char *task_parameters,...) {
+vu_task_ctx_t *create_task(size_t task_id,
+                           vu_task_type_t task_type,
+                           task_status task_status,
+                           vu_feed feed_to_update,
+                           size_t agent_to_scan) {
     vu_task_ctx_t *task = NULL;
     os_calloc(1, sizeof(vu_task_ctx_t), task);
 
-    va_list args;
-    va_start(args, task_parameters);
-
-    size_t id = va_arg(args, size_t);
-    vu_task_type_t type = va_arg(args, vu_task_type_t);
-    task_status status = va_arg(args, task_status);
-
-    task->task_id = id;
-    task->task_type = type;
-    task->task_status = status;
-
-    if (type == VU_ON_DEMAND_SCAN) {
-        size_t agent_id = va_arg(args, size_t);
-        task->agent_to_scan = agent_id;
-    } else if (type == VU_INTERVAL_FEED_UPDATE) {
-        vu_feed dist_ref = va_arg(args, vu_feed);
-        task->feed_to_update = dist_ref;
-    }
-
-    va_end(args);
+    task->task_id = task_id;
+    task->task_type = task_type;
+    task->task_status = task_status;
+    task->feed_to_update = feed_to_update;
+    task->agent_to_scan = agent_to_scan;
 
     return task;
 }
@@ -4584,42 +4573,38 @@ end:
 }
 
 int wm_vuldet_check_feed(update_node *upd, int8_t *updated) {
-    if (wm_vuldet_check_update_period(upd)) {
-        vu_task_ctx_t *task = create_task("%lu %d %d %d", 1, VU_INTERVAL_FEED_UPDATE, WM_TASK_PENDING, upd->dist_ref);
-        linked_queue_push_ex(vu_tasks_queue, task);
+    if (!wm_vuldet_silent_feed(upd->dist_tag_ref)) {
+        mtinfo(WM_VULNDETECTOR_LOGTAG, VU_STARTING_UPDATE, vu_feed_ext[upd->dist_tag_ref]);
+    } else {
+        mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_STARTING_UPDATE, vu_feed_ext[upd->dist_tag_ref]);
+    }
+    if (wm_vuldet_update_feed(upd, updated)) {
+        if (!upd->attempted) {
+            upd->last_sync = time(NULL) - upd->interval + WM_VULNDETECTOR_RETRY_UPDATE;
+            upd->attempted = 1;
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UPDATE_RETRY, upd->dist, upd->version ? upd->version : "provider", (long unsigned)WM_VULNDETECTOR_RETRY_UPDATE);
+        } else {
+            upd->last_sync = time(NULL);
+            upd->attempted = 0;
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UPDATE_RETRY, upd->dist, upd->version ? upd->version : "provider", upd->interval);
+        }
+
+        if (upd->dist_tag_ref == FEED_CPEW) {
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_NVD_UPD_CANCEL, "Wazuh CPE Helper");
+            *updated = -1;
+        }
+
+        return OS_INVALID;
+    } else {
         if (!wm_vuldet_silent_feed(upd->dist_tag_ref)) {
-            mtinfo(WM_VULNDETECTOR_LOGTAG, VU_STARTING_UPDATE, vu_feed_ext[upd->dist_tag_ref]);
+            mtinfo(WM_VULNDETECTOR_LOGTAG, VU_ENDING_UPDATE, upd->dist_ext);
         } else {
             mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_STARTING_UPDATE, vu_feed_ext[upd->dist_tag_ref]);
         }
-        if (wm_vuldet_update_feed(upd, updated)) {
-            if (!upd->attempted) {
-                upd->last_sync = time(NULL) - upd->interval + WM_VULNDETECTOR_RETRY_UPDATE;
-                upd->attempted = 1;
-                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UPDATE_RETRY, upd->dist, upd->version ? upd->version : "provider", (long unsigned)WM_VULNDETECTOR_RETRY_UPDATE);
-            } else {
-                upd->last_sync = time(NULL);
-                upd->attempted = 0;
-                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UPDATE_RETRY, upd->dist, upd->version ? upd->version : "provider", upd->interval);
-            }
-
-            if (upd->dist_tag_ref == FEED_CPEW) {
-                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_NVD_UPD_CANCEL, "Wazuh CPE Helper");
-                *updated = -1;
-            }
-
-            return OS_INVALID;
-        } else {
-            if (!wm_vuldet_silent_feed(upd->dist_tag_ref)) {
-                mtinfo(WM_VULNDETECTOR_LOGTAG, VU_ENDING_UPDATE, upd->dist_ext);
-            } else {
-                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_STARTING_UPDATE, vu_feed_ext[upd->dist_tag_ref]);
-            }
-            upd->last_sync = time(NULL);
-            time_t last_feed_upd = wm_vuldet_get_last_feed_update(upd->dist_tag_ref);
-            if (last_feed_upd != -1) {
-                upd->last_update = last_feed_upd;
-            }
+        upd->last_sync = time(NULL);
+        time_t last_feed_upd = wm_vuldet_get_last_feed_update(upd->dist_tag_ref);
+        if (last_feed_upd != -1) {
+            upd->last_update = last_feed_upd;
         }
     }
     return 0;
@@ -4681,33 +4666,38 @@ int wm_vuldet_run_update(update_node **updates) {
 
     // Check updates for all the feeds
     for (int os = 0; os < OS_SUPP_SIZE; os++) {
-        if (!updates[os])
-            continue;
+        if (updates[os] && wm_vuldet_check_update_period(updates[os])) {
+            vu_task_ctx_t *task = create_task(OS_INVALID, VU_INTERVAL_FEED_UPDATE, WM_TASK_PENDING, updates[os]->dist_ref, 0);
+            if (OS_INVALID == register_task(task)) {
+                    mwarn("Couldn't establish communication with task manager. There's no ID for task");
+            }
+            linked_queue_push_ex(vu_tasks_queue, task);
 
-        // If none of RedHat's OVALs have been updated,
-        // we can deduce that the JSON is already up to date.
-        if (updates[os]->dist_ref == FEED_JREDHAT && up_status == 1) {
-            updates[os]->last_sync = time(NULL);
-            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UPDATE_DATE, vu_feed_ext[FEED_JREDHAT]);
-            continue;
-        }
-
-        if (wm_vuldet_check_feed(updates[os], &updated)) {
-            ret = OS_INVALID;
-            if (updated == -1) {
-                // The CPE helper update failed (updated is only set to -1 when evaluating the CPE helper)
-                wm_vuldet_release_update_node(updates, CPE_WDIC);
-                wm_vuldet_release_update_node(updates, CVE_NVD);
+            // If none of RedHat's OVALs have been updated,
+            // we can deduce that the JSON is already up to date.
+            if (updates[os]->dist_ref == FEED_JREDHAT && up_status == 1) {
+                updates[os]->last_sync = time(NULL);
+                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UPDATE_DATE, vu_feed_ext[FEED_JREDHAT]);
                 continue;
             }
-        }
 
-        /** @updated -> If the RHEL feed was successfully updated(1).
-        * +1 Represents the availability of the RHEL feeds. Otherwise we
-        * won't be capable of distinguishing between non available RHEL feeds, and
-        * available but up-to-date feeds. (In both cases @up_status would be 0).
-        **/
-        up_status |= (updates[os]->dist_ref == FEED_REDHAT)? updated + 1 : up_status;
+            if (wm_vuldet_check_feed(updates[os], &updated)) {
+                ret = OS_INVALID;
+                if (updated == -1) {
+                    // The CPE helper update failed (updated is only set to -1 when evaluating the CPE helper)
+                    wm_vuldet_release_update_node(updates, CPE_WDIC);
+                    wm_vuldet_release_update_node(updates, CVE_NVD);
+                    continue;
+                }
+            }
+
+            /** @updated -> If the RHEL feed was successfully updated(1).
+            * +1 Represents the availability of the RHEL feeds. Otherwise we
+            * won't be capable of distinguishing between non available RHEL feeds, and
+            * available but up-to-date feeds. (In both cases @up_status would be 0).
+            **/
+            up_status |= (updates[os]->dist_ref == FEED_REDHAT)? updated + 1 : up_status;
+        }
     }
 
     // Remove Debian status feed
@@ -5209,6 +5199,20 @@ end:
     return retval;
 }
 
+w_err_t register_task(vu_task_ctx_t *task) {
+    srand(time(NULL));
+
+    // TODO: Interaction with task manager to set information in the database
+    // and obtain a task ID.
+
+    // Generating a dummy task IDs from 1 to 10.
+    int id = rand() % 10 + 1;
+
+    task->task_id = id;
+
+    return OS_SUCCESS;
+}
+
 void *wm_vuldet_main(wm_vuldet_t * vuldet) {
     wm_vuldet_init(vuldet);
 
@@ -5216,7 +5220,7 @@ void *wm_vuldet_main(wm_vuldet_t * vuldet) {
 
     wm_vuldet_init_queues();
 
-    while (TRUE) {
+    while (true) {
         curr_time = time(NULL);
         // Update CVE databases
         if (vuldet->flags.update && wm_vuldet_run_update(vuldet->updates)) {
@@ -5225,7 +5229,10 @@ void *wm_vuldet_main(wm_vuldet_t * vuldet) {
 
         if ((curr_time - vuldet->last_scan >= vuldet->scan_interval)) {
             if (!VU_TASKS_QUEUE_FLAGS[VU_INTERVAL_SCAN]) {
-                vu_task_ctx_t *task = create_task("%lu %d %d", 1, VU_INTERVAL_SCAN, WM_TASK_PENDING);
+                vu_task_ctx_t *task = create_task(OS_INVALID, VU_INTERVAL_SCAN, WM_TASK_PENDING, 0, 0);
+                if (OS_INVALID == register_task(task)) {
+                    mwarn("Couldn't establish communication with task manager. There's no ID for task");
+                }
                 linked_queue_push_ex(vu_tasks_queue, task);
             } else {
                 vuldet->last_scan = curr_time;
@@ -5236,8 +5243,11 @@ void *wm_vuldet_main(wm_vuldet_t * vuldet) {
         /* Checks for messages in the queue */
         vu_task_message_ctx_t *msg = (vu_task_message_ctx_t *)linked_queue_pop_ex_no_cond_wait(vu_messages_queue);
         while(msg) {
-            /* TODO: Dummy message that represent interaction with task manager */
-            minfo("Task ID '%lu' status '%s' message '%s'", msg->task_id, task_statuses[msg->task_status], msg->status_message);
+            /* TODO: Dummy message that represents the interaction with the task manager */
+            minfo("Task ID: '%lu' status: '%s' message: '%s'", msg->task_id, task_statuses[msg->task_status], msg->status_message);
+            if (msg->status_message) {
+                os_free(msg->status_message);
+            }
             os_free(msg);
             msg = (vu_task_message_ctx_t *)linked_queue_pop_ex_no_cond_wait(vu_messages_queue);
         }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4615,14 +4615,6 @@ int wm_vuldet_check_feed(update_node *upd, int8_t *updated) {
             } else {
                 mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_STARTING_UPDATE, vu_feed_ext[upd->dist_tag_ref]);
             }
-
-            vu_task_message_ctx_t *msg = NULL;
-            os_calloc(1, sizeof(vu_task_message_ctx_t), msg);
-            msg->task_id = 1;
-            msg->task_status = WM_TASK_DONE;
-            msg->status_message = "Feed update finished";
-            linked_queue_push_ex(vu_messages_queue, msg);
-
             upd->last_sync = time(NULL);
             time_t last_feed_upd = wm_vuldet_get_last_feed_update(upd->dist_tag_ref);
             if (last_feed_upd != -1) {
@@ -5235,6 +5227,8 @@ void *wm_vuldet_main(wm_vuldet_t * vuldet) {
             if (!VU_TASKS_QUEUE_FLAGS[VU_INTERVAL_SCAN]) {
                 vu_task_ctx_t *task = create_task("%lu %d %d", 1, VU_INTERVAL_SCAN, WM_TASK_PENDING);
                 linked_queue_push_ex(vu_tasks_queue, task);
+            } else {
+                vuldet->last_scan = curr_time;
             }
             wm_vuldet_run_scan(vuldet);
         }
@@ -5246,14 +5240,6 @@ void *wm_vuldet_main(wm_vuldet_t * vuldet) {
             minfo("Task ID '%lu' status '%s' message '%s'", msg->task_id, task_statuses[msg->task_status], msg->status_message);
             os_free(msg);
             msg = (vu_task_message_ctx_t *)linked_queue_pop_ex_no_cond_wait(vu_messages_queue);
-        }
-
-        /* Checks for tasks in the queue */
-        vu_task_ctx_t *task = (vu_task_ctx_t *)linked_queue_pop_ex_no_cond_wait(vu_tasks_queue);
-        while(task) {
-            minfo("Task ID '%lu' status '%s' type: '%d'", task->task_id, task_statuses[task->task_status], task->task_type);
-            os_free(task);
-            task = (vu_task_ctx_t *)linked_queue_pop_ex_no_cond_wait(vu_messages_queue);
         }
     }
 
@@ -7819,13 +7805,6 @@ void wm_vuldet_run_scan(wm_vuldet_t *vuldet) {
             break;
         }
     }
-
-    vu_task_message_ctx_t *msg = NULL;
-    os_calloc(1, sizeof(vu_task_message_ctx_t), msg);
-    msg->task_id = 1;
-    msg->task_status = WM_TASK_DONE;
-    msg->status_message = "Scan finished";
-    linked_queue_push_ex(vu_messages_queue, msg);
 
     vuldet->scan_agents = NULL;
     vuldet->last_scan = time(NULL);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -338,7 +338,6 @@ STATIC cJSON *wm_vuldet_json_fread(char *json_file);
 STATIC cJSON *wm_vuldet_get_cvss(const char *scoring_vector);
 STATIC int wm_vuldet_get_term_condition(char *i_term, char **term, char **comp_field, char **condition);
 STATIC void wm_vuldet_run_scan(wm_vuldet_t *vuldet);
-STATIC void wm_vuldet_run_sleep(wm_vuldet_t *vuldet);
 STATIC void wm_vuldet_init(wm_vuldet_t *vuldet);
 STATIC void wm_vuldet_update_last_scan(scan_ctx_t* scan_ctx);
 STATIC char *wm_vuldet_normalize_date(char **date);
@@ -5197,8 +5196,6 @@ void *wm_vuldet_main(wm_vuldet_t * vuldet) {
         if ((curr_time - vuldet->last_scan >= vuldet->scan_interval)) {
             wm_vuldet_run_scan(vuldet);
         }
-
-        wm_vuldet_run_sleep(vuldet);
     }
 
     return NULL;
@@ -7766,37 +7763,6 @@ void wm_vuldet_run_scan(wm_vuldet_t *vuldet) {
 
     vuldet->scan_agents = NULL;
     vuldet->last_scan = time(NULL);
-
-}
-
-void wm_vuldet_run_sleep(wm_vuldet_t * vuldet) {
-    time_t t_now = time(NULL);
-    time_t time_sleep = (vuldet->last_scan + vuldet->scan_interval) - t_now;
-    int i;
-
-    if (time_sleep <= 0) {
-        time_sleep = 1;
-        i = OS_SUPP_SIZE;
-    } else {
-        i = 0;
-    }
-
-    // Check the remaining time for all updates and adjust the sleep time
-    for (; i < OS_SUPP_SIZE; i++) {
-        if (vuldet->updates[i]) {
-            time_t t_diff = (vuldet->updates[i]->last_sync + vuldet->updates[i]->interval) - t_now;
-            // Stop checking if we have any pending updates
-            if (t_diff <= 0) {
-                time_sleep = 1;
-                break;
-            } else if (t_diff < time_sleep) {
-                time_sleep = t_diff;
-            }
-        }
-    }
-
-    mtdebug2(WM_VULNDETECTOR_LOGTAG, "Sleeping for %lu seconds...", time_sleep);
-    sleep(time_sleep);
 }
 
 void wm_vuldet_init(wm_vuldet_t * vuldet) {
@@ -7821,7 +7787,6 @@ void wm_vuldet_init(wm_vuldet_t * vuldet) {
     SSL_load_error_strings();
     OpenSSL_add_all_algorithms();
 
-
     for (i = 0; SSL_library_init() < 0 && i < WM_MAX_ATTEMPTS; i++) {
         sleep(WM_MAX_WAIT);
     }
@@ -7832,14 +7797,12 @@ void wm_vuldet_init(wm_vuldet_t * vuldet) {
     }
 
     if (!flags->run_on_start) {
-        time_t time_sleep = vuldet->scan_interval;
+        vuldet->last_scan = time(NULL);
         for (i = 0; i < OS_SUPP_SIZE; i++) {
-            if (vuldet->updates[i] && (vuldet->updates[i]->interval < time_sleep)) {
-                time_sleep = vuldet->updates[i]->interval;
+            if (vuldet->updates[i]) {
+                vuldet->updates[i]->last_sync = time(NULL);
             }
         }
-        // Initial sleep
-        sleep(time_sleep);
     }
 
     /* Get node name of this manager in cluster */

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -656,6 +656,34 @@ void vu_tasks_queue_pop_callback (void* data) {
     }
 }
 
+vu_task_ctx_t *create_task(const char *task_parameters,...) {
+    vu_task_ctx_t *task = NULL;
+    os_calloc(1, sizeof(vu_task_ctx_t), task);
+
+    va_list args;
+    va_start(args, task_parameters);
+
+    size_t id = va_arg(args, size_t);
+    vu_task_type_t type = va_arg(args, vu_task_type_t);
+    task_status status = va_arg(args, task_status);
+
+    task->task_id = id;
+    task->task_type = type;
+    task->task_status = status;
+
+    if (type == VU_ON_DEMAND_SCAN) {
+        size_t agent_id = va_arg(args, size_t);
+        task->agent_to_scan = agent_id;
+    } else if (type == VU_INTERVAL_FEED_UPDATE) {
+        vu_feed dist_ref = va_arg(args, vu_feed);
+        task->feed_to_update = dist_ref;
+    }
+
+    va_end(args);
+
+    return task;
+}
+
 vu_feed wm_vuldet_set_allowed_feed(const char *os_name, const char *os_version, update_node **updates, vu_feed *agent_dist) {
     vu_feed retval = FEED_UNKNOWN;
     int i;
@@ -4557,6 +4585,8 @@ end:
 
 int wm_vuldet_check_feed(update_node *upd, int8_t *updated) {
     if (wm_vuldet_check_update_period(upd)) {
+        vu_task_ctx_t *task = create_task("%lu %d %d %d", 1, VU_INTERVAL_FEED_UPDATE, WM_TASK_PENDING, upd->dist_ref);
+        linked_queue_push_ex(vu_tasks_queue, task);
         if (!wm_vuldet_silent_feed(upd->dist_tag_ref)) {
             mtinfo(WM_VULNDETECTOR_LOGTAG, VU_STARTING_UPDATE, vu_feed_ext[upd->dist_tag_ref]);
         } else {
@@ -4585,6 +4615,14 @@ int wm_vuldet_check_feed(update_node *upd, int8_t *updated) {
             } else {
                 mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_STARTING_UPDATE, vu_feed_ext[upd->dist_tag_ref]);
             }
+
+            vu_task_message_ctx_t *msg = NULL;
+            os_calloc(1, sizeof(vu_task_message_ctx_t), msg);
+            msg->task_id = 1;
+            msg->task_status = WM_TASK_DONE;
+            msg->status_message = "Feed update finished";
+            linked_queue_push_ex(vu_messages_queue, msg);
+
             upd->last_sync = time(NULL);
             time_t last_feed_upd = wm_vuldet_get_last_feed_update(upd->dist_tag_ref);
             if (last_feed_upd != -1) {
@@ -5194,16 +5232,28 @@ void *wm_vuldet_main(wm_vuldet_t * vuldet) {
         }
 
         if ((curr_time - vuldet->last_scan >= vuldet->scan_interval)) {
+            if (!VU_TASKS_QUEUE_FLAGS[VU_INTERVAL_SCAN]) {
+                vu_task_ctx_t *task = create_task("%lu %d %d", 1, VU_INTERVAL_SCAN, WM_TASK_PENDING);
+                linked_queue_push_ex(vu_tasks_queue, task);
+            }
             wm_vuldet_run_scan(vuldet);
         }
 
         /* Checks for messages in the queue */
-        vu_task_message_ctx *data = (vu_task_message_ctx *)linked_queue_pop_ex_no_cond_wait(vu_messages_queue);
-        while(data) {
+        vu_task_message_ctx_t *msg = (vu_task_message_ctx_t *)linked_queue_pop_ex_no_cond_wait(vu_messages_queue);
+        while(msg) {
             /* TODO: Dummy message that represent interaction with task manager */
-            minfo("Update status '%s' for task ID '%d'", task_statuses[data->task_status], data->task_id);
-            os_free(data);
-            data = (vu_task_message_ctx *)linked_queue_pop_ex_no_cond_wait(vu_messages_queue);
+            minfo("Task ID '%lu' status '%s' message '%s'", msg->task_id, task_statuses[msg->task_status], msg->status_message);
+            os_free(msg);
+            msg = (vu_task_message_ctx_t *)linked_queue_pop_ex_no_cond_wait(vu_messages_queue);
+        }
+
+        /* Checks for tasks in the queue */
+        vu_task_ctx_t *task = (vu_task_ctx_t *)linked_queue_pop_ex_no_cond_wait(vu_tasks_queue);
+        while(task) {
+            minfo("Task ID '%lu' status '%s' type: '%d'", task->task_id, task_statuses[task->task_status], task->task_type);
+            os_free(task);
+            task = (vu_task_ctx_t *)linked_queue_pop_ex_no_cond_wait(vu_messages_queue);
         }
     }
 
@@ -7769,6 +7819,13 @@ void wm_vuldet_run_scan(wm_vuldet_t *vuldet) {
             break;
         }
     }
+
+    vu_task_message_ctx_t *msg = NULL;
+    os_calloc(1, sizeof(vu_task_message_ctx_t), msg);
+    msg->task_id = 1;
+    msg->task_status = WM_TASK_DONE;
+    msg->status_message = "Scan finished";
+    linked_queue_push_ex(vu_messages_queue, msg);
 
     vuldet->scan_agents = NULL;
     vuldet->last_scan = time(NULL);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -656,11 +656,11 @@ void vu_tasks_queue_pop_callback (void* data) {
     }
 }
 
-vu_task_ctx_t *create_task(size_t task_id,
-                           vu_task_type_t task_type,
-                           task_status task_status,
-                           vu_feed feed_to_update,
-                           size_t agent_to_scan) {
+vu_task_ctx_t *create_task(const int task_id,
+                           const vu_task_type_t task_type,
+                           const task_status task_status,
+                           const vu_feed feed_to_update,
+                           const int agent_to_scan) {
     vu_task_ctx_t *task = NULL;
     os_calloc(1, sizeof(vu_task_ctx_t), task);
 
@@ -671,6 +671,13 @@ vu_task_ctx_t *create_task(size_t task_id,
     task->agent_to_scan = agent_to_scan;
 
     return task;
+}
+
+void task_message_free(vu_task_message_ctx_t *msg) {
+    if (msg->status_message) {
+        os_free(msg->status_message);
+    }
+    os_free(msg);
 }
 
 vu_feed wm_vuldet_set_allowed_feed(const char *os_name, const char *os_version, update_node **updates, vu_feed *agent_dist) {
@@ -4667,9 +4674,9 @@ int wm_vuldet_run_update(update_node **updates) {
     // Check updates for all the feeds
     for (int os = 0; os < OS_SUPP_SIZE; os++) {
         if (updates[os] && wm_vuldet_check_update_period(updates[os])) {
-            vu_task_ctx_t *task = create_task(OS_INVALID, VU_INTERVAL_FEED_UPDATE, WM_TASK_PENDING, updates[os]->dist_ref, 0);
+            vu_task_ctx_t *task = create_task(OS_INVALID, VU_INTERVAL_FEED_UPDATE, WM_TASK_PENDING, updates[os]->dist_ref, OS_INVALID);
             if (OS_INVALID == register_task(task)) {
-                    mwarn("Couldn't establish communication with task manager. There's no ID for task");
+                mwarn("Couldn't establish communication with task manager. There's no ID for task");
             }
             linked_queue_push_ex(vu_tasks_queue, task);
 
@@ -5204,10 +5211,8 @@ w_err_t register_task(vu_task_ctx_t *task) {
 
     // TODO: Interaction with task manager to set information in the database
     // and obtain a task ID.
-
     // Generating a dummy task IDs from 1 to 10.
     int id = rand() % 10 + 1;
-
     task->task_id = id;
 
     return OS_SUCCESS;
@@ -5229,7 +5234,7 @@ void *wm_vuldet_main(wm_vuldet_t * vuldet) {
 
         if ((curr_time - vuldet->last_scan >= vuldet->scan_interval)) {
             if (!VU_TASKS_QUEUE_FLAGS[VU_INTERVAL_SCAN]) {
-                vu_task_ctx_t *task = create_task(OS_INVALID, VU_INTERVAL_SCAN, WM_TASK_PENDING, 0, 0);
+                vu_task_ctx_t *task = create_task(OS_INVALID, VU_INTERVAL_SCAN, WM_TASK_PENDING, FEED_UNKNOWN, OS_INVALID);
                 if (OS_INVALID == register_task(task)) {
                     mwarn("Couldn't establish communication with task manager. There's no ID for task");
                 }
@@ -5244,11 +5249,8 @@ void *wm_vuldet_main(wm_vuldet_t * vuldet) {
         vu_task_message_ctx_t *msg = (vu_task_message_ctx_t *)linked_queue_pop_ex_no_cond_wait(vu_messages_queue);
         while(msg) {
             /* TODO: Dummy message that represents the interaction with the task manager */
-            minfo("Task ID: '%lu' status: '%s' message: '%s'", msg->task_id, task_statuses[msg->task_status], msg->status_message);
-            if (msg->status_message) {
-                os_free(msg->status_message);
-            }
-            os_free(msg);
+            minfo("Task ID: '%d' status: '%s' message: '%s'", msg->task_id, task_statuses[msg->task_status], msg->status_message);
+            task_message_free(msg);
             msg = (vu_task_message_ctx_t *)linked_queue_pop_ex_no_cond_wait(vu_messages_queue);
         }
     }
@@ -8660,13 +8662,10 @@ void wm_vuldet_init_queues() {
     vu_tasks_queue = linked_queue_init(vu_tasks_queue_push_callback, vu_tasks_queue_pop_callback);
     vu_messages_queue = linked_queue_init(NULL, NULL);
 
-    if (!vu_tasks_queue) {
-        merror("Unable to create the tasks queue for vulnerability detector.");
-        pthread_exit(NULL);
-    }
-
-    if (!vu_messages_queue) {
-        merror("Unable to create the messages queue for vulnerability detector.");
+    if (!vu_tasks_queue || !vu_messages_queue) {
+        merror("Unable to initialize queues for vulnerability detector.");
+        linked_queue_free(vu_tasks_queue);
+        linked_queue_free(vu_messages_queue);
         pthread_exit(NULL);
     }
 }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -87,7 +87,7 @@ STATIC void wm_vuldet_add_vulnerability_info(wm_vuldet_db *ctrl_block);
 STATIC void wm_vuldet_clean_vulnerability_info(wm_vuldet_db *ctrl_block);
 
 STATIC references *wm_vuldet_extract_advisories(cJSON *advisories);
-STATIC int wm_vuldet_check_db();
+STATIC void wm_vuldet_check_db();
 
 /**
  * @brief Insert the CVEs information, fetched from the feeds, into VULNERABILITIES_INFO table.
@@ -420,13 +420,13 @@ STATIC int wm_vuldet_compare_vendors(char * vendor);
  */
 STATIC void wm_vuldel_truncate_revision(char * revision);
 
-w_linked_queue_t *vu_msg_queue = NULL;
 time_t curr_time;
 int wdb_vuldet_sock = -1;
 int *vu_queue;
 // Define time to sleep between messages sent
 int usec;
 
+w_linked_queue_t *vu_messages_queue = NULL;
 w_linked_queue_t* vu_tasks_queue = NULL;
 
 const wm_context WM_VULNDETECTOR_CONTEXT = {
@@ -646,13 +646,13 @@ bool VU_TASKS_QUEUE_FLAGS[VU_TASK_TYPES_SIZE] = {0};
 
 void vu_tasks_queue_push_callback (void* data) {
     if (data) {
-        VU_TASKS_QUEUE_FLAGS[((vu_task_context_t*)data)->task_type] = true;
+        VU_TASKS_QUEUE_FLAGS[((vu_task_ctx_t*)data)->task_type] = true;
     }
 }
 
 void vu_tasks_queue_pop_callback (void* data) {
     if (data) {
-        VU_TASKS_QUEUE_FLAGS[((vu_task_context_t*)data)->task_type] = false;
+        VU_TASKS_QUEUE_FLAGS[((vu_task_ctx_t*)data)->task_type] = false;
     }
 }
 
@@ -3304,12 +3304,11 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
     return 0;
 }
 
-int wm_vuldet_check_db() {
+void wm_vuldet_check_db() {
     if (wm_vuldet_create_file(CVE_DB, schema_vuln_detector_sql)) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_INVALID_DB_INT);
         pthread_exit(NULL);
     }
-    return 0;
 }
 
 void wm_vuldet_add_vulnerability_info(wm_vuldet_db *ctrl_block) {
@@ -5185,7 +5184,7 @@ void *wm_vuldet_main(wm_vuldet_t * vuldet) {
 
     wm_vuldet_check_db();
 
-    wm_vuldet_init_queue();
+    wm_vuldet_init_queues();
 
     while (TRUE) {
         curr_time = time(NULL);
@@ -5199,12 +5198,12 @@ void *wm_vuldet_main(wm_vuldet_t * vuldet) {
         }
 
         /* Checks for messages in the queue */
-        wm_vuldet_task_msg_ctx *data = (wm_vuldet_task_msg_ctx *)linked_queue_pop_ex_no_cond_wait(vu_msg_queue);
+        vu_task_message_ctx *data = (vu_task_message_ctx *)linked_queue_pop_ex_no_cond_wait(vu_messages_queue);
         while(data) {
             /* TODO: Dummy message that represent interaction with task manager */
             minfo("Update status '%s' for task ID '%d'", task_statuses[data->task_status], data->task_id);
             os_free(data);
-            data = (wm_vuldet_task_msg_ctx *)linked_queue_pop_ex_no_cond_wait(vu_msg_queue);
+            data = (vu_task_message_ctx *)linked_queue_pop_ex_no_cond_wait(vu_messages_queue);
         }
     }
 
@@ -7817,8 +7816,6 @@ void wm_vuldet_init(wm_vuldet_t * vuldet) {
 
     /* Get node name of this manager in cluster */
     vuldet->node_name = get_node_name();
-
-    vu_msg_queue = linked_queue_init();
 }
 
 void wm_vuldet_update_last_scan(scan_ctx_t* scan_ctx) {
@@ -8613,15 +8610,19 @@ int wm_vuldet_get_software(int agent_id, bool not_triaged, cJSON** requested_ite
     return result;
 }
 
-int wm_vuldet_init_queue() {
+void wm_vuldet_init_queues() {
     vu_tasks_queue = linked_queue_init(vu_tasks_queue_push_callback, vu_tasks_queue_pop_callback);
+    vu_messages_queue = linked_queue_init(NULL, NULL);
 
     if (!vu_tasks_queue) {
-        mwarn("Unable to create the tasks queue for vulnerability detector.");
-        return OS_INVALID;
+        merror("Unable to create the tasks queue for vulnerability detector.");
+        pthread_exit(NULL);
     }
 
-    return OS_SUCCESS;
+    if (!vu_messages_queue) {
+        merror("Unable to create the messages queue for vulnerability detector.");
+        pthread_exit(NULL);
+    }
 }
 
 #endif

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -926,11 +926,27 @@ void wm_vuldet_init_queues();
 /**
  * @brief Creates a task context to be scheduled in the task queue.
  *
- * @param task_parameters
- * @param ...
+ * @param task_id Task identifier. Must be unique.
+ * @param task_type Specifies whether the task is a feed update or a scan
+ *                  and whether is triggered by interval or on demand.
+ * @param task_status Status of the task.
+ * @param feed_to_update Feed vendor identifier.
+ * @param agent_to_scan Agent identifier.
  * @return A task object on success. NULL on error.
  */
-vu_task_ctx_t *create_task(const char *task_parameters,...);
+vu_task_ctx_t *create_task(size_t task_id,
+                           vu_task_type_t task_type,
+                           task_status task_status,
+                           vu_feed feed_to_update,
+                           size_t agent_to_scan);
+
+/**
+ * @brief Sends information to the task manager and receives a task ID.
+ *
+ * @param task Task which needs to update its task ID.
+ * @return w_err_t OS_SUCCESS if the communication was successfully established. OS_INVALID otherwise.
+ */
+w_err_t register_task(vu_task_ctx_t *task);
 
 /**
  * @brief Correlate OVAL and NVD feeds for a more fine tuned result.

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -344,16 +344,16 @@ typedef enum package_tags {
 
 // Task context for vu_tasks_queue
 typedef struct vu_task_ctx_t {
-    size_t task_id;
+    int task_id;
     vu_task_type_t task_type;
     task_status task_status;
     vu_feed feed_to_update;
-    size_t agent_to_scan;
+    int agent_to_scan;
 } vu_task_ctx_t;
 
 // Message task context for vu_messages_queue
 typedef struct vu_task_message_ctx_t {
-    size_t task_id;
+    int task_id;
     task_status task_status;
     char *status_message;
 } vu_task_message_ctx_t;
@@ -934,11 +934,18 @@ void wm_vuldet_init_queues();
  * @param agent_to_scan Agent identifier.
  * @return A task object on success. NULL on error.
  */
-vu_task_ctx_t *create_task(size_t task_id,
-                           vu_task_type_t task_type,
-                           task_status task_status,
-                           vu_feed feed_to_update,
-                           size_t agent_to_scan);
+vu_task_ctx_t *create_task(const int task_id,
+                           const vu_task_type_t task_type,
+                           const task_status task_status,
+                           const vu_feed feed_to_update,
+                           const int agent_to_scan);
+
+/**
+ * @brief Free memory taken by a task message.
+ *
+ * @param msg Struct to be freed.
+ */
+void task_message_free(vu_task_message_ctx_t *msg);
 
 /**
  * @brief Sends information to the task manager and receives a task ID.

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -133,20 +133,20 @@ typedef enum vu_task_type_t {
     VU_TASK_TYPES_SIZE // This should be the last constant
 } vu_task_type_t;
 
-// Status of tasks in vu_tasks_queue
-typedef enum vu_task_status_t {
-    VU_TASK_STATUS_VALID,
-    VU_TASK_STATUS_CANCELLED
-} vu_task_status_t;
-
 // Task context for vu_tasks_queue
-typedef struct vu_task_context_t {
+typedef struct vu_task_ctx_t {
     size_t taskID;
     vu_task_type_t task_type;
-    vu_task_status_t task_status;
+    task_status task_status;
     char* feed_to_update;
     int agent_to_scan;
-} vu_task_context_t;
+} vu_task_ctx_t;
+
+typedef struct vu_task_message_ctx_t {
+    int task_id;
+    task_status task_status;
+    char *status_message;
+} vu_task_message_ctx;
 
 void vu_tasks_queue_push_callback (void* data);
 void vu_tasks_queue_pop_callback (void* data);
@@ -502,12 +502,6 @@ typedef struct wm_vuldet_t {
     wm_vuldet_state state;
     wm_vuldet_flags flags;
 } wm_vuldet_t;
-
-typedef struct wm_vuldet_task_msg_ctx {
-    int task_id;
-    task_status task_status;
-    char *status_message;
-} wm_vuldet_task_msg_ctx;
 
 typedef enum {
     V_START,
@@ -922,8 +916,11 @@ void wm_vuldet_free_nvd_node(nvd_vulnerability *data);
 void wm_vuldet_free_nvd_list(nvd_vulnerability *nvd_it);
 const char *wm_vuldet_get_unified_severity(char *severity);
 
-// Initialize tasks queue
-int wm_vuldet_init_queue();
+/**
+ * @brief Initializes global tasks and messages queue.
+ * Vulnerability detector thread finalizes execution on error.
+ */
+void wm_vuldet_init_queues();
 
 /**
  * @brief Correlate OVAL and NVD feeds for a more fine tuned result.

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -133,21 +133,6 @@ typedef enum vu_task_type_t {
     VU_TASK_TYPES_SIZE // This should be the last constant
 } vu_task_type_t;
 
-// Task context for vu_tasks_queue
-typedef struct vu_task_ctx_t {
-    size_t taskID;
-    vu_task_type_t task_type;
-    task_status task_status;
-    char* feed_to_update;
-    int agent_to_scan;
-} vu_task_ctx_t;
-
-typedef struct vu_task_message_ctx_t {
-    int task_id;
-    task_status task_status;
-    char *status_message;
-} vu_task_message_ctx;
-
 void vu_tasks_queue_push_callback (void* data);
 void vu_tasks_queue_pop_callback (void* data);
 
@@ -356,6 +341,22 @@ typedef enum package_tags {
     PACKAGE_REFERENCE,
     PACKAGE_TYPE,
 } package_tags;
+
+// Task context for vu_tasks_queue
+typedef struct vu_task_ctx_t {
+    size_t task_id;
+    vu_task_type_t task_type;
+    task_status task_status;
+    vu_feed feed_to_update;
+    size_t agent_to_scan;
+} vu_task_ctx_t;
+
+// Message task context for vu_messages_queue
+typedef struct vu_task_message_ctx_t {
+    size_t task_id;
+    task_status task_status;
+    char *status_message;
+} vu_task_message_ctx_t;
 
 typedef struct cve_vuln_cond_NVD {
     int id;
@@ -921,6 +922,15 @@ const char *wm_vuldet_get_unified_severity(char *severity);
  * Vulnerability detector thread finalizes execution on error.
  */
 void wm_vuldet_init_queues();
+
+/**
+ * @brief Creates a task context to be scheduled in the task queue.
+ *
+ * @param task_parameters
+ * @param ...
+ * @return A task object on success. NULL on error.
+ */
+vu_task_ctx_t *create_task(const char *task_parameters,...);
 
 /**
  * @brief Correlate OVAL and NVD feeds for a more fine tuned result.


### PR DESCRIPTION
|Related issue|
|---|
|#13128|

## Description

This PR changes the behavior of the main thread:
- The thread doesn't sleep between scan or feed updates. 
- Reads messages from a message queue to interact, later, with the task manager.
- Pushes task context structures to be popped by the working thread. 


## DoD

![image](https://user-images.githubusercontent.com/13010397/165401473-7921b088-7298-4746-86d8-bb97acf6aff3.png)

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Source upgrade
- [X] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report