### PR TITLE
Disconnect the Vulnerability Detector retry scan logic from the scan itself - Implementation

### DIFF
--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -398,7 +398,7 @@ int Read_Vuln(const OS_XML *xml, xml_node **nodes, void *d1, char d2) {
     vuldet->min_full_scan_interval = VU_DEF_MIN_FULL_SCAN_INTERVAL;
     vuldet->retry_interval = VU_DEF_RETRY_INTERVAL;
     vuldet->scan_interval = WM_VULNDETECTOR_DEFAULT_INTERVAL;
-    vuldet->scan_agents = NULL;
+    vuldet->agent_to_scan = NULL;
     cur_wmodule->context = &WM_VULNDETECTOR_CONTEXT;
     cur_wmodule->tag = strdup(cur_wmodule->context->name);
     cur_wmodule->data = vuldet;

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -350,7 +350,7 @@
 #define VU_OVAL_UPDATE_ERROR        "(5513): CVE database could not be updated."
 #define VU_CREATE_DB_ERROR          "(5514): The database could not be checked or created."
 #define VU_SOFTWARE_REQUEST_ERROR   "(5515): Agent '%.3d' software could not be requested."
-#define VU_NO_AGENT_ERROR           "(5516): The agent '%.3zu' information could not be processed."
+#define VU_NO_AGENT_ERROR           "(5516): The agent '%.3d' information could not be processed."
 #define VU_CREATE_HASH_ERRO         "(5517): The '%s' hash table could not be created."
 #define VU_SYSC_SCAN_REQUEST_ERROR  "(5518): Last software scan from the agent '%.3d' could not be requested."
 #define VU_NO_SYSC_SCANS            "(5519): No package inventory found for agent '%.3d', so their vulnerabilities will not be checked."

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -350,7 +350,7 @@
 #define VU_OVAL_UPDATE_ERROR        "(5513): CVE database could not be updated."
 #define VU_CREATE_DB_ERROR          "(5514): The database could not be checked or created."
 #define VU_SOFTWARE_REQUEST_ERROR   "(5515): Agent '%.3d' software could not be requested."
-#define VU_NO_AGENT_ERROR           "(5516): The agents information could not be processed."
+#define VU_NO_AGENT_ERROR           "(5516): The agent '%.3zu' information could not be processed."
 #define VU_CREATE_HASH_ERRO         "(5517): The '%s' hash table could not be created."
 #define VU_SYSC_SCAN_REQUEST_ERROR  "(5518): Last software scan from the agent '%.3d' could not be requested."
 #define VU_NO_SYSC_SCANS            "(5519): No package inventory found for agent '%.3d', so their vulnerabilities will not be checked."

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -417,7 +417,6 @@ int usec;
 
 w_linked_queue_t *vu_messages_queue = NULL;
 w_linked_queue_t* vu_tasks_queue = NULL;
-w_linked_queue_t* vu_messages_queue = NULL;
 
 const wm_context WM_VULNDETECTOR_CONTEXT = {
     "vulnerability-detector",
@@ -5340,8 +5339,6 @@ void wm_vuldet_feed_update_by_interval(vu_task_ctx_t* current_task, wm_vuldet_t*
 }
 
 void wm_vuldet_scan_by_interval(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet) {
-    int* agents_array = NULL;
-    int i = 0;
     int sock = wm_vuldet_get_wdb_socket();
     scan_agent *agents = NULL;
     scan_agent *f_agent = NULL;
@@ -5354,7 +5351,7 @@ void wm_vuldet_scan_by_interval(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet
     do {
         os_calloc(1, sizeof(scan_agent), agent_aux);
         if (wm_vuldet_collect_agent_info(i == -1 ? 000 : agents_array[i], vuldet, agent_aux)) {
-             mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR, i == -1 ? (size_t)000 : (size_t)agents_array[i]);
+             mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR, i == -1 ? 000 : agents_array[i]);
              wm_vuldet_free_scan_agent(agent_aux);
         } else {
             if (agents) {
@@ -5404,11 +5401,20 @@ void wm_vuldet_scan_by_interval(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet
                     agents = agent_aux;
                 }
             }
-            current_task = (vu_task_context_t*) linked_queue_read_ex(vu_tasks_queue);
+            current_task = (vu_task_ctx_t*) linked_queue_read_ex(vu_tasks_queue);
         }
-        i++;
-        current_task = (vu_task_ctx_t*) linked_queue_read_ex(vu_tasks_queue);
-    }
+
+        if (retry_agents && !abort_scan && WM_TASK_CANCELLED != current_task->task_status) {
+            time_t sleep_time = first_fail_scan + vuldet->retry_interval - time(NULL);
+            if (sleep_time <= 0) {
+                sleep_time = 1;
+            }
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, "Going to sleep %ld seconds before retrying pending agents", sleep_time);
+            sleep (sleep_time);
+        }
+    } while (retry_agents && !abort_scan && WM_TASK_CANCELLED != current_task->task_status);
+    wm_vuldet_clean_all_scan_agent_structures(f_agent);
+
     mtinfo(WM_VULNDETECTOR_LOGTAG, VU_END_SCAN);
     vuldet->last_scan = time(NULL);
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -201,9 +201,10 @@ time_t wm_vuldet_get_last_feed_update(vu_feed feed);
  *
  * @param agent_id Agent identifier.
  * @param vuldet The vulnerability detector main data structure.
+ * @param agent The structure to save the agent data
  * @return 0 on success, -1 otherwise.
  */
-STATIC int wm_vuldet_collect_agent_info(int agent_id, wm_vuldet_t *vuldet);
+STATIC int wm_vuldet_collect_agent_info(int agent_id, wm_vuldet_t *vuldet, scan_agent *agent);
 
 /**
  * @brief Compare two packages structures (src_name, bin_name, version and arch).
@@ -326,7 +327,6 @@ STATIC void wm_vuldet_set_subversion(char *version, char **os_minor);
 STATIC cJSON *wm_vuldet_json_fread(char *json_file);
 STATIC cJSON *wm_vuldet_get_cvss(const char *scoring_vector);
 STATIC int wm_vuldet_get_term_condition(char *i_term, char **term, char **comp_field, char **condition);
-STATIC int wm_vuldet_run_scan(wm_vuldet_t *vuldet);
 STATIC void wm_vuldet_init(wm_vuldet_t *vuldet);
 STATIC void wm_vuldet_update_last_scan(scan_ctx_t* scan_ctx);
 STATIC char *wm_vuldet_normalize_date(char **date);
@@ -417,6 +417,7 @@ int usec;
 
 w_linked_queue_t *vu_messages_queue = NULL;
 w_linked_queue_t* vu_tasks_queue = NULL;
+w_linked_queue_t* vu_messages_queue = NULL;
 
 const wm_context WM_VULNDETECTOR_CONTEXT = {
     "vulnerability-detector",
@@ -2538,14 +2539,13 @@ int wm_vuldet_find_obsolete_vulnerabilities(scan_ctx_t* scan_ctx) {
 }
 
 int wm_vuldet_check_agent_vulnerabilities(wm_vuldet_t *vuldet) {
-    scan_agent *agents_it;
+    scan_agent *agents_it = NULL;
     sqlite3 *db;
     sqlite3_stmt *stmt = NULL;
-    bool retry_agents = false;
-    bool abort_scan = false;
-    int result;
+    int result = OS_SUCCESS;
+    int db_result = OS_SUCCESS;
 
-    if (!vuldet->scan_agents) {
+    if (!vuldet->agent_to_scan) {
         mtinfo(WM_VULNDETECTOR_LOGTAG, VU_AG_NO_TARGET);
         return 0;
     } else if (sqlite3_open_v2(CVE_DB, &db, SQLITE_OPEN_READWRITE, NULL) != SQLITE_OK) {
@@ -2553,113 +2553,102 @@ int wm_vuldet_check_agent_vulnerabilities(wm_vuldet_t *vuldet) {
         return wm_vuldet_sql_error(db, stmt);
     }
 
-    // Iterate agents to look for vulnerabilities
-    do {
-        retry_agents = false;
-        time_t first_fail_scan = 0;
-        for (agents_it = vuldet->scan_agents; agents_it; agents_it = agents_it->next) {
-            scan_ctx_t scan_ctx = {0};
-            scan_ctx.agent_id = atoi(agents_it->agent_id);
-            scan_ctx.agent_name = agents_it->agent_name;
-            scan_ctx.agent_ip = agents_it->agent_ip;
+    if (wm_vuldet_nvd_empty() == 0) {
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_NVD_EMPTY);
+        return OS_INVALID;
+    }
 
-            if (agents_it->pending_attempts == 0) continue;
+    agents_it = vuldet->agent_to_scan;
+    if (agents_it->pending_attempts == 0) {
+        result = OS_SUCCESS;
+        goto end;
+    }
+    time_t start = time(NULL);
 
-            time_t start = time(NULL);
+    scan_ctx_t scan_ctx = {0};
+    scan_ctx.agent_id = atoi(agents_it->agent_id);
+    scan_ctx.agent_name = agents_it->agent_name;
+    scan_ctx.agent_ip = agents_it->agent_ip;
 
-            // Check if there are available vulnerabilities for this agent
-            if (agents_it->dist != FEED_WIN && agents_it->dist != FEED_MAC) {
-                result = wm_vuldet_db_empty(db, agents_it->dist_ver);
-                if (result == 0) {
-                    // There is no data in the VULNERABILITIES table for this agent
-                    // It has to be skipped instead of being scanned against the NVD to avoid false positives
-                    mtwarn(WM_VULNDETECTOR_LOGTAG, VU_OVAL_UNAVAILABLE_DATA, scan_ctx.agent_id);
-                    agents_it->pending_attempts = 0;
-                    continue;
-                } else if (result == OS_INVALID) {
-                    // DB error
-                    abort_scan = true;
-                    break;
-                }
-            }
-
-            //Check which type of scan is required
-            time_t last_full_scan = wm_vuldet_get_last_full_scan(&scan_ctx);
-            if (last_full_scan < 0) {
-                // DB error
-                abort_scan = true;
-                break;
-            }
-            else if (last_full_scan == 0) {
-                scan_ctx.scan_type = VU_BASELINE_SCAN;
-                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_BASELINE_SCAN, scan_ctx.agent_id);
-            }
-            else if (curr_time - last_full_scan >= vuldet->min_full_scan_interval &&
-                    wm_vuldet_feed_changed (vuldet->updates, agents_it, last_full_scan)) {
-                scan_ctx.scan_type = VU_FULL_SCAN;
-                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_FULL_SCAN, scan_ctx.agent_id);
-            }
-            else {
-                scan_ctx.scan_type = VU_PARTIAL_SCAN;
-                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_PART_SCAN, scan_ctx.agent_id);
-            }
-
-            // Reset the tables before scanning each agent
-            wm_vuldet_reset_tables(db);
-
-            // Collect agent software
-            if (OS_SUCCESS != wm_vuldet_collect_agent_software(agents_it, db, &scan_ctx)) {
-                agents_it->pending_attempts--;
-                if (agents_it->pending_attempts) {
-                    retry_agents = true;
-                    if (!first_fail_scan) first_fail_scan = time(NULL);
-                }
-                else {
-                    mtinfo(WM_VULNDETECTOR_LOGTAG, VU_GET_SOFTWARE_ERROR, scan_ctx.agent_id, WM_VULNDETECTOR_MAX_AGENT_SCAN_ATTEMPS);
-                }
-                continue;
-            }
-
-            mtinfo(WM_VULNDETECTOR_LOGTAG, VU_START_AG_AN, scan_ctx.agent_id);
-
-            // Find and report agent vulnerabilities
-            if (OS_SUCCESS != wm_vuldet_find_agent_vulnerabilities(db, agents_it, &vuldet->flags, &scan_ctx)) {
-                mterror(WM_VULNDETECTOR_LOGTAG, VU_REPORT_ERROR, scan_ctx.agent_id, sqlite3_errmsg(db));
-                abort_scan = true;
-                break;
-            }
-
-            // Find and report obsolete vulnerabilities
-            if (OS_SUCCESS != wm_vuldet_find_obsolete_vulnerabilities(&scan_ctx) ) {
-                mterror(WM_VULNDETECTOR_LOGTAG, "The agent '%.3d' obsolete vulnerability could not be processed", scan_ctx.agent_id);
-                abort_scan = true;
-                break;
-            }
-
-            // Update the time of the last scan
-            wm_vuldet_update_last_scan(&scan_ctx);
-
-            mtinfo(WM_VULNDETECTOR_LOGTAG, VU_AGENT_FINISH, scan_ctx.agent_id);
-            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_FUNCTION_TIME, time(NULL) - start, "scan", scan_ctx.agent_id);
+    // Check if there are available vulnerabilities for this agent
+    if (agents_it->dist != FEED_WIN && agents_it->dist != FEED_MAC) {
+        db_result = wm_vuldet_db_empty(db, agents_it->dist_ver);
+        if (db_result == 0) {
+            // There is no data in the VULNERABILITIES table for this agent
+            // It has to be skipped instead of being scanned against the NVD to avoid false positives
+            mtwarn(WM_VULNDETECTOR_LOGTAG, VU_OVAL_UNAVAILABLE_DATA, scan_ctx.agent_id);
             agents_it->pending_attempts = 0;
+            result = OS_SUCCESS;
+            goto end;
+        } else if (db_result == OS_INVALID) {
+            // DB error
+            result = OS_INVALID;
+            goto end;
         }
+    }
 
-        if (retry_agents) {
-            time_t sleep_time = first_fail_scan + vuldet->retry_interval - time(NULL);
-            if (sleep_time <= 0) {
-                sleep_time = 1;
-            }
-            mtdebug1(WM_VULNDETECTOR_LOGTAG, "Going to sleep %ld seconds before retrying pending agents", sleep_time);
-            sleep (sleep_time);
+    //Check which type of scan is required
+    time_t last_full_scan = wm_vuldet_get_last_full_scan(&scan_ctx);
+    if (last_full_scan < 0) {
+        // DB error
+        result = OS_INVALID;
+        goto end;
+    }
+    else if (last_full_scan == 0) {
+        scan_ctx.scan_type = VU_BASELINE_SCAN;
+        mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_BASELINE_SCAN, scan_ctx.agent_id);
+    }
+    else if (curr_time - last_full_scan >= vuldet->min_full_scan_interval &&
+            wm_vuldet_feed_changed (vuldet->updates, agents_it, last_full_scan)) {
+        scan_ctx.scan_type = VU_FULL_SCAN;
+        mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_FULL_SCAN, scan_ctx.agent_id);
+    }
+    else {
+        scan_ctx.scan_type = VU_PARTIAL_SCAN;
+        mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_PART_SCAN, scan_ctx.agent_id);
+    }
+
+    // Reset the tables before scanning each agent
+    wm_vuldet_reset_tables(db);
+
+    // Collect agent software
+    if (OS_SUCCESS != wm_vuldet_collect_agent_software(agents_it, db, &scan_ctx)) {
+        agents_it->pending_attempts--;
+        if (0 == agents_it->pending_attempts) {
+            mtinfo(WM_VULNDETECTOR_LOGTAG, VU_GET_SOFTWARE_ERROR, atoi(agents_it->agent_id), WM_VULNDETECTOR_MAX_AGENT_SCAN_ATTEMPS);
         }
+        goto end;
+    }
 
-    } while (retry_agents && !abort_scan);
+    mtinfo(WM_VULNDETECTOR_LOGTAG, VU_START_AG_AN, scan_ctx.agent_id);
 
+    // Find and report agent vulnerabilities
+    if (OS_SUCCESS != wm_vuldet_find_agent_vulnerabilities(db, agents_it, &vuldet->flags, &scan_ctx)) {
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_REPORT_ERROR, scan_ctx.agent_id, sqlite3_errmsg(db));
+        result = OS_INVALID;
+        goto end;
+    }
+
+    // Find and report obsolete vulnerabilities
+    if (OS_SUCCESS != wm_vuldet_find_obsolete_vulnerabilities(&scan_ctx) ) {
+        mterror(WM_VULNDETECTOR_LOGTAG, "The agent '%.3d' obsolete vulnerability could not be processed", scan_ctx.agent_id);
+        result = OS_INVALID;
+        goto end;
+    }
+
+    // Update the time of the last scan
+    wm_vuldet_update_last_scan(&scan_ctx);
+
+    mtinfo(WM_VULNDETECTOR_LOGTAG, VU_AGENT_FINISH, scan_ctx.agent_id);
+    mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_FUNCTION_TIME, time(NULL) - start, "scan", scan_ctx.agent_id);
+    agents_it->pending_attempts = 0;
+
+end:
     // Reset the tables
     wm_vuldet_reset_tables(db);
 
     sqlite3_close_v2(db);
-    return 0;
+    return result;
 }
 
 int wm_vuldet_sql_error(sqlite3 *db, sqlite3_stmt *stmt) {
@@ -5283,18 +5272,24 @@ void wm_vuldet_create_and_send_message(vu_task_ctx_t* task, task_status TASK_STA
 }
 
 void wm_vuldet_on_demand_scan(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet) {
+    scan_agent *agent = NULL;
+    os_calloc(1, sizeof(scan_agent), agent);
+
     wm_vuldet_create_and_send_message(current_task, WM_TASK_IN_PROGRESS, NULL);
-    if (wm_vuldet_collect_agent_info(current_task->agent_to_scan, vuldet)) {
-        mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR);
+    if (wm_vuldet_collect_agent_info(current_task->agent_to_scan, vuldet, agent)) {
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR, current_task->agent_to_scan);
         wm_vuldet_create_and_send_message(current_task, WM_TASK_FAILED, NULL);
     } else {
-        if (wm_vuldet_run_scan(vuldet)) {
+        vuldet->agent_to_scan = agent;
+        if (wm_vuldet_check_agent_vulnerabilities(vuldet)) {
             wm_vuldet_create_and_send_message(current_task, WM_TASK_FAILED, NULL);
             mterror(WM_VULNDETECTOR_LOGTAG, VU_AG_CHECK_ERR);
         } else {
             wm_vuldet_create_and_send_message(current_task, WM_TASK_DONE, NULL);
         }
     }
+
+    wm_vuldet_free_scan_agent(agent);
 }
 
 void wm_vuldet_on_demand_feed_update(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet) {
@@ -5348,38 +5343,82 @@ void wm_vuldet_scan_by_interval(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet
     int* agents_array = NULL;
     int i = 0;
     int sock = wm_vuldet_get_wdb_socket();
-    char status_message[OS_SIZE_64] = {0};
+    scan_agent *agents = NULL;
+    scan_agent *f_agent = NULL;
+    scan_agent *agent_aux = NULL;
 
-    // Scaning the manager
-    if (wm_vuldet_collect_agent_info(000, vuldet)) {
-        mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR);
-    } else {
-        snprintf(status_message, OS_SIZE_64, " Agent: manager.");
-        wm_vuldet_create_and_send_message(current_task, WM_TASK_IN_PROGRESS, status_message);
-        if (wm_vuldet_run_scan(vuldet)) {
-            mterror(WM_VULNDETECTOR_LOGTAG, VU_AG_CHECK_ERR);
+    // Collecting agents data
+    int i = -1;
+    int* agents_array = wdb_get_agents_by_connection_status(AGENT_CS_ACTIVE, &sock);
+
+    do {
+        os_calloc(1, sizeof(scan_agent), agent_aux);
+        if (wm_vuldet_collect_agent_info(i == -1 ? 000 : agents_array[i], vuldet, agent_aux)) {
+             mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR, i == -1 ? (size_t)000 : (size_t)agents_array[i]);
+             wm_vuldet_free_scan_agent(agent_aux);
+        } else {
+            if (agents) {
+                agents->next = agent_aux;
+            } else {
+                f_agent = agent_aux;
+            }
+            agents = agent_aux;
+            agents->next = NULL;
         }
-    }
+        i++;
+    } while(agents_array[i] != OS_INVALID);
+    os_free(agents_array);
 
     // Scanning agents
-    agents_array = wdb_get_agents_by_connection_status(AGENT_CS_ACTIVE, &sock);
-    while(agents_array && agents_array[i] != OS_INVALID && current_task && WM_TASK_CANCELLED != current_task->task_status) {
-        if (wm_vuldet_collect_agent_info(agents_array[i], vuldet)) {
-            mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR);
-        } else {
-            snprintf(status_message, OS_SIZE_64, " Agent: %.3d.", agents_array[i]);
+    bool retry_agents = false;
+    bool abort_scan = false;
+    char status_message[OS_SIZE_64] = {0};
+
+    mtinfo(WM_VULNDETECTOR_LOGTAG, VU_START_SCAN);
+    do {
+        retry_agents = false;
+        time_t first_fail_scan = 0;
+        agents = f_agent;
+        while (agents && current_task && WM_TASK_CANCELLED != current_task->task_status) {
+            vuldet->agent_to_scan = agents;
+            snprintf(status_message, OS_SIZE_64, " Agent: %.3d.", atoi(agents->agent_id));
             wm_vuldet_create_and_send_message(current_task, WM_TASK_IN_PROGRESS, status_message);
-            if (wm_vuldet_run_scan(vuldet)) {
+
+            if (wm_vuldet_check_agent_vulnerabilities(vuldet)) {
                 mterror(WM_VULNDETECTOR_LOGTAG, VU_AG_CHECK_ERR);
+                abort_scan = true;
+                break;
+            } else {
+                if (agents->pending_attempts) {
+                    retry_agents = true;
+                    if (!first_fail_scan) {
+                        first_fail_scan = time(NULL);
+                    }
+                    agents = agents->next;
+                } else {
+                    agent_aux = agents->next;
+                    if (f_agent->agent_id == agents->agent_id) {
+                        f_agent = agent_aux;
+                    }
+                    wm_vuldet_free_scan_agent(agents);
+                    agents = agent_aux;
+                }
             }
+            current_task = (vu_task_context_t*) linked_queue_read_ex(vu_tasks_queue);
         }
         i++;
         current_task = (vu_task_ctx_t*) linked_queue_read_ex(vu_tasks_queue);
     }
     mtinfo(WM_VULNDETECTOR_LOGTAG, VU_END_SCAN);
+    vuldet->last_scan = time(NULL);
 
-    wm_vuldet_create_and_send_message(current_task, WM_TASK_DONE, NULL);
-    os_free(agents_array);
+    if (WM_TASK_CANCELLED == current_task->task_status) {
+        wm_vuldet_create_and_send_message(current_task, WM_TASK_CANCELLED, NULL);
+    } else if (abort_scan) {
+        wm_vuldet_create_and_send_message(current_task, WM_TASK_FAILED, NULL);
+    } else {
+        wm_vuldet_create_and_send_message(current_task, WM_TASK_DONE, NULL);
+    }
 }
 
 void wm_vuldet_working_thread(void* vuldet_data) {
@@ -5478,7 +5517,7 @@ void *wm_vuldet_main(wm_vuldet_t* vuldet) {
     return NULL;
 }
 
-int wm_vuldet_collect_agent_info(int agent_id, wm_vuldet_t *vuldet) {
+int wm_vuldet_collect_agent_info(int agent_id, wm_vuldet_t *vuldet, scan_agent *agent) {
     cJSON *j_agent_info = NULL;
     cJSON *j_osinfo = NULL;
     cJSON *j_field = NULL;
@@ -5488,13 +5527,7 @@ int wm_vuldet_collect_agent_info(int agent_id, wm_vuldet_t *vuldet) {
     int dist_error = -1;
     bool is_rolling = FALSE;
     w_err_t ret = OS_SUCCESS;
-    scan_agent *agent = NULL;
     int sock = wm_vuldet_get_wdb_socket();
-
-    // Prepare and fill structure.
-    os_calloc(1, sizeof(scan_agent), agent);
-    agent->next = NULL;
-    vuldet->scan_agents = agent;
 
     // Getting agent-info data from global.db.
     j_agent_info = wdb_get_agent_info(agent_id, &sock);
@@ -5811,10 +5844,6 @@ int wm_vuldet_collect_agent_info(int agent_id, wm_vuldet_t *vuldet) {
 next:
     if (j_agent_info) cJSON_Delete(j_agent_info);
     if (j_osinfo) cJSON_Delete(j_osinfo);
-    if (OS_INVALID == ret) {
-        wm_vuldet_free_scan_agent(agent);
-        vuldet->scan_agents = NULL;
-    }
 
     return ret;
 }
@@ -5844,7 +5873,7 @@ void wm_vuldet_destroy(wm_vuldet_t * vuldet) {
         }
     }
 
-    for (agent = vuldet->scan_agents; agent;) {
+    for (agent = vuldet->agent_to_scan; agent;) {
         scan_agent *agent_aux = agent->next;
         wm_vuldet_free_scan_agent(agent);
         if (agent_aux) {
@@ -7965,19 +7994,8 @@ cpe *wm_vuldet_generate_cpe(const char *part, const char *vendor, const char *pr
     return new_cpe;
 }
 
-int wm_vuldet_run_scan(wm_vuldet_t *vuldet) {
-    int result = OS_INVALID;
-    mtinfo(WM_VULNDETECTOR_LOGTAG, VU_START_SCAN);
-
-    if (wm_vuldet_nvd_empty() == 0) {
-        mterror(WM_VULNDETECTOR_LOGTAG, VU_NVD_EMPTY);
-        return result;
-    }
-
-    result = wm_vuldet_check_agent_vulnerabilities(vuldet);
-
-    scan_agent *agent;
-    for (agent = vuldet->scan_agents; agent;) {
+void wm_vuldet_clean_all_scan_agent_structures(scan_agent* agent) {
+    while(agent) {
         scan_agent *agent_aux = agent->next;
 
         wm_vuldet_free_scan_agent(agent);
@@ -7987,10 +8005,6 @@ int wm_vuldet_run_scan(wm_vuldet_t *vuldet) {
             break;
         }
     }
-
-    vuldet->scan_agents = NULL;
-
-    return result;
 }
 
 void wm_vuldet_init(wm_vuldet_t * vuldet) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5292,18 +5292,15 @@ bool wm_vuldet_on_demand_scan(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet) 
     if (!current_task->agent_data) {
         os_calloc(1, sizeof(scan_agent), current_task->agent_data);
     } else {
-        if (current_task->agent_last_scan_time != 0) {
-            time_t sleep_time = current_task->agent_last_scan_time + vuldet->retry_interval - time(NULL);
-            if (sleep_time > 0) {
-                mtdebug1(WM_VULNDETECTOR_LOGTAG, "Going to sleep %ld seconds before retrying pending agents", sleep_time);
-                sleep(sleep_time);
-            }
-            current_task->agent_last_scan_time = 0;
+        time_t sleep_time = current_task->agent_last_scan_time + vuldet->retry_interval - time(NULL);
+        if (sleep_time > 0) {
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, "Going to sleep %ld seconds before retrying pending agents", sleep_time);
+            sleep(sleep_time);
         }
     }
 
     wm_vuldet_create_and_send_message(current_task, WM_TASK_IN_PROGRESS, NULL);
-    if (wm_vuldet_collect_agent_info(current_task->agent_to_scan, vuldet, current_task->agent_data)) {
+    if (current_task->agent_last_scan_time == 0 && wm_vuldet_collect_agent_info(current_task->agent_to_scan, vuldet, current_task->agent_data)) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR, current_task->agent_to_scan);
         wm_vuldet_create_and_send_message(current_task, WM_TASK_FAILED, NULL);
     } else {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -666,7 +666,8 @@ vu_task_ctx_t *create_task(const int task_id,
                            const vu_task_type_t task_type,
                            const task_status task_status,
                            const vu_feed feed_to_update,
-                           const int agent_to_scan) {
+                           const int agent_to_scan,
+                           scan_agent* agent_data) {
     vu_task_ctx_t *task = NULL;
     os_calloc(1, sizeof(vu_task_ctx_t), task);
 
@@ -675,6 +676,8 @@ vu_task_ctx_t *create_task(const int task_id,
     task->task_status = task_status;
     task->feed_to_update = feed_to_update;
     task->agent_to_scan = agent_to_scan;
+    task->agent_data = agent_data;
+    task->agent_last_scan_time = 0;
 
     return task;
 }
@@ -687,6 +690,9 @@ void vu_task_msg_ctx_free(vu_task_msg_ctx_t *msg) {
 }
 
 void vu_task_ctx_free (vu_task_ctx_t* task) {
+    if (task) {
+        wm_vuldet_free_scan_agent(task->agent_data);
+    }
     os_free(task);
 }
 
@@ -2615,6 +2621,7 @@ int wm_vuldet_check_agent_vulnerabilities(wm_vuldet_t *vuldet) {
         agents_it->pending_attempts--;
         if (0 == agents_it->pending_attempts) {
             mtinfo(WM_VULNDETECTOR_LOGTAG, VU_GET_SOFTWARE_ERROR, atoi(agents_it->agent_id), WM_VULNDETECTOR_MAX_AGENT_SCAN_ATTEMPS);
+            agents_it->pending_attempts = OS_INVALID;
         }
         goto end;
     }
@@ -4690,7 +4697,7 @@ void wm_vuldet_schedule_updates(update_node **updates) {
     for (int os = 0; os < OS_SUPP_SIZE; os++) {
         if (updates[os] && wm_vuldet_check_update_period(updates[os])) {
             if (!VU_INTERVAL_FEED_UPDATE_FLAGS[updates[os]->dist_ref]) {
-                vu_task_ctx_t *task = create_task(OS_INVALID, VU_INTERVAL_FEED_UPDATE, WM_TASK_PENDING, updates[os]->dist_ref, OS_INVALID);
+                vu_task_ctx_t *task = create_task(OS_INVALID, VU_INTERVAL_FEED_UPDATE, WM_TASK_PENDING, updates[os]->dist_ref, OS_INVALID, NULL);
                 if (OS_INVALID == register_task(task)) {
                     mwarn("Couldn't establish communication with task manager. There's no ID for task");
                 }
@@ -5259,6 +5266,10 @@ void wm_vuldet_create_and_send_message(vu_task_ctx_t* task, task_status TASK_STA
                 snprintf(status_message, OS_SIZE_128, "Task failed.%s", details ? details : "");
                 os_strdup(status_message, message->status_message);
                 break;
+            case WM_TASK_PENDING:
+                snprintf(status_message, OS_SIZE_128, "Task pending.%s", details ? details : "");
+                os_strdup(status_message, message->status_message);
+                break;
             default:
                 os_free(message);
                 message = NULL;
@@ -5270,25 +5281,51 @@ void wm_vuldet_create_and_send_message(vu_task_ctx_t* task, task_status TASK_STA
     }
 }
 
-void wm_vuldet_on_demand_scan(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet) {
-    scan_agent *agent = NULL;
-    os_calloc(1, sizeof(scan_agent), agent);
+bool wm_vuldet_on_demand_scan(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet) {
+    bool retry_agent = false;
+    char status_message[OS_SIZE_64] = {0};
+
+    if (!current_task || !vuldet) {
+        return false;
+    }
+
+    if (!current_task->agent_data) {
+        os_calloc(1, sizeof(scan_agent), current_task->agent_data);
+    } else {
+        if (current_task->agent_last_scan_time != 0) {
+            time_t sleep_time = current_task->agent_last_scan_time + vuldet->retry_interval - time(NULL);
+            if (sleep_time > 0) {
+                mtdebug1(WM_VULNDETECTOR_LOGTAG, "Going to sleep %ld seconds before retrying pending agents", sleep_time);
+                sleep(sleep_time);
+            }
+            current_task->agent_last_scan_time = 0;
+        }
+    }
 
     wm_vuldet_create_and_send_message(current_task, WM_TASK_IN_PROGRESS, NULL);
-    if (wm_vuldet_collect_agent_info(current_task->agent_to_scan, vuldet, agent)) {
+    if (wm_vuldet_collect_agent_info(current_task->agent_to_scan, vuldet, current_task->agent_data)) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR, current_task->agent_to_scan);
         wm_vuldet_create_and_send_message(current_task, WM_TASK_FAILED, NULL);
     } else {
-        vuldet->agent_to_scan = agent;
+        vuldet->agent_to_scan = current_task->agent_data;
         if (wm_vuldet_check_agent_vulnerabilities(vuldet)) {
             wm_vuldet_create_and_send_message(current_task, WM_TASK_FAILED, NULL);
             mterror(WM_VULNDETECTOR_LOGTAG, VU_AG_CHECK_ERR);
         } else {
-            wm_vuldet_create_and_send_message(current_task, WM_TASK_DONE, NULL);
+            if (current_task->agent_data->pending_attempts > 0) {
+                retry_agent = true;
+                snprintf(status_message, OS_SIZE_64, " Agent software not ready. It will be tried again later.");
+                current_task->agent_last_scan_time = time(NULL);
+                wm_vuldet_create_and_send_message(current_task, WM_TASK_PENDING, status_message);
+            } else if (current_task->agent_data->pending_attempts < 0){
+                wm_vuldet_create_and_send_message(current_task, WM_TASK_FAILED, NULL);
+            } else {
+                wm_vuldet_create_and_send_message(current_task, WM_TASK_DONE, NULL);
+            }
         }
     }
 
-    wm_vuldet_free_scan_agent(agent);
+    return retry_agent;
 }
 
 void wm_vuldet_on_demand_feed_update(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet) {
@@ -5386,7 +5423,7 @@ void wm_vuldet_scan_by_interval(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet
                 abort_scan = true;
                 break;
             } else {
-                if (agents->pending_attempts) {
+                if (agents->pending_attempts > 0) {
                     retry_agents = true;
                     if (!first_fail_scan) {
                         first_fail_scan = time(NULL);
@@ -5436,23 +5473,34 @@ void wm_vuldet_working_thread(void* vuldet_data) {
         if (current_task) {
             switch (current_task->task_type) {
                 case VU_ON_DEMAND_SCAN:
-                    wm_vuldet_on_demand_scan(current_task, vuldet);
+                    if (wm_vuldet_on_demand_scan(current_task, vuldet)) {
+                        linked_queue_unlink_and_push_node(vu_tasks_queue, vu_tasks_queue->first);
+                    } else {
+                        // Removing task from queue
+                        vu_task_ctx_free((vu_task_ctx_t*) linked_queue_pop_ex_no_cond_wait(vu_tasks_queue));
+                    }
                     break;
                 case VU_ON_DEMAND_FEED_UPDATE:
                     wm_vuldet_on_demand_feed_update(current_task, vuldet);
+                    // Removing task from queue
+                    vu_task_ctx_free((vu_task_ctx_t*) linked_queue_pop_ex_no_cond_wait(vu_tasks_queue));
                     break;
                 case VU_INTERVAL_FEED_UPDATE:
                     wm_vuldet_feed_update_by_interval(current_task, vuldet);
+                    // Removing task from queue
+                    vu_task_ctx_free((vu_task_ctx_t*) linked_queue_pop_ex_no_cond_wait(vu_tasks_queue));
                     break;
                 case VU_INTERVAL_SCAN:
                     wm_vuldet_scan_by_interval(current_task, vuldet);
+                    // Removing task from queue
+                    vu_task_ctx_free((vu_task_ctx_t*) linked_queue_pop_ex_no_cond_wait(vu_tasks_queue));
                     break;
                 default:
                     mdebug1("Invalid task type for vulnerability detector.");
+                    // Removing task from queue
+                    vu_task_ctx_free((vu_task_ctx_t*) linked_queue_pop_ex_no_cond_wait(vu_tasks_queue));
                     break;
             }
-            // Removing task from queue
-            vu_task_ctx_free((vu_task_ctx_t*) linked_queue_pop_ex(vu_tasks_queue));
         } else {
             sleep(1);
         }
@@ -5492,7 +5540,7 @@ void *wm_vuldet_main(wm_vuldet_t* vuldet) {
 
             if ((curr_time - vuldet->last_scan >= vuldet->scan_interval)) {
                 if (!VU_TASKS_QUEUE_FLAGS[VU_INTERVAL_SCAN]) {
-                    vu_task_ctx_t *task = create_task(OS_INVALID, VU_INTERVAL_SCAN, WM_TASK_PENDING, FEED_UNKNOWN, OS_INVALID);
+                    vu_task_ctx_t *task = create_task(OS_INVALID, VU_INTERVAL_SCAN, WM_TASK_PENDING, FEED_UNKNOWN, OS_INVALID, NULL);
                     if (OS_INVALID == register_task(task)) {
                         mwarn("Couldn't establish communication with task manager. There's no ID for task");
                     }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5281,7 +5281,7 @@ void wm_vuldet_create_and_send_message(vu_task_ctx_t* task, task_status TASK_STA
     }
 }
 
-bool wm_vuldet_on_demand_scan(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet) {
+bool wm_vuldet_scan_on_demand(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet) {
     bool retry_agent = false;
     char status_message[OS_SIZE_64] = {0};
 
@@ -5325,7 +5325,7 @@ bool wm_vuldet_on_demand_scan(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet) 
     return retry_agent;
 }
 
-void wm_vuldet_on_demand_feed_update(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet) {
+void wm_vuldet_feed_update_on_demand(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet) {
     wm_vuldet_create_and_send_message(current_task, WM_TASK_IN_PROGRESS, NULL);
     if (wm_vuldet_run_update(vuldet->updates)) {
         wm_vuldet_create_and_send_message(current_task, WM_TASK_FAILED, NULL);
@@ -5384,9 +5384,9 @@ void wm_vuldet_scan_by_interval(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet
 
     do {
         os_calloc(1, sizeof(scan_agent), agent_aux);
-        if (wm_vuldet_collect_agent_info(i == -1 ? 000 : agents_array[i], vuldet, agent_aux)) {
-             mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR, i == -1 ? 000 : agents_array[i]);
-             wm_vuldet_free_scan_agent(agent_aux);
+        if (wm_vuldet_collect_agent_info(i == -1 ? MANAGER_ID : agents_array[i], vuldet, agent_aux)) {
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR, i == -1 ? MANAGER_ID : agents_array[i]);
+            wm_vuldet_free_scan_agent(agent_aux);
         } else {
             if (agents) {
                 agents->next = agent_aux;
@@ -5440,11 +5440,10 @@ void wm_vuldet_scan_by_interval(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet
 
         if (retry_agents && !abort_scan && WM_TASK_CANCELLED != current_task->task_status) {
             time_t sleep_time = first_fail_scan + vuldet->retry_interval - time(NULL);
-            if (sleep_time <= 0) {
-                sleep_time = 1;
+            if (sleep_time > 0) {
+                mtdebug1(WM_VULNDETECTOR_LOGTAG, "Going to sleep %ld seconds before retrying pending agents", sleep_time);
+                sleep (sleep_time);
             }
-            mtdebug1(WM_VULNDETECTOR_LOGTAG, "Going to sleep %ld seconds before retrying pending agents", sleep_time);
-            sleep (sleep_time);
         }
     } while (retry_agents && !abort_scan && WM_TASK_CANCELLED != current_task->task_status);
     wm_vuldet_clean_all_scan_agent_structures(f_agent);
@@ -5470,7 +5469,7 @@ void wm_vuldet_working_thread(void* vuldet_data) {
         if (current_task) {
             switch (current_task->task_type) {
                 case VU_ON_DEMAND_SCAN:
-                    if (wm_vuldet_on_demand_scan(current_task, vuldet)) {
+                    if (wm_vuldet_scan_on_demand(current_task, vuldet)) {
                         linked_queue_unlink_and_push_node(vu_tasks_queue, vu_tasks_queue->first);
                     } else {
                         // Removing task from queue
@@ -5478,7 +5477,7 @@ void wm_vuldet_working_thread(void* vuldet_data) {
                     }
                     break;
                 case VU_ON_DEMAND_FEED_UPDATE:
-                    wm_vuldet_on_demand_feed_update(current_task, vuldet);
+                    wm_vuldet_feed_update_on_demand(current_task, vuldet);
                     // Removing task from queue
                     vu_task_ctx_free((vu_task_ctx_t*) linked_queue_pop_ex_no_cond_wait(vu_tasks_queue));
                     break;
@@ -5498,8 +5497,6 @@ void wm_vuldet_working_thread(void* vuldet_data) {
                     vu_task_ctx_free((vu_task_ctx_t*) linked_queue_pop_ex_no_cond_wait(vu_tasks_queue));
                     break;
             }
-        } else {
-            sleep(1);
         }
     }
 }
@@ -5900,7 +5897,6 @@ next:
 }
 
 void wm_vuldet_destroy(wm_vuldet_t * vuldet) {
-    scan_agent *agent;
     update_node **update;
     int i, j;
 
@@ -5924,15 +5920,8 @@ void wm_vuldet_destroy(wm_vuldet_t * vuldet) {
         }
     }
 
-    for (agent = vuldet->agent_to_scan; agent;) {
-        scan_agent *agent_aux = agent->next;
-        wm_vuldet_free_scan_agent(agent);
-        if (agent_aux) {
-            agent = agent_aux;
-        } else {
-            break;
-        }
-    }
+    wm_vuldet_clean_all_scan_agent_structures(vuldet->agent_to_scan);
+
     free(vuldet);
 }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -86,6 +86,7 @@
 #define VU_AGENT_REQUEST_LIMIT   3
 #define VU_ALERT_HEADER "[%03d] (%s) %s"
 #define VU_ALERT_JSON "1:" VU_WM_NAME ":%s"
+#define MANAGER_ID 0
 
 /**
  * Default size for the CVE hash table.
@@ -986,7 +987,7 @@ void wm_vuldet_create_and_send_message(vu_task_ctx_t* task, task_status TASK_STA
  * @param vuldet The vulnerability detector structure.
  * @return true if the agent has pending retries, false otherwise.
  */
-bool wm_vuldet_on_demand_scan(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet);
+bool wm_vuldet_scan_on_demand(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet);
 
 /**
  * @brief Method to run all the required steps for a feed update on demand. All the feeds will be updated.
@@ -994,7 +995,7 @@ bool wm_vuldet_on_demand_scan(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet);
  * @param current_task The task containing the data of the agent to scan.
  * @param vuldet The vulnerability detector structure.
  */
-void wm_vuldet_on_demand_feed_update(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet);
+void wm_vuldet_feed_update_on_demand(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet);
 
 /**
  * @brief Method to run all the required steps for a feed update by interval. Only the specified feed will be updated.

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -874,15 +874,6 @@ typedef struct scan_ctx_t {
     bool            package_scan;
 } scan_ctx_t;
 
-// Task context for vu_tasks_queue
-typedef struct vu_task_context_t {
-    size_t taskID;
-    vu_task_type_t task_type;
-    task_status task_status;
-    cve_db feed_to_update;
-    int agent_to_scan;
-} vu_task_context_t;
-
 // Macros
 #define wm_vuldet_is_single_provider(x) (x == FEED_UBUNTU || x == FEED_DEBIAN || x == FEED_REDHAT || x == FEED_ALAS)
 #define wm_vuldet_silent_feed(x) (x == FEED_CPEW)
@@ -1054,7 +1045,7 @@ void wm_vuldet_working_thread(void* vuldet_data);
  * @param TASK_STATUS The status of the task to be written in the message.
  * @param details Optional parameter to add more details to the message.
  */
-void wm_vuldet_create_and_send_message(vu_task_context_t* task, task_status TASK_STATUS, char* details);
+void wm_vuldet_create_and_send_message(vu_task_ctx_t* task, task_status TASK_STATUS, char* details);
 
 /**
  * @brief Method to run all the required steps for a scan on demand for a specific agent.
@@ -1062,7 +1053,7 @@ void wm_vuldet_create_and_send_message(vu_task_context_t* task, task_status TASK
  * @param current_task The task containing the data of the agent to scan.
  * @param vuldet The vulnerability detector structure.
  */
-void wm_vuldet_on_demand_scan(vu_task_context_t* current_task, wm_vuldet_t* vuldet);
+void wm_vuldet_on_demand_scan(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet);
 
 /**
  * @brief Method to run all the required steps for a feed update on demand. All the feeds will be updated.
@@ -1070,7 +1061,7 @@ void wm_vuldet_on_demand_scan(vu_task_context_t* current_task, wm_vuldet_t* vuld
  * @param current_task The task containing the data of the agent to scan.
  * @param vuldet The vulnerability detector structure.
  */
-void wm_vuldet_on_demand_feed_update(vu_task_context_t* current_task, wm_vuldet_t* vuldet);
+void wm_vuldet_on_demand_feed_update(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet);
 
 /**
  * @brief Method to run all the required steps for a feed update by interval. Only the specified feed will be updated.
@@ -1078,7 +1069,7 @@ void wm_vuldet_on_demand_feed_update(vu_task_context_t* current_task, wm_vuldet_
  * @param current_task The task containing the data of the agent to scan.
  * @param vuldet The vulnerability detector structure.
  */
-void wm_vuldet_feed_update_by_interval(vu_task_context_t* current_task, wm_vuldet_t* vuldet);
+void wm_vuldet_feed_update_by_interval(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet);
 
 /**
  * @brief Method to run all the required steps for a scan by interval. All the connected agents and the manager
@@ -1087,7 +1078,7 @@ void wm_vuldet_feed_update_by_interval(vu_task_context_t* current_task, wm_vulde
  * @param current_task The task containing the data of the agent to scan.
  * @param vuldet The vulnerability detector structure.
  */
-void wm_vuldet_scan_by_interval(vu_task_context_t* current_task, wm_vuldet_t* vuldet);
+void wm_vuldet_scan_by_interval(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet);
 
 /**
  * @brief Performs all the required cleaning actions after a feed update.

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -341,22 +341,6 @@ typedef enum package_tags {
     PACKAGE_TYPE,
 } package_tags;
 
-// Task context for vu_tasks_queue
-typedef struct vu_task_ctx_t {
-    int task_id;
-    vu_task_type_t task_type;
-    task_status task_status;
-    vu_feed feed_to_update;
-    int agent_to_scan;
-} vu_task_ctx_t;
-
-// Message task context for vu_messages_queue
-typedef struct vu_task_msg_ctx_t {
-    int task_id;
-    task_status task_status;
-    char *status_message;
-} vu_task_msg_ctx_t;
-
 typedef struct cve_vuln_cond_NVD {
     int id;
     int conf_id;
@@ -874,6 +858,24 @@ typedef struct scan_ctx_t {
     bool            package_scan;
 } scan_ctx_t;
 
+// Task context for vu_tasks_queue
+typedef struct vu_task_ctx_t {
+    int task_id;                 // If not present, no messages will be pushed.
+    vu_task_type_t task_type;    // The type of task to run.
+    task_status task_status;     // The status may be WM_TASK_PENDING or WM_TASK_CANCELLED.
+    vu_feed feed_to_update;      // Used by VU_INTERVAL_FEED_UPDATE tasks, indicates the vendor to update.
+    int agent_to_scan;           // Used by VU_ON_DEMAND_SCAN tasks to indicate the agent that will be scanned.
+    scan_agent* agent_data;      // Used by VU_ON_DEMAND_SCAN tasks in case of agent retries.
+    time_t agent_last_scan_time; // Used by VU_ON_DEMAND_SCAN tasks in case of agent retries.
+} vu_task_ctx_t;
+
+// Message task context for vu_messages_queue
+typedef struct vu_task_msg_ctx_t {
+    int task_id;
+    task_status task_status;
+    char *status_message;
+} vu_task_msg_ctx_t;
+
 // Macros
 #define wm_vuldet_is_single_provider(x) (x == FEED_UBUNTU || x == FEED_DEBIAN || x == FEED_REDHAT || x == FEED_ALAS)
 #define wm_vuldet_silent_feed(x) (x == FEED_CPEW)
@@ -926,13 +928,15 @@ void wm_vuldet_init_queues();
  * @param task_status Status of the task.
  * @param feed_to_update Feed vendor identifier.
  * @param agent_to_scan Agent identifier.
+ * @param agent_data Agent data structure for scan on demand.
  * @return A task object on success. NULL on error.
  */
 vu_task_ctx_t *create_task(const int task_id,
                            const vu_task_type_t task_type,
                            const task_status task_status,
                            const vu_feed feed_to_update,
-                           const int agent_to_scan);
+                           const int agent_to_scan,
+                           scan_agent* agent_data);
 
 /**
  * @brief Free memory taken by a task message.
@@ -980,8 +984,9 @@ void wm_vuldet_create_and_send_message(vu_task_ctx_t* task, task_status TASK_STA
  *
  * @param current_task The task containing the data of the agent to scan.
  * @param vuldet The vulnerability detector structure.
+ * @return true if the agent has pending retries, false otherwise.
  */
-void wm_vuldet_on_demand_scan(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet);
+bool wm_vuldet_on_demand_scan(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet);
 
 /**
  * @brief Method to run all the required steps for a feed update on demand. All the feeds will be updated.
@@ -998,21 +1003,6 @@ void wm_vuldet_on_demand_feed_update(vu_task_ctx_t* current_task, wm_vuldet_t* v
  * @param vuldet The vulnerability detector structure.
  */
 void wm_vuldet_feed_update_by_interval(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet);
-
-/**
- * @brief Method to run all the required steps for a scan by interval. All the connected agents and the manager
- *        will be scanned.
- *
- * @param current_task The task containing the data of the agent to scan.
- * @param vuldet The vulnerability detector structure.
- */
-void wm_vuldet_scan_by_interval(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet);
-
-/**
- * @brief Performs all the required cleaning actions after a feed update.
- *
- */
-void wm_vuldet_clean_after_run_update();
 
 /**
  * @brief Creates a new task for every vendor to update.
@@ -1020,56 +1010,6 @@ void wm_vuldet_clean_after_run_update();
  * @param updates The update nodes array.
  */
 void wm_vuldet_schedule_updates(update_node **updates);
-
-/**
- * @brief Launches the vulnerability detector working thread.
- *
- * @param working_thread The thread identifier.
- * @param vuldet The vulnerability detector structure.
- * @return int OS_SUCCESS if the thread was launched, OS_INVALID otherwise.
- */
-int wm_vuldet_run_working_thread(pthread_t* working_thread, wm_vuldet_t* vuldet);
-
-/**
- * @brief Main loop to read and execute vulnerability detector scheduled tasks.
- *
- * @param vuldet_data Vulnerability detector data structure.
- */
-void wm_vuldet_working_thread(void* vuldet_data);
-
-/**
- * @brief Method to create a message from a task and a status and push it to the messages queue.
- *        If the task has an invalid task ID, the message is discarded.
- *
- * @param task The task to create the message from.
- * @param TASK_STATUS The status of the task to be written in the message.
- * @param details Optional parameter to add more details to the message.
- */
-void wm_vuldet_create_and_send_message(vu_task_ctx_t* task, task_status TASK_STATUS, char* details);
-
-/**
- * @brief Method to run all the required steps for a scan on demand for a specific agent.
- *
- * @param current_task The task containing the data of the agent to scan.
- * @param vuldet The vulnerability detector structure.
- */
-void wm_vuldet_on_demand_scan(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet);
-
-/**
- * @brief Method to run all the required steps for a feed update on demand. All the feeds will be updated.
- *
- * @param current_task The task containing the data of the agent to scan.
- * @param vuldet The vulnerability detector structure.
- */
-void wm_vuldet_on_demand_feed_update(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet);
-
-/**
- * @brief Method to run all the required steps for a feed update by interval. Only the specified feed will be updated.
- *
- * @param current_task The task containing the data of the agent to scan.
- * @param vuldet The vulnerability detector structure.
- */
-void wm_vuldet_feed_update_by_interval(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet);
 
 /**
  * @brief Method to run all the required steps for a scan by interval. All the connected agents and the manager

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -496,7 +496,7 @@ typedef struct wm_vuldet_t {
     time_t min_full_scan_interval;
     time_t retry_interval;
     time_t last_scan;
-    scan_agent *scan_agents;
+    scan_agent *agent_to_scan;
     int queue_fd;
     wm_vuldet_state state;
     wm_vuldet_flags flags;
@@ -874,6 +874,15 @@ typedef struct scan_ctx_t {
     bool            package_scan;
 } scan_ctx_t;
 
+// Task context for vu_tasks_queue
+typedef struct vu_task_context_t {
+    size_t taskID;
+    vu_task_type_t task_type;
+    task_status task_status;
+    cve_db feed_to_update;
+    int agent_to_scan;
+} vu_task_context_t;
+
 // Macros
 #define wm_vuldet_is_single_provider(x) (x == FEED_UBUNTU || x == FEED_DEBIAN || x == FEED_REDHAT || x == FEED_ALAS)
 #define wm_vuldet_silent_feed(x) (x == FEED_CPEW)
@@ -1020,6 +1029,78 @@ void wm_vuldet_clean_after_run_update();
  * @param updates The update nodes array.
  */
 void wm_vuldet_schedule_updates(update_node **updates);
+
+/**
+ * @brief Launches the vulnerability detector working thread.
+ *
+ * @param working_thread The thread identifier.
+ * @param vuldet The vulnerability detector structure.
+ * @return int OS_SUCCESS if the thread was launched, OS_INVALID otherwise.
+ */
+int wm_vuldet_run_working_thread(pthread_t* working_thread, wm_vuldet_t* vuldet);
+
+/**
+ * @brief Main loop to read and execute vulnerability detector scheduled tasks.
+ *
+ * @param vuldet_data Vulnerability detector data structure.
+ */
+void wm_vuldet_working_thread(void* vuldet_data);
+
+/**
+ * @brief Method to create a message from a task and a status and push it to the messages queue.
+ *        If the task has an invalid task ID, the message is discarded.
+ *
+ * @param task The task to create the message from.
+ * @param TASK_STATUS The status of the task to be written in the message.
+ * @param details Optional parameter to add more details to the message.
+ */
+void wm_vuldet_create_and_send_message(vu_task_context_t* task, task_status TASK_STATUS, char* details);
+
+/**
+ * @brief Method to run all the required steps for a scan on demand for a specific agent.
+ *
+ * @param current_task The task containing the data of the agent to scan.
+ * @param vuldet The vulnerability detector structure.
+ */
+void wm_vuldet_on_demand_scan(vu_task_context_t* current_task, wm_vuldet_t* vuldet);
+
+/**
+ * @brief Method to run all the required steps for a feed update on demand. All the feeds will be updated.
+ *
+ * @param current_task The task containing the data of the agent to scan.
+ * @param vuldet The vulnerability detector structure.
+ */
+void wm_vuldet_on_demand_feed_update(vu_task_context_t* current_task, wm_vuldet_t* vuldet);
+
+/**
+ * @brief Method to run all the required steps for a feed update by interval. Only the specified feed will be updated.
+ *
+ * @param current_task The task containing the data of the agent to scan.
+ * @param vuldet The vulnerability detector structure.
+ */
+void wm_vuldet_feed_update_by_interval(vu_task_context_t* current_task, wm_vuldet_t* vuldet);
+
+/**
+ * @brief Method to run all the required steps for a scan by interval. All the connected agents and the manager
+ *        will be scanned.
+ *
+ * @param current_task The task containing the data of the agent to scan.
+ * @param vuldet The vulnerability detector structure.
+ */
+void wm_vuldet_scan_by_interval(vu_task_context_t* current_task, wm_vuldet_t* vuldet);
+
+/**
+ * @brief Performs all the required cleaning actions after a feed update.
+ *
+ */
+void wm_vuldet_clean_after_run_update();
+
+/**
+ * @brief Frees all the memory allocated for the agents data.
+ *
+ * @param agent The first agent of the list to free.
+ */
+void wm_vuldet_clean_all_scan_agent_structures(scan_agent* agent);
 
 /**
  * @brief Correlate OVAL and NVD feeds for a more fine tuned result.


### PR DESCRIPTION
|Related issue|
|---|
|#13244|

## Description

This PR moves the retry logic outside the vulnerability detector scan to make it compatible with the new tasks architecture.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
