### PR TITLE
Solve GDB default symbol files search paths

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -824,7 +824,7 @@ ifeq (${TARGET}, winagent)
 		$(foreach binary, ${EXECUTABLE_FILES}, ${MING_BASE}objcopy --strip-unneeded ${binary};) \
 	fi
 else
-	@$(foreach binary, ${EXECUTABLE_FILES}, (objdump -h $(binary) | grep -q .debug_info && objcopy --only-keep-debug $(binary) ${SYMBOLS_PATH}/$(basename $(notdir $(binary))).debug && objcopy --strip-unneeded $(binary)) || true;)
+	@$(foreach binary, ${EXECUTABLE_FILES}, (objdump -h $(binary) | grep -q .debug_info && objcopy --only-keep-debug $(binary) ${SYMBOLS_PATH}/$(basename $(notdir $(binary))).debug && objcopy --strip-unneeded $(binary) && objcopy --add-gnu-debuglink=${SYMBOLS_PATH}/$(basename $(notdir $(binary))).debug $(binary)) || true;)
 endif
 endif
 ifeq (${uname_S}, Darwin)

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -933,6 +933,12 @@ InstallCommon()
     chmod 750 ${INSTALLDIR}/.symbols
     chmod -R 640 ${INSTALLDIR}/.symbols/*
   fi
+
+  if [ "X${NUNAME}" = "XLinux" ]; then
+    ln -sf ${INSTALLDIR}/.symbols ${INSTALLDIR}/active-response/bin/.debug
+    ln -sf ${INSTALLDIR}/.symbols ${INSTALLDIR}/bin/.debug
+    ln -sf ${INSTALLDIR}/.symbols ${INSTALLDIR}/lib/.debug
+  fi
 }
 
 InstallLocal()


### PR DESCRIPTION
|Related issue|
|---|
|#13446|

## Description

This PR aims to allow symlinks inside every binary folder that create symbol files(bin, active-response/bin/and libs) necessary to GDB symbols autoload mechanism. Those links will point, in case debuginfo package is installed, to .symbols folder

## Example

```
[root@centos8 vagrant]# ll -a /var/ossec/bin/
total 3884
drwxr-x---.  2 root root     190 May 13 18:20 .
drwxr-x---. 15 root wazuh    181 May 13 18:23 ..
-rwxr-x---.  1 root root  190024 May 13 18:17 agent-auth
lrwxrwxrwx.  1 root root      19 May 13 18:17 .debug -> /var/ossec/.symbols
-rwxr-x---.  1 root root  194504 May 13 18:17 manage_agents
-rwxr-x---.  1 root root  684688 May 13 18:17 wazuh-agentd
-rwxr-x---.  1 root root    7148 May 13 18:17 wazuh-control
-rwxr-x---.  1 root root  650552 May 13 18:17 wazuh-execd
-rwxr-x---.  1 root root  691712 May 13 18:17 wazuh-logcollector
-rwxr-x---.  1 root root  625912 May 13 18:17 wazuh-modulesd
-rwxr-x---.  1 root root  917952 May 13 18:17 wazuh-syscheckd


[root@centos8 vagrant]# rpm -i wazuh-agent-debuginfo-4.4.0-1.x86_64.rpm 
[root@centos8 vagrant]# ll -a /var/ossec/bin/
total 3884
drwxr-x---.  2 root root     190 May 13 18:20 .
drwxr-x---. 16 root wazuh    197 May 13 18:46 ..
-rwxr-x---.  1 root root  190024 May 13 18:17 agent-auth
lrwxrwxrwx.  1 root root      19 May 13 18:17 .debug -> /var/ossec/.symbols
-rwxr-x---.  1 root root  194504 May 13 18:17 manage_agents
-rwxr-x---.  1 root root  684688 May 13 18:17 wazuh-agentd
-rwxr-x---.  1 root root    7148 May 13 18:17 wazuh-control
-rwxr-x---.  1 root root  650552 May 13 18:17 wazuh-execd
-rwxr-x---.  1 root root  691712 May 13 18:17 wazuh-logcollector
-rwxr-x---.  1 root root  625912 May 13 18:17 wazuh-modulesd
-rwxr-x---.  1 root root  917952 May 13 18:17 wazuh-syscheckd


[root@centos8 vagrant]# gdb /var/ossec/bin/wazuh-logcollector 
GNU gdb (GDB) Red Hat Enterprise Linux 8.2-16.el8
Copyright (C) 2018 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-redhat-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from /var/ossec/bin/wazuh-logcollector...Reading symbols from /var/ossec/bin/.debug/wazuh-logcollector.debug...done.
done.
(gdb) 
```
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors