### PR TITLE
Update 0380-windows_decoders.xml

### DIFF
--- a/ruleset/decoders/0380-windows_decoders.xml
+++ b/ruleset/decoders/0380-windows_decoders.xml
@@ -35,9 +35,9 @@
   <parent>windows-date-format</parent>
   <type>firewall</type>
   <use_own_name>true</use_own_name>
-  <prematch offset="after_parent">^OPEN|^CLOSE|^DROP</prematch>
+  <prematch offset="after_parent">^OPEN|^CLOSE|^DROP|^ALLOW</prematch>
   <regex offset="after_parent">^(\w+) (\w+) </regex>
-  <regex>(\S+) (\S+) (\d+) (\d+) </regex>
+  <regex>(\S+) (\S+) (\S+) (\S+) </regex>
   <order>action, protocol, srcip, dstip, srcport, dstport</order>
 </decoder>
 


### PR DESCRIPTION
Adjust Windows FW decoder to also recognize allowed packets, seems OPEN ist not in use anymore. This *might* differ in different Windows versions, but W10 write "ALLOW" to log. 

Also a dropped ping is not decoded as ports a not used and a dash is not decimal. ((\d+))

|Related issue|
none

## Description

Adjust Windows FW decoder to also recognize allowed packets, seems OPEN ist not in use anymore. This *might* differ in different Windows versions, but W10 write "ALLOW" to log. 

Also a dropped ping is not decoded as ports a not used and a dash is not decimal. ((\d+))

## Logs/Alerts example

2022-03-28 01:31:15 ALLOW ICMP 172.21.192.82 172.25.5.73 - - 0 - - - - 8 0 - SEND
2022-03-28 01:31:20 ALLOW TCP 172.21.192.82 172.21.176.144 57008 135 0 - 0 0 0 - - - SEND
