### PR TITLE
Modify the Makefile to fix the multi-threaded compilation problem.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -848,6 +848,7 @@ $(error Do not use 'winagent' directly, use 'TARGET=winagent')
 endif
 .PHONY: winagent
 winagent: external win32/libwinpthread-1.dll win32/libgcc_s_sjlj-1.dll
+	@${MAKE} $(BUILD_LIBS) CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
 	${MAKE} ${WINDOWS_BINS} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
 	${MAKE} ${WINDOWS_ACTIVE_RESPONSES} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
 	@${MAKE} strip TARGET=${TARGET} DISABLE_STRIP_SYMBOLS=${DISABLE_STRIP_SYMBOLS}

--- a/src/Makefile
+++ b/src/Makefile
@@ -848,7 +848,7 @@ $(error Do not use 'winagent' directly, use 'TARGET=winagent')
 endif
 .PHONY: winagent
 winagent: external win32/libwinpthread-1.dll win32/libgcc_s_sjlj-1.dll
-	@${MAKE} $(BUILD_LIBS) CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
+	${MAKE} $(BUILD_LIBS) CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
 	${MAKE} ${WINDOWS_BINS} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
 	${MAKE} ${WINDOWS_ACTIVE_RESPONSES} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
 	@${MAKE} strip TARGET=${TARGET} DISABLE_STRIP_SYMBOLS=${DISABLE_STRIP_SYMBOLS}


### PR DESCRIPTION
|Related issue|
|---|
|#13053|


## Description

This PR aims to fix the linker error when compiling the winagent with the `make` command with `-j` option. When we tried to compile the wingent with multithreading a linker error occurred because the libwazuhext.dll library wasn't built.  After the change, the multithreading compilation for winagent was fixed. Some tests were done to check this.

<details>
<summary>make -j2 TARGET=winagent DEBUG=1 TEST=1</summary>

```
cd external/googletest/ && mkdir -p build && cd build && cmake .. -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix -DCMAKE_BUILD_TYPE=Debug  -DBUILD_GMOCK=ON -DBUILD_SHARED_LIBS=0 && make && cp -r lib ..
cp /usr/i686-w64-mingw32/lib/libwinpthread-1.dll win32/libwinpthread-1.dll
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Python: /usr/bin/python3.8 (found version "3.8.10") found components: Interpreter 
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/external/googletest/build
make[1]: Entering directory '/home/hanes/wazuh/src/external/googletest/build'
make[2]: Entering directory '/home/hanes/wazuh/src/external/googletest/build'
make[3]: Entering directory '/home/hanes/wazuh/src/external/googletest/build'
Scanning dependencies of target gtest
make[3]: Leaving directory '/home/hanes/wazuh/src/external/googletest/build'
make[3]: Entering directory '/home/hanes/wazuh/src/external/googletest/build'
[ 12%] Building CXX object googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.obj
[ 25%] Linking CXX static library ../lib/libgtestd.a
make[3]: Leaving directory '/home/hanes/wazuh/src/external/googletest/build'
[ 25%] Built target gtest
make[3]: Entering directory '/home/hanes/wazuh/src/external/googletest/build'
make[3]: Entering directory '/home/hanes/wazuh/src/external/googletest/build'
Scanning dependencies of target gmock
Scanning dependencies of target gtest_main
make[3]: Leaving directory '/home/hanes/wazuh/src/external/googletest/build'
make[3]: Entering directory '/home/hanes/wazuh/src/external/googletest/build'
make[3]: Leaving directory '/home/hanes/wazuh/src/external/googletest/build'
make[3]: Entering directory '/home/hanes/wazuh/src/external/googletest/build'
[ 37%] Building CXX object googletest/CMakeFiles/gtest_main.dir/src/gtest_main.cc.obj
[ 50%] Building CXX object googlemock/CMakeFiles/gmock.dir/src/gmock-all.cc.obj
[ 62%] Linking CXX static library ../lib/libgtest_maind.a
make[3]: Leaving directory '/home/hanes/wazuh/src/external/googletest/build'
[ 62%] Built target gtest_main
[ 75%] Linking CXX static library ../lib/libgmockd.a
make[3]: Leaving directory '/home/hanes/wazuh/src/external/googletest/build'
[ 75%] Built target gmock
make[3]: Entering directory '/home/hanes/wazuh/src/external/googletest/build'
Scanning dependencies of target gmock_main
make[3]: Leaving directory '/home/hanes/wazuh/src/external/googletest/build'
make[3]: Entering directory '/home/hanes/wazuh/src/external/googletest/build'
[ 87%] Building CXX object googlemock/CMakeFiles/gmock_main.dir/src/gmock_main.cc.obj
[100%] Linking CXX static library ../lib/libgmock_maind.a
make[3]: Leaving directory '/home/hanes/wazuh/src/external/googletest/build'
[100%] Built target gmock_main
make[2]: Leaving directory '/home/hanes/wazuh/src/external/googletest/build'
make[1]: Leaving directory '/home/hanes/wazuh/src/external/googletest/build'
make[1]: Entering directory '/home/hanes/wazuh/src'
    CC config/wmodules-aws.o
    CC config/localfile-config.o
    CC config/wmodules-docker.o
    CC config/rootcheck-config.o
    CC config/config.o
    CC config/remote-config.o
    CC config/active-response.o
    CC config/wmodules-osquery-monitor.o
    CC config/integrator-config.o
    CC config/wmodules-agent-upgrade.o
    CC config/socket-config.o
    CC config/wmodules-fluent.o
    CC config/reports-config.o
    CC config/agentlessd-config.o
    CC config/wmodules_syscollector.o
    CC config/wmodules-task-manager.o
    CC config/wmodules-config.o
    CC config/wmodules-github.o
    CC config/buffer-config.o
    CC config/syscheck-config.o
    CC config/global-config.o
    CC config/labels-config.o
    CC config/email-alerts-config.o
    CC config/wmodules-sca.o
    CC config/authd-config.o
    CC config/cluster-config.o
    CC config/rules-config.o
    CC config/wmodules-oscap.o
    CC config/wmodules-key-request.o
    CC config/wmodules-vuln-detector.o
    CC config/wmodules-azure.o
    CC config/wmodules-office365.o
    CC config/dbd-config.o
    CC config/alerts-config.o
    CC config/wmodules-command.o
    CC config/csyslogd-config.o
    CC config/client-config.o
    CC config/wmodules-ciscat.o
    CC config/wmodules-gcp.o
    CC config/logtest-config.o
    CC wazuh_modules/wm_control.o
    CC wazuh_modules/wm_gcp.o
    CC wazuh_modules/wmodules.o
wazuh_modules/wm_gcp.c: In function ‘wm_gcp_pubsub_main’:
wazuh_modules/wm_gcp.c:143:9: warning: returning ‘void *’ from a function with return type ‘DWORD’ {aka ‘long unsigned int’} makes integer from pointer without a cast [-Wint-conversion]
  143 |         pthread_exit(NULL);
      |         ^~~~~~~~~~~~
wazuh_modules/wm_gcp.c: In function ‘wm_gcp_bucket_main’:
wazuh_modules/wm_gcp.c:182:9: warning: returning ‘void *’ from a function with return type ‘DWORD’ {aka ‘long unsigned int’} makes integer from pointer without a cast [-Wint-conversion]
  182 |         pthread_exit(NULL);
      |         ^~~~~~~~~~~~
    CC wazuh_modules/wm_azure.o
    CC wazuh_modules/wm_office365.o
    CC wazuh_modules/wm_exec.o
    CC wazuh_modules/wm_osquery_monitor.o
    CC wazuh_modules/wm_task_general.o
    CC wazuh_modules/wm_aws.o
    CC wazuh_modules/wm_syscollector.o
    CC wazuh_modules/wmcom.o
    CC wazuh_modules/wm_keyrequest.o
    CC wazuh_modules/wm_github.o
    CC wazuh_modules/wm_database.o
wazuh_modules/wm_github.c: In function ‘wm_github_execute_scan’:
wazuh_modules/wm_github.c:225:12: warning: variable ‘last_scan_time’ set but not used [-Wunused-but-set-variable]
  225 |     time_t last_scan_time;
      |            ^~~~~~~~~~~~~~
    CC wazuh_modules/wm_download.o
    CC wazuh_modules/wm_docker.o
    CC wazuh_modules/wm_sca.o
    CC wazuh_modules/wm_fluent.o
    CC wazuh_modules/wm_oscap.o
    CC wazuh_modules/wm_command.o
    CC wazuh_modules/wm_ciscat.o
    CC wazuh_modules/agent_upgrade/wm_agent_upgrade.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.o
    CC wazuh_db/wdb_metadata.o
    CC wazuh_db/wdb_agents.o
    CC wazuh_db/wdb_integrity.o
    CC wazuh_db/wdb_global.o
    CC wazuh_db/wdb_syscollector.o
    CC wazuh_db/wdb_upgrade.o
    CC wazuh_db/wdb_task.o
    CC wazuh_db/wdb_delta_event.o
    CC wazuh_db/wdb_scan_info.o
    CC wazuh_db/wdb.o
    CC wazuh_db/wdb_parser.o
    CC wazuh_db/wdb_fim.o
    CC wazuh_db/wdb_sca.o
    CC wazuh_db/wdb_rootcheck.o
    CC wazuh_db/wdb_ciscat.o
    CC wazuh_db/helpers/wdb_global_helpers.o
    CC wazuh_db/helpers/wdb_agents_helpers.o
    CC wazuh_db/schema_upgrade_v2.o
    CC wazuh_db/schema_global_upgrade_v3.o
    CC wazuh_db/schema_upgrade_v7.o
    CC wazuh_db/schema_upgrade_v1.o
    CC wazuh_db/schema_upgrade_v6.o
    CC wazuh_db/schema_agents.o
    CC wazuh_db/schema_global_upgrade_v1.o
    CC wazuh_db/schema_task_manager.o
    CC wazuh_db/schema_upgrade_v8.o
    CC wazuh_db/schema_upgrade_v4.o
    CC wazuh_db/schema_global.o
    CC wazuh_db/schema_global_upgrade_v2.o
    CC wazuh_db/schema_global_upgrade_v4.o
    CC wazuh_db/schema_upgrade_v5.o
    CC wazuh_db/schema_upgrade_v3.o
    CC wazuh_db/schema_vuln_detector.o
    CC os_crypto/blowfish/bf_op.o
    CC os_crypto/md5/md5_op.o
    CC os_crypto/sha1/sha1_op.o
    CC os_crypto/shared/keys.o
    CC os_crypto/shared/msgs.o
    CC os_crypto/md5_sha1/md5_sha1_op.o
    CC os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.o
    CC os_crypto/sha256/sha256_op.o
    CC os_crypto/sha512/sha512_op.o
    CC os_crypto/aes/aes_op.o
    CC os_crypto/hmac/hmac.o
    CC os_crypto/signature/signature.o
    CC shared/json-queue.o
    CC shared/read-alert.o
    CC shared/enrollment_op.o
    CC shared/read-agents.o
    CC shared/notify_op.o
    CC shared/regex_op.o
    CC shared/rootcheck_op.o
    CC shared/os_utils.o
    CC shared/bzip2_op.o
    CC shared/exec_op.o
    CC shared/mem_op.o
    CC shared/json_op.o
    CC shared/request_op.o
    CC shared/log_builder.o
    CC shared/time_op.o
    CC shared/file_op.o
    CC shared/queue_linked_op.o
    CC shared/vector_op.o
    CC shared/rbtree_op.o
    CC shared/fs_op.o
    CC shared/cluster_utils.o
    CC shared/integrity_op.o
    CC shared/audit_op.o
    CC shared/store_op.o
    CC shared/syscheck_op.o
    CC shared/yaml2json.o
    CC shared/debug_op.o
    CC shared/report_op.o
    CC shared/sig_op.o
    CC shared/sym_load.o
    CC shared/wait_op.o
    CC shared/help.o
    CC shared/labels_op.o
    CC shared/auth_client.o
    CC shared/list_op.o
    CC shared/mq_op.o
    CC shared/privsep_op.o
    CC shared/b64.o
    CC shared/custom_output_search_replace.o
    CC shared/file-queue.o
    CC shared/math_op.o
    CC shared/atomic.o
    CC shared/rules_op.o
    CC shared/string_op.o
    CC shared/url.o
    CC shared/version_op.o
    CC shared/remoted_op.o
    CC shared/pthreads_op.o
    CC shared/hash_op.o
    CC shared/buffer_op.o
    CC shared/validate_op.o
    CC shared/utf8_op.o
    CC shared/schedule_scan.o
    CC shared/expression.o
    CC shared/sysinfo_utils.o
    CC shared/bqueue_op.o
    CC shared/queue_op.o
    CC shared/randombytes.o
    CC shared/agent_op.o
    CC shared/wazuhdb_op.o
    CC os_net/os_net.o
    CC os_regex/os_regex_match.o
    CC os_regex/os_regex.o
    CC os_regex/os_regex_str.o
    CC os_regex/os_match.o
    CC os_regex/os_regex_compile.o
    CC os_regex/os_regex_startswith.o
    CC os_regex/os_regex_free_pattern.o
    CC os_regex/os_match_compile.o
    CC os_regex/os_regex_strbreak.o
    CC os_regex/os_match_free_pattern.o
    CC os_regex/os_regex_maps.o
    CC os_regex/os_regex_execute.o
    CC os_regex/os_match_execute.o
    CC os_xml/os_xml_variables.o
    CC os_xml/os_xml_writer.o
    CC os_xml/os_xml_access.o
    CC os_xml/os_xml.o
    CC os_xml/os_xml_node_access.o
    CC os_zlib/os_zlib.o
    CC unit_tests/wrappers/common.o
    CC unit_tests/wrappers/externals/bzip2/bzlib_wrappers.o
    CC unit_tests/wrappers/externals/zlib/zlib_wrappers.o
    CC unit_tests/wrappers/externals/cJSON/cJSON_wrappers.o
unit_tests/wrappers/externals/cJSON/cJSON_wrappers.c: In function ‘__wrap_cJSON_IsString’:
unit_tests/wrappers/externals/cJSON/cJSON_wrappers.c:104:54: warning: unused parameter ‘item’ [-Wunused-parameter]
  104 | cJSON_bool __wrap_cJSON_IsString(const cJSON * const item) {
      |                                  ~~~~~~~~~~~~~~~~~~~~^~~~
    CC unit_tests/wrappers/externals/openssl/ssl_lib_wrappers.o
    CC unit_tests/wrappers/externals/openssl/digest_wrappers.o
    CC unit_tests/wrappers/externals/openssl/ssl_init_wrappers.o
    CC unit_tests/wrappers/externals/openssl/init_wrappers.o
    CC unit_tests/wrappers/externals/openssl/bio_wrappers.o
    CC unit_tests/wrappers/externals/sqlite/sqlite3_wrappers.o
    CC unit_tests/wrappers/externals/pcre2/pcre2_wrappers.o
    CC unit_tests/wrappers/libc/stdio_wrappers.o
    CC unit_tests/wrappers/libc/time_wrappers.o
    CC unit_tests/wrappers/libc/stdlib_wrappers.o
    CC unit_tests/wrappers/libc/string_wrappers.o
    CC unit_tests/wrappers/posix/pwd_wrappers.o
    CC unit_tests/wrappers/posix/signal_wrappers.o
    CC unit_tests/wrappers/posix/unistd_wrappers.o
    CC unit_tests/wrappers/posix/dirent_wrappers.o
    CC unit_tests/wrappers/posix/pthread_wrappers.o
    CC unit_tests/wrappers/posix/select_wrappers.o
    CC unit_tests/wrappers/posix/stat_wrappers.o
    CC unit_tests/wrappers/posix/time_wrappers.o
    CC unit_tests/wrappers/posix/grp_wrappers.o
    CC unit_tests/wrappers/wazuh/os_crypto/sha256_op_wrappers.o
    CC unit_tests/wrappers/wazuh/os_crypto/md5_op_wrappers.o
    CC unit_tests/wrappers/wazuh/os_crypto/keys_wrappers.o
    CC unit_tests/wrappers/wazuh/os_crypto/msgs_wrappers.o
    CC unit_tests/wrappers/wazuh/os_crypto/sha1_op_wrappers.o
    CC unit_tests/wrappers/wazuh/os_crypto/signature_wrappers.o
    CC unit_tests/wrappers/wazuh/os_execd/exec_wrappers.o
    CC unit_tests/wrappers/wazuh/os_net/os_net_wrappers.o
    CC unit_tests/wrappers/wazuh/os_regex/os_regex_wrappers.o
    CC unit_tests/wrappers/wazuh/os_xml/os_xml_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/syscheck_op_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/file_op_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/audit_op_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/labels_op_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/privsep_op_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/queue_op_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/debug_op_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/atomic_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/pthreads_op_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/string_op_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/mq_op_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/hash_op_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/vector_op_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/auth_client_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/json_op_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/schedule_scan_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/notify_op_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/expression_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/validate_op_wrappers.o
unit_tests/wrappers/wazuh/shared/expression_wrappers.c: In function ‘__wrap_w_expression_match’:
unit_tests/wrappers/wazuh/shared/expression_wrappers.c:30:53: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
   30 |             regex_match->sub_strings[0] = w_strndup((char*)mock(), 128);
      |                                                     ^
unit_tests/wrappers/wazuh/shared/expression_wrappers.c:33:57: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
   33 |                 regex_match->sub_strings[1] = w_strndup((char*)mock(), 128);
      |                                                         ^
    CC unit_tests/wrappers/wazuh/shared/bqueue_op_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/read-agents_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/randombytes_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/agent_op_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/cluster_op_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/rootcheck_op_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/sysinfo_utils_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/fs_op_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/sym_load_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/exec_op_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/url_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/time_op_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/os_utils_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/rbtree_op_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/queue_linked_op_wrappers.o
    CC unit_tests/wrappers/wazuh/shared/integrity_op_wrappers.o
    CC unit_tests/wrappers/wazuh/syscheckd/run_realtime_wrappers.o
    CC unit_tests/wrappers/wazuh/syscheckd/audit_rule_handling_wrappers.o
    CC unit_tests/wrappers/wazuh/syscheckd/run_check_wrappers.o
    CC unit_tests/wrappers/wazuh/syscheckd/registry.o
    CC unit_tests/wrappers/wazuh/syscheckd/syscom_wrappers.o
    CC unit_tests/wrappers/wazuh/syscheckd/fim_db_registries_wrappers.o
    CC unit_tests/wrappers/wazuh/syscheckd/syscheck_audit_wrappers.o
    CC unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.o
    CC unit_tests/wrappers/wazuh/syscheckd/audit_parse_wrappers.o
    CC unit_tests/wrappers/wazuh/syscheckd/win_whodata_wrappers.o
    CC unit_tests/wrappers/wazuh/syscheckd/fim_sync_wrappers.o
    CC unit_tests/wrappers/wazuh/syscheckd/config_wrappers.o
    CC unit_tests/wrappers/wazuh/syscheckd/create_db_wrappers.o
    CC unit_tests/wrappers/wazuh/syscheckd/fim_diff_changes_wrappers.o
    CC unit_tests/wrappers/wazuh/wazuh_db/wdb_syscollector_wrappers.o
    CC unit_tests/wrappers/wazuh/wazuh_db/wdb_task_wrappers.o
    CC unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.o
    CC unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.o
    CC unit_tests/wrappers/wazuh/wazuh_db/wdb_metadata_wrappers.o
    CC unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.o
    CC unit_tests/wrappers/wazuh/wazuh_db/wdb_global_helpers_wrappers.o
    CC unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.o
    CC unit_tests/wrappers/wazuh/wazuh_modules/wm_agent_upgrade_wrappers.o
    CC unit_tests/wrappers/wazuh/wazuh_modules/wm_agent_upgrade_agent_wrappers.o
    CC unit_tests/wrappers/wazuh/wazuh_modules/wm_vuln_detector_wrappers.o
    CC unit_tests/wrappers/wazuh/wazuh_modules/wmodules_wrappers.o
    CC unit_tests/wrappers/wazuh/wazuh_modules/wm_task_manager_wrappers.o
    CC unit_tests/wrappers/wazuh/wazuh_modules/wm_exec_wrappers.o
    CC unit_tests/wrappers/wazuh/monitord/monitord_wrappers.o
    CC unit_tests/wrappers/wazuh/os_auth/os_auth_wrappers.o
    CC unit_tests/wrappers/wazuh/addagent/manage_agents_wrappers.o
    CC unit_tests/wrappers/wazuh/config/syscheck_config_wrappers.o
    CC unit_tests/wrappers/wazuh/client-agent/buffer_wrappers.o
    CC unit_tests/wrappers/wazuh/client-agent/start_agent.o
    CC unit_tests/wrappers/wazuh/remoted/remoted_op_wrappers.o
    CC unit_tests/wrappers/wazuh/remoted/shared_download_wrappers.o
    CC unit_tests/wrappers/wazuh/remoted/request_wrappers.o
    CC unit_tests/wrappers/wazuh/data_provider/sysInfo_wrappers.o
    CC unit_tests/wrappers/wazuh/logcollector/macos_log_wrappers.o
    CC unit_tests/wrappers/wazuh/logcollector/logcollector_wrappers.o
    CC unit_tests/wrappers/windows/heapapi_wrappers.o
    CC unit_tests/wrappers/windows/sddl_wrappers.o
    CC unit_tests/wrappers/windows/winsock_wrappers.o
    CC unit_tests/wrappers/windows/winbase_wrappers.o
    CC unit_tests/wrappers/windows/winevt_wrappers.o
    CC unit_tests/wrappers/windows/handleapi_wrappers.o
    CC unit_tests/wrappers/windows/url_wrappers.o
    CC unit_tests/wrappers/windows/sysinfoapi_wrappers.o
    CC unit_tests/wrappers/windows/aclapi_wrappers.o
    CC unit_tests/wrappers/windows/errhandlingapi_wrappers.o
    CC unit_tests/wrappers/windows/fileapi_wrappers.o
    CC unit_tests/wrappers/windows/processthreadsapi_wrappers.o
    CC unit_tests/wrappers/windows/stringapiset_wrappers.o
    CC unit_tests/wrappers/windows/synchapi_wrappers.o
    CC unit_tests/wrappers/windows/timezoneapi_wrappers.o
    CC unit_tests/wrappers/windows/securitybaseapi_wrappers.o
    CC unit_tests/wrappers/windows/io_wrappers.o
    CC unit_tests/wrappers/windows/winreg_wrappers.o
    CC unit_tests/wrappers/windows/libc/stdio_wrappers.o
    CC os_auth/ssl.o
    CC os_auth/check_cert.o
    CC addagent/validate.o
    CC analysisd/logmsg.o
    CC win32/version-dll.o
    CC libwazuhext.dll
    LINK libwazuh.a
i686-w64-mingw32-ar: `u' modifier ignored since `D' is the default (see `U')
    RANLIB libwazuh.a
make[1]: Leaving directory '/home/hanes/wazuh/src'
make win32/wazuh-agent.exe win32/wazuh-agent-eventchannel.exe win32/manage_agents.exe win32/setup-windows.exe win32/setup-syscheck.exe win32/setup-iis.exe win32/os_win32ui.exe win32/agent-auth.exe win32/syscollector CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
make[1]: Entering directory '/home/hanes/wazuh/src'
    CC win32/version-app.o
    CC win32/icon.o
    CC win32/win_agent.o
    CC win32/win_service.o
    CC win32/win_utils.o
    CC syscheckd/db/schema_fim_db.o
    CC syscheckd/create_db.o
    CC syscheckd/syscom.o
    CC syscheckd/syscheck.o
    CC syscheckd/fim_diff_changes.o
    CC syscheckd/fim_sync.o
    CC syscheckd/run_check.o
    CC syscheckd/main.o
    CC syscheckd/config.o
    CC syscheckd/run_realtime.o
    CC syscheckd/db/fim_db.o
    CC syscheckd/db/fim_db_files.o
    CC syscheckd/db/fim_db_registries.o
    CC syscheckd/whodata/audit_healthcheck.o
    CC syscheckd/whodata/audit_rule_handling.o
    CC syscheckd/whodata/syscheck_audit.o
    CC syscheckd/whodata/audit_parse.o
    CC syscheckd/whodata/win_whodata.o
    CC syscheckd/registry/registry.o
    CC syscheckd/registry/events.o
    CC rootcheck/unix-process.o
    CC rootcheck/rootcheck-config.o
    CC rootcheck/config.o
    CC rootcheck/check_rc_files.o
    CC rootcheck/check_rc_ports.o
    CC rootcheck/common_rcl.o
    CC rootcheck/win-process.o
    CC rootcheck/common.o
    CC rootcheck/check_rc_trojans.o
    CC rootcheck/check_rc_if.o
    CC rootcheck/check_rc_sys.o
    CC rootcheck/check_open_ports.o
    CC rootcheck/os_string.o
    CC rootcheck/win-common.o
    CC rootcheck/check_rc_readproc.o
    CC rootcheck/check_rc_dev.o
    CC rootcheck/run_rk_check.o
    CC rootcheck/check_rc_policy.o
    CC rootcheck/check_rc_pids.o
    CC rootcheck/rootcheck.o
    CC client-agent/sendmsg.o
    CC client-agent/request.o
    CC client-agent/config.o
    CC client-agent/rotate_log.o
    CC client-agent/state.o
    CC client-agent/receiver.o
    CC client-agent/restart_agent.o
    CC client-agent/buffer.o
    CC client-agent/receiver-win.o
    CC client-agent/start_agent.o
    CC client-agent/agcom.o
    CC client-agent/notify.o
    CC logcollector/read_ossecalert.o
    CC logcollector/state.o
    CC logcollector/config.o
    CC logcollector/logcollector.o
    CC logcollector/read_djb_multilog.o
    CC logcollector/read_postgresql_log.o
    CC logcollector/read_ucs2_le.o
    CC logcollector/read_mssql_log.o
    CC logcollector/read_win_el.o
    CC logcollector/lccom.o
    CC logcollector/read_macos.o
    CC logcollector/read_json.o
    CC logcollector/read_win_event_channel.o
    CC logcollector/read_syslog.o
    CC logcollector/macos_log.o
    CC logcollector/read_audit.o
    CC logcollector/read_multiline_regex.o
    CC logcollector/read_nmapg.o
    CC logcollector/read_command.o
    CC logcollector/read_mysql_log.o
    CC logcollector/read_ucs2_be.o
    CC logcollector/read_multiline.o
    CC logcollector/read_fullcommand.o
    CC logcollector/read_snortfull.o
    CC os_execd/exec.o
    CC os_execd/config.o
    CC os_execd/wcom.o
    CC os_execd/execd.o
    CC os_execd/win_execd.o
    CC active-response/active_responses.o
    CC monitord/rotate_log.o
    CC monitord/compress_log.o
    CC syscheckd/create_db-event.o
    CC syscheckd/syscom-event.o
    CC syscheckd/syscheck-event.o
    CC syscheckd/fim_diff_changes-event.o
    CC syscheckd/fim_sync-event.o
    CC syscheckd/run_check-event.o
    CC syscheckd/config-event.o
    CC syscheckd/run_realtime-event.o
    CC syscheckd/db/fim_db-event.o
    CC syscheckd/db/fim_db_files-event.o
    CC syscheckd/db/fim_db_registries-event.o
    CC syscheckd/whodata/audit_healthcheck-event.o
    CC syscheckd/whodata/audit_rule_handling-event.o
    CC syscheckd/whodata/syscheck_audit-event.o
    CC syscheckd/whodata/audit_parse-event.o
    CC syscheckd/whodata/win_whodata-event.o
    CC syscheckd/registry/registry-event.o
    CC syscheckd/registry/events-event.o
    CC logcollector/read_ossecalert-event.o
    CC logcollector/state-event.o
    CC logcollector/config-event.o
    CC logcollector/logcollector-event.o
    CC logcollector/read_djb_multilog-event.o
    CC logcollector/read_postgresql_log-event.o
    CC logcollector/read_ucs2_le-event.o
    CC logcollector/read_mssql_log-event.o
    CC logcollector/read_win_el-event.o
    CC logcollector/lccom-event.o
    CC logcollector/read_macos-event.o
    CC logcollector/read_json-event.o
    CC logcollector/read_win_event_channel-event.o
    CC logcollector/read_syslog-event.o
    CC logcollector/macos_log-event.o
    CC logcollector/read_audit-event.o
    CC logcollector/read_multiline_regex-event.o
    CC logcollector/read_nmapg-event.o
    CC logcollector/read_command-event.o
    CC logcollector/read_mysql_log-event.o
    CC logcollector/read_ucs2_be-event.o
    CC logcollector/read_multiline-event.o
    CC logcollector/read_fullcommand-event.o
    CC logcollector/read_snortfull-event.o
    CC win32/win_service_rk.o
    CC addagent/read_from_user.o
    CC addagent/main.o
    CC addagent/manage_keys.o
    CC addagent/manage_agents.o
    CC win32/setup-win.o
    CC win32/setup-shared.o
    CC win32/setup-syscheck.o
    CC win32/setup-iis.o
    CC win32/ui/common.o
    CC win32/ui/os_win32ui.o
    CC os_auth/main-client.o
cd shared_modules/dbsync/ && mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix -DUNIT_TEST=ON  -DCMAKE_BUILD_TYPE=Debug -DRESOURCE_OBJ=win32/version-dll.o .. && make
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/shared_modules/dbsync/build
make[2]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[3]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[  2%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync.cpp.obj
cd data_provider/ && mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix  -DUNIT_TEST=ON  -DCMAKE_BUILD_TYPE=Debug -DRESOURCE_OBJ=win32/version-dll.o .. && make
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/data_provider/build
make[2]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
make[3]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
Scanning dependencies of target sysinfo
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
[  4%] Building CXX object CMakeFiles/sysinfo.dir/src/network/networkInterfaceWindows.cpp.obj
[  5%] Building CXX object CMakeFiles/dbsync.dir/src/dbsyncPipelineFactory.cpp.obj
[  8%] Building CXX object CMakeFiles/sysinfo.dir/src/osinfo/sysOsInfoWin.cpp.obj
[ 13%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packagesWindows.cpp.obj
[  7%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync_implementation.cpp.obj
[ 10%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_dbengine.cpp.obj
[ 17%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfoWin.cpp.obj
[ 13%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_wrapper.cpp.obj
[ 15%] Linking CXX shared library bin/dbsync.dll
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 15%] Built target dbsync
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target sqlite_unit_test
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 18%] Building CXX object tests/sqlite/CMakeFiles/sqlite_unit_test.dir/main.cpp.obj
[ 21%] Building CXX object tests/sqlite/CMakeFiles/sqlite_unit_test.dir/sqlite_test.cpp.obj
[ 21%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfo.cpp.obj
[ 26%] Linking CXX shared library bin/sysinfo.dll
[ 23%] Building CXX object tests/sqlite/CMakeFiles/sqlite_unit_test.dir/__/__/src/sqlite/sqlite_wrapper.cpp.obj
[ 26%] Linking CXX executable ../../bin/sqlite_unit_test.exe
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 26%] Built target sqlite_unit_test
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync_unit_test
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 28%] Building CXX object tests/interface/CMakeFiles/dbsync_unit_test.dir/__/__/src/dbsync.cpp.obj
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
[ 26%] Built target sysinfo
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
Scanning dependencies of target sysInfoWindows_unit_test
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
[ 30%] Building CXX object tests/sysInfoWin/CMakeFiles/sysInfoWindows_unit_test.dir/main.cpp.obj
[ 34%] Building CXX object tests/sysInfoWin/CMakeFiles/sysInfoWindows_unit_test.dir/sysInfoWin_test.cpp.obj
[ 31%] Building CXX object tests/interface/CMakeFiles/dbsync_unit_test.dir/__/__/src/dbsyncPipelineFactory.cpp.obj
[ 39%] Linking CXX executable ../../bin/sysInfoWindows_unit_test.exe
[ 34%] Building CXX object tests/interface/CMakeFiles/dbsync_unit_test.dir/__/__/src/dbsync_implementation.cpp.obj
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
[ 39%] Built target sysInfoWindows_unit_test
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
Scanning dependencies of target sysInfoNetworkWindows_unit_test
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
[ 43%] Building CXX object tests/sysInfoNetworkWindows/CMakeFiles/sysInfoNetworkWindows_unit_test.dir/main.cpp.obj
[ 47%] Building CXX object tests/sysInfoNetworkWindows/CMakeFiles/sysInfoNetworkWindows_unit_test.dir/sysInfoNetworkWindows_test.cpp.obj
[ 36%] Building CXX object tests/interface/CMakeFiles/dbsync_unit_test.dir/__/__/src/sqlite/sqlite_dbengine.cpp.obj
[ 52%] Building CXX object tests/sysInfoNetworkWindows/CMakeFiles/sysInfoNetworkWindows_unit_test.dir/__/__/src/network/networkInterfaceWindows.cpp.obj
[ 39%] Building CXX object tests/interface/CMakeFiles/dbsync_unit_test.dir/__/__/src/sqlite/sqlite_wrapper.cpp.obj
[ 42%] Building CXX object tests/interface/CMakeFiles/dbsync_unit_test.dir/dbsync_test.cpp.obj
[ 56%] Linking CXX executable ../../bin/sysInfoNetworkWindows_unit_test.exe
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
[ 56%] Built target sysInfoNetworkWindows_unit_test
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
Scanning dependencies of target sysinfo_unit_test
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
[ 60%] Building CXX object tests/sysInfo/CMakeFiles/sysinfo_unit_test.dir/main.cpp.obj
[ 65%] Building CXX object tests/sysInfo/CMakeFiles/sysinfo_unit_test.dir/sysInfoParsers_test.cpp.obj
[ 69%] Building CXX object tests/sysInfo/CMakeFiles/sysinfo_unit_test.dir/sysInfo_test.cpp.obj
[ 44%] Building CXX object tests/interface/CMakeFiles/dbsync_unit_test.dir/main.cpp.obj
[ 47%] Linking CXX executable ../../bin/dbsync_unit_test.exe
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 47%] Built target dbsync_unit_test
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsyncPipelineFactory_unit_test
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 50%] Building CXX object tests/pipelineFactory/CMakeFiles/dbsyncPipelineFactory_unit_test.dir/dbsyncPipelineFactory_test.cpp.obj
[ 73%] Building CXX object tests/sysInfo/CMakeFiles/sysinfo_unit_test.dir/sysOsInfo_test.cpp.obj
[ 78%] Building CXX object tests/sysInfo/CMakeFiles/sysinfo_unit_test.dir/__/__/src/osinfo/sysOsParsers.cpp.obj
[ 52%] Building CXX object tests/pipelineFactory/CMakeFiles/dbsyncPipelineFactory_unit_test.dir/main.cpp.obj
[ 55%] Building CXX object tests/pipelineFactory/CMakeFiles/dbsyncPipelineFactory_unit_test.dir/__/__/src/dbsync.cpp.obj
[ 82%] Building CXX object tests/sysInfo/CMakeFiles/sysinfo_unit_test.dir/__/__/src/sysInfo.cpp.obj
[ 86%] Linking CXX executable ../../bin/sysinfo_unit_test.exe
[ 57%] Building CXX object tests/pipelineFactory/CMakeFiles/dbsyncPipelineFactory_unit_test.dir/__/__/src/dbsyncPipelineFactory.cpp.obj
[ 60%] Building CXX object tests/pipelineFactory/CMakeFiles/dbsyncPipelineFactory_unit_test.dir/__/__/src/dbsync_implementation.cpp.obj
[ 63%] Building CXX object tests/pipelineFactory/CMakeFiles/dbsyncPipelineFactory_unit_test.dir/__/__/src/sqlite/sqlite_dbengine.cpp.obj
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
[ 86%] Built target sysinfo_unit_test
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
Scanning dependencies of target sysInfoPort_unit_test
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/data_provider/build'
[ 91%] Building CXX object tests/sysInfoPorts/CMakeFiles/sysInfoPort_unit_test.dir/main.cpp.obj
[ 95%] Building CXX object tests/sysInfoPorts/CMakeFiles/sysInfoPort_unit_test.dir/sysInfoPort_test.cpp.obj
[100%] Linking CXX executable ../../bin/sysInfoPort_unit_test.exe
[ 65%] Building CXX object tests/pipelineFactory/CMakeFiles/dbsyncPipelineFactory_unit_test.dir/__/__/src/sqlite/sqlite_wrapper.cpp.obj
[ 68%] Linking CXX executable ../../bin/dbsyncPipelineFactory_unit_test.exe
make[4]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
[100%] Built target sysInfoPort_unit_test
make[3]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/data_provider/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbengine_unit_test
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 71%] Building CXX object tests/dbengine/CMakeFiles/dbengine_unit_test.dir/dbengine_test.cpp.obj
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 71%] Built target dbsyncPipelineFactory_unit_test
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target fim_integration_test
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 73%] Building CXX object integrationTests/fim/CMakeFiles/fim_integration_test.dir/fimIntegrationTest.cpp.obj
[ 76%] Building CXX object integrationTests/fim/CMakeFiles/fim_integration_test.dir/main.cpp.obj
[ 78%] Building CXX object integrationTests/fim/CMakeFiles/fim_integration_test.dir/__/__/src/dbsync.cpp.obj
[ 81%] Building CXX object tests/dbengine/CMakeFiles/dbengine_unit_test.dir/main.cpp.obj
[ 84%] Building CXX object tests/dbengine/CMakeFiles/dbengine_unit_test.dir/__/__/src/sqlite/sqlite_dbengine.cpp.obj
[ 86%] Building CXX object integrationTests/fim/CMakeFiles/fim_integration_test.dir/__/__/src/dbsyncPipelineFactory.cpp.obj
[ 89%] Linking CXX executable ../../bin/dbengine_unit_test.exe
[ 92%] Building CXX object integrationTests/fim/CMakeFiles/fim_integration_test.dir/__/__/src/dbsync_implementation.cpp.obj
[ 94%] Building CXX object integrationTests/fim/CMakeFiles/fim_integration_test.dir/__/__/src/sqlite/sqlite_dbengine.cpp.obj
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[ 94%] Built target dbengine_unit_test
[ 97%] Building CXX object integrationTests/fim/CMakeFiles/fim_integration_test.dir/__/__/src/sqlite/sqlite_wrapper.cpp.obj
    CC win32/wazuh-agent.exe
    CC win32/wazuh-agent-eventchannel.exe
    CC win32/manage_agents.exe
    CC win32/setup-windows.exe
    CC win32/setup-syscheck.exe
    CC win32/setup-iis.exe
[100%] Linking CXX executable ../../bin/fim_integration_test.exe
    CC win32/os_win32ui.exe
    CC win32/agent-auth.exe
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
[100%] Built target fim_integration_test
make[3]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/shared_modules/dbsync/build'
cd shared_modules/rsync/ &&  mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix -DUNIT_TEST=ON  -DCMAKE_BUILD_TYPE=Debug -DRESOURCE_OBJ=win32/version-dll.o .. && make
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/shared_modules/rsync/build
make[2]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[3]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
Scanning dependencies of target rsync
Scanning dependencies of target rsync_unit_test
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[  4%] Building CXX object CMakeFiles/rsync.dir/src/rsync.cpp.obj
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[  8%] Building CXX object tests/interface/CMakeFiles/rsync_unit_test.dir/__/__/src/rsync.cpp.obj
[ 13%] Building CXX object CMakeFiles/rsync.dir/src/rsyncImplementation.cpp.obj
[ 17%] Building CXX object tests/interface/CMakeFiles/rsync_unit_test.dir/__/__/src/rsyncImplementation.cpp.obj
[ 21%] Linking CXX shared library bin/rsync.dll
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[ 21%] Built target rsync
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
Scanning dependencies of target rsync_implementation_unit_test
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[ 26%] Building CXX object tests/implementation/CMakeFiles/rsync_implementation_unit_test.dir/__/__/src/rsync.cpp.obj
[ 30%] Building CXX object tests/interface/CMakeFiles/rsync_unit_test.dir/main.cpp.obj
[ 34%] Building CXX object tests/interface/CMakeFiles/rsync_unit_test.dir/rsync_test.cpp.obj
[ 39%] Building CXX object tests/implementation/CMakeFiles/rsync_implementation_unit_test.dir/__/__/src/rsyncImplementation.cpp.obj
[ 43%] Building CXX object tests/interface/CMakeFiles/rsync_unit_test.dir/home/hanes/wazuh/src/shared_modules/dbsync/src/dbsync.cpp.obj
[ 47%] Building CXX object tests/implementation/CMakeFiles/rsync_implementation_unit_test.dir/main.cpp.obj
[ 52%] Building CXX object tests/implementation/CMakeFiles/rsync_implementation_unit_test.dir/rsyncImplementationTest.cpp.obj
[ 56%] Building CXX object tests/interface/CMakeFiles/rsync_unit_test.dir/home/hanes/wazuh/src/shared_modules/dbsync/src/dbsyncPipelineFactory.cpp.obj
[ 60%] Building CXX object tests/interface/CMakeFiles/rsync_unit_test.dir/home/hanes/wazuh/src/shared_modules/dbsync/src/dbsync_implementation.cpp.obj
[ 65%] Building CXX object tests/implementation/CMakeFiles/rsync_implementation_unit_test.dir/home/hanes/wazuh/src/shared_modules/dbsync/src/dbsync.cpp.obj
[ 69%] Building CXX object tests/interface/CMakeFiles/rsync_unit_test.dir/home/hanes/wazuh/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp.obj
[ 73%] Building CXX object tests/implementation/CMakeFiles/rsync_implementation_unit_test.dir/home/hanes/wazuh/src/shared_modules/dbsync/src/dbsyncPipelineFactory.cpp.obj
[ 78%] Building CXX object tests/interface/CMakeFiles/rsync_unit_test.dir/home/hanes/wazuh/src/shared_modules/dbsync/src/sqlite/sqlite_wrapper.cpp.obj
[ 82%] Linking CXX executable ../../bin/rsync_unit_test.exe
[ 86%] Building CXX object tests/implementation/CMakeFiles/rsync_implementation_unit_test.dir/home/hanes/wazuh/src/shared_modules/dbsync/src/dbsync_implementation.cpp.obj
[ 91%] Building CXX object tests/implementation/CMakeFiles/rsync_implementation_unit_test.dir/home/hanes/wazuh/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp.obj
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[ 91%] Built target rsync_unit_test
[ 95%] Building CXX object tests/implementation/CMakeFiles/rsync_implementation_unit_test.dir/home/hanes/wazuh/src/shared_modules/dbsync/src/sqlite/sqlite_wrapper.cpp.obj
[100%] Linking CXX executable ../../bin/rsync_implementation_unit_test.exe
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
[100%] Built target rsync_implementation_unit_test
make[3]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/shared_modules/rsync/build'
cd shared_modules/utils/tests/ &&  mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix -DCMAKE_BUILD_TYPE=Debug .. && make
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/shared_modules/utils/tests/build
make[2]: Entering directory '/home/hanes/wazuh/src/shared_modules/utils/tests/build'
make[3]: Entering directory '/home/hanes/wazuh/src/shared_modules/utils/tests/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/utils/tests/build'
Scanning dependencies of target utils_unit_test
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/utils/tests/build'
make[4]: Entering directory '/home/hanes/wazuh/src/shared_modules/utils/tests/build'
[  6%] Building CXX object CMakeFiles/utils_unit_test.dir/cmdHelper_test.cpp.obj
[ 12%] Building CXX object CMakeFiles/utils_unit_test.dir/byteArrayHelper_test.cpp.obj
[ 18%] Building CXX object CMakeFiles/utils_unit_test.dir/filesystemHelper_test.cpp.obj
[ 25%] Building CXX object CMakeFiles/utils_unit_test.dir/hashHelper_test.cpp.obj
[ 31%] Building CXX object CMakeFiles/utils_unit_test.dir/main.cpp.obj
[ 37%] Building CXX object CMakeFiles/utils_unit_test.dir/mapWrapperSafe_test.cpp.obj
[ 43%] Building CXX object CMakeFiles/utils_unit_test.dir/msgDispatcher_test.cpp.obj
[ 50%] Building CXX object CMakeFiles/utils_unit_test.dir/pipelineNodes_test.cpp.obj
[ 56%] Building CXX object CMakeFiles/utils_unit_test.dir/stringHelper_test.cpp.obj
[ 62%] Building CXX object CMakeFiles/utils_unit_test.dir/threadDispatcher_test.cpp.obj
[ 68%] Building CXX object CMakeFiles/utils_unit_test.dir/threadSafeQueue_test.cpp.obj
[ 75%] Building CXX object CMakeFiles/utils_unit_test.dir/timeHelper_test.cpp.obj
[ 81%] Building CXX object CMakeFiles/utils_unit_test.dir/encodingWindows_test.cpp.obj
[ 87%] Building CXX object CMakeFiles/utils_unit_test.dir/registryHelper_test.cpp.obj
[ 93%] Building CXX object CMakeFiles/utils_unit_test.dir/windowsHelper_test.cpp.obj
[100%] Linking CXX executable utils_unit_test.exe
make[4]: Leaving directory '/home/hanes/wazuh/src/shared_modules/utils/tests/build'
[100%] Built target utils_unit_test
make[3]: Leaving directory '/home/hanes/wazuh/src/shared_modules/utils/tests/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/shared_modules/utils/tests/build'
cd wazuh_modules/syscollector/ && mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix -DUNIT_TEST=ON  -DCMAKE_BUILD_TYPE=Debug -DRESOURCE_OBJ=win32/version-dll.o .. && make
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/src/wazuh_modules/syscollector/build
make[2]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[3]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
Scanning dependencies of target syscollector
Scanning dependencies of target syscollectorimp_unit_test
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[  5%] Building CXX object CMakeFiles/syscollector.dir/src/syscollector.cpp.obj
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[ 10%] Building CXX object tests/sysCollectorImp/CMakeFiles/syscollectorimp_unit_test.dir/main.cpp.obj
[ 15%] Building CXX object tests/sysCollectorImp/CMakeFiles/syscollectorimp_unit_test.dir/syscollectorImp_test.cpp.obj
[ 20%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorImp.cpp.obj
[ 25%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorNormalizer.cpp.obj
[ 30%] Linking CXX shared library bin/syscollector.dll
[ 35%] Building CXX object tests/sysCollectorImp/CMakeFiles/syscollectorimp_unit_test.dir/__/__/src/syscollectorImp.cpp.obj
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[ 35%] Built target syscollector
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
Scanning dependencies of target sys_normalizer_unit_test
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[4]: Entering directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[ 40%] Building CXX object tests/sysNormalizer/CMakeFiles/sys_normalizer_unit_test.dir/main.cpp.obj
[ 45%] Building CXX object tests/sysNormalizer/CMakeFiles/sys_normalizer_unit_test.dir/sysNormalizer_test.cpp.obj
[ 50%] Building CXX object tests/sysCollectorImp/CMakeFiles/syscollectorimp_unit_test.dir/__/__/src/syscollectorNormalizer.cpp.obj
[ 55%] Building CXX object tests/sysNormalizer/CMakeFiles/sys_normalizer_unit_test.dir/__/__/src/syscollectorNormalizer.cpp.obj
[ 60%] Building CXX object tests/sysCollectorImp/CMakeFiles/syscollectorimp_unit_test.dir/home/hanes/wazuh/src/shared_modules/rsync/src/rsync.cpp.obj
[ 65%] Linking CXX executable ../../bin/sys_normalizer_unit_test.exe
[ 70%] Building CXX object tests/sysCollectorImp/CMakeFiles/syscollectorimp_unit_test.dir/home/hanes/wazuh/src/shared_modules/rsync/src/rsyncImplementation.cpp.obj
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[ 70%] Built target sys_normalizer_unit_test
[ 75%] Building CXX object tests/sysCollectorImp/CMakeFiles/syscollectorimp_unit_test.dir/home/hanes/wazuh/src/shared_modules/dbsync/src/dbsync.cpp.obj
[ 80%] Building CXX object tests/sysCollectorImp/CMakeFiles/syscollectorimp_unit_test.dir/home/hanes/wazuh/src/shared_modules/dbsync/src/dbsyncPipelineFactory.cpp.obj
[ 85%] Building CXX object tests/sysCollectorImp/CMakeFiles/syscollectorimp_unit_test.dir/home/hanes/wazuh/src/shared_modules/dbsync/src/dbsync_implementation.cpp.obj
[ 90%] Building CXX object tests/sysCollectorImp/CMakeFiles/syscollectorimp_unit_test.dir/home/hanes/wazuh/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp.obj
[ 95%] Building CXX object tests/sysCollectorImp/CMakeFiles/syscollectorimp_unit_test.dir/home/hanes/wazuh/src/shared_modules/dbsync/src/sqlite/sqlite_wrapper.cpp.obj
[100%] Linking CXX executable ../../bin/syscollectorimp_unit_test.exe
make[4]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
[100%] Built target syscollectorimp_unit_test
make[3]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[2]: Leaving directory '/home/hanes/wazuh/src/wazuh_modules/syscollector/build'
make[1]: Leaving directory '/home/hanes/wazuh/src'
make win32/restart-wazuh.exe win32/route-null.exe win32/netsh.exe CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
make[1]: Entering directory '/home/hanes/wazuh/src'
    CC shared/file_op_proc.o
    CC shared/debug_op_proc.o
    CC active-response/restart-wazuh.o
    CC active-response/route-null.o
    CC active-response/netsh.o
    CC libwazuhshared.dll
    CC win32/restart-wazuh.exe
    CC win32/route-null.exe
    CC win32/netsh.exe
make[1]: Leaving directory '/home/hanes/wazuh/src'
make[1]: Entering directory '/home/hanes/wazuh/src'
make[1]: Leaving directory '/home/hanes/wazuh/src'
cd win32/ && ./unix2dos.pl ossec.conf > default-ossec.conf
cd win32/ && ./unix2dos.pl help.txt > help_win.txt
cd win32/ && ./unix2dos.pl ../../etc/internal_options.conf > internal_options.conf
cd win32/ && ./unix2dos.pl ../../etc/local_internal_options-win.conf > default-local_internal_options.conf
cd win32/ && ./unix2dos.pl ../../LICENSE > LICENSE.txt
cd win32/ && ./unix2dos.pl ../VERSION > VERSION
cd win32/ && ./unix2dos.pl ../REVISION > REVISION
cd win32/ && makensis wazuh-installer.nsi
Processing config: /etc/nsisconf.nsh
Processing script file: "wazuh-installer.nsi" (UTF8)

Processed 1 file, writing output (x86-ansi):
warning 7998: ANSI targets are deprecated

Output: "wazuh-agent-4.4.0.exe"
Install: 6 pages (384 bytes), 3 sections (12360 bytes), 1166 instructions (32648 bytes), 407 strings (33462 bytes), 1 language table (346 bytes).
Uninstall: 4 pages (320 bytes), 1 section (4120 bytes), 520 instructions (14560 bytes), 233 strings (4161 bytes), 1 language table (290 bytes).

Using zlib compression.

EXE header size:               97280 / 78336 bytes
Install code:                  16882 / 70448 bytes
Install data:                7104732 / 22353179 bytes
Uninstall code+data:           42039 / 56939 bytes
CRC (0x0EC4C5F6):                  4 / 4 bytes

Total size:                  7260937 / 22558906 bytes (32.1%)

1 warning:
  7998: ANSI targets are deprecated
make settings
make[1]: Entering directory '/home/hanes/wazuh/src'

General settings:
    TARGET:                  winagent
    V:                       
    DEBUG:                   1
    DEBUGAD                  
    INSTALLDIR:              
    BUILD_VERSION            
    DATABASE:                
    ONEWAY:                  no
    CLEANFULL:               no
    RESOURCES_URL:           https://packages.wazuh.com/deps/16-9913
    EXTERNAL_SRC_ONLY:       
User settings:
    WAZUH_GROUP:             wazuh
    WAZUH_USER:              wazuh
USE settings:
    USE_ZEROMQ:              no
    USE_GEOIP:               no
    USE_PRELUDE:             no
    USE_INOTIFY:             no
    USE_BIG_ENDIAN:          no
    USE_SELINUX:             no
    USE_AUDIT:               no
    DISABLE_SYSC:            no
    DISABLE_CISCAT:          no
    DISABLE_STRIP_SYMBOLS:   no
Mysql settings:
    includes:                
    libs:                    
Pgsql settings:
    includes:                
    libs:                    
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DENABLE_SYSC -DENABLE_CISCAT
Compiler:
    CFLAGS                   -pthread -g -O0 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DENABLE_SYSC -DENABLE_CISCAT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Ishared_modules/common -Ishared_modules/dbsync/include -Ishared_modules/rsync/include -Iwazuh_modules/syscollector/include  -Idata_provider/include  -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include  -g -O0 --coverage -DWAZUH_UNIT_TESTING
    LDFLAGS                  -pthread -O0 -Lshared_modules/dbsync/build/bin -Lshared_modules/rsync/build/bin  -Lwazuh_modules/syscollector/build/bin -Ldata_provider/build/bin -g -O0 --coverage -DWAZUH_UNIT_TESTING
    LIBS                      -lcmocka
    CC                       gcc
    MAKE                     make
make[1]: Leaving directory '/home/hanes/wazuh/src'

Done building winagent

```

</details>


## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors