### PR TITLE
Fix a memory leak in Analysisd when overwriting a rule multiple times

### DIFF
--- a/ruleset/testing/ruleset/test_overwrite_rules.xml
+++ b/ruleset/testing/ruleset/test_overwrite_rules.xml
@@ -1,6 +1,6 @@
 <group name="qa,test,">
 
-  <!-- 
+  <!--
       First use case:
         Testing overwritten rules followed by child rules. See https://github.com/wazuh/wazuh/issues/13414
   -->
@@ -25,7 +25,7 @@
     <description>Rule to overwrite the original.</description>
   </rule>
 
-  <!-- 
+  <!--
     Second use case:
       Testing overwrite & if_matched_sid
       Every option apart from if_matched_sid should be overwritten
@@ -47,7 +47,7 @@
     <description>Overwrite if_matched_sid.</description>
   </rule>
 
-  <!-- 
+  <!--
     Third use case:
       Testing overwrite & if_matched_group
       Every option apart from if_matched_group should be overwritten
@@ -95,7 +95,7 @@
     <description>Overwrite and CDB list.</description>
   </rule>
 
-  <!-- 
+  <!--
     Fifth use case:
       Testing overwrite & list & decoded_as
   -->
@@ -109,6 +109,40 @@
     <decoded_as>test_overwrite</decoded_as>
     <field name="example">TEST5</field>
     <description>Successfully field match.</description>
+  </rule>
+
+  <!--
+    Sixth use case:
+      Testing multiple overwrite
+  -->
+  <rule id="999920" level="3">
+    <decoded_as>test_overwrite</decoded_as>
+    <field name="example">TEST</field>
+    <description>Testing multiple overwrite.</description>
+  </rule>
+
+  <rule id="999920" level="3" overwrite="yes">
+    <decoded_as>test_overwrite</decoded_as>
+    <field name="example">TEST</field>
+    <description>Testing multiple overwrite.</description>
+  </rule>
+
+  <rule id="999920" level="3" overwrite="yes">
+    <decoded_as>test_overwrite</decoded_as>
+    <field name="example">TEST</field>
+    <description>Testing multiple overwrite.</description>
+  </rule>
+
+  <rule id="999920" level="3" overwrite="yes">
+    <decoded_as>test_overwrite</decoded_as>
+    <field name="example">TEST</field>
+    <description>Testing multiple overwrite.</description>
+  </rule>
+
+  <rule id="999920" level="3" overwrite="yes">
+    <decoded_as>test_overwrite</decoded_as>
+    <field name="example">MULTIPLE</field>
+    <description>Testing multiple overwrite.</description>
   </rule>
 
 </group>

--- a/ruleset/testing/ruleset/test_overwrite_rules.xml
+++ b/ruleset/testing/ruleset/test_overwrite_rules.xml
@@ -145,4 +145,50 @@
     <description>Testing multiple overwrite.</description>
   </rule>
 
+  <!--
+    Seventh use case:
+      Testing overwrite with if_sid
+  -->
+
+  <rule id="999921" level="3">
+    <decoded_as>test_overwrite</decoded_as>
+    <field name="example">TEST7</field>
+    <description>Testing overwrite with if_sid.</description>
+  </rule>
+
+  <rule id="999922" level="3">
+    <if_sid>999921</if_sid>
+    <field name="example">TEST7</field>
+    <description>Testing overwrite with if_sid.</description>
+  </rule>
+
+  <rule id="999922" level="3" overwrite="yes">
+    <if_sid>999921</if_sid>
+    <field name="example">TEST7</field>
+    <description>Testing overwrite with if_sid.</description>
+  </rule>
+
+  <!--
+    Eighth use case:
+      Testing overwrite with if_sid
+  -->
+
+  <rule id="999923" level="3">
+    <decoded_as>test_overwrite</decoded_as>
+    <field name="example">TEST8</field>
+    <description>Testing overwrite with if_level.</description>
+  </rule>
+
+  <rule id="999924" level="3">
+    <if_level>3</if_level>
+    <field name="example">TEST8</field>
+    <description>Testing overwrite with if_level.</description>
+  </rule>
+
+  <rule id="999924" level="3" overwrite="yes">
+    <if_level>3</if_level>
+    <field name="example">TEST8</field>
+    <description>Testing overwrite with if_level.</description>
+  </rule>
+
 </group>

--- a/ruleset/testing/tests/overwrite.ini
+++ b/ruleset/testing/tests/overwrite.ini
@@ -56,3 +56,15 @@ log 1 pass = Apr 14 13:38:51 testUser test_overwrite_field[13244]: Test example 
 rule = 999920
 alert = 3
 decoder = test_overwrite
+
+[overwrite with if_sid]
+log 1 pass = Apr 14 13:38:51 testUser test_overwrite_field[13244]: Test example 'TEST7' field
+rule = 999922
+alert = 3
+decoder = test_overwrite
+
+[overwrite with if_level]
+log 1 pass = Apr 14 13:38:51 testUser test_overwrite_field[13244]: Test example 'TEST8' field
+rule = 999924
+alert = 3
+decoder = test_overwrite

--- a/ruleset/testing/tests/overwrite.ini
+++ b/ruleset/testing/tests/overwrite.ini
@@ -50,3 +50,9 @@ log 1 pass = Apr 14 13:38:51 testUser test_overwrite_field[13244]: Test example 
 rule = 999919
 alert = 6
 decoder = test_overwrite
+
+[multiple overwrite]
+log 1 pass = Apr 14 13:38:51 testUser test_overwrite_field[13244]: Test example 'MULTIPLE' field
+rule = 999920
+alert = 3
+decoder = test_overwrite

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -221,8 +221,8 @@ typedef struct _RuleInfo {
 
     bool internal_saving;      ///< Used to free RuleInfo structure in wazuh-logtest
 
-    /* Pointer to the rule which overwrites this one if it exists */
-    struct _RuleInfo *rule_overwrite;
+    /* Pointers to the rules which this one overwrites if it exists */
+    OSList * rule_overwrite;
 } RuleInfo;
 
 typedef struct _rules_tmp_params_t {
@@ -395,7 +395,7 @@ void Rules_OP_CreateRules(void);
  * @param log_msg List to save log messages.
  * @return 0 on success, otherwise -1
  */
-int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_node, 
+int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_node,
                        EventList **last_event_list, OSStore **decoder_list, OSList* log_msg);
 
 int AddHash_Rule(RuleNode *node);

--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -396,6 +396,9 @@ int OS_AddRuleInfo(RuleNode *r_node, RuleInfo *newrule, int sid, OSList* log_msg
                     smwarn(log_msg, ANALYSISD_INV_OVERWRITE, "if_sid", sid);
                 }
             }
+
+            os_free(newrule->if_sid);
+
             if (newrule->if_group && !newrule->if_matched_group) {
                 if (!r_node->ruleinfo->if_group ||
                         strcmp(r_node->ruleinfo->if_group, newrule->if_group)) {
@@ -408,6 +411,8 @@ int OS_AddRuleInfo(RuleNode *r_node, RuleInfo *newrule, int sid, OSList* log_msg
                     smwarn(log_msg, ANALYSISD_INV_OVERWRITE, "if_level", sid);
                 }
             }
+
+            os_free(newrule->if_level);
 
             if (r_node->ruleinfo->if_matched_regex) {
                 OSRegex_FreePattern(r_node->ruleinfo->if_matched_regex);

--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -452,7 +452,13 @@ int OS_AddRuleInfo(RuleNode *r_node, RuleInfo *newrule, int sid, OSList* log_msg
             r_node->ruleinfo->mitre_technique_id = newrule->mitre_technique_id;
 
             /* Finally the reference to newrule is store so it is freed at the end */
-            r_node->ruleinfo->rule_overwrite = newrule;
+
+            if (r_node->ruleinfo->rule_overwrite == NULL) {
+                r_node->ruleinfo->rule_overwrite = OSList_Create();
+                OSList_SetFreeDataPointer(r_node->ruleinfo->rule_overwrite, free);
+            }
+
+            OSList_PushData(r_node->ruleinfo->rule_overwrite, newrule);
 
             return (1);
         }
@@ -680,7 +686,7 @@ void os_remove_ruleinfo(RuleInfo *ruleinfo) {
     free_strarray(ruleinfo->mitre_tactic_id);
     free_strarray(ruleinfo->mitre_technique_id);
 
-    os_free(ruleinfo->rule_overwrite);
+    OSList_Destroy(ruleinfo->rule_overwrite);
     os_free(ruleinfo);
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|Fixes #13505|

This PR aims to fix this memory leak, that appears when overwriting a rule more than once:

```
==20785==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 544 byte(s) in 1 object(s) allocated from:
    #0 0x7efca38b0a37 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x55bc4b1cc394 in zerorulemember analysisd/rules.c:2065
    #2 0x55bc4b1b56b8 in Rules_OP_ReadRules analysisd/rules.c:385
    #3 0x55bc4b1e6b45 in main analysisd/analysisd.c:687
    #4 0x7efca2cc7fcf in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Indirect leak of 5 byte(s) in 1 object(s) allocated from:
    #0 0x7efca38b0a37 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x55bc4b1cbdb2 in loadmemory analysisd/rules.c:2004
    #2 0x55bc4b1bf2c1 in Rules_OP_ReadRules analysisd/rules.c:955
    #3 0x55bc4b1e6b45 in main analysisd/analysisd.c:687
    #4 0x7efca2cc7fcf in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: 549 byte(s) leaked in 2 allocation(s).
```

## Rationale

Rules with the `overwrite` flag replace the previous rule at `OS_AddRuleInfo()`. That function saves a pointer to the new rule structure into member `rule_overwrite`. But, if we redefine the same rule again, this pointer is overwritten, and we leak the second rule's structure.

## Proposed fix

Replace the pointer to a rule with a list of pointers. Thus, each rule will support many overwrites (the limit is undefined).

## Tests

- [x] Defining a rule 5 times (using `overwrite`) does not produce a memory leak (using AddressSanitizer).
- [x] The rule test included in this PR reveals three memory leaks in 4.3.1 but not in this branch.