### PR TITLE
13393 - Rule 92656 added field condition win.eventdata.logonType eq 10 to avoid false positives

### DIFF
--- a/ruleset/rules/0840-win_event_channel.xml
+++ b/ruleset/rules/0840-win_event_channel.xml
@@ -73,6 +73,7 @@
 
   <rule id="92656" level="15">
     <if_sid>60106</if_sid>
+    <field name="win.eventdata.logonType" type="pcre2">^10$</field>
     <field name="win.eventdata.ipAddress" type="pcre2">::1|127\.0\.0\.1</field>
     <description>User: $(win.eventdata.subjectDomainName)\$(win.eventdata.targetUserName) logged using Remote Desktop Connection (RDP) from loopback address, possible exploit over reverse tunneling using stolen credentials.</description>
     <mitre>


### PR DESCRIPTION
|Related issue|
|---|
| #13393 |

Rule 92656 "User logged using Remote Desktop Connection (RDP) from loopback address" is missing check to detect if the connection has RDP type.
This will cause false positives. To fix this issue the rule needs this field to be added:

```
<field name="win.eventdata.logonType" type="pcre2">10</field>
```

Final rule is: 

```
  <rule id="92656" level="15">
    <if_sid>60106</if_sid>
    <field name="win.eventdata.logonType" type="pcre2">^10$</field>
    <field name="win.eventdata.ipAddress" type="pcre2">::1|127\.0\.0\.1</field>
    <description>User: $(win.eventdata.subjectDomainName)\$(win.eventdata.targetUserName) logged using Remote Desktop Connection (RDP) from loopback address, possible exploit over reverse tunneling using stolen credentials.</description>
    <mitre>
      <id>T1021.001</id>
      <id>T1078.002</id>
    </mitre>
  </rule>
```