### PR TITLE
Allow report_changes to support paths close to the maximum limit

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -551,14 +551,12 @@
 #define FIM_DB_ERROR_RM_NOT_SCANNED                 "(6709): Failed to delete from db all unscanned files."
 #define FIM_ERROR_WHODATA_INIT                      "(6710): Failed to start the Whodata engine. Directories/files will be monitored in Realtime mode"
 #define FIM_ERROR_GET_ABSOLUTE_PATH                 "(6711): Cannot get absolute path of '%s': %s (%d)"
-#define FIM_ERROR_REMOVE_COLON                      "(6712): Cannot remove heading colon from full path '%s'"
 #define FIM_DIFF_DELETE_DIFF_FOLDER_ERROR           "(6713): Cannot remove diff folder for file: '%s'"
 #ifdef WIN32
 #define FIM_DIFF_COMMAND_OUTPUT_ERROR               "(6714): Command fc output an error"
 #else
 #define FIM_DIFF_COMMAND_OUTPUT_ERROR               "(6714): Command diff output an error"
 #endif
-#define FIM_DIFF_FILE_PATH_TOO_LONG                 "(6715): The path of the file monitored '%s' is too long to compute differences."
 #define FIM_WARN_OPEN_HANDLE_FILE                   "(6716): Could not open handle for '%s'. Error code: %lu"
 #define FIM_WARN_GET_FILETIME                       "(6717): Could not get the filetime of the file '%s'. Error code: %lu."
 #ifndef WIN32

--- a/src/syscheckd/fim_diff_changes.c
+++ b/src/syscheckd/fim_diff_changes.c
@@ -940,9 +940,8 @@ void fim_diff_process_delete_file(const char *filename){
 
     OS_SHA1_Str(buffer, -1, encoded_path);
 
-    os_malloc(sizeof(char) * (strlen(DIFF_DIR) + 5 + strlen(encoded_path)), full_path);
-    snprintf(full_path, PATH_MAX, "%s/file/", DIFF_DIR);
-    strcat(full_path, encoded_path);
+    snprintf(buffer, PATH_MAX, "%s/file/%s", DIFF_DIR, encoded_path);
+    os_strdup(buffer, full_path);
 
     ret = fim_diff_delete_compress_folder(full_path);
     if(ret == -1){

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -247,7 +247,7 @@ void start_daemon()
 
     snprintf(diff_file_dir, PATH_MAX, "%s/file/", DIFF_DIR);
     snprintf(diff_registry_dir, PATH_MAX, "%s/registry/", DIFF_DIR);
-    snprintf(diff_local_dir, PATH_MAX, "%s/registry/", DIFF_DIR);
+    snprintf(diff_local_dir, PATH_MAX, "%s/local/", DIFF_DIR);
 
     if (cldir_ex(diff_file_dir) == -1 && errno != ENOENT) {
         merror("Unable to clear directory '%s': %s (%d)", diff_file_dir, strerror(errno), errno);

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -245,16 +245,20 @@ void start_daemon()
     char diff_registry_dir[PATH_MAX];
     char diff_local_dir[PATH_MAX];
 
-    snprintf(diff_file_dir, PATH_MAX, "%s/file/", DIFF_DIR);
-    snprintf(diff_registry_dir, PATH_MAX, "%s/registry/", DIFF_DIR);
-    snprintf(diff_local_dir, PATH_MAX, "%s/local/", DIFF_DIR);
 
+    // The contents of the report_changes diff directory must be deleted whenever the agent is started.
+    // Directory used for files.
+    snprintf(diff_file_dir, PATH_MAX, "%s/file/", DIFF_DIR);
     if (cldir_ex(diff_file_dir) == -1 && errno != ENOENT) {
         merror("Unable to clear directory '%s': %s (%d)", diff_file_dir, strerror(errno), errno);
     }
+    // Directory used for registries.
+    snprintf(diff_registry_dir, PATH_MAX, "%s/registry/", DIFF_DIR);
     if (cldir_ex(diff_registry_dir) == -1 && errno != ENOENT) {
         merror("Unable to clear directory '%s': %s (%d)", diff_registry_dir, strerror(errno), errno);
     }
+    // Old directory used by report_changes, may be leftover from an old installation
+    snprintf(diff_local_dir, PATH_MAX, "%s/local/", DIFF_DIR);
     if (cldir_ex(diff_local_dir) == -1 && errno != ENOENT) {
         merror("Unable to clear directory '%s': %s (%d)", diff_local_dir, strerror(errno), errno);
     }

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -240,13 +240,23 @@ void start_daemon()
         syscheck.time = 604800;
     }
 
-    // Deleting content local/diff directory
-    char diff_dir[PATH_MAX];
+    // Deleting content of FIM diff directory
+    char diff_file_dir[PATH_MAX];
+    char diff_registry_dir[PATH_MAX];
+    char diff_local_dir[PATH_MAX];
 
-    snprintf(diff_dir, PATH_MAX, "%s/local/", DIFF_DIR);
+    snprintf(diff_file_dir, PATH_MAX, "%s/file/", DIFF_DIR);
+    snprintf(diff_registry_dir, PATH_MAX, "%s/registry/", DIFF_DIR);
+    snprintf(diff_local_dir, PATH_MAX, "%s/registry/", DIFF_DIR);
 
-    if (cldir_ex(diff_dir) == -1 && errno != ENOENT) {
-        merror("Unable to clear directory '%s': %s (%d)", diff_dir, strerror(errno), errno);
+    if (cldir_ex(diff_file_dir) == -1 && errno != ENOENT) {
+        merror("Unable to clear directory '%s': %s (%d)", diff_file_dir, strerror(errno), errno);
+    }
+    if (cldir_ex(diff_registry_dir) == -1 && errno != ENOENT) {
+        merror("Unable to clear directory '%s': %s (%d)", diff_registry_dir, strerror(errno), errno);
+    }
+    if (cldir_ex(diff_local_dir) == -1 && errno != ENOENT) {
+        merror("Unable to clear directory '%s': %s (%d)", diff_local_dir, strerror(errno), errno);
     }
 
     if (syscheck.disabled) {

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -644,18 +644,17 @@ char *fim_file_diff(const char *filename, const directory_t *configuration);
  * @brief Deletes the filename diff folder and modify diff_folder_size if disk_quota enabled
  *
  * @param filename Path of the file that has been deleted
- * @return 0 if success, -1 on error
  */
-int fim_diff_process_delete_file(const char *filename);
+void fim_diff_process_delete_file(const char *filename);
 
+#ifdef WIN32
 /**
  * @brief Deletes the registry diff folder and modify diff_folder_size if disk_quota enabled
  *
  * @param key_name Path of the registry that has been deleted
  * @param arch Arch type of the registry
- * @return 0 if success, -1 on error
  */
-int fim_diff_process_delete_registry(const char *key_name, int arch);
+void fim_diff_process_delete_registry(const char *key_name, int arch);
 
 /**
  * @brief Deletes the value diff folder and modifies diff_folder_size if disk_quota enabled
@@ -663,9 +662,9 @@ int fim_diff_process_delete_registry(const char *key_name, int arch);
  * @param key_name Path of the registry that contains the deleted value
  * @param value_name Path of the value that has been deleted
  * @param arch Arch type of the registry
- * @return 0 if success, -1 on error
  */
-int fim_diff_process_delete_value(const char *key_name, const char *value_name, int arch);
+void fim_diff_process_delete_value(const char *key_name, const char *value_name, int arch);
+#endif
 
 /**
  * @brief Initializes all syscheck data

--- a/src/unit_tests/syscheckd/registry/test_registry.c
+++ b/src/unit_tests/syscheckd/registry/test_registry.c
@@ -1074,6 +1074,8 @@ static void test_fim_registry_process_value_delete_event_success(void **state) {
     fim_event_mode event_mode = FIM_SCHEDULED;
     void *w_event = NULL;
     expect_fim_db_remove_registry_value_data_call(syscheck.database, data->entry->registry_entry.value, FIMDB_OK);
+    expect_string(__wrap__mdebug2, formatted_msg, "(6355): Can't remove folder 'queue/diff/registry/[x64] b9b175e8810d3475f15976dd3b5f9210f3af6604/3f17670fd80d6563a3d4283adfe14140907b75b0', it does not exist.");
+
     fim_registry_process_value_delete_event(syscheck.database, data->entry, &mutex, &alert, &event_mode, w_event);
 }
 
@@ -1103,6 +1105,8 @@ static void test_fim_registry_process_key_delete_event_success(void **state) {
     int alert = 1;
     fim_event_mode event_mode = FIM_SCHEDULED;
     void *w_event = NULL;
+
+    expect_string(__wrap__mdebug2, formatted_msg, "(6355): Can't remove folder 'queue/diff/registry/[x64] b9b175e8810d3475f15976dd3b5f9210f3af6604', it does not exist.");
 
     expect_fim_db_get_values_from_registry_key_call(syscheck.database, data->file, FIM_DB_DISK, FIMDB_OK);
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/11583|



## Description

Hello team,
We have changed the module report_changes, in the function that initializes all the names of the directories. Since for each file monitored with report_changes we need to store a copy in a local Wazuh directory, until now we generated the name using the same path of the original file, this could cause filename length problems.
Now we have implemented that the filename is generated using a hash, this way we avoid length problems.

File name of the stored file before the change:
`C:\Program Files (x86)\ossec-agent\queue\diff\local\c\file\path`
After:
`C:\Program Files (x86)\ossec-agent\queue\diff\file\750621a746c8d786022a931ab9a99b918f7208f4`

In addition, diff directories are now correctly deleted when starting the syscheck module.
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
- Memory tests for Windows
  - [x] Scan-build report