### PR TITLE
Add message controller feature.

### DIFF
--- a/src/data_provider/src/sysInfo.cpp
+++ b/src/data_provider/src/sysInfo.cpp
@@ -10,18 +10,7 @@
  */
 #include "sysInfo.hpp"
 #include "sysInfo.h"
-
-struct CJsonDeleter
-{
-    void operator()(char* json)
-    {
-        cJSON_free(json);
-    }
-    void operator()(cJSON* json)
-    {
-        cJSON_Delete(json);
-    }
-};
+#include "cjsonSmartDeleter.hpp"
 
 nlohmann::json SysInfo::hardware()
 {
@@ -228,7 +217,7 @@ int sysinfo_packages_cb(callback_data_t callback_data)
             {
                 [callback_data](nlohmann::json & jsonResult)
                 {
-                    const std::unique_ptr<cJSON, CJsonDeleter> spJson{ cJSON_Parse(jsonResult.dump().c_str()) };
+                    const std::unique_ptr<cJSON, CJsonSmartDeleter> spJson{ cJSON_Parse(jsonResult.dump().c_str()) };
                     callback_data.callback(GENERIC, spJson.get(), callback_data.user_data);
                 }
             };
@@ -260,7 +249,7 @@ int sysinfo_processes_cb(callback_data_t callback_data)
             {
                 [callback_data](nlohmann::json & jsonResult)
                 {
-                    const std::unique_ptr<cJSON, CJsonDeleter> spJson{ cJSON_Parse(jsonResult.dump().c_str()) };
+                    const std::unique_ptr<cJSON, CJsonSmartDeleter> spJson{ cJSON_Parse(jsonResult.dump().c_str()) };
                     callback_data.callback(GENERIC, spJson.get(), callback_data.user_data);
                 }
             };

--- a/src/data_provider/tests/sysInfo/sysInfo_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysInfo_test.cpp
@@ -11,6 +11,7 @@
 #include "sysInfo_test.h"
 #include "sysInfo.hpp"
 #include "sysInfo.h"
+#include "cjsonSmartDeleter.hpp"
 
 void SysInfoTest::SetUp() {};
 
@@ -93,20 +94,12 @@ class CallbackMock
         MOCK_METHOD(void, callbackMock, (nlohmann::json&), ());
 };
 
-struct CJsonDeleter final
-{
-    void operator()(char* json)
-    {
-        cJSON_free(json);
-    }
-};
-
 static void callback(const ReturnTypeCallback type,
                      const cJSON* json,
                      void* ctx)
 {
     CallbackMock* wrapper { reinterpret_cast<CallbackMock*>(ctx)};
-    const std::unique_ptr<char, CJsonDeleter> spJsonBytes{ cJSON_PrintUnformatted(json) };
+    const std::unique_ptr<char, CJsonSmartFree> spJsonBytes{ cJSON_PrintUnformatted(json) };
     wrapper->callbackMock(type, std::string(spJsonBytes.get()));
 }
 

--- a/src/shared_modules/dbsync/cppcheckSuppress.txt
+++ b/src/shared_modules/dbsync/cppcheckSuppress.txt
@@ -1,3 +1,3 @@
 *:*src/sqlite/sqlite_dbengine.cpp:73
 *:*src/sqlite/sqlite_dbengine.cpp:182
-*:*testtool/action.h:625
+*:*testtool/action.h:614

--- a/src/shared_modules/dbsync/src/dbsync.cpp
+++ b/src/shared_modules/dbsync/src/dbsync.cpp
@@ -15,24 +15,13 @@
 #include "dbsync.hpp"
 #include "dbsync_implementation.h"
 #include "dbsyncPipelineFactory.h"
+#include "cjsonSmartDeleter.hpp"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 using namespace DbSync;
-
-struct CJsonDeleter
-{
-    void operator()(char* json)
-    {
-        cJSON_free(json);
-    }
-    void operator()(cJSON* json)
-    {
-        cJSON_Delete(json);
-    }
-};
 
 static std::function<void(const std::string&)> gs_logFunction;
 
@@ -114,11 +103,11 @@ TXN_HANDLE dbsync_create_txn(const DBSYNC_HANDLE handle,
             {
                 [callback_data](ReturnTypeCallback result, const nlohmann::json & jsonResult)
                 {
-                    const std::unique_ptr<cJSON, CJsonDeleter> spJson{ cJSON_Parse(jsonResult.dump().c_str()) };
+                    const std::unique_ptr<cJSON, CJsonSmartDeleter> spJson{ cJSON_Parse(jsonResult.dump().c_str()) };
                     callback_data.callback(result, spJson.get(), callback_data.user_data);
                 }
             };
-            const std::unique_ptr<char, CJsonDeleter> spJsonBytes{cJSON_Print(tables)};
+            const std::unique_ptr<char, CJsonSmartFree> spJsonBytes{cJSON_Print(tables)};
             txn = PipelineFactory::instance().create(handle, nlohmann::json::parse(spJsonBytes.get()), thread_number, max_queue_size, callbackWrapper);
         }
         catch (const DbSync::dbsync_error& ex)
@@ -186,7 +175,7 @@ int dbsync_sync_txn_row(const TXN_HANDLE txn,
     {
         try
         {
-            const std::unique_ptr<char, CJsonDeleter> spJsonBytes{cJSON_PrintUnformatted(js_input)};
+            const std::unique_ptr<char, CJsonSmartFree> spJsonBytes{cJSON_PrintUnformatted(js_input)};
             PipelineFactory::instance().pipeline(txn)->syncRow(nlohmann::json::parse(spJsonBytes.get()));
             retVal = 0;
         }
@@ -222,7 +211,7 @@ int dbsync_add_table_relationship(const DBSYNC_HANDLE handle,
     {
         try
         {
-            const std::unique_ptr<char, CJsonDeleter> spJsonBytes{cJSON_Print(js_input)};
+            const std::unique_ptr<char, CJsonSmartFree> spJsonBytes{cJSON_Print(js_input)};
             DBSyncImplementation::instance().addTableRelationship(handle, nlohmann::json::parse(spJsonBytes.get()));
             retVal = 0;
         }
@@ -261,7 +250,7 @@ int dbsync_insert_data(const DBSYNC_HANDLE handle,
     {
         try
         {
-            const std::unique_ptr<char, CJsonDeleter> spJsonBytes{cJSON_Print(js_insert)};
+            const std::unique_ptr<char, CJsonSmartFree> spJsonBytes{cJSON_Print(js_insert)};
             DBSyncImplementation::instance().insertBulkData(handle, nlohmann::json::parse(spJsonBytes.get()));
             retVal = 0;
         }
@@ -350,11 +339,11 @@ int dbsync_sync_row(const DBSYNC_HANDLE handle,
             {
                 [callback_data](ReturnTypeCallback result, const nlohmann::json & jsonResult)
                 {
-                    const std::unique_ptr<cJSON, CJsonDeleter> spJson{ cJSON_Parse(jsonResult.dump().c_str()) };
+                    const std::unique_ptr<cJSON, CJsonSmartDeleter> spJson{ cJSON_Parse(jsonResult.dump().c_str()) };
                     callback_data.callback(result, spJson.get(), callback_data.user_data);
                 }
             };
-            const std::unique_ptr<char, CJsonDeleter> spJsonBytes{ cJSON_PrintUnformatted(js_input) };
+            const std::unique_ptr<char, CJsonSmartFree> spJsonBytes{ cJSON_PrintUnformatted(js_input) };
             DBSyncImplementation::instance().syncRowData(handle, nlohmann::json::parse(spJsonBytes.get()), callbackWrapper);
             retVal = 0;
         }
@@ -400,11 +389,11 @@ int dbsync_select_rows(const DBSYNC_HANDLE handle,
             {
                 [callback_data](ReturnTypeCallback result, const nlohmann::json & jsonResult)
                 {
-                    const std::unique_ptr<cJSON, CJsonDeleter> spJson{ cJSON_Parse(jsonResult.dump().c_str()) };
+                    const std::unique_ptr<cJSON, CJsonSmartDeleter> spJson{ cJSON_Parse(jsonResult.dump().c_str()) };
                     callback_data.callback(result, spJson.get(), callback_data.user_data);
                 }
             };
-            const std::unique_ptr<char, CJsonDeleter> spJsonBytes{ cJSON_PrintUnformatted(js_data_input) };
+            const std::unique_ptr<char, CJsonSmartFree> spJsonBytes{ cJSON_PrintUnformatted(js_data_input) };
             DBSyncImplementation::instance().selectData(handle, nlohmann::json::parse(spJsonBytes.get()), callbackWrapper);
             retVal = 0;
         }
@@ -445,7 +434,7 @@ int dbsync_delete_rows(const DBSYNC_HANDLE handle,
     {
         try
         {
-            const std::unique_ptr<char, CJsonDeleter> spJsonBytes{ cJSON_PrintUnformatted(js_key_values) };
+            const std::unique_ptr<char, CJsonSmartFree> spJsonBytes{ cJSON_PrintUnformatted(js_key_values) };
             DBSyncImplementation::instance().deleteRowsData(handle, nlohmann::json::parse(spJsonBytes.get()));
             retVal = 0;
         }
@@ -487,12 +476,12 @@ int dbsync_get_deleted_rows(const TXN_HANDLE  txn,
     {
         try
         {
-            const std::unique_ptr<char, CJsonDeleter> spJsonBytes{ cJSON_PrintUnformatted(js_options) };
+            const std::unique_ptr<char, CJsonSmartFree> spJsonBytes{ cJSON_PrintUnformatted(js_options) };
             const auto callbackWrapper
             {
                 [callback_data](ReturnTypeCallback result, const nlohmann::json & jsonResult)
                 {
-                    const std::unique_ptr<cJSON, CJsonDeleter> spJson{ cJSON_Parse(jsonResult.dump().c_str()) };
+                    const std::unique_ptr<cJSON, CJsonSmartDeleter> spJson{ cJSON_Parse(jsonResult.dump().c_str()) };
                     callback_data.callback(result, spJson.get(), callback_data.user_data);
                 }
             };
@@ -550,7 +539,7 @@ int dbsync_update_with_snapshot(const DBSYNC_HANDLE handle,
                     result[s_opMap.at(resultType)].push_back(jsonResult);
                 }
             };
-            const std::unique_ptr<char, CJsonDeleter> spJsonBytes{cJSON_PrintUnformatted(js_snapshot)};
+            const std::unique_ptr<char, CJsonSmartFree> spJsonBytes{cJSON_PrintUnformatted(js_snapshot)};
             DBSyncImplementation::instance().updateSnapshotData(handle, nlohmann::json::parse(spJsonBytes.get()), callbackWrapper);
             *js_result = cJSON_Parse(result.dump().c_str());
             retVal = 0;
@@ -602,11 +591,11 @@ int dbsync_update_with_snapshot_cb(const DBSYNC_HANDLE handle,
             {
                 [callback_data](ReturnTypeCallback result, const nlohmann::json & jsonResult)
                 {
-                    const std::unique_ptr<cJSON, CJsonDeleter> spJson{ cJSON_Parse(jsonResult.dump().c_str()) };
+                    const std::unique_ptr<cJSON, CJsonSmartDeleter> spJson{ cJSON_Parse(jsonResult.dump().c_str()) };
                     callback_data.callback(result, spJson.get(), callback_data.user_data);
                 }
             };
-            const std::unique_ptr<char, CJsonDeleter> spJsonBytes{cJSON_PrintUnformatted(js_snapshot)};
+            const std::unique_ptr<char, CJsonSmartFree> spJsonBytes{cJSON_PrintUnformatted(js_snapshot)};
             DBSyncImplementation::instance().updateSnapshotData(handle, nlohmann::json::parse(spJsonBytes.get()), callbackWrapper);
             retVal = 0;
         }

--- a/src/shared_modules/dbsync/testtool/action.h
+++ b/src/shared_modules/dbsync/testtool/action.h
@@ -14,21 +14,10 @@
 #include <mutex>
 #include "dbsync.h"
 #include "makeUnique.h"
+#include "cjsonSmartDeleter.hpp"
 
 namespace TestDeleters
 {
-    struct CJsonDeleter final
-    {
-        void operator()(char* json)
-        {
-            cJSON_free(json);
-        }
-        void operator()(cJSON* json)
-        {
-            cJSON_Delete(json);
-        }
-    };
-
     struct ResultDeleter final
     {
         void operator()(cJSON* json)
@@ -49,7 +38,7 @@ struct InsertDataAction final : public IAction
 {
     void execute(std::unique_ptr<TestContext>& ctx, const nlohmann::json& value) override
     {
-        const std::unique_ptr<cJSON, TestDeleters::CJsonDeleter> jsInput
+        const std::unique_ptr<cJSON, CJsonSmartDeleter> jsInput
         {
             cJSON_Parse(value.at("body").dump().c_str())
         };
@@ -74,7 +63,7 @@ struct UpdateWithSnapshotAction final : public IAction
 {
     void execute(std::unique_ptr<TestContext>& ctx, const nlohmann::json& value) override
     {
-        const std::unique_ptr<cJSON, TestDeleters::CJsonDeleter> currentSnapshotPtr
+        const std::unique_ptr<cJSON, CJsonSmartDeleter> currentSnapshotPtr
         {
             cJSON_Parse(value["body"].dump().c_str())
         };
@@ -90,7 +79,7 @@ struct UpdateWithSnapshotAction final : public IAction
             const std::string outputFileName{ ctx->outputPath + "/" + oFileName.str() };
 
             std::ofstream outputFile{ outputFileName };
-            const std::unique_ptr<char, TestDeleters::CJsonDeleter> snapshotDiff{ cJSON_Print(snapshotLambdaPtr.get()) };
+            const std::unique_ptr<char, CJsonSmartFree> snapshotDiff{ cJSON_Print(snapshotLambdaPtr.get()) };
             outputFile << snapshotDiff.get() << std::endl;
         }
     }
@@ -111,7 +100,7 @@ static void txnCallback(ReturnTypeCallback type, const cJSON* json, void* user_d
         std::stringstream oFileName;
         oFileName << "txn_" << reinterpret_cast<size_t>(ctx->txnContext) << ".json";
         const auto outputFileName{ ctx->outputPath + "/" + oFileName.str() };
-        const std::unique_ptr<char, TestDeleters::CJsonDeleter> spJsonBytes{cJSON_PrintUnformatted(json)};
+        const std::unique_ptr<char, CJsonSmartFree> spJsonBytes{cJSON_PrintUnformatted(json)};
         const auto newJson{nlohmann::json::parse(spJsonBytes.get())};
         nlohmann::json jsonResult;
         jsonResult.push_back(newJson);
@@ -127,7 +116,7 @@ struct CreateTransactionAction final : public IAction
     void execute(std::unique_ptr<TestContext>& ctx,
                  const nlohmann::json& value) override
     {
-        const std::unique_ptr<cJSON, TestDeleters::CJsonDeleter> jsonTables
+        const std::unique_ptr<cJSON, CJsonSmartDeleter> jsonTables
         {
             cJSON_Parse(value["body"]["tables"].dump().c_str())
         };
@@ -218,7 +207,7 @@ static void getCallbackCtx(ReturnTypeCallback /*type*/,
         jsonResult = nlohmann::json::parse(inputFile);
     }
 
-    const std::unique_ptr<char, TestDeleters::CJsonDeleter> spJsonBytes{cJSON_PrintUnformatted(json)};
+    const std::unique_ptr<char, CJsonSmartFree> spJsonBytes{cJSON_PrintUnformatted(json)};
     const auto& newJson { nlohmann::json::parse(spJsonBytes.get()) };
     jsonResult.push_back(newJson);
 
@@ -233,7 +222,7 @@ struct GetDeletedRowsAction final : public IAction
                  const nlohmann::json& value) override
     {
         const auto options = value.contains("options") ? value["options"] : nlohmann::json::object();
-        const std::unique_ptr<cJSON, TestDeleters::CJsonDeleter> jsOptions
+        const std::unique_ptr<cJSON, CJsonSmartDeleter> jsOptions
         {
             cJSON_Parse(options.dump().c_str())
         };
@@ -264,7 +253,7 @@ struct SyncRowAction final : public IAction
     void execute(std::unique_ptr<TestContext>& ctx,
                  const nlohmann::json& value) override
     {
-        const std::unique_ptr<cJSON, TestDeleters::CJsonDeleter> jsInput
+        const std::unique_ptr<cJSON, CJsonSmartDeleter> jsInput
         {
             cJSON_Parse(value["body"].dump().c_str())
         };
@@ -293,7 +282,7 @@ struct SyncTxnRowsAction final : public IAction
     void execute(std::unique_ptr<TestContext>& ctx,
                  const nlohmann::json& value) override
     {
-        const std::unique_ptr<cJSON, TestDeleters::CJsonDeleter> jsInput
+        const std::unique_ptr<cJSON, CJsonSmartDeleter> jsInput
         {
             cJSON_Parse(value["body"].dump().c_str())
         };
@@ -319,7 +308,7 @@ struct DeleteRowsAction final : public IAction
     void execute(std::unique_ptr<TestContext>& ctx,
                  const nlohmann::json& value) override
     {
-        const std::unique_ptr<cJSON, TestDeleters::CJsonDeleter> jsInput
+        const std::unique_ptr<cJSON, CJsonSmartDeleter> jsInput
         {
             cJSON_Parse(value.at("body").dump().c_str())
         };
@@ -345,7 +334,7 @@ struct SelectRowsAction final : public IAction
     void execute(std::unique_ptr<TestContext>& ctx,
                  const nlohmann::json& value) override
     {
-        const std::unique_ptr<cJSON, TestDeleters::CJsonDeleter> jsInput
+        const std::unique_ptr<cJSON, CJsonSmartDeleter> jsInput
         {
             cJSON_Parse(value.at("body").dump().c_str())
         };
@@ -375,7 +364,7 @@ struct AddTableRelationship final : public IAction
     void execute(std::unique_ptr<TestContext>& ctx,
                  const nlohmann::json& value) override
     {
-        const std::unique_ptr<cJSON, TestDeleters::CJsonDeleter> jsInput
+        const std::unique_ptr<cJSON, CJsonSmartDeleter> jsInput
         {
             cJSON_Parse(value.at("body").dump().c_str())
         };

--- a/src/shared_modules/rsync/cppcheckSuppress.txt
+++ b/src/shared_modules/rsync/cppcheckSuppress.txt
@@ -1,3 +1,3 @@
-*:*src/rsyncImplementation.cpp:158
-*:*tests/implementation/rsyncImplementationTest.cpp:260
-*:*tests/interface/rsync_test.cpp:249
+*:*src/rsyncImplementation.cpp:172
+*:*tests/implementation/rsyncImplementationTest.cpp:259
+*:*tests/interface/rsync_test.cpp:238

--- a/src/shared_modules/rsync/include/rsync.hpp
+++ b/src/shared_modules/rsync/include/rsync.hpp
@@ -336,6 +336,14 @@ class EXPORTED StartSyncConfiguration final : public Configuration<StartSyncConf
          *
          */
         StartSyncConfiguration & rangeChecksum(QueryParameter& parameter);
+
+        /**
+         * @brief Set flag to indicate a sync is ondemand (Message controller is ommited).
+         *
+         * @param syncOnDemand Flag to indicate a sync is ondemand.
+         *
+         */
+        StartSyncConfiguration & syncOnDemand(const bool syncOnDemand);
 };
 
 

--- a/src/shared_modules/rsync/include/rsync.hpp
+++ b/src/shared_modules/rsync/include/rsync.hpp
@@ -28,10 +28,11 @@
 #include <functional>
 #include "json.hpp"
 #include "commonDefs.h"
+#include "builder.hpp"
 
 using SyncCallbackData = const std::function<void(const std::string&)>;
 
-class EXPORTED RemoteSync 
+class EXPORTED RemoteSync
 {
 public:
     /**
@@ -42,7 +43,7 @@ public:
     static void initialize(std::function<void(const std::string&)> logFunction);
 
     /**
-     * @brief Remote sync initializes the instance. 
+     * @brief Remote sync initializes the instance.
      */
     RemoteSync();
 
@@ -67,7 +68,7 @@ public:
      * @param dbsyncHandle       DBSync handle to synchronize databases.
      * @param startConfiguration Statement used as a synchronization start.
      * @param callbackData       This callback is used to send sync information.
-     * 
+     *
      */
     virtual void startSync(const DBSYNC_HANDLE   dbsyncHandle,
                            const nlohmann::json& startConfiguration,
@@ -83,12 +84,12 @@ public:
      * @param callbackData       This callback is used to send sync information.
      *
      */
-    virtual void registerSyncID(const std::string&    messageHeaderID, 
+    virtual void registerSyncID(const std::string&    messageHeaderID,
                                 const DBSYNC_HANDLE   dbsyncHandle,
                                 const nlohmann::json& syncConfiguration,
                                 SyncCallbackData      callbackData);
     /**
-     * @brief Pushes the \p payload message within a queue to process it in an async 
+     * @brief Pushes the \p payload message within a queue to process it in an async
      *  dispatch queue.
      *
      * @param payload Message to be queued and processed.
@@ -106,6 +107,235 @@ private:
     RSYNC_HANDLE m_handle;
     bool m_shouldBeRemoved;
 
+};
+
+template <typename T>
+class EXPORTED Configuration : public Utils::Builder<T>
+{
+    protected:
+        nlohmann::json m_jsConfiguration;
+    public:
+        Configuration() = default;
+        // LCOV_EXCL_START
+        virtual ~Configuration() = default;
+        // LCOV_EXCL_STOP
+        nlohmann::json& config()
+        {
+            return m_jsConfiguration;
+        }
+
+        /**
+         * @brief Set table name.
+         *
+         * @param table Table name to be queried.
+         *
+         */
+        T& table(const std::string& table)
+        {
+            m_jsConfiguration["table"] = table;
+            return static_cast<T&>(*this); // Return reference to self
+        }
+
+        /**
+         * @brief Set component name.
+         *
+         * @param component Component name to be established.
+         *
+         */
+        T& component(const std::string& component)
+        {
+            m_jsConfiguration["component"] = component;
+            return static_cast<T&>(*this); // Return reference to self
+        }
+
+        /**
+         * @brief Set index.
+         *
+         * @param index Index to be established.
+         *
+         */
+        T& index(const std::string& index)
+        {
+            m_jsConfiguration["index"] = index;
+            return static_cast<T&>(*this); // Return reference to self
+        }
+
+        /**
+         * @brief Set last event field.
+         *
+         * @param lastEvent last event field name to be established.
+         *
+         */
+        T& lastEvent(const std::string& lastEvent)
+        {
+            m_jsConfiguration["last_event"] = lastEvent;
+            return static_cast<T&>(*this); // Return reference to self
+        }
+
+        /**
+         * @brief Set checksumField name.
+         *
+         * @param checksumField Component name to be established.
+         *
+         */
+        T& checksumField(const std::string& checksumField)
+        {
+            m_jsConfiguration["checksum_field"] = checksumField;
+            return static_cast<T&>(*this); // Return reference to self
+        }
+};
+
+class EXPORTED QueryParameter final : public Utils::Builder<QueryParameter>
+{
+    protected:
+        nlohmann::json m_jsQueryParameter;
+    public:
+        QueryParameter() = default;
+        // LCOV_EXCL_START
+        virtual ~QueryParameter() = default;
+        // LCOV_EXCL_STOP
+
+        /**
+         * @brief Get query parameter json.
+         *
+         * @return Query parameter json.
+         */
+        const nlohmann::json& queryParameter()
+        {
+            return m_jsQueryParameter;
+        }
+
+        /**
+         * @brief Set row filter field.
+         *
+         * @param rowFilter Field name to be used as a row filter.
+         */
+        QueryParameter & rowFilter(const std::string& filter);
+
+        /**
+         * @brief Set column list to be queried.
+         *
+         * @param columns Column list to be queried.
+         */
+        QueryParameter & columnList(const std::vector<std::string>& fields);
+
+        /**
+         * @brief Set distinct flag.
+         *
+         * @param distinct Distinct flag to be set.
+         */
+        QueryParameter & distinctOpt(const bool distinct);
+
+        /**
+         * @brief Set order by field.
+         *
+         * @param orderBy Field name to be used as order by.
+         */
+        QueryParameter & orderByOpt(const std::string& orderBy);
+
+        /**
+         * @brief Set count field name.
+         *
+         * @param countFieldName Field name to be used as count.
+         */
+        QueryParameter & countFieldName(const std::string& countFieldName);
+
+        /**
+         * @brief Set count limit value.
+         *
+         * @param count Count limit to be set.
+         */
+        QueryParameter & countOpt(const uint32_t count);
+};
+
+class EXPORTED RegisterConfiguration final : public Configuration<RegisterConfiguration>
+{
+    public:
+        RegisterConfiguration() = default;
+        // LCOV_EXCL_START
+        virtual ~RegisterConfiguration() = default;
+        // LCOV_EXCL_STOP
+
+        /**
+        * @brief Set the decoder type to be applied in the received message.
+        *
+        * @param decoderType Decoder type to be applied in the received message.
+        *
+        */
+        RegisterConfiguration & decoderType(const std::string& decoderType);
+
+        /**
+         * @brief Set the minimal sync interval time for the message controller.
+         *
+         * @param intervalTime Time in seconds to be set.
+         *
+         */
+        RegisterConfiguration & minimalSyncIntervalTime(const uint32_t intervalTime);
+
+        /**
+         * @brief Set the nodata object to be used during the selection of data when all data are requested.
+        *
+        * @param parameter Nodata object to be used during the selection of data when all data are requested.
+        *
+        */
+        RegisterConfiguration & noData(QueryParameter& parameter);
+
+        /**
+         * @brief Set the query parameter to be used during the binary search to get the number of rows.
+         *
+         * @param parameter Query parameter to be used during the binary search to get the number of rows.
+         *
+         */
+        RegisterConfiguration & countRange(QueryParameter& parameter);
+
+        /**
+        * @brief Set the query parameter to be used during the single row search.
+        *
+        * @param parameter Query parameter to be used during the single row search.
+        *
+        */
+        RegisterConfiguration & rowData(QueryParameter& parameter);
+
+        /**
+         * @brief Set the query parameter to be used during the selection of data for the binary search.
+         *
+         * @param parameter Query parameter to be used during the selection of data for the binary search.
+         *
+         */
+        RegisterConfiguration & rangeChecksum(QueryParameter& parameter);
+};
+
+class EXPORTED StartSyncConfiguration final : public Configuration<StartSyncConfiguration>
+{
+    public:
+        StartSyncConfiguration() = default;
+        // LCOV_EXCL_START
+        virtual ~StartSyncConfiguration() = default;
+        // LCOV_EXCL_STOP
+
+        /**
+         * @brief Set the query parameter to be used during the selection of data for the binary search on the left side.
+         *
+         * @param parameter Query parameter to be used during the selection of data for the binary search on the left side.
+         *
+         */
+        StartSyncConfiguration & first(QueryParameter& parameter);
+
+        /**
+         * @brief Set the query parameter to be used during the selection of data for the binary search on the right side.
+         *
+         * @param parameter Query parameter to be used during the selection of data for the binary search on the right side.
+         *
+         */
+        StartSyncConfiguration & last(QueryParameter& parameter);
+
+        /**
+         * @brief Set the query parameter to be used during the selection of data used to get the global checksum value.
+         *
+         * @param parameter Query parameter to be used during the selection of data for to get the global checksum value.
+         *
+         */
+        StartSyncConfiguration & rangeChecksum(QueryParameter& parameter);
 };
 
 

--- a/src/shared_modules/rsync/src/dbsyncWrapper.h
+++ b/src/shared_modules/rsync/src/dbsyncWrapper.h
@@ -13,6 +13,7 @@
 #define _DBSYNC_WRAPPER_H
 
 #include "dbsync.h"
+#include "rsync_exception.h"
 
 namespace RSync
 {

--- a/src/shared_modules/rsync/src/imessageCreator.h
+++ b/src/shared_modules/rsync/src/imessageCreator.h
@@ -12,6 +12,8 @@
 #ifndef _IMESSAGE_CREATOR_H
 #define _IMESSAGE_CREATOR_H
 
+#include "json.hpp"
+#include "rsyncImplementation.h"
 
 namespace RSync
 {

--- a/src/shared_modules/rsync/src/imessageDecoder.h
+++ b/src/shared_modules/rsync/src/imessageDecoder.h
@@ -11,6 +11,10 @@
 
 #ifndef _IMESSAGE_DECODER_H
 #define _IMESSAGE_DECODER_H
+
+#include <vector>
+#include <string>
+
 namespace RSync
 {
     struct SyncInputData final

--- a/src/shared_modules/rsync/src/messageController.hpp
+++ b/src/shared_modules/rsync/src/messageController.hpp
@@ -1,0 +1,80 @@
+/*
+ * Wazuh RSYNC
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 5, 2020.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _MESSAGECONTROLLER_HPP
+#define _MESSAGECONTROLLER_HPP
+
+#include <chrono>
+#include <string>
+#include <map>
+#include <mutex>
+#include <shared_mutex>
+#include "singleton.hpp"
+
+
+class MessageController final : public Singleton<MessageController>
+{
+    private:
+        struct ComponentContext
+        {
+            std::chrono::steady_clock::time_point lastMsgTime;
+            std::chrono::seconds intervalTime;
+        };
+        std::shared_timed_mutex m_mutex;
+        std::map<std::string, ComponentContext> m_componentContexts;
+
+    public:
+        bool waitToStartSync(const std::string& messageHeaderId)
+        {
+            auto retVal { false };
+            std::shared_lock<std::shared_timed_mutex> lock(m_mutex);
+            const auto itCtx { m_componentContexts.find(messageHeaderId) };
+
+            if (itCtx != m_componentContexts.end())
+            {
+                retVal = std::chrono::steady_clock::now() - itCtx->second.lastMsgTime <= itCtx->second.intervalTime;
+            }
+            return retVal;
+        }
+
+        void setComponentContext(const std::string& messageHeaderId,
+                                 const std::chrono::seconds& intervalTime)
+        {
+            std::unique_lock<std::shared_timed_mutex> lock(m_mutex);
+
+            if (intervalTime.count() > 0)
+            {
+                m_componentContexts[messageHeaderId] =
+                {
+                    std::chrono::time_point<std::chrono::steady_clock>(),
+                    intervalTime
+                };
+            }
+            else
+            {
+                m_componentContexts.erase(messageHeaderId);
+            }
+        }
+
+        void refreshLastMsgTime(const std::string& messageHeaderId)
+        {
+            std::unique_lock<std::shared_timed_mutex> lock(m_mutex);
+            const auto itCtx { m_componentContexts.find(messageHeaderId) };
+
+            if (itCtx != m_componentContexts.end())
+            {
+                itCtx->second.lastMsgTime = std::chrono::steady_clock::now();
+            }
+        }
+
+};
+
+#endif // _MESSAGECONTROLLER_HPP

--- a/src/shared_modules/rsync/src/messageController.hpp
+++ b/src/shared_modules/rsync/src/messageController.hpp
@@ -1,7 +1,7 @@
 /*
  * Wazuh RSYNC
  * Copyright (C) 2015, Wazuh Inc.
- * September 5, 2020.
+ * May 26, 2022.
  *
  * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public

--- a/src/shared_modules/rsync/src/messageCreatorFactory.h
+++ b/src/shared_modules/rsync/src/messageCreatorFactory.h
@@ -12,6 +12,7 @@
 #ifndef _MESSAGE_CREATOR_FACTORY_H
 #define _MESSAGE_CREATOR_FACTORY_H
 
+#include <memory>
 #include "messageChecksum.h"
 #include "messageRowData.h"
 #include "rsync_exception.h"

--- a/src/shared_modules/rsync/src/rsync.cpp
+++ b/src/shared_modules/rsync/src/rsync.cpp
@@ -375,3 +375,8 @@ StartSyncConfiguration& StartSyncConfiguration::rangeChecksum(QueryParameter& pa
     return *this;
 }
 
+StartSyncConfiguration& StartSyncConfiguration::syncOnDemand(const bool syncOnDemand)
+{
+    m_jsConfiguration["sync_on_demand"] = syncOnDemand;
+    return *this;
+}

--- a/src/shared_modules/rsync/src/rsync.cpp
+++ b/src/shared_modules/rsync/src/rsync.cpp
@@ -90,7 +90,7 @@ EXPORTED int rsync_start_sync(const RSYNC_HANDLE handle,
                     callback_data.callback(payload.c_str(), payload.size(), callback_data.user_data);
                 }
             };
-            const std::unique_ptr<char, CJsonDeleter> spJsonBytes{cJSON_PrintUnformatted(start_configuration)};
+            const std::unique_ptr<char, CJsonSmartFree> spJsonBytes{cJSON_PrintUnformatted(start_configuration)};
             RSyncImplementation::instance().startRSync(handle, std::make_shared<DBSyncWrapper>(dbsync_handle), nlohmann::json::parse(spJsonBytes.get()), callbackWrapper);
             retVal = 0;
         }
@@ -131,7 +131,7 @@ EXPORTED int rsync_register_sync_id(const RSYNC_HANDLE handle,
                     callback_data.callback(payload.c_str(), payload.size(), callback_data.user_data);
                 }
             };
-            const std::unique_ptr<char, CJsonDeleter> spJsonBytes{cJSON_Print(sync_configuration)};
+            const std::unique_ptr<char, CJsonSmartFree> spJsonBytes{cJSON_Print(sync_configuration)};
             RSyncImplementation::instance().registerSyncId(handle, message_header_id, std::make_shared<DBSyncWrapper>(dbsync_handle), nlohmann::json::parse(spJsonBytes.get()), callbackWrapper);
             retVal = 0;
         }
@@ -284,3 +284,94 @@ void RemoteSync::pushMessage(const std::vector<uint8_t>& payload)
 {
     RSyncImplementation::instance().push(m_handle, payload);
 }
+
+QueryParameter& QueryParameter::rowFilter(const std::string& rowFilter)
+{
+    m_jsQueryParameter["row_filter"] = rowFilter;
+    return *this;
+}
+
+QueryParameter& QueryParameter::columnList(const std::vector<std::string>& columns)
+{
+    m_jsQueryParameter["column_list"] = columns;
+    return *this;
+}
+
+QueryParameter& QueryParameter::distinctOpt(const bool distinct)
+{
+    m_jsQueryParameter["distinct_opt"] = distinct;
+    return *this;
+}
+
+QueryParameter& QueryParameter::orderByOpt(const std::string& orderBy)
+{
+    m_jsQueryParameter["order_by_opt"] = orderBy;
+    return *this;
+}
+
+QueryParameter& QueryParameter::countOpt(const uint32_t count)
+{
+    m_jsQueryParameter["count_opt"] = count;
+    return *this;
+}
+
+QueryParameter& QueryParameter::countFieldName(const std::string& fieldName)
+{
+    m_jsQueryParameter["count_field_name"] = fieldName;
+    return *this;
+}
+
+RegisterConfiguration& RegisterConfiguration::decoderType(const std::string& parameter)
+{
+    m_jsConfiguration["decoder_type"] = parameter;
+    return *this;
+}
+
+RegisterConfiguration& RegisterConfiguration::noData(QueryParameter& parameter)
+{
+    m_jsConfiguration["no_data_query_json"] = parameter.queryParameter();
+    return *this;
+}
+
+RegisterConfiguration& RegisterConfiguration::countRange(QueryParameter& parameter)
+{
+    m_jsConfiguration["count_range_query_json"] = parameter.queryParameter();
+    return *this;
+}
+
+RegisterConfiguration& RegisterConfiguration::rowData(QueryParameter& parameter)
+{
+    m_jsConfiguration["row_data_query_json"] = parameter.queryParameter();
+    return *this;
+}
+
+RegisterConfiguration& RegisterConfiguration::rangeChecksum(QueryParameter& parameter)
+{
+    m_jsConfiguration["range_checksum_query_json"] = parameter.queryParameter();
+    return *this;
+}
+
+RegisterConfiguration& RegisterConfiguration::minimalSyncIntervalTime(const uint32_t parameter)
+{
+    m_jsConfiguration["minimal_sync_interval"] = parameter;
+    return *this;
+}
+
+StartSyncConfiguration& StartSyncConfiguration::first(QueryParameter& parameter)
+{
+    m_jsConfiguration["first_query"] = parameter.queryParameter();
+    return *this;
+}
+
+StartSyncConfiguration& StartSyncConfiguration::last(QueryParameter& parameter)
+{
+    m_jsConfiguration["last_query"] = parameter.queryParameter();
+    return *this;
+}
+
+StartSyncConfiguration& StartSyncConfiguration::rangeChecksum(QueryParameter& parameter)
+{
+    m_jsConfiguration["range_checksum_query_json"] = parameter.queryParameter();
+    return *this;
+}
+

--- a/src/shared_modules/rsync/src/rsync.cpp
+++ b/src/shared_modules/rsync/src/rsync.cpp
@@ -254,15 +254,7 @@ void RemoteSync::startSync(const DBSYNC_HANDLE   dbsyncHandle,
                            const nlohmann::json& startConfiguration,
                            SyncCallbackData      callbackData)
 {
-    const auto callbackWrapper
-    {
-        [callbackData](const std::string & payload)
-        {
-            callbackData(payload);
-        }
-    };
-    RSyncImplementation::instance().startRSync(m_handle, std::make_shared<DBSyncWrapper>(dbsyncHandle), startConfiguration, callbackWrapper);
-
+    RSyncImplementation::instance().startRSync(m_handle, std::make_shared<DBSyncWrapper>(dbsyncHandle), startConfiguration, callbackData);
 }
 
 void RemoteSync::registerSyncID(const std::string&    messageHeaderID,
@@ -270,14 +262,7 @@ void RemoteSync::registerSyncID(const std::string&    messageHeaderID,
                                 const nlohmann::json& syncConfiguration,
                                 SyncCallbackData      callbackData)
 {
-    const auto callbackWrapper
-    {
-        [callbackData](const std::string & payload)
-        {
-            callbackData(payload);
-        }
-    };
-    RSyncImplementation::instance().registerSyncId(m_handle, messageHeaderID, std::make_shared<DBSyncWrapper>(dbsyncHandle), syncConfiguration, callbackWrapper);
+    RSyncImplementation::instance().registerSyncId(m_handle, messageHeaderID, std::make_shared<DBSyncWrapper>(dbsyncHandle), syncConfiguration, callbackData);
 }
 
 void RemoteSync::pushMessage(const std::vector<uint8_t>& payload)

--- a/src/shared_modules/rsync/src/rsyncImplementation.cpp
+++ b/src/shared_modules/rsync/src/rsyncImplementation.cpp
@@ -18,6 +18,8 @@
 
 using namespace RSync;
 
+constexpr auto DEFAULT_SYNC_INTERVAL_VALUE { 0 };
+
 void RSyncImplementation::release()
 {
     std::lock_guard<std::mutex> lock{ m_mutex };
@@ -62,7 +64,7 @@ void RSyncImplementation::startRSync(const RSYNC_HANDLE handle,
     const auto& component           { jsStartParams.at("component").get_ref<const std::string&>() };
     const auto& itSyncOnDemand      { jsStartParams.find("sync_on_demand")   };
 
-    const auto syncOnDemand { itSyncOnDemand != jsStartParams.end()&& itSyncOnDemand->get<bool>() };
+    const auto syncOnDemand { itSyncOnDemand != jsStartParams.end() && itSyncOnDemand->get<bool>() };
 
     if (syncOnDemand || !MessageController::instance().waitToStartSync(component))
     {
@@ -186,13 +188,13 @@ void RSyncImplementation::registerSyncId(const RSYNC_HANDLE handle,
         }
     };
 
-    auto syncInterval { std::chrono::seconds(0) };
+    auto syncInterval { std::chrono::seconds(DEFAULT_SYNC_INTERVAL_VALUE) };
     const auto itInterval { syncConfiguration.find("minimal_sync_interval") };
 
     if (itInterval != syncConfiguration.end())
     {
         const auto intervalValue { itInterval->get<int32_t>() };
-        syncInterval = std::chrono::seconds(intervalValue > 0 ? intervalValue : 0);
+        syncInterval = intervalValue > 0 ? std::chrono::seconds(intervalValue) : syncInterval;
     }
 
     MessageController::instance().setComponentContext(syncConfiguration.at("component").get_ref<const std::string&>(),

--- a/src/shared_modules/rsync/src/rsyncImplementation.cpp
+++ b/src/shared_modules/rsync/src/rsyncImplementation.cpp
@@ -18,7 +18,10 @@
 
 using namespace RSync;
 
-constexpr auto DEFAULT_SYNC_INTERVAL_VALUE { 0 };
+constexpr auto DEFAULT_SYNC_INTERVAL_VALUE
+{
+    0
+};
 
 void RSyncImplementation::release()
 {
@@ -57,18 +60,18 @@ void RSyncImplementation::startRSync(const RSYNC_HANDLE handle,
                                      const ResultCallback callbackWrapper)
 {
     const auto ctx                  { remoteSyncContext(handle) };
-    const auto& jsStartParams       { startConfiguration                     };
-    const auto& jsStartParamsTable  { jsStartParams.at("table")              };
-    const auto& firstQuery          { jsStartParams.find("first_query")      };
-    const auto& lastQuery           { jsStartParams.find("last_query")       };
-    const auto& component           { jsStartParams.at("component").get_ref<const std::string&>() };
-    const auto& itSyncOnDemand      { jsStartParams.find("sync_on_demand")   };
 
-    const auto syncOnDemand { itSyncOnDemand != jsStartParams.end() && itSyncOnDemand->get<bool>() };
+    const auto& jsStartParamsTable  { startConfiguration.at("table")              };
+    const auto& firstQuery          { startConfiguration.find("first_query")      };
+    const auto& lastQuery           { startConfiguration.find("last_query")       };
+    const auto& component           { startConfiguration.at("component").get_ref<const std::string&>() };
+    const auto& itSyncOnDemand      { startConfiguration.find("sync_on_demand")   };
+
+    const auto syncOnDemand { itSyncOnDemand != startConfiguration.end()&& itSyncOnDemand->get<bool>() };
 
     if (syncOnDemand || !MessageController::instance().waitToStartSync(component))
     {
-        if (!jsStartParamsTable.empty() && firstQuery != jsStartParams.end() && lastQuery != jsStartParams.end())
+        if (!jsStartParamsTable.empty() && firstQuery != startConfiguration.end() && lastQuery != startConfiguration.end())
         {
             const auto& jsFirstLastOutput { executeSelectQuery(spDBSyncWrapper, jsStartParamsTable, firstQuery.value(), lastQuery.value()) };
             const auto& jsonFirstQueryResult { jsFirstLastOutput.at("first_result") };
@@ -83,7 +86,7 @@ void RSyncImplementation::startRSync(const RSYNC_HANDLE handle,
 
             if (!jsonFirstQueryResult.empty() && !jsonLastQueryResult.empty())
             {
-                const auto& indexField { jsStartParams.at("index").get_ref<const std::string&>() };
+                const auto& indexField { startConfiguration.at("index").get_ref<const std::string&>() };
                 const auto& begin      { jsonFirstQueryResult.at(indexField) };
                 const auto& end        { jsonLastQueryResult.at(indexField)  };
 
@@ -94,7 +97,7 @@ void RSyncImplementation::startRSync(const RSYNC_HANDLE handle,
                 {
                     checksumCtx.rightCtx.begin = begin;
                     checksumCtx.rightCtx.end   = end;
-                    fillChecksum(spDBSyncWrapper, jsStartParams, begin, end, checksumCtx);
+                    fillChecksum(spDBSyncWrapper, startConfiguration, begin, end, checksumCtx);
                 }
                 else
                 {
@@ -104,7 +107,7 @@ void RSyncImplementation::startRSync(const RSYNC_HANDLE handle,
                     const auto endString{std::to_string(endNumber)};
                     checksumCtx.rightCtx.begin = beginString;
                     checksumCtx.rightCtx.end   = endString;
-                    fillChecksum(spDBSyncWrapper, jsStartParams, beginString, endString, checksumCtx);
+                    fillChecksum(spDBSyncWrapper, startConfiguration, beginString, endString, checksumCtx);
                 }
             }
             else
@@ -114,7 +117,7 @@ void RSyncImplementation::startRSync(const RSYNC_HANDLE handle,
 
             // rightCtx will have the final checksum based on fillChecksum method. After processing all checksum select data
             // checksumCtx.rightCtx will have the needed (final) information
-            messageCreator->send(callbackWrapper, jsStartParams, checksumCtx.rightCtx);
+            messageCreator->send(callbackWrapper, startConfiguration, checksumCtx.rightCtx);
             MessageController::instance().refreshLastMsgTime(component);
         }
         else

--- a/src/shared_modules/rsync/src/rsyncImplementation.h
+++ b/src/shared_modules/rsync/src/rsyncImplementation.h
@@ -15,24 +15,13 @@
 #include <memory>
 #include <mutex>
 #include <functional>
+#include <shared_mutex>
 #include "commonDefs.h"
 #include "json.hpp"
 #include "msgDispatcher.h"
 #include "syncDecoder.h"
 #include "dbsyncWrapper.h"
-
-struct CJsonDeleter
-{
-    void operator()(char* json)
-    {
-        cJSON_free(json);
-    }
-    void operator()(cJSON* json)
-    {
-        cJSON_Delete(json);
-    }
-};
-
+#include "cjsonSmartDeleter.hpp"
 
 namespace RSync
 {

--- a/src/shared_modules/rsync/src/syncDecoder.h
+++ b/src/shared_modules/rsync/src/syncDecoder.h
@@ -13,6 +13,7 @@
 #define _MSGDECODER_SYNC_H
 
 #include <iostream>
+#include <mutex>
 #include "commonDefs.h"
 #include "rsync_exception.h"
 #include "messageDecoderFactory.h"

--- a/src/shared_modules/rsync/tests/implementation/rsyncImplementationTest.cpp
+++ b/src/shared_modules/rsync/tests/implementation/rsyncImplementationTest.cpp
@@ -16,7 +16,6 @@
 #include "../mocks/dbsyncmock.h"
 
 using ::testing::_;
-using ::testing::Return;
 
 void RSyncImplementationTest::SetUp()
 {
@@ -53,7 +52,7 @@ TEST_F(RSyncImplementationTest, InvalidDecoder)
 TEST_F(RSyncImplementationTest, ValidDecoder)
 {
     const auto handle { RSync::RSyncImplementation::instance().create() };
-    const auto config { R"({"decoder_type":"JSON_RANGE"})" };
+    const auto config { R"({"decoder_type":"JSON_RANGE", "component":"test_decoder"})" };
 
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().registerSyncId(handle, "test_id", nullptr, nlohmann::json::parse(config), {}));
 
@@ -64,7 +63,7 @@ TEST_F(RSyncImplementationTest, ValidDecoder)
 TEST_F(RSyncImplementationTest, ValidDecoderPushedNoData)
 {
     const auto handle { RSync::RSyncImplementation::instance().create() };
-    const auto config { R"({"decoder_type":"JSON_RANGE","table":"test","no_data_query_json":{"row_filter":"","column_list":"","distinct_opt":"","order_by_opt":""}})" };
+    const auto config { R"({"decoder_type":"JSON_RANGE", "component":"test_decoder","table":"test","no_data_query_json":{"row_filter":"","column_list":"","distinct_opt":"","order_by_opt":""}})" };
     auto mockDbSync { std::make_shared<MockDBSync>() };
 
     EXPECT_CALL(*mockDbSync, select(_, _));

--- a/src/shared_modules/rsync/tests/interface/rsync_test.cpp
+++ b/src/shared_modules/rsync/tests/interface/rsync_test.cpp
@@ -1102,23 +1102,27 @@ TEST_F(RSyncTest, RegisterStartSyncAndPushWithSyncLimitIntervalCPP)
         .index("path")
         .lastEvent("last_event")
         .checksumField("checksum")
-        .noData(QueryParameter::builder().rowFilter(" ")
+        .noData(
+            QueryParameter::builder().rowFilter(" ")
         .columnList({"path, inode_id, mode, last_event, entry_type, scanned, options, checksum"})
         .distinctOpt(false)
         .orderByOpt("")
         .countOpt(100))
-        .countRange(QueryParameter::builder().rowFilter("WHERE path BETWEEN '?' and '?' ORDER BY path")
-                    .countFieldName("count")
+        .countRange(
+            QueryParameter::builder().rowFilter("WHERE path BETWEEN '?' and '?' ORDER BY path")
+            .countFieldName("count")
         .columnList({"count(*) AS count "})
         .distinctOpt(false)
         .orderByOpt("")
         .countOpt(100))
-        .rowData(QueryParameter::builder().rowFilter("WHERE path ='?'")
+        .rowData(
+            QueryParameter::builder().rowFilter("WHERE path ='?'")
         .columnList({"path, inode_id, mode, last_event, entry_type, scanned, options, checksum"})
         .distinctOpt(false)
         .orderByOpt("")
         .countOpt(100))
-        .rangeChecksum(QueryParameter::builder().rowFilter("WHERE path BETWEEN '?' and '?' ORDER BY path")
+        .rangeChecksum(
+            QueryParameter::builder().rowFilter("WHERE path BETWEEN '?' and '?' ORDER BY path")
         .columnList({"path, inode_id, mode, last_event, entry_type, scanned, options, checksum"})
         .distinctOpt(false)
         .orderByOpt("")
@@ -1325,23 +1329,27 @@ TEST_F(RSyncTest, RegisterStartSyncAndPushWithSyncLimitRemoveCPP)
         .index("path")
         .lastEvent("last_event")
         .checksumField("checksum")
-        .noData(QueryParameter::builder().rowFilter(" ")
+        .noData(
+            QueryParameter::builder().rowFilter(" ")
         .columnList({"path, inode_id, mode, last_event, entry_type, scanned, options, checksum"})
         .distinctOpt(false)
         .orderByOpt("")
         .countOpt(100))
-        .countRange(QueryParameter::builder().rowFilter("WHERE path BETWEEN '?' and '?' ORDER BY path")
-                    .countFieldName("count")
+        .countRange(
+            QueryParameter::builder().rowFilter("WHERE path BETWEEN '?' and '?' ORDER BY path")
+            .countFieldName("count")
         .columnList({"count(*) AS count "})
         .distinctOpt(false)
         .orderByOpt("")
         .countOpt(100))
-        .rowData(QueryParameter::builder().rowFilter("WHERE path ='?'")
+        .rowData(
+            QueryParameter::builder().rowFilter("WHERE path ='?'")
         .columnList({"path, inode_id, mode, last_event, entry_type, scanned, options, checksum"})
         .distinctOpt(false)
         .orderByOpt("")
         .countOpt(100))
-        .rangeChecksum(QueryParameter::builder().rowFilter("WHERE path BETWEEN '?' and '?' ORDER BY path")
+        .rangeChecksum(
+            QueryParameter::builder().rowFilter("WHERE path BETWEEN '?' and '?' ORDER BY path")
         .columnList({"path, inode_id, mode, last_event, entry_type, scanned, options, checksum"})
         .distinctOpt(false)
         .orderByOpt("")
@@ -1435,6 +1443,157 @@ TEST_F(RSyncTest, RegisterStartSyncAndPushWithSyncLimitRemoveCPP)
     EXPECT_EQ(messageCounter.load(), TOTAL_EXPECTED_MESSAGES);
 }
 
+TEST_F(RSyncTest, RegisterStartSyncAndPushWithOnDemandSyncCPP)
+{
+    std::unique_ptr<DBSync> dbSync;
+    EXPECT_NO_THROW(dbSync = std::make_unique<DBSync>(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, SQL_STMT_INFO));
+
+    std::unique_ptr<RemoteSync> remoteSync;
+    EXPECT_NO_THROW(remoteSync = std::make_unique<RemoteSync>());
+
+    const auto expectedResult1
+    {
+        R"({"component":"test_component","data":{"begin":"5","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"1","id":)"
+    };
+
+    const auto expectedResult2
+    {
+        R"(},"type":"integrity_check_global"})"
+    };
+
+    const auto expectedResult3
+    {
+        R"({"component":"test_component","data":{"begin":"/boot/grub2/fonts/unicode.pf2","checksum":"acfe3a5baf97f842838c13b32e7e61a11e144e64","end":"/boot/grub2/grubenv","id":1,"tail":"/boot/grub2/i386-pc/datehook.mod"},"type":"integrity_check_left"})"
+    };
+
+    const auto expectedResult4
+    {
+        R"({"component":"test_component","data":{"begin":"/boot/grub2/i386-pc/datehook.mod","checksum":"891333533a9c7d989b92928d200ed8402fe67813","end":"/boot/grub2/i386-pc/gzio.mod","id":1},"type":"integrity_check_right"})"
+    };
+
+
+    auto registerConfig
+    {
+        RegisterConfiguration::builder().decoderType("JSON_RANGE")
+        .table("entry_path")
+        .component("test_component")
+        .index("path")
+        .lastEvent("last_event")
+        .checksumField("checksum")
+        .noData(
+            QueryParameter::builder().rowFilter(" ")
+        .columnList({"path, inode_id, mode, last_event, entry_type, scanned, options, checksum"})
+        .distinctOpt(false)
+        .orderByOpt("")
+        .countOpt(100))
+        .countRange(
+            QueryParameter::builder().rowFilter("WHERE path BETWEEN '?' and '?' ORDER BY path")
+            .countFieldName("count")
+        .columnList({"count(*) AS count "})
+        .distinctOpt(false)
+        .orderByOpt("")
+        .countOpt(100))
+        .rowData(
+            QueryParameter::builder().rowFilter("WHERE path ='?'")
+        .columnList({"path, inode_id, mode, last_event, entry_type, scanned, options, checksum"})
+        .distinctOpt(false)
+        .orderByOpt("")
+        .countOpt(100))
+        .rangeChecksum(
+            QueryParameter::builder().rowFilter("WHERE path BETWEEN '?' and '?' ORDER BY path")
+        .columnList({"path, inode_id, mode, last_event, entry_type, scanned, options, checksum"})
+        .distinctOpt(false)
+        .orderByOpt("")
+        .countOpt(100))
+        .minimalSyncIntervalTime(5)
+
+    };
+
+    std::atomic_uint64_t messageCounter { 0 };
+    constexpr auto TOTAL_EXPECTED_MESSAGES { 4ull };
+    const auto checkExpected
+    {
+        [&](const std::string & payload) -> ::testing::AssertionResult
+        {
+            auto retVal { ::testing::AssertionFailure() };
+            // Necessary to avoid checking against "ID" which is defined as: time(nullptr)
+            auto firstSegment  { payload.find(expectedResult1) };
+            auto secondSegment { payload.find(expectedResult2) };
+            auto thirdSegment  { payload.find(expectedResult3) };
+            auto fourSegment   { payload.find(expectedResult4) };
+
+            if ((std::string::npos != firstSegment && std::string::npos != secondSegment)
+                    || std::string::npos != thirdSegment
+                    || std::string::npos != fourSegment)
+            {
+                retVal = ::testing::AssertionSuccess();
+                ++messageCounter;
+            }
+
+            return retVal;
+        }
+    };
+
+    std::function<void(const std::string&)> callbackWrapper
+    {
+        [&](const std::string & payload)
+        {
+            EXPECT_PRED1(checkExpected, payload);
+        }
+    };
+
+    SyncCallbackData callbackData
+    {
+        [&callbackWrapper](const std::string & payload)
+        {
+            callbackWrapper(payload);
+        }
+    };
+
+    ASSERT_NO_THROW(remoteSync->registerSyncID("test_id", dbSync->handle(), registerConfig.config(), callbackData));
+
+    auto startSyncConfig
+    {
+        StartSyncConfiguration::builder().table("entry_path")
+        .component("test_component")
+        .index("inode_id")
+        .lastEvent("last_event")
+        .checksumField("checksum")
+        .rangeChecksum(
+            QueryParameter::builder().rowFilter("WHERE inode_id BETWEEN '?' and '?' ORDER BY inode_id")
+        .columnList({"inode_id, checksum"})
+        .distinctOpt(false)
+        .orderByOpt("")
+        .countOpt(100))
+        .first(
+            QueryParameter::builder().rowFilter(" ")
+        .columnList({"inode_id"})
+        .distinctOpt(false)
+        .orderByOpt("inode_id ASC")
+        .countOpt(1))
+        .last(
+            QueryParameter::builder().rowFilter(" ")
+        .columnList({"inode_id"})
+        .distinctOpt(false)
+        .orderByOpt("inode_id DESC")
+        .countOpt(1))
+    };
+
+    EXPECT_NO_THROW(remoteSync->startSync(dbSync->handle(), startSyncConfig.config(), callbackData));
+
+    std::string buffer1{R"(test_id checksum_fail {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
+
+    ASSERT_NO_THROW(remoteSync->pushMessage({ buffer1.begin(), buffer1.end() }));
+
+    startSyncConfig.syncOnDemand(true);
+
+    EXPECT_NO_THROW(remoteSync->startSync(dbSync->handle(), startSyncConfig.config(), callbackData));
+    remoteSync.reset();
+
+    EXPECT_EQ(messageCounter.load(), TOTAL_EXPECTED_MESSAGES);
+}
+
+
 TEST(RSyncBuilderRegisterConfigurationTest, TestExpectedHappyCase)
 {
     auto registerConfig
@@ -1444,20 +1603,24 @@ TEST(RSyncBuilderRegisterConfigurationTest, TestExpectedHappyCase)
         .component("syscollector_osinfo")
         .index("os_name")
         .checksumField("checksum")
-        .noData(QueryParameter::builder().rowFilter("WHERE os_name BETWEEN '?' and '?' ORDER BY os_name")
+        .noData(
+            QueryParameter::builder().rowFilter("WHERE os_name BETWEEN '?' and '?' ORDER BY os_name")
         .columnList({"*"})
         .distinctOpt(false)
         .orderByOpt(""))
-        .countRange(QueryParameter::builder().countFieldName("count")
-                    .rowFilter("WHERE os_name BETWEEN '?' and '?' ORDER BY os_name")
+        .countRange(
+            QueryParameter::builder().countFieldName("count")
+            .rowFilter("WHERE os_name BETWEEN '?' and '?' ORDER BY os_name")
         .columnList({"count(*) AS count "})
         .distinctOpt(false)
         .orderByOpt(""))
-        .rowData(QueryParameter::builder().rowFilter("WHERE os_name ='?'")
+        .rowData(
+            QueryParameter::builder().rowFilter("WHERE os_name ='?'")
         .columnList({"*"})
         .distinctOpt(false)
         .orderByOpt(""))
-        .rangeChecksum(QueryParameter::builder().rowFilter("WHERE os_name BETWEEN '?' and '?' ORDER BY os_name")
+        .rangeChecksum(
+            QueryParameter::builder().rowFilter("WHERE os_name BETWEEN '?' and '?' ORDER BY os_name")
         .columnList({"*"})
         .distinctOpt(false)
         .orderByOpt(""))
@@ -1476,23 +1639,26 @@ TEST(RSyncBuilderStartSyncConfigurationTest, TestExpectedHappyCase)
         .index("os_name")
         .checksumField("checksum")
         .lastEvent("last_event")
-        .rangeChecksum(QueryParameter::builder().rowFilter("WHERE os_name BETWEEN '?' and '?' ORDER BY os_name")
+        .syncOnDemand(true)
+        .rangeChecksum(
+            QueryParameter::builder().rowFilter("WHERE os_name BETWEEN '?' and '?' ORDER BY os_name")
         .columnList({"os_name", "checksum"})
         .distinctOpt(false)
         .orderByOpt("")
         .countOpt(100))
-        .first(QueryParameter::builder().rowFilter(" ")
+        .first(
+            QueryParameter::builder().rowFilter(" ")
         .columnList({"os_name"})
         .distinctOpt(false)
         .orderByOpt("os_name DESC")
         .countOpt(1))
-        .last(QueryParameter::builder().rowFilter(" ")
+        .last(
+            QueryParameter::builder().rowFilter(" ")
         .columnList({"os_name"})
         .distinctOpt(false)
         .orderByOpt("os_name ASC")
         .countOpt(1))
     };
-
     EXPECT_EQ(startSyncConfig.config().dump(),
-              R"({"checksum_field":"checksum","component":"syscollector_osinfo","first_query":{"column_list":["os_name"],"count_opt":1,"distinct_opt":false,"order_by_opt":"os_name DESC","row_filter":" "},"index":"os_name","last_event":"last_event","last_query":{"column_list":["os_name"],"count_opt":1,"distinct_opt":false,"order_by_opt":"os_name ASC","row_filter":" "},"range_checksum_query_json":{"column_list":["os_name","checksum"],"count_opt":100,"distinct_opt":false,"order_by_opt":"","row_filter":"WHERE os_name BETWEEN '?' and '?' ORDER BY os_name"},"table":"dbsync_osinfo"})");
+              R"({"checksum_field":"checksum","component":"syscollector_osinfo","first_query":{"column_list":["os_name"],"count_opt":1,"distinct_opt":false,"order_by_opt":"os_name DESC","row_filter":" "},"index":"os_name","last_event":"last_event","last_query":{"column_list":["os_name"],"count_opt":1,"distinct_opt":false,"order_by_opt":"os_name ASC","row_filter":" "},"range_checksum_query_json":{"column_list":["os_name","checksum"],"count_opt":100,"distinct_opt":false,"order_by_opt":"","row_filter":"WHERE os_name BETWEEN '?' and '?' ORDER BY os_name"},"sync_on_demand":true,"table":"dbsync_osinfo"})");
 }

--- a/src/shared_modules/rsync/tests/interface/rsync_test.cpp
+++ b/src/shared_modules/rsync/tests/interface/rsync_test.cpp
@@ -17,6 +17,7 @@
 #include "rsync.hpp"
 #include "dbsync.h"
 #include "dbsync.hpp"
+#include "cjsonSmartDeleter.hpp"
 
 constexpr auto DATABASE_TEMP {"TEMP.db"};
 constexpr auto SQL_STMT_INFO
@@ -62,18 +63,6 @@ static void callbackRSyncWrapper(const void* payload, size_t size, void* userDat
     }
 }
 
-struct CJsonDeleter
-{
-    void operator()(char* json)
-    {
-        cJSON_free(json);
-    }
-    void operator()(cJSON* json)
-    {
-        cJSON_Delete(json);
-    }
-};
-
 static void logFunction(const char* msg)
 {
     if (msg)
@@ -110,7 +99,7 @@ TEST_F(RSyncTest, startSyncWithInvalidParams)
     {
         R"({"table":"entry_path"})"
     };
-    const std::unique_ptr<cJSON, CJsonDeleter> jsSelect{ cJSON_Parse(startConfigStmt) };
+    const std::unique_ptr<cJSON, CJsonSmartDeleter> jsSelect{ cJSON_Parse(startConfigStmt) };
     sync_callback_data_t callbackData { callback, nullptr };
 
     ASSERT_NE(0, rsync_start_sync(nullptr, dbsyncHandle, jsSelect.get(), {}));
@@ -131,7 +120,7 @@ TEST_F(RSyncTest, startSyncWithoutExtraParams)
     {
         R"({"table":"entry_path"})"
     };
-    const std::unique_ptr<cJSON, CJsonDeleter> jsSelect{ cJSON_Parse(startConfigStmt) };
+    const std::unique_ptr<cJSON, CJsonSmartDeleter> jsSelect{ cJSON_Parse(startConfigStmt) };
 
     ASSERT_NE(0, rsync_start_sync(rsyncHandle, dbsyncHandle, jsSelect.get(), {}));
 }
@@ -171,7 +160,7 @@ TEST_F(RSyncTest, startSyncWithBadSelectQuery)
                }],
             })"
     };
-    const std::unique_ptr<cJSON, CJsonDeleter> jsSelect{ cJSON_Parse(startConfigStmt) };
+    const std::unique_ptr<cJSON, CJsonSmartDeleter> jsSelect{ cJSON_Parse(startConfigStmt) };
 
     ASSERT_NE(0, rsync_start_sync(rsyncHandle, dbsyncHandle, jsSelect.get(), {}));
 }
@@ -235,7 +224,7 @@ TEST_F(RSyncTest, startSyncWithIntegrityClear)
                 }
             })"
     };
-    const std::unique_ptr<cJSON, CJsonDeleter> jsSelect{ cJSON_Parse(startConfigStmt) };
+    const std::unique_ptr<cJSON, CJsonSmartDeleter> jsSelect{ cJSON_Parse(startConfigStmt) };
 
     const auto checkExpected
     {
@@ -318,7 +307,7 @@ TEST_F(RSyncTest, startSyncIntegrityGlobal)
                 }
             })"
     };
-    const std::unique_ptr<cJSON, CJsonDeleter> jsSelect{ cJSON_Parse(startConfigStmt) };
+    const std::unique_ptr<cJSON, CJsonSmartDeleter> jsSelect{ cJSON_Parse(startConfigStmt) };
 
     const auto checkExpected
     {
@@ -476,7 +465,7 @@ TEST_F(RSyncTest, RegisterAndPush)
     EXPECT_CALL(wrapper, callbackMock(expectedResult6)).Times(1);
     EXPECT_CALL(wrapper, callbackMock(expectedResult7)).Times(1);
 
-    const std::unique_ptr<cJSON, CJsonDeleter> spRegisterConfigStmt{ cJSON_Parse(registerConfigStmt) };
+    const std::unique_ptr<cJSON, CJsonSmartDeleter> spRegisterConfigStmt{ cJSON_Parse(registerConfigStmt) };
     ASSERT_EQ(0, rsync_register_sync_id(handle_rsync, "test_id", handle_dbsync, spRegisterConfigStmt.get(), callbackData));
 
     std::string buffer1{R"(test_id checksum_fail {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
@@ -550,7 +539,7 @@ TEST_F(RSyncTest, RegisterIncorrectQueryAndPush)
 
     sync_callback_data_t callbackData { callback, &wrapper };
 
-    const std::unique_ptr<cJSON, CJsonDeleter> spRegisterConfigStmt{ cJSON_Parse(registerConfigStmt) };
+    const std::unique_ptr<cJSON, CJsonSmartDeleter> spRegisterConfigStmt{ cJSON_Parse(registerConfigStmt) };
     ASSERT_EQ(0, rsync_register_sync_id(handle_rsync, "test_id", handle_dbsync, spRegisterConfigStmt.get(), callbackData));
 
     std::string buffer1{R"(test_id checksum_fail {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
@@ -1074,4 +1063,436 @@ TEST_F(RSyncTest, RegisterAndPushCPPByInodePartialNODataRange)
 
     std::this_thread::sleep_for(std::chrono::seconds(3));
     remoteSync.reset();
+}
+
+TEST_F(RSyncTest, RegisterStartSyncAndPushWithSyncLimitIntervalCPP)
+{
+    std::unique_ptr<DBSync> dbSync;
+    EXPECT_NO_THROW(dbSync = std::make_unique<DBSync>(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, SQL_STMT_INFO));
+
+    std::unique_ptr<RemoteSync> remoteSync;
+    EXPECT_NO_THROW(remoteSync = std::make_unique<RemoteSync>());
+
+    const auto expectedResult1
+    {
+        R"({"component":"test_component","data":{"begin":"5","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"1","id":)"
+    };
+
+    const auto expectedResult2
+    {
+        R"(},"type":"integrity_check_global"})"
+    };
+
+    const auto expectedResult3
+    {
+        R"({"component":"test_component","data":{"begin":"/boot/grub2/fonts/unicode.pf2","checksum":"acfe3a5baf97f842838c13b32e7e61a11e144e64","end":"/boot/grub2/grubenv","id":1,"tail":"/boot/grub2/i386-pc/datehook.mod"},"type":"integrity_check_left"})"
+    };
+
+    const auto expectedResult4
+    {
+        R"({"component":"test_component","data":{"begin":"/boot/grub2/i386-pc/datehook.mod","checksum":"891333533a9c7d989b92928d200ed8402fe67813","end":"/boot/grub2/i386-pc/gzio.mod","id":1},"type":"integrity_check_right"})"
+    };
+
+
+    auto registerConfig
+    {
+        RegisterConfiguration::builder().decoderType("JSON_RANGE")
+        .table("entry_path")
+        .component("test_component")
+        .index("path")
+        .lastEvent("last_event")
+        .checksumField("checksum")
+        .noData(QueryParameter::builder().rowFilter(" ")
+        .columnList({"path, inode_id, mode, last_event, entry_type, scanned, options, checksum"})
+        .distinctOpt(false)
+        .orderByOpt("")
+        .countOpt(100))
+        .countRange(QueryParameter::builder().rowFilter("WHERE path BETWEEN '?' and '?' ORDER BY path")
+                    .countFieldName("count")
+        .columnList({"count(*) AS count "})
+        .distinctOpt(false)
+        .orderByOpt("")
+        .countOpt(100))
+        .rowData(QueryParameter::builder().rowFilter("WHERE path ='?'")
+        .columnList({"path, inode_id, mode, last_event, entry_type, scanned, options, checksum"})
+        .distinctOpt(false)
+        .orderByOpt("")
+        .countOpt(100))
+        .rangeChecksum(QueryParameter::builder().rowFilter("WHERE path BETWEEN '?' and '?' ORDER BY path")
+        .columnList({"path, inode_id, mode, last_event, entry_type, scanned, options, checksum"})
+        .distinctOpt(false)
+        .orderByOpt("")
+        .countOpt(100))
+        .minimalSyncIntervalTime(2)
+
+    };
+
+    std::atomic_uint64_t messageCounter { 0 };
+    constexpr auto TOTAL_EXPECTED_MESSAGES { 4ull };
+    const auto checkExpected
+    {
+        [&](const std::string & payload) -> ::testing::AssertionResult
+        {
+            auto retVal { ::testing::AssertionFailure() };
+            // Necessary to avoid checking against "ID" which is defined as: time(nullptr)
+            auto firstSegment  { payload.find(expectedResult1) };
+            auto secondSegment { payload.find(expectedResult2) };
+            auto thirdSegment  { payload.find(expectedResult3) };
+            auto fourSegment   { payload.find(expectedResult4) };
+
+            if ((std::string::npos != firstSegment && std::string::npos != secondSegment)
+                    || std::string::npos != thirdSegment
+                    || std::string::npos != fourSegment)
+            {
+                retVal = ::testing::AssertionSuccess();
+                ++messageCounter;
+            }
+
+            return retVal;
+        }
+    };
+
+    std::function<void(const std::string&)> callbackWrapper
+    {
+        [&](const std::string & payload)
+        {
+            EXPECT_PRED1(checkExpected, payload);
+        }
+    };
+
+    SyncCallbackData callbackData
+    {
+        [&callbackWrapper](const std::string & payload)
+        {
+            callbackWrapper(payload);
+        }
+    };
+
+    ASSERT_NO_THROW(remoteSync->registerSyncID("test_id", dbSync->handle(), registerConfig.config(), callbackData));
+
+    auto startSyncConfig
+    {
+        StartSyncConfiguration::builder().table("entry_path")
+        .component("test_component")
+        .index("inode_id")
+        .lastEvent("last_event")
+        .checksumField("checksum")
+        .rangeChecksum(
+            QueryParameter::builder().rowFilter("WHERE inode_id BETWEEN '?' and '?' ORDER BY inode_id")
+        .columnList({"inode_id, checksum"})
+        .distinctOpt(false)
+        .orderByOpt("")
+        .countOpt(100))
+        .first(
+            QueryParameter::builder().rowFilter(" ")
+        .columnList({"inode_id"})
+        .distinctOpt(false)
+        .orderByOpt("inode_id ASC")
+        .countOpt(1))
+        .last(
+            QueryParameter::builder().rowFilter(" ")
+        .columnList({"inode_id"})
+        .distinctOpt(false)
+        .orderByOpt("inode_id DESC")
+        .countOpt(1))
+    };
+
+    EXPECT_NO_THROW(remoteSync->startSync(dbSync->handle(), startSyncConfig.config(), callbackData));
+
+    std::string buffer1{R"(test_id checksum_fail {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
+
+    ASSERT_NO_THROW(remoteSync->pushMessage({ buffer1.begin(), buffer1.end() }));
+
+    std::this_thread::sleep_for(std::chrono::seconds(4));
+
+    EXPECT_NO_THROW(remoteSync->startSync(dbSync->handle(), startSyncConfig.config(), callbackData));
+    EXPECT_NO_THROW(remoteSync->startSync(dbSync->handle(), startSyncConfig.config(), callbackData));
+    remoteSync.reset();
+
+    EXPECT_EQ(messageCounter.load(), TOTAL_EXPECTED_MESSAGES);
+}
+
+TEST_F(RSyncTest, RegisterStartSyncAndNullIntervalsCPP)
+{
+    std::unique_ptr<DBSync> dbSync;
+    EXPECT_NO_THROW(dbSync = std::make_unique<DBSync>(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, SQL_STMT_INFO));
+
+    std::unique_ptr<RemoteSync> remoteSync;
+    EXPECT_NO_THROW(remoteSync = std::make_unique<RemoteSync>());
+
+    auto registerConfig
+    {
+        RegisterConfiguration::builder().decoderType("JSON_RANGE")
+        .table("entry_path")
+        .component("test_component")
+        .index("path")
+        .lastEvent("last_event")
+        .checksumField("checksum")
+        .noData(
+            QueryParameter::builder().rowFilter(" ")
+        .columnList({"path, inode_id, mode, last_event, entry_type, scanned, options, checksum"})
+        .distinctOpt(false)
+        .orderByOpt("")
+        .countOpt(100))
+        .countRange(
+            QueryParameter::builder().rowFilter("WHERE path BETWEEN '?' and '?' ORDER BY path")
+            .countFieldName("count")
+        .columnList({"count(*) AS count "})
+        .distinctOpt(false)
+        .orderByOpt("")
+        .countOpt(100))
+        .rowData(
+            QueryParameter::builder().rowFilter("WHERE path ='?'")
+        .columnList({"path, inode_id, mode, last_event, entry_type, scanned, options, checksum"})
+        .distinctOpt(false)
+        .orderByOpt("")
+        .countOpt(100))
+        .rangeChecksum(
+            QueryParameter::builder().rowFilter("WHERE path BETWEEN '?' and '?' ORDER BY path")
+        .columnList({"path, inode_id, mode, last_event, entry_type, scanned, options, checksum"})
+        .distinctOpt(false)
+        .orderByOpt("")
+        .countOpt(100))
+        .minimalSyncIntervalTime(5)
+
+    };
+
+    CallbackMock wrapper;
+    SyncCallbackData callbackData
+    {
+        [&wrapper](const std::string & data)
+        {
+            wrapper.callbackMock(data);
+        }
+    };
+
+    ASSERT_NO_THROW(remoteSync->registerSyncID("test_id", dbSync->handle(), registerConfig.config(), callbackData));
+
+    auto startSyncConfig
+    {
+        StartSyncConfiguration::builder().table("entry_path")
+        .component("test_component")
+        .index("inode_id")
+        .lastEvent("last_event")
+        .checksumField("checksum")
+        .rangeChecksum(
+            QueryParameter::builder().rowFilter("WHERE inode_id BETWEEN '?' and '?' ORDER BY inode_id")
+        .columnList({"inode_id, checksum"})
+        .distinctOpt(false)
+        .orderByOpt("")
+        .countOpt(100))
+    };
+
+    EXPECT_ANY_THROW(remoteSync->startSync(dbSync->handle(), startSyncConfig.config(), callbackData));
+
+    remoteSync.reset();
+}
+
+TEST_F(RSyncTest, RegisterStartSyncAndPushWithSyncLimitRemoveCPP)
+{
+    std::unique_ptr<DBSync> dbSync;
+    EXPECT_NO_THROW(dbSync = std::make_unique<DBSync>(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, SQL_STMT_INFO));
+
+    std::unique_ptr<RemoteSync> remoteSync;
+    EXPECT_NO_THROW(remoteSync = std::make_unique<RemoteSync>());
+
+    const auto expectedResult1
+    {
+        R"({"component":"test_component","data":{"begin":"5","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"1","id":)"
+    };
+
+    const auto expectedResult2
+    {
+        R"(},"type":"integrity_check_global"})"
+    };
+
+    const auto expectedResult3
+    {
+        R"({"component":"test_component","data":{"begin":"/boot/grub2/fonts/unicode.pf2","checksum":"acfe3a5baf97f842838c13b32e7e61a11e144e64","end":"/boot/grub2/grubenv","id":1,"tail":"/boot/grub2/i386-pc/datehook.mod"},"type":"integrity_check_left"})"
+    };
+
+    const auto expectedResult4
+    {
+        R"({"component":"test_component","data":{"begin":"/boot/grub2/i386-pc/datehook.mod","checksum":"891333533a9c7d989b92928d200ed8402fe67813","end":"/boot/grub2/i386-pc/gzio.mod","id":1},"type":"integrity_check_right"})"
+    };
+
+
+    auto registerConfig
+    {
+        RegisterConfiguration::builder().decoderType("JSON_RANGE")
+        .table("entry_path")
+        .component("test_component")
+        .index("path")
+        .lastEvent("last_event")
+        .checksumField("checksum")
+        .noData(QueryParameter::builder().rowFilter(" ")
+        .columnList({"path, inode_id, mode, last_event, entry_type, scanned, options, checksum"})
+        .distinctOpt(false)
+        .orderByOpt("")
+        .countOpt(100))
+        .countRange(QueryParameter::builder().rowFilter("WHERE path BETWEEN '?' and '?' ORDER BY path")
+                    .countFieldName("count")
+        .columnList({"count(*) AS count "})
+        .distinctOpt(false)
+        .orderByOpt("")
+        .countOpt(100))
+        .rowData(QueryParameter::builder().rowFilter("WHERE path ='?'")
+        .columnList({"path, inode_id, mode, last_event, entry_type, scanned, options, checksum"})
+        .distinctOpt(false)
+        .orderByOpt("")
+        .countOpt(100))
+        .rangeChecksum(QueryParameter::builder().rowFilter("WHERE path BETWEEN '?' and '?' ORDER BY path")
+        .columnList({"path, inode_id, mode, last_event, entry_type, scanned, options, checksum"})
+        .distinctOpt(false)
+        .orderByOpt("")
+        .countOpt(100))
+        .minimalSyncIntervalTime(5)
+
+    };
+
+    std::atomic_uint64_t messageCounter { 0 };
+    constexpr auto TOTAL_EXPECTED_MESSAGES { 4ull };
+    const auto checkExpected
+    {
+        [&](const std::string & payload) -> ::testing::AssertionResult
+        {
+            auto retVal { ::testing::AssertionFailure() };
+            // Necessary to avoid checking against "ID" which is defined as: time(nullptr)
+            auto firstSegment  { payload.find(expectedResult1) };
+            auto secondSegment { payload.find(expectedResult2) };
+            auto thirdSegment  { payload.find(expectedResult3) };
+            auto fourSegment   { payload.find(expectedResult4) };
+
+            if ((std::string::npos != firstSegment && std::string::npos != secondSegment)
+                    || std::string::npos != thirdSegment
+                    || std::string::npos != fourSegment)
+            {
+                retVal = ::testing::AssertionSuccess();
+                ++messageCounter;
+            }
+
+            return retVal;
+        }
+    };
+
+    std::function<void(const std::string&)> callbackWrapper
+    {
+        [&](const std::string & payload)
+        {
+            EXPECT_PRED1(checkExpected, payload);
+        }
+    };
+
+    SyncCallbackData callbackData
+    {
+        [&callbackWrapper](const std::string & payload)
+        {
+            callbackWrapper(payload);
+        }
+    };
+
+    ASSERT_NO_THROW(remoteSync->registerSyncID("test_id", dbSync->handle(), registerConfig.config(), callbackData));
+
+    auto startSyncConfig
+    {
+        StartSyncConfiguration::builder().table("entry_path")
+        .component("test_component")
+        .index("inode_id")
+        .lastEvent("last_event")
+        .checksumField("checksum")
+        .rangeChecksum(
+            QueryParameter::builder().rowFilter("WHERE inode_id BETWEEN '?' and '?' ORDER BY inode_id")
+        .columnList({"inode_id, checksum"})
+        .distinctOpt(false)
+        .orderByOpt("")
+        .countOpt(100))
+        .first(
+            QueryParameter::builder().rowFilter(" ")
+        .columnList({"inode_id"})
+        .distinctOpt(false)
+        .orderByOpt("inode_id ASC")
+        .countOpt(1))
+        .last(
+            QueryParameter::builder().rowFilter(" ")
+        .columnList({"inode_id"})
+        .distinctOpt(false)
+        .orderByOpt("inode_id DESC")
+        .countOpt(1))
+    };
+
+    EXPECT_NO_THROW(remoteSync->startSync(dbSync->handle(), startSyncConfig.config(), callbackData));
+
+    std::string buffer1{R"(test_id checksum_fail {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
+
+    ASSERT_NO_THROW(remoteSync->pushMessage({ buffer1.begin(), buffer1.end() }));
+
+    registerConfig.minimalSyncIntervalTime(0);
+    ASSERT_NO_THROW(remoteSync->registerSyncID("test_id", dbSync->handle(), registerConfig.config(), callbackData));
+
+    EXPECT_NO_THROW(remoteSync->startSync(dbSync->handle(), startSyncConfig.config(), callbackData));
+    remoteSync.reset();
+
+    EXPECT_EQ(messageCounter.load(), TOTAL_EXPECTED_MESSAGES);
+}
+
+TEST(RSyncBuilderRegisterConfigurationTest, TestExpectedHappyCase)
+{
+    auto registerConfig
+    {
+        RegisterConfiguration::builder().decoderType("JSON_RANGE")
+        .table("dbsync_osinfo")
+        .component("syscollector_osinfo")
+        .index("os_name")
+        .checksumField("checksum")
+        .noData(QueryParameter::builder().rowFilter("WHERE os_name BETWEEN '?' and '?' ORDER BY os_name")
+        .columnList({"*"})
+        .distinctOpt(false)
+        .orderByOpt(""))
+        .countRange(QueryParameter::builder().countFieldName("count")
+                    .rowFilter("WHERE os_name BETWEEN '?' and '?' ORDER BY os_name")
+        .columnList({"count(*) AS count "})
+        .distinctOpt(false)
+        .orderByOpt(""))
+        .rowData(QueryParameter::builder().rowFilter("WHERE os_name ='?'")
+        .columnList({"*"})
+        .distinctOpt(false)
+        .orderByOpt(""))
+        .rangeChecksum(QueryParameter::builder().rowFilter("WHERE os_name BETWEEN '?' and '?' ORDER BY os_name")
+        .columnList({"*"})
+        .distinctOpt(false)
+        .orderByOpt(""))
+    };
+
+    EXPECT_EQ(registerConfig.config().dump(),
+              R"({"checksum_field":"checksum","component":"syscollector_osinfo","count_range_query_json":{"column_list":["count(*) AS count "],"count_field_name":"count","distinct_opt":false,"order_by_opt":"","row_filter":"WHERE os_name BETWEEN '?' and '?' ORDER BY os_name"},"decoder_type":"JSON_RANGE","index":"os_name","no_data_query_json":{"column_list":["*"],"distinct_opt":false,"order_by_opt":"","row_filter":"WHERE os_name BETWEEN '?' and '?' ORDER BY os_name"},"range_checksum_query_json":{"column_list":["*"],"distinct_opt":false,"order_by_opt":"","row_filter":"WHERE os_name BETWEEN '?' and '?' ORDER BY os_name"},"row_data_query_json":{"column_list":["*"],"distinct_opt":false,"order_by_opt":"","row_filter":"WHERE os_name ='?'"},"table":"dbsync_osinfo"})");
+}
+
+TEST(RSyncBuilderStartSyncConfigurationTest, TestExpectedHappyCase)
+{
+    auto startSyncConfig
+    {
+        StartSyncConfiguration::builder().component("syscollector_osinfo")
+        .table("dbsync_osinfo")
+        .index("os_name")
+        .checksumField("checksum")
+        .lastEvent("last_event")
+        .rangeChecksum(QueryParameter::builder().rowFilter("WHERE os_name BETWEEN '?' and '?' ORDER BY os_name")
+        .columnList({"os_name", "checksum"})
+        .distinctOpt(false)
+        .orderByOpt("")
+        .countOpt(100))
+        .first(QueryParameter::builder().rowFilter(" ")
+        .columnList({"os_name"})
+        .distinctOpt(false)
+        .orderByOpt("os_name DESC")
+        .countOpt(1))
+        .last(QueryParameter::builder().rowFilter(" ")
+        .columnList({"os_name"})
+        .distinctOpt(false)
+        .orderByOpt("os_name ASC")
+        .countOpt(1))
+    };
+
+    EXPECT_EQ(startSyncConfig.config().dump(),
+              R"({"checksum_field":"checksum","component":"syscollector_osinfo","first_query":{"column_list":["os_name"],"count_opt":1,"distinct_opt":false,"order_by_opt":"os_name DESC","row_filter":" "},"index":"os_name","last_event":"last_event","last_query":{"column_list":["os_name"],"count_opt":1,"distinct_opt":false,"order_by_opt":"os_name ASC","row_filter":" "},"range_checksum_query_json":{"column_list":["os_name","checksum"],"count_opt":100,"distinct_opt":false,"order_by_opt":"","row_filter":"WHERE os_name BETWEEN '?' and '?' ORDER BY os_name"},"table":"dbsync_osinfo"})");
 }

--- a/src/shared_modules/rsync/testtool/agentEmulator.cpp
+++ b/src/shared_modules/rsync/testtool/agentEmulator.cpp
@@ -13,7 +13,7 @@
 #include <ctime>
 #include <cstdlib>
 #include "agentEmulator.h"
-
+#include "cjsonSmartDeleter.hpp"
 
 
 constexpr auto CREATE_STATEMENT { "CREATE TABLE data_values(`key` BIGINT, `data1` BIGINT, `data2` BIGINT, `data3` BIGINT, PRIMARY KEY (`key`)) WITHOUT ROWID;"};
@@ -33,27 +33,11 @@ static DBSYNC_HANDLE createDbsyncHandle(const std::string& dbName)
     return handle;
 }
 
-struct SmartDeleterJson final
-{
-    void operator()(cJSON* data)
-    {
-        cJSON_Delete(data);
-    }
-};
-
-struct CJsonDeleter final
-{
-    void operator()(char* json)
-    {
-        cJSON_free(json);
-    }
-};
-
 static void callback(const ReturnTypeCallback /*type*/,
                      const cJSON* /*json*/,
                      void* /*ctx*/)
 {
-    // const std::unique_ptr<char, CJsonDeleter> spJsonBytes{ cJSON_PrintUnformatted(json) };
+    // const std::unique_ptr<char, CJsonSmartFree> spJsonBytes{ cJSON_PrintUnformatted(json) };
     // std::cout << spJsonBytes.get() << std::endl;
 }
 
@@ -126,7 +110,7 @@ void AgentEmulator::updateData()
         {
             R"({"table":"data_values","data":[{"key":)" + key + R"(, "data1":)" + data1 + R"(, "data2":)" + data2 + R"(, "data3":)" + data3 + R"(}]})"
         };
-        const std::unique_ptr<cJSON, SmartDeleterJson> jsSync{ cJSON_Parse(dataToSync.c_str()) };
+        const std::unique_ptr<cJSON, CJsonSmartDeleter> jsSync{ cJSON_Parse(dataToSync.c_str()) };
         callback_data_t callbackData { callback, nullptr };
 
         dbsync_sync_row(m_dbSyncHandle, jsSync.get(), callbackData);

--- a/src/shared_modules/utils/cjsonSmartDeleter.hpp
+++ b/src/shared_modules/utils/cjsonSmartDeleter.hpp
@@ -1,0 +1,21 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015, Wazuh Inc.
+ * May 17, 2022.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _CJSON_SMART_DELETER_HPP
+#define _CJSON_SMART_DELETER_HPP
+
+#include "customDeleter.hpp"
+#include "cJSON.h"
+
+struct CJsonSmartFree final : CustomDeleter<decltype(&cJSON_free), cJSON_free> {};
+struct CJsonSmartDeleter final : CustomDeleter<decltype(&cJSON_Delete), cJSON_Delete> {};
+
+#endif // _CJSON_SMART_DELETER_HPP

--- a/src/shared_modules/utils/customDeleter.hpp
+++ b/src/shared_modules/utils/customDeleter.hpp
@@ -1,0 +1,25 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015, Wazuh Inc.
+ * May 17, 2022.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _CUSTOM_DELETER_HPP
+#define _CUSTOM_DELETER_HPP
+
+template <typename F, F func>
+struct CustomDeleter
+{
+    template <typename T>
+    constexpr void operator()(T* arg) const
+    {
+        func(arg);
+    }
+};
+
+#endif // _CUSTOM_DELETER_HPP

--- a/src/shared_modules/utils/msgDispatcher.h
+++ b/src/shared_modules/utils/msgDispatcher.h
@@ -39,17 +39,10 @@ namespace Utils
             // LCOV_EXCL_START
             ~MsgDispatcher() = default;
             // LCOV_EXCL_STOP
-            bool addCallback(const Key& key, const std::function<void(Value)>& callback)
+            void setCallback(const Key& key, const std::function<void(Value)>& callback)
             {
                 std::lock_guard<std::mutex> lock{ m_mutex };
-                const auto ret{ m_callbacks.find(key) == m_callbacks.end() };
-
-                if (ret)
-                {
-                    m_callbacks[key] = callback;
-                }
-
-                return ret;
+                m_callbacks[key] = callback;
             }
             void removeCallback(const Key& key)
             {

--- a/src/shared_modules/utils/singleton.hpp
+++ b/src/shared_modules/utils/singleton.hpp
@@ -1,0 +1,31 @@
+/*
+ * Wazuh Utils - Singleton template
+ * Copyright (C) 2015, Wazuh Inc.
+ * May 20, 2022.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _SINGLETON_HPP
+#define _SINGLETON_HPP
+
+template<typename T>
+class Singleton
+{
+    public:
+        static T& instance()
+        {
+            static T s_instance;
+            return s_instance;
+        }
+    protected:
+        Singleton() = default;
+        virtual ~Singleton() = default;
+        Singleton(const Singleton&) = delete;
+        Singleton& operator=(const Singleton&) = delete;
+};
+
+#endif // _SINGLETON_HPP

--- a/src/shared_modules/utils/tests/msgDispatcher_test.cpp
+++ b/src/shared_modules/utils/tests/msgDispatcher_test.cpp
@@ -32,7 +32,6 @@ void MsgDispatcherTest::SetUp() {};
 
 void MsgDispatcherTest::TearDown() {};
 
-using ::testing::_;
 using ::testing::Return;
 using namespace Utils;
 
@@ -58,11 +57,11 @@ TEST_F(MsgDispatcherTest, MsgDispatcherPushAndRundown)
     EXPECT_CALL(dispatcher, callback(decoded1.second)).Times(1);
     EXPECT_CALL(dispatcher, callback(decoded2.second)).Times(1);
     EXPECT_CALL(dispatcher, callback(decoded3.second)).Times(0);
-    EXPECT_TRUE(dispatcher.addCallback(key1, [&dispatcher](const Value & value)
+    EXPECT_NO_THROW(dispatcher.setCallback(key1, [&dispatcher](const Value & value)
     {
         dispatcher.callback(value);
     }));
-    EXPECT_TRUE(dispatcher.addCallback(key2, [&dispatcher](const Value & value)
+    EXPECT_NO_THROW(dispatcher.setCallback(key2, [&dispatcher](const Value & value)
     {
         dispatcher.callback(value);
     }));
@@ -99,11 +98,11 @@ TEST_F(MsgDispatcherTest, MsgDispatcherPushSync)
     EXPECT_CALL(dispatcher, callback(decoded1.second)).Times(1);
     EXPECT_CALL(dispatcher, callback(decoded2.second)).Times(1);
     EXPECT_CALL(dispatcher, callback(decoded3.second)).Times(0);
-    EXPECT_TRUE(dispatcher.addCallback(key1, [&dispatcher](const Value & value)
+    EXPECT_NO_THROW(dispatcher.setCallback(key1, [&dispatcher](const Value & value)
     {
         dispatcher.callback(value);
     }));
-    EXPECT_TRUE(dispatcher.addCallback(key2, [&dispatcher](const Value & value)
+    EXPECT_NO_THROW(dispatcher.setCallback(key2, [&dispatcher](const Value & value)
     {
         dispatcher.callback(value);
     }));
@@ -118,15 +117,15 @@ TEST_F(MsgDispatcherTest, MsgDispatcherAddCallbackTwice)
     const Key key1{100};
     const Key key2{200};
     TestMsgDispatcher dispatcher;
-    EXPECT_TRUE(dispatcher.addCallback(key1, [&dispatcher](const Value & value)
+    EXPECT_NO_THROW(dispatcher.setCallback(key1, [&dispatcher](const Value & value)
     {
         dispatcher.callback(value);
     }));
-    EXPECT_TRUE(dispatcher.addCallback(key2, [&dispatcher](const Value & value)
+    EXPECT_NO_THROW(dispatcher.setCallback(key2, [&dispatcher](const Value & value)
     {
         dispatcher.callback(value);
     }));
-    EXPECT_FALSE(dispatcher.addCallback(key2, [&dispatcher](const Value & value)
+    EXPECT_NO_THROW(dispatcher.setCallback(key2, [&dispatcher](const Value & value)
     {
         dispatcher.callback(value);
     }));
@@ -152,11 +151,11 @@ TEST_F(MsgDispatcherTest, MsgDispatcherRemoveCallback)
     EXPECT_CALL(dispatcher, callback(decoded1.second)).Times(1);
     EXPECT_CALL(dispatcher, callback(decoded2.second)).Times(1);
     EXPECT_CALL(dispatcher, callback(decoded3.second)).Times(0);
-    EXPECT_TRUE(dispatcher.addCallback(key1, [&dispatcher](const Value & value)
+    EXPECT_NO_THROW(dispatcher.setCallback(key1, [&dispatcher](const Value & value)
     {
         dispatcher.callback(value);
     }));
-    EXPECT_TRUE(dispatcher.addCallback(key2, [&dispatcher](const Value & value)
+    EXPECT_NO_THROW(dispatcher.setCallback(key2, [&dispatcher](const Value & value)
     {
         dispatcher.callback(value);
     }));

--- a/src/syscheckd/cppcheckSuppress.txt
+++ b/src/syscheckd/cppcheckSuppress.txt
@@ -1,5 +1,5 @@
-*:*src/syscheckd/src/db/src/file.cpp:78
-*:*src/syscheckd/src/db/src/file.cpp:392
+*:*src/syscheckd/src/db/src/file.cpp:88
+*:*src/syscheckd/src/db/src/file.cpp:378
 *:*src/db/testtool/action.h:378
 *:*src/syscheckd/src/db/src/db.cpp:100
 *:*src/syscheckd/src/create_db.c:859

--- a/src/syscheckd/cppcheckSuppress.txt
+++ b/src/syscheckd/cppcheckSuppress.txt
@@ -1,5 +1,5 @@
 *:*src/syscheckd/src/db/src/file.cpp:88
 *:*src/syscheckd/src/db/src/file.cpp:378
 *:*src/db/testtool/action.h:378
-*:*src/syscheckd/src/db/src/db.cpp:100
+*:*src/syscheckd/src/db/src/db.cpp:88
 *:*src/syscheckd/src/create_db.c:859

--- a/src/syscheckd/src/db/src/db.cpp
+++ b/src/syscheckd/src/db/src/db.cpp
@@ -21,19 +21,7 @@
 #include "dbRegistryValue.hpp"
 #include "fimDBSpecialization.h"
 #include "stringHelper.h"
-
-
-struct CJsonDeleter
-{
-    void operator()(char* json)
-    {
-        cJSON_free(json);
-    }
-    void operator()(cJSON* json)
-    {
-        cJSON_Delete(json);
-    }
-};
+#include "cjsonSmartDeleter.hpp"
 
 void DB::init(const int storage,
               const int syncInterval,
@@ -282,7 +270,7 @@ FIMDBErrorCode fim_sync_push_msg(const char* msg)
 
 TXN_HANDLE fim_db_transaction_start(const char* table, result_callback_t row_callback, void* user_data)
 {
-    const std::unique_ptr<cJSON, CJsonDeleter> jsInput
+    const std::unique_ptr<cJSON, CJsonSmartDeleter> jsInput
     {
         cJSON_Parse(table)
     };
@@ -319,7 +307,7 @@ FIMDBErrorCode fim_db_transaction_sync_row(TXN_HANDLE txn_handler, const fim_ent
             }
         }
 
-        const std::unique_ptr<cJSON, CJsonDeleter> jsInput
+        const std::unique_ptr<cJSON, CJsonSmartDeleter> jsInput
         {
             cJSON_Parse((*syncItem->toJSON()).dump().c_str())
         };
@@ -339,7 +327,7 @@ FIMDBErrorCode fim_db_transaction_deleted_rows(TXN_HANDLE txn_handler,
 {
     auto retval {FIMDB_OK};
     callback_data_t cb_data = { .callback = res_callback, .user_data = txn_ctx };
-    const std::unique_ptr<cJSON, CJsonDeleter> jsOptions
+    const std::unique_ptr<cJSON, CJsonSmartDeleter> jsOptions
     {
         cJSON_Parse(GetDeletedQuery::builder().allColumns().query().dump().c_str())
     };

--- a/src/syscheckd/src/db/src/file.cpp
+++ b/src/syscheckd/src/db/src/file.cpp
@@ -15,7 +15,7 @@
 #include "db.hpp"
 #include "fimDB.hpp"
 #include "dbFileItem.hpp"
-
+#include "cjsonSmartDeleter.hpp"
 
 static const char* FIM_EVENT_TYPE_ARRAY[] =
 {
@@ -38,20 +38,6 @@ enum SEARCH_FIELDS
     SEARCH_FIELD_INODE,
     SEARCH_FIELD_DEV
 };
-
-// LCOV_EXCL_START
-struct CJsonDeleter
-{
-    void operator()(char* json)
-    {
-        cJSON_free(json);
-    }
-    void operator()(cJSON* json)
-    {
-        cJSON_Delete(json);
-    }
-};
-// LCOV_EXCL_STOP
 
 nlohmann::json DB::createJsonEvent(const nlohmann::json& fileJson, const nlohmann::json& resultJson, ReturnTypeCallback type, create_json_event_ctx* ctx)
 {
@@ -591,7 +577,7 @@ FIMDBErrorCode fim_db_file_update(fim_entry* data, callback_context_t callback)
             create_json_event_ctx* ctx { reinterpret_cast<create_json_event_ctx*>(callback.context)};
             DB::instance().updateFile(*file->toJSON(), ctx, [callback](const nlohmann::json jsonResult)
             {
-                const std::unique_ptr<cJSON, CJsonDeleter> spJson{ cJSON_Parse(jsonResult.dump().c_str()) };
+                const std::unique_ptr<cJSON, CJsonSmartDeleter> spJson{ cJSON_Parse(jsonResult.dump().c_str()) };
                 callback.callback(spJson.get(), callback.context);
             });
             retVal = FIMDB_OK;


### PR DESCRIPTION
|Related issue|
|---|
|Closes #13500 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

During the development of FIM to implement DBSync and RSync, we have found a high CPU usage caused by synchronizations between manager and agent databases. This is because when there are a lot of entries in the DBs, and the synchronization interval is not large enough, the syncs start to overlap and increase the total duration, although in theory the synchronization could be carried out until the end correctly, this causes a very high CPU usage for a long time, here you can see the graphs and conclusions:
https://github.com/wazuh/wazuh/issues/10223#issuecomment-1127681266

With sync:
![with](https://user-images.githubusercontent.com/60003131/168612981-89e1a5cb-3dd5-4edc-9c3e-fc48b42dced0.png)

Without sync:
![without](https://user-images.githubusercontent.com/60003131/168613091-f89d1566-065f-43bd-806b-30bd3e9df77f.png)


For this, we have thought to add a waiting mechanism that blocks RSync until the synchronization messages between manager and agent are finished. Currently there is a similar mechanism to this in FIM synchronization, in master branch:
https://github.com/wazuh/wazuh/blob/5bad41699e4d502b2a6d1cdd47a418194a19957b/src/syscheckd/fim_sync.c#L54-L96