### PR TITLE
Fix framework unit tests failures after 4.3 merge and failures when run by the `root` user

### DIFF
--- a/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
@@ -353,12 +353,14 @@ def test_DistributedAPI_forward_request_errors(mock_client_execute, mock_get_sol
        new=AsyncMock(side_effect=WazuhInternalError(1001)))
 def test_DistributedAPI_logger():
     """Test custom logger inside DistributedAPI class."""
+    log_file_path = '/tmp/dapi_test.log'
     new_logger = logging.getLogger('dapi_test')
-    fh = logging.FileHandler('/tmp/dapi_test.log')
+    fh = logging.FileHandler(log_file_path)
     fh.setLevel(logging.DEBUG)
     new_logger.addHandler(fh)
     dapi_kwargs = {'f': agent.get_agents_summary_status, 'logger': new_logger}
     raise_if_exc_routine(dapi_kwargs=dapi_kwargs, expected_error=1001)
+    os.remove(log_file_path)
 
 
 @patch('wazuh.core.cluster.local_client.LocalClient.send_file', new=AsyncMock(return_value='{"Testing": 1}'))

--- a/framework/wazuh/tests/data/schema_cve_test.sql
+++ b/framework/wazuh/tests/data/schema_cve_test.sql
@@ -78,14 +78,5 @@ VALUES ('Smokedetector', '-', 'x86', 'CVE-2019-1020011', 'PACKAGE', 'PENDING', '
         'SmokeDetector intentionally does automatic deployments of updated copies of SmokeDetector without server operator authority.',
         '2019-07-29', '2021-07-21');
 
-INSERT INTO vuln_cves (name, version, architecture, cve, type, status, detection_time, severity, cvss2_score,
-                       cvss3_score, reference, external_references, condition, title, published, updated)
-VALUES ('Mozilla Firefox 53.0 (x64 en-US)', '53.0', 'x64', 'CVE-2021-38503', 'PACKAGE', 'OBSOLETE', '1623656949', 'High', 7.5, 10,
-        'ab712fb636baccbb7484f7b3daf5b4c0ce485960',
-        '["https://www.mozilla.org/security/advisories/mfsa2021-48/","https://bugzilla.mozilla.org/show_bug.cgi?id=1729517","https://lists.debian.org/debian-lts-announce/2021/12/msg00030.html"]',
-        'Package unfixed',
-        'The iframe sandbox rules were not correctly applied to XSLT stylesheets, allowing an iframe to bypass restrictions such as executing scripts or navigating the top-level frame. This vulnerability affects Firefox < 94, Thunderbird < 91.3, and Firefox ESR < 91.3.',
-        '2021-08-12', '2022-03-16');
-
 INSERT INTO vuln_metadata (LAST_PARTIAL_SCAN, LAST_FULL_SCAN)
 VALUES (1623656949, 1623656751);

--- a/framework/wazuh/tests/test_decoder.py
+++ b/framework/wazuh/tests/test_decoder.py
@@ -165,17 +165,10 @@ def test_get_decoder_file_exceptions():
     assert result.render()['data']['failed_items'][0]['error']['code'] == 1501
 
     # File permissions
-    filename = 'test2_decoders.xml'
-    old_permissions = stat.S_IMODE(os.lstat(os.path.join(
-        test_data_path, 'tests/data/decoders', filename)).st_mode)
-    try:
-        os.chmod(os.path.join(test_data_path, 'tests/data/decoders', filename), 000)
-        # UUT 3rd call forcing a permissions error opening decoder file
-        result = decoder.get_decoder_file(filename=filename)
+    with patch('builtins.open', side_effect=PermissionError):
+        result = decoder.get_decoder_file(filename='test2_decoders.xml')
         assert not result.affected_items
         assert result.render()['data']['failed_items'][0]['error']['code'] == 1502
-    finally:
-        os.chmod(os.path.join(test_data_path, 'tests/data/decoders', filename), old_permissions)
 
 
 @pytest.mark.parametrize('file, overwrite', [

--- a/framework/wazuh/tests/test_vulnerability.py
+++ b/framework/wazuh/tests/test_vulnerability.py
@@ -39,20 +39,17 @@ def send_msg_to_wdb(msg, raw=False):
 
 
 @pytest.mark.parametrize('params, field_name, expected_items', [
-    ({}, 'cve', ['CVE-2019-1020016', 'CVE-2019-1020014', 'CVE-2019-1020018', 'CVE-2019-1020019', 'CVE-2021-38503',
-                 'CVE-2019-1020011']),
+    ({}, 'cve', ['CVE-2019-1020016', 'CVE-2019-1020014', 'CVE-2019-1020018', 'CVE-2019-1020019', 'CVE-2019-1020011']),
     ({'limit': 2}, 'cve', ['CVE-2019-1020016', 'CVE-2019-1020014']),
-    ({'offset': 5, 'limit': 1}, 'cve', ['CVE-2019-1020011']),
+    ({'offset': 4, 'limit': 1}, 'cve', ['CVE-2019-1020011']),
     ({'sort': parse_api_param('+name', 'sort')}, 'name', ['Ash-aio', 'Credential Helpers', 'Discourse',
-                                                          'Invenio-previewer', 'Mozilla Firefox 53.0 (x64 en-US)',
-                                                          'Smokedetector']),
-    ({'sort': parse_api_param('-name', 'sort')}, 'name', ['Smokedetector', 'Mozilla Firefox 53.0 (x64 en-US)',
-                                                          'Invenio-previewer', 'Discourse', 'Credential Helpers',
-                                                          'Ash-aio']),
+                                                          'Invenio-previewer', 'Smokedetector']),
+    ({'sort': parse_api_param('-name', 'sort')}, 'name', ['Smokedetector', 'Invenio-previewer', 'Discourse',
+                                                          'Credential Helpers', 'Ash-aio']),
     ({'sort': parse_api_param('+cve', 'sort')}, 'cve', ['CVE-2019-1020011', 'CVE-2019-1020014', 'CVE-2019-1020016',
-                                                        'CVE-2019-1020018', 'CVE-2019-1020019', 'CVE-2021-38503']),
-    ({'sort': parse_api_param('-cve', 'sort')}, 'cve', ['CVE-2021-38503', 'CVE-2019-1020019', 'CVE-2019-1020018',
-                                                        'CVE-2019-1020016', 'CVE-2019-1020014', 'CVE-2019-1020011']),
+                                                        'CVE-2019-1020018', 'CVE-2019-1020019']),
+    ({'sort': parse_api_param('-cve', 'sort')}, 'cve', ['CVE-2019-1020019', 'CVE-2019-1020018', 'CVE-2019-1020016',
+                                                        'CVE-2019-1020014', 'CVE-2019-1020011']),
     ({'search': parse_api_param('PowerPC', 'search')}, 'cve', ['CVE-2019-1020018']),
     ({'search': parse_api_param('x86', 'search')}, 'cve', ['CVE-2019-1020016', 'CVE-2019-1020014', 'CVE-2019-1020011']),
     ({'search': parse_api_param('-x86', 'search')}, 'cve', ['CVE-2019-1020018', 'CVE-2019-1020019']),
@@ -63,11 +60,11 @@ def send_msg_to_wdb(msg, raw=False):
     ({'filters': {'version': '0.1.0', 'architecture': 'ARM'}}, 'cve', ['CVE-2019-1020019']),
     ({'filters': {'cve': 'CVE-2019-1020016'}}, 'cve', ['CVE-2019-1020016']),
     ({'filters': {'cve': 'CVE-2019-1020016', 'architecture': 'ARM'}}, 'cve', []),
-    ({'filters': {'status': 'OBSOLETE'}}, 'cve', ['CVE-2019-1020016', 'CVE-2019-1020014', 'CVE-2021-38503']),
+    ({'filters': {'status': 'OBSOLETE'}}, 'cve', ['CVE-2019-1020016', 'CVE-2019-1020014']),
     ({'filters': {'status': 'VALID'}}, 'cve', ['CVE-2019-1020018', 'CVE-2019-1020019']),
     ({'filters': {'status': 'PENDING'}}, 'cve', ['CVE-2019-1020011']),
     ({'filters': {'type': 'OS'}}, 'cve', ['CVE-2019-1020016', 'CVE-2019-1020018', 'CVE-2019-1020019']),
-    ({'filters': {'type': 'PACKAGE'}}, 'cve', ['CVE-2019-1020014', 'CVE-2021-38503', 'CVE-2019-1020011']),
+    ({'filters': {'type': 'PACKAGE'}}, 'cve', ['CVE-2019-1020014', 'CVE-2019-1020011']),
     ({'q': 'name=Ash-aio;version>1.5'}, 'cve', ['CVE-2019-1020016']),
     ({'q': 'name=Ash-aio;version>2.5'}, 'cve', []),
     ({'q': 'architecture=ARM,architecture=PowerPC'}, 'cve', ['CVE-2019-1020018', 'CVE-2019-1020019']),
@@ -76,9 +73,7 @@ def send_msg_to_wdb(msg, raw=False):
     ({'q': 'condition!=Package unfixed'}, 'cve', []),
     ({'q': 'published>2019-07-28;updated<2019-08-31'}, 'cve', ['CVE-2019-1020016', 'CVE-2019-1020019']),
     ({'q': 'title~docker-credential-helpers before 0.6.3'}, 'cve', ['CVE-2019-1020014']),
-    ({'q': 'name=Mozilla Firefox 53.0 (x64 en-US)'}, 'cve', ['CVE-2021-38503']),
-    ({'q': '(name=Mozilla Firefox 53.0 (x64 en-US),version!=53.0);architecture=x64'}, 'cve', ['CVE-2021-38503']),
-    ({'select': ['architecture'], 'distinct': False}, 'architecture', ['x86', 'x86', 'PowerPC', 'ARM', 'x64', 'x86']),
+    ({'select': ['architecture'], 'distinct': False}, 'architecture', ['x86', 'x86', 'PowerPC', 'ARM', 'x86']),
     ({'select': ['architecture'], 'distinct': True}, 'architecture', ['x86', 'PowerPC', 'ARM']),
 ])
 @patch('wazuh.core.utils.path.exists', return_value=True)
@@ -137,5 +132,5 @@ def test_vulnerability_get_inventory_summary(socket_mock, send_mock, exists_mock
 
     # Check that result is sorted by count values
     result = get_inventory_summary(agent_list=[agent_id], field=field, limit=limit)
-    assert result['data'][field] == {'High': 3}, f'Expected "High" to be the severity with the most entries based on ' \
+    assert result['data'][field] == {'High': 2}, f'Expected "High" to be the severity with the most entries based on ' \
                                                  'our testing database'


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/13337 |


## Description

This PR closes #https://github.com/wazuh/wazuh/issues/13337

In this pull request, I have fixed the framework unit test failures after 4.3 was merged into master.

I have also reviewed some failures appearing when the framework tests are run by the `root` user.

```console
# pytest framework/
...
============================================= 1866 passed, 34 warnings in 228.16s (0:03:48) =============================================
```
