### PR TITLE
Fix deprecated MITRE mapping in rules

### DIFF
--- a/ruleset/rules/0245-web_rules.xml
+++ b/ruleset/rules/0245-web_rules.xml
@@ -69,7 +69,7 @@
     <url>%20ONLOAD=|INPUT%20|iframe%20</url>
     <description>XSS (Cross Site Scripting) attempt.</description>
     <mitre>
-      <id>T1064</id>
+      <id>T1059.007</id>
     </mitre>
     <group>attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.7,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SI.4,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
@@ -206,7 +206,7 @@
     <description>Multiple XSS (Cross Site Scripting) attempts </description>
     <description>from same source ip.</description>
     <mitre>
-      <id>T1064</id>
+      <id>T1059.007</id>
     </mitre>
     <group>attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.7,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SI.4,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>

--- a/ruleset/rules/0270-web_appsec_rules.xml
+++ b/ruleset/rules/0270-web_appsec_rules.xml
@@ -72,7 +72,7 @@
     <regex> "GET /\S+/cache/external\S+.php</regex>
     <description>TimThumb backdoor access attempt.</description>
     <mitre>
-      <id>T1108</id>
+      <id>T1505.003</id>
     </mitre>
     <group>pci_dss_6.5,pci_dss_11.4,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_SI.4,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
    </rule>

--- a/ruleset/rules/0275-squid_rules.xml
+++ b/ruleset/rules/0275-squid_rules.xml
@@ -97,7 +97,7 @@
     <info type="link">http://www.symantec.com/avcenter/venc/data/w32.beagle.dp.html</info>
     <info type="text">W32.Beagle.DP is a Worm that drops Trojan.Lodear and opens a back door on the compromised computer.</info>
     <mitre>
-      <id>T1108</id>
+      <id>T1505.003</id>
     </mitre>
     <group>automatic_attack,pci_dss_11.4,pci_dss_6.2,gdpr_IV_35.7.d,nist_800_53_SI.4,nist_800_53_SI.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
@@ -108,7 +108,7 @@
     <url>/jk/exp.wmf$|/PopupSh.ocx$</url>
     <description>Squid: Attempt to access a worm/trojan related site.</description>
     <mitre>
-      <id>T1108</id>
+      <id>T1505.003</id>
     </mitre>
     <group>automatic_attack,pci_dss_11.4,pci_dss_6.2,gdpr_IV_35.7.d,nist_800_53_SI.4,nist_800_53_SI.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>

--- a/ruleset/rules/0800-sysmon_id_1.xml
+++ b/ruleset/rules/0800-sysmon_id_1.xml
@@ -213,7 +213,7 @@
     <field name="win.eventdata.commandLine" type="pcre2">(?i)(Remove-Item|ri|rm|rmdir|del|erase|rd)\b</field>
     <description>Powershell was used to delete files or directories.</description>
     <mitre>
-      <id>T107.004</id>
+      <id>T1070.004</id>
     </mitre>
   </rule>
 


### PR DESCRIPTION
Changed rules: 31105, 31154, 31505, 35054, 35055, 92021

|Related issue|
|----|
|closes #13517 |


## Description
Rules containing deprecated MITRE technique id were identified. Please improve the rules by adding correct MITRE TID

## Rules
| RuleID  | Description | Old MITRE ID | New MITRE ID
| ------------- | ------------- |  ------------- | ------------- |
| 31105  | XSS (Cross Site Scripting) attempt.  | T1064 | T1059.007   |
| 31154  | Multiple XSS (Cross Site Scripting) attempts  | T1064 | T1059.007   |
| 31505  | TimThumb backdoor access attempt.  | T1108 | T1505.003   |
| 35054  | W32.Beagle.DP is a Worm that drops Trojan.Lodear and opens a back door on the compromised computer.  | T1108 | T1505.003  |
| 35055  | Squid: Multiple attempts to access a non-existent file.  | T1108 | T1505.003   |
| 92021  | Powershell was used to delete files or directories.  | T107.004 | T1070.004   |

The last one is believed to have been a typo and was fixed in the process.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->


<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
 - [✅  ] runtests.py executed without errors
 (except for the overwrite.ini, this needed to be skipped as it was giving conflicts with wazuh-analysisd
<details>

```May 18 14:06:11 debian-gnu-linux-10 systemd[1]: Starting Wazuh manager...
May 18 14:06:12 debian-gnu-linux-10 env[24283]: 2022/05/18 14:06:12 wazuh-analysisd: WARNING: (7605): It is not possible to overwrite 'if_matched_sid' value in rule '999914'. The original value is retained.
May 18 14:06:12 debian-gnu-linux-10 env[24283]: 2022/05/18 14:06:12 wazuh-analysisd: WARNING: (7605): It is not possible to overwrite 'if_matched_group' value in rule '999917'. The original value is retained.
May 18 14:06:12 debian-gnu-linux-10 env[24283]: 2022/05/18 14:06:12 wazuh-analysisd: WARNING: (7616): List 'etc/lists/black_list' could not be loaded. Rule '999918' will be ignored.
May 18 14:06:13 debian-gnu-linux-10 env[24283]: Starting Wazuh v4.3.1...
May 18 14:06:14 debian-gnu-linux-10 env[24283]: 2022/05/18 14:06:14 wazuh-testrule: WARNING: (7605): It is not possible to overwrite 'if_matched_sid' value in rule '999914'. The original value is retained. 2022/
May 18 14:06:14 debian-gnu-linux-10 env[24283]: wazuh-analysisd: Configuration error. Exiting.
May 18 14:06:14 debian-gnu-linux-10 systemd[1]: wazuh-manager.service: Control process exited, code=exited, status=1/FAILURE
May 18 14:06:14 debian-gnu-linux-10 systemd[1]: wazuh-manager.service: Failed with result 'exit-code'.
May 18 14:06:14 debian-gnu-linux-10 systemd[1]: Failed to start Wazuh manager.
```
</details>