### PR TITLE
Added feed update task flags per vendor

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -630,19 +630,63 @@ const char *vu_cpe_dic_option[] = {
     "set_targethw_only_if_product_matches"
 };
 
-// Task flags for vu_tasks_queue
-bool VU_TASKS_QUEUE_FLAGS[VU_TASK_TYPES_SIZE] = {0};
-bool VU_TASKS_QUEUE_FEED_UPDATE_FLAGS[FEED_UNKNOWN] = {0};
+/* Task flags for vu_tasks_queue */
+bool VU_TASKS_QUEUE_FLAGS[VU_TASK_TYPES_SIZE] = {false};
+/* Task flags for feed vendor */
+bool VU_INTERVAL_FEED_UPDATE_FLAGS[VU_INTERVAL_FEED_UPDATE_SIZE] = {false};
+
+vu_interval_feed_update_t get_vendor_feed_flag(vu_feed feed_to_update) {
+    switch (feed_to_update) {
+        case FEED_UBUNTU:
+            return VU_INTERVAL_FEED_UPDATE_UBUNTU;
+            break;
+        case FEED_DEBIAN:
+            return VU_INTERVAL_FEED_UPDATE_DEBIAN;
+            break;
+        case FEED_JREDHAT:
+            return VU_INTERVAL_FEED_UPDATE_JREDHAT;
+            break;
+        case FEED_REDHAT:
+            return VU_INTERVAL_FEED_UPDATE_REDHAT;
+            break;
+        case FEED_ALAS:
+            return VU_INTERVAL_FEED_UPDATE_ALAS;
+            break;
+        case FEED_ARCH:
+            return VU_INTERVAL_FEED_UPDATE_ARCH;
+            break;
+        case FEED_MSU:
+            return VU_INTERVAL_FEED_UPDATE_MSU;
+            break;
+        case FEED_NVD:
+            return VU_INTERVAL_FEED_UPDATE_NVD;
+            break;
+        case FEED_CPEW:
+            return VU_INTERVAL_FEED_UPDATE_CPEW;
+            break;
+        default:
+            return VU_INTERVAL_FEED_UPDATE_UNKNOWN;
+            break;
+    }
+}
 
 void vu_tasks_queue_push_callback (void* data) {
     if (data) {
-        VU_TASKS_QUEUE_FLAGS[((vu_task_ctx_t*)data)->task_type] = true;
+        if (((vu_task_ctx_t*)data)->task_type == VU_INTERVAL_FEED_UPDATE) {
+            VU_INTERVAL_FEED_UPDATE_FLAGS[get_vendor_feed_flag(((vu_task_ctx_t*)data)->feed_to_update)] = true;
+        } else {
+            VU_TASKS_QUEUE_FLAGS[((vu_task_ctx_t*)data)->task_type] = true;
+        }
     }
 }
 
 void vu_tasks_queue_pop_callback (void* data) {
     if (data) {
-        VU_TASKS_QUEUE_FLAGS[((vu_task_ctx_t*)data)->task_type] = false;
+        if (((vu_task_ctx_t*)data)->task_type == VU_INTERVAL_FEED_UPDATE) {
+            VU_INTERVAL_FEED_UPDATE_FLAGS[get_vendor_feed_flag(((vu_task_ctx_t*)data)->feed_to_update)] = false;
+        } else {
+            VU_TASKS_QUEUE_FLAGS[((vu_task_ctx_t*)data)->task_type] = false;
+        }
     }
 }
 
@@ -4683,14 +4727,20 @@ void wm_vuldet_schedule_updates(update_node **updates) {
 
     // Check updates for all the feeds
     for (int os = 0; os < OS_SUPP_SIZE; os++) {
-        if (updates[os] && wm_vuldet_check_update_period(updates[os]) && !VU_TASKS_QUEUE_FEED_UPDATE_FLAGS[updates[os]->dist_ref]) {
-            // TODO modify the flags with the proper callback
-            VU_TASKS_QUEUE_FEED_UPDATE_FLAGS[updates[os]->dist_ref] = 1;
-            vu_task_ctx_t *task = create_task(OS_INVALID, VU_INTERVAL_FEED_UPDATE, WM_TASK_PENDING, updates[os]->dist_ref, OS_INVALID);
-            if (OS_INVALID == register_task(task)) {
-                mwarn("Couldn't establish communication with task manager. There's no ID for task");
+        if (updates[os] && wm_vuldet_check_update_period(updates[os])) {
+            vu_interval_feed_update_t feed_flag = get_vendor_feed_flag(updates[os]->dist_ref);
+            if (feed_flag < VU_INTERVAL_FEED_UPDATE_SIZE &&
+                !VU_INTERVAL_FEED_UPDATE_FLAGS[get_vendor_feed_flag(updates[os]->dist_ref)]) {
+
+                vu_task_ctx_t *task = create_task(OS_INVALID, VU_INTERVAL_FEED_UPDATE, WM_TASK_PENDING, updates[os]->dist_ref, OS_INVALID);
+                if (OS_INVALID == register_task(task)) {
+                    mwarn("Couldn't establish communication with task manager. There's no ID for task");
+                }
+                linked_queue_push_ex(vu_tasks_queue, task);
+            } else {
+                mwarn("Feed for '%s' by interval already scheduled in tasks queue", vu_feed_tag[updates[os]->dist_ref]);
+                updates[os]->last_sync = time(NULL);
             }
-            linked_queue_push_ex(vu_tasks_queue, task);
         }
     }
 }
@@ -5392,8 +5442,6 @@ void wm_vuldet_working_thread(void* vuldet_data) {
                     break;
                 case VU_INTERVAL_FEED_UPDATE:
                     wm_vuldet_feed_update_by_interval(current_task, vuldet);
-                    // TODO modify the flags with the proper callback
-                    VU_TASKS_QUEUE_FEED_UPDATE_FLAGS[current_task->feed_to_update] = 0;
                     break;
                 case VU_INTERVAL_SCAN:
                     wm_vuldet_scan_by_interval(current_task, vuldet);
@@ -5448,9 +5496,10 @@ void *wm_vuldet_main(wm_vuldet_t* vuldet) {
                         mwarn("Couldn't establish communication with task manager. There's no ID for task");
                     }
                     linked_queue_push_ex(vu_tasks_queue, task);
+                } else {
+                    mwarn("Scan by interval already scheduled in tasks queue");
+                    vuldet->last_scan = curr_time;
                 }
-
-                vuldet->last_scan = curr_time;
             }
             /* Checks for messages in the queue */
             vu_task_msg_ctx_t *msg = (vu_task_msg_ctx_t *)linked_queue_pop_ex_no_cond_wait(vu_messages_queue);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -429,6 +429,13 @@ const wm_context WM_VULNDETECTOR_CONTEXT = {
 
 const char *version_null = "0:0";
 
+const char *vu_task_type_tag[] = {
+    "Scan on demand",
+    "Feed update on demand",
+    "Feed update by interval",
+    "Scan by interval"
+};
+
 const char *vu_os_platform_rolling_distros[] = {
     "arch"
 };
@@ -718,7 +725,7 @@ void vu_task_ctx_free (vu_task_ctx_t* task) {
     os_free(task);
 }
 
-// Vulnerability detector threads flags
+// Vulnerability detector working thread flag.
 static volatile int wm_vuldet_working_thread_active = 1;
 
 vu_feed wm_vuldet_set_allowed_feed(const char *os_name, const char *os_version, update_node **updates, vu_feed *agent_dist) {
@@ -755,14 +762,15 @@ int wm_vuldet_check_update_period(update_node *upd) {
         return 0;
     }
 
-    bool time_to_update = !upd->last_sync || (upd->interval != WM_VULNDETECTOR_ONLY_ONE_UPD && (upd->last_sync + (time_t) upd->interval) < time(NULL));
+    bool time_to_schedule = !upd->last_sync || (upd->interval != WM_VULNDETECTOR_ONLY_ONE_UPD && (upd->last_sync + (time_t) upd->interval) < time(NULL));
 
-    if (time_to_update) {
+    if (time_to_schedule) {
         upd->last_sync = time(NULL);
     }
 
-    return time_to_update;
+    return time_to_schedule;
 }
+
 int wm_vuldet_sync_feed(update_node *upd, int8_t *need_update) {
     return wm_vuldet_fetch_feed(upd, need_update) == OS_INVALID || (*need_update && wm_vuldet_index_feed(upd));
 }
@@ -4736,6 +4744,8 @@ void wm_vuldet_schedule_updates(update_node **updates) {
                 if (OS_INVALID == register_task(task)) {
                     mwarn("Couldn't establish communication with task manager. There's no ID for task");
                 }
+                mdebug2("Scheduling task type '%s' ID: '%d' vendor: '%s'",
+                        vu_task_type_tag[task->task_type], task->task_id, vu_feed_tag[task->feed_to_update]);
                 linked_queue_push_ex(vu_tasks_queue, task);
             } else {
                 mwarn("Feed for '%s' by interval already scheduled in tasks queue", vu_feed_tag[updates[os]->dist_ref]);
@@ -5495,10 +5505,12 @@ void *wm_vuldet_main(wm_vuldet_t* vuldet) {
                     if (OS_INVALID == register_task(task)) {
                         mwarn("Couldn't establish communication with task manager. There's no ID for task");
                     }
+                    mdebug2("Scheduling task type '%s' ID: '%d'", vu_task_type_tag[task->task_type], task->task_id);
+                    vuldet->last_scan = time(NULL);
                     linked_queue_push_ex(vu_tasks_queue, task);
                 } else {
                     mwarn("Scan by interval already scheduled in tasks queue");
-                    vuldet->last_scan = curr_time;
+                    vuldet->last_scan = time(NULL);
                 }
             }
             /* Checks for messages in the queue */
@@ -5898,7 +5910,6 @@ void wm_vuldet_destroy(wm_vuldet_t * vuldet) {
     }
     free(vuldet);
 }
-
 
 cJSON *wm_vuldet_dump(const wm_vuldet_t * vuldet){
     cJSON *root = cJSON_CreateObject();

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -430,10 +430,10 @@ const wm_context WM_VULNDETECTOR_CONTEXT = {
 const char *version_null = "0:0";
 
 const char *vu_task_type_tag[] = {
-    "Scan on demand",
-    "Feed update on demand",
-    "Feed update by interval",
-    "Scan by interval"
+    [VU_ON_DEMAND_SCAN] = "Scan on demand",
+    [VU_ON_DEMAND_FEED_UPDATE] = "Feed update on demand",
+    [VU_INTERVAL_FEED_UPDATE] = "Feed update by interval",
+    [VU_INTERVAL_SCAN] = "Scan by interval"
 };
 
 const char *vu_os_platform_rolling_distros[] = {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4719,7 +4719,6 @@ void wm_vuldet_schedule_updates(update_node **updates) {
 int wm_vuldet_run_update(update_node **updates) {
     int ret = 0;
     int8_t updated = 1;
-    int up_status = 0;
 
     if (!updates) {
         return ret;
@@ -4728,13 +4727,6 @@ int wm_vuldet_run_update(update_node **updates) {
     // Check updates for all the feeds
     for (int os = 0; os < OS_SUPP_SIZE; os++) {
         if (updates[os]) {
-            // If none of RedHat's OVALs have been updated,
-            // we can deduce that the JSON is already up to date.
-            if (updates[os]->dist_ref == FEED_JREDHAT && up_status == 1) {
-                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UPDATE_DATE, vu_feed_ext[FEED_JREDHAT]);
-                continue;
-            }
-
             if (wm_vuldet_check_feed(updates[os], &updated)) {
                 ret = OS_INVALID;
                 if (updated == -1) {
@@ -4743,13 +4735,6 @@ int wm_vuldet_run_update(update_node **updates) {
                     continue;
                 }
             }
-
-            /** @updated -> If the RHEL feed was successfully updated(1).
-            * +1 Represents the availability of the RHEL feeds. Otherwise we
-            * won't be capable of distinguishing between non available RHEL feeds, and
-            * available but up-to-date feeds. (In both cases @up_status would be 0).
-            **/
-            up_status |= (updates[os]->dist_ref == FEED_REDHAT)? updated + 1 : up_status;
         }
     }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -640,47 +640,12 @@ const char *vu_cpe_dic_option[] = {
 /* Task flags for vu_tasks_queue */
 bool VU_TASKS_QUEUE_FLAGS[VU_TASK_TYPES_SIZE] = {false};
 /* Task flags for feed vendor */
-bool VU_INTERVAL_FEED_UPDATE_FLAGS[VU_INTERVAL_FEED_UPDATE_SIZE] = {false};
-
-vu_interval_feed_update_t get_vendor_feed_flag(vu_feed feed_to_update) {
-    switch (feed_to_update) {
-        case FEED_UBUNTU:
-            return VU_INTERVAL_FEED_UPDATE_UBUNTU;
-            break;
-        case FEED_DEBIAN:
-            return VU_INTERVAL_FEED_UPDATE_DEBIAN;
-            break;
-        case FEED_JREDHAT:
-            return VU_INTERVAL_FEED_UPDATE_JREDHAT;
-            break;
-        case FEED_REDHAT:
-            return VU_INTERVAL_FEED_UPDATE_REDHAT;
-            break;
-        case FEED_ALAS:
-            return VU_INTERVAL_FEED_UPDATE_ALAS;
-            break;
-        case FEED_ARCH:
-            return VU_INTERVAL_FEED_UPDATE_ARCH;
-            break;
-        case FEED_MSU:
-            return VU_INTERVAL_FEED_UPDATE_MSU;
-            break;
-        case FEED_NVD:
-            return VU_INTERVAL_FEED_UPDATE_NVD;
-            break;
-        case FEED_CPEW:
-            return VU_INTERVAL_FEED_UPDATE_CPEW;
-            break;
-        default:
-            return VU_INTERVAL_FEED_UPDATE_UNKNOWN;
-            break;
-    }
-}
+bool VU_INTERVAL_FEED_UPDATE_FLAGS[FEED_UNKNOWN] = {false};
 
 void vu_tasks_queue_push_callback (void* data) {
     if (data) {
         if (((vu_task_ctx_t*)data)->task_type == VU_INTERVAL_FEED_UPDATE) {
-            VU_INTERVAL_FEED_UPDATE_FLAGS[get_vendor_feed_flag(((vu_task_ctx_t*)data)->feed_to_update)] = true;
+            VU_INTERVAL_FEED_UPDATE_FLAGS[((vu_task_ctx_t*)data)->feed_to_update] = true;
         } else {
             VU_TASKS_QUEUE_FLAGS[((vu_task_ctx_t*)data)->task_type] = true;
         }
@@ -690,7 +655,7 @@ void vu_tasks_queue_push_callback (void* data) {
 void vu_tasks_queue_pop_callback (void* data) {
     if (data) {
         if (((vu_task_ctx_t*)data)->task_type == VU_INTERVAL_FEED_UPDATE) {
-            VU_INTERVAL_FEED_UPDATE_FLAGS[get_vendor_feed_flag(((vu_task_ctx_t*)data)->feed_to_update)] = false;
+            VU_INTERVAL_FEED_UPDATE_FLAGS[((vu_task_ctx_t*)data)->feed_to_update] = false;
         } else {
             VU_TASKS_QUEUE_FLAGS[((vu_task_ctx_t*)data)->task_type] = false;
         }
@@ -762,7 +727,7 @@ int wm_vuldet_check_update_period(update_node *upd) {
         return 0;
     }
 
-    bool time_to_schedule = !upd->last_sync || (upd->interval != WM_VULNDETECTOR_ONLY_ONE_UPD && (upd->last_sync + (time_t) upd->interval) < time(NULL));
+    bool time_to_schedule = !upd->last_sync || (upd->interval != WM_VULNDETECTOR_ONLY_ONE_UPD && (upd->last_sync + (time_t) upd->interval) <= time(NULL));
 
     if (time_to_schedule) {
         upd->last_sync = time(NULL);
@@ -4736,10 +4701,7 @@ void wm_vuldet_schedule_updates(update_node **updates) {
     // Check updates for all the feeds
     for (int os = 0; os < OS_SUPP_SIZE; os++) {
         if (updates[os] && wm_vuldet_check_update_period(updates[os])) {
-            vu_interval_feed_update_t feed_flag = get_vendor_feed_flag(updates[os]->dist_ref);
-            if (feed_flag < VU_INTERVAL_FEED_UPDATE_SIZE &&
-                !VU_INTERVAL_FEED_UPDATE_FLAGS[get_vendor_feed_flag(updates[os]->dist_ref)]) {
-
+            if (!VU_INTERVAL_FEED_UPDATE_FLAGS[updates[os]->dist_ref]) {
                 vu_task_ctx_t *task = create_task(OS_INVALID, VU_INTERVAL_FEED_UPDATE, WM_TASK_PENDING, updates[os]->dist_ref, OS_INVALID);
                 if (OS_INVALID == register_task(task)) {
                     mwarn("Couldn't establish communication with task manager. There's no ID for task");
@@ -4748,8 +4710,7 @@ void wm_vuldet_schedule_updates(update_node **updates) {
                         vu_task_type_tag[task->task_type], task->task_id, vu_feed_tag[task->feed_to_update]);
                 linked_queue_push_ex(vu_tasks_queue, task);
             } else {
-                mwarn("Feed for '%s' by interval already scheduled in tasks queue", vu_feed_tag[updates[os]->dist_ref]);
-                updates[os]->last_sync = time(NULL);
+                mdebug1("Feed for '%s' by interval already scheduled in tasks queue", vu_feed_tag[updates[os]->dist_ref]);
             }
         }
     }
@@ -5506,12 +5467,11 @@ void *wm_vuldet_main(wm_vuldet_t* vuldet) {
                         mwarn("Couldn't establish communication with task manager. There's no ID for task");
                     }
                     mdebug2("Scheduling task type '%s' ID: '%d'", vu_task_type_tag[task->task_type], task->task_id);
-                    vuldet->last_scan = time(NULL);
                     linked_queue_push_ex(vu_tasks_queue, task);
                 } else {
-                    mwarn("Scan by interval already scheduled in tasks queue");
-                    vuldet->last_scan = time(NULL);
+                    mdebug1("Scan by interval already scheduled in tasks queue");
                 }
+                vuldet->last_scan = time(NULL);
             }
             /* Checks for messages in the queue */
             vu_task_msg_ctx_t *msg = (vu_task_msg_ctx_t *)linked_queue_pop_ex_no_cond_wait(vu_messages_queue);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -132,6 +132,20 @@ typedef enum vu_task_type_t {
     VU_TASK_TYPES_SIZE // This should be the last constant
 } vu_task_type_t;
 
+typedef enum vu_interval_feed_update_t {
+    VU_INTERVAL_FEED_UPDATE_UBUNTU,
+    VU_INTERVAL_FEED_UPDATE_DEBIAN,
+    VU_INTERVAL_FEED_UPDATE_JREDHAT,
+    VU_INTERVAL_FEED_UPDATE_REDHAT,
+    VU_INTERVAL_FEED_UPDATE_ALAS,
+    VU_INTERVAL_FEED_UPDATE_ARCH,
+    VU_INTERVAL_FEED_UPDATE_MSU,
+    VU_INTERVAL_FEED_UPDATE_NVD,
+    VU_INTERVAL_FEED_UPDATE_CPEW,
+    VU_INTERVAL_FEED_UPDATE_SIZE,
+    VU_INTERVAL_FEED_UPDATE_UNKNOWN
+} vu_interval_feed_update_t;
+
 void vu_tasks_queue_push_callback (void* data);
 void vu_tasks_queue_pop_callback (void* data);
 
@@ -920,6 +934,14 @@ const char *wm_vuldet_get_unified_severity(char *severity);
  * Vulnerability detector thread finalizes execution on error.
  */
 void wm_vuldet_init_queues();
+
+/**
+ * @brief Creates a vendor feed subset.
+ *
+ * @param feed_to_update Feed vendor.
+ * @return vu_interval_feed_update_t New enum for the specific vendor.
+ */
+vu_interval_feed_update_t get_vendor_feed_flag(vu_feed feed_to_update);
 
 /**
  * @brief Creates a task context to be scheduled in the task queue.

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -529,7 +529,6 @@ typedef enum {
 } parser_state;
 
 // Report queue
-
 struct vu_report {
     char *cve;
     char *reference;
@@ -687,7 +686,6 @@ typedef struct wm_vuldet_db {
 } wm_vuldet_db;
 
 // NVD - CPE structures
-
 typedef struct translation_cond {
     const char *translation;
     const char *field;
@@ -744,7 +742,6 @@ typedef struct vu_search_terms {
 } vu_search_terms;
 
 // NVD -CVE structures
-
 typedef struct nvd_references {
     char *url;
     char *refsource;
@@ -815,7 +812,6 @@ typedef struct vu_nvd_report {
 } vu_nvd_report;
 
 // CPE helper structures
-
 typedef struct vu_cpe_dic_section {
     char ***vendor;
     char ***product;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -132,20 +132,6 @@ typedef enum vu_task_type_t {
     VU_TASK_TYPES_SIZE // This should be the last constant
 } vu_task_type_t;
 
-typedef enum vu_interval_feed_update_t {
-    VU_INTERVAL_FEED_UPDATE_UBUNTU,
-    VU_INTERVAL_FEED_UPDATE_DEBIAN,
-    VU_INTERVAL_FEED_UPDATE_JREDHAT,
-    VU_INTERVAL_FEED_UPDATE_REDHAT,
-    VU_INTERVAL_FEED_UPDATE_ALAS,
-    VU_INTERVAL_FEED_UPDATE_ARCH,
-    VU_INTERVAL_FEED_UPDATE_MSU,
-    VU_INTERVAL_FEED_UPDATE_NVD,
-    VU_INTERVAL_FEED_UPDATE_CPEW,
-    VU_INTERVAL_FEED_UPDATE_SIZE,
-    VU_INTERVAL_FEED_UPDATE_UNKNOWN
-} vu_interval_feed_update_t;
-
 void vu_tasks_queue_push_callback (void* data);
 void vu_tasks_queue_pop_callback (void* data);
 
@@ -930,14 +916,6 @@ const char *wm_vuldet_get_unified_severity(char *severity);
  * Vulnerability detector thread finalizes execution on error.
  */
 void wm_vuldet_init_queues();
-
-/**
- * @brief Creates a vendor feed subset.
- *
- * @param feed_to_update Feed vendor.
- * @return vu_interval_feed_update_t New enum for the specific vendor.
- */
-vu_interval_feed_update_t get_vendor_feed_flag(vu_feed feed_to_update);
 
 /**
  * @brief Creates a task context to be scheduled in the task queue.


### PR DESCRIPTION
|Related issue|
|---|
|#13204|

## Description

This PR adds a set of flags to avoid scheduling more than one feed update task of the same vendor. Check the comment below for a detailed explanation.

## Scan-build report

![8](https://user-images.githubusercontent.com/13010397/165835372-329af00e-faff-4279-98ad-f34260866911.png)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report