### PR TITLE
Delete implications of cluster `disabled` option from framework code

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -8062,12 +8062,6 @@ paths:
                   properties:
                     data:
                       properties:
-                        enabled:
-                          description: "Whether the cluster is enabled in the Wazuh configuration"
-                          type: string
-                          enum:
-                          - "yes"
-                          - "no"
                         running:
                           description: "Whether the cluster daemon is running"
                           type: string
@@ -8076,7 +8070,6 @@ paths:
                           - "no"
               example:
                 data:
-                  enabled: "yes"
                   running: "yes"
                 error: 0
         '400':
@@ -8144,9 +8137,6 @@ paths:
                         hidden:
                           description: "Whether to hide the cluster information in the alerts"
                           type: string
-                        disabled:
-                          description: "Whether the cluster is enabled or not"
-                          type: boolean
               example:
                 data:
                   affected_items:
@@ -8159,7 +8149,6 @@ paths:
                       nodes:
                         - wazuh-master
                       hidden: no
-                      disabled: false
                   total_affected_items: 1
                   total_failed_items: 0
                   failed_items: []
@@ -8680,7 +8669,6 @@ paths:
                         nodes:
                           - "wazuh-master"
                         hidden: no
-                        disabled: no
                   total_affected_items: 1
                   total_failed_items: 0
                   failed_items: []

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -2008,7 +2008,6 @@ stages:
       error: !anyint
       data:
         bind_addr: !anystr
-        disabled: !anybool
         hidden: !anystr
         key: !anystr
         name: !anystr

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -26,7 +26,6 @@ stages:
               bind_addr: !anystr
               nodes: !anything
               hidden: !anystr
-              disabled: false
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
@@ -483,7 +482,6 @@ stages:
       json:
         error: 0
         data:
-          enabled: "yes"
           running: "yes"
 
 ---

--- a/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
@@ -24,7 +24,6 @@ stages:
               bind_addr: !anystr
               nodes: !anything
               hidden: !anystr
-              disabled: false
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
@@ -286,7 +285,6 @@ stages:
       json:
         error: !anyint
         data:
-          enabled: "yes"
           running: "yes"
 
 ---

--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -221,7 +221,7 @@ def main():
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.ERROR, format='%(levelname)s: %(message)s')
 
     cluster_status = wazuh.core.cluster.utils.get_cluster_status()
-    if cluster_status['enabled'] == 'no' or cluster_status['running'] == 'no':
+    if cluster_status['running'] == 'no':
         logging.error("Cluster is not running.")
         sys.exit(1)
 

--- a/framework/scripts/tests/test_cluster_control.py
+++ b/framework/scripts/tests/test_cluster_control.py
@@ -209,7 +209,7 @@ def test_usage(basename_mock, print_mock):
 @patch('argparse.ArgumentParser')
 @patch('wazuh.core.cluster.cluster.check_cluster_config')
 @patch('wazuh.core.cluster.utils.read_config', return_value='')
-@patch('wazuh.core.cluster.utils.get_cluster_status', return_value={'enabled': 'no', 'running': 'yes'})
+@patch('wazuh.core.cluster.utils.get_cluster_status', return_value={'running': 'no'})
 def test_main(get_cluster_status_mock, read_config_mock, check_cluster_config, parser_mock, logging_mock,
               logging_error_mock, asyncio_run_mock, exit_mock):
     """Test the main function."""
@@ -268,7 +268,7 @@ def test_main(get_cluster_status_mock, read_config_mock, check_cluster_config, p
         cluster_control.main()
         logging_error_mock.assert_has_calls([call('Cluster is not running.'), call('Wrong arguments.')])
         usage_mock.assert_called_once_with()
-        exit_mock.assert_called_with(1)
+        assert exit_mock.call_args_list[0] == call(1)
 
         exit_mock.reset_mock()
         read_config_mock.assert_called_once_with()
@@ -304,12 +304,12 @@ def test_main(get_cluster_status_mock, read_config_mock, check_cluster_config, p
                                              'help': 'Show usage', 'name': '--usage', 'nargs': None,  'type': None}]
 
         # Test the fifth condition
-        get_cluster_status_mock.return_value['enabled'] = 'yes'
+        get_cluster_status_mock.return_value['running'] = 'yes'
         args_mock.filter_status = False
         args_mock.usage = True
 
         cluster_control.main()
-        exit_mock.assert_called_with(0)
+        assert exit_mock.call_args_list[0] == call(0)
 
         # Test the first exception
         usage_mock.side_effect = KeyboardInterrupt()

--- a/framework/scripts/tests/test_wazuh_clusterd.py
+++ b/framework/scripts/tests/test_wazuh_clusterd.py
@@ -296,8 +296,7 @@ def test_main(print_mock, path_exists_mock, chown_mock, chmod_mock, setuid_mock,
     with patch.object(common, 'wazuh_uid', return_value='uid_test'):
         with patch.object(common, 'wazuh_gid', return_value='gid_test'):
 
-            with patch.object(wazuh_clusterd.cluster_utils, 'read_config',
-                              return_value={'disabled': False, 'node_type': 'master'}):
+            with patch.object(wazuh_clusterd.cluster_utils, 'read_config', return_value={'node_type': 'master'}):
                 with patch.object(wazuh_clusterd.main_logger, 'error') as main_logger_mock:
                     with patch.object(wazuh_clusterd.main_logger, 'info') as main_logger_info_mock:
                         with patch.object(wazuh_clusterd.cluster_utils, 'read_config', side_effect=Exception):
@@ -310,12 +309,6 @@ def test_main(print_mock, path_exists_mock, chown_mock, chmod_mock, setuid_mock,
                                                           'gid_test')
                             chmod_mock.assert_called_with(f'{common.WAZUH_PATH}/logs/cluster.log', 432)
                             exit_mock.assert_called_once_with(1)
-                            exit_mock.reset_mock()
-
-                        with patch.object(wazuh_clusterd.cluster_utils, 'read_config', return_value={'disabled': True}):
-                            with pytest.raises(SystemExit):
-                                wazuh_clusterd.main()
-                            exit_mock.assert_called_once_with(0)
                             exit_mock.reset_mock()
 
                         with patch('wazuh.core.cluster.cluster.check_cluster_config', side_effect=IndexError):

--- a/framework/scripts/tests/test_wazuh_clusterd.py
+++ b/framework/scripts/tests/test_wazuh_clusterd.py
@@ -295,8 +295,8 @@ def test_main(print_mock, path_exists_mock, chown_mock, chmod_mock, setuid_mock,
     wazuh_clusterd.cluster_utils = cluster_utils
     with patch.object(common, 'wazuh_uid', return_value='uid_test'):
         with patch.object(common, 'wazuh_gid', return_value='gid_test'):
-
-            with patch.object(wazuh_clusterd.cluster_utils, 'read_config', return_value={'node_type': 'master'}):
+            with patch.object(wazuh_clusterd.cluster_utils, 'read_config',
+                              return_value={'disabled': False, 'node_type': 'master'}):
                 with patch.object(wazuh_clusterd.main_logger, 'error') as main_logger_mock:
                     with patch.object(wazuh_clusterd.main_logger, 'info') as main_logger_info_mock:
                         with patch.object(wazuh_clusterd.cluster_utils, 'read_config', side_effect=Exception):
@@ -309,6 +309,12 @@ def test_main(print_mock, path_exists_mock, chown_mock, chmod_mock, setuid_mock,
                                                           'gid_test')
                             chmod_mock.assert_called_with(f'{common.WAZUH_PATH}/logs/cluster.log', 432)
                             exit_mock.assert_called_once_with(1)
+                            exit_mock.reset_mock()
+
+                        with patch.object(wazuh_clusterd.cluster_utils, 'read_config', return_value={'disabled': True}):
+                            with pytest.raises(SystemExit):
+                                wazuh_clusterd.main()
+                            exit_mock.assert_called_once_with(0)
                             exit_mock.reset_mock()
 
                         with patch('wazuh.core.cluster.cluster.check_cluster_config', side_effect=IndexError):

--- a/framework/scripts/wazuh_clusterd.py
+++ b/framework/scripts/wazuh_clusterd.py
@@ -159,8 +159,6 @@ def main():
         main_logger.error(e)
         sys.exit(1)
 
-    if cluster_configuration['disabled']:
-        sys.exit(0)
     try:
         wazuh.core.cluster.cluster.check_cluster_config(cluster_configuration)
     except Exception as e:

--- a/framework/scripts/wazuh_clusterd.py
+++ b/framework/scripts/wazuh_clusterd.py
@@ -159,6 +159,8 @@ def main():
         main_logger.error(e)
         sys.exit(1)
 
+    if cluster_configuration['disabled']:
+        sys.exit(0)
     try:
         wazuh.core.cluster.cluster.check_cluster_config(cluster_configuration)
     except Exception as e:

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -12,7 +12,6 @@ from wazuh.core.InputValidator import InputValidator
 from wazuh.core.agent import WazuhDBQueryAgents, WazuhDBQueryGroupByAgents, WazuhDBQueryMultigroups, Agent, \
     WazuhDBQueryGroup, get_agents_info, get_groups, core_upgrade_agents, get_rbac_filters, send_restart_command
 from wazuh.core.cluster.cluster import get_node
-from wazuh.core.cluster.utils import read_cluster_config
 from wazuh.core.exception import WazuhError, WazuhInternalError, WazuhException, WazuhResourceNotFound
 from wazuh.core.results import WazuhResult, AffectedItemsWazuhResult
 from wazuh.core.utils import chmod_r, chown_r, get_hash, mkdir_with_mode, md5, process_array, clear_temporary_caches, \
@@ -20,8 +19,7 @@ from wazuh.core.utils import chmod_r, chown_r, get_hash, mkdir_with_mode, md5, p
 from wazuh.core.wazuh_queue import WazuhQueue
 from wazuh.rbac.decorators import expose_resources
 
-cluster_enabled = not read_cluster_config(from_import=True)['disabled']
-node_id = get_node().get('node') if cluster_enabled else None
+node_id = get_node().get('node')
 
 # Error codes generated from upgrade socket error codes that should be excluded in upgrade functions
 # 1819 -> The WPK for this platform is not available

--- a/framework/wazuh/cluster.py
+++ b/framework/wazuh/cluster.py
@@ -5,13 +5,12 @@ from wazuh.core import common
 from wazuh.core.cluster import local_client
 from wazuh.core.cluster.cluster import get_node
 from wazuh.core.cluster.control import get_health, get_nodes
-from wazuh.core.cluster.utils import get_cluster_status, read_cluster_config, read_config
+from wazuh.core.cluster.utils import get_cluster_status, read_config
 from wazuh.core.exception import WazuhError, WazuhResourceNotFound
 from wazuh.core.results import AffectedItemsWazuhResult, WazuhResult
 from wazuh.rbac.decorators import expose_resources, async_list_handler
 
-cluster_enabled = not read_cluster_config(from_import=True)['disabled']
-node_id = get_node().get('node') if cluster_enabled else None
+node_id = get_node().get('node')
 
 
 @expose_resources(actions=['cluster:read'], resources=[f'node:id:{node_id}'])

--- a/framework/wazuh/core/active_response.py
+++ b/framework/wazuh/core/active_response.py
@@ -6,7 +6,6 @@ import json
 from wazuh.core import common
 from wazuh.core.agent import Agent
 from wazuh.core.cluster.cluster import get_node
-from wazuh.core.cluster.utils import read_cluster_config
 from wazuh.core.exception import WazuhError
 from wazuh.core.utils import WazuhVersion
 from wazuh.core.wazuh_queue import WazuhQueue
@@ -77,8 +76,7 @@ def create_json_message(command: str = '', arguments: list = None, alert: dict =
     if not command:
         raise WazuhError(1650)
 
-    cluster_enabled = not read_cluster_config()['disabled']
-    node_name = get_node().get('node') if cluster_enabled else None
+    node_name = get_node().get('node')
 
     msg_queue = json.dumps(
         create_wazuh_socket_message(origin={'name': node_name, 'module': common.origin_module.get()},

--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -102,17 +102,6 @@ def get_node():
     return data
 
 
-def check_cluster_status():
-    """Get whether cluster is enabled in current active configuration.
-
-    Returns
-    -------
-    bool
-        Whether cluster is enabled.
-    """
-    return not read_config()['disabled']
-
-
 #
 # Files
 #

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -27,7 +27,6 @@ from wazuh import agent
 from wazuh.cluster import get_node_wrapper, get_nodes_info
 from wazuh.core import common, exception
 from wazuh.core.cluster import local_client, common as c_common
-from wazuh.core.cluster.cluster import check_cluster_status
 from wazuh.core.exception import WazuhException, WazuhClusterError, WazuhError
 from wazuh.core.wazuh_socket import wazuh_sendsync
 
@@ -139,14 +138,13 @@ class DistributedAPI:
                 self.debug_log(f"Receiving parameters {self.f_kwargs}")
 
             is_dapi_enabled = self.cluster_items['distributed_api']['enabled']
-            is_cluster_disabled = self.node == local_client and not check_cluster_status()
 
             # First case: execute the request locally.
             # If the distributed api is not enabled
-            # If the cluster is disabled or the request type is local_any
+            # If the request type is local_any
             # if the request was made in the master node and the request type is local_master
             # if the request came forwarded from the master node and its type is distributed_master
-            if not is_dapi_enabled or is_cluster_disabled or self.request_type == 'local_any' or \
+            if not is_dapi_enabled or self.request_type == 'local_any' or \
                     (self.request_type == 'local_master' and self.node_info['type'] == 'master') or \
                     (self.request_type == 'distributed_master' and self.from_cluster):
 

--- a/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
@@ -114,15 +114,15 @@ def test_DistributedAPI_debug_log():
        new=AsyncMock(return_value=WazuhResult({'result': 'forward'})))
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.execute_remote_request',
        new=AsyncMock(return_value=WazuhResult({'result': 'remote'})))
-@pytest.mark.parametrize('api_request, request_type, node, expected, cluster_enabled, f_kwargs', [
-    (agent.get_agents_summary_status, 'local_master', 'master', 'local', True, None),
-    (agent.restart_agents, 'distributed_master', 'master', 'forward', True, None),
-    (cluster.get_node_wrapper, 'local_any', 'worker', 'local', True, 'token_nbf_time'),
-    (ciscat.get_ciscat_results, 'distributed_master', 'worker', 'remote', True, None),
-    (manager.status, 'local_master', 'worker', 'local', False, {'password': 'testing'}),
-    (manager.status, 'local_master', 'worker', 'local', False, None)
+@pytest.mark.parametrize('api_request, request_type, node, expected, f_kwargs', [
+    (agent.get_agents_summary_status, 'local_master', 'master', 'local', None),
+    (agent.restart_agents, 'distributed_master', 'master', 'forward', None),
+    (cluster.get_node_wrapper, 'local_any', 'worker', 'local', 'token_nbf_time'),
+    (ciscat.get_ciscat_results, 'distributed_master', 'worker', 'remote', None),
+    (manager.status, 'local_master', 'worker', 'remote', {'password': 'testing'}),
+    (manager.status, 'local_master', 'worker', 'remote', None)
 ])
-def test_DistributedAPI_distribute_function(api_request, request_type, node, expected, cluster_enabled, f_kwargs):
+def test_DistributedAPI_distribute_function(api_request, request_type, node, expected, f_kwargs):
     """Test distribute_function functionality with different test cases.
 
     Parameters
@@ -135,16 +135,13 @@ def test_DistributedAPI_distribute_function(api_request, request_type, node, exp
         Node type (Master and Workers).
     expected : str
         Expected result.
-    cluster_enabled : bool
-        Indicates whether cluster is enabled or not.
     """
 
-    # Mock check_cluster_status and get_node
-    with patch('wazuh.core.cluster.dapi.dapi.check_cluster_status', return_value=cluster_enabled):
-        with patch('wazuh.core.cluster.cluster.get_node', return_value={'type': node}):
-            dapi = DistributedAPI(f=api_request, logger=logger, request_type=request_type, f_kwargs=f_kwargs)
-            data = raise_if_exc(loop.run_until_complete(dapi.distribute_function()))
-            assert data.render()['result'] == expected
+    # Mock get_node
+    with patch('wazuh.core.cluster.cluster.get_node', return_value={'type': node}):
+        dapi = DistributedAPI(f=api_request, logger=logger, request_type=request_type, f_kwargs=f_kwargs)
+        data = raise_if_exc(loop.run_until_complete(dapi.distribute_function()))
+        assert data.render()['result'] == expected
 
 
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.execute_local_request',
@@ -321,9 +318,8 @@ def test_DistributedAPI_get_client(loop_mock):
 
 
 @patch('wazuh.core.cluster.cluster.get_node', return_value={'type': 'worker'})
-@patch('wazuh.core.cluster.dapi.dapi.check_cluster_status', return_value=True)
 @patch('wazuh.core.cluster.local_client.LocalClient.execute', return_value='invalid_json')
-def test_DistributedAPI_remote_request_errors(mock_client_execute, mock_check_cluster_status, mock_get_node):
+def test_DistributedAPI_remote_request_errors(mock_client_execute, mock_get_node):
     """Check the behaviour when the execute_remote_request function raised an error"""
     # Test execute_remote_request when it raises a JSONDecodeError
     dapi_kwargs = {'f': manager.status, 'logger': logger, 'request_type': 'local_master'}
@@ -338,11 +334,9 @@ def test_DistributedAPI_remote_request():
 
 
 @patch('wazuh.core.cluster.cluster.get_node', return_value={'type': 'master', 'node': 'master-node'})
-@patch('wazuh.core.cluster.dapi.dapi.check_cluster_status', return_value=True)
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.get_solver_node', return_value={'worker1': ['001', '002']})
 @patch('wazuh.core.cluster.local_client.LocalClient.execute', return_value='invalid_json')
-def test_DistributedAPI_forward_request_errors(mock_client_execute, mock_get_solver_node, mock_check_cluster_status,
-                                               mock_get_node):
+def test_DistributedAPI_forward_request_errors(mock_client_execute, mock_get_solver_node, mock_get_node):
     """Check the behaviour when the forward_request function raised an error"""
     # Test forward_request when it raises a JSONDecodeError
     dapi_kwargs = {'f': agent.reconnect_agents, 'logger': logger, 'request_type': 'distributed_master'}
@@ -369,8 +363,7 @@ def test_DistributedAPI_logger():
 @patch('wazuh.core.cluster.local_client.LocalClient.execute', new=AsyncMock(return_value='{"Testing": 1}'))
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.get_solver_node',
        new=AsyncMock(return_value=WazuhResult({'testing': ['001', '002']})))
-@patch('wazuh.core.cluster.dapi.dapi.check_cluster_status', return_value=True)
-def test_DistributedAPI_tmp_file(mock_cluster_status):
+def test_DistributedAPI_tmp_file():
     """Test the behaviour when processing temporal files to be send. Master node and unknown node."""
     open('/tmp/dapi_file.txt', 'a').close()
     with patch('wazuh.core.cluster.cluster.get_node', return_value={'type': 'master', 'node': 'unknown'}):
@@ -388,8 +381,7 @@ def test_DistributedAPI_tmp_file(mock_cluster_status):
 @patch('wazuh.core.cluster.local_client.LocalClient.send_file', new=AsyncMock(return_value='{"Testing": 1}'))
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.get_solver_node',
        new=AsyncMock(return_value=WazuhResult({'testing': ['001', '002']})))
-@patch('wazuh.core.cluster.dapi.dapi.check_cluster_status', return_value=True)
-def test_DistributedAPI_tmp_file_cluster_error(mock_cluster_status):
+def test_DistributedAPI_tmp_file_cluster_error():
     """Test the behaviour when an error raises with temporal files function."""
     open('/tmp/dapi_file.txt', 'a').close()
     with patch('wazuh.core.cluster.cluster.get_node', return_value={'type': 'master', 'node': 'unknown'}):
@@ -414,8 +406,7 @@ def test_DistributedAPI_tmp_file_cluster_error(mock_cluster_status):
 @patch('wazuh.agent.Agent.get_agents_overview', return_value={'items': [{'id': '001', 'node_name': 'master'},
                                                                         {'id': '002', 'node_name': 'master'},
                                                                         {'id': '003', 'node_name': 'unknown'}]})
-@patch('wazuh.core.cluster.dapi.dapi.check_cluster_status', return_value=True)
-def test_DistributedAPI_get_solver_node(mock_cluster_status, mock_agents_overview):
+def test_DistributedAPI_get_solver_node(mock_agents_overview):
     """Test `get_solver_node` function."""
     nodes_info_result = AffectedItemsWazuhResult()
     nodes_info_result.affected_items.append({'name': 'master'})

--- a/framework/wazuh/core/cluster/tests/test_cluster.py
+++ b/framework/wazuh/core/cluster/tests/test_cluster.py
@@ -106,11 +106,6 @@ def test_get_node():
         assert get_node["type"] == test_dict["node_type"]
 
 
-def test_check_cluster_status():
-    """Check the correct output of the check_cluster_status function."""
-    assert isinstance(cluster.check_cluster_status(), bool)
-
-
 @patch('os.path.getmtime', return_value=45)
 @patch('wazuh.core.cluster.cluster.blake2b', return_value="hash")
 @patch("wazuh.core.cluster.cluster.path.join", return_value="/mock/foo/bar")

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -16,7 +16,6 @@ with patch('wazuh.core.common.getgrnam'):
                 from wazuh.core.results import WazuhResult
 
 default_cluster_config = {
-    'disabled': True,
     'node_type': 'master',
     'name': 'wazuh',
     'node_name': 'node01',
@@ -50,21 +49,12 @@ def test_read_cluster_config():
     with patch('wazuh.core.cluster.utils.get_ossec_conf', return_value={'cluster': default_cluster_config}):
         utils.read_config.cache_clear()
         default_cluster_config.pop('hidden')
-        default_cluster_config['disabled'] = 'no'
         config = utils.read_cluster_config()
         config_simple = utils.read_config()
         assert config == config_simple
         assert config == default_cluster_config
 
         default_cluster_config['node_type'] = 'client'
-        config = utils.read_cluster_config()
-        assert config == default_cluster_config
-
-        default_cluster_config['disabled'] = 'None'
-        with pytest.raises(WazuhError, match='.* 3004 .*'):
-            utils.read_cluster_config()
-
-        default_cluster_config['disabled'] = 'yes'
         config = utils.read_cluster_config()
         assert config == default_cluster_config
 
@@ -145,11 +135,11 @@ def test_get_cluster_status():
     """Check if cluster is enabled and running. Also check that cluster is shown as not running when a
     WazuhInternalError is raised."""
     status = utils.get_cluster_status()
-    assert {'enabled': 'no', 'running': 'no'} == status
+    assert {'running': 'no'} == status
 
     with patch('wazuh.core.cluster.utils.get_manager_status', side_effect=WazuhInternalError(1913)):
         status = utils.get_cluster_status()
-        assert {'enabled': 'no', 'running': 'no'} == status
+        assert {'running': 'no'} == status
 
 
 def test_manager_restart():

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -32,7 +32,6 @@ def read_cluster_config(config_file=common.OSSEC_CONF, from_import=False) -> typ
 
     If some fields are missing in the ossec.conf cluster configuration, they are replaced
     with default values.
-    If there is no cluster configuration at all, the default configuration is marked as disabled.
 
     Parameters
     ----------
@@ -47,7 +46,6 @@ def read_cluster_config(config_file=common.OSSEC_CONF, from_import=False) -> typ
         Dictionary with cluster configuration.
     """
     cluster_default_configuration = {
-        'disabled': False,
         'node_type': 'master',
         'name': 'wazuh',
         'node_name': 'node01',
@@ -62,8 +60,7 @@ def read_cluster_config(config_file=common.OSSEC_CONF, from_import=False) -> typ
         config_cluster = get_ossec_conf(section='cluster', conf_file=config_file, from_import=from_import)['cluster']
     except WazuhException as e:
         if e.code == 1106:
-            # If no cluster configuration is present in ossec.conf, return default configuration but disabling it.
-            cluster_default_configuration['disabled'] = True
+            # If no cluster configuration is present in ossec.conf, return default configuration.
             return cluster_default_configuration
         else:
             raise WazuhError(3006, extra_message=e.message)
@@ -78,14 +75,6 @@ def read_cluster_config(config_file=common.OSSEC_CONF, from_import=False) -> typ
         raise WazuhError(3004, extra_message="Cluster port must be an integer.")
 
     config_cluster['port'] = int(config_cluster['port'])
-    if config_cluster['disabled'] == 'no':
-        config_cluster['disabled'] = False
-    elif config_cluster['disabled'] == 'yes':
-        config_cluster['disabled'] = True
-    elif not isinstance(config_cluster['disabled'], bool):
-        raise WazuhError(3004,
-                         extra_message=f"Allowed values for 'disabled' field are 'yes' and 'no'. "
-                                       f"Found: '{config_cluster['disabled']}'")
 
     if config_cluster['node_type'] == 'client':
         logger.info("Deprecated node type 'client'. Using 'worker' instead.")
@@ -152,11 +141,10 @@ def get_cluster_status() -> typing.Dict:
     dict
         Cluster status.
     """
-    cluster_status = {"enabled": "no" if read_cluster_config()['disabled'] else "yes"}
     try:
-        cluster_status |= {"running": "yes" if get_manager_status()['wazuh-clusterd'] == 'running' else "no"}
+        cluster_status = {"running": "yes" if get_manager_status()['wazuh-clusterd'] == 'running' else "no"}
     except WazuhInternalError:
-        cluster_status |= {"running": "no"}
+        cluster_status = {"running": "no"}
 
     return cluster_status
 

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -8,7 +8,7 @@ from os.path import exists
 from wazuh import Wazuh
 from wazuh.core import common, configuration
 from wazuh.core.cluster.cluster import get_node
-from wazuh.core.cluster.utils import manager_restart, read_cluster_config
+from wazuh.core.cluster.utils import manager_restart
 from wazuh.core.configuration import get_ossec_conf, write_ossec_conf
 from wazuh.core.exception import WazuhError
 from wazuh.core.manager import status, get_api_conf, get_ossec_logs, get_logs_summary, validate_ossec_conf
@@ -16,7 +16,7 @@ from wazuh.core.results import AffectedItemsWazuhResult
 from wazuh.core.utils import process_array, safe_move, validate_wazuh_xml, full_copy
 from wazuh.rbac.decorators import expose_resources
 
-cluster_enabled = not read_cluster_config(from_import=True)['disabled']
+cluster_enabled = True
 node_id = get_node().get('node') if cluster_enabled else 'manager'
 
 

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -11,7 +11,6 @@ import xmltodict
 import wazuh.core.configuration as configuration
 from wazuh.core import common
 from wazuh.core.cluster.cluster import get_node
-from wazuh.core.cluster.utils import read_cluster_config
 from wazuh.core.exception import WazuhError
 from wazuh.core.results import AffectedItemsWazuhResult
 from wazuh.core.rule import check_status, load_rules_from_file, format_rule_decoder_file, REQUIRED_FIELDS, \
@@ -20,8 +19,7 @@ from wazuh.core.utils import process_array, safe_move, validate_wazuh_xml, uploa
     to_relative_path
 from wazuh.rbac.decorators import expose_resources
 
-cluster_enabled = not read_cluster_config(from_import=True)['disabled']
-node_id = get_node().get('node') if cluster_enabled else 'manager'
+node_id = get_node().get('node')
 
 
 def get_rules(rule_ids=None, status=None, group=None, pci_dss=None, gpg13=None, gdpr=None, hipaa=None, nist_800_53=None,

--- a/framework/wazuh/stats.py
+++ b/framework/wazuh/stats.py
@@ -11,7 +11,7 @@ from wazuh.core.exception import WazuhException, WazuhResourceNotFound
 from wazuh.rbac.decorators import expose_resources
 
 cluster_enabled = True
-node_id = get_node().get('node')
+node_id = get_node().get('node') if cluster_enabled else None
 
 
 @expose_resources(actions=[f"{'cluster' if cluster_enabled else 'manager'}:read"],

--- a/framework/wazuh/stats.py
+++ b/framework/wazuh/stats.py
@@ -5,14 +5,13 @@
 
 from wazuh.core.agent import Agent, get_agents_info
 from wazuh.core.cluster.cluster import get_node
-from wazuh.core.cluster.utils import read_cluster_config
 from wazuh.core.results import AffectedItemsWazuhResult
 from wazuh.core.stats import get_daemons_stats_, hourly_, totals_, weekly_
 from wazuh.core.exception import WazuhException, WazuhResourceNotFound
 from wazuh.rbac.decorators import expose_resources
 
-cluster_enabled = not read_cluster_config(from_import=True)['disabled']
-node_id = get_node().get('node') if cluster_enabled else None
+cluster_enabled = True
+node_id = get_node().get('node')
 
 
 @expose_resources(actions=[f"{'cluster' if cluster_enabled else 'manager'}:read"],

--- a/framework/wazuh/task.py
+++ b/framework/wazuh/task.py
@@ -5,12 +5,9 @@
 import logging
 from typing import Dict
 
-from wazuh.core.cluster.cluster import get_node
-from wazuh.core.cluster.utils import read_cluster_config
 from wazuh.core.common import DATABASE_LIMIT
 from wazuh.core.results import AffectedItemsWazuhResult
 from wazuh.core.task import WazuhDBQueryTask
-from wazuh.core.utils import sort_array
 from wazuh.rbac.decorators import expose_resources
 
 logger = logging.getLogger('wazuh')

--- a/framework/wazuh/tests/test_cluster.py
+++ b/framework/wazuh/tests/test_cluster.py
@@ -19,8 +19,8 @@ with patch('wazuh.core.common.wazuh_uid'):
         from wazuh.core.cluster.local_client import LocalClient
         from wazuh.core.results import WazuhResult
 
-default_config = {'disabled': True, 'node_type': 'master', 'name': 'wazuh', 'node_name': 'node01',
-                  'key': '', 'port': 1516, 'bind_addr': '0.0.0.0', 'nodes': ['NODE_IP'], 'hidden': 'no'}
+default_config = {'node_type': 'master', 'name': 'wazuh', 'node_name': 'node01', 'key': '', 'port': 1516,
+                  'bind_addr': '0.0.0.0', 'nodes': ['NODE_IP'], 'hidden': 'no'}
 
 
 @patch('wazuh.cluster.read_config', return_value=default_config)
@@ -56,7 +56,7 @@ def test_node_wrapper_exception(mock_get_node):
 def test_get_status_json():
     """Verify that get_status_json returns the default status information."""
     result = cluster.get_status_json()
-    expected = WazuhResult({'data': {"enabled": "no" if default_config['disabled'] else "yes", "running": "no"}})
+    expected = WazuhResult({'data': {"running": "no"}})
     assert result == expected
 
 

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -184,7 +184,7 @@ def test_get_api_config():
     result = get_api_config().render()
 
     assert 'node_api_config' in result['data']['affected_items'][0], 'node_api_config key not found in result'
-    assert result['data']['affected_items'][0]['node_name'] == 'node01', 'Not expected node name'
+    assert result['data']['affected_items'][0]['node_name'] == 'manager', 'Not expected node name'
 
 
 @patch('socket.socket')

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -184,7 +184,7 @@ def test_get_api_config():
     result = get_api_config().render()
 
     assert 'node_api_config' in result['data']['affected_items'][0], 'node_api_config key not found in result'
-    assert result['data']['affected_items'][0]['node_name'] == 'manager', 'Not expected node name'
+    assert result['data']['affected_items'][0]['node_name'] == 'node01', 'Not expected node name'
 
 
 @patch('socket.socket')


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/13382 |


## Description

This pull request closes https://github.com/wazuh/wazuh/issues/13382.

I have removed all references to the `disabled` cluster configuration option in this PR. As it was said in the related epic issue, the Wazuh cluster will always be enabled by default so the framework implications are no longer needed.

I have also updated framework unit tests, API integration tests, and the API specification.

Note that modules like `stats`, `manager`, etc have hardcoded variables like the following:

```python
cluster_enabled = True
node_id = get_node().get('node')
```

I have done this as this part of the code will be refactored when solving the issue https://github.com/wazuh/wazuh/issues/13408. 

