### PR TITLE
Add detection rules generated from APT emulation exercises

### DIFF
--- a/ruleset/rules/0595-win-sysmon_rules.xml
+++ b/ruleset/rules/0595-win-sysmon_rules.xml
@@ -46,7 +46,7 @@
   <rule id="61604" level="0">
     <if_sid>61600</if_sid>
     <field name="win.system.eventID">^2$</field>
-    <description>Sysmon - Event 2: A process changed a file creation time by $(win.eventdata.sourceImage)</description>
+    <description>Sysmon - Event 2: $(win.eventdata.sourceImage) changed file $(win.eventdata.targetFilename) creation time </description>
     <options>no_full_log</options>
     <group>sysmon_event2,</group>
   </rule>
@@ -54,7 +54,7 @@
   <rule id="61605" level="0">
     <if_sid>61600</if_sid>
     <field name="win.system.eventID">^3$</field>
-    <description>Sysmon - Event 3: Network connection by $(win.eventdata.sourceImage)</description>
+    <description>Sysmon - Event 3: Network connection to $(win.eventdata.destinationIp):$(win.eventdata.destinationPort) by $(win.eventdata.image)</description>
     <options>no_full_log</options>
     <group>sysmon_event3,</group>
   </rule>
@@ -62,7 +62,7 @@
   <rule id="61606" level="0">
     <if_sid>61600</if_sid>
     <field name="win.system.eventID">^4$</field>
-    <description>Sysmon - Event 4: Sysmon service state changed by $(win.eventdata.sourceImage)</description>
+    <description>Sysmon - Event 4: Sysmon service state changed to "$(win.eventdata.state)"</description>
     <options>no_full_log</options>
     <group>sysmon_event4,</group>
   </rule>
@@ -70,7 +70,7 @@
   <rule id="61607" level="0">
     <if_sid>61600</if_sid>
     <field name="win.system.eventID">^5$</field>
-    <description>Sysmon - Event 5: Process terminated by $(win.eventdata.sourceImage)</description>
+    <description>Sysmon - Event 5: Process terminated $(win.eventdata.image)</description>
     <options>no_full_log</options>
     <group>sysmon_event5,</group>
   </rule>
@@ -78,7 +78,7 @@
   <rule id="61608" level="0">
     <if_sid>61600</if_sid>
     <field name="win.system.eventID">^6$</field>
-    <description>Sysmon - Event 6: Driver loaded by $(win.eventdata.sourceImage)</description>
+    <description>Sysmon - Event 6: Driver loaded $(win.eventdata.imageLoaded)</description>
     <options>no_full_log</options>
     <group>sysmon_event6,</group>
   </rule>
@@ -86,7 +86,7 @@
   <rule id="61609" level="0">
     <if_sid>61600</if_sid>
     <field name="win.system.eventID">^7$</field>
-    <description>Sysmon - Event 7: Image loaded by $(win.eventdata.sourceImage)</description>
+    <description>Sysmon - Event 7: Image $(win.eventdata.imageLoaded) loaded by $(win.eventdata.image)</description>
     <options>no_full_log</options>
     <group>sysmon_event7,</group>
   </rule>
@@ -94,7 +94,7 @@
   <rule id="61610" level="0">
     <if_sid>61600</if_sid>
     <field name="win.system.eventID">^8$</field>
-    <description>Sysmon - Event 8: CreateRemoteThread by $(win.eventdata.sourceImage)</description>
+    <description>Sysmon - Event 8: CreateRemoteThread by $(win.eventdata.sourceImage) on $(win.eventdata.targetImage), possible process injection</description>
     <options>no_full_log</options>
     <group>sysmon_event8,</group>
   </rule>
@@ -110,7 +110,7 @@
   <rule id="61612" level="0">
     <if_sid>61600</if_sid>
     <field name="win.system.eventID">^10$</field>
-    <description>Sysmon - Event 10: ProcessAccess by $(win.eventdata.sourceImage)</description>
+    <description>Sysmon - Event 10: $(win.eventdata.targetImage) process accessed by $(win.eventdata.sourceImage)</description>
     <options>no_full_log</options>
     <group>sysmon_event_10,</group>
   </rule>
@@ -118,7 +118,7 @@
   <rule id="61613" level="0">
     <if_sid>61600</if_sid>
     <field name="win.system.eventID">^11$</field>
-    <description>Sysmon - Event 11: FileCreate by $(win.eventdata.sourceImage)</description>
+    <description>Sysmon - Event 11: FileCreate by $(win.eventdata.image)</description>
     <options>no_full_log</options>
     <group>sysmon_event_11,</group>
   </rule>
@@ -126,7 +126,7 @@
   <rule id="61614" level="0">
     <if_sid>61600</if_sid>
     <field name="win.system.eventID">^12$</field>
-    <description>Sysmon - Event 12: RegistryEvent (Object create and delete) by $(win.eventdata.sourceImage)</description>
+    <description>Sysmon - Event 12: RegistryEvent $(win.eventdata.eventType) on $(win.eventdata.targetObject) by $(win.eventdata.image)</description>
     <options>no_full_log</options>
     <group>sysmon_event_12,</group>
   </rule>
@@ -134,7 +134,7 @@
   <rule id="61615" level="0">
     <if_sid>61600</if_sid>
     <field name="win.system.eventID">^13$</field>
-    <description>Sysmon - Event 13: RegistryEvent (Value Set) by $(win.eventdata.sourceImage)</description>
+    <description>Sysmon - Event 13: RegistryEvent $(win.eventdata.eventType) on $(win.eventdata.targetObject) by $(win.eventdata.image)</description>
     <options>no_full_log</options>
     <group>sysmon_event_13,</group>
   </rule>
@@ -142,7 +142,7 @@
   <rule id="61616" level="0">
     <if_sid>61600</if_sid>
     <field name="win.system.eventID">^14$</field>
-    <description>Sysmon - Event 14: RegistryEvent (Key and Value Rename) by $(win.eventdata.sourceImage)</description>
+    <description>Sysmon - Event 14: RegistryEvent (Key and Value Rename) by $(win.eventdata.image)</description>
     <options>no_full_log</options>
     <group>sysmon_event_14,</group>
   </rule>
@@ -150,10 +150,98 @@
   <rule id="61617" level="0">
     <if_sid>61600</if_sid>
     <field name="win.system.eventID">^15$</field>
-    <description>Sysmon - Event 15: FileCreateStreamHash by $(win.eventdata.sourceImage)</description>
+    <description>Sysmon - Event 15: $(win.eventdata.targetFilename) FileCreateStreamHash by process $(win.eventdata.image)</description>
     <options>no_full_log</options>
     <group>sysmon_event_15,</group>
   </rule>
+
+  <rule id="61644" level="0">
+    <if_sid>61600</if_sid>
+    <field name="win.system.eventID">^16$</field>
+    <description>Sysmon - Event 16: Sysmon configuration changed using file $(win.eventdata.configuration)</description>
+    <group>sysmon_event_16,</group>
+  </rule>
+
+  <rule id="61645" level="0">
+    <if_sid>61600</if_sid>
+    <field name="win.system.eventID">^17$</field>
+    <description>Sysmon - Event 17: Pipe created</description>
+    <options>no_full_log</options>
+    <group>sysmon_event_17,</group>
+  </rule>
+
+  <rule id="61646" level="0">
+    <if_sid>61600</if_sid>
+    <field name="win.system.eventID">^18$</field>
+    <description>Sysmon - Event 18: Pipe connected</description>
+    <options>no_full_log</options>
+    <group>sysmon_event_18,</group>
+  </rule>
+
+  <rule id="61647" level="0">
+    <if_sid>61600</if_sid>
+    <field name="win.system.eventID">^19$</field>
+    <description>Sysmon - Event 19: WmiEventFilter activity</description>
+    <options>no_full_log</options>
+    <group>sysmon_event_19,</group>
+  </rule>
+
+  <rule id="61648" level="0">
+    <if_sid>61600</if_sid>
+    <field name="win.system.eventID">^20$</field>
+    <description>Sysmon - Event 20: WmiEventConsumer activity</description>
+    <options>no_full_log</options>
+    <group>sysmon_event_20,</group>
+  </rule>
+
+  <rule id="61649" level="0">
+    <if_sid>61600</if_sid>
+    <field name="win.system.eventID">^21$</field>
+    <description>Sysmon - Event 21: WmiEventConsumerToFilter activity</description>
+    <options>no_full_log</options>
+    <group>sysmon_event_21,</group>
+  </rule>
+
+  <rule id="61650" level="0">
+    <if_sid>61600</if_sid>
+    <field name="win.system.eventID">^22$</field>
+    <description>Sysmon - Event 22: DNS Query event</description>
+    <options>no_full_log</options>
+    <group>sysmon_event_22,</group>
+  </rule>
+
+  <rule id="61651" level="0">
+    <if_sid>61600</if_sid>
+    <field name="win.system.eventID">^23$</field>
+    <description>Sysmon - Event 23: File deleted and archived</description>
+    <options>no_full_log</options>
+    <group>sysmon_event_23,</group>
+  </rule>
+
+  <rule id="61652" level="0">
+    <if_sid>61600</if_sid>
+    <field name="win.system.eventID">^24$</field>
+    <description>Sysmon - Event 24: Clipboard change</description>
+    <options>no_full_log</options>
+    <group>sysmon_event_24,</group>
+  </rule>
+
+  <rule id="61653" level="0">
+    <if_sid>61600</if_sid>
+    <field name="win.system.eventID">^25$</field>
+    <description>Sysmon - Event 25: Process tampering - Image change</description>
+    <options>no_full_log</options>
+    <group>sysmon_event_25,</group>
+  </rule>
+
+  <rule id="61654" level="0">
+    <if_sid>61600</if_sid>
+    <field name="win.system.eventID">^26$</field>
+    <description>Sysmon - Event 26: File deleted</description>
+    <options>no_full_log</options>
+    <group>sysmon_event_26,</group>
+  </rule>
+
 </group>
 
 <group name="windows,sysmon,sysmon_process-anomalies,">

--- a/ruleset/rules/0800-sysmon_id_1.xml
+++ b/ruleset/rules/0800-sysmon_id_1.xml
@@ -1,8 +1,8 @@
 <!--
-  -  Copyright (C) 2015, Wazuh Inc.
+  Copyright (C) 2015, Wazuh Inc.
 -->
 
-<!-- 
+<!--
   Sysmon Event ID 1 rules: 92000 - 92100
 -->
 
@@ -213,7 +213,7 @@
     <field name="win.eventdata.commandLine" type="pcre2">(?i)(Remove-Item|ri|rm|rmdir|del|erase|rd)\b</field>
     <description>Powershell was used to delete files or directories.</description>
     <mitre>
-      <id>T107.004</id>
+      <id>T1070.004</id>
     </mitre>
   </rule>
 
@@ -226,7 +226,7 @@
       <id>T1033</id>
     </mitre>
   </rule>
-  
+
   <rule id="92023" level="8">
     <if_group>sysmon_event1</if_group>
     <field name="win.eventdata.originalFileName" type="pcre2">(?i)PowerShell.EXE</field>
@@ -248,13 +248,506 @@
     </mitre>
   </rule>
 
-  <rule id="92025" level="14">
+  <rule id="92025" level="0">
     <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.originalFileName" type="pcre2">(?i)reg.EXE</field>
+    <description>Reg.exe execution</description>
+    <mitre>
+      <id>T1112</id>
+      <id>T1012</id>
+    </mitre>
+  </rule>
+
+  <rule id="92026" level="14">
+    <if_sid>92025</if_sid>
     <field name="win.eventdata.originalFileName" type="pcre2">(?i)reg.EXE</field>
     <field name="win.eventdata.commandLine" type="pcre2">(?i)save.+\\\\SAM</field>
     <description>Reg.exe used to dump SAM hive.</description>
     <mitre>
       <id>T1003.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="92027" level="4">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.image" type="pcre2">\\powershell\.exe</field>
+    <field name="win.eventdata.parentImage" type="pcre2">(?i)\\powershell\.exe</field>
+    <description>Powershell process spawned powershell instance</description>
+    <mitre>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="92028" level="0">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)\.ps1</field>
+    <field name="win.eventdata.originalFileName" type="pcre2">(?i)powershell\.exe$</field>
+    <description>Powershell executed script</description>
+    <mitre>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="92029" level="6">
+    <if_sid>92028</if_sid>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)[c-z]:\\\\(Windows\\\\Temp|Users)\\.+\.(bat|cmd|lnk|pif|vbs|vbe|js|wsh|ps1)</field>
+    <description>Powershell executed script from suspicious location</description>
+    <mitre>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="92030" level="3">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.originalFileName" type="pcre2">qwinsta</field>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)\/server</field>
+    <description>Gathered user information from Remote Desktop Service sessions</description>
+    <mitre>
+      <id>T1033</id>
+    </mitre>
+  </rule>
+
+  <rule id="92031" level="3">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.originalFileName" type="pcre2">(?i)(net\.EXE|net1\.EXE)</field>
+    <description>Discovery activity executed.</description>
+    <mitre>
+      <id>T1087</id>
+    </mitre>
+  </rule>
+
+  <rule id="92032" level="3">
+    <if_sid>92031, 61603</if_sid>
+    <field name="win.eventdata.parentImage" type="pcre2">(?i)cmd\.EXE</field>
+    <field name="win.eventdata.parentCommandLine" type="pcre2">(?i)\s\/C\s</field>
+    <description>Suspicious Windows cmd shell execution</description>
+    <mitre>
+      <id>T1087</id>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="92033" level="3">
+    <if_sid>92031</if_sid>
+    <field name="win.eventdata.parentImage" type="pcre2">(?i)powershell\.EXE</field>
+    <description>Discovery activity spawned via powershell execution</description>
+    <mitre>
+      <id>T1087</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="92034" level="3">
+    <if_sid>92032</if_sid>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)view</field>
+    <description>Discovery activity spawned via cmd shell execution</description>
+    <mitre>
+      <id>T1135</id>
+    </mitre>
+  </rule>
+
+  <rule id="92035" level="3">
+    <if_sid>92034</if_sid>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)domain</field>
+    <description>A net.exe domain discovery command was executed</description>
+    <mitre>
+      <id>T1135</id>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="92036" level="3">
+    <if_sid>92032</if_sid>
+    <list field="win.eventdata.originalFileName" lookup="match_key">etc/lists/uncommon-cmd-opened-process</list>
+    <description>A $(win.eventdata.image) binary was started by a Windows cmd shell.</description>
+    <mitre>
+      <id>T1059.003</id>
+      <id>T1574.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="92037" level="3">
+    <if_sid>92031, 92033</if_sid>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)use\s</field>
+    <description>A net.exe connection to a remote resource was started by $(win.eventdata.parentImage).</description>
+    <mitre>
+      <id>T1567</id>
+    </mitre>
+  </rule>
+
+  <rule id="92038" level="12">
+    <if_sid>92037</if_sid>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)(live|outlook|google|drive|microsoft|dropbox)</field>
+    <description>A connection to cloud resource was started by $(win.eventdata.parentImage).</description>
+    <mitre>
+      <id>T1102</id>
+      <id>T1567.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="92039" level="3">
+    <if_sid>92031</if_sid>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)user\s</field>
+    <description>A net.exe account discovery command was initiated.</description>
+    <mitre>
+      <id>T1087</id>
+    </mitre>
+  </rule>
+
+  <rule id="92040" level="12">
+    <if_sid>92039</if_sid>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)add\s</field>
+    <description>$(win.eventdata.originalFileName) executed a user creation command.</description>
+    <mitre>
+      <id>T1136.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="92041" level="10">
+    <if_sid>92025</if_sid>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)add.+\/d\s+(")?(?:[A-Za-z\d+\/]{4})*(?:[A-Za-z\d+\/]{3}=|[A-Za-z\d+\/]{2}==)?</field>
+    <description>Value added to registry key has Base64-like pattern</description>
+    <mitre>
+      <id>T1027</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="92042" level="0">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.originalFileName" type="pcre2">(?i)netsh.EXE</field>
+    <description>Netsh command invoked</description>
+  </rule>
+
+  <rule id="92043" level="10">
+    <if_sid>92042</if_sid>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)advfirewall|firewall</field>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)add\srule</field>
+    <description>Netsh used to add firewall rule</description>
+    <mitre>
+      <id>T1562.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="92044" level="14">
+    <if_sid>92043</if_sid>
+    <field name="win.eventdata.commandLine" type="pcre2">localport=5900</field>
+    <description>Netsh used to add firewall rule referencing port 5900, usually used for VNC</description>
+    <mitre>
+      <id>T1562.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="92045" level="14">
+    <if_sid>92025</if_sid>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)IMPORT\s+[C-Z]:\\\\Users\\\\Public\\\\.+\.reg</field>
+    <description>Reg.exe modified registry using .reg file in suspicious location</description>
+    <mitre>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="92046" level="12">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.originalFileName" type="pcre2">(?i)(cmd|powershell|rundll32)\.EXE</field>
+    <field name="win.eventdata.parentImage" type="pcre2">(?i)fodhelper\.EXE</field>
+    <description>Possible use of fodhelper.exe used to bypass UAC and execute of malicious software</description>
+    <mitre>
+      <id>T1548.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="92047" level="12">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.originalFileName" type="pcre2">(?i)mshta\.EXE</field>
+    <field name="win.eventdata.parentImage" type="pcre2">(?i)(winword|excel|powerpnt)\.EXE</field>
+    <description>Office application started mshta.exe</description>
+    <mitre>
+      <id>T1218.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="92048" level="15">
+    <if_sid>92047</if_sid>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)(vbscript|javascript)</field>
+    <description>Office application started mshta.exe and executed scripting command</description>
+    <mitre>
+      <id>T1218.005</id>
+      <id>T1059</id>
+    </mitre>
+  </rule>
+
+  <rule id="92049" level="12">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)verclsid.exe\s+/S\s+/C\s+\{</field>
+    <description>Verclsid.exe may have been used to execute COM payload</description>
+    <mitre>
+      <id>T1218.012</id>
+    </mitre>
+  </rule>
+
+  <rule id="92050" level="12">
+    <if_sid>92049</if_sid>
+    <field name="win.eventdata.parentImage" type="pcre2">(?i)(winword|excel|powerpnt)\.EXE</field>
+    <description>Office application invoked Verclsid.exe, possible COM payload execution</description>
+    <mitre>
+      <id>T1218.012</id>
+      <id>T1559.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="92051" level="12">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.originalFileName" type="pcre2">(?i)wscript\.exe</field>
+    <field name="win.eventdata.image" type="pcre2" negate="yes">(?i)wscript\.exe</field>
+    <description>Executed a renamed copy of wscript.exe</description>
+    <mitre>
+      <id>T1036.003</id>
+      <id>T1059.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="92052" level="4">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.originalFileName" type="pcre2">(?i)cmd\.EXE</field>
+    <field name="win.eventdata.parentImage" type="pcre2" negate="yes">(?i)(explorer|cmd)\.EXE</field>
+    <description>Windows command prompt started by an abnormal process</description>
+    <mitre>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="92053" level="12">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.parentCommandLine" type="pcre2">(?i)\s\/b\s\/e\:jscript</field>
+    <description>Detected a suspicious process launched with a jscript engine signature</description>
+    <mitre>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="92054" level="14">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.parentCommandLine" type="pcre2">(?i)svchost.exe -k netsvcs -p</field>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)appdata\\\\.+\.exe.+\.js$</field>
+    <description>Suspicious execution of .js file by $(win.eventdata.image)</description>
+    <mitre>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="92055" level="12">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.originalFileName" type="pcre2">(?i)(ComputerDefaults|fodhelper)\.EXE</field>
+    <description>Known auto-elevated utility $(win.eventdata.originalFileName) may have been used to bypass UAC</description>
+    <mitre>
+      <id>T1548.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="92056" level="14">
+    <if_sid>92055</if_sid>
+    <field name="win.eventdata.parentCommandLine" type="pcre2">(?i)powershell\.EXE</field>
+    <description>Powershell process invoked known auto-elevated utility $(win.eventdata.originalFileName), may have been used to bypass UAC</description>
+    <mitre>
+      <id>T1548.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="92057" level="12">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.parentImage" type="pcre2">(?i)powershell\.exe</field>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)powershell\.exe.+\-\b(encodedcommand|e|ea|ec|encodeda|encode|en|enco)\b</field>
+    <description>Powershell.exe spawned a powershell process which executed a base64 encoded command.</description>
+    <mitre>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="92058" level="12">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.originalFileName" type="pcre2">(?i)sdbinst\.EXE</field>
+    <description>Application Compatibility Database launched.</description>
+    <mitre>
+      <id>T1546.011</id>
+    </mitre>
+  </rule>
+
+  <rule id="92059" level="14">
+    <if_sid>92058</if_sid>
+    <field name="win.eventdata.parentCommandLine" type="pcre2">(?i)powershell\.exe.+\-(encodedcommand|e|ea|ec|encodeda|encode|en|enco)</field>
+    <description>Possible Shimming. Application Compatibility Database launched from an encoded powershell command.</description>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1546.011</id>
+    </mitre>
+  </rule>
+
+  <rule id="92060" level="15">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.parentImage" type="pcre2">(*UTF)\N{U+202E}</field>
+    <description>Suspicious process (right to left override character) spawned a subprocess</description>
+    <mitre>
+      <id>T1036.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="92061" level="3">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.originalFileName" type="pcre2">(?i)sdclt\.exe</field>
+    <field name="win.eventdata.parentImage" type="pcre2">(?i)(cmd\.exe|powershell\.exe)</field>
+    <field name="win.eventdata.integrityLevel" type="pcre2">(?i)(medium|high)</field>
+    <description>Windows backup and restore tool $(win.eventdata.originalFileName) launched via $(win.eventdata.parentImage) with $(win.eventdata.integrityLevel) integrity level.</description>
+    <mitre>
+      <id>T1548</id>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="92062" level="14">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.parentImage" type="pcre2">(?i)control\.exe</field>
+    <field name="win.eventdata.integrityLevel" type="pcre2">(?i)high</field>
+    <field name="win.eventdata.image" type="pcre2">(?i)powershell\.exe</field>
+    <description>Powershell launched with a $(win.eventdata.integrityLevel) integrity level by $(win.eventdata.parentImage).</description>
+    <mitre>
+      <id>T1548</id>
+      <id>T1548.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="92063" level="6">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.originalFileName" type="pcre2">(?i)sdelete\.exe</field>
+    <description>File deletion by $(win.eventdata.originalFileName). Command: $(win.eventdata.commandLine)</description>
+    <mitre>
+      <id>T1070.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="92064" level="15">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.image" type="pcre2">(*UTF)\N{U+202E}</field>
+    <description>Executed suspicious process with right to left override character in binary file, possible malicious file masquerading</description>
+    <mitre>
+      <id>T1036.002</id>
+      <id>T1204.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="92065" level="6">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.parentImage" type="pcre2">(?i)Windows\\\\Temp.+\.(exe|dll)</field>
+    <field name="win.eventdata.originalFileName" type="pcre2">(?i)PowerShell\.exe</field>
+    <description>Powershell.exe launched by binary $(win.eventdata.parentImage) in a suspicious location.</description>
+    <mitre>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="92066" level="4">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.parentImage" type="pcre2">(?i)powershell.exe</field>
+    <field name="win.eventdata.image" type="pcre2">(?i)Windows\\\\(SysWOW64|Temp).+\.exe</field>
+    <description>$(win.eventdata.image) binary in a suspicious location launched by $(win.eventdata.parentImage).</description>
+    <mitre>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="92067" level="6">
+    <if_sid>92066</if_sid>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)\.(zip|7z|rar)</field>
+    <description>$(win.eventdata.image) launched by $(win.eventdata.parentImage) executed a compressed file creation command.</description>
+    <mitre>
+      <id>T1560.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="92068" level="3">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.parentCommandLine" type="pcre2">(?i)PSEXESVC\.exe</field>
+    <description>PSEXEC was used to execute: $(win.eventdata.commandLine)</description>
+    <mitre>
+      <id>T1569.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="92069" level="0">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.parentImage" type="pcre2">(?i)WmiPrvSE\.exe</field>
+    <description>Windows management instrumentation started a process</description>
+    <mitre>
+      <id>T1047</id>
+    </mitre>
+  </rule>
+
+  <rule id="92070" level="6">
+    <if_sid>92069</if_sid>
+    <field name="win.eventdata.originalFileName" type="pcre2">(?i)PowerShell\.EXE</field>
+    <description>Windows management instrumentation (WMI) created a powershell process</description>
+    <mitre>
+      <id>T1047</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="92071" level="12">
+    <if_sid>92070</if_sid>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)powershell\.exe.+\-(encodedcommand|e|ea|ec|encodeda|encode|en|enco)</field>
+    <description>A powershell process created by WMI executed a base64 encoded command</description>
+    <mitre>
+      <id>T1047</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="92072" level="4">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)certutil.exe.+\-decode</field>
+    <description>Certutil decoding a file</description>
+    <mitre>
+      <id>T1140</id>
+    </mitre>
+  </rule>
+
+  <rule id="92073" level="6">
+    <if_sid>92072</if_sid>
+    <field name="win.eventdata.parentCommandLine" type="pcre2">(?i)powershell\.exe</field>
+    <description>Powershell executing certutil to decode a file</description>
+    <mitre>
+      <id>T1140</id>
+    </mitre>
+  </rule>
+
+  <rule id="92074" level="12">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.originalFileName" type="pcre2">(?i)(curl|wget)\.exe</field>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)\-(o|out|outfile).+\.(dll|exe)</field>
+    <description>$(win.eventdata.originalFileName) launched with commands to create a binary file</description>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="92075" level="12">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.originalFileName" type="pcre2">(?i)certutil\.exe</field>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)\-urlcache.+\.(dll|exe)</field>
+    <description>$(win.eventdata.originalFileName) launched with commands to create a binary file</description>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="92076" level="6">
+    <if_group>sysmon_event1</if_group>
+    <field name="win.eventdata.originalFileName" type="pcre2">(?i)RUNDLL32.EXE</field>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i).lock</field>
+    <description>Rundll32 executing suspicious .lock file, possible persistence tactic</description>
+    <mitre>
+      <id>T1546</id>
+      <id>T1218</id>
     </mitre>
   </rule>
 

--- a/ruleset/rules/0800-sysmon_id_1.xml
+++ b/ruleset/rules/0800-sysmon_id_1.xml
@@ -358,7 +358,7 @@
 
   <rule id="92036" level="3">
     <if_sid>92032</if_sid>
-    <list field="win.eventdata.originalFileName" lookup="match_key">etc/lists/uncommon-cmd-opened-process</list>
+    <field name="win.eventdata.originalFileName" type="pcre2">(?i)(SystemPropertiesAdvanced|net)\.EXE</field>
     <description>A $(win.eventdata.image) binary was started by a Windows cmd shell.</description>
     <mitre>
       <id>T1059.003</id>

--- a/ruleset/rules/0810-sysmon_id_3.xml
+++ b/ruleset/rules/0810-sysmon_id_3.xml
@@ -2,14 +2,24 @@
   Copyright (C) 2015, Wazuh Inc.
 -->
 
-<!-- 
+<!--
   Sysmon Event ID 3 rules: 92101 - 92150
 -->
 
 <group name="sysmon_eid3_detections,">
 
-  <rule id="92101" level="6">
+  <rule id="92101" level="0">
     <if_group>sysmon_event3</if_group>
+    <field name="win.eventdata.image" type="pcre2">(?i)\\powershell\.exe</field>
+    <field name="win.eventdata.protocol">^tcp$</field>
+    <description>Powershell process communicating over TCP</description>
+    <mitre>
+      <id>T1095</id>
+    </mitre>
+  </rule>
+
+  <rule id="92102" level="6">
+    <if_sid>92101</if_sid>
     <field name="win.eventdata.image" type="pcre2">(?i)\\powershell\.exe</field>
     <field name="win.eventdata.destinationPort">^135$</field>
     <description>Suspicious DCOM/RPC activity from Powershell process.</description>
@@ -18,9 +28,8 @@
     </mitre>
   </rule>
 
-  <rule id="92102" level="6">
-    <if_group>sysmon_event3</if_group>
-    <field name="win.eventdata.image" type="pcre2">(?i)\\powershell\.exe</field>
+  <rule id="92103" level="6">
+    <if_sid>92101</if_sid>
     <field name="win.eventdata.destinationPort">^389$</field>
     <description>LDAP activity from Powershell process, possible remote system discovery.</description>
     <mitre>
@@ -28,17 +37,34 @@
     </mitre>
   </rule>
 
-  <rule id="92103" level="3">
+  <rule id="92104" level="15">
     <if_group>sysmon_event3</if_group>
-    <field name="win.eventdata.image" type="pcre2">^System$</field>
-    <field name="win.eventdata.destinationPort" type="pcre2">^445$</field>
-    <description>Windows System process activity over SMB port - Possible suspicious access to Windows admin shares.</description>
+    <field name="win.eventdata.image" type="pcre2">(*UTF)\N{U+202E}</field>
+    <description>Suspicious binary created network connection to $(win.eventdata.destinationIp):$(win.eventdata.destinationPort)</description>
+    <mitre>
+      <id>T1095</id>
+    </mitre>
+  </rule>
+
+  <rule id="92105" level="3">
+    <if_group>sysmon_event3</if_group>
+    <field name="win.eventdata.destinationPort" type="pcre2">^(135|445)$</field>
+    <description>Possible suspicious access to Windows admin shares</description>
     <mitre>
       <id>T1021.002</id>
     </mitre>
   </rule>
 
-  <rule id="92104" level="4">
+  <rule id="92106" level="3">
+    <if_sid>92105</if_sid>
+    <field name="win.eventdata.image" type="pcre2">^System$</field>
+    <description>Windows System process activity over SMB port - Possible suspicious access to Windows admin shares</description>
+    <mitre>
+      <id>T1021.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="92107" level="4">
     <if_group>sysmon_event3</if_group>
     <field name="win.eventdata.image" type="pcre2">\\(c|w)script\.exe</field>
     <field name="win.eventdata.protocol" type="pcre2">tcp</field>
@@ -48,7 +74,7 @@
     </mitre>
   </rule>
 
-  <rule id="92105" level="0">
+  <rule id="92108" level="0">
     <if_group>sysmon_event3</if_group>
     <field name="win.eventdata.destinationPort" type="pcre2">3389</field>
     <description>Detected RDP port network activity from $(win.eventdata.sourceIp) to $(win.eventdata.destinationIp).</description>
@@ -57,13 +83,22 @@
     </mitre>
   </rule>
 
-  <rule id="92106" level="15">
-    <if_sid>92105</if_sid>
+  <rule id="92109" level="15">
+    <if_sid>92108</if_sid>
     <field name="win.eventdata.destinationIp" type="pcre2">0:0:0:0:0:0:0:1|127\.0\.0\.1</field>
     <field name="win.eventdata.sourceIp" type="pcre2">0:0:0:0:0:0:0:1|127\.0\.0\.1</field>
     <description>Network activity using RDP port from-to loopback address, possible exploit using reverse tunneling.</description>
     <mitre>
       <id>T1021.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="92110" level="4">
+    <if_sid>92101, 61605</if_sid>
+    <field name="win.eventdata.destinationPort" type="pcre2">^5985$</field>
+    <description>Detected WinRM activity from $(win.eventdata.sourceIp) to $(win.eventdata.destinationIp)</description>
+    <mitre>
+      <id>T1021.006</id>
     </mitre>
   </rule>
 

--- a/ruleset/rules/0820-sysmon_id_7.xml
+++ b/ruleset/rules/0820-sysmon_id_7.xml
@@ -2,7 +2,7 @@
   Copyright (C) 2015, Wazuh Inc.
 -->
 
-<!-- 
+<!--
   Sysmon Event ID 7 rules: 92151 - 92199
 -->
 
@@ -38,6 +38,43 @@
     <description>Suspicious process loaded VaultCli.dll module. Possible use to dump stored passwords.</description>
     <mitre>
       <id>T1555</id>
+    </mitre>
+  </rule>
+
+  <rule id="92154" level="4">
+    <if_group>sysmon_event7</if_group>
+    <field name="win.eventdata.imageLoaded" type="pcre2">(?i)taskschd.dll</field>
+    <description>Process loaded taskschd.dll module. May be used to create delayed malware execution</description>
+    <mitre>
+      <id>T1053.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="92155" level="12">
+    <if_sid>92154</if_sid>
+    <field name="win.eventdata.image" type="pcre2">(?i)mshta\.exe$</field>
+    <description>Mshta loaded taskschd.dll module. May be used to create delayed malware execution</description>
+    <mitre>
+      <id>T1053.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="92156" level="12">
+    <if_group>sysmon_event7</if_group>
+    <field name="win.eventdata.image" type="pcre2">(?i)(winword|excel|powerpnt)\.EXE</field>
+    <field name="win.eventdata.originalFileName" type="pcre2">(?i)VBEUI.DLL</field>
+    <description>Office application loaded vbeui.dll module. May be used to execute scripting code</description>
+    <mitre>
+      <id>T1059.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="92157" level="6">
+    <if_group>sysmon_event7</if_group>
+    <field name="win.eventdata.imageLoaded" type="pcre2">(?i)[c-z]:\\\\Windows\\\\Temp\\\\.+\.dll</field>
+    <description>An executable - $(win.eventdata.image) - loaded $(win.eventdata.imageLoaded) from the Temp directory.</description>
+    <mitre>
+      <id>T1546.011</id>
     </mitre>
   </rule>
 

--- a/ruleset/rules/0830-sysmon_id_11.xml
+++ b/ruleset/rules/0830-sysmon_id_11.xml
@@ -2,66 +2,67 @@
   Copyright (C) 2015, Wazuh Inc.
 -->
 
-<!-- 
+<!--
   Sysmon Event ID 11 rules 92200 - 92299
 -->
 
 <group name="sysmon_eid11_detections,">
-   
-  <rule id="92200" level="4">
+
+  <rule id="92200" level="6">
     <if_group>sysmon_event_11</if_group>
-    <field name="win.eventdata.image" type="pcre2">(?i)\\(c|w)script\.exe</field>
     <field name="win.eventdata.targetFilename" type="pcre2">(?i)[c-z]:\\\\(Windows\\\\Temp|Users).+\.(bat|cmd|lnk|pif|vbs|vbe|js|wsh|ps1)</field>
-    <description>Script created a new scripting file under System or User data folder.</description>
+    <description>Scripting file created under system or User folder</description>
     <mitre>
+      <id>T1059</id>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="92201" level="9">
+    <if_sid>92200</if_sid>
+    <field name="win.eventdata.image" type="pcre2">(?i)\\((c|w)script|powershell)\.exe</field>
+    <description>$(win.eventdata.image) created a new scripting file under User data folder</description>
+    <mitre>
+      <id>T1105</id>
       <id>T1059</id>
     </mitre>
   </rule>
 
-  <rule id="92201" level="6">
+  <rule id="92202" level="6">
     <if_group>sysmon_event_11</if_group>
-    <field name="win.eventdata.image" type="pcre2">\\(?i)powershell\.exe</field>
-    <field name="win.eventdata.targetFilename" type="pcre2">(?i)AppData\\\\Roaming\\\\.*\\\\.+\.(exe|bin|dll)</field>
-    <description>Powershell process created executable file in AppData temp folder.</description>
-    <mitre>
-      <id>T1105</id>
-    </mitre>
-  </rule>
-
-  <rule id="92202" level="12">
-    <if_group>sysmon_event_11</if_group>
-    <field name="win.eventdata.targetFilename" type="pcre2">(?i)[c-z]:\\\\Users\\\\Public\\\\.*\.(exe|bin|dll|vbs|bat|js)</field>
-    <description>Binary file dropped in Users\Public folder.</description>
-    <mitre>
-      <id>T1105</id>
-    </mitre>
-  </rule>
-
-  <rule id="92203" level="15">
-    <if_sid>92202</if_sid>
-    <field name="win.eventdata.image" type="pcre2">(?i)(scp|pscp|FZSFTP|sftp)\.exe</field>
-    <description>Binary file dropped in Users\Public folder by SSH enabled copy software.</description>
-    <mitre>
-      <id>T1105</id>
-    </mitre>
-  </rule>
-
-  <rule id="92204" level="15">
-    <if_group>sysmon_event_11</if_group>
-    <field name="win.eventdata.targetFilename" type="pcre2">(?i)[c-z]:\\\\Users\\\\.+\\\\AppData\\\\Local\\\\Temp\\\\.+\.(exe|bin|dll|vbs|bat|js)</field>
-    <description>Executable file dropped in folder commonly used by malware.</description>
-    <mitre>
-      <id>T1105</id>
-    </mitre>
-  </rule>
-  
-  <rule id="92205" level="6">
-    <if_group>sysmon_event_11</if_group>
-    <field name="win.eventdata.image" type="pcre2">^System$</field>
+    <field name="win.eventdata.image" type="pcre2">(?i)PAExec.</field>
     <field name="win.eventdata.targetFilename" type="pcre2">(?i)[c-z]:\\\\Windows\\\\.+(.exe$|\.dll)$</field>
-    <description>Binary dropped in Windows root folder by System process. Possible abuse of Windows admin shares.</description>
+    <description>Binary dropped in Windows root folder by $(win.eventdata.image) process. Possible abuse of Windows admin shares</description>
     <mitre>
       <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="92203" level="6">
+    <if_group>sysmon_event_11</if_group>
+    <field name="win.eventdata.image" type="pcre2">(?i)powershell\.exe</field>
+    <field name="win.eventdata.targetFilename" type="pcre2">(?i)\.(exe|bat|dll|bin)</field>
+    <description>Executable file created by powershell: $(win.eventdata.targetFilename)</description>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="92204" level="9">
+    <if_sid>92203</if_sid>
+    <field name="win.eventdata.targetFilename" type="pcre2">(?i)AppData\\\\(Roaming|local)</field>
+    <description>Powershell process created executable file in AppData temp folder</description>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="92205" level="9">
+    <if_sid>92203</if_sid>
+    <field name="win.eventdata.targetFilename" type="pcre2">(?i)Windows\\\\(system|syswow64|temp)</field>
+    <description>Powershell process created an executable file in Windows root folder</description>
+    <mitre>
+      <id>T1105</id>
     </mitre>
   </rule>
 
@@ -69,9 +70,209 @@
     <if_group>sysmon_event_11</if_group>
     <field name="win.eventdata.image" type="pcre2">\\spoolsv.exe$</field>
     <field name="win.eventdata.targetFilename" type="pcre2">(?i)[c-z]:\\\\Windows\\\\System32\\\\spool\\\\drivers.+\.dll</field>
-    <description>DLL file created by printer spool service, possible malware binary drop from PrintNightmare exploit.</description>
+    <description>DLL file created by printer spool service, possible malware binary drop from PrintNightmare exploit</description>
     <mitre>
       <id>T1574.010</id>
+    </mitre>
+  </rule>
+
+  <rule id="92207" level="12">
+    <if_group>sysmon_event_11</if_group>
+    <field name="win.eventdata.targetFilename" type="pcre2">(?i)[c-z]:\\\\Users\\\\Public\\\\.*\.(exe|bin|dll|vbs|bat|js|msi)</field>
+    <description>Executable file dropped in Users\Public folder.</description>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="92208" level="15">
+    <if_sid>92207</if_sid>
+    <field name="win.eventdata.image" type="pcre2">(?i)(scp|pscp|FZSFTP|sftp)\.exe</field>
+    <description>Executable file dropped in Users\Public folder by SSH enabled copy software</description>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="92209" level="6">
+    <if_group>sysmon_event_11</if_group>
+    <field name="win.eventdata.targetFilename" type="pcre2">(?i)[c-z]:\\\\Users\\\\Public\\\\.*\.reg</field>
+    <description>Suspicious registry modification file created in Users\Public folder</description>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="92210" level="6">
+    <if_group>sysmon_event_11</if_group>
+    <field name="win.eventdata.targetFilename" type="pcre2">(?i)[c-z]:\\\\Users\\\\Public\\\\.*\.(7z|zip|rar)</field>
+    <description>Suspicious file compression activity in Users\Public folder</description>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="92211" level="14">
+    <if_group>sysmon_event_11</if_group>
+    <field name="win.eventdata.image" type="pcre2">(?i)rundll32.exe</field>
+    <field name="win.eventdata.targetFilename" type="pcre2">\.(exe|bin|dll|vbs|bat|js|msi)</field>
+    <description>Suspicious executable file creation by rundll32: $(win.eventdata.targetFilename)</description>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="92212" level="14">
+    <if_group>sysmon_event_11</if_group>
+    <field name="win.eventdata.image" type="pcre2">(?i)powershell.exe</field>
+    <field name="win.eventdata.targetFilename" type="pcre2">\.(7z|zip|rar)</field>
+    <description>Suspicious file compression activity by powershell: $(win.eventdata.targetFilename)</description>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="92213" level="15">
+    <if_group>sysmon_event_11</if_group>
+    <field name="win.eventdata.targetFilename" type="pcre2">(?i)[c-z]:\\\\Users\\\\.+\\\\AppData\\\\Local\\\\Temp\\\\.+\.(exe|bin|dll|vbs|bat|js)</field>
+    <description>Executable file dropped in folder commonly used by malware</description>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="92214" level="15">
+    <if_group>sysmon_event_11</if_group>
+    <field name="win.eventdata.image" type="pcre2">(?i)(winword|excel|powerpnt)\.exe</field>
+    <field name="win.eventdata.targetFilename" type="pcre2">(?i)appdata\\\\.+\.lnk</field>
+    <description>Suspicious file created by Microsoft Office process: $(win.eventdata.image) created $(win.eventdata.targetFilename)</description>
+    <mitre>
+      <id>T1027</id>
+    </mitre>
+  </rule>
+
+  <rule id="92215" level="12">
+    <if_group>sysmon_event_11</if_group>
+    <field name="win.eventdata.image" type="pcre2">(?i)mshta\.exe</field>
+    <field name="win.eventdata.targetFilename" type="pcre2">(?i)\.(exe|bat|dll)</field>
+    <description>Executable file created by mshta: $(win.eventdata.targetFilename)</description>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="92216" level="0">
+    <if_group>sysmon_event_11</if_group>
+    <field name="win.eventdata.targetFilename" type="pcre2">(?i)[c-z]:\\\\(Windows\\\\Temp|Users).+\.tmp</field>
+    <field name="win.eventdata.image" type="pcre2">(?i)\\powershell\.exe</field>
+    <description>Powershell created a new temporary file $(win.eventdata.targetFilename) under system folder</description>
+    <mitre>
+      <id>T1105</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="92217" level="6">
+    <if_group>sysmon_event_11</if_group>
+    <field name="win.eventdata.targetFilename" type="pcre2">(?i)[c-z]:\\\\Windows\\\\.+(.exe$|\.dll)$</field>
+    <description>Binary dropped in Windows root folder.</description>
+    <mitre>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="92218" level="6">
+    <if_sid>92217</if_sid>
+    <field name="win.eventdata.image" type="pcre2">^System$</field>
+    <description>Possible abuse of Windows admin shares by binary dropped in Windows root folder by system process.</description>
+    <mitre>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="92219" level="6">
+    <if_sid>92217</if_sid>
+    <field name="win.eventdata.image" type="pcre2">(?i)svchost\.exe</field>
+    <field name="win.eventdata.targetFilename" type="pcre2">(?i)[c-z]:\\\\Windows\\\\.+(\.dll)$</field>
+    <description>Possible DLL search order hijack by $(win.eventdata.targetFilename) created in Windows root folder.</description>
+    <mitre>
+      <id>T1574.001</id>
+      <id>T1574.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="92220" level="6">
+    <if_sid>92217</if_sid>
+    <field name="win.eventdata.image" type="pcre2">(?i)wsmprovhost\.exe</field>
+    <description>$(win.eventdata.targetFilename) binary created in Windows root folder by WinRM process $(win.eventdata.image).</description>
+    <mitre>
+      <id>T1574</id>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="92221" level="3">
+    <if_group>sysmon_event_11</if_group>
+    <field name="win.eventdata.image" type="pcre2">(?i)\.scr</field>
+    <description>A screensaver executable $(win.eventdata.image) created $(win.eventdata.targetFilename)</description>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="92222" level="3">
+    <if_group>sysmon_event_11</if_group>
+    <field name="win.eventdata.image" type="pcre2">(?i)(accesschk|calc|hex2dec)\.exe</field>
+    <field name="win.eventdata.targetFilename" type="pcre2">(?i)Windows\\\\(SysWOW64|Temp|System32|System)</field>
+    <description>An executable $(win.eventdata.image) created a file in a system folder</description>
+    <mitre>
+      <id>T1036</id>
+    </mitre>
+  </rule>
+
+  <rule id="92223" level="3">
+    <if_group>sysmon_event_11</if_group>
+    <field name="win.eventdata.targetFilename" type="pcre2">(?i)\.pfx</field>
+    <description>PFX file $(win.eventdata.targetFilename) was created</description>
+    <mitre>
+      <id>T1552</id>
+    </mitre>
+  </rule>
+
+  <rule id="92224" level="6">
+    <if_sid>92223</if_sid>
+    <field name="win.eventdata.image" type="pcre2">(?i)powershell\.exe</field>
+    <description>Powershell process created PFX file $(win.eventdata.targetFilename). Possible private key or certificate exportation</description>
+    <mitre>
+      <id>T1552.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="92225" level="6">
+    <if_group>sysmon_event_11</if_group>
+    <field name="win.eventdata.targetFilename" type="pcre2">(?i)\\\\ProgramData\\\\Microsoft\\\\Windows\\\\Start Menu\\\\Programs\\\\StartUp.+\.(exe|com|dll|vbs|js|bat|cmd|pif|wsh|ps1|lnk|txt)</field>
+    <description>An executable file has been copied to Windows start-up folder</description>
+    <mitre>
+      <id>T1547.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="92226" level="14">
+    <if_sid>92225</if_sid>
+    <field name="win.eventdata.image" type="pcre2">(?i)powershell\.exe</field>
+    <description>Powershell process has copied an executable file to Windows start-up folder</description>
+    <mitre>
+      <id>T1547.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="92227" level="6">
+    <if_group>sysmon_event_11</if_group>
+    <field name="win.eventdata.image" type="pcre2">(?i)(curl|wget|certutil)\.exe</field>
+    <field name="win.eventdata.targetFileName" type="pcre2">(?i)\.dll</field>
+    <description>$(win.eventdata.image) process created a dll binary $(win.eventdata.fileName)</description>
+    <mitre>
+      <id>T1105</id>
     </mitre>
   </rule>
 

--- a/ruleset/rules/0840-win_event_channel.xml
+++ b/ruleset/rules/0840-win_event_channel.xml
@@ -2,7 +2,7 @@
   Copyright (C) 2015, Wazuh Inc.
 -->
 
-<!-- 
+<!--
   General Windows Event channel detection rules: 92650 - 92700
 -->
 
@@ -33,9 +33,10 @@
   <rule id="92652" level="6">
     <if_sid>92651</if_sid>
     <field name="win.eventdata.authenticationPackageName" type="pcre2">NTLM</field>
-    <description>Successful Remote Logon Detected - NTLM authentication, possible pass-the-hash attack.</description>
+    <description>Successful Remote Logon Detected - User:$(win.eventdata.subjectDomainName)\$(win.eventdata.targetUserName) - NTLM authentication, possible pass-the-hash attack.</description>
     <mitre>
       <id>T1550.002</id>
+      <id>T1078.002</id>
     </mitre>
     <group>authentication_success,gdpr_IV_32.2,gpg13_7.1,gpg13_7.2,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,pci_dss_10.2.5,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
@@ -80,6 +81,20 @@
       <id>T1021.001</id>
       <id>T1078.002</id>
     </mitre>
+  </rule>
+
+  <rule id="92657" level="6">
+    <if_sid>92652</if_sid>
+    <field name="win.eventdata.workstationName" type="pcre2">.+</field>
+    <description>Successful Remote Logon Detected - User:$(win.eventdata.subjectDomainName)\$(win.eventdata.targetUserName) - NTLM authentication, possible pass-the-hash attack - Possible RDP connection. Verify that $(win.eventdata.workstationName) is allowed to perform RDP connections</description>
+    <mitre>
+      <id>T1550.002</id>
+      <id>T1078.002</id>
+      <id>T1021.001</id>
+    </mitre>
+    <group>
+      authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
+    </group>
   </rule>
 
 </group>

--- a/ruleset/rules/0860-sysmon_id_13.xml
+++ b/ruleset/rules/0860-sysmon_id_13.xml
@@ -3,7 +3,7 @@
 -->
 
 <!--
-  Sysmon Event 13 rules ID: 92300 - 92302
+  Sysmon Event 13 rules ID: 92300 - 92399
 -->
 
 <group name="sysmon_eid13_detections,">
@@ -32,6 +32,55 @@
     <description>Registry entry to be executed on next logon was modified using command line application reg.exe</description>
     <mitre>
       <id>T1547.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="92303" level="12">
+    <if_sid>92300</if_sid>
+    <field name="win.eventdata.details" type="pcre2">(?i)(VNC|tvnserver\.exe)</field>
+    <description>Registry entry to be executed on next logon points to a remote access tool</description>
+    <mitre>
+      <id>T1547.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="92304" level="6">
+    <if_group>sysmon_event_13</if_group>
+    <field name="win.eventdata.targetObject" type="pcre2">(?i)CLASSES\\\\(FOLDER|MS-SETTINGS)\\\\SHELL\\\\OPEN\\\\COMMAND</field>
+    <description>Modified registry key associated to UAC bypass by auto-elevated processes</description>
+    <mitre>
+      <id>T1548.002</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="92305" level="12">
+    <if_sid>92304</if_sid>
+    <field name="win.eventdata.details" type="pcre2">(?i)(cmd|powershell)\.exe</field>
+    <description>Command interpreter added to registry key associated to UAC bypass by auto-elevated processes</description>
+    <mitre>
+      <id>T1548.002</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="92306" level="12">
+    <if_sid>92304</if_sid>
+    <field name="win.eventdata.image" type="pcre2">(?i)(cmd|powershell)\.exe</field>
+    <description>$(win.eventdata.image) added to the registry a subkey associated with UAC bypass by auto-elevated processes</description>
+    <mitre>
+      <id>T1548.002</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="92307" level="3">
+    <if_group>sysmon_event_13</if_group>
+    <field name="win.eventdata.details" type="pcre2">(?i)\.exe</field>
+    <field name="win.eventdata.targetObject" type="pcre2">(?i)System\\\\CurrentControlSet\\\\Services</field>
+    <description>Evidence of New service creation found in registry under $(win.eventdata.targetObject) binary is: $(win.eventdata.details)</description>
+    <mitre>
+      <id>T1543.003</id>
     </mitre>
   </rule>
 

--- a/ruleset/rules/0870-sysmon_id_8.xml
+++ b/ruleset/rules/0870-sysmon_id_8.xml
@@ -6,12 +6,40 @@
     Sysmon Event ID 8 rules
 -->
 
-<group name="sysmon_eid8_detections,windows,">
+<group name="sysmon,sysmon_eid8_detections,windows,">
 
   <rule id="92400" level="12">
     <if_group>sysmon_event8</if_group>
     <field name="win.eventdata.targetImage" type="pcre2">(?i)[c-z]:\\\\Windows\\\\explorer\.exe</field>
     <description>Possible code injection on explorer.exe by $(win.eventdata.sourceImage)</description>
+    <mitre>
+      <id>T1055</id>
+    </mitre>
+  </rule>
+
+  <rule id="92401" level="12">
+    <if_group>sysmon_event8</if_group>
+      <field name="win.eventdata.targetImage" type="pcre2">(?i)\\\\mstsc\.exe</field>
+      <description>Possible code injection on mstsc.exe (Windows RDP utility) by $(win.eventdata.sourceImage)</description>
+      <mitre>
+        <id>T1055</id>
+      </mitre>
+  </rule>
+
+  <rule id="92402" level="3">
+    <if_group>sysmon_event8</if_group>
+    <field name="win.eventdata.targetImage" type="pcre2">(?i)(synchost\.exe|svchost\.exe)</field>
+    <description>Possible code injection by $(win.eventdata.sourceImage) on $(win.eventdata.targetImage)</description>
+    <mitre>
+      <id>T1055.003</id>
+      <id>T1055.012</id>
+    </mitre>
+  </rule>
+
+  <rule id="92403" level="12">
+    <if_group>sysmon_event8</if_group>
+    <field name="win.eventdata.targetImage" type="pcre2">(?i)lsass\.exe</field>
+    <description>Local Security Authority Subsystem Service (LSASS) process was accessed by $(win.eventdata.sourceImage), possible code injection for credential dumping.</description>
     <mitre>
       <id>T1055</id>
     </mitre>

--- a/ruleset/rules/0915-win-powershell_rules.xml
+++ b/ruleset/rules/0915-win-powershell_rules.xml
@@ -3,14 +3,14 @@
 -->
 
 <!--
-  Powershell Rules 91601 - 92000
+  Powershell Rules 91801 - 92000
 -->
 
 <group name="windows, powershell,">
 
-<!-- Powershell Operational grouping -->
+  <!-- Powershell Operational grouping -->
   <rule id="91801" level="0">
-    <if_sid>60000</if_sid>
+    <if_sid>60000, 60010</if_sid>
     <field name="win.system.channel">^Microsoft-Windows-PowerShell/Operational$</field>
     <options>no_full_log</options>
     <description>Group of Windows rules for the Powershell/Operational channel.</description>
@@ -29,7 +29,7 @@
     <field name="win.system.message" type="pcre2">CopyFromScreen</field>
     <options>no_full_log</options>
     <description>Screen capture method invoked from PowerShell script.</description>
-     <mitre>
+    <mitre>
       <id>T1113</id>
     </mitre>
   </rule>
@@ -49,6 +49,374 @@
     <description>Powershell script "Get-NetUser executed".</description>
     <mitre>
       <id>T1087.002</id>>
+    </mitre>
+  </rule>
+
+  <rule id="91807" level="0">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Get-ItemProperty</field>
+    <description>Powershell script did a query on using Get-ItemProperty</description>
+  </rule>
+  >
+
+  <rule id="91808" level="0">
+    <if_sid>91807</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)-Path\sHK(CU|LM)</field>
+    <description>Powershell script queried registry value</description>
+    <mitre>
+      <id>T1012</id>>
+    </mitre>
+  </rule>
+
+  <rule id="91809" level="10">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)FromBase64String</field>
+    <description>Powershell script may be using Base64 decoding method</description>
+    <mitre>
+      <id>T1140</id>>
+    </mitre>
+  </rule>
+
+  <rule id="91810" level="10">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)CreateThread</field>
+    <description>Powershell script may be executing suspicious code with CreateThread API</description>
+    <mitre>
+      <id>T1106</id>>
+    </mitre>
+  </rule>
+
+  <rule id="91811" level="4">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Expand-Archive</field>
+    <description>Powershell script executed "Expand-Archive"</description>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="91812" level="0">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Remove-Item\s-Path</field>
+    <description>Powershell script executed an object deletion.</description>
+    <mitre>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="91813" level="3">
+    <if_sid>91812</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)\sHK(LM|CU)\:</field>
+    <description>Powershell script deleted a registry key from an object.</description>
+    <mitre>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="91814" level="4">
+    <if_sid>91813</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)\\\\Software\\\\Classes\\\\Folder</field>
+    <description>Powershell script deleted an auto start entry registry key.</description>
+    <mitre>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="91815" level="4">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Get-Process</field>
+    <description>Powershell executing process discovery</description>
+    <mitre>
+      <id>T1057</id>
+    </mitre>
+  </rule>
+
+  <rule id="91816" level="4">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)(\$env\:TEMP|\$env\:USERNAME|\$env\:COMPUTERNAME|\$env\:USERDOMAIN|\$PID)</field>
+    <description>Powershell script querying system environment variables</description>
+    <mitre>
+      <id>T1082</id>
+    </mitre>
+  </rule>
+
+  <rule id="91817" level="4">
+    <if_sid>91816, 91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)ConvertSidToStringSid</field>
+    <description>Powershell script executed "ConvertSidToStringSid" API. Possible domain SID enumeration.</description>
+    <mitre>
+      <id>T1033</id>
+      <id>T1082</id>
+    </mitre>
+  </rule>
+
+  <rule id="91818" level="4">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)new-service</field>
+    <description>Powershell script executed "New-Service" command</description>
+    <mitre>
+      <id>T1543.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="91819" level="4">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)ChildItem</field>
+    <description>Powershell script searching filesystem</description>
+    <mitre>
+      <id>T1083</id>
+    </mitre>
+  </rule>
+
+  <rule id="91820" level="4">
+    <if_sid>91819</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)recurse</field>
+    <description>Powershell script recursively collected files from a filesystem search</description>
+    <mitre>
+      <id>T1083</id>
+      <id>T1119</id>
+    </mitre>
+  </rule>
+
+  <rule id="91821" level="4">
+    <if_sid>91820, 91821</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Compress-Archive</field>
+    <description>Powershell script created a compressed file from results of filesystem search</description>
+    <mitre>
+      <id>T1083</id>
+      <id>T1074.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="91822" level="12">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Invoke-Command</field>
+    <description>Powershell script used "Invoke-command" cmdlet to execute sub script</description>
+    <mitre>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="91823" level="14">
+    <if_sid>91822</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)(ComputerName|Cn)</field>
+    <description>Powershell script used "Invoke-command" cmdlet to execute code on remote computer</description>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1021.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="91824" level="4">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Get-Clipboard</field>
+    <description>Powershell collected clipboard data</description>
+    <mitre>
+      <id>T1115</id>
+    </mitre>
+  </rule>
+
+  <rule id="91825" level="4">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Compress-7Zip</field>
+    <description>Powershell executed file compression</description>
+    <mitre>
+      <id>T1560.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="91826" level="4">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Copy-Item</field>
+    <description>Powershell executed "Copy-Item"</description>
+    <mitre>
+      <id>T1560</id>
+    </mitre>
+  </rule>
+
+  <rule id="91827" level="4">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Set-WmiInstance</field>
+    <description>Powershell executed "Set-WmiInstance". Possible creation or update of a WMI instance.</description>
+    <mitre>
+      <id>T1560</id>
+    </mitre>
+  </rule>
+
+  <rule id="91828" level="6">
+    <if_sid>91827</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Text\.Encoding</field>
+    <description>Powershell executed a creation or update of a WMI instance with encoded values</description>
+    <mitre>
+      <id>T1027</id>
+    </mitre>
+  </rule>
+
+  <rule id="91829" level="4">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)GetComputerNameEx</field>
+    <description>Powershell executed "GetComputerNameEx". Possible system configuration discovery.</description>
+    <mitre>
+      <id>T1082</id>
+    </mitre>
+  </rule>
+
+  <rule id="91830" level="4">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)NetWkstaGetInfo</field>
+    <description>Powershell executed "NetWkstaGetInfo". Possible network configuration discovery.</description>
+    <mitre>
+      <id>T1016</id>
+    </mitre>
+  </rule>
+
+  <rule id="91831" level="4">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)GetUserNameEx</field>
+    <description>Powershell executed "GetUserNameEx". Possible user information discovery.</description>
+    <mitre>
+      <id>T1033</id>
+    </mitre>
+  </rule>
+
+  <rule id="91832" level="4">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)CreateToolhelp32Snapshot</field>
+    <description>Powershell executed "CreateToolhelp32Snapshot". Possible process discovery.</description>
+    <mitre>
+      <id>T1057</id>
+    </mitre>
+  </rule>
+
+  <rule id="91833" level="3">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)(Get-ChildItem|gci).+(env\:windir|system32|windows)</field>
+    <description>Possible discovery activity: Powershell executed "Get-ChildItem" command on a system folder</description>
+    <mitre>
+      <id>T1083</id>
+    </mitre>
+  </rule>
+
+  <rule id="91834" level="6">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)(SetCreationTime|SetLastAccessTime|SetLastWriteTime)</field>
+    <description>Powershell executed a command that modifies file timestamp, possible timestomp attempt</description>
+    <mitre>
+      <id>T1070.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="91835" level="6">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)AntiVirusProduct</field>
+    <description>Powershell tampering with WMI AntiVirusProduct class - Antivirus Software discovery</description>
+    <mitre>
+      <id>T1518.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="91836" level="3">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Uninstall</field>
+    <description>Powershell tampering software installation info on system registry</description>
+    <mitre>
+      <id>T1012</id>
+    </mitre>
+  </rule>
+
+  <rule id="91837" level="4">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)(Get-Content.+\-Stream|IEX|Invoke-Expresion)</field>
+    <description>Powershell executed "Get-Content -Stream or Invoke-Expresion". Possible string execution as code</description>
+    <mitre>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="91838" level="4">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)(gwmi|get-wmiobject).+ Win32_BIOS</field>
+    <description>Powershell queried Win32_BIOS. Possible sandbox detection activity</description>
+    <mitre>
+      <id>T1497</id>
+      <id>T1082</id>
+    </mitre>
+  </rule>
+
+  <rule id="91839" level="4">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)(gwmi|get-wmiobject).+ Win32_ComputerSystem</field>
+    <description>Powershell queried Win32_ComputerSystem. Possible system discovery activity</description>
+    <mitre>
+      <id>T1497</id>
+      <id>T1033</id>
+      <id>T1016</id>
+    </mitre>
+  </rule>
+
+  <rule id="91840" level="4">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)(gwmi|get-wmiobject).+ Win32_PnPEntity</field>
+    <description>Powershell queried Win32_PnPEntity. Possible devices/adapter discovery activity</description>
+    <mitre>
+      <id>T1120</id>
+    </mitre>
+  </rule>
+
+  <rule id="91841" level="4">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)(gwmi|get-wmiobject).+ Win32_Process</field>
+    <description>Powershell queried Win32_Process. Possible process discovery activity</description>
+    <mitre>
+      <id>T1057</id>
+    </mitre>
+  </rule>
+
+  <rule id="91842" level="4">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Get-Item \-Path</field>
+    <description>Powershell executed "Get-Item -Path". Script trying to see files in path</description>
+    <mitre>
+      <id>T1083</id>
+    </mitre>
+  </rule>
+
+  <rule id="91843" level="3">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)New-ItemProperty.+\-Path</field>
+    <description>Powershell executed "New-ItemProperty -Path". Possible addition of new item to registry</description>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="91844" level="12">
+    <if_sid>91843</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)SOFTWARE\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Run</field>
+    <description>Possible addition of new item to Windows startup registry</description>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1059.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="91845" level="10">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Microsoft.Office.Interop.Outlook</field>
+    <description>Outlook add-in was loaded by powershell, possible use for email collection</description>
+    <mitre>
+      <id>T1114.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="91846" level="10">
+    <if_sid>91802</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)::CreateFromDirectory</field>
+    <description>Powershell used .NET compression method, possible data extraction operation</description>
+    <mitre>
+      <id>T1560.001</id>
     </mitre>
   </rule>
 

--- a/ruleset/rules/0945-sysmon_id_10.xml
+++ b/ruleset/rules/0945-sysmon_id_10.xml
@@ -1,0 +1,38 @@
+<!--
+  -  Sysmon Event ID 10 rules
+  -  Created by Wazuh, Inc.
+  -  Copyright (C) 2015, Wazuh Inc.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<group name="sysmon_eid10_detections,">
+  <rule id="92900" level="12">
+    <if_group>sysmon_event_10</if_group>
+    <field name="win.eventdata.targetImage" type="pcre2">(?i)lsass\.exe</field>
+    <field name="win.eventdata.grantedAccess" type="pcre2">(?i)(0x1010|0x40)</field>
+    <field name="win.eventdata.sourceImage" type="pcre2" negate="yes">(?i)(C:\\\\Program Files|wmiprvse\.exe)</field>
+    <description>Lsass process was accessed by $(win.eventdata.sourceImage) with read permissions, possible credential dump</description>
+    <mitre>
+      <id>T1003.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="92910" level="12">
+    <if_group>sysmon_event_10</if_group>
+    <field name="win.eventdata.targetImage" type="pcre2">(?i)explorer\.exe</field>
+    <description>Explorer process was accessed by $(win.eventdata.sourceImage), possible process injection</description>
+    <mitre>
+      <id>T1055</id>
+    </mitre>
+  </rule>
+
+  <rule id="92920" level="14">
+    <if_group>sysmon_event_10</if_group>
+    <field name="win.eventdata.targetImage" type="pcre2">(?i)mstsc\.exe</field>
+    <description>Windows Remote Dektop utility process was accessed by $(win.eventdata.sourceImage), possible process injection</description>
+    <mitre>
+      <id>T1055</id>
+    </mitre>
+  </rule>
+
+</group>

--- a/ruleset/rules/0950-sysmon_id_20.xml
+++ b/ruleset/rules/0950-sysmon_id_20.xml
@@ -1,0 +1,30 @@
+<!--
+  -  Sysmon Event ID 20 rules
+  -  Created by Wazuh, Inc.
+  -  Copyright (C) 2015, Wazuh Inc.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<group name="sysmon_eid20_detections,">
+
+    <rule id="89501" level="12">
+        <if_group>sysmon_event_20</if_group>
+        <field name="win.eventdata.type" type="pcre2">(?i)(Command Line|Script)</field>
+        <description>WmiConsumerEvent created, possible persistence tactic</description>
+        <mitre>
+            <id>T1546.003</id>
+        </mitre>
+    </rule>
+
+    <rule id="89502" level="14">
+        <if_sid>89501</if_sid>
+        <if_group>sysmon_event_20</if_group>
+        <field name="win.eventdata.destination" type="pcre2">(?i)(powershell|rundll32.exe|cmd.exe)</field>
+        <description>WmiConsumerEvent created, possible persistence tactic using executables</description>
+        <mitre>
+            <id>T1546.003</id>
+        </mitre>
+    </rule>
+
+</group>
+


### PR DESCRIPTION
|Related issue|
|---|
|#13555|

## Description

This PR adds rules that were generated from MITRE APT emulation plans.

Modified files:

- 0595-win-sysmon_rules.xml
  - Added  detection support for new Sysmon events 
- 0800-sysmon_id_1.xml
  - Contains detections related to APT29 steps 20, 18, 14, 11, 9, 8, , 34
  - Detections related to Fin7 steps  19, 12, 15, 14, 11 
- 0810-sysmon_id_3.xml 
  - Contains detections related to APT29 steps 20, 16, 15, 8 ,1
- 0820-sysmon_id_7.xml
  -  Contains detections related to Fin7 steps 11, 20
- 0830-sysmon_id_11.xml
  - Contains detections related to APT29 steps 17, 16, 14, 4 ,6, 3
  - Contains detections related to Fin7 steps 20, 19, 17, 16, 12, 15, 11
- 0840-win_event_channel.xml
  - Contains detections related to Fin7 step 19
- 0860-sysmon_id_13.xml
  - Contains detections related to APT29 steps 5, 3  
  - Contains detections related to Fin7 step 15
- 0870-sysmon_id_8.xml
  - Contains detections related to APT29 steps 9, 6
  - Contains detections related to Fin7 steps 20, 18
- 0915-win-powershell_rules.xml
  - Detect threats using Powershell scriptblock feature 
- 0945-sysmon_id_10.xml
  - Contains detections related to Fin7 steps 15
- 0950-sysmon_id_20.xml
  - Contains detections related to APT29 steps 15




## Tests
Restarting wazuh-manager...
|Component |  Tested  |  Total   | Coverage |
| -------- | -------- | -------- | -------- |
|  Rules   |   1171   |   4247   |  27.57%  |
| Decoders |    75    |   165    |  45.45%  |

|          File           |  Passed  |  Failed  |  Status  |
|        --------         | -------- | -------- | -------- |
|./tests/proftpd.ini      |    7     |    0     |   ✅    |
|./tests/exim.ini         |    7     |    0     |   ✅    |
|./tests/squid_rules.ini  |    2     |    0     |   ✅    |
|./tests/sysmon_eid_3.ini |    10    |    0     |   ✅    |
|./tests/checkpoint_smart1.ini|    18    |    0     |   ✅    |
|./tests/iptables.ini     |    8     |    0     |   ✅    |
|./tests/sysmon_eid_10.ini|    4     |    0     |   ✅    |
|./tests/SonicWall.ini    |    11    |    0     |   ✅    |
|./tests/panda_paps.ini   |    8     |    0     |   ✅    |
|./tests/fortiauth.ini    |    4     |    0     |   ✅    |
|./tests/openldap.ini     |    9     |    0     |   ✅    |
|./tests/f5_big_ip.ini    |    48    |    0     |   ✅    |
|./tests/sophos.ini       |    8     |    0     |   ✅    |
|./tests/opensmtpd.ini    |    7     |    0     |   ✅    |
|./tests/netscreen.ini    |    4     |    0     |   ✅    |
|./tests/rsh.ini          |    2     |    0     |   ✅    |
|./tests/arbor.ini        |    2     |    0     |   ✅    |
|./tests/web_rules.ini    |    10    |    0     |   ✅    |
|./tests/exchange.ini     |    2     |    0     |   ✅    |
|./tests/vuln_detector.ini|    2     |    0     |   ✅    |
|./tests/sysmon_eid_7.ini |    6     |    0     |   ✅    |
|./tests/cpanel.ini       |    7     |    0     |   ✅    |
|./tests/apparmor.ini     |    5     |    0     |   ✅    |
|./tests/pam.ini          |    5     |    0     |   ✅    |
|./tests/apache.ini       |    12    |    0     |   ✅    |
|./tests/fireeye.ini      |    3     |    0     |   ✅    |
|./tests/sysmon.ini       |    3     |    0     |   ✅    |
|./tests/dovecot.ini      |    15    |    0     |   ✅    |
|./tests/nginx.ini        |    12    |    0     |   ✅    |
|./tests/nextcloud.ini    |    8     |    0     |   ✅    |
|./tests/unbound.ini      |    0     |    0     |   ✅    |
|./tests/paloalto.ini     |    16    |    0     |   ✅    |
|./tests/sysmon_eid_13.ini|    7     |    0     |   ✅    |
|./tests/ossec.ini        |    5     |    0     |   ✅    |
|./tests/cisco_ftd.ini    |    42    |    0     |   ✅    |
|./tests/sysmon_eid_1.ini |    59    |    0     |   ✅    |
|./tests/github.ini       |   324    |    0     |   ✅    |
|./tests/fortimail.ini    |    6     |    0     |   ✅    |
|./tests/named.ini        |    5     |    0     |   ✅    |
|./tests/powershell.ini   |    32    |    0     |   ✅    |
|./tests/openvpn_ldap.ini |    2     |    0     |   ✅    |
|./tests/sysmon_eid_8.ini |    4     |    0     |   ✅    |
|./tests/cloudflare-waf.ini|    13    |    0     |   ✅    |
|./tests/huawei_usg.ini   |    3     |    0     |   ✅    |
|./tests/eset.ini         |    8     |    0     |   ✅    |
|./tests/gcp.ini          |    31    |    0     |   ✅    |
|./tests/samba.ini        |    4     |    0     |   ✅    |
|./tests/pfsense.ini      |    2     |    0     |   ✅    |
|./tests/cisco_asa.ini    |    88    |    0     |   ✅    |
|./tests/systemd.ini      |    2     |    0     |   ✅    |
|./tests/web_appsec.ini   |    31    |    0     |   ✅    |
|./tests/sysmon_eid_11.ini|    28    |    0     |   ✅    |
|./tests/cisco_ios.ini    |    17    |    0     |   ✅    |
|./tests/pix.ini          |    22    |    0     |   ✅    |
|./tests/php.ini          |    2     |    0     |   ✅    |
|./tests/office365.ini    |   128    |    0     |   ✅    |
|./tests/fortigate.ini    |    45    |    0     |   ✅    |
|./tests/audit_scp.ini    |    8     |    0     |   ✅    |
|./tests/win_application.ini|    0     |    0     |   ✅    |
|./tests/fortiddos.ini    |    1     |    0     |   ✅    |
|./tests/cimserver.ini    |    2     |    0     |   ✅    |
|./tests/freepbx.ini      |    6     |    0     |   ✅    |
|./tests/sshd.ini         |    47    |    0     |   ✅    |
|./tests/win_event_channel.ini|    8     |    0     |   ✅    |
|./tests/gitlab.ini       |    27    |    0     |   ✅    |
|./tests/glpi.ini         |    3     |    0     |   ✅    |
|./tests/api.ini          |    20    |    0     |   ✅    |
|./tests/dropbear.ini     |    3     |    0     |   ✅    |
|./tests/firewalld.ini    |    2     |    0     |   ✅    |
|./tests/mailscanner.ini  |    1     |    0     |   ✅    |
|./tests/owlh.ini         |    4     |    0     |   ✅    |
|./tests/sysmon_eid_20.ini|    2     |    0     |   ✅    |
|./tests/oscap.ini        |    32    |    0     |   ✅    |
|./tests/mcafee_epo.ini   |    1     |    0     |   ✅    |
|./tests/doas.ini         |    4     |    0     |   ✅    |
|./tests/junos.ini        |    3     |    0     |   ✅    |
|./tests/sudo.ini         |    8     |    0     |   ✅    |
|./tests/syslog.ini       |    6     |    0     |   ✅    |
|./tests/sophos_fw.ini    |    10    |    0     |   ✅    |
|./tests/vsftpd.ini       |    4     |    0     |   ✅    |
|./tests/postfix.ini      |    2     |    0     |   ✅    |
|./tests/modsecurity.ini  |    6     |    0     |   ✅    |
|./tests/su.ini           |    5     |    0     |   ✅    |
|./tests/kernel_usb.ini   |    6     |    0     |   ✅    |
|./tests/aws_s3_access.ini|    10    |    0     |   ✅    |
|./tests/auditd.ini       |    31    |    0     |   ✅    |
