### PR TITLE
Fix FIM directory configuration fallback to real-time

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -450,7 +450,7 @@
 #define FIM_ERROR_WHODATA_AUDIT_SUPPORT             "(6620): Audit support not built. Whodata is not available."
 #define FIM_ERROR_WHODATA_EVENTCHANNEL              "(6621): Event Channel subscription could not be made. Whodata scan is disabled."
 #define FIM_ERROR_WHODATA_RESTORE_POLICIES          "(6622): There is no backup of audit policies. Policies will not be restored."
-
+#define FIM_ERROR_WHODATA_UNINITIALIZED             "(6623): Trying to monitor '%s' in who-data mode, but who-data is not initialized."
 
 #define FIM_ERROR_WHODATA_NOTFIND_DIRPOS            "(6625): The '%s' file does not have an associated directory."
 #define FIM_ERROR_WHODATA_HANDLER_REMOVE            "(6626): The handler '%s' could not be removed from the whodata hash table."

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -294,6 +294,15 @@ int main(int argc, char **argv)
                     dir_it->options |= REALTIME_ACTIVE;
                 }
             }
+
+            OSList_foreach(node_it, syscheck.wildcards) {
+                dir_it = node_it->data;
+                if (dir_it->options & WHODATA_ACTIVE) {
+                    dir_it->options &= ~WHODATA_ACTIVE;
+                    dir_it->options |= REALTIME_ACTIVE;
+                }
+            }
+
             w_mutex_lock(&syscheck.fim_realtime_mutex);
             if (syscheck.realtime == NULL) {
                 realtime_start();

--- a/src/syscheckd/whodata/audit_rule_handling.c
+++ b/src/syscheckd/whodata/audit_rule_handling.c
@@ -32,6 +32,11 @@ static void _add_whodata_directory(const char *path) {
     OSListNode *node;
     whodata_directory_t *directory;
 
+    if (whodata_directories == NULL) {
+        merror(FIM_ERROR_WHODATA_UNINITIALIZED, path);
+        return;
+    }
+
     // Search for duplicates
     for (node = OSList_GetFirstNode(whodata_directories); node != NULL;
          node = OSList_GetNextNode(whodata_directories)) {


### PR DESCRIPTION
|Related issue|QA issue|
|---|---|
|Fixes #13239|https://github.com/wazuh/wazuh-qa/issues/1447|

This PR aims to fix the issue above through these changes:

1. Apply the configuration fallback to the wildcarded pattern list, in addition to the actual directory list.
2. Let FIM log an error and skip attempts to add a directory to the who-data component when it's uninitialized.

We expect FIM to never produce the log added in the second point. If it did, that would mean that there is another bug.

## Tests

- [x] Set up a wildcarded directory with who-data, having Auditd uninstalled.
- [x] Set up a wildcarded directory with who-data, and uninstall Auditd after the first scan.
- [x] Programatically avoid step 1 and expect the error log. Syscheck continues working:
```
ERROR: (6623): Trying to monitor '/etc/cron.d' in who-data mode, but who-data is not initialized.
```
- [x] Run on Valgrind.
```
LEAK SUMMARY:
   definitely lost: 0 bytes in 0 blocks
   indirectly lost: 0 bytes in 0 blocks
     possibly lost: 87,640 bytes in 22 blocks
   still reachable: 647,173 bytes in 673 blocks
```