### PR TITLE
Fix regex that transforms into datetime in the logtest framework function

### DIFF
--- a/framework/wazuh/core/logtest.py
+++ b/framework/wazuh/core/logtest.py
@@ -31,7 +31,7 @@ def send_logtest_msg(command: str = None, parameters: dict = None):
     logtest_socket.close()
     try:
         response['data']['output']['timestamp'] = datetime.strptime(
-            response['data']['output']['timestamp'], "%Y-%m-%dT%H:%M:%S.%f+0000").strftime(decimals_date_format)
+            response['data']['output']['timestamp'], "%Y-%m-%dT%H:%M:%S.%f%z").strftime(decimals_date_format)
     except KeyError:
         pass
 

--- a/framework/wazuh/core/logtest.py
+++ b/framework/wazuh/core/logtest.py
@@ -3,6 +3,9 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from datetime import datetime
+
+import pytz
+
 from wazuh.core.common import LOGTEST_SOCKET, decimals_date_format, origin_module
 from wazuh.core.wazuh_socket import WazuhSocketJSON, create_wazuh_socket_message
 
@@ -31,7 +34,8 @@ def send_logtest_msg(command: str = None, parameters: dict = None):
     logtest_socket.close()
     try:
         response['data']['output']['timestamp'] = datetime.strptime(
-            response['data']['output']['timestamp'], "%Y-%m-%dT%H:%M:%S.%f%z").strftime(decimals_date_format)
+            response['data']['output']['timestamp'], "%Y-%m-%dT%H:%M:%S.%f%z").astimezone(pytz.utc).strftime(
+            decimals_date_format)
     except KeyError:
         pass
 

--- a/framework/wazuh/core/tests/test_logtest.py
+++ b/framework/wazuh/core/tests/test_logtest.py
@@ -28,10 +28,10 @@ def test_send_logtest_msg(create_message_mock, close_mock, send_mock, init_mock,
     params : dict
         Params that will be sent to the logtest socket.
     """
-    expected_response = {'data': {'response': True, 'output': {'timestamp': '1970-01-01T00:00:00.000000+0000'}}}
-    with patch('wazuh.core.logtest.WazuhSocketJSON.receive', return_value=expected_response):
+    with patch('wazuh.core.logtest.WazuhSocketJSON.receive',
+               return_value={'data': {'response': True, 'output': {'timestamp': '1970-01-01T00:00:00.000000+0200'}}}):
         response = send_logtest_msg(**params)
         init_mock.assert_called_with(LOGTEST_SOCKET)
         create_message_mock.assert_called_with(origin={'name': 'Logtest', 'module': 'framework'}, **params)
-        assert response == expected_response
+        assert response == {'data': {'response': True, 'output': {'timestamp': '1970-01-01T00:00:00.000000Z'}}}
 

--- a/framework/wazuh/core/tests/test_logtest.py
+++ b/framework/wazuh/core/tests/test_logtest.py
@@ -29,9 +29,9 @@ def test_send_logtest_msg(create_message_mock, close_mock, send_mock, init_mock,
         Params that will be sent to the logtest socket.
     """
     with patch('wazuh.core.logtest.WazuhSocketJSON.receive',
-               return_value={'data': {'response': True, 'output': {'timestamp': '1970-01-01T00:00:00.000000+0200'}}}):
+               return_value={'data': {'response': True, 'output': {'timestamp': '1970-01-01T00:00:00.000000-0200'}}}):
         response = send_logtest_msg(**params)
         init_mock.assert_called_with(LOGTEST_SOCKET)
         create_message_mock.assert_called_with(origin={'name': 'Logtest', 'module': 'framework'}, **params)
-        assert response == {'data': {'response': True, 'output': {'timestamp': '1970-01-01T00:00:00.000000Z'}}}
+        assert response == {'data': {'response': True, 'output': {'timestamp': '1970-01-01T02:00:00.000000Z'}}}
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/13412|



## Description



This PR closes https://github.com/wazuh/wazuh/issues/13412.

As it was said in the related issue's body, we need to use `%Y-%m-%dT%H:%M:%S.%f%z` instead of `%Y-%m-%dT%H:%M:%S.%f+0000`.

The `%z` directive matches the UTC offset in the form `±HHMM[SS]` (or an empty string if the object is naive).

I have also added a function to change to UTC as it is needed to avoid losing the UTC offset.

I have also reviewed other regexes used for datetime objects and it doesn't appear to be more conflictive regexes. They cannot be grouped in variables in a common file either.