### PR TITLE
Basic engine definitions functionality

### DIFF
--- a/src/engine/source/builder/CMakeLists.txt
+++ b/src/engine/source/builder/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(builders OBJECT
     builders/stageBuilderOutputs.cpp
     builders/stageParse.cpp
     registry.cpp
+    definitions.cpp
 )
 
 target_include_directories(builders

--- a/src/engine/source/builder/builder.hpp
+++ b/src/engine/source/builder/builder.hpp
@@ -17,6 +17,7 @@
 #include "builderTypes.hpp"
 #include "graph.hpp"
 #include "registry.hpp"
+#include "definitions.hpp"
 
 namespace builder
 {
@@ -52,6 +53,7 @@ private:
             for (auto& m : v.GetArray())
             {
                 json::Document asset = m_catalog.getAsset(atype, m.GetString());
+                internals::substituteDefinitions(asset);
                 g.addNode(make(asset));
             }
         }

--- a/src/engine/source/builder/definitions.cpp
+++ b/src/engine/source/builder/definitions.cpp
@@ -4,9 +4,7 @@
 
 #include <fmt/format.h>
 
-namespace builder
-{
-namespace internals
+namespace builder::internals
 {
 
 void substituteDefinitions(base::Document& asset)
@@ -36,7 +34,8 @@ void substituteDefinitions(base::Document& asset)
          it != definitionsObject.MemberEnd();
          ++it)
     {
-        definitionsMap["$" + std::string(it->name.GetString())] = base::Document {it->value};
+        definitionsMap["$" + std::string(it->name.GetString())] =
+            base::Document {it->value};
     }
 
     asset.m_doc.RemoveMember("definitions");
@@ -79,5 +78,4 @@ void substituteDefinitions(base::Document& asset)
     asset = base::Document {jsonString.c_str()};
 }
 
-} // namespace internals
-} // namespace builder
+} // namespace builder::internals

--- a/src/engine/source/builder/definitions.cpp
+++ b/src/engine/source/builder/definitions.cpp
@@ -1,0 +1,83 @@
+#include "definitions.hpp"
+
+#include <algorithm>
+
+#include <fmt/format.h>
+
+namespace builder
+{
+namespace internals
+{
+
+void substituteDefinitions(base::Document& asset)
+{
+    if (!asset.m_doc.IsObject())
+    {
+        throw std::runtime_error(fmt::format(
+            "Expected [object], got [{}] in substitute definitions function",
+            asset.m_doc.GetType()));
+    }
+
+    auto definitions = asset.m_doc.FindMember("definitions");
+    if (definitions == asset.m_doc.MemberEnd())
+    {
+        return;
+    }
+
+    if (!definitions->value.IsObject())
+    {
+        throw std::runtime_error(
+            fmt::format("Expected definitions to be an object, got [{}]",
+                        definitions->value.GetType()));
+    }
+    auto definitionsObject = definitions->value.GetObject();
+    std::unordered_map<std::string, base::Document> definitionsMap;
+    for (auto it = definitionsObject.MemberBegin();
+         it != definitionsObject.MemberEnd();
+         ++it)
+    {
+        definitionsMap["$" + std::string(it->name.GetString())] = base::Document {it->value};
+    }
+
+    asset.m_doc.RemoveMember("definitions");
+
+    std::string jsonString = asset.str();
+    for (auto& pair : definitionsMap)
+    {
+        std::string valueStr = [&]() -> std::string
+        {
+            if (pair.second.m_doc.IsString())
+            {
+                return pair.second.m_doc.GetString();
+            }
+            else if (pair.second.m_doc.IsNumber())
+            {
+                return std::to_string(pair.second.m_doc.GetInt());
+            }
+            else
+            {
+                throw std::runtime_error(
+                    fmt::format("Expected [string] or [number], got [{}] in "
+                                "substitute definitions function",
+                                pair.second.m_doc.GetType()));
+            }
+        }();
+
+        auto index = 0;
+        while (true)
+        {
+            index = jsonString.find(pair.first, index);
+            if (index == std::string::npos)
+            {
+                break;
+            }
+            jsonString.replace(index, pair.first.size(), valueStr);
+            index += valueStr.size();
+        }
+    }
+
+    asset = base::Document {jsonString.c_str()};
+}
+
+} // namespace internals
+} // namespace builder

--- a/src/engine/source/builder/definitions.hpp
+++ b/src/engine/source/builder/definitions.hpp
@@ -1,0 +1,16 @@
+#ifndef _DEFINITIONS_H_
+#define _DEFINITIONS_H_
+
+#include "builderTypes.hpp"
+
+namespace builder
+{
+namespace internals
+{
+
+void substituteDefinitions(base::Document& asset);
+
+}
+} // namespace builder
+
+#endif // _DEFINITIONS_H_

--- a/src/engine/source/builder/definitions.hpp
+++ b/src/engine/source/builder/definitions.hpp
@@ -3,14 +3,11 @@
 
 #include "builderTypes.hpp"
 
-namespace builder
-{
-namespace internals
+namespace builder::internals
 {
 
 void substituteDefinitions(base::Document& asset);
 
-}
-} // namespace builder
+} // namespace builder::internals
 
 #endif // _DEFINITIONS_H_

--- a/src/engine/test/source/builder/CMakeLists.txt
+++ b/src/engine/test/source/builder/CMakeLists.txt
@@ -160,3 +160,9 @@ add_executable(combinatorBuilderBroadcastTest
   ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/combinatorBuilderBroadcast_test.cpp
 )
 gtest_discover_tests(combinatorBuilderBroadcastTest)
+
+add_executable(definitions_test
+  ${BUILDER_TEST_SOURCE_DIR}/definitions_test.cpp
+  ${ENGINE_SOURCE_DIR}/builder/definitions.cpp
+)
+gtest_discover_tests(definitions_test)

--- a/src/engine/test/source/builder/CMakeLists.txt
+++ b/src/engine/test/source/builder/CMakeLists.txt
@@ -163,6 +163,5 @@ gtest_discover_tests(combinatorBuilderBroadcastTest)
 
 add_executable(definitions_test
   ${BUILDER_TEST_SOURCE_DIR}/definitions_test.cpp
-  ${ENGINE_SOURCE_DIR}/builder/definitions.cpp
 )
 gtest_discover_tests(definitions_test)

--- a/src/engine/test/source/builder/definitions_test.cpp
+++ b/src/engine/test/source/builder/definitions_test.cpp
@@ -1,0 +1,58 @@
+#include "testUtils.hpp"
+#include <gtest/gtest.h>
+
+#include "definitions.hpp"
+
+TEST(DefinitionsTest, SubstituteDefinitions)
+{
+    base::Document asset {
+        R"({
+            "definitions": {
+                "foo": "bar",
+                "foo2": "bar2"
+            },
+            "check": "$foo AND $foo2"
+        })"};
+    auto expected = R"({"check":"bar AND bar2"})";
+
+    ASSERT_NO_THROW(builder::internals::substituteDefinitions(asset));
+    ASSERT_EQ(asset.str(), expected);
+}
+
+TEST(DefinitionsTest, EmptyDefinitionsDoesNothing)
+{
+    base::Document asset {
+        R"({
+            "definitions": {},
+            "check": "$foo"
+        })"};
+
+    ASSERT_NO_THROW(builder::internals::substituteDefinitions(asset));
+    ASSERT_EQ(asset.str(), R"({"check":"$foo"})");
+}
+
+TEST(DefinitionsTest, EmptyDefinitionVariableThrow)
+{
+    base::Document asset {
+        R"({
+            "definitions": {
+                "foo": null
+            },
+            "check": "$foo AND $bar"
+        })"};
+
+    ASSERT_THROW(builder::internals::substituteDefinitions(asset),
+                 std::runtime_error);
+}
+
+TEST(DefinitionsTest, NoDefinitionsDoesNothing)
+{
+    base::Document asset {
+        R"({
+            "check": "$foo"
+        })"};
+    auto expected = R"({"check":"$foo"})";
+
+    ASSERT_NO_THROW(builder::internals::substituteDefinitions(asset));
+    ASSERT_EQ(asset.str(), expected);
+}


### PR DESCRIPTION
|Related issue|
|---|
|Closes #13182 |

As part of the logic expression module definitions must be implemented.

This PR adds a basic definitions substitution function to the Builder. This functions replaces definitions where they appear in the Json asset. This function is called on the builder when retrieves asset json from the Catalog.

## Test (local)
![image](https://user-images.githubusercontent.com/32262972/168583125-b327ff8a-9192-4120-b4b8-0376aa96fbe5.png)
