### PR TITLE
Task message queue limited size

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -359,6 +359,9 @@ wazuh_database.interval=60
 # 0. Use system default
 wazuh_database.max_queued_events=0
 
+# Vulnerability Detector task message queue size
+wazuh_vuln_detector.task_message_queue_size=10000
+
 # Enable download module
 # 0. Disabled
 # 1. Enabled (default)

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -360,7 +360,7 @@ wazuh_database.interval=60
 wazuh_database.max_queued_events=0
 
 # Vulnerability Detector task message queue size
-wazuh_vuln_detector.task_message_queue_size=10000
+wazuh_vuln_detector.message_queue_size=10000
 
 # Enable download module
 # 0. Disabled

--- a/src/headers/queue_op.h
+++ b/src/headers/queue_op.h
@@ -20,22 +20,22 @@
 #include <pthread.h>
 
 /**
- * queue main structure 
+ * queue main structure
  * */
 typedef struct queue_t {
-    void ** data; ///> Pointer to the circular buffer
-    size_t begin; ///> Stores the index of the next empty space
-    size_t end;   ///> Stores the index of the next element
-    size_t size;  ///> Size of the queue
-    pthread_mutex_t mutex; ///> mutex for mutual exclusion
-    pthread_cond_t available; ///> condition variable when queue is empty
-    pthread_cond_t available_not_empty; ///> Condition variable when queue is full
-    unsigned int elements; ///> counts the number of elements stored in the queue
+    void ** data;                           ///> Pointer to the circular buffer
+    size_t begin;                           ///> Stores the index of the next empty space
+    size_t end;                             ///> Stores the index of the next element
+    size_t size;                            ///> Size of the queue
+    pthread_mutex_t mutex;                  ///> mutex for mutual exclusion
+    pthread_cond_t available;               ///> condition variable when queue is empty
+    pthread_cond_t available_not_empty;     ///> Condition variable when queue is full
+    unsigned int elements;                  ///> counts the number of elements stored in the queue
 } w_queue_t;
 
 /**
  * @brief Initializes a new queue structure
- * 
+ *
  * @param n size of the circular queue (fits n - 1 elements)
  * @return initialize queue structure
  * */
@@ -43,14 +43,14 @@ w_queue_t * queue_init(size_t n);
 
 /**
  * @brief Frees an existent queue
- * 
- * @param queue 
+ *
+ * @param queue
  * */
 void queue_free(w_queue_t * queue);
 
 /**
  * @brief Evaluates whether the queue is full or not
- * 
+ *
  * @param queue
  * @return 1 if true, 0 if false
  * */
@@ -58,15 +58,15 @@ int queue_full(const w_queue_t * queue);
 
 /**
  * @brief Evaluates whether the queue is empty or not
- * 
+ *
  * @param queue
  * @return 1 if true, 0 if false
  * */
 int queue_empty(const w_queue_t * queue);
 
-/** 
+/**
  * @brief Tries to insert an element into the queue
- * 
+ *
  * @param queue the queue
  * @param data data to be inserted
  * @return -1 if queue is full
@@ -74,10 +74,10 @@ int queue_empty(const w_queue_t * queue);
  * */
 int queue_push(w_queue_t * queue, void * data);
 
-/** 
- * @brief Same as queue_push but with mutual exclusion 
+/**
+ * @brief Same as queue_push but with mutual exclusion
  * for multithreaded applications
- * 
+ *
  * @param queue the queue
  * @param data data to be inserted
  * @return -1 if queue is full
@@ -85,10 +85,10 @@ int queue_push(w_queue_t * queue, void * data);
  * */
 int queue_push_ex(w_queue_t * queue, void * data);
 
-/** 
+/**
  * @brief Same as queue_push_ex but if queue is full will
  * wait until there is space for the element (THREAD BLOCK)
- * 
+ *
  * @param queue the queue
  * @param data data to be inserted
  * @return 0 always
@@ -97,7 +97,7 @@ int queue_push_ex_block(w_queue_t * queue, void * data);
 
 /**
  * @brief Retrieves next item in the queue
- * 
+ *
  * @param queue the queue
  * @return element if queue has a next
  *         NULL if queue is empty
@@ -105,18 +105,27 @@ int queue_push_ex_block(w_queue_t * queue, void * data);
 void * queue_pop(w_queue_t * queue);
 
 /**
- * @brief Same as queue_pop but with mutual exclusion 
+ * @brief Same as queue_pop but with mutual exclusion
  * for multithreaded applications. If queue is empty THREAD WILL BLOCK
- * 
+ *
  * @param queue the queue
  * @return next element in the queue
  * */
 void * queue_pop_ex(w_queue_t * queue);
 
 /**
+ * @brief Same as queue_pop but with mutual exclusion
+ * for multithreaded applications. If queue is empty THREAD WON'T BLOCK
+ *
+ * @param queue The queue
+ * @return Next element in the queue
+ */
+void * queue_pop_ex_no_cond_wait(w_queue_t * queue);
+
+/**
  * @brief Same as queue_pop_ex but with a configured timeout for the
  * wait. If queue is empty THREAD WILL BLOCK
- * 
+ *
  * @param queue the queue
  * @param abstime timeout specification
  * @return next element in the queue

--- a/src/shared/queue_op.c
+++ b/src/shared/queue_op.c
@@ -111,6 +111,20 @@ void * queue_pop_ex(w_queue_t * queue) {
     return data;
 }
 
+void * queue_pop_ex_no_cond_wait(w_queue_t * queue) {
+    void * data;
+
+    w_mutex_lock(&queue->mutex);
+
+    if (data = queue_pop(queue), data) {
+        w_cond_signal(&queue->available_not_empty);
+    }
+
+    w_mutex_unlock(&queue->mutex);
+
+    return data;
+}
+
 void * queue_pop_ex_timedwait(w_queue_t * queue, const struct timespec * abstime) {
     void * data;
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -415,7 +415,7 @@ int *vu_queue;
 // Define time to sleep between messages sent
 int usec;
 
-w_linked_queue_t *vu_messages_queue = NULL;
+w_queue_t *vu_messages_queue = NULL;
 w_linked_queue_t* vu_tasks_queue = NULL;
 
 const wm_context WM_VULNDETECTOR_CONTEXT = {
@@ -5276,7 +5276,7 @@ void wm_vuldet_create_and_send_message(vu_task_ctx_t* task, task_status TASK_STA
                 break;
         }
         if (message) {
-            linked_queue_push_ex(vu_messages_queue, (void*) message);
+            queue_push_ex_block(vu_messages_queue, (void*) message);
         }
     }
 }
@@ -5546,12 +5546,12 @@ void *wm_vuldet_main(wm_vuldet_t* vuldet) {
                 vuldet->last_scan = time(NULL);
             }
             /* Checks for messages in the queue */
-            vu_task_msg_ctx_t *msg = (vu_task_msg_ctx_t *)linked_queue_pop_ex_no_cond_wait(vu_messages_queue);
+            vu_task_msg_ctx_t *msg = (vu_task_msg_ctx_t *)queue_pop_ex_no_cond_wait(vu_messages_queue);
             while(msg) {
                 /* TODO: Dummy message that represents the interaction with the task manager */
                 minfo("Task ID: '%d' status: '%s' message: '%s'", msg->task_id, task_statuses[msg->task_status], msg->status_message);
                 vu_task_msg_ctx_free(msg);
-                msg = (vu_task_msg_ctx_t *)linked_queue_pop_ex_no_cond_wait(vu_messages_queue);
+                msg = (vu_task_msg_ctx_t *)queue_pop_ex_no_cond_wait(vu_messages_queue);
             }
         }
         wm_vuldet_working_thread_active = 0;
@@ -5560,7 +5560,7 @@ void *wm_vuldet_main(wm_vuldet_t* vuldet) {
     }
 
     linked_queue_free(vu_tasks_queue);
-    linked_queue_free(vu_messages_queue);
+    queue_free(vu_messages_queue);
 
     return NULL;
 }
@@ -8885,12 +8885,13 @@ int wm_vuldet_get_software(int agent_id, bool not_triaged, cJSON** requested_ite
 
 void wm_vuldet_init_queues() {
     vu_tasks_queue = linked_queue_init(vu_tasks_queue_push_callback, vu_tasks_queue_pop_callback);
-    vu_messages_queue = linked_queue_init(NULL, NULL);
+    vu_messages_queue = queue_init(getDefine_Int("wazuh_vuln_detector", "task_message_queue_size",
+                                                  VU_TASK_MSG_MIN_QUEUE_SIZE, VU_TASK_MSG_MAX_QUEUE_SIZE));
 
     if (!vu_tasks_queue || !vu_messages_queue) {
         merror("Unable to initialize queues for vulnerability detector.");
         linked_queue_free(vu_tasks_queue);
-        linked_queue_free(vu_messages_queue);
+        queue_free(vu_messages_queue);
         pthread_exit(NULL);
     }
 }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5276,6 +5276,9 @@ void wm_vuldet_create_and_send_message(vu_task_ctx_t* task, task_status TASK_STA
                 break;
         }
         if (message) {
+            if (queue_full(vu_messages_queue)) {
+                mwarn("Task message queue with size '%ld' is full. Vulnerability detector will be blocked.", vu_messages_queue->size);
+            }
             queue_push_ex_block(vu_messages_queue, (void*) message);
         }
     }
@@ -5517,7 +5520,10 @@ void *wm_vuldet_main(wm_vuldet_t* vuldet) {
 
     wm_vuldet_check_db();
 
-    wm_vuldet_init_queues();
+    int message_queue_size = getDefine_Int("wazuh_vuln_detector", "message_queue_size",
+                                           VU_TASK_MSG_MIN_QUEUE_SIZE, VU_TASK_MSG_MAX_QUEUE_SIZE);
+
+    wm_vuldet_init_queues(message_queue_size);
 
     // TODO split the structures for the working and the sheduler threads
     wm_vuldet_t vuldet_cpy = {0};
@@ -8883,10 +8889,9 @@ int wm_vuldet_get_software(int agent_id, bool not_triaged, cJSON** requested_ite
     return result;
 }
 
-void wm_vuldet_init_queues() {
+void wm_vuldet_init_queues(int message_queue_size) {
     vu_tasks_queue = linked_queue_init(vu_tasks_queue_push_callback, vu_tasks_queue_pop_callback);
-    vu_messages_queue = queue_init(getDefine_Int("wazuh_vuln_detector", "task_message_queue_size",
-                                                  VU_TASK_MSG_MIN_QUEUE_SIZE, VU_TASK_MSG_MAX_QUEUE_SIZE));
+    vu_messages_queue = queue_init(message_queue_size);
 
     if (!vu_tasks_queue || !vu_messages_queue) {
         merror("Unable to initialize queues for vulnerability detector.");

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -121,6 +121,10 @@
 #define VU_BUILD_REF_BUGZ "https://bugzilla.redhat.com/show_bug.cgi?id=%s"
 #define VU_BUILD_REF_RHSA "https://access.redhat.com/errata/%s"
 
+// Task message queue size
+#define VU_TASK_MSG_MIN_QUEUE_SIZE 1000
+#define VU_TASK_MSG_MAX_QUEUE_SIZE 100000
+
 // Types of scans
 typedef enum vu_scan_type_t { VU_BASELINE_SCAN , VU_FULL_SCAN, VU_PARTIAL_SCAN } vu_scan_type_t;
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -123,7 +123,7 @@
 
 // Task message queue size
 #define VU_TASK_MSG_MIN_QUEUE_SIZE 1000
-#define VU_TASK_MSG_MAX_QUEUE_SIZE 100000
+#define VU_TASK_MSG_MAX_QUEUE_SIZE 1000000
 
 // Types of scans
 typedef enum vu_scan_type_t { VU_BASELINE_SCAN , VU_FULL_SCAN, VU_PARTIAL_SCAN } vu_scan_type_t;
@@ -921,8 +921,9 @@ const char *wm_vuldet_get_unified_severity(char *severity);
 /**
  * @brief Initializes global tasks and messages queue.
  * Vulnerability detector thread finalizes execution on error.
+ * @param message_queue_size Define the number of messages the queue can hold as message_queue_size - 1.
  */
-void wm_vuldet_init_queues();
+void wm_vuldet_init_queues(int message_queue_size);
 
 /**
  * @brief Creates a task context to be scheduled in the task queue.


### PR DESCRIPTION
|Related issue|
|---|
|#13343|

## Description

This PR limits the task message queue to a maximum size. Once the queue reaches its maximum capacity, the working thread won't be able to keep pushing messages.

## Scan-build 

![2](https://user-images.githubusercontent.com/13010397/167193948-dd945dd3-1f94-4e7c-bc98-c15ae99eba5e.png)

## Coverage

![1](https://user-images.githubusercontent.com/13010397/167192073-a4eee309-adc1-4aab-ab2c-21a7e9357a41.png)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)