### PR TITLE
Let CIS-CAT module halt if ciscat_binary is set to an invalid value

### DIFF
--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -330,7 +330,7 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char *java_pa
     // CIS-CAT Pro V3
     if (!strcmp(ciscat_binary, WM_CISCAT_V3_BINARY_WIN)) {
         // Accepting Terms of Use
-    
+
         wm_strcat(&command, "-a", ' ');
 
         // Specify location for reports
@@ -356,7 +356,7 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char *java_pa
         wm_strcat(&command, "-n", ' ');
 
         // Add not selected checks
- 
+
         wm_strcat(&command, "-y", ' ');
     } else if (!strcmp(ciscat_binary, WM_CISCAT_V4_BINARY_WIN)) {
         // CIS-CAT Pro V4
@@ -376,6 +376,12 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char *java_pa
 
         // Get txt reports
         wm_strcat(&command, "-txt", ' ');
+    } else {
+        mterror(WM_CISCAT_LOGTAG, "CIS-CAT binary (%s) is neither %s nor %s. Exiting...", ciscat_binary, WM_CISCAT_V3_BINARY_WIN, WM_CISCAT_V4_BINARY_WIN);
+        ciscat->flags.error = 1;
+        os_free(ciscat_script);
+        pthread_exit(NULL);
+        return;
     }
 
     // Send rootcheck message
@@ -471,7 +477,7 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char *java_pa
     }
 
     // Create arguments
-    wm_strcat(&command, path, '/');    
+    wm_strcat(&command, path, '/');
     wm_strcat(&command, ciscat_binary, '/');
 
     switch (eval->type) {
@@ -497,7 +503,7 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char *java_pa
 
     char reports_path[PATH_MAX];
     os_snprintf(reports_path, sizeof(reports_path), "%s/%s", pwd, WM_CISCAT_REPORTS);
-    
+
     // CIS-CAT Pro V3
     if (!strcmp(ciscat_binary, WM_CISCAT_V3_BINARY)) {
         // Accepting Terms of Use
@@ -505,7 +511,7 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char *java_pa
         wm_strcat(&command, "-a", ' ');
 
         // Specify location for reports
-        
+
         wm_strcat(&command, "-r", ' ');
         wm_strcat(&command, reports_path, ' ');
 
@@ -531,7 +537,7 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char *java_pa
         wm_strcat(&command, "-y", ' ');
     } else if (!strcmp(ciscat_binary, WM_CISCAT_V4_BINARY)) {
         // CIS-CAT Pro V4
-        
+
         // Specify location for reports
 
         wm_strcat(&command, "-rd", ' ');
@@ -547,6 +553,10 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char *java_pa
 
         // Get txt reports
         wm_strcat(&command, "-txt", ' ');
+    } else {
+        mterror(WM_CISCAT_LOGTAG, "CIS-CAT binary (%s) is neither %s nor %s. Exiting...", ciscat_binary, WM_CISCAT_V3_BINARY, WM_CISCAT_V4_BINARY);
+        ciscat->flags.error = 1;
+        pthread_exit(NULL);
     }
 
     // Send rootcheck message
@@ -1592,4 +1602,3 @@ void wm_ciscat_destroy(wm_ciscat *ciscat) {
     #endif
 }
 #endif
-


### PR DESCRIPTION
## Rationale

@jotacarma90 reported this defect at the CIS-CAT module implementation by `scan-build`:

```c
char * command = NULL;

if (!strcmp(ciscat_binary, WM_CISCAT_V3_BINARY_WIN)) {
    // Allocate command
} else if (!strcmp(ciscat_binary, WM_CISCAT_V4_BINARY_WIN)) {
    // Allocate command
}

// Read command
```

According to the conditional flow, the code may reach the final line having `command` set to `NULL`. This should not happen in practice since `ciscat_binary` must be either `WM_CISCAT_V3_BINARY_WIN` or `WM_CISCAT_V4_BINARY_WIN` (in the Windows agent implementation). However, we need to address this issue.

### Source

This issue is related to #12582.

## Proposed fix

Add a fallthrough block (`else`), which shall log that the module reached an inconsistent state and must exit. We should stop the module using `pthread_exit()`, but it is not declared with `__nothrow` in the Windows headers:

```c
void WINPTHREAD_API pthread_exit(void *res);
```

Because of this, we need to add an extra `return` statement.

## Tests

- [x] Scan-build no longer reports this defect.
- [x] A normal use case does not let CIS-CAT module reach the newly added code.