### PR TITLE
Fix macOS agent debug symbol installation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -832,7 +832,7 @@ else
 endif
 endif
 ifeq (${uname_S}, Darwin)
-	@$(foreach binary, ${EXECUTABLE_FILES}, (dsymutil -s $(binary) | grep -q N_OSO && symutil -o ${SYMBOLS_PATH}/$(binary).dSYM $(binary) && strip -S $(binary)) || true;)
+	@$(foreach binary, ${EXECUTABLE_FILES}, (dsymutil -s $(binary) | grep -q N_OSO && dsymutil -o ${SYMBOLS_PATH}/$(binary).dSYM $(binary) && strip -S $(binary)) || true;)
 endif
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -91,7 +91,6 @@ DISABLE_STRIP_SYMBOLS?=no
 ifeq (${TARGET}, winagent)
 EXECUTABLE_FILES := $(shell find win32 -maxdepth 1 -type f -name "*.exe"  -perm /a=x)
 EXECUTABLE_FILES += $(shell find . -type f -name "*.dll" ! -path "./external/*" ! -path "./win32/*" -perm /a=x)
-EXECUTABLE_FILES := $(EXECUTABLE_FILES:./%=%)
 else
 ifeq (${uname_S}, Linux)
 EXECUTABLE_FILES := $(shell find . -maxdepth 1 -type f ! -name "*.so"  -perm /a=x)
@@ -135,7 +134,7 @@ endif
 # Debug symbols and optimization of CMake subprojects
 CMAKE_BUILD_TYPE?=Release
 ifeq (${DBG_SYM_SUPPORT},yes)
-CMAKE_BUILD_TYPE=RelWithDbgInfo
+CMAKE_BUILD_TYPE=RelWithDebInfo
 endif
 ifneq (,$(filter ${DEBUG},YES yes y Y 1))
 CMAKE_BUILD_TYPE=Debug
@@ -823,17 +822,17 @@ endif
 ifeq (,$(filter ${DISABLE_STRIP_SYMBOLS},YES yes y Y 1))
 ifeq (${uname_S}, Linux)
 ifeq (${TARGET}, winagent)
-	@-if test -n "${WIN_STRIP_TOOL_PATH}" -a -d "${WIN_STRIP_TOOL_PATH}" -a -f "${WIN_STRIP_TOOL_PATH}/cv2pdb.exe" && command -v wine > /dev/null 2>&1; then \
-		$(foreach binary, ${EXECUTABLE_FILES}, wine ${WIN_STRIP_TOOL_PATH}/cv2pdb.exe $(binary) $(binary) ${SYMBOLS_PATH}/$(basename $(notdir $(binary))).pdb;) \
+	@if test -n "${WIN_STRIP_TOOL_PATH}" -a -d "${WIN_STRIP_TOOL_PATH}" -a -f "${WIN_STRIP_TOOL_PATH}/cv2pdb.exe" && command -v wine > /dev/null 2>&1; then \
+		$(foreach binary, ${EXECUTABLE_FILES}, (${MING_BASE}objdump -h $(binary) | grep -q ".debug_info" && wine ${WIN_STRIP_TOOL_PATH}/cv2pdb.exe $(binary) $(binary) ${SYMBOLS_PATH}/$(basename $(notdir $(binary))).pdb) || true;) \
 	else \
 		$(foreach binary, ${EXECUTABLE_FILES}, ${MING_BASE}objcopy --strip-unneeded ${binary};) \
 	fi
 else
-	@-$(foreach binary, ${EXECUTABLE_FILES}, objcopy --only-keep-debug $(binary) ${SYMBOLS_PATH}/$(basename $(notdir $(binary))).debug; objcopy --strip-unneeded $(binary);)
+	@$(foreach binary, ${EXECUTABLE_FILES}, (objdump -h $(binary) | grep -q .debug_info && objcopy --only-keep-debug $(binary) ${SYMBOLS_PATH}/$(basename $(notdir $(binary))).debug && objcopy --strip-unneeded $(binary)) || true;)
 endif
 endif
 ifeq (${uname_S}, Darwin)
-	@$(foreach binary, ${EXECUTABLE_FILES}, dsymutil -o ${SYMBOLS_PATH}/$(binary).dSYM $(binary) && strip -S $(binary);)
+	@$(foreach binary, ${EXECUTABLE_FILES}, (dsymutil -s $(binary) | grep -q N_OSO && symutil -o ${SYMBOLS_PATH}/$(binary).dSYM $(binary) && strip -S $(binary)) || true;)
 endif
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -832,7 +832,7 @@ else
 endif
 endif
 ifeq (${uname_S}, Darwin)
-	@$(foreach binary, ${EXECUTABLE_FILES}, (dsymutil -s $(binary) | grep -q N_OSO && dsymutil -o ${SYMBOLS_PATH}/$(binary).dSYM $(binary) && strip -S $(binary)) || true;)
+	@$(foreach binary, ${EXECUTABLE_FILES}, (dsymutil -s $(binary) | grep -q N_OSO && dsymutil -o ${SYMBOLS_PATH}/$(basename $(notdir $(binary))).dSYM $(binary) && strip -S $(binary)) || true;)
 endif
 endif
 

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -928,8 +928,10 @@ InstallCommon()
   # are not supported for this platform, it will simply be empty.
   rm -rf ${INSTALLDIR}/.symbols
   if find symbols ! -path symbols ! -name .gitignore | grep . > /dev/null ;then
-    ${INSTALL} -d -m 0750 -o root -g 0 ${INSTALLDIR}/.symbols
-    ${INSTALL} -m 0640 -o root -g 0 symbols/* ${INSTALLDIR}/.symbols
+    cp -r symbols ${INSTALLDIR}/.symbols
+    chown -R 0:0 ${INSTALLDIR}/.symbols
+    chmod 750 ${INSTALLDIR}/.symbols
+    chmod -R 640 ${INSTALLDIR}/.symbols/*
   fi
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#13246|

## Description

This PR aims to fix the macOS debug symbols (dSYM bundles) during installation from sources, while keeping privileges as designed (750 for symbols dir and 640 for symbols)

- macOS
```bash
Done building agent

Wait for success...
UIDs available: 101 102 103
success
PF
Removing old SCA policies...
Installing SCA policies...


 - System is Darwin.
 - Init script modified to start Wazuh during boot.

 - Configuration finished properly.

 - To start Wazuh:
      /var/ossec/bin/wazuh-control start

 - To stop Wazuh:
      /var/ossec/bin/wazuh-control stop

 - The configuration can be viewed or modified at /var/ossec/etc/ossec.conf


   Thanks for using Wazuh.
   Please don't hesitate to contact us if you need help or find
   any bugs.

   Use our public Mailing List at:
          https://groups.google.com/forum/#!forum/wazuh

   More information can be found at:
          - http://www.wazuh.com

    ---  Press ENTER to finish (maybe more information below). ---


   - Add the following lines to the beginning of your PF rules:
     More information at: 
     https://documentation.wazuh.com


      table <wazuh_fwtable> persist #wazuh_fwtable 
      block in quick from <wazuh_fwtable> to any
      block out quick from any to <wazuh_fwtable>



 - More information at: 
   https://documentation.wazuh.com/

bash-3.2# ls -la /var/ossec/.symbols/
total 8
drwxr-x---  28 root  wheel  952 Apr 26 13:03 .
drwxr-x---  16 root  wazuh  544 Apr 26 13:03 ..
-rw-r--r--   1 root  wheel   14 Apr 26 13:03 .gitignore
drw-r-----   3 root  wheel  102 Apr 26 13:03 agent-auth.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 default-firewall-drop.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 disable-account.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 firewalld-drop.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 host-deny.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 ip-customblock.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 ipfw.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 kaspersky.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 libdbsync.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 librsync.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 libsyscollector.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 libsysinfo.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 libwazuhext.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 libwazuhshared.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 manage_agents.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 npf.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 pf.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 restart-wazuh.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 route-null.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 wazuh-agentd.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 wazuh-execd.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 wazuh-logcollector.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 wazuh-modulesd.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 wazuh-slack.dSYM
drw-r-----   3 root  wheel  102 Apr 26 13:03 wazuh-syscheckd.dSYM

```
- Linux 
```bash
Done building agent

Wait for success...
success
Removing old SCA policies...
Installing SCA policies...


Synchronizing state of wazuh-agent.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable wazuh-agent

 - Configuration finished properly.

 - To start Wazuh:
      /var/ossec/bin/wazuh-control start

 - To stop Wazuh:
      /var/ossec/bin/wazuh-control stop

 - The configuration can be viewed or modified at /var/ossec/etc/ossec.conf


   Thanks for using Wazuh.
   Please don't hesitate to contact us if you need help or find
   any bugs.

   Use our public Mailing List at:
          https://groups.google.com/forum/#!forum/wazuh

   More information can be found at:
          - http://www.wazuh.com

    ---  Press ENTER to finish (maybe more information below). ---


 - More information at: 
   https://documentation.wazuh.com/

╭─root@wazuh-dev ~/repos/wazuh ‹13246-fix-macos-debuginfo-install› 
╰─# ls -la /var/ossec/.symbols 
total 77024
drwxr-x---  2 root root      4096 Apr 26 20:21 .
drwxr-x--- 16 root wazuh     4096 Apr 26 20:21 ..
-rw-r-----  1 root root    822200 Apr 26 20:21 agent-auth.debug
-rw-r-----  1 root root     67728 Apr 26 20:21 default-firewall-drop.debug
-rw-r-----  1 root root     53992 Apr 26 20:21 disable-account.debug
-rw-r-----  1 root root     56800 Apr 26 20:21 firewalld-drop.debug
-rw-r--r--  1 root root        14 Apr 26 20:21 .gitignore
-rw-r-----  1 root root     62840 Apr 26 20:21 host-deny.debug
-rw-r-----  1 root root     52160 Apr 26 20:21 ip-customblock.debug
-rw-r-----  1 root root     53664 Apr 26 20:21 ipfw.debug
-rw-r-----  1 root root     50712 Apr 26 20:21 kaspersky.debug
-rw-r-----  1 root root   9729344 Apr 26 20:21 libdbsync.debug
-rw-r-----  1 root root   6579032 Apr 26 20:21 librsync.debug
-rw-r-----  1 root root   9152880 Apr 26 20:21 libsyscollector.debug
-rw-r-----  1 root root  15598768 Apr 26 20:21 libsysinfo.debug
-rw-r-----  1 root root  20179000 Apr 26 20:21 libwazuhext.debug
-rw-r-----  1 root root    485400 Apr 26 20:21 libwazuhshared.debug
-rw-r-----  1 root root    855760 Apr 26 20:21 manage_agents.debug
-rw-r-----  1 root root     55008 Apr 26 20:21 npf.debug
-rw-r-----  1 root root     54584 Apr 26 20:21 pf.debug
-rw-r-----  1 root root     48200 Apr 26 20:21 restart-wazuh.debug
-rw-r-----  1 root root     49544 Apr 26 20:21 route-null.debug
-rw-r-----  1 root root   2856560 Apr 26 20:21 wazuh-agentd.debug
-rw-r-----  1 root root   2700816 Apr 26 20:21 wazuh-execd.debug
-rw-r-----  1 root root   2947728 Apr 26 20:21 wazuh-logcollector.debug
-rw-r-----  1 root root   2599576 Apr 26 20:21 wazuh-modulesd.debug
-rw-r-----  1 root root     59016 Apr 26 20:21 wazuh-slack.debug
-rw-r-----  1 root root   3636632 Apr 26 20:21 wazuh-syscheckd.debug
```
## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [x] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors