### PR TITLE
Update timeouts for GET /mitre/software and GET /mitre/techniques to 15 and 30 seconds

### DIFF
--- a/api/api/controllers/mitre_controller.py
+++ b/api/api/controllers/mitre_controller.py
@@ -13,6 +13,9 @@ from wazuh.core.cluster.dapi.dapi import DistributedAPI
 
 logger = logging.getLogger('wazuh-api')
 
+MITRE_TECHNIQUES_TIMEOUT = 30
+MITRE_SOFTWARE_TIMEOUT = 15
+
 
 async def get_metadata(request, pretty=False, wait_for_complete=False):
     """Return the metadata of the MITRE's database
@@ -209,8 +212,9 @@ async def get_techniques(request, technique_ids=None, pretty=False, wait_for_com
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
-                          )
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          api_timeout=MITRE_TECHNIQUES_TIMEOUT)
+
     data = raise_if_exc(await dapi.distribute_function())
 
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
@@ -378,8 +382,9 @@ async def get_software(request, software_ids=None, pretty=False, wait_for_comple
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
-                          )
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          api_timeout=MITRE_SOFTWARE_TIMEOUT)
+
     data = raise_if_exc(await dapi.distribute_function())
 
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)

--- a/api/api/controllers/test/test_mitre_controller.py
+++ b/api/api/controllers/test/test_mitre_controller.py
@@ -170,8 +170,9 @@ async def test_get_software(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_r
                                       is_async=False,
                                       wait_for_complete=False,
                                       logger=ANY,
-                                      rbac_permissions=mock_request['token_info']['rbac_policies']
-                                      )
+                                      rbac_permissions=mock_request['token_info']['rbac_policies'],
+                                      api_timeout=15)
+
     mock_exc.assert_called_once_with(mock_dfunc.return_value)
     mock_remove.assert_called_once_with(f_kwargs)
     assert isinstance(result, web_response.Response)
@@ -238,8 +239,9 @@ async def test_get_techniques(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock
                                       is_async=False,
                                       wait_for_complete=False,
                                       logger=ANY,
-                                      rbac_permissions=mock_request['token_info']['rbac_policies']
-                                      )
+                                      rbac_permissions=mock_request['token_info']['rbac_policies'],
+                                      api_timeout=30)
+
     mock_exc.assert_called_once_with(mock_dfunc.return_value)
     mock_remove.assert_called_once_with(f_kwargs)
     assert isinstance(result, web_response.Response)

--- a/api/test/integration/test_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_mitre_endpoints.tavern.yaml
@@ -44,7 +44,6 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        wait_for_complete: True
         limit: 1
         offset: 0
     response:
@@ -364,7 +363,6 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        wait_for_complete: True
         limit: 1
         offset: 0
     response:
@@ -653,7 +651,6 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        wait_for_complete: True
         limit: 1
         offset: 0
     response:
@@ -954,7 +951,6 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        wait_for_complete: True
         limit: 1
         offset: 0
     response:
@@ -1262,7 +1258,6 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        wait_for_complete: True
         limit: 1
         offset: 0
     response:
@@ -1564,7 +1559,6 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        wait_for_complete: True
         limit: 1
         offset: 0
     response:

--- a/api/test/integration/test_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_mitre_endpoints.tavern.yaml
@@ -951,6 +951,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
+        wait_for_complete: true
         limit: 1
         offset: 0
     response:
@@ -1559,6 +1560,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
+        wait_for_complete: true
         limit: 1
         offset: 0
     response:

--- a/api/test/integration/test_rbac_black_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_mitre_endpoints.tavern.yaml
@@ -28,7 +28,7 @@ marks:
 
 stages:
 
-  # GET /mitre/techniques
+  # GET /mitre/mitigations
   - name: Request MITRE mitigations (Denied)
     request:
       verify: False

--- a/api/test/integration/test_rbac_white_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_mitre_endpoints.tavern.yaml
@@ -33,8 +33,6 @@ stages:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/mitre/mitigations"
       method: GET
-      params:
-        wait_for_complete: True
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -54,8 +52,6 @@ stages:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/mitre/references"
       method: GET
-      params:
-        wait_for_complete: True
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -75,8 +71,6 @@ stages:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/mitre/techniques"
       method: GET
-      params:
-        wait_for_complete: True
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -96,8 +90,6 @@ stages:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/mitre/tactics"
       method: GET
-      params:
-        wait_for_complete: True
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -114,8 +106,6 @@ stages:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/mitre/groups"
       method: GET
-      params:
-        wait_for_complete: True
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -132,8 +122,6 @@ stages:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/mitre/software"
       method: GET
-      params:
-        wait_for_complete: True
       headers:
         Authorization: "Bearer {test_login_token}"
     response:

--- a/api/test/integration/test_rbac_white_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_mitre_endpoints.tavern.yaml
@@ -71,6 +71,8 @@ stages:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/mitre/techniques"
       method: GET
+      params:
+        wait_for_complete: true
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -122,6 +124,8 @@ stages:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/mitre/software"
       method: GET
+      params:
+        wait_for_complete: true
       headers:
         Authorization: "Bearer {test_login_token}"
     response:

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -106,7 +106,8 @@ class DistributedAPI:
 
         self.local_clients = []
         self.local_client_arg = local_client_arg
-        self.api_request_timeout = api_timeout if api_timeout else aconf.api_conf['intervals']['request_timeout']
+        self.api_request_timeout = max(api_timeout, aconf.api_conf['intervals']['request_timeout']) \
+            if api_timeout else aconf.api_conf['intervals']['request_timeout']
 
     def debug_log(self, message):
         """Use debug or debug2 depending on the log type.


### PR DESCRIPTION
|Related issue|
|---|
|#13426|



## Description

This PR closes #13426.

After the times obtained in https://github.com/wazuh/wazuh/issues/13426#issuecomment-1132727280, we decided that the best solution would be indicating custom API timeouts for the `GET /mitre/software` and `GET /mitre/techniques` endpoints.

These timeouts would be 15 seconds and 30 seconds, respectively.

A minor change would be needed in the `DistributedAPI` class constructor as when we specify a timeout, the timeout is fixed to that value and changing the intervals > request_timeout value in the `api.yaml` configuration won't make changes in those specific timeouts.

```python
self.api_request_timeout = api_timeout if api_timeout else aconf.api_conf['intervals']['request_timeout']
```

Solution: this will make a custom `request_timeout` value work for the conflictive MITRE endpoints only when the timeout is higher than 15 and 30.

```python
self.api_request_timeout = max(api_timeout, aconf.api_conf['intervals']['request_timeout']) \
    if api_timeout else aconf.api_conf['intervals']['request_timeout']
```

**Configuration examples:**

For the **default** intervals > **request_timeout**, all the API requests will have timeout = 10 but MITRE techniques and software endpoints that will have 30 and 15. 

For intervals > **request_timeout = 12**, all the API requests will have timeout = 12 but MITRE techniques and software endpoints that will have 30 and 15. 

For intervals > **request_timeout = 20**, all the API requests will have timeout = 20 but MITRE techniques endpoint that will have 30. 

For intervals > **request_timeout = 35**, all the API requests will have timeout = 35.

