### PR TITLE
Truncate long strings while parsing XML

### DIFF
--- a/src/os_xml/os_xml.c
+++ b/src/os_xml/os_xml.c
@@ -27,9 +27,19 @@ static int _writememory(const char *str, XML_TYPE type, size_t size,
                         unsigned int parent, OS_XML *_lxml) __attribute__((nonnull));
 static int _xml_fgetc(FILE *fp, OS_XML *_lxml) __attribute__((nonnull));
 int _xml_sgetc(OS_XML *_lxml)  __attribute__((nonnull));
-static int _ReadElem(unsigned int parent, OS_XML *_lxml, unsigned int recursion_level, bool flag_truncate) __attribute__((nonnull));
 static int _getattributes(unsigned int parent, OS_XML *_lxml) __attribute__((nonnull));
 static void xml_error(OS_XML *_lxml, const char *msg, ...) __attribute__((format(printf, 2, 3), nonnull));
+
+/**
+ * @brief Recursive method to read XML elements.
+ *
+ * @param parent Current depth.
+ * @param _lxml XML structure.
+ * @param recursion_level Max recursion level allowed.
+ * @param flag_truncate If TRUE, truncates the content of a tag when it's bigger than XML_MAXSIZE. Fails if set to FALSE.
+ * @return int Returns 0, -1 or -2.
+ */
+static int _ReadElem(unsigned int parent, OS_XML *_lxml, unsigned int recursion_level, bool flag_truncate) __attribute__((nonnull));
 
 /* Local fgetc */
 static int _xml_fgetc(FILE *fp, OS_XML *_lxml)

--- a/src/os_xml/os_xml.c
+++ b/src/os_xml/os_xml.c
@@ -27,7 +27,7 @@ static int _writememory(const char *str, XML_TYPE type, size_t size,
                         unsigned int parent, OS_XML *_lxml) __attribute__((nonnull));
 static int _xml_fgetc(FILE *fp, OS_XML *_lxml) __attribute__((nonnull));
 int _xml_sgetc(OS_XML *_lxml)  __attribute__((nonnull));
-static int _ReadElem(unsigned int parent, OS_XML *_lxml, unsigned int recursion_level) __attribute__((nonnull));
+static int _ReadElem(unsigned int parent, OS_XML *_lxml, unsigned int recursion_level, bool flag_truncate) __attribute__((nonnull));
 static int _getattributes(unsigned int parent, OS_XML *_lxml) __attribute__((nonnull));
 static void xml_error(OS_XML *_lxml, const char *msg, ...) __attribute__((format(printf, 2, 3), nonnull));
 
@@ -128,7 +128,7 @@ void OS_ClearXML(OS_XML *_lxml)
     _lxml->stash_i = 0;
 }
 
-int ParseXML(OS_XML *_lxml, bool truncate_string){
+int ParseXML(OS_XML *_lxml, bool flag_truncate) {
     int r;
     unsigned int i;
     char *str_base = _lxml->string;
@@ -139,7 +139,7 @@ int ParseXML(OS_XML *_lxml, bool truncate_string){
     // Reset stash
     _lxml->stash_i = 0;
 
-    if ((r = _ReadElem(0, _lxml, 0)) < 0) { /* First position */
+    if ((r = _ReadElem(0, _lxml, 0, flag_truncate)) < 0) { /* First position */
         if (r != LEOF) {
 
             if(_lxml->fp){
@@ -175,19 +175,22 @@ int ParseXML(OS_XML *_lxml, bool truncate_string){
     return (0);
 }
 
-int OS_ReadXMLString(const char *string, OS_XML *_lxml){
+int OS_ReadXMLString_Ex(const char *string, OS_XML *_lxml, bool flag_truncate){
     /* Initialize xml structure */
     memset(_lxml, 0, sizeof(OS_XML));
 
     _lxml->string = strdup(string);
     _lxml->fp = NULL;
 
-    return ParseXML(_lxml, false);
+    return ParseXML(_lxml, flag_truncate);
 }
 
-/* Read na XML file and generate the necessary structs */
-int OS_ReadXML(const char *file, OS_XML *_lxml)
-{
+int OS_ReadXMLString(const char *string, OS_XML *_lxml){
+    return OS_ReadXMLString_Ex(string, _lxml, false);
+}
+
+/* Read a XML file and generate the necessary structs */
+int OS_ReadXML_Ex(const char *file, OS_XML *_lxml, bool flag_truncate) {
     FILE *fp;
 
     /* Initialize xml structure */
@@ -202,26 +205,11 @@ int OS_ReadXML(const char *file, OS_XML *_lxml)
     _lxml->fp = fp;
     _lxml->string = NULL;
 
-    return ParseXML(_lxml, false);
+    return ParseXML(_lxml, flag_truncate);
 }
 
-/* Read na XML file and generate the necessary structs */
-int OS_ReadXML_Ex(const char *file, OS_XML *_lxml) {
-    FILE *fp;
-
-    /* Initialize xml structure */
-    memset(_lxml, 0, sizeof(OS_XML));
-
-    fp = fopen(file, "r");
-    if (!fp) {
-        xml_error(_lxml, "XMLERR: File '%s' not found.", file);
-        return (-2);
-    }
-    w_file_cloexec(fp);
-    _lxml->fp = fp;
-    _lxml->string = NULL;
-
-    return ParseXML(_lxml, true);
+int OS_ReadXML(const char *file, OS_XML *_lxml) {
+    return OS_ReadXML_Ex(file, _lxml, false);
 }
 
 static int _oscomment(OS_XML *_lxml)
@@ -253,13 +241,14 @@ static int _oscomment(OS_XML *_lxml)
     return (0);
 }
 
-static int _ReadElem(unsigned int parent, OS_XML *_lxml, unsigned int recursion_level) {
+static int _ReadElem(unsigned int parent, OS_XML *_lxml, unsigned int recursion_level, bool flag_truncate) {
     int c=0;
     unsigned int count = 0;
     unsigned int _currentlycont = 0;
     short int location = -1;
     int cmp = 0;
     int retval = -1;
+    bool ignore_content = false;
 
     int prevv = 1;
     char *elem = NULL;
@@ -296,8 +285,12 @@ static int _ReadElem(unsigned int parent, OS_XML *_lxml, unsigned int recursion_
 
         /* Max size */
         if (count >= XML_MAXSIZE) {
-            xml_error(_lxml, "XMLERR: String overflow.");
-            goto end;
+            if (flag_truncate && 1 == location) {
+                ignore_content = true;
+            } else {
+                xml_error(_lxml, "XMLERR: String overflow.");
+                goto end;
+            }
         }
 
         /* Check for comments */
@@ -373,7 +366,7 @@ static int _ReadElem(unsigned int parent, OS_XML *_lxml, unsigned int recursion_
 
         else if ((location == 2) && (c == _R_CONFE)) {
             closedelim[count] = '\0';
-                if (strcmp(closedelim, elem) != 0) {
+            if (strcmp(closedelim, elem) != 0) {
                 xml_error(_lxml, "XMLERR: Element '%s' not closed.", elem);
                 goto end;
             }
@@ -396,11 +389,12 @@ static int _ReadElem(unsigned int parent, OS_XML *_lxml, unsigned int recursion_
                 cont[count] = '\0';
                 count = 0;
                 location = 2;
+                ignore_content = false;
             } else {
                 _xml_ungetc(c, _lxml);
                 _xml_ungetc(_R_CONFS, _lxml);
 
-                if (_ReadElem(parent + 1, _lxml, recursion_level) < 0) {
+                if (_ReadElem(parent + 1, _lxml, recursion_level, flag_truncate) < 0) {
                     goto end;
                 }
                 count = 0;
@@ -408,7 +402,7 @@ static int _ReadElem(unsigned int parent, OS_XML *_lxml, unsigned int recursion_
         } else {
             if (location == 0) {
                 elem[count++] = (char) c;
-            } else if (location == 1) {
+            } else if (location == 1 && !ignore_content) {
                 cont[count++] = (char) c;
             } else if (location == 2) {
                 closedelim[count++] = (char) c;

--- a/src/os_xml/os_xml.c
+++ b/src/os_xml/os_xml.c
@@ -128,7 +128,7 @@ void OS_ClearXML(OS_XML *_lxml)
     _lxml->stash_i = 0;
 }
 
-int ParseXML(OS_XML *_lxml){
+int ParseXML(OS_XML *_lxml, bool truncate_string){
     int r;
     unsigned int i;
     char *str_base = _lxml->string;
@@ -182,7 +182,7 @@ int OS_ReadXMLString(const char *string, OS_XML *_lxml){
     _lxml->string = strdup(string);
     _lxml->fp = NULL;
 
-    return ParseXML(_lxml);
+    return ParseXML(_lxml, false);
 }
 
 /* Read na XML file and generate the necessary structs */
@@ -202,7 +202,26 @@ int OS_ReadXML(const char *file, OS_XML *_lxml)
     _lxml->fp = fp;
     _lxml->string = NULL;
 
-    return ParseXML(_lxml);
+    return ParseXML(_lxml, false);
+}
+
+/* Read na XML file and generate the necessary structs */
+int OS_ReadXML_Ex(const char *file, OS_XML *_lxml) {
+    FILE *fp;
+
+    /* Initialize xml structure */
+    memset(_lxml, 0, sizeof(OS_XML));
+
+    fp = fopen(file, "r");
+    if (!fp) {
+        xml_error(_lxml, "XMLERR: File '%s' not found.", file);
+        return (-2);
+    }
+    w_file_cloexec(fp);
+    _lxml->fp = fp;
+    _lxml->string = NULL;
+
+    return ParseXML(_lxml, true);
 }
 
 static int _oscomment(OS_XML *_lxml)

--- a/src/os_xml/os_xml.h
+++ b/src/os_xml/os_xml.h
@@ -14,6 +14,7 @@
 #define OS_XML_H
 
 #include <stdio.h>
+#include <stdbool.h>
 
 /* XML Node structure */
 typedef struct _xml_node {
@@ -53,11 +54,14 @@ typedef xml_node **XML_NODE;
 /* Start the XML structure reading a file */
 int OS_ReadXML(const char *file, OS_XML *lxml) __attribute__((nonnull));
 
+/* Start the XML structure reading a file. Truncates long strings */
+int OS_ReadXML_Ex(const char *file, OS_XML *lxml) __attribute__((nonnull));
+
 /* Start the XML structure reading a string */
 int OS_ReadXMLString(const char *string, OS_XML *_lxml) __attribute__((nonnull));
 
 /* Parse the XML */
-int ParseXML(OS_XML *_lxml) __attribute__((nonnull));
+int ParseXML(OS_XML *_lxml, bool truncate_string) __attribute__((nonnull));
 
 /* Clear the XML structure memory */
 void OS_ClearXML(OS_XML *_lxml) __attribute__((nonnull));

--- a/src/os_xml/os_xml.h
+++ b/src/os_xml/os_xml.h
@@ -53,15 +53,17 @@ typedef xml_node **XML_NODE;
 
 /* Start the XML structure reading a file */
 int OS_ReadXML(const char *file, OS_XML *lxml) __attribute__((nonnull));
+int OS_ReadXML_Ex(const char *file, OS_XML *_lxml, bool flag_truncate) __attribute__((nonnull));
 
 /* Start the XML structure reading a file. Truncates long strings */
 int OS_ReadXML_Ex(const char *file, OS_XML *lxml) __attribute__((nonnull));
 
 /* Start the XML structure reading a string */
 int OS_ReadXMLString(const char *string, OS_XML *_lxml) __attribute__((nonnull));
+int OS_ReadXMLString_Ex(const char *string, OS_XML *_lxml, bool flag_truncate) __attribute__((nonnull));
 
 /* Parse the XML */
-int ParseXML(OS_XML *_lxml, bool truncate_string) __attribute__((nonnull));
+int ParseXML(OS_XML *_lxml, bool flag_truncate) __attribute__((nonnull));
 
 /* Clear the XML structure memory */
 void OS_ClearXML(OS_XML *_lxml) __attribute__((nonnull));

--- a/src/os_xml/os_xml.h
+++ b/src/os_xml/os_xml.h
@@ -53,10 +53,9 @@ typedef xml_node **XML_NODE;
 
 /* Start the XML structure reading a file */
 int OS_ReadXML(const char *file, OS_XML *lxml) __attribute__((nonnull));
-int OS_ReadXML_Ex(const char *file, OS_XML *_lxml, bool flag_truncate) __attribute__((nonnull));
 
 /* Start the XML structure reading a file. Truncates long strings */
-int OS_ReadXML_Ex(const char *file, OS_XML *lxml) __attribute__((nonnull));
+int OS_ReadXML_Ex(const char *file, OS_XML *_lxml, bool flag_truncate) __attribute__((nonnull));
 
 /* Start the XML structure reading a string */
 int OS_ReadXMLString(const char *string, OS_XML *_lxml) __attribute__((nonnull));

--- a/src/os_xml/os_xml.h
+++ b/src/os_xml/os_xml.h
@@ -51,17 +51,56 @@ typedef struct _OS_XML {
 
 typedef xml_node **XML_NODE;
 
-/* Start the XML structure reading a file */
+/**
+ * @brief Parses a XML file and stores the content in the OS_XML struct.
+ *        This legacy method will always fail if the content of a tag is bigger than XML_MAXSIZE.
+ *
+ * @param file The source file to read.
+ * @param lxml The struct to store the result.
+ * @return int OS_SUCCESS on success, OS_INVALID otherwise.
+ */
 int OS_ReadXML(const char *file, OS_XML *lxml) __attribute__((nonnull));
 
-/* Start the XML structure reading a file. Truncates long strings */
+/**
+ * @brief Parses a XML file and stores the content in the OS_XML struct.
+ *
+ * @param file The source file to read.
+ * @param lxml The struct to store the result.
+ * @param flag_truncate Toggles the behavior in case of the content of a tag is bigger than XML_MAXSIZE:
+ *                      truncate on TRUE or fail on FALSE.
+ * @return int OS_SUCCESS on success, OS_INVALID otherwise.
+ */
 int OS_ReadXML_Ex(const char *file, OS_XML *_lxml, bool flag_truncate) __attribute__((nonnull));
 
-/* Start the XML structure reading a string */
+/**
+ * @brief Parses a XML string and stores the content in the OS_XML struct.
+ *        This legacy method will always fail if the content of a tag is bigger than XML_MAXSIZE.
+ *
+ * @param string The source string to read.
+ * @param lxml The struct to store the result.
+ * @return int OS_SUCCESS on success, OS_INVALID otherwise.
+ */
 int OS_ReadXMLString(const char *string, OS_XML *_lxml) __attribute__((nonnull));
+
+/**
+ * @brief Parses a XML string and stores the content in the OS_XML struct.
+ *
+ * @param string The source string to read.
+ * @param lxml The struct to store the result.
+ * @param flag_truncate Toggles the behavior in case of the content of a tag is bigger than XML_MAXSIZE:
+ *                      truncate on TRUE or fail on FALSE.
+ * @return int OS_SUCCESS on success, OS_INVALID otherwise.
+ */
 int OS_ReadXMLString_Ex(const char *string, OS_XML *_lxml, bool flag_truncate) __attribute__((nonnull));
 
-/* Parse the XML */
+/**
+ * @brief Parses a XML string or file.
+ *
+ * @param _lxml The xml struct.
+ * @param flag_truncate Toggles the behavior in case of the content of a tag is bigger than XML_MAXSIZE:
+ *                      truncate on TRUE or fail on FALSE.
+ * @return int OS_SUCCESS on success, OS_INVALID otherwise.
+ */
 int ParseXML(OS_XML *_lxml, bool flag_truncate) __attribute__((nonnull));
 
 /* Clear the XML structure memory */

--- a/src/unit_tests/os_xml/test_os_xml.c
+++ b/src/unit_tests/os_xml/test_os_xml.c
@@ -421,11 +421,27 @@ void test_invalid_file(void **state) {
     assert_int_equal(data->xml.err_line, 0);
 }
 
-void test_unclosed_node(void **state) {
+void test_unclosed_node1(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     create_xml_file("<root>", data->xml_file_name, 256);
 
     assert_int_not_equal(OS_ReadXML(data->xml_file_name, &data->xml), 0);
+    assert_string_equal(data->xml.err, "XMLERR: End of file and some elements were not closed.");
+    assert_int_equal(data->xml.err_line, 1);
+}
+
+void test_unclosed_node2(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    char overflow_string[XML_MAXSIZE + 10];
+    memset(overflow_string, 'c', XML_MAXSIZE + 9);
+    overflow_string[XML_MAXSIZE + 9] = '\0';
+
+    char xml_string[2 * XML_MAXSIZE];
+    snprintf(xml_string, 2 * XML_MAXSIZE - 1, "<test>%s", overflow_string);
+    create_xml_file(xml_string, data->xml_file_name, 256);
+
+    assert_int_not_equal(OS_ReadXML_Ex(data->xml_file_name, &data->xml, true), 0);
     assert_string_equal(data->xml.err, "XMLERR: End of file and some elements were not closed.");
     assert_int_equal(data->xml.err_line, 1);
 }
@@ -879,7 +895,7 @@ void test_os_get_attributes(void **state) {
     assert_null(data->content5[2]);
 }
 
-void test_node_name_overflow(void **state) {
+void test_node_name_overflow1(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
 
     char overflow_string[XML_MAXSIZE + 10];
@@ -891,6 +907,22 @@ void test_node_name_overflow(void **state) {
     create_xml_file(xml_string, data->xml_file_name, 256);
 
     assert_int_not_equal(OS_ReadXML(data->xml_file_name, &data->xml), 0);
+    assert_string_equal(data->xml.err, "XMLERR: String overflow.");
+    assert_int_equal(data->xml.err_line, 1);
+}
+
+void test_node_name_overflow2(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    char overflow_string[XML_MAXSIZE + 10];
+    memset(overflow_string, 'c', XML_MAXSIZE + 9);
+    overflow_string[XML_MAXSIZE + 9] = '\0';
+
+    char xml_string[2 * XML_MAXSIZE];
+    snprintf(xml_string, 2 * XML_MAXSIZE - 1, "<%s/>", overflow_string);
+    create_xml_file(xml_string, data->xml_file_name, 256);
+
+    assert_int_not_equal(OS_ReadXML_Ex(data->xml_file_name, &data->xml, true), 0);
     assert_string_equal(data->xml.err, "XMLERR: String overflow.");
     assert_int_equal(data->xml.err_line, 1);
 }
@@ -926,7 +958,7 @@ void test_node_value_truncate_overflow(void **state) {
 
     assert_int_equal(OS_ReadXML_Ex(data->xml_file_name, &data->xml, true), 0);
     assert_non_null(data->content5 = OS_GetContents(&data->xml, xml_path));
-    assert_string_equal(data->content5[0], overflow_string+10);
+    assert_string_equal(data->content5[0], overflow_string+9);
 }
 
 void test_node_attribute_name_overflow(void **state) {
@@ -1055,7 +1087,10 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_invalid_file, test_setup, test_teardown),
 
         // Unclosed node XML test
-        cmocka_unit_test_setup_teardown(test_unclosed_node, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_unclosed_node1, test_setup, test_teardown),
+
+        // Unclosed node XML test when truncate flag is set
+        cmocka_unit_test_setup_teardown(test_unclosed_node2, test_setup, test_teardown),
 
         // Unclosed second node XML test
         cmocka_unit_test_setup_teardown(test_unclosed_second_node, test_setup, test_teardown),
@@ -1158,7 +1193,10 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_os_get_attributes, test_setup, test_teardown),
 
         // Node name inside XML overflow test
-        cmocka_unit_test_setup_teardown(test_node_name_overflow, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_node_name_overflow1, test_setup, test_teardown),
+
+        // Node name inside XML overflow test. Node name is never truncated
+        cmocka_unit_test_setup_teardown(test_node_name_overflow2, test_setup, test_teardown),
 
         // Node value inside XML overflow test
         cmocka_unit_test_setup_teardown(test_node_value_overflow, test_setup, test_teardown),

--- a/src/unit_tests/os_xml/test_os_xml.c
+++ b/src/unit_tests/os_xml/test_os_xml.c
@@ -924,7 +924,7 @@ void test_node_value_truncate_overflow(void **state) {
 
     const char *xml_path[] = { "test", NULL };
 
-    assert_int_equal(OS_ReadXML_Ex(data->xml_file_name, &data->xml), 0);
+    assert_int_equal(OS_ReadXML_Ex(data->xml_file_name, &data->xml, true), 0);
     assert_non_null(data->content5 = OS_GetContents(&data->xml, xml_path));
     assert_string_equal(data->content5[0], overflow_string+10);
 }

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
@@ -40,7 +40,7 @@ list(APPEND vulndetector_flags "-Wl,--wrap,_merror -Wl,--wrap,_mterror -Wl,--wra
                                 -Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 -Wl,--wrap,time -Wl,--wrap,wstr_end -Wl,--wrap=fgetc \
                                 -Wl,--wrap,json_fread -Wl,--wrap,remove -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,wurl_request -Wl,--wrap,sleep \
                                 -Wl,--wrap,sqlite3_open_v2 -Wl,--wrap,fgets -Wl,--wrap,fwrite -Wl,--wrap,localtime -Wl,--wrap,OS_GetOneContentforElement \
-                                -Wl,--wrap,OS_ReadXML -Wl,--wrap,OS_GetElementsbyNode -Wl,--wrap,OSRegex_Compile -Wl,--wrap,OSRegex_Execute \
+                                -Wl,--wrap,OS_ReadXML -Wl,--wrap,OS_ReadXML_Ex -Wl,--wrap,OS_GetElementsbyNode -Wl,--wrap,OSRegex_Compile -Wl,--wrap,OSRegex_Execute \
                                 -Wl,--wrap,w_get_file_content -Wl,--wrap,wm_vuldet_json_nvd_parser -Wl,--wrap,wm_vuldet_json_wcpe_parser \
                                 -Wl,--wrap,wm_vuldet_json_msu_parser -Wl,--wrap,opendir -Wl,--wrap,closedir -Wl,--wrap,readdir -Wl,--wrap,w_is_file \
                                 -Wl,--wrap,fflush -Wl,--wrap,fprintf -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,getpid \

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/mocks_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/mocks_wm_vuln_detector.c
@@ -45,6 +45,11 @@ int __wrap_OS_ReadXML(__attribute__ ((__unused__)) const char *file,
     return mock();
 }
 
+int __wrap_OS_ReadXML_Ex(__attribute__ ((__unused__)) const char *file,
+                      __attribute__ ((__unused__)) OS_XML *_lxml) {
+    return mock();
+}
+
 char* __wrap_OS_GetOneContentforElement(__attribute__ ((__unused__)) OS_XML *_lxml,
                                         __attribute__ ((__unused__)) const char **element_name) {
     return mock_type(char *);

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/mocks_wm_vuln_detector.h
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/mocks_wm_vuln_detector.h
@@ -28,6 +28,8 @@ int __wrap_w_uncompress_bz2_gz_file(const char * path, const char * dest);
 
 int __wrap_OS_ReadXML(const char *file, OS_XML *_lxml);
 
+int __wrap_OS_ReadXML_Ex(const char *file, OS_XML *_lxml);
+
 char* __wrap_OS_GetOneContentforElement(OS_XML *_lxml, const char **element_name);
 
 void __wrap_OS_ClearXML(OS_XML *_lxml);

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -12141,7 +12141,7 @@ void test_wm_vuldet_oval_process_xml_preparser_ReadXML_fail_Ubuntu(void **state)
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5412): Starting parse step of feed 'UBUNTU'");
 
-    will_return(__wrap_OS_ReadXML, -1);
+    will_return(__wrap_OS_ReadXML_Ex, -1);
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5502): Could not load the CVE OVAL for 'UBUNTU'. ''");
@@ -12213,7 +12213,7 @@ void test_wm_vuldet_oval_process_xml_preparser_ReadXML_fail_Debian(void **state)
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5412): Starting parse step of feed 'DEBIAN'");
 
-    will_return(__wrap_OS_ReadXML, -1);
+    will_return(__wrap_OS_ReadXML_Ex, -1);
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5502): Could not load the CVE OVAL for 'DEBIAN'. ''");
@@ -12287,7 +12287,7 @@ void test_wm_vuldet_oval_process_xml_preparser_node_NULL_Ubuntu(void **state)
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5412): Starting parse step of feed 'UBUNTU'");
 
-    will_return(__wrap_OS_ReadXML, 1);
+    will_return(__wrap_OS_ReadXML_Ex, 1);
 
     will_return(__wrap_OS_GetElementsbyNode, node);
 
@@ -12360,7 +12360,7 @@ void test_wm_vuldet_oval_process_xml_preparser_node_NULL_Debian(void **state)
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5412): Starting parse step of feed 'DEBIAN'");
 
-    will_return(__wrap_OS_ReadXML, 1);
+    will_return(__wrap_OS_ReadXML_Ex, 1);
 
     will_return(__wrap_OS_GetElementsbyNode, node);
 
@@ -12436,7 +12436,7 @@ void test_wm_vuldet_oval_process_xml_preparser_child_node_NULL_Ubuntu(void **sta
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5412): Starting parse step of feed 'UBUNTU'");
 
-    will_return(__wrap_OS_ReadXML, 1);
+    will_return(__wrap_OS_ReadXML_Ex, 1);
 
     will_return(__wrap_OS_GetElementsbyNode, node);
 
@@ -12514,7 +12514,7 @@ void test_wm_vuldet_oval_process_xml_preparser_child_node_NULL_Debian(void **sta
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5412): Starting parse step of feed 'DEBIAN'");
 
-    will_return(__wrap_OS_ReadXML, 1);
+    will_return(__wrap_OS_ReadXML_Ex, 1);
 
     will_return(__wrap_OS_GetElementsbyNode, node);
 
@@ -12597,7 +12597,7 @@ void test_wm_vuldet_oval_process_oval_xml_parser_invalid_Ubuntu(void **state)
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5412): Starting parse step of feed 'UBUNTU'");
 
-    will_return(__wrap_OS_ReadXML, 1);
+    will_return(__wrap_OS_ReadXML_Ex, 1);
 
     will_return(__wrap_OS_GetElementsbyNode, node);
 
@@ -12686,7 +12686,7 @@ void test_wm_vuldet_oval_process_oval_xml_parser_invalid_Debian(void **state)
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5412): Starting parse step of feed 'DEBIAN'");
 
-    will_return(__wrap_OS_ReadXML, 1);
+    will_return(__wrap_OS_ReadXML_Ex, 1);
 
     will_return(__wrap_OS_GetElementsbyNode, node);
 
@@ -12779,7 +12779,7 @@ void test_wm_vuldet_oval_process_OK_Ubuntu(void **state)
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5412): Starting parse step of feed 'UBUNTU'");
 
-    will_return(__wrap_OS_ReadXML, 1);
+    will_return(__wrap_OS_ReadXML_Ex, 1);
 
     will_return(__wrap_OS_GetElementsbyNode, node);
 
@@ -12866,7 +12866,7 @@ void test_wm_vuldet_oval_process_OK_Debian(void **state)
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5412): Starting parse step of feed 'DEBIAN'");
 
-    will_return(__wrap_OS_ReadXML, 1);
+    will_return(__wrap_OS_ReadXML_Ex, 1);
 
     will_return(__wrap_OS_GetElementsbyNode, node);
 

--- a/src/unit_tests/wrappers/wazuh/os_xml/os_xml_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/os_xml/os_xml_wrappers.h
@@ -19,5 +19,6 @@ xml_node ** __wrap_OS_GetElementsbyNode(const OS_XML * _lxml, const xml_node * n
 void __wrap_OS_ClearNode(xml_node ** node);
 void __wrap_OS_ClearXML(OS_XML * _lxml) __attribute__((nonnull));
 int __wrap_OS_ReadXML(const char * file, OS_XML * lxml) __attribute__((nonnull));
+int __wrap_OS_ReadXML_Ex(const char * file, OS_XML * lxml) __attribute__((nonnull));
 
 #endif

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4098,7 +4098,7 @@ int wm_vuldet_oval_process(update_node *update, char *path, wm_vuldet_db *parsed
     }
 
     mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_UPDATE_PAR, vu_feed_tag[update->dist_tag_ref]);
-    if (OS_ReadXML_Ex(tmp_file, &xml) < 0) {
+    if (OS_ReadXML_Ex(tmp_file, &xml, true) < 0) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_LOAD_CVE_ERROR, vu_feed_tag[update->dist_tag_ref], xml.err);
         goto free_mem;
     }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4098,7 +4098,7 @@ int wm_vuldet_oval_process(update_node *update, char *path, wm_vuldet_db *parsed
     }
 
     mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_UPDATE_PAR, vu_feed_tag[update->dist_tag_ref]);
-    if (OS_ReadXML(tmp_file, &xml) < 0) {
+    if (OS_ReadXML_Ex(tmp_file, &xml) < 0) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_LOAD_CVE_ERROR, vu_feed_tag[update->dist_tag_ref], xml.err);
         goto free_mem;
     }


### PR DESCRIPTION
|Related issue|
|---|
|#13556|

## Description

This PR implements the changes to fix a string overflow error while parsing the information in the OVAL file for Ubuntu Bionic. 
Any string as part of the content of the file will be truncated to 20480 characters.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Source upgrade
- [X] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report

<!-- Checks for huge PRs that affect the product more generally -->
- [X] Added unit tests (for new features)