### PR TITLE
Removed duplicated log in FIM sync

### DIFF
--- a/src/syscheckd/src/db/src/fimDB.cpp
+++ b/src/syscheckd/src/db/src/fimDB.cpp
@@ -141,7 +141,6 @@ void FIMDB::pushMessage(const std::string& data)
         try
         {
             m_rsyncHandler->pushMessage(std::vector<uint8_t> {buff, buff + rawData.size()});
-            m_loggingFunction(LOG_DEBUG_VERBOSE, "Message pushed: " + data);
         }
         // LCOV_EXCL_START
         catch (const std::exception& ex)

--- a/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
@@ -86,7 +86,6 @@ TEST_F(DBTestFixture, TestFimSyncPushMsg)
     const auto test{R"(fim_file no_data {"begin":"a2fbef8f81af27155dcee5e3927ff6243593b91a","end":"a2fbef8f81af27155dcee5e3927ff6243593b91b","id":1})"};
     const auto fileFIMTest { std::make_unique<FileItem>(insertFileStatement) };
     ASSERT_EQ(fim_db_file_update(fileFIMTest->toFimEntry(), callback_data_added), FIMDB_OK);
-    EXPECT_CALL(*mockLog, loggingFunction(LOG_DEBUG_VERBOSE, std::string("Message pushed: ") + test)).Times(1);
     EXPECT_CALL(*mockLog, loggingFunction(LOG_INFO, "FIM sync module started.")).Times(1);
     EXPECT_CALL(*mockLog, loggingFunction(LOG_DEBUG, "Executing FIM sync.")).Times(1);
     EXPECT_CALL(*mockLog, loggingFunction(LOG_DEBUG, "Finished FIM sync.")).Times(1);
@@ -240,4 +239,3 @@ TEST(DBTest, TestValidFimLimit)
     delete mockLog;
     delete mockSync;
 }
-

--- a/src/syscheckd/src/db/tests/db/FIMDB/fimDBTests/fimDBImpTests.cpp
+++ b/src/syscheckd/src/db/tests/db/FIMDB/fimDBTests/fimDBImpTests.cpp
@@ -283,7 +283,6 @@ TEST_F(FimDBFixture, fimSyncPushMsgSuccess)
     const auto buff{reinterpret_cast<const uint8_t*>(rawData.c_str())};
 
     EXPECT_CALL(*mockRSync, pushMessage(std::vector<uint8_t> {buff, buff + rawData.size()}));
-    EXPECT_CALL(*mockLog, loggingFunction(LOG_DEBUG_VERBOSE, "Message pushed: " + data));
 
     fimDBMock.pushMessage(data);
 }

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -1655,7 +1655,6 @@ void Syscollector::push(const std::string& data)
         try
         {
             m_spRsync->pushMessage(std::vector<uint8_t> {buff, buff + rawData.size()});
-            m_logFunction(LOG_DEBUG_VERBOSE, "Message pushed: " + data);
         }
         // LCOV_EXCL_START
         catch (const std::exception& ex)


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/13502|

## Description
This PR removes a debug message from the FIM sync, which was duplicated and was generating a lot of unnecessary flooding in the logs.
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation