### PR TITLE
Fixing memory leaks in the ciscat unit tests caused by the new `ciscat_binary` variable in the module context structure

### DIFF
--- a/src/unit_tests/wazuh_modules/ciscat/test_wm_ciscat.c
+++ b/src/unit_tests/wazuh_modules/ciscat/test_wm_ciscat.c
@@ -38,15 +38,16 @@ static void wmodule_cleanup(wmodule *module){
     while(eval != 0) {
         wm_ciscat_eval *aux = eval;
         eval = eval->next;
-        free(aux->profile);
-        free(aux->path);
-        free(aux);
+        os_free(aux->profile);
+        os_free(aux->path);
+        os_free(aux);
     }
-    free(module_data->ciscat_path);
-    free(module_data->java_path);
-    free(module_data);
-    free(module->tag);
-    free(module);
+    os_free(module_data->ciscat_binary);
+    os_free(module_data->ciscat_path);
+    os_free(module_data->java_path);
+    os_free(module_data);
+    os_free(module->tag);
+    os_free(module);
 }
 
 /***  SETUPS/TEARDOWNS  ******/
@@ -100,7 +101,10 @@ static int teardown_test_read(void **state) {
     OS_ClearNode(test->nodes);
     OS_ClearXML(&(test->xml));
     wm_ciscat *module_data = (wm_ciscat*)test->module->data;
-    sched_scan_free(&(module_data->scan_config));
+    if (module_data) {
+        os_free(module_data->ciscat_binary);
+        sched_scan_free(&(module_data->scan_config));
+    }
     wmodule_cleanup(test->module);
     os_free(test);
     return 0;

--- a/src/unit_tests/wazuh_modules/ciscat/test_wm_ciscat.c
+++ b/src/unit_tests/wazuh_modules/ciscat/test_wm_ciscat.c
@@ -25,6 +25,7 @@
 #include "../../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../../wrappers/wazuh/shared/file_op_wrappers.h"
 #include "../../wrappers/wazuh/shared/randombytes_wrappers.h"
+#include "../../wrappers/wazuh/shared/mq_op_wrappers.h"
 
 #define TEST_MAX_DATES 5
 
@@ -59,7 +60,7 @@ static int setup_module() {
         "<interval>3m</interval>\n"
         "<scan-on-start>no</scan-on-start>\n"
         "<java_path>/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/bin</java_path>\n"
-        "<ciscat_path>wodles/ciscat</ciscat_path>\n"
+        "<ciscat_path>/var/ossec/wodles/ciscat</ciscat_path>\n"
         "<content type=\"xccdf\" path=\"benchmarks/CIS_Ubuntu_Linux_16.04_LTS_Benchmark_v1.0.0-xccdf.xml\">\n"
         "    <profile>xccdf_org.cisecurity.benchmarks_profile_Level_2_-_Server</profile>\n"
         "</content>\n"
@@ -120,10 +121,14 @@ void test_interval_execution(void **state) {
     module_data->scan_config.interval = 120; // 2min
     module_data->scan_config.month_interval = false;
 
+    expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
+    expect_value(__wrap_StartMQ, type, WRITE);
+    will_return(__wrap_StartMQ, 0);
     expect_string(__wrap_IsDir, file, "/var/ossec/wodles/ciscat");
     will_return(__wrap_IsDir, 0);
     will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
     will_return(__wrap_FOREVER, 0);
+    will_return_always(__wrap_os_random, 12345);
     expect_string_count(__wrap__mterror, tag, "wazuh-modulesd:ciscat", TEST_MAX_DATES + 1);
     expect_string_count(__wrap__mterror, formatted_msg, "Benchmark file '/var/ossec/wodles/ciscat/benchmarks/CIS_Ubuntu_Linux_16.04_LTS_Benchmark_v1.0.0-xccdf.xml' not found.", TEST_MAX_DATES + 1);
     expect_any_always(__wrap__mtinfo, tag);
@@ -257,8 +262,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_read_scheduling_daytime_configuration, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_read_scheduling_interval_configuration, setup_test_read, teardown_test_read)
     };
-    int result;
-    result = cmocka_run_group_tests(tests_with_startup, setup_module, teardown_module);
-    result &= cmocka_run_group_tests(tests_without_startup, NULL, NULL);
+    int result = (cmocka_run_group_tests(tests_with_startup, setup_module, teardown_module) ||
+                  cmocka_run_group_tests(tests_without_startup, NULL, NULL));
     return result;
 }


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/13215 |

## Description

This pull request fixes some memory leaks reported by the **ciscat** unit tests because of the addition of the new `ciscat_binary` variable in the module context structure. This variable is set during the module initialization and was not properly released in the tests' teardown.

In addition, it was discovered that a group of tests was failing but not reported by Jenkins. This was because the `result` of the first group of tests was overridden by the result of the second group of tests. After fixing this, we had to update the tests to make it work properly.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Fixed unit tests