### PR TITLE
Add support for Ubuntu Jammy in Vulnerability Detector

### DIFF
--- a/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
+++ b/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
@@ -11,6 +11,7 @@
       <os>xenial</os>
       <os>bionic</os>
       <os>focal</os>
+      <os>jammy</os>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -161,6 +161,11 @@ int wm_vuldet_set_feed_version(char *feed, char *version, update_node **upd_list
             os_strdup(vu_feed_tag[FEED_FOCAL], upd->version);
             upd->dist_tag_ref = FEED_FOCAL;
             upd->dist_ext = vu_feed_ext[FEED_FOCAL];
+        } else if (!strcmp(version, "22") || strcasestr(version, vu_feed_tag[FEED_JAMMY])) {
+            os_index = CVE_JAMMY;
+            os_strdup(vu_feed_tag[FEED_JAMMY], upd->version);
+            upd->dist_tag_ref = FEED_JAMMY;
+            upd->dist_ext = vu_feed_ext[FEED_JAMMY];
         } else {
             merror("Invalid Ubuntu version '%s'", version);
             retval = OS_INVALID;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -494,6 +494,7 @@ const char *vu_feed_tag[] = {
     "XENIAL",
     "BIONIC",
     "FOCAL",
+    "JAMMY",
     // Debian versions
     "STRETCH",
     "BUSTER",
@@ -548,6 +549,7 @@ const char *vu_feed_ext[] = {
     "Ubuntu Xenial",
     "Ubuntu Bionic",
     "Ubuntu Focal",
+    "Ubuntu Jammy",
     // Debian versions
     "Debian Stretch",
     "Debian Buster",
@@ -5309,7 +5311,9 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
         }
 
         if (strcasestr(agti_os_name, vu_feed_ext[FEED_UBUNTU])) {
-            if (strstr(agti_os_major, "20")) {
+            if (strstr(agti_os_major, "22")) {
+                agent_dist_ver = FEED_JAMMY;
+            } else if (strstr(agti_os_major, "20")) {
                 agent_dist_ver = FEED_FOCAL;
             } else if (strstr(agti_os_major, "18")) {
                 agent_dist_ver = FEED_BIONIC;
@@ -6010,6 +6014,7 @@ int wm_vuldet_generate_os_and_kernel_package(sqlite3 *db, scan_agent *agent) {
         case FEED_XENIAL:
         case FEED_BIONIC:
         case FEED_FOCAL:
+        case FEED_JAMMY:
             product_name[0] = vu_os_product_name_list[PR_UBUNTU];
             vendor = vu_vendor_list[V_UBUNTU];
         break;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -258,6 +258,7 @@ typedef enum vu_feed {
     FEED_XENIAL,
     FEED_BIONIC,
     FEED_FOCAL,
+    FEED_JAMMY,
     // Debian versions
     FEED_STRETCH,
     FEED_BUSTER,
@@ -414,6 +415,7 @@ typedef enum cve_db {
     CVE_XENIAL,
     CVE_BIONIC,
     CVE_FOCAL,
+    CVE_JAMMY,
     CVE_STRETCH,
     CVE_BUSTER,
     CVE_BULLSEYE,


### PR DESCRIPTION
|Related issue|
|---|
|#13162|

## Description

The purpose of this PR is to add support for **Ubuntu 22 (Jammy Jellyfish)** in the _vulnerability detector_ module.

First, the OVAL provided by Canonical is downloaded: https://security-metadata.canonical.com/oval/com.ubuntu.jammy.cve.oval.xml.bz2

The vulnerabilities are then parsed and inserted into the database.

And finally, when an _Ubuntu 22_ agent is detected, then if the configuration is well set, it scans the agent and reports the vulnerabilities it contains.

## Configuration options

```xml
    <!-- Ubuntu OS vulnerabilities -->
    <provider name="canonical">
      <enabled>yes</enabled>
      <os>trusty</os>
      <os>xenial</os>
      <os>bionic</os>
      <os>focal</os>
      <os>jammy</os>
      <update_interval>1h</update_interval>
    </provider>
```

## Logs/Alerts example

Next, I show the logs related to what is commented in the description (the OS of agent `001` is _Ubuntu 22_):

- Correct configuration check:
```
2022/04/28 10:25:03 wazuh-modulesd[13023] wmodules-vuln-detector.c:595 at wm_vuldet_read_provider(): DEBUG: Added canonical (jammy) feed. Interval: 3600s | Path: 'none' | Url: 'none' | Timeout: 300s
```

- Download and insert vulnerabilities in the database:
```
2022/04/28 10:26:00 wazuh-modulesd:vulnerability-detector[13523] wm_vuln_detector.c:4559 at wm_vuldet_check_feed(): INFO: (5400): Starting 'Ubuntu Jammy' database update.
2022/04/28 10:26:00 wazuh-modulesd:download[13523] wm_download.c:230 at wm_download_dispatch(): DEBUG: Downloading 'https://security-metadata.canonical.com/oval/com.ubuntu.jammy.cve.oval.xml.bz2' to 'tmp/req-1288393924'
2022/04/28 10:26:00 wazuh-modulesd:download[13523] wm_download.c:250 at wm_download_dispatch(): DEBUG: Download of 'https://security-metadata.canonical.com/oval/com.ubuntu.jammy.cve.oval.xml.bz2' finished.
2022/04/28 10:26:00 wazuh-modulesd[13523] url.c:418 at wurl_request_uncompress_bz2_gz(): DEBUG: File from URL 'https://security-metadata.canonical.com/oval/com.ubuntu.jammy.cve.oval.xml.bz2' was successfully uncompressed into 'tmp/vuln-temp'
2022/04/28 10:26:00 wazuh-modulesd:vulnerability-detector[13523] wm_vuln_detector.c:4315 at wm_vuldet_fetch_oval(): DEBUG: (5407): The feed 'Ubuntu Jammy' is outdated. Fetching the last version.
2022/04/28 10:26:00 wazuh-modulesd:vulnerability-detector[13523] wm_vuln_detector.c:4097 at wm_vuldet_oval_process(): DEBUG: (5411): Starting preparse step of feed 'JAMMY'
2022/04/28 10:26:00 wazuh-modulesd:vulnerability-detector[13523] wm_vuln_detector.c:4102 at wm_vuldet_oval_process(): DEBUG: (5412): Starting parse step of feed 'JAMMY'
2022/04/28 10:26:00 wazuh-modulesd:vulnerability-detector[13523] wm_vuln_detector.c:4243 at wm_vuldet_index_feed(): DEBUG: (5414): Refreshing 'Ubuntu Jammy' databases.
2022/04/28 10:26:00 wazuh-modulesd:vulnerability-detector[13523] wm_vuln_detector.c:2960 at wm_vuldet_insert(): DEBUG: (5415): Inserting vulnerabilities.
2022/04/28 10:26:00 wazuh-modulesd:vulnerability-detector[13523] wm_vuln_detector.c:4249 at wm_vuldet_index_feed(): DEBUG: (5427): Refresh of 'Ubuntu Jammy' database finished.
2022/04/28 10:26:00 wazuh-modulesd:vulnerability-detector[13523] wm_vuln_detector.c:4260 at wm_vuldet_index_feed(): DEBUG: remove(tmp/vuln-temp.bz2): No such file or directory
2022/04/28 10:26:00 wazuh-modulesd:vulnerability-detector[13523] wm_vuln_detector.c:4582 at wm_vuldet_check_feed(): INFO: (5430): The update of the 'Ubuntu Jammy' feed finished successfully.
```
- Ubuntu 22 agent scan:
> Because the OVAL does not have any vulnerability yet, it is not possible to scan the Ubuntu 22 agent. When there is a vulnerability, the agent should be scanned correctly.
```
2022/04/28 10:31:45 wazuh-modulesd:vulnerability-detector[13523] wm_vuln_detector.c:2526 at wm_vuldet_check_agent_vulnerabilities(): WARNING: (5575): Unavailable vulnerability data for the agent '001' OS. Skipping it.
2022/04/28 10:31:45 wazuh-modulesd:vulnerability-detector[13523] wm_vuln_detector.c:7727 at wm_vuldet_run_scan(): INFO: (5472): Vulnerability scan finished.
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
```
==1898== LEAK SUMMARY:
==1898==    definitely lost: 0 bytes in 0 blocks
==1898==    indirectly lost: 0 bytes in 0 blocks
```

