### PR TITLE
Catch exception in cluster when reading not well-formed configuration

### DIFF
--- a/framework/scripts/tests/test_wazuh_clusterd.py
+++ b/framework/scripts/tests/test_wazuh_clusterd.py
@@ -295,19 +295,29 @@ def test_main(print_mock, path_exists_mock, chown_mock, chmod_mock, setuid_mock,
     wazuh_clusterd.cluster_utils = cluster_utils
     with patch.object(common, 'wazuh_uid', return_value='uid_test'):
         with patch.object(common, 'wazuh_gid', return_value='gid_test'):
-            with patch.object(wazuh_clusterd.cluster_utils, 'read_config', return_value={'disabled': True}):
-                with pytest.raises(SystemExit):
-                    wazuh_clusterd.main()
-                path_exists_mock.assert_any_call(f'{common.WAZUH_PATH}/logs/cluster.log')
-                chown_mock.assert_called_with(f'{common.WAZUH_PATH}/logs/cluster.log', 'uid_test', 'gid_test')
-                chmod_mock.assert_called_with(f'{common.WAZUH_PATH}/logs/cluster.log', 432)
-                exit_mock.assert_called_once_with(0)
-                exit_mock.reset_mock()
 
             with patch.object(wazuh_clusterd.cluster_utils, 'read_config',
                               return_value={'disabled': False, 'node_type': 'master'}):
                 with patch.object(wazuh_clusterd.main_logger, 'error') as main_logger_mock:
                     with patch.object(wazuh_clusterd.main_logger, 'info') as main_logger_info_mock:
+                        with patch.object(wazuh_clusterd.cluster_utils, 'read_config', side_effect=Exception):
+                            with pytest.raises(SystemExit):
+                                wazuh_clusterd.main()
+                            main_logger_mock.assert_called_once()
+                            main_logger_mock.reset_mock()
+                            path_exists_mock.assert_any_call(f'{common.WAZUH_PATH}/logs/cluster.log')
+                            chown_mock.assert_called_with(f'{common.WAZUH_PATH}/logs/cluster.log', 'uid_test',
+                                                          'gid_test')
+                            chmod_mock.assert_called_with(f'{common.WAZUH_PATH}/logs/cluster.log', 432)
+                            exit_mock.assert_called_once_with(1)
+                            exit_mock.reset_mock()
+
+                        with patch.object(wazuh_clusterd.cluster_utils, 'read_config', return_value={'disabled': True}):
+                            with pytest.raises(SystemExit):
+                                wazuh_clusterd.main()
+                            exit_mock.assert_called_once_with(0)
+                            exit_mock.reset_mock()
+
                         with patch('wazuh.core.cluster.cluster.check_cluster_config', side_effect=IndexError):
                             with pytest.raises(SystemExit):
                                 wazuh_clusterd.main()

--- a/framework/scripts/wazuh_clusterd.py
+++ b/framework/scripts/wazuh_clusterd.py
@@ -153,7 +153,12 @@ def main():
         os.chown(f'{common.WAZUH_PATH}/logs/cluster.log', common.wazuh_uid(), common.wazuh_gid())
         os.chmod(f'{common.WAZUH_PATH}/logs/cluster.log', 0o660)
 
-    cluster_configuration = cluster_utils.read_config(config_file=args.config_file)
+    try:
+        cluster_configuration = cluster_utils.read_config(config_file=args.config_file)
+    except Exception as e:
+        main_logger.error(e)
+        sys.exit(1)
+
     if cluster_configuration['disabled']:
         sys.exit(0)
     try:


### PR DESCRIPTION
|Related issue|
|---|
|Closes #13130|

## Description

This PR fixes the unhandled error in the cluster reported at #13130 when using a wrong configuration in the `ossec.conf`. 

As it can be seen below, the cluster should not show the error even in previous versions if using `wazuh-control`, since other services would report it before. In any case, the error could be reproduced when running the `wazuh-clusterd.py` script. It is fixed now:
```
root@wazuh-master:/# 
root@wazuh-master:/# 
# /var/ossec/bin/wazuh-control start
2022/05/10 12:29:37 wazuh-csyslogd: CRITICAL: (1226): Error reading XML file 'etc/ossec.conf':  (line 0).
root@wazuh-master:/# 
root@wazuh-master:/# 
root@wazuh-master:/# 
wazuh-csyslogd: Configuration error. Exiting
root@wazuh-master:/# /var/ossec/bin/wazuh-clusterd -f
2022/05/10 12:29:43 ERROR: [Cluster] [Main] Error 3006 - Error reading cluster configuration: Requested component does not exist: not well-formed (invalid token): line 357, column 15
root@wazuh-master:/# 
```
