### PR TITLE
Read scan type from task

### DIFF
--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -41,7 +41,7 @@
 #define VU_UPDATE_VU_INFO     "(5426): Inserting '%s' vulnerabilities information."
 #define VU_STOP_REFRESH_DB    "(5427): Refresh of '%s' database finished."
 #define VU_DOWNLOAD_PAGE_SUC  "(5428): Page '%d' successfully downloaded."
-#define VU_CPEW_UPD_CANCEL     "(5429): The '%s' update has failed, so this feed will not be updated any more."
+#define VU_CPEW_UPD_CANCEL    "(5429): The '%s' update has failed, so this feed will not be updated any more."
 #define VU_ENDING_UPDATE      "(5430): The update of the '%s' feed finished successfully."
 #define VU_START_SCAN         "(5431): Starting vulnerability scan."
 #define VU_AG_NEVER_CON       "(5432): Agent '%s' never connected."
@@ -50,8 +50,8 @@
 #define VU_AG_NO_TARGET       "(5435): The analysis can not be launched because there are no target agents."
 #define VU_DEB_STATUS_FETCH   "(5436): Fetching Debian Security Tracker from '%s'"
 #define VU_AGENT_SOFTWARE_REQ "(5437): Collecting agent '%.3d' software."
-#define VU_AG_FULL_SCAN       "(5438): A full scan will be run on agent '%.3d'"
-#define VU_AG_PART_SCAN       "(5439): A partial scan will be run on agent '%.3d'"
+#define VU_AGENT_SCAN         "(5438): A '%s' scan will be run on agent '%.3d'"
+#define VU_FAILED_UPDATE      "(5439): The update of the '%s' feed failed."
 #define VU_NO_PACKAGE_SCAN    "(5440): The package inventory of the agent '%.3d' is not available, but a hotfix analysis will be launched."
 #define VU_SOCKET_RETRY       "(5441): Unable to connect to socket '%s'. Waiting '%d' seconds."
 #define VU_NO_HOTFIX_AVAIL    "(5442): Hotfixes data not reported by the agent '%.3d'."
@@ -97,9 +97,6 @@
 #define VU_DISCARD_CVE_ENTRY  "(5488): Package '%s' not affected by '%s' with misleading condition (%s '%s')."
 #define VU_DISCARD_DU         "(5489): '%s' vulnerability information discarded for agent '%.3d' ('KB%s'): Dynamic Updates (DU) are only available when upgrading to new Windows 10 versions."
 #define VU_REMOVED_VULN       "(5490): The vulnerability '%s' affecting '%s' was eliminated"
-#define VU_AG_BASELINE_SCAN   "(5491): A baseline scan will be run on agent '%.3d'"
-#define VU_FAILED_UPDATE      "(5492): The update of the '%s' feed failed."
-
 
 /* File integrity monitoring debug messages */
 #define FIM_DIFF_SKIPPED                    "(6200): Diff execution skipped for containing insecure characters."

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -430,6 +430,12 @@ const wm_context WM_VULNDETECTOR_CONTEXT = {
 
 const char *version_null = "0:0";
 
+const char *vu_scan_type_tag[] = {
+    [VU_BASELINE_SCAN] = "baseline",
+    [VU_FULL_SCAN] = "full",
+    [VU_PARTIAL_SCAN] = "partial"
+};
+
 const char *vu_task_type_tag[] = {
     [VU_ON_DEMAND_SCAN] = "Scan on demand",
     [VU_ON_DEMAND_FEED_UPDATE] = "Feed update on demand",
@@ -2606,19 +2612,7 @@ int wm_vuldet_check_agent_vulnerabilities(wm_vuldet_t *vuldet, vu_scan_type_t sc
         }
     }
 
-    switch (scan_ctx.scan_type) {
-        case VU_BASELINE_SCAN:
-            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_BASELINE_SCAN, scan_ctx.agent_id);
-            break;
-        case VU_FULL_SCAN:
-            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_FULL_SCAN, scan_ctx.agent_id);
-            break;
-        case VU_PARTIAL_SCAN:
-            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_PART_SCAN, scan_ctx.agent_id);
-            break;
-        default:
-            break;
-    }
+    mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AGENT_SCAN, vu_scan_type_tag[scan_ctx.scan_type], scan_ctx.agent_id);
 
     // Reset the tables before scanning each agent
     wm_vuldet_reset_tables(db);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2588,21 +2588,36 @@ int wm_vuldet_check_agent_vulnerabilities(wm_vuldet_t *vuldet, vu_scan_type_t sc
     }
 
     //Check which type of scan is required
-    time_t last_full_scan = wm_vuldet_get_last_full_scan(&scan_ctx);
-    if (last_full_scan < 0) {
-        // DB error
-        result = OS_INVALID;
-        goto end;
-    } else if (last_full_scan == 0 || scan_type == VU_BASELINE_SCAN) {
-        scan_ctx.scan_type = VU_BASELINE_SCAN;
-        mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_BASELINE_SCAN, scan_ctx.agent_id);
-    } else if (curr_time - last_full_scan >= vuldet->min_full_scan_interval &&
-             wm_vuldet_feed_changed (vuldet->updates, agents_it, last_full_scan)) {
-        scan_ctx.scan_type = VU_FULL_SCAN;
-        mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_FULL_SCAN, scan_ctx.agent_id);
+    if (scan_type != VU_UNKNOWN_SCAN) {
+        scan_ctx.scan_type = scan_type;
     } else {
-        scan_ctx.scan_type = VU_PARTIAL_SCAN;
-        mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_PART_SCAN, scan_ctx.agent_id);
+        time_t last_full_scan = wm_vuldet_get_last_full_scan(&scan_ctx);
+        if (last_full_scan < 0) {
+            // DB error
+            result = OS_INVALID;
+            goto end;
+        } else if (last_full_scan == 0) {
+            scan_ctx.scan_type = VU_BASELINE_SCAN;
+        } else if (curr_time - last_full_scan >= vuldet->min_full_scan_interval &&
+                wm_vuldet_feed_changed (vuldet->updates, agents_it, last_full_scan)) {
+            scan_ctx.scan_type = VU_FULL_SCAN;
+        } else {
+            scan_ctx.scan_type = VU_PARTIAL_SCAN;
+        }
+    }
+
+    switch (scan_ctx.scan_type) {
+        case VU_BASELINE_SCAN:
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_BASELINE_SCAN, scan_ctx.agent_id);
+            break;
+        case VU_FULL_SCAN:
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_FULL_SCAN, scan_ctx.agent_id);
+            break;
+        case VU_PARTIAL_SCAN:
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_PART_SCAN, scan_ctx.agent_id);
+            break;
+        default:
+            break;
     }
 
     // Reset the tables before scanning each agent

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -155,9 +155,10 @@ STATIC int wm_vuldet_find_obsolete_vulnerabilities(scan_ctx_t* scan_ctx);
  * @brief Traverse the agents linked list, gather the installed packages and search
  * for known vulnerabilities.
  * @param vuldet The vulnerability detector main data structure.
+ * @param scan_type Scan type to run.
  * @return 0 on success, -1 otherwise.
  */
-STATIC int wm_vuldet_check_agent_vulnerabilities(wm_vuldet_t *vuldet);
+STATIC int wm_vuldet_check_agent_vulnerabilities(wm_vuldet_t *vuldet, vu_scan_type_t scan_type);
 
 /**
  * @brief Discard any installed Linux kernel package which is not running.
@@ -666,6 +667,7 @@ vu_task_ctx_t *create_task(const int task_id,
                            const vu_task_type_t task_type,
                            const task_status task_status,
                            const vu_feed feed_to_update,
+                           const vu_scan_type_t scan_type,
                            const int agent_to_scan,
                            scan_agent* agent_data) {
     vu_task_ctx_t *task = NULL;
@@ -675,6 +677,7 @@ vu_task_ctx_t *create_task(const int task_id,
     task->task_type = task_type;
     task->task_status = task_status;
     task->feed_to_update = feed_to_update;
+    task->scan_type = scan_type;
     task->agent_to_scan = agent_to_scan;
     task->agent_data = agent_data;
     task->agent_last_scan_time = 0;
@@ -1599,7 +1602,7 @@ int wm_vuldet_process_agent_vulnerabilities(sqlite3 *db, OSHash *cve_table, scan
                     "exists");
             }
 
-            if (scan_ctx->scan_type != VU_BASELINE_SCAN && !update) {
+            if (!update || scan_ctx->scan_type == VU_BASELINE_SCAN) {
                 // Sending CVE report
                 if (wm_vuldet_send_cve_report(report)) {
                     mterror(WM_VULNDETECTOR_LOGTAG, VU_SEND_AGENT_REPORT_ERROR, report->cve, report->software, scan_ctx->agent_id);
@@ -2437,7 +2440,6 @@ int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, scan_agent *agents_it, OSH
 }
 
 int wm_vuldet_find_agent_vulnerabilities(sqlite3 *db, scan_agent *agent, wm_vuldet_flags *flags, scan_ctx_t* scan_ctx) {
-
     int retval = OS_INVALID;
     OSHash *cve_table = NULL;
     int sock = wm_vuldet_get_wdb_socket();
@@ -2450,8 +2452,7 @@ int wm_vuldet_find_agent_vulnerabilities(sqlite3 *db, scan_agent *agent, wm_vuld
     //Set the pending status previous to the scan
     if (scan_ctx->scan_type == VU_FULL_SCAN) {
         wdb_update_vuln_cves_status(scan_ctx->agent_id, "*", VULN_CVES_STATUS_PENDING, &sock);
-    }
-    else if(scan_ctx->scan_type == VU_PARTIAL_SCAN && scan_ctx->os_scan) {
+    } else if(scan_ctx->scan_type == VU_PARTIAL_SCAN && scan_ctx->os_scan) {
         wdb_update_vuln_cves_status_by_type(scan_ctx->agent_id, VULN_CVES_TYPE_OS, VULN_CVES_STATUS_PENDING, &sock);
     }
 
@@ -2461,9 +2462,7 @@ int wm_vuldet_find_agent_vulnerabilities(sqlite3 *db, scan_agent *agent, wm_vuld
             goto end;
         }
         retval = 0;
-    }
-    // Unix vulnerabilities
-    else {
+    } else { // Unix vulnerabilities
         // To add a new node, call wm_vuldet_add_cve_node().
         // @cve_table stores cve_vuln_pkg type nodes.
         cve_table = OSHash_Create();
@@ -2506,10 +2505,6 @@ int wm_vuldet_find_obsolete_vulnerabilities(scan_ctx_t* scan_ctx) {
     cJSON* j_obsolete_vulns = NULL;
     cJSON *j_vuln = NULL;
 
-    if (scan_ctx->scan_type == VU_BASELINE_SCAN) {
-        return OS_SUCCESS;
-    }
-
     j_obsolete_vulns = wdb_remove_vuln_cves_by_status(scan_ctx->agent_id, VULN_CVES_STATUS_PENDING, &sock);
     if (!j_obsolete_vulns) {
         return OS_INVALID;
@@ -2543,7 +2538,7 @@ int wm_vuldet_find_obsolete_vulnerabilities(scan_ctx_t* scan_ctx) {
     return retval;
 }
 
-int wm_vuldet_check_agent_vulnerabilities(wm_vuldet_t *vuldet) {
+int wm_vuldet_check_agent_vulnerabilities(wm_vuldet_t *vuldet, vu_scan_type_t scan_type) {
     scan_agent *agents_it = NULL;
     sqlite3 *db;
     sqlite3_stmt *stmt = NULL;
@@ -2598,17 +2593,14 @@ int wm_vuldet_check_agent_vulnerabilities(wm_vuldet_t *vuldet) {
         // DB error
         result = OS_INVALID;
         goto end;
-    }
-    else if (last_full_scan == 0) {
+    } else if (last_full_scan == 0 || scan_type == VU_BASELINE_SCAN) {
         scan_ctx.scan_type = VU_BASELINE_SCAN;
         mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_BASELINE_SCAN, scan_ctx.agent_id);
-    }
-    else if (curr_time - last_full_scan >= vuldet->min_full_scan_interval &&
-            wm_vuldet_feed_changed (vuldet->updates, agents_it, last_full_scan)) {
+    } else if (curr_time - last_full_scan >= vuldet->min_full_scan_interval &&
+             wm_vuldet_feed_changed (vuldet->updates, agents_it, last_full_scan)) {
         scan_ctx.scan_type = VU_FULL_SCAN;
         mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_FULL_SCAN, scan_ctx.agent_id);
-    }
-    else {
+    } else {
         scan_ctx.scan_type = VU_PARTIAL_SCAN;
         mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_PART_SCAN, scan_ctx.agent_id);
     }
@@ -4697,7 +4689,7 @@ void wm_vuldet_schedule_updates(update_node **updates) {
     for (int os = 0; os < OS_SUPP_SIZE; os++) {
         if (updates[os] && wm_vuldet_check_update_period(updates[os])) {
             if (!VU_INTERVAL_FEED_UPDATE_FLAGS[updates[os]->dist_ref]) {
-                vu_task_ctx_t *task = create_task(OS_INVALID, VU_INTERVAL_FEED_UPDATE, WM_TASK_PENDING, updates[os]->dist_ref, OS_INVALID, NULL);
+                vu_task_ctx_t *task = create_task(OS_INVALID, VU_INTERVAL_FEED_UPDATE, WM_TASK_PENDING, updates[os]->dist_ref, VU_UNKNOWN_SCAN, OS_INVALID, NULL);
                 if (OS_INVALID == register_task(task)) {
                     mwarn("Couldn't establish communication with task manager. There's no ID for task");
                 }
@@ -5305,7 +5297,7 @@ bool wm_vuldet_scan_on_demand(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet) 
         wm_vuldet_create_and_send_message(current_task, WM_TASK_FAILED, NULL);
     } else {
         vuldet->agent_to_scan = current_task->agent_data;
-        if (wm_vuldet_check_agent_vulnerabilities(vuldet)) {
+        if (wm_vuldet_check_agent_vulnerabilities(vuldet, current_task->scan_type)) {
             wm_vuldet_create_and_send_message(current_task, WM_TASK_FAILED, NULL);
             mterror(WM_VULNDETECTOR_LOGTAG, VU_AG_CHECK_ERR);
         } else {
@@ -5415,7 +5407,7 @@ void wm_vuldet_scan_by_interval(vu_task_ctx_t* current_task, wm_vuldet_t* vuldet
             snprintf(status_message, OS_SIZE_64, " Agent: %.3d.", atoi(agents->agent_id));
             wm_vuldet_create_and_send_message(current_task, WM_TASK_IN_PROGRESS, status_message);
 
-            if (wm_vuldet_check_agent_vulnerabilities(vuldet)) {
+            if (wm_vuldet_check_agent_vulnerabilities(vuldet, current_task->scan_type)) {
                 mterror(WM_VULNDETECTOR_LOGTAG, VU_AG_CHECK_ERR);
                 abort_scan = true;
                 break;
@@ -5534,7 +5526,7 @@ void *wm_vuldet_main(wm_vuldet_t* vuldet) {
 
             if ((curr_time - vuldet->last_scan >= vuldet->scan_interval)) {
                 if (!VU_TASKS_QUEUE_FLAGS[VU_INTERVAL_SCAN]) {
-                    vu_task_ctx_t *task = create_task(OS_INVALID, VU_INTERVAL_SCAN, WM_TASK_PENDING, FEED_UNKNOWN, OS_INVALID, NULL);
+                    vu_task_ctx_t *task = create_task(OS_INVALID, VU_INTERVAL_SCAN, WM_TASK_PENDING, FEED_UNKNOWN, VU_UNKNOWN_SCAN, OS_INVALID, NULL);
                     if (OS_INVALID == register_task(task)) {
                         mwarn("Couldn't establish communication with task manager. There's no ID for task");
                     }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -122,7 +122,7 @@
 #define VU_BUILD_REF_RHSA "https://access.redhat.com/errata/%s"
 
 // Types of scans
-typedef enum vu_scan_type_t { VU_BASELINE_SCAN , VU_FULL_SCAN, VU_PARTIAL_SCAN } vu_scan_type_t;
+typedef enum vu_scan_type_t { VU_BASELINE_SCAN , VU_FULL_SCAN, VU_PARTIAL_SCAN, VU_UNKNOWN_SCAN } vu_scan_type_t;
 
 // Type of tasks in vu_tasks_queue
 typedef enum vu_task_type_t {
@@ -865,6 +865,7 @@ typedef struct vu_task_ctx_t {
     vu_task_type_t task_type;    // The type of task to run.
     task_status task_status;     // The status may be WM_TASK_PENDING or WM_TASK_CANCELLED.
     vu_feed feed_to_update;      // Used by VU_INTERVAL_FEED_UPDATE tasks, indicates the vendor to update.
+    vu_scan_type_t scan_type;    // The type of the scan to run.
     int agent_to_scan;           // Used by VU_ON_DEMAND_SCAN tasks to indicate the agent that will be scanned.
     scan_agent* agent_data;      // Used by VU_ON_DEMAND_SCAN tasks in case of agent retries.
     time_t agent_last_scan_time; // Used by VU_ON_DEMAND_SCAN tasks in case of agent retries.
@@ -928,6 +929,7 @@ void wm_vuldet_init_queues();
  *                  and whether is triggered by interval or on demand.
  * @param task_status Status of the task.
  * @param feed_to_update Feed vendor identifier.
+ * @param scan_type Scan type to run.
  * @param agent_to_scan Agent identifier.
  * @param agent_data Agent data structure for scan on demand.
  * @return A task object on success. NULL on error.
@@ -936,6 +938,7 @@ vu_task_ctx_t *create_task(const int task_id,
                            const vu_task_type_t task_type,
                            const task_status task_status,
                            const vu_feed feed_to_update,
+                           vu_scan_type_t scan_type,
                            const int agent_to_scan,
                            scan_agent* agent_data);
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2332,8 +2332,7 @@ int wm_vuldet_process_agent_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd
                 "exists");
         }
 
-        if (scan_ctx->scan_type != VU_BASELINE_SCAN && !update) {
-            // No report should be generated for baseline scans or already reported vulnerabilities
+        if (!update || scan_ctx->scan_type == VU_BASELINE_SCAN) {
             // Sending CVE report
             wm_vuldet_send_cve_report(report);
         }


### PR DESCRIPTION
|Related issue|
|---|
|#13361|

## Description

This PR changes the baseline scan making it alerts the vulnerabilities found without considering if they were or were not previously alerted.

## Configuration options

<details>
<summary> Click to expand! </summary>

```xml
  <vulnerability-detector>
    <enabled>yes</enabled>
    <interval>5m</interval>
    <min_full_scan_interval>2m</min_full_scan_interval>
    <run_on_start>yes</run_on_start>

    <!-- Ubuntu OS vulnerabilities -->
    <provider name="canonical">
      <enabled>yes</enabled>
      <os>trusty</os>
      <os>xenial</os>
      <os>bionic</os>
      <os>focal</os>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Debian OS vulnerabilities -->
    <provider name="debian">
      <enabled>yes</enabled>
      <os>stretch</os>
      <os>buster</os>
      <os>bullseye</os>
      <update_interval>1h</update_interval>
    </provider>

    <!-- RedHat OS vulnerabilities -->
    <provider name="redhat">
      <enabled>yes</enabled>
      <os>5</os>
      <os>6</os>
      <os>7</os>
      <os>8</os>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Amazon Linux OS vulnerabilities -->
    <provider name="alas">
      <enabled>no</enabled>
      <os>amazon-linux</os>
      <os>amazon-linux-2</os>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Arch OS vulnerabilities -->
    <provider name="arch">
      <enabled>yes</enabled>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Windows OS vulnerabilities -->
    <provider name="msu">
      <enabled>yes</enabled>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Aggregate vulnerabilities -->
    <provider name="nvd">
      <enabled>yes</enabled>
      <update_from_year>2010</update_from_year>
      <update_interval>1h</update_interval>
    </provider>

  </vulnerability-detector>
```

</summary>
</details>

## Scan-build report

![image](https://user-images.githubusercontent.com/13010397/169138802-10fa4084-d585-454a-add2-4258ff1a5914.png)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report