### PR TITLE
Review unit tests in fimdb

### DIFF
--- a/src/syscheckd/src/db/include/db.h
+++ b/src/syscheckd/src/db/include/db.h
@@ -103,6 +103,8 @@ int fim_db_get_count_file_entry();
  *
  * @param data The information linked to the path to be created or updated.
  * @param callback Callback to send the fim message.
+ *
+ * @return FIMDB_OK on success.
  */
 FIMDBErrorCode fim_db_file_update(fim_entry* data, callback_context_t callback);
 
@@ -121,14 +123,17 @@ FIMDBErrorCode fim_db_file_inode_search(unsigned long long int inode, unsigned l
  * @brief Push a message to the syscheck queue
  *
  * @param msg The specific message to be pushed
+ *
+ * @return FIMDB_OK on success.
  */
-void fim_sync_push_msg(const char* msg);
+FIMDBErrorCode fim_sync_push_msg(const char* msg);
 
 /**
  * @brief Thread that performs the syscheck data synchronization
  *
+ * @return FIMDB_OK on success.
  */
-void fim_run_integrity();
+FIMDBErrorCode fim_run_integrity();
 
 /*
  * @brief Function that starts a new DBSync transaction.

--- a/src/syscheckd/src/db/src/db.cpp
+++ b/src/syscheckd/src/db/src/db.cpp
@@ -243,23 +243,31 @@ FIMDBErrorCode fim_db_init(int storage,
     return retVal;
 }
 
-void fim_run_integrity()
+FIMDBErrorCode fim_run_integrity()
 {
+    auto retval { FIMDB_ERR };
+
     try
     {
         DB::instance().runIntegrity();
+        retval = FIMDB_OK;
     }
     catch (const std::exception& err)
     {
         FIMDB::instance().logFunction(LOG_ERROR, err.what());
     }
+
+    return retval;
 }
 
-void fim_sync_push_msg(const char* msg)
+FIMDBErrorCode fim_sync_push_msg(const char* msg)
 {
+    auto retval { FIMDB_ERR };
+
     try
     {
         DB::instance().pushMessage(msg);
+        retval = FIMDB_OK;
     }
     // LCOV_EXCL_START
     catch (const std::exception& err)
@@ -268,6 +276,8 @@ void fim_sync_push_msg(const char* msg)
     }
 
     // LCOV_EXCL_STOP
+
+    return retval;
 }
 
 TXN_HANDLE fim_db_transaction_start(const char* table, result_callback_t row_callback, void* user_data)

--- a/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
@@ -93,8 +93,10 @@ TEST_F(DBTestFixture, TestFimSyncPushMsg)
     EXPECT_CALL(*mockSync, syncMsg("fim_file", testing::_)).Times(1);
     EXPECT_NO_THROW(
     {
-        fim_run_integrity();
-        fim_sync_push_msg(test);
+        auto result = fim_run_integrity();
+        ASSERT_EQ(result, FIMDB_OK);
+        result = fim_sync_push_msg(test);
+        ASSERT_EQ(result, FIMDB_OK);
     });
 }
 
@@ -106,7 +108,8 @@ TEST_F(DBTestFixture, TestFimRunIntegrity)
 
     EXPECT_NO_THROW(
     {
-        fim_run_integrity();
+        auto result = fim_run_integrity();
+        ASSERT_EQ(result, FIMDB_OK);
     });
 }
 
@@ -119,8 +122,10 @@ TEST_F(DBTestFixture, TestFimRunIntegrityInitTwice)
 
     EXPECT_NO_THROW(
     {
-        fim_run_integrity();
-        fim_run_integrity();
+        auto result = fim_run_integrity();
+        ASSERT_EQ(result, FIMDB_OK);
+        result = fim_run_integrity();
+        ASSERT_EQ(result, FIMDB_ERR);
     });
 }
 

--- a/src/syscheckd/src/db/tests/db/ComponentTest/fileInterface/fileTest.cpp
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/fileInterface/fileTest.cpp
@@ -277,15 +277,8 @@ TEST_F(DBTestFixture, TestFimDBFileInodeSearch)
         callback_context_t callback_data;
         callback_data.callback = callbackTestSearchPath;
         callback_data.context = test;
-        try
-        {
-            result = fim_db_file_inode_search(18277083, 2456, callback_data);
-            ASSERT_EQ(result, FIMDB_OK);
-        }
-        catch(...)
-        {
-            os_free(test);
-        }
+        result = fim_db_file_inode_search(18277083, 2456, callback_data);
+        ASSERT_EQ(result, FIMDB_OK);
         os_free(test);
         result = fim_db_file_update(fileFIMTest2->toFimEntry(), callback_data_modified);
         ASSERT_EQ(result, FIMDB_OK);
@@ -319,15 +312,8 @@ TEST_F(DBTestFixture, TestFimDBFilePatternSearch)
         test = strdup("/etc/wgetrc");
         callback_data.callback = callbackTestSearchPath;
         callback_data.context = test;
-        try
-        {
-            result = fim_db_file_pattern_search("/etc/%", callback_data);
-            ASSERT_EQ(result, FIMDB_OK);
-        }
-        catch(...)
-        {
-            os_free(test);
-        }
+        result = fim_db_file_pattern_search("/etc/%", callback_data);
+        ASSERT_EQ(result, FIMDB_OK);
         os_free(test);
     });
 }
@@ -425,15 +411,8 @@ TEST_F(DBTestFixture, TestFimDBFileInodeSearchWithBigInode)
         callback_context_t callback_data;
         callback_data.callback = callbackTestSearchPath;
         callback_data.context = test;
-        try
-        {
-            result = fim_db_file_inode_search(18277083, 2456, callback_data);
-            ASSERT_EQ(result, FIMDB_OK);
-        }
-        catch(...)
-        {
-            os_free(test);
-        }
+        result = fim_db_file_inode_search(18277083, 2456, callback_data);
+        ASSERT_EQ(result, FIMDB_OK);
         os_free(test);
         result = fim_db_file_update(fileFIMTest2->toFimEntry(), callback_data_modified);
         ASSERT_EQ(result, FIMDB_OK);

--- a/src/syscheckd/src/db/tests/db/ComponentTest/fileInterface/fileTest.cpp
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/fileInterface/fileTest.cpp
@@ -120,10 +120,14 @@ TEST_F(DBTestFixture, TestFimDBFileUpdate)
         const auto fileFIMTest2 { std::make_unique<FileItem>(insertStatement2["data"].front()) };
         const auto fileFIMTestUpdated2 { std::make_unique<FileItem>(updateStatement2["data"].front()) };
 
-        fim_db_file_update(fileFIMTest->toFimEntry(), callback_data_added);
-        fim_db_file_update(fileFIMTestUpdated->toFimEntry(), callback_data_modified);
-        fim_db_file_update(fileFIMTest2->toFimEntry(), callback_data_added);
-        fim_db_file_update(fileFIMTestUpdated2->toFimEntry(), callback_data_modified);
+        auto result = fim_db_file_update(fileFIMTest->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
+        result = fim_db_file_update(fileFIMTestUpdated->toFimEntry(), callback_data_modified);
+        ASSERT_EQ(result, FIMDB_OK);
+        result = fim_db_file_update(fileFIMTest2->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
+        result = fim_db_file_update(fileFIMTestUpdated2->toFimEntry(), callback_data_modified);
+        ASSERT_EQ(result, FIMDB_OK);
     });
 }
 TEST_F(DBTestFixture, TestFimDBRemovePath)
@@ -133,10 +137,13 @@ TEST_F(DBTestFixture, TestFimDBRemovePath)
     const auto fileFIMTest3 { std::make_unique<FileItem>(insertStatement3["data"].front()) };
     EXPECT_NO_THROW(
     {
-        fim_db_file_update(fileFIMTest1->toFimEntry(), callback_data_added);
-        fim_db_file_update(fileFIMTest2->toFimEntry(), callback_data_added);
-        fim_db_file_update(fileFIMTest3->toFimEntry(), callback_data_added);
-        auto result = fim_db_remove_path("/etc/wgetrc");
+        auto result = fim_db_file_update(fileFIMTest1->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
+        result = fim_db_file_update(fileFIMTest2->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
+        result = fim_db_file_update(fileFIMTest3->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
+        result = fim_db_remove_path("/etc/wgetrc");
         ASSERT_EQ(result, FIMDB_OK);
         result = fim_db_remove_path("/tmp/test.txt");
         ASSERT_EQ(result, FIMDB_OK);
@@ -153,14 +160,17 @@ TEST_F(DBTestFixture, TestFimDBGetPath)
 
     EXPECT_NO_THROW(
     {
-        fim_db_file_update(fileFIMTest1->toFimEntry(), callback_data_added);
-        fim_db_file_update(fileFIMTest2->toFimEntry(), callback_data_added);
-        fim_db_file_update(fileFIMTest3->toFimEntry(), callback_data_added);
+        auto result = fim_db_file_update(fileFIMTest1->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
+        result = fim_db_file_update(fileFIMTest2->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
+        result = fim_db_file_update(fileFIMTest3->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
         const auto fileFIMTest { std::make_unique<FileItem>(insertStatement1["data"].front()) };
         callback_context_t callback_data;
         callback_data.callback = callBackTestFIMEntry;
         callback_data.context = fileFIMTest->toFimEntry();
-        auto result = fim_db_get_path("/etc/wgetrc", callback_data);
+        result = fim_db_get_path("/etc/wgetrc", callback_data);
         ASSERT_EQ(result, FIMDB_OK);
     });
 }
@@ -173,31 +183,36 @@ TEST_F(DBTestFixture, TestFimDBGetCountFileEntry)
 
     EXPECT_NO_THROW(
     {
-        auto result = fim_db_get_count_file_entry();
-        ASSERT_EQ(result, 0);
-        fim_db_file_update(fileFIMTest1->toFimEntry(), callback_data_added);
-        fim_db_file_update(fileFIMTest2->toFimEntry(), callback_data_added);
-        fim_db_file_update(fileFIMTest3->toFimEntry(), callback_data_added);
-        result = fim_db_get_count_file_entry();
-        ASSERT_EQ(result, 3);
+        auto count = fim_db_get_count_file_entry();
+        ASSERT_EQ(count, 0);
+        auto result = fim_db_file_update(fileFIMTest1->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
+        result = fim_db_file_update(fileFIMTest2->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
+        result = fim_db_file_update(fileFIMTest3->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
+        count = fim_db_get_count_file_entry();
+        ASSERT_EQ(count, 3);
         result = fim_db_remove_path("/etc/wgetrc");
         ASSERT_EQ(result, FIMDB_OK);
-        result = fim_db_get_count_file_entry();
-        ASSERT_EQ(result, 2);
-        fim_db_file_update(fileFIMTest1->toFimEntry(), callback_data_added);
-        result = fim_db_get_count_file_entry();
-        ASSERT_EQ(result, 3);
-        fim_db_file_update(fileFIMTest1->toFimEntry(), callback_data_modified);
-        result = fim_db_get_count_file_entry();
-        ASSERT_EQ(result, 3);
+        count = fim_db_get_count_file_entry();
+        ASSERT_EQ(count, 2);
+        result =fim_db_file_update(fileFIMTest1->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
+        count = fim_db_get_count_file_entry();
+        ASSERT_EQ(count, 3);
+        result =fim_db_file_update(fileFIMTest1->toFimEntry(), callback_data_modified);
+        ASSERT_EQ(result, FIMDB_OK);
+        count = fim_db_get_count_file_entry();
+        ASSERT_EQ(count, 3);
         result = fim_db_remove_path("/etc/wgetrc");
         ASSERT_EQ(result, FIMDB_OK);
         result = fim_db_remove_path("/tmp/test.txt");
         ASSERT_EQ(result, FIMDB_OK);
         result = fim_db_remove_path("/tmp/test2.txt");
         ASSERT_EQ(result, FIMDB_OK);
-        result = fim_db_get_count_file_entry();
-        ASSERT_EQ(result, 0);
+        count = fim_db_get_count_file_entry();
+        ASSERT_EQ(count, 0);
     });
 }
 
@@ -209,31 +224,36 @@ TEST_F(DBTestFixture, TestFimDBGetCountFileInode)
 
     EXPECT_NO_THROW(
     {
-        auto result = fim_db_get_count_file_inode();
-        ASSERT_EQ(result, 0);
-        fim_db_file_update(fileFIMTest1->toFimEntry(), callback_data_added);
-        fim_db_file_update(fileFIMTest2->toFimEntry(), callback_data_added);
-        fim_db_file_update(fileFIMTest3->toFimEntry(), callback_data_added);
-        result = fim_db_get_count_file_inode();
-        ASSERT_EQ(result, 3);
+        auto count = fim_db_get_count_file_inode();
+        ASSERT_EQ(count, 0);
+        auto result = fim_db_file_update(fileFIMTest1->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
+        result = fim_db_file_update(fileFIMTest2->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
+        result = fim_db_file_update(fileFIMTest3->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
+        count = fim_db_get_count_file_inode();
+        ASSERT_EQ(count, 3);
         result = fim_db_remove_path("/etc/wgetrc");
         ASSERT_EQ(result, FIMDB_OK);
-        result = fim_db_get_count_file_inode();
-        ASSERT_EQ(result, 2);
-        fim_db_file_update(fileFIMTest1->toFimEntry(), callback_data_added);
-        result = fim_db_get_count_file_inode();
-        ASSERT_EQ(result, 3);
-        fim_db_file_update(fileFIMTest1->toFimEntry(), callback_data_modified);
-        result = fim_db_get_count_file_inode();
-        ASSERT_EQ(result, 3);
+        count = fim_db_get_count_file_inode();
+        ASSERT_EQ(count, 2);
+        result = fim_db_file_update(fileFIMTest1->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
+        count = fim_db_get_count_file_inode();
+        ASSERT_EQ(count, 3);
+        result = fim_db_file_update(fileFIMTest1->toFimEntry(), callback_data_modified);
+        ASSERT_EQ(result, FIMDB_OK);
+        count = fim_db_get_count_file_inode();
+        ASSERT_EQ(count, 3);
         result = fim_db_remove_path("/etc/wgetrc");
         ASSERT_EQ(result, FIMDB_OK);
         result = fim_db_remove_path("/tmp/test.txt");
         ASSERT_EQ(result, FIMDB_OK);
         result = fim_db_remove_path("/tmp/test2.txt");
         ASSERT_EQ(result, FIMDB_OK);
-        result = fim_db_get_count_file_inode();
-        ASSERT_EQ(result, 0);
+        count = fim_db_get_count_file_inode();
+        ASSERT_EQ(count, 0);
     });
 }
 
@@ -246,9 +266,12 @@ TEST_F(DBTestFixture, TestFimDBFileInodeSearch)
 
     EXPECT_NO_THROW(
     {
-        fim_db_file_update(fileFIMTest1->toFimEntry(), callback_data_added);
-        fim_db_file_update(fileFIMTest2->toFimEntry(), callback_data_added);
-        fim_db_file_update(fileFIMTest3->toFimEntry(), callback_data_added);
+        auto result = fim_db_file_update(fileFIMTest1->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
+        result = fim_db_file_update(fileFIMTest2->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
+        result = fim_db_file_update(fileFIMTest3->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
         char *test;
         test = strdup("/etc/wgetrc");
         callback_context_t callback_data;
@@ -256,17 +279,20 @@ TEST_F(DBTestFixture, TestFimDBFileInodeSearch)
         callback_data.context = test;
         try
         {
-            fim_db_file_inode_search(18277083, 2456, callback_data);
+            result = fim_db_file_inode_search(18277083, 2456, callback_data);
+            ASSERT_EQ(result, FIMDB_OK);
         }
         catch(...)
         {
             os_free(test);
         }
         os_free(test);
-        fim_db_file_update(fileFIMTest2->toFimEntry(), callback_data_modified);
+        result = fim_db_file_update(fileFIMTest2->toFimEntry(), callback_data_modified);
+        ASSERT_EQ(result, FIMDB_OK);
         callback_data.callback = callbackTestSearch;
         callback_data.context = NULL;
-        fim_db_file_inode_search(18457083, 2151, callback_data);
+        result = fim_db_file_inode_search(18457083, 2151, callback_data);
+        ASSERT_EQ(result, FIMDB_OK);
     });
 }
 
@@ -278,20 +304,25 @@ TEST_F(DBTestFixture, TestFimDBFilePatternSearch)
 
     EXPECT_NO_THROW(
     {
-        fim_db_file_update(fileFIMTest1->toFimEntry(), callback_data_added);
-        fim_db_file_update(fileFIMTest2->toFimEntry(), callback_data_added);
-        fim_db_file_update(fileFIMTest3->toFimEntry(), callback_data_added);
+        auto result = fim_db_file_update(fileFIMTest1->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
+        result = fim_db_file_update(fileFIMTest2->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
+        result = fim_db_file_update(fileFIMTest3->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
         callback_context_t callback_data;
         callback_data.callback = callbackTestSearch;
         callback_data.context = nullptr;
-        fim_db_file_pattern_search("/tmp/%", callback_data);
+        result = fim_db_file_pattern_search("/tmp/%", callback_data);
+        ASSERT_EQ(result, FIMDB_OK);
         char *test;
         test = strdup("/etc/wgetrc");
         callback_data.callback = callbackTestSearchPath;
         callback_data.context = test;
         try
         {
-            fim_db_file_pattern_search("/etc/%", callback_data);
+            result = fim_db_file_pattern_search("/etc/%", callback_data);
+            ASSERT_EQ(result, FIMDB_OK);
         }
         catch(...)
         {
@@ -352,8 +383,8 @@ TEST_F(DBTestFixture, TestFimDBFileUpdateNullParameters)
 
     EXPECT_NO_THROW(
     {
-        fim_db_file_update(nullptr, callback_data_added);
-        fim_db_file_update(fileFIMTest->toFimEntry(), callback_null);
+        ASSERT_EQ(fim_db_file_update(nullptr, callback_data_added), FIMDB_ERR);
+        ASSERT_EQ(fim_db_file_update(fileFIMTest->toFimEntry(), callback_null), FIMDB_ERR);
     });
 }
 
@@ -383,9 +414,12 @@ TEST_F(DBTestFixture, TestFimDBFileInodeSearchWithBigInode)
 
     EXPECT_NO_THROW(
     {
-        fim_db_file_update(fileFIMTest1->toFimEntry(), callback_data_added);
-        fim_db_file_update(fileFIMTest2->toFimEntry(), callback_data_added);
-        fim_db_file_update(fileFIMTest3->toFimEntry(), callback_data_added);
+        auto result = fim_db_file_update(fileFIMTest1->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
+        result = fim_db_file_update(fileFIMTest2->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
+        result = fim_db_file_update(fileFIMTest3->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
         char *test;
         test = strdup("/etc/wgetrc");
         callback_context_t callback_data;
@@ -393,16 +427,19 @@ TEST_F(DBTestFixture, TestFimDBFileInodeSearchWithBigInode)
         callback_data.context = test;
         try
         {
-            fim_db_file_inode_search(18277083, 2456, callback_data);
+            result = fim_db_file_inode_search(18277083, 2456, callback_data);
+            ASSERT_EQ(result, FIMDB_OK);
         }
         catch(...)
         {
             os_free(test);
         }
         os_free(test);
-        fim_db_file_update(fileFIMTest2->toFimEntry(), callback_data_modified);
+        result = fim_db_file_update(fileFIMTest2->toFimEntry(), callback_data_modified);
+        ASSERT_EQ(result, FIMDB_OK);
         callback_data.callback = callbackTestSearch;
         callback_data.context = NULL;
-        fim_db_file_inode_search(1152921500312810880, 8432, callback_data);
+        result = fim_db_file_inode_search(1152921500312810880, 8432, callback_data);
+        ASSERT_EQ(result, FIMDB_OK);
     });
 }


### PR DESCRIPTION
|EPIC|Component|
|---|---|
| https://github.com/wazuh/wazuh/issues/9103 | FIM |

### Description
Add some changes to component tests in order to test correctly interface between c and c++. It implies:

- Modify some function to return a result value
- Modify tests to check return value in c functions

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Unit tests passed
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] cppcheck (static code analysis)
  - [x] Coverage (unit tests coverage code)
  - [x] Sformat (code style)
  - [x] Scan build
 
Closes #13252  