### PR TITLE
Restore default value of `disabled` cluster tag

### DIFF
--- a/framework/wazuh/core/cluster/tests/test_cluster.py
+++ b/framework/wazuh/core/cluster/tests/test_cluster.py
@@ -90,8 +90,8 @@ def test_read_configuration(read_config):
             assert configuration[k] == read_config['cluster'][k]
 
         # values not present in the read user configuration will be filled with default values
-        if read_config != {} and 'disabled' not in read_config.get('cluster', {}):
-            default_cluster_configuration['disabled'] = 'yes'
+        if 'disabled' not in read_config and read_config != {}:
+            default_cluster_configuration['disabled'] = 'no'
         for k in default_cluster_configuration.keys() - read_config.keys():
             assert configuration[k] == default_cluster_configuration[k]
 

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -48,7 +48,7 @@ def read_cluster_config(config_file=common.ossec_conf, from_import=False) -> typ
         Dictionary with cluster configuration.
     """
     cluster_default_configuration = {
-        'disabled': True,
+        'disabled': False,
         'node_type': 'master',
         'name': 'wazuh',
         'node_name': 'node01',


### PR DESCRIPTION
## Description

This PR restores the previous behavior of the `disabled` cluster tag when it is not included in the `ossec.conf`. The following PR is reverted:
- https://github.com/wazuh/wazuh/pull/12489
