### PR TITLE
Let sshd-disconnect decoder match invalid user logoff logs

### DIFF
--- a/ruleset/decoders/0310-ssh_decoders.xml
+++ b/ruleset/decoders/0310-ssh_decoders.xml
@@ -228,9 +228,10 @@
 
 <!-- Dissconected from user -->
 <!-- 2020-03-24 08:38:47.230409-0700  localhost sshd[2531]: Disconnected from user user 172.18.1.100 port 43042 -->
+<!-- 2020-03-24 08:38:47.230409-0700  localhost sshd[2531]: Disconnected from invalid user root 172.18.1.100 port 43042 -->
 <decoder name="sshd-disconnect">
   <parent>sshd</parent>
-  <prematch>Disconnected from user </prematch>
+  <prematch type="pcre2">Disconnected from (invalid )?user </prematch>
   <regex offset="after_prematch">^(\S+) (\S+) port (\d+)</regex>
   <order>srcuser,srcip,srcport</order>
 </decoder>

--- a/ruleset/testing/tests/sshd.ini
+++ b/ruleset/testing/tests/sshd.ini
@@ -158,6 +158,12 @@ rule = 5761
 alert = 0
 decoder = sshd
 
+[SSHD Disconnected from invalid]
+log 2 pass = 2020-03-24 08:38:47.230409-0700  localhost sshd[2531]: Disconnected from invalid user root 172.18.1.100 port 43042
+rule = 5710
+alert = 5
+decoder = sshd
+
 [SSHD insecure connection attempt]
 log 1 pass = 2020-03-24 10:32:31.672920-0700  localhost sshd[5374]: Did not receive identification string from 172.18.1.1 port 45824
 rule = 5706


### PR DESCRIPTION
|Related issue|
|---|
|Fixes #13552|

As reported at #13552, the decoder `sshd-disconnect` does not match invalid user logoff messages:

### Input log

```
May 20 16:00:55 redacted sshd[356205]: Disconnected from invalid user root 43.142.19.58 port 57140 [preauth]
```

### Current result

```
**Phase 2: Completed decoding.
        name: 'sshd'
```

### Result after this fix

```
**Phase 2: Completed decoding.
        name: 'sshd'
        parent: 'sshd'
        srcip: '43.142.19.58'
        srcport: '57140'
        srcuser: 'root'
```

## Tests

- [x] Test this use case.
- [x] Add the new log to the Ruleset test suite.