### PR TITLE
Add optional symbols installation

### DIFF
--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -931,8 +931,8 @@ InstallCommon()
   rm -rf ${INSTALLDIR}/.symbols
   if [ "X${USER_DEBUG_SYMBOLS}" = "Xy" ]; then
     echo "Installing debug symbols..."
-    if ([ "X${NUNAME}" = "XLinux" ] || [ "X$DIST_NAME" = "Xdarwin" ] ); then
-      if test -d symbols && find symbols ! -path symbols ! -name .gitignore | grep -q . ;then
+    if [ "X${NUNAME}" = "XLinux" -o "X${NUNAME}" = "XDarwin" ]; then
+      if test -d symbols && find symbols ! -path symbols ! -name .gitignore | grep -q . ; then
         cp -r symbols ${INSTALLDIR}/.symbols
         chown -R 0:0 ${INSTALLDIR}/.symbols
         chmod 750 ${INSTALLDIR}/.symbols


### PR DESCRIPTION


|Related issue|
|---|
|#13532|

## Description

This PR aims to allow users to choose symbols deployment during installation from sources for GNU/Linux and macOS OS.

- Add USER_DEBUG_SYMBOLS option to enable/disable symbols deployment
- Add checks to limit such option to Linux/macOS
- Add src/symbols folder existance check
- Add messages in case of any problem

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors