### PR TITLE
The way used to read alerts are changed

### DIFF
--- a/src/headers/file-queue.h
+++ b/src/headers/file-queue.h
@@ -13,7 +13,6 @@
 
 #define MAX_FQUEUE  256
 #define FQ_TIMEOUT  5
-#define MAX_READ_ATTEMPTS   3
 
 /* File queue */
 typedef struct _file_queue {
@@ -21,7 +20,6 @@ typedef struct _file_queue {
     int year;
     int day;
     int flags;
-    int read_attempts;
 
     char mon[4];
     char file_name[MAX_FQUEUE + 1];

--- a/src/shared/file-queue.c
+++ b/src/shared/file-queue.c
@@ -105,7 +105,6 @@ int Init_FileQueue(file_queue *fileq, const struct tm *p, int flags)
     }
     fileq->last_change = 0;
     fileq->flags = 0;
-    fileq->read_attempts = 0;
 
     fileq->day = p->tm_mday;
     fileq->year = p->tm_year + 1900;

--- a/src/shared/json-queue.c
+++ b/src/shared/json-queue.c
@@ -87,10 +87,10 @@ cJSON * jqueue_next(file_queue * queue) {
                 return NULL;
             }
 
+            clearerr(queue->fp);
             return jqueue_parse_json(queue);
 
         } else {
-            sleep(1);
             return NULL;
         }
     }
@@ -108,16 +108,18 @@ void jqueue_close(file_queue * queue) {
  * @param queue pointer to the file_queue struct
  * @post The flag variable may be set to CRALERT_READ_FAILED if the read operation got no data.
  * @post The read position is restored if failed to get a JSON object.
- * @retval NULL No data read or could not get a valid JSON object. Pointer to the JSON object otherwise.
+ * @retval NULL No data read or could not get a valid JSON object or read overlong alert. Pointer to the JSON object otherwise.
  */
 cJSON * jqueue_parse_json(file_queue * queue) {
     cJSON * object = NULL;
     char buffer[OS_MAXSTR + 1];
+    int64_t initial_pos;
     int64_t current_pos;
+    int64_t offset;
     const char * jsonErrPtr;
     char * end;
 
-    current_pos = w_ftell(queue->fp);
+    initial_pos = w_ftell(queue->fp);
 
     if (fgets(buffer, OS_MAXSTR + 1, queue->fp)) {
 
@@ -125,28 +127,37 @@ cJSON * jqueue_parse_json(file_queue * queue) {
             *end = '\0';
 
             if ((object = cJSON_ParseWithOpts(buffer, &jsonErrPtr, 0), object) && (*jsonErrPtr == '\0')) {
-                queue->read_attempts = 0;
                 return object;
             }
-        }
 
-        // The read JSON is invalid
-        if (object) {
+            // The read JSON is invalid
             cJSON_Delete(object);
+
+            mwarn("Invalid JSON alert read from '%s': '%s'", queue->file_name, buffer);
+            return NULL;
         }
 
-        queue->read_attempts++;
-        mdebug2("Invalid JSON alert read from '%s'. Remaining attempts: %d", queue->file_name, MAX_READ_ATTEMPTS - queue->read_attempts);
-
-        if (queue->read_attempts < MAX_READ_ATTEMPTS) {
-            if (current_pos >= 0) {
-                if (fseek(queue->fp, current_pos, SEEK_SET) != 0) {
-                    queue->flags = CRALERT_READ_FAILED;
+        current_pos = initial_pos;
+        offset = w_ftell(queue->fp);
+        while ((offset-current_pos) == OS_MAXSTR) {
+            if (fgets(buffer, OS_MAXSTR + 1, queue->fp)) {
+                current_pos = offset;
+                offset = w_ftell(queue->fp);
+                if (strchr(buffer, '\n')) {
+                    mwarn("Overlong JSON alert read from '%s'", queue->file_name);
+                    return NULL;
                 }
+            } else {
+                break;
             }
-        } else {
-            queue->read_attempts = 0;
-            merror("Invalid JSON alert read from '%s'. Skipping it.", queue->file_name);
+        }
+
+        mdebug2("Can't read from '%s'. Trying again", queue->file_name);
+
+        if (initial_pos >= 0) {
+            if (fseek(queue->fp, initial_pos, SEEK_SET) != 0) {
+                queue->flags = CRALERT_READ_FAILED;
+            }
         }
     } else {
         // Force the queue reload when the read fails

--- a/src/unit_tests/shared/test_json-queue.c
+++ b/src/unit_tests/shared/test_json-queue.c
@@ -36,7 +36,6 @@ int setup_queue(void **state) {
     file_queue * queue;
 
     os_calloc(1, sizeof(file_queue), queue);
-    queue->read_attempts = 0;
     queue->flags = 0;
     queue->fp = (FILE *)1;
     *state = queue;
@@ -71,7 +70,6 @@ void test_jqueue_parse_json_valid(void ** state) {
 
     output = cJSON_PrintUnformatted(object);
     assert_string_equal(output, "{\"test\":\"valid_json\"}");
-    assert_int_equal(queue->read_attempts, 0);
     assert_int_equal(queue->flags, 0);
 
     os_free(output);
@@ -92,39 +90,46 @@ void test_jqueue_parse_json_invalid(void ** state) {
     expect_value(__wrap_fgets, __stream, queue->fp);
     will_return(__wrap_fgets, buffer);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "Invalid JSON alert read from '/home/test'. Remaining attempts: 2");
-    will_return(__wrap_fseek, 0);
+    expect_string(__wrap__mwarn, formatted_msg, "Invalid JSON alert read from '/home/test': '{\"test\":\"invalid_value'");
 
     object = jqueue_parse_json(queue);
 
     assert_null(object);
-    assert_int_equal(queue->read_attempts, 1);
     assert_int_equal(queue->flags, 0);
 }
 
-void test_jqueue_parse_json_max_attempts(void ** state) {
+void test_jqueue_parse_json_overlong_alert(void ** state) {
     file_queue * queue = *state;
-    char buffer[OS_MAXSTR + 1];
+    char buffer1[OS_MAXSTR + 1];
+    char buffer2[OS_MAXSTR + 1];
     int64_t current_pos = 0;
     cJSON * object = NULL;
 
-    queue->read_attempts = 2;
-
     snprintf(queue->file_name, MAX_FQUEUE, "%s", "/home/test");
-    snprintf(buffer, OS_MAXSTR, "%s\n", "{\"test\":\"invalid_value");
 
+    for (int i = 0; i < OS_MAXSTR; i++) {
+        buffer1[i] = 'a';
+    }
+    buffer1[OS_MAXSTR]='\0';
+
+    snprintf(buffer2, OS_MAXSTR, "%s\n","aaaa");
     expect_any(__wrap_w_ftell, x);
     will_return(__wrap_w_ftell, 1);
-    expect_value(__wrap_fgets, __stream, queue->fp);
-    will_return(__wrap_fgets, buffer);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "Invalid JSON alert read from '/home/test'. Remaining attempts: 0");
-    expect_string(__wrap__merror, formatted_msg, "Invalid JSON alert read from '/home/test'. Skipping it.");
+    expect_value(__wrap_fgets, __stream, queue->fp);
+    will_return(__wrap_fgets, buffer1);
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, 65537);
+    expect_value(__wrap_fgets, __stream, queue->fp);
+    will_return(__wrap_fgets, buffer2);
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, 65537);
+
+    expect_string(__wrap__mwarn, formatted_msg, "Overlong JSON alert read from '/home/test'");
 
     object = jqueue_parse_json(queue);
 
     assert_null(object);
-    assert_int_equal(queue->read_attempts, 0);
     assert_int_equal(queue->flags, 0);
 }
 
@@ -141,7 +146,38 @@ void test_jqueue_parse_json_fgets_fail(void ** state) {
     object = jqueue_parse_json(queue);
 
     assert_null(object);
-    assert_int_equal(queue->read_attempts, 0);
+    assert_int_equal(queue->flags, CRALERT_READ_FAILED);
+}
+
+void test_jqueue_parse_json_fgets_fail_and_retry(void ** state) {
+    file_queue * queue = *state;
+    char buffer[OS_MAXSTR + 1];
+    int64_t current_pos = 0;
+    cJSON * object = NULL;
+
+    snprintf(queue->file_name, MAX_FQUEUE, "%s", "/home/test");
+
+    for (int i = 0; i < OS_MAXSTR; i++) {
+        buffer[i] = 'a';
+    }
+    buffer[OS_MAXSTR]='\0';
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, 1);
+    expect_value(__wrap_fgets, __stream, queue->fp);
+    will_return(__wrap_fgets, buffer);
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, 65537);
+    expect_value(__wrap_fgets, __stream, queue->fp);
+    will_return(__wrap_fgets, NULL);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Can't read from '/home/test'. Trying again");
+
+    will_return(__wrap_fseek, 1);
+
+    object = jqueue_parse_json(queue);
+
+    assert_null(object);
     assert_int_equal(queue->flags, CRALERT_READ_FAILED);
 }
 
@@ -149,8 +185,9 @@ int main(void) {
     const struct CMUnitTest tests[] = {
             cmocka_unit_test_setup_teardown(test_jqueue_parse_json_valid, setup_queue, teardown_queue),
             cmocka_unit_test_setup_teardown(test_jqueue_parse_json_invalid, setup_queue, teardown_queue),
-            cmocka_unit_test_setup_teardown(test_jqueue_parse_json_max_attempts, setup_queue, teardown_queue),
-            cmocka_unit_test_setup_teardown(test_jqueue_parse_json_fgets_fail, setup_queue, teardown_queue)
+            cmocka_unit_test_setup_teardown(test_jqueue_parse_json_overlong_alert, setup_queue, teardown_queue),
+            cmocka_unit_test_setup_teardown(test_jqueue_parse_json_fgets_fail, setup_queue, teardown_queue),
+            cmocka_unit_test_setup_teardown(test_jqueue_parse_json_fgets_fail_and_retry, setup_queue, teardown_queue)
     };
     return cmocka_run_group_tests(tests, setup_group, teardown_group);
 }


### PR DESCRIPTION
|Related issue|
|---|
[12664](https://github.com/wazuh/wazuh/issues/12664)
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The way used to read alerts are changed. Now there are no limited attempts to read them and changed the logic of the function in charge of doing this. The new way is:
 - If the alert read is valid JSON, the alert is parsed and returned.
 - If the alert read is invalid JSON, an error message is displayed and NULL is returned.
 - If the alert read is too long (more than 64Kb), error message is displayed and NULL is returned.
 - If the file cannot be read, and it is none of the above cases, check if the inode changed and try again.

## Logs/Alerts example

- Invalid JSON:
```2022/04/26 17:55:22 wazuh-integratord: ERROR: Invalid JSON alert read from 'logs/alerts/alerts.json': '{"timestamp":"2022-04-25T18:19:08.873+0200","rule":{"level":7,"description":"Listened ports status (netstat) changed (new port opened or closed).","id":"533","firedtimes":1,"mail":false,"groups":["ossec"],"pci_dss,"location":"netstat listening ports"}'```

- Alert too long:
```2022/04/26 17:55:39 wazuh-integratord: ERROR: Overlong JSON alert read from 'logs/alerts/alerts.json'```

- Inode changed:
```2022/04/26 17:55:39 wazuh-integratord: DEBUG: jqueue_next(): Alert file inode changed. Reloading.```
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)
