### PR TITLE
Change encoding in virustotal.py script, in open function

### DIFF
--- a/integrations/virustotal
+++ b/integrations/virustotal
@@ -55,7 +55,7 @@ def main(args):
     debug(alert_file_location)
 
     # Load alert. Parse JSON object.
-    with open(alert_file_location) as alert_file:
+    with open(alert_file_location, encoding='latin-1') as alert_file:
         json_alert = json.load(alert_file)
     debug("# Processing alert")
     debug(json_alert)

--- a/integrations/virustotal
+++ b/integrations/virustotal
@@ -55,7 +55,7 @@ def main(args):
     debug(alert_file_location)
 
     # Load alert. Parse JSON object.
-    with open(alert_file_location, encoding='latin-1') as alert_file:
+    with open(alert_file_location, encoding='utf-16', errors='ignore') as alert_file:
         json_alert = json.load(alert_file)
     debug("# Processing alert")
     debug(json_alert)

--- a/integrations/virustotal
+++ b/integrations/virustotal
@@ -55,7 +55,7 @@ def main(args):
     debug(alert_file_location)
 
     # Load alert. Parse JSON object.
-    with open(alert_file_location, encoding='utf-16', errors='ignore') as alert_file:
+    with open(alert_file_location, errors='ignore') as alert_file:
         json_alert = json.load(alert_file)
     debug("# Processing alert")
     debug(json_alert)


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/8199|


## Description
This PR is to change the encoding used in the virustotal integration script, because in Windows some characters caused an error when displaying virustotal alerts.


## Configuration options
Manager:
```
<integration>
  <name>virustotal</name>
  <api_key>API_KEY</api_key>
  <group>syscheck</group>
  <alert_format>json</alert_format>
</integration>
```
Agent:

`    <directories realtime="yes">c:\testdir</directories>`



## Logs/Alerts example

After create a file with name: `cópia`

```
** Alert 1652876697.1111518: - virustotal,
2022 May 18 12:24:57 (jmv74211-PC) 10.0.3.15->virustotal
Rule: 87104 (level 3) -> 'VirusTotal: Alert - c:\testdir\cópia - No positives found'
{"virustotal": {"found": 1, "malicious": 0, "source": {"alert_id": "1652876696.1108839", "file": "c:\\testdir\\c\u00f3pia", "md5": "d41d8cd98f00b204e9800998ecf8427e", "sha1": "da39a3ee5e6b4b0d3255bfef95601890afd80709"}, "sha1": "da39a3ee5e6b4b0d3255bfef95601890afd80709", "scan_date": "2022-05-18 12:19:26", "positives": 0, "total": 57, "permalink": "https://www.virustotal.com/gui/file/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/detection/f-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-1652876366"}, "integration": "virustotal"}
virustotal.found: 1
virustotal.malicious: 0
virustotal.source.alert_id: 1652876696.1108839
virustotal.source.file: c:\testdir\cópia
virustotal.source.md5: d41d8cd98f00b204e9800998ecf8427e
virustotal.source.sha1: da39a3ee5e6b4b0d3255bfef95601890afd80709
virustotal.sha1: da39a3ee5e6b4b0d3255bfef95601890afd80709
virustotal.scan_date: 2022-05-18 12:19:26
virustotal.positives: 0
virustotal.total: 57
virustotal.permalink: https://www.virustotal.com/gui/file/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/detection/f-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-1652876366
integration: virustotal
```

## Tests


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [ ] QA templates contemplate the added capabilities

Closes #8199