### PR TITLE
Allow multiple 'bind_addr' to be used in cluster config

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -8147,7 +8147,7 @@ paths:
                       key: 9d273b53510fef702b54a92e9cffc82e
                       port: 1516
                       bind_addr:
-                        - 0.0.0.0
+                        - "0.0.0.0"
                       nodes:
                         - wazuh-master
                       hidden: no

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -8126,8 +8126,9 @@ paths:
                           description: "Port used by the **master** node to communicate with workers"
                           type: integer
                         bind_addr:
-                          description: "Network interface used by the **master** to listen to incoming connections"
-                          type: string
+                          description: "List of network interfaces used by the **master** to listen to incoming 
+                          connections"
+                          type: array
                         nodes:
                           description: "List of cluster master nodes. This list is used by **worker** nodes to connect
                           to the master"
@@ -8145,7 +8146,8 @@ paths:
                       node_type: master
                       key: 9d273b53510fef702b54a92e9cffc82e
                       port: 1516
-                      bind_addr: 0.0.0.0
+                      bind_addr:
+                        - 0.0.0.0
                       nodes:
                         - wazuh-master
                       hidden: no
@@ -8665,7 +8667,8 @@ paths:
                         node_type: "master"
                         key: "9d273b53510fef702b54a92e9cffc82e"
                         port: "1516"
-                        bind_addr: "0.0.0.0"
+                        bind_addr:
+                          - "0.0.0.0"
                         nodes:
                           - "wazuh-master"
                         hidden: no
@@ -9515,7 +9518,8 @@ paths:
                       node_type: "master"
                       key: "9d273b53510fef702b54a92e9cffc82e"
                       port: 1516
-                      bind_addr: "0.0.0.0"
+                      bind_addr:
+                        - "0.0.0.0"
                       nodes:
                         - "wazuh-master"
                       hidden: "no"

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -2007,7 +2007,8 @@ stages:
     json:
       error: !anyint
       data:
-        bind_addr: !anystr
+        bind_addr: !anything
+        disabled: !anybool
         hidden: !anystr
         key: !anystr
         name: !anystr

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -23,7 +23,7 @@ stages:
               node_type: !anystr
               key: !anystr
               port: !anyint
-              bind_addr: !anystr
+              bind_addr: !anything
               nodes: !anything
               hidden: !anystr
           failed_items: []

--- a/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
@@ -21,7 +21,7 @@ stages:
               node_type: !anystr
               key: !anystr
               port: !anyint
-              bind_addr: !anystr
+              bind_addr: !anything
               nodes: !anything
               hidden: !anystr
           failed_items: []

--- a/framework/scripts/wazuh_clusterd.py
+++ b/framework/scripts/wazuh_clusterd.py
@@ -166,6 +166,8 @@ def main():
     if args.test_config:
         sys.exit(0)
 
+    from wazuh.core import exception
+
     cluster_status = wazuh.core.cluster.utils.get_cluster_status()
     if cluster_status['running'] == 'yes':
         main_logger.error("Cluster is already running.", exc_info=False)
@@ -212,6 +214,8 @@ def main():
     except MemoryError:
         main_logger.error("Directory '/tmp' needs read, write & execution "
                           "permission for 'wazuh' user")
+    except exception.WazuhError as e:
+        main_logger.error(e)
     except Exception as e:
         main_logger.error(f"Unhandled exception: {e}")
     finally:

--- a/framework/wazuh/core/cluster/server.py
+++ b/framework/wazuh/core/cluster/server.py
@@ -536,10 +536,9 @@ class AbstractServer:
                 port=self.configuration['port'],
                 ssl=self.ssl_context)
         except OSError as e:
-            self.logger.error(f"Could not start master: {e}")
-            raise KeyboardInterrupt
+            raise exception.WazuhClusterError(3025, extra_message=e)
 
-        self.logger.info(f'Serving on {server.sockets[0].getsockname()}')
+        self.logger.info('Serving on ' + ', '.join([str(socket.getsockname()) for socket in server.sockets]) + '.')
         self.tasks.append(server.serve_forever)
 
         async with server:

--- a/framework/wazuh/core/cluster/tests/test_cluster.py
+++ b/framework/wazuh/core/cluster/tests/test_cluster.py
@@ -40,7 +40,7 @@ default_cluster_configuration = {
         'node_name': 'node01',
         'key': '',
         'port': 1516,
-        'bind_addr': '0.0.0.0',
+        'bind_addr': ['0.0.0.0'],
         'nodes': ['NODE_IP'],
         'hidden': 'no'
     }
@@ -54,7 +54,7 @@ custom_cluster_configuration = {
         'node_name': 'node01',
         'key': 'a' * 32,
         'port': 1516,
-        'bind_addr': '0.0.0.0',
+        'bind_addr': ['0.0.0.0'],
         'nodes': ['172.10.0.100'],
         'hidden': False
     }

--- a/framework/wazuh/core/cluster/tests/test_server.py
+++ b/framework/wazuh/core/cluster/tests/test_server.py
@@ -595,7 +595,7 @@ async def test_AbstractServer_start_ko(keepalive_mock, set_event_loop_policy_moc
     with patch("asyncio.get_running_loop", return_value=LoopMock()):
         with patch("logging.getLogger", return_value=logger):
             with patch.object(logger, "error") as mock_logger:
-                with pytest.raises(KeyboardInterrupt):
+                with pytest.raises(exception.WazuhClusterError, match=r'.* 3025 .*'):
                     abstract_server = AbstractServer(performance_test=1, concurrency_test=2,
                                                      configuration={"bind_addr": 3, "port": 10000},
                                                      cluster_items={"intervals":
@@ -605,4 +605,3 @@ async def test_AbstractServer_start_ko(keepalive_mock, set_event_loop_policy_moc
                                                                     },
                                                      logger=logger)
                     await abstract_server.start()
-                    mock_logger.assert_called_once_with("Could not start master: ")

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -25,7 +25,7 @@ default_cluster_config = {
     'password': None,
     'key': '',
     'port': 1516,
-    'bind_addr': '0.0.0.0',
+    'bind_addr': ['0.0.0.0'],
     'nodes': ['NODE_IP'],
     'hidden': 'no'
 }

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -56,7 +56,7 @@ def read_cluster_config(config_file=common.OSSEC_CONF, from_import=False) -> typ
         'password': None,
         'key': '',
         'port': 1516,
-        'bind_addr': '0.0.0.0',
+        'bind_addr': ['0.0.0.0'],
         'nodes': ['NODE_IP'],
         'hidden': 'no'
     }

--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -89,7 +89,7 @@ conf_sections = {
 
     'cluster': {
         'type': 'last',
-        'list_options': ['nodes']
+        'list_options': ['nodes', 'bind_addr']
     },
     'vulnerability-detector': {
         'type': 'merge',

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -411,6 +411,10 @@ class WazuhException(Exception):
                'remediation': 'Check the cluster.log located at WAZUH_HOME/logs/cluster.log file to see if there are '
                               'connection errors. Restart the `wazuh-manager` service.'},
         3024: "Length of command exceeds limit defined in wazuh.cluster.common.Handler.cmd_len.",
+        3025: {'message': "Could not start the server",
+               'remediation': "Ensure that the cluster configuration in the"
+                              f"[ossec.conf](https://documentation.wazuh.com/{DOCU_VERSION}/user-manual/reference/"
+                              f"ossec-conf/cluster.html) is correct."},
         3026: "Error sending request: Memory error. Request chunk size divided by 2.",
         3027: "Unknown received task name",
         3028: {'message': "Worker node ID already exists",

--- a/framework/wazuh/tests/test_cluster.py
+++ b/framework/wazuh/tests/test_cluster.py
@@ -19,8 +19,8 @@ with patch('wazuh.core.common.wazuh_uid'):
         from wazuh.core.cluster.local_client import LocalClient
         from wazuh.core.results import WazuhResult
 
-default_config = {'node_type': 'master', 'name': 'wazuh', 'node_name': 'node01', 'key': '', 'port': 1516,
-                  'bind_addr': '0.0.0.0', 'nodes': ['NODE_IP'], 'hidden': 'no'}
+default_config = {'disabled': True, 'node_type': 'master', 'name': 'wazuh', 'node_name': 'node01',
+                  'key': '', 'port': 1516, 'bind_addr': ['0.0.0.0'], 'nodes': ['NODE_IP'], 'hidden': 'no'}
 
 
 @patch('wazuh.cluster.read_config', return_value=default_config)

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -184,7 +184,7 @@ def test_get_api_config():
     result = get_api_config().render()
 
     assert 'node_api_config' in result['data']['affected_items'][0], 'node_api_config key not found in result'
-    assert result['data']['affected_items'][0]['node_name'] == 'manager', 'Not expected node name'
+    assert result['data']['affected_items'][0]['node_name'] == 'node01', 'Not expected node name'
 
 
 @patch('socket.socket')


### PR DESCRIPTION
|Related issue|
|---|
| Closes #13336 |

## Description
### Multiple binded addresses
This PR changes the [bind_addr](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/cluster.html#bind-addr) cluster option so now it can be specified multiple times with different values. 

Until now, a master node server could be binded to `0.0.0.0` (so connections in any interface would be accepted) or to a specific IP like `192.168.60.2/24` (so only those clients in the 192.168.60.x network could connect). After this change and as requested in #13336, a master node will be able to bind itself to multiple different interfaces but not all of them, if needed. Here there is an example configuration:
```XML
  <cluster>
    <name>wazuh</name>
        <node_name>master-node</node_name>
        <node_type>master</node_type>
        <key>9d273b53510fef702b54a92e9cffc82e</key>
        <port>1516</port>
        <bind_addr>172.19.0.4</bind_addr>
        <bind_addr>192.168.60.2</bind_addr>
        <nodes>
            <node>wazuh-master</node>
        </nodes>
        <hidden>no</hidden>
        <disabled>no</disabled>
     </cluster>
```
### Show all binded addresses
Now, a log showing all binded addresses is shown in the `cluster.log`:
```
2022/05/23 12:54:13 INFO: [Master] [Main] Serving on ('192.168.60.2', 1516), ('172.19.0.4', 1516).
```


### Fixed unhandled exception
I have noticed that when using an incorrect value (for example a malformed IP), a weird exception was raised despite being caught:
```
# /var/ossec/bin/wazuh-clusterd -f
2022/05/23 11:33:06 DEBUG: [Cluster] [Main] Removing '/var/ossec/queue/cluster/'.
2022/05/23 11:33:06 DEBUG: [Cluster] [Main] Removed '/var/ossec/queue/cluster/'.
Starting cluster in foreground (pid: 3391)
2022/05/23 11:33:06 INFO: [Local Server] [Main] Serving on /var/ossec/queue/cluster/c-internal.sock
2022/05/23 11:33:06 DEBUG: [Local Server] [Keep alive] Calculating.
2022/05/23 11:33:06 DEBUG: [Local Server] [Keep alive] Calculated.
2022/05/23 11:33:06 ERROR: [Master] [Main] Could not start master: [Errno -2] Name or service not known
2022/05/23 11:33:06 INFO: [Cluster] [Main] SIGINT received. Bye!
ERROR:root:  File "/var/ossec/framework/scripts/wazuh_clusterd.py", line 200, in main
    asyncio.run(main_function(args, cluster_configuration, cluster_items, main_logger))
Unhandled exception:  Task exception was never retrieved
  File "/var/ossec/framework/python/lib/python3.9/asyncio/runners.py", line 47, in run
    _cancel_all_tasks(loop)
Unhandled exception:  Task exception was never retrieved
  File "/var/ossec/framework/python/lib/python3.9/asyncio/runners.py", line 63, in _cancel_all_tasks
    loop.run_until_complete(
Unhandled exception:  Task exception was never retrieved
  File "/var/ossec/framework/python/lib/python3.9/asyncio/base_events.py", line 629, in run_until_complete
    self.run_forever()
Unhandled exception:  Task exception was never retrieved
  File "/var/ossec/framework/python/lib/python3.9/asyncio/base_events.py", line 596, in run_forever
    self._run_once()
Unhandled exception:  Task exception was never retrieved
  File "/var/ossec/framework/python/lib/python3.9/asyncio/base_events.py", line 1890, in _run_once
    handle._run()
Unhandled exception:  Task exception was never retrieved
  File "/var/ossec/framework/python/lib/python3.9/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
Unhandled exception:  Task exception was never retrieved
  File "/var/ossec/framework/scripts/wazuh_clusterd.py", line 67, in master_main
    await asyncio.gather(my_server.start(), my_local_server.start())
Unhandled exception:  Task exception was never retrieved
  File "/var/ossec/framework/python/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
Unhandled exception:  Task exception was never retrieved
  File "/var/ossec/framework/python/lib/python3.9/asyncio/base_events.py", line 629, in run_until_complete
    self.run_forever()
Unhandled exception:  Task exception was never retrieved
  File "/var/ossec/framework/python/lib/python3.9/asyncio/base_events.py", line 596, in run_forever
    self._run_once()
Unhandled exception:  Task exception was never retrieved
  File "/var/ossec/framework/python/lib/python3.9/asyncio/base_events.py", line 1890, in _run_once
    handle._run()
Unhandled exception:  Task exception was never retrieved
  File "/var/ossec/framework/python/lib/python3.9/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
Unhandled exception:  Task exception was never retrieved
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.5.0-py3.9.egg/wazuh/core/cluster/server.py", line 551, in start
    raise KeyboardInterrupt
```

I have fixed this so that a more concise message is displayed:
```
# /var/ossec/bin/wazuh-clusterd -f
2022/05/23 12:20:27 DEBUG: [Cluster] [Main] Removing '/var/ossec/queue/cluster/'.
2022/05/23 12:20:27 DEBUG: [Cluster] [Main] Removed '/var/ossec/queue/cluster/'.
Starting cluster in foreground (pid: 3645)
2022/05/23 12:20:27 INFO: [Local Server] [Main] Serving on /var/ossec/queue/cluster/c-internal.sock
2022/05/23 12:20:27 DEBUG: [Local Server] [Keep alive] Calculating.
2022/05/23 12:20:27 DEBUG: [Local Server] [Keep alive] Calculated.
2022/05/23 12:20:27 ERROR: [Cluster] [Main] Error 3025 - Could not start the server: [Errno 98] Address already in use
root@wazuh-master:/# 
```
