### PR TITLE
Integrity_check_clear not works

### DIFF
--- a/src/shared_modules/rsync/cppcheckSuppress.txt
+++ b/src/shared_modules/rsync/cppcheckSuppress.txt
@@ -1,3 +1,3 @@
 *:*src/rsyncImplementation.cpp:158
-*:*tests/implementation/rsyncImplementationTest.cpp:260
-*:*tests/interface/rsync_test.cpp:249
+*:*tests/implementation/rsyncImplementationTest.cpp:262
+*:*tests/interface/rsync_test.cpp:251

--- a/src/shared_modules/rsync/src/messageChecksum.h
+++ b/src/shared_modules/rsync/src/messageChecksum.h
@@ -61,7 +61,7 @@ namespace RSync
 
                     outputMessage["data"] = outputData;
 
-                    if (!data.checksum.empty())
+                    if (!data.checksum.empty() || INTEGRITY_CLEAR == data.type)
                     {
                         callback(outputMessage.dump());
                     }

--- a/src/shared_modules/rsync/tests/implementation/rsyncImplementationTest.cpp
+++ b/src/shared_modules/rsync/tests/implementation/rsyncImplementationTest.cpp
@@ -250,6 +250,8 @@ TEST_F(RSyncImplementationTest, ValidDecoderPushedChecksumFailToSplit)
         (*callback)(json);
     })));
 
+    std::atomic<uint64_t> messageCounter { 0 };
+    constexpr auto TOTAL_EXPECTED_MESSAGES { 2ull };
 
     const auto checkExpected
     {
@@ -260,6 +262,7 @@ TEST_F(RSyncImplementationTest, ValidDecoderPushedChecksumFailToSplit)
             if (0 == payload.compare(expectedResult1) || 0 == payload.compare(expectedResult2))
             {
                 retVal = ::testing::AssertionSuccess();
+                ++messageCounter;
             }
 
             return retVal;
@@ -285,6 +288,8 @@ TEST_F(RSyncImplementationTest, ValidDecoderPushedChecksumFailToSplit)
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().push(handle, data));
 
     EXPECT_NO_THROW(RSync::RSyncImplementation::instance().release());
+
+    EXPECT_EQ(TOTAL_EXPECTED_MESSAGES, messageCounter.load());
 }
 
 TEST_F(RSyncImplementationTest, ValidDecoderPushedChecksumInvalidOperation)

--- a/src/shared_modules/rsync/tests/interface/rsync_test.cpp
+++ b/src/shared_modules/rsync/tests/interface/rsync_test.cpp
@@ -236,6 +236,8 @@ TEST_F(RSyncTest, startSyncWithIntegrityClear)
             })"
     };
     const std::unique_ptr<cJSON, CJsonDeleter> jsSelect{ cJSON_Parse(startConfigStmt) };
+    std::atomic<uint64_t> messageCounter { 0 };
+    constexpr auto TOTAL_EXPECTED_MESSAGES { 1ull };
 
     const auto checkExpected
     {
@@ -249,6 +251,7 @@ TEST_F(RSyncTest, startSyncWithIntegrityClear)
             if (std::string::npos != firstSegment && std::string::npos != secondSegment)
             {
                 retVal = ::testing::AssertionSuccess();
+                ++messageCounter;
             }
 
             return retVal;
@@ -265,6 +268,7 @@ TEST_F(RSyncTest, startSyncWithIntegrityClear)
     sync_callback_data_t callbackData { callbackRSyncWrapper, &callbackWrapper };
 
     ASSERT_EQ(0, rsync_start_sync(rsyncHandle, dbsyncHandle, jsSelect.get(), callbackData));
+    EXPECT_EQ(messageCounter.load(), TOTAL_EXPECTED_MESSAGES);
 }
 
 TEST_F(RSyncTest, startSyncIntegrityGlobal)
@@ -319,6 +323,8 @@ TEST_F(RSyncTest, startSyncIntegrityGlobal)
             })"
     };
     const std::unique_ptr<cJSON, CJsonDeleter> jsSelect{ cJSON_Parse(startConfigStmt) };
+    std::atomic<uint64_t> messageCounter { 0 };
+    constexpr auto TOTAL_EXPECTED_MESSAGES { 1ull };
 
     const auto checkExpected
     {
@@ -332,6 +338,7 @@ TEST_F(RSyncTest, startSyncIntegrityGlobal)
             if (std::string::npos != firstSegment && std::string::npos != secondSegment)
             {
                 retVal = ::testing::AssertionSuccess();
+                ++messageCounter;
             }
 
             return retVal;
@@ -350,6 +357,7 @@ TEST_F(RSyncTest, startSyncIntegrityGlobal)
     ASSERT_EQ(0, rsync_start_sync(rsyncHandle, dbsyncHandle, jsSelect.get(), callbackData));
 
     dbsync_teardown();
+    EXPECT_EQ(messageCounter.load(), TOTAL_EXPECTED_MESSAGES);
 }
 TEST_F(RSyncTest, registerSyncId)
 {
@@ -750,6 +758,9 @@ TEST_F(RSyncTest, startSyncWithIntegrityClearCPP)
             })"
     };
 
+    std::atomic<uint64_t> messageCounter{0};
+    constexpr auto TOTAL_EXPECTED_MESSAGES { 1ull };
+
     const auto checkExpected
     {
         [&](const std::string & payload) -> ::testing::AssertionResult
@@ -762,6 +773,7 @@ TEST_F(RSyncTest, startSyncWithIntegrityClearCPP)
             if (std::string::npos != firstSegment && std::string::npos != secondSegment)
             {
                 retVal = ::testing::AssertionSuccess();
+                ++messageCounter;
             }
 
             return retVal;
@@ -785,6 +797,7 @@ TEST_F(RSyncTest, startSyncWithIntegrityClearCPP)
     };
 
     EXPECT_NO_THROW(remoteSync->startSync(dbSync->handle(), nlohmann::json::parse(startConfigStmt), callbackData));
+    EXPECT_EQ(messageCounter.load(), TOTAL_EXPECTED_MESSAGES);
 }
 
 TEST_F(RSyncTest, startSyncWithIntegrityClearCPPSelectByInode)

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -449,6 +449,10 @@ TEST_F(SyscollectorImpTest, noHardware)
     {
         R"({"data":{"checksum":"ea17673e7422c0ab04c4f1f111a5828be8cd366a","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"9dff246584835755137820c975f034d089e90b6f","metric":" ","type":"ipv6"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
     };
+    const auto expectedResult21
+    {
+        R"({"component":"syscollector_hwinfo","data":{},"type":"integrity_clear"})"
+    };
 
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult3)).Times(1);
@@ -468,6 +472,7 @@ TEST_F(SyscollectorImpTest, noHardware)
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
     EXPECT_CALL(wrapper, callbackMock(expectedResult19)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult20)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult21)).Times(1);
 
     std::thread t
     {
@@ -617,6 +622,10 @@ TEST_F(SyscollectorImpTest, noOs)
     {
         R"({"data":{"checksum":"ea17673e7422c0ab04c4f1f111a5828be8cd366a","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"9dff246584835755137820c975f034d089e90b6f","metric":" ","type":"ipv6"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
     };
+    const auto expectedResult21
+    {
+        R"({"component":"syscollector_osinfo","data":{},"type":"integrity_clear"})"
+    };
 
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult3)).Times(1);
@@ -636,6 +645,7 @@ TEST_F(SyscollectorImpTest, noOs)
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
     EXPECT_CALL(wrapper, callbackMock(expectedResult19)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult20)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult21)).Times(1);
 
     std::thread t
     {
@@ -760,6 +770,19 @@ TEST_F(SyscollectorImpTest, noNetwork)
     {
         R"({"component":"syscollector_hotfixes","data":{"begin":"KB12345678","end":"KB12345678"},"type":"integrity_check_global"})"
     };
+    const auto expectedResult20
+    {
+        R"({"component":"syscollector_network_address","data":{},"type":"integrity_clear"})"
+    };
+    const auto expectedResult21
+    {
+        R"({"component":"syscollector_network_protocol","data":{},"type":"integrity_clear"})"
+    };
+    const auto expectedResult22
+    {
+        R"({"component":"syscollector_network_iface","data":{},"type":"integrity_clear"})"
+    };
+
 
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
@@ -773,6 +796,9 @@ TEST_F(SyscollectorImpTest, noNetwork)
     EXPECT_CALL(wrapper, callbackMock(expectedResult17)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
     EXPECT_CALL(wrapper, callbackMock(expectedResult19)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult20)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult21)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult22)).Times(1);
 
     std::thread t
     {
@@ -919,6 +945,11 @@ TEST_F(SyscollectorImpTest, noPackages)
     {
         R"({"data":{"checksum":"ea17673e7422c0ab04c4f1f111a5828be8cd366a","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"9dff246584835755137820c975f034d089e90b6f","metric":" ","type":"ipv6"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
     };
+    const auto expectedResult21
+    {
+        R"({"component":"syscollector_packages","data":{},"type":"integrity_clear"})"
+    };
+
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult3)).Times(1);
@@ -937,6 +968,7 @@ TEST_F(SyscollectorImpTest, noPackages)
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
     EXPECT_CALL(wrapper, callbackMock(expectedResult19)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult20)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult21)).Times(1);
 
     std::thread t
     {
@@ -1085,6 +1117,10 @@ TEST_F(SyscollectorImpTest, noPorts)
     {
         R"({"data":{"checksum":"ea17673e7422c0ab04c4f1f111a5828be8cd366a","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"9dff246584835755137820c975f034d089e90b6f","metric":" ","type":"ipv6"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
     };
+    const auto expectedResult21
+    {
+        R"({"component":"syscollector_ports","data":{},"type":"integrity_clear"})"
+    };
 
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
@@ -1104,7 +1140,7 @@ TEST_F(SyscollectorImpTest, noPorts)
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
     EXPECT_CALL(wrapper, callbackMock(expectedResult19)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult20)).Times(1);
-
+    EXPECT_CALL(wrapper, callbackMock(expectedResult21)).Times(1);
 
     std::thread t
     {
@@ -1266,6 +1302,7 @@ TEST_F(SyscollectorImpTest, noPortsAll)
     {
         R"({"data":{"checksum":"ea17673e7422c0ab04c4f1f111a5828be8cd366a","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"9dff246584835755137820c975f034d089e90b6f","metric":" ","type":"ipv6"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
     };
+
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult3)).Times(1);
@@ -1433,6 +1470,12 @@ TEST_F(SyscollectorImpTest, noProcesses)
     {
         R"({"data":{"checksum":"ea17673e7422c0ab04c4f1f111a5828be8cd366a","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"9dff246584835755137820c975f034d089e90b6f","metric":" ","type":"ipv6"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
     };
+    const auto expectedResult21
+    {
+        R"({"component":"syscollector_processes","data":{},"type":"integrity_clear"})"
+    };
+
+
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult3)).Times(1);
@@ -1451,7 +1494,7 @@ TEST_F(SyscollectorImpTest, noProcesses)
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
     EXPECT_CALL(wrapper, callbackMock(expectedResult19)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult20)).Times(1);
-
+    EXPECT_CALL(wrapper, callbackMock(expectedResult21)).Times(1);
 
     std::thread t
     {
@@ -1601,6 +1644,10 @@ TEST_F(SyscollectorImpTest, noHotfixes)
     {
         R"({"data":{"checksum":"ea17673e7422c0ab04c4f1f111a5828be8cd366a","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"9dff246584835755137820c975f034d089e90b6f","metric":" ","type":"ipv6"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
     };
+    const auto expectedResult19
+    {
+        R"({"component":"syscollector_hotfixes","data":{},"type":"integrity_clear"})"
+    };
 
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
@@ -1620,6 +1667,7 @@ TEST_F(SyscollectorImpTest, noHotfixes)
     EXPECT_CALL(wrapper, callbackMock(expectedResult16)).Times(1);
     EXPECT_CALL(wrapper, callbackMock(expectedResult17)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult19)).Times(1);
 
     std::thread t
     {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #13188 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

We have seen that the `integrity_check_clear` command isn't sent by FIMDB when the database is empty. 

# Steps to reproduce
- Create a folder with several files
- Start the Wazuh agent and wait until the manager database is updated.
- Shutdown the Wazuh agent and delete all the files inside the monitored folder
- Start the Wazuh agent and check that the command isn't sent.
- Also, check the manager database the entries are not removed.

# Logs
```
2022/04/20 13:43:05 wazuh-syscheckd[6003] logging_helper.c:56 at loggingFunction(): INFO: FIM sync module started.
2022/04/20 13:43:05 wazuh-syscheckd[6003] logging_helper.c:62 at loggingFunction(): DEBUG: Executing FIM sync.
2022/04/20 13:43:05 wazuh-syscheckd[6003] logging_helper.c:62 at loggingFunction(): DEBUG: Finished FIM sync.
2022/04/20 13:43:05 wazuh-syscheckd[6003] pthreads_op.c:45 at CreateThreadJoinable(): DEBUG: Thread stack size set to: 8192 KiB
2022/04/20 13:43:05 wazuh-syscheckd[6003] pthreads_op.c:45 at CreateThreadJoinable(): DEBUG: Thread stack size set to: 8192 KiB
2022/04/20 13:43:05 wazuh-syscheckd[6003] run_check.c:637 at symlink_checker_thread(): DEBUG: (6033): Starting symbolic link updater. Interval '600'.
2022/04/20 13:43:16 wazuh-syscheckd[6003] create_db.c:502 at fim_scan(): INFO: (6008): File integrity monitoring scan started.
2022/04/20 13:43:16 wazuh-syscheckd[6003] run_check.c:117 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"scan_start","data":{"timestamp":1650462196}}
2022/04/20 13:43:16 wazuh-syscheckd[6003] create_db.c:514 at fim_scan(): DEBUG: (6348): Size of 'queue/diff' folder: 0.00000 KB.
2022/04/20 13:43:16 wazuh-syscheckd[6003] create_db.c:614 at fim_scan(): INFO: (6009): File integrity monitoring scan ended.
2022/04/20 13:43:16 wazuh-syscheckd[6003] run_check.c:117 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"scan_end","data":{"timestamp":1650462196}}
2022/04/20 13:43:16 wazuh-syscheckd[6003] create_db.c:1786 at fim_print_info(): DEBUG: (6330): The scan has been running during: 0.005 sec (0.003 clock sec)
2022/04/20 13:43:16 wazuh-syscheckd[6003] create_db.c:1801 at fim_print_info(): DEBUG: (6336): Fim inode entries: '0', path count: '0'
2022/04/20 13:43:27 wazuh-syscheckd[6003] create_db.c:502 at fim_scan(): INFO: (6008): File integrity monitoring scan started.

````
