### PR TITLE
Fix handling syscollector insertion deltas

### DIFF
--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -2055,7 +2055,7 @@ static void fill_event_alert(Eventinfo * lf, const struct deltas_fields_match_li
                     wstr_replace(*field_values_iterator, FIELD_SEPARATOR_DBSYNC_ESCAPE, FIELD_SEPARATOR_DBSYNC);
                 fillData(lf, head->current.value, value);
                 os_free(value);
-            } else {
+            } else if (strcmp(*field_values_iterator, "NULL") != 0) {
                 fillData(lf, head->current.value, *field_values_iterator);
             }
         }

--- a/src/unit_tests/wazuh_db/test_wdb_delta_event.c
+++ b/src/unit_tests/wazuh_db/test_wdb_delta_event.c
@@ -22,7 +22,7 @@
 #include "wazuhdb_op.h"
 
 
-bool wdb_dbsync_stmt_bind_from_string(sqlite3_stmt * stmt, int index, field_type_t type, const char * value, const char * replace);
+bool wdb_dbsync_stmt_bind_from_string(sqlite3_stmt * stmt, int index, field_type_t type, const char * value, const char ** replace);
 
 /*
 * Dummy tables information
@@ -386,16 +386,14 @@ void test_wdb_dbsync_stmt_bind_from_string_type_real(void ** state) {
 void test_wdb_dbsync_stmt_bind_from_string_type_real_replace(void ** state) {
 
     sqlite3_stmt * test_stmt = (sqlite3_stmt *) 1;
-    const char * test_value_str = "NULL";
-    const double test_value_replace = 0;
+    const char * test_value_str[] = {"", NULL};
 
     const int test_index = 1;
 
-    expect_value(__wrap_sqlite3_bind_double, index, test_index);
-    expect_value(__wrap_sqlite3_bind_double, value, test_value_replace);
-    will_return(__wrap_sqlite3_bind_double, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_null, index, test_index);
+    will_return(__wrap_sqlite3_bind_null, SQLITE_OK);
 
-    assert_true(wdb_dbsync_stmt_bind_from_string(test_stmt, test_index, FIELD_REAL, test_value_str, test_value_str));
+    assert_true(wdb_dbsync_stmt_bind_from_string(test_stmt, test_index, FIELD_REAL, *test_value_str, test_value_str));
 }
 
 void test_wdb_dbsync_stmt_bind_from_string_type_real_invalid(void ** state) {
@@ -438,15 +436,13 @@ void test_wdb_dbsync_stmt_bind_from_string_type_integer(void ** state) {
 void test_wdb_dbsync_stmt_bind_from_string_type_integer_replace(void ** state) {
 
     sqlite3_stmt * test_stmt = (sqlite3_stmt *) 1;
-    const char * test_value_str = "NULL";
-    const int test_value_replace = 0;
+    const char * test_value_str[] = {"", NULL};
     const int test_index = 1;
 
-    expect_value(__wrap_sqlite3_bind_int, index, test_index);
-    expect_value(__wrap_sqlite3_bind_int, value, test_value_replace);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_null, index, test_index);
+    will_return(__wrap_sqlite3_bind_null, SQLITE_OK);
 
-    assert_true(wdb_dbsync_stmt_bind_from_string(test_stmt, test_index, FIELD_INTEGER, test_value_str, test_value_str));
+    assert_true(wdb_dbsync_stmt_bind_from_string(test_stmt, test_index, FIELD_INTEGER, *test_value_str, test_value_str));
 }
 
 void test_wdb_dbsync_stmt_bind_from_string_type_integer_invalid(void ** state) {
@@ -488,15 +484,13 @@ void test_wdb_dbsync_stmt_bind_from_string_type_text(void ** state) {
 void test_wdb_dbsync_stmt_bind_from_string_type_text_replace(void ** state) {
 
     sqlite3_stmt * test_stmt = (sqlite3_stmt *) 1;
-    const char * test_value = "NULL";
-    const char * test_value_replace = "";
+    const char * test_value_replace[] = {"", NULL};
     const int test_index = 1;
 
-    expect_value(__wrap_sqlite3_bind_text, pos, test_index);
-    expect_string(__wrap_sqlite3_bind_text, buffer, test_value_replace);
-    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_null, index, test_index);
+    will_return(__wrap_sqlite3_bind_null, SQLITE_OK);
 
-    assert_true(wdb_dbsync_stmt_bind_from_string(test_stmt, test_index, FIELD_TEXT, test_value, test_value));
+    assert_true(wdb_dbsync_stmt_bind_from_string(test_stmt, test_index, FIELD_TEXT, *test_value_replace, test_value_replace));
 }
 
 void test_wdb_dbsync_stmt_bind_from_string_type_text_bind_error(void ** state) {
@@ -530,16 +524,14 @@ void test_wdb_dbsync_stmt_bind_from_string_type_integer_long(void ** state) {
 void test_wdb_dbsync_stmt_bind_from_string_type_integer_long_replace(void ** state) {
 
     sqlite3_stmt * test_stmt = (sqlite3_stmt *) 1;
-    const char * test_value_str = "NULL";
-    const long long test_value_replace = 0;
+    const char * test_value_str[] = {"", NULL};
 
     const int test_index = 1;
 
-    expect_value(__wrap_sqlite3_bind_int64, index, test_index);
-    expect_value(__wrap_sqlite3_bind_int64, value, test_value_replace);
-    will_return(__wrap_sqlite3_bind_int64, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_null, index, test_index);
+    will_return(__wrap_sqlite3_bind_null, SQLITE_OK);
 
-    assert_true(wdb_dbsync_stmt_bind_from_string(test_stmt, test_index, FIELD_INTEGER_LONG, test_value_str, test_value_str));
+    assert_true(wdb_dbsync_stmt_bind_from_string(test_stmt, test_index, FIELD_INTEGER_LONG, *test_value_str, test_value_str));
 }
 
 void test_wdb_dbsync_stmt_bind_from_string_type_integer_long_invalid(void ** state) {
@@ -565,18 +557,6 @@ void test_wdb_dbsync_stmt_bind_from_string_type_integer_long_bind_error(void ** 
     assert_false(wdb_dbsync_stmt_bind_from_string(test_stmt, test_index, FIELD_INTEGER_LONG, test_value_str, NULL));
 }
 
-void test_wdb_dbsync_stmt_bind_from_string_type_integer_long_bind_null(void ** state) {
-
-    sqlite3_stmt * test_stmt = (sqlite3_stmt *) 1;
-    const char * test_value_str = "";
-    const int test_index = 1;
-
-    expect_value(__wrap_sqlite3_bind_null, index, test_index);
-    will_return(__wrap_sqlite3_bind_null, SQLITE_OK);
-
-    assert_true(wdb_dbsync_stmt_bind_from_string(test_stmt, test_index, FIELD_INTEGER_LONG, test_value_str, NULL));
-}
-
 int main()
 {
     const struct CMUnitTest tests[] = {
@@ -598,7 +578,6 @@ int main()
         cmocka_unit_test(test_wdb_dbsync_stmt_bind_from_string_type_integer_long_replace),
         cmocka_unit_test(test_wdb_dbsync_stmt_bind_from_string_type_integer_long_invalid),
         cmocka_unit_test(test_wdb_dbsync_stmt_bind_from_string_type_integer_long_bind_error),
-        cmocka_unit_test(test_wdb_dbsync_stmt_bind_from_string_type_integer_long_bind_null),
         /* wdb_single_row_insert_dbsync */
         cmocka_unit_test_setup_teardown(test_wdb_single_row_insert_dbsync_err, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_single_row_insert_dbsync_get_cache_stmt_fail, test_setup, test_teardown),

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -875,15 +875,16 @@ void test_wdb_global_get_groups_integrity_hash_mismatch(void **state)
 {
     cJSON* j_result = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
+    os_sha1 digest = "";
 
     expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_GROUP_SYNCREQ_FIND);
     will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1);
     will_return(__wrap_wdb_step, SQLITE_DONE);
-    expect_string(__wrap_wdb_get_global_group_hash, hexdigest, "");
+    expect_string(__wrap_wdb_get_global_group_hash, hexdigest, digest);
     will_return(__wrap_wdb_get_global_group_hash, OS_INVALID);
 
     will_return(__wrap_cJSON_CreateArray, __real_cJSON_CreateArray());
-    j_result = wdb_global_get_groups_integrity(data->wdb, "");
+    j_result = wdb_global_get_groups_integrity(data->wdb, digest);
 
     char *result = cJSON_PrintUnformatted(j_result);
     assert_string_equal(result, "[\"hash_mismatch\"]");
@@ -895,15 +896,16 @@ void test_wdb_global_get_groups_integrity_synced(void **state)
 {
     cJSON* j_result = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
+    os_sha1 digest = "";
 
     expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_GROUP_SYNCREQ_FIND);
     will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1);
     will_return(__wrap_wdb_step, SQLITE_DONE);
-    expect_string(__wrap_wdb_get_global_group_hash, hexdigest, "");
+    expect_string(__wrap_wdb_get_global_group_hash, hexdigest, digest);
     will_return(__wrap_wdb_get_global_group_hash, OS_SUCCESS);
 
     will_return(__wrap_cJSON_CreateArray, __real_cJSON_CreateArray());
-    j_result = wdb_global_get_groups_integrity(data->wdb, "");
+    j_result = wdb_global_get_groups_integrity(data->wdb, digest);
 
     char *result = cJSON_PrintUnformatted(j_result);
     assert_string_equal(result, "[\"synced\"]");

--- a/src/unit_tests/wazuh_db/test_wdb_integrity.c
+++ b/src/unit_tests/wazuh_db/test_wdb_integrity.c
@@ -126,7 +126,8 @@ static void test_wdb_calculate_stmt_checksum_success(void **state)
 
 static void test_wdbi_checksum_wbs_null(void **state)
 {
-    expect_assert_failure(wdbi_checksum(NULL, 0, ""));
+    os_sha1 digest = "";
+    expect_assert_failure(wdbi_checksum(NULL, 0, digest));
 }
 
 static void test_wdbi_checksum_hexdigest_null(void **state)
@@ -180,7 +181,8 @@ static void test_wdbi_checksum_success(void **state)
 
 static void test_wdbi_checksum_range_wbs_null(void **state)
 {
-    expect_assert_failure(wdbi_checksum_range(NULL, 0, "test_begin", "test_end", ""));
+    os_sha1 digest = "";
+    expect_assert_failure(wdbi_checksum_range(NULL, 0, "test_begin", "test_end", digest));
 }
 
 static void test_wdbi_checksum_range_hexdigest_null(void **state)

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -2804,8 +2804,8 @@ void test_dbsync_modify_type_exists_data_text_null_value(void ** state) {
 
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
     expect_string(__wrap_sqlite3_bind_text, buffer, "data1");
-    expect_value(__wrap_sqlite3_bind_text, pos, 2);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "");
+    expect_value(__wrap_sqlite3_bind_null, index, 2);
+    will_return(__wrap_sqlite3_bind_null, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 3);
     expect_string(__wrap_sqlite3_bind_text, buffer, "data2");
 
@@ -3262,7 +3262,8 @@ void test_dbsync_insert_type_exists_data_return_values(void **state) {
 
     will_return_always(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return_always(__wrap_sqlite3_bind_text, SQLITE_ERROR);
-    will_return_always(__wrap_sqlite3_bind_int64, SQLITE_ERROR);
+    will_return_always(__wrap_sqlite3_bind_null, SQLITE_ERROR);
+
 
     expect_value(__wrap_sqlite3_bind_int, index, 1);
     expect_value(__wrap_sqlite3_bind_int, value, 0);
@@ -3279,35 +3280,25 @@ void test_dbsync_insert_type_exists_data_return_values(void **state) {
     expect_value(__wrap_sqlite3_bind_int, index, 5);
     expect_value(__wrap_sqlite3_bind_int, value, 4);
 
-    expect_value(__wrap_sqlite3_bind_text, pos, 6);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "");
+    expect_value(__wrap_sqlite3_bind_null, index, 6);
 
-    expect_value(__wrap_sqlite3_bind_int, index, 7);
-    expect_value(__wrap_sqlite3_bind_int, value, 0);
+    expect_value(__wrap_sqlite3_bind_null, index, 7);
 
-    expect_value(__wrap_sqlite3_bind_int, index, 8);
-    expect_value(__wrap_sqlite3_bind_int, value, 0);
+    expect_value(__wrap_sqlite3_bind_null, index, 8);
 
-    expect_value(__wrap_sqlite3_bind_int, index, 9);
-    expect_value(__wrap_sqlite3_bind_int, value, 0);
+    expect_value(__wrap_sqlite3_bind_null, index, 9);
 
-    expect_value(__wrap_sqlite3_bind_int64, index, 10);
-    expect_value(__wrap_sqlite3_bind_int64, value, 0);
+    expect_value(__wrap_sqlite3_bind_null, index, 10);
 
-    expect_value(__wrap_sqlite3_bind_text, pos, 11);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "");
+    expect_value(__wrap_sqlite3_bind_null, index, 11);
 
-    expect_value(__wrap_sqlite3_bind_int, index, 12);
-    expect_value(__wrap_sqlite3_bind_int, value, 0);
+    expect_value(__wrap_sqlite3_bind_null, index, 12);
 
-    expect_value(__wrap_sqlite3_bind_text, pos, 13);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "");
+    expect_value(__wrap_sqlite3_bind_null, index, 13);
 
-    expect_value(__wrap_sqlite3_bind_text, pos, 14);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "");
+    expect_value(__wrap_sqlite3_bind_null, index, 14);
 
-    expect_value(__wrap_sqlite3_bind_text, pos, 15);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "");
+    expect_value(__wrap_sqlite3_bind_null, index, 15);
 
     will_return_always(__wrap_sqlite3_errmsg, error_value);
 
@@ -3597,8 +3588,8 @@ void test_dbsync_insert_type_exists_data_correct_null_value_from_json(void **sta
     expect_value(__wrap_sqlite3_bind_text, pos, 3);
     expect_string(__wrap_sqlite3_bind_text, buffer, "_NULL_");
 
-    expect_value(__wrap_sqlite3_bind_text, pos, 4);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "");
+    expect_value(__wrap_sqlite3_bind_null, index, 4);
+    will_return(__wrap_sqlite3_bind_null, SQLITE_OK);
 
     will_return_always(__wrap_sqlite3_bind_text, SQLITE_OK);
 
@@ -3654,8 +3645,8 @@ void test_dbsync_modify_type_exists_data_null_value_from_json(void **state) {
 
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
     expect_string(__wrap_sqlite3_bind_text, buffer, "data1");
-    expect_value(__wrap_sqlite3_bind_text, pos, 2);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "");
+    expect_value(__wrap_sqlite3_bind_null, index, 2);
+    will_return(__wrap_sqlite3_bind_null, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 3);
     expect_string(__wrap_sqlite3_bind_text, buffer, "_NULL_");
 

--- a/src/unit_tests/wazuh_db/test_wdb_syscollector.c
+++ b/src/unit_tests/wazuh_db/test_wdb_syscollector.c
@@ -2199,16 +2199,19 @@ void test_wdb_osinfo_insert_cache_fail(void ** state) {
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "at wdb_osinfo_insert(): cannot cache statement");
 
+    os_sha1 digest = "hexdigest";
     output =
         wdb_osinfo_insert(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version",
                           "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname",
-                          "release", "version", "os_release", "os_display_version", "checksum", false, "hexdigest", 1);
+                          "release", "version", "os_release", "os_display_version", "checksum", false, digest, 1);
     assert_int_equal(output, -1);
 }
 
 void test_wdb_osinfo_insert_sql_fail(void ** state) {
     int output = 0;
     wdb_t * data = (wdb_t *) *state;
+    os_sha1 digest = "hexdigest";
+
 
     will_return(__wrap_wdb_stmt_cache, 0);
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
@@ -2266,7 +2269,7 @@ void test_wdb_osinfo_insert_sql_fail(void ** state) {
     expect_string(__wrap_sqlite3_bind_text, buffer, "checksum");
     will_return(__wrap_sqlite3_bind_text, 0);
     expect_value(__wrap_sqlite3_bind_text, pos, 19);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "hexdigest");
+    expect_string(__wrap_sqlite3_bind_text, buffer, digest);
     will_return(__wrap_sqlite3_bind_text, 0);
     expect_value(__wrap_sqlite3_bind_int, index, 20);
     expect_value(__wrap_sqlite3_bind_int, value, 1);
@@ -2279,13 +2282,14 @@ void test_wdb_osinfo_insert_sql_fail(void ** state) {
     output =
         wdb_osinfo_insert(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version",
                           "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname",
-                          "release", "version", "os_release", "os_display_version", "checksum", false, "hexdigest", 1);
+                          "release", "version", "os_release", "os_display_version", "checksum", false, digest, 1);
     assert_int_equal(output, -1);
 }
 
 void test_wdb_osinfo_insert_success(void ** state) {
     int output = 0;
     wdb_t * data = (wdb_t *) *state;
+    os_sha1 digest = "hexdigest";
 
     will_return(__wrap_wdb_stmt_cache, 0);
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
@@ -2343,7 +2347,7 @@ void test_wdb_osinfo_insert_success(void ** state) {
     expect_string(__wrap_sqlite3_bind_text, buffer, "checksum");
     will_return(__wrap_sqlite3_bind_text, 0);
     expect_value(__wrap_sqlite3_bind_text, pos, 19);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "hexdigest");
+    expect_string(__wrap_sqlite3_bind_text, buffer, digest);
     will_return(__wrap_sqlite3_bind_text, 0);
     expect_value(__wrap_sqlite3_bind_int, index, 20);
     expect_value(__wrap_sqlite3_bind_int, value, 1);
@@ -2353,7 +2357,7 @@ void test_wdb_osinfo_insert_success(void ** state) {
     output =
         wdb_osinfo_insert(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version",
                           "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname",
-                          "release", "version", "os_release", "os_display_version", "checksum", false, "hexdigest", 1);
+                          "release", "version", "os_release", "os_display_version", "checksum", false, digest, 1);
     assert_int_equal(output, 0);
 }
 

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -168,7 +168,7 @@ static struct column_list const TABLE_OS[] = {
     { .value = { FIELD_TEXT, 17, false, false, "checksum" }, .next = &TABLE_OS[17] },
     { .value = { FIELD_TEXT, 18, false, false, "os_display_version" }, .next = &TABLE_OS[18] },
     { .value = { FIELD_INTEGER, 19, false, false, "triaged" }, .next = &TABLE_OS[19] },
-    { .value = { FIELD_TEXT, 20, false, false, "reference" }, .next = NULL },
+    { .value = { FIELD_TEXT, 20, true, false, "reference" }, .next = NULL },
 };
 #define OS_FIELD_COUNT 19
 


### PR DESCRIPTION
|Related issue|
|---|
|#12550|

## Description

This PR aims to fix/change some aspects regarding syscollector deltas handling

### Storing fields as db's null when their value is an empty string

Some syscollector fields could have empty strings as their values. Before this PR, these fields were stored as it in the inventory db, changing the behavior compared to versions without deltas.

Steps to reproduce:
- Create a delta event to analysisd queue containing an empty field (see argvs and cmd)
```
2022/05/30 08:24:20 wazuh-modulesd:syscollector[5435] wm_syscollector.c:107 at wm_sys_log(): DEBUG: Delta sent: {"data":{"argvs":null,"checksum":"e817194ac47e2b09ee1ee66f48351f62c69b6c62","cmd":null,"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u16:2-e","nice":0,"nlwp":1,"pgrp":0,"pid":"6868","ppid":2,"priority":20,"processor":6,"resident":0,"rgroup":"root","ruser":"root","scan_time":"2022/05/30 08:24:15","session":0,"sgroup":"root","share":0,"size":0,"start_time":1653899041,"state":"I","stime":0,"suser":"root","tgid":6868,"tty":0,"utime":0,"vm_size":0},"operation":"INSERTED","type":"dbsync_processes"}
```

Before change behavior
- Query to inventory database shows an empty string

Expected behavior
- Stored field contains null element

Current behavior
- Stored field contains null element
```
sqlite> select * from sys_processes where PID="6868" and argvs is null;
   scan_id = 0
 scan_time = 2022/05/30 08:28:38
       pid = 6868
      name = kworker/u16:2-e
     state = I
      ppid = 2
     utime = 0
     stime = 4
       cmd = 
     argvs = 
     euser = root
     ruser = root
     suser = root
    egroup = root
    rgroup = root
    sgroup = root
    fgroup = root
  priority = 20
      nice = 0
      size = 0
   vm_size = 0
  resident = 0
     share = 0
start_time = 1653899041
      pgrp = 0
   session = 0
      nlwp = 1
      tgid = 6868
       tty = 0
 processor = 5
  checksum = da70921d54176004350fb508c33b1920c8a9e495
```
```
curl -sSk -X GET "https://localhost:55000/syscollector/000/processes?pid=6868" -H "Authorization: Bearer $TOKEN"                                             130 ↵
{"data": {"affected_items": [{"scan": {"id": 0, "time": "2022-05-30T08:30:51+00:00"}, "state": "I", "session": 0, "name": "kworker/u16:2-e", "pid": "6868", "egroup": "root", "tty": 0, "share": 0, "utime": 0, "sgroup": "root", "ppid": 2, "nice": 0, "rgroup": "root", "start_time": 1653899041, "ruser": "root", "suser": "root", "processor": 4, "euser": "root", "priority": 20, "vm_size": 0, "stime": 7, "tgid": 6868, "fgroup": "root", "nlwp": 1, "resident": 0, "pgrp": 0, "size": 0, "agent_id": "000"}], "total_affected_items": 1, "total_failed_items": 0, "failed_items": []}, "message": "All specified syscollector information was returned", "error": 0}
```
### Avoid showing null values on syscollector alerts

Steps to reproduce:
### Storing fields as db's null when their value is an empty string
```
2022/05/30 08:36:01 wazuh-modulesd:syscollector[9339] wm_syscollector.c:107 at wm_sys_log(): DEBUG: Delta sent: {"data":{"checksum":"346a833071b479864c524a5f9ce80b4f0e7590a9","inode":326471,"item_id":"99860bca303f4696fe08400de9a3f841937453eb","local_ip":"0.0.0.0","local_port":55000,"pid":0,"process":null,"protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"scan_time":"2022/05/30 08:36:00","state":"listening","tx_queue":0},"operation":"INSERTED","type":"dbsync_ports"}
```
Before change behavior
- Alert contains "NULL" value

Expected behavior
 - Field was not shown in the alert

Current behavior
 - Field was not shown in the alert
```
sqlite> select * from sys_ports where local_port=55000 and process is null;
0|2022/05/30 08:36:00|tcp|0.0.0.0|55000|0.0.0.0|0|0|0|326471|listening|0||346a833071b479864c524a5f9ce80b4f0e7590a9|99860bca303f4696fe08400de9a3f841937453eb
```
```json
{
  "timestamp": "2022-05-30T08:36:01.447+0000",
  "rule": {
    "level": 3,
    "description": "Syscollector port creation event.",
    "id": "100311",
    "firedtimes": 1,
    "mail": false,
    "groups": [
      "syscollector"
    ]
  },
  "agent": {
    "id": "000",
    "name": "wazuh-dev"
  },
  "manager": {
    "name": "wazuh-dev"
  },
  "id": "1653899761.344919",
  "full_log": "{\"data\":{\"checksum\":\"346a833071b479864c524a5f9ce80b4f0e7590a9\",\"inode\":326471,\"item_id\":\"99860bca303f4696fe08400de9a3f841937453eb\",\"local_ip\":\"0.0.0.0\",\"local_port\":55000,\"pid\":0,\"process\":null,\"protocol\":\"tcp\",\"remote_ip\":\"0.0.0.0\",\"remote_port\":0,\"rx_queue\":0,\"scan_time\":\"2022/05/30 08:36:00\",\"state\":\"listening\",\"tx_queue\":0},\"operation\":\"INSERTED\",\"type\":\"dbsync_ports\"}",
  "decoder": {
    "name": "syscollector"
  },
  "data": {
    "type": "dbsync_ports",
    "port": {
      "protocol": "tcp",
      "local_ip": "0.0.0.0",
      "local_port": "55000",
      "remote_ip": "0.0.0.0",
      "remote_port": "0",
      "tx_queue": "0",
      "rx_queue": "0",
      "inode": "326471",
      "state": "listening",
      "pid": "0"
    },
    "operation_type": "INSERTED"
  },
  "location": "syscollector"
}
```
### Other fixes
Some UT with warnings were fixed
<details>
    <summary>Warnings</summary>

```    
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_syscollector.c:2203:9: warning: ‘wdb_osinfo_insert’ accessing 41 bytes in a region of size 10 [-Wstringop-overflow=]
     2203 |         wdb_osinfo_insert(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version",
          |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2204 |                           "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname",
          |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2205 |                           "release", "version", "os_release", "os_display_version", "checksum", false, "hexdigest", 1);
          |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_syscollector.c:2203:9: note: referencing argument 21 of type ‘char *’
    In file included from /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_syscollector.c:10:
    /root/repos/wazuh/src/wazuh_db/wdb.h:751:5: note: in a call to function ‘wdb_osinfo_insert’
      751 | int wdb_osinfo_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * hostname, const char * architecture, const char * os_name, const char * os_version, const char * os_codename, const char * os_major, const char * os_minor, const char * os_patch, const char * os_build, const char * os_platform, const char * sysname, const char * release, const char * version, const char * os_release, const char * os_display_version, const char * checksum, const bool replace, os_sha1 hexdigest, int triaged);
          |     ^~~~~~~~~~~~~~~~~
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_syscollector.c: In function ‘test_wdb_osinfo_insert_sql_fail’:
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_syscollector.c:2280:9: warning: ‘wdb_osinfo_insert’ accessing 41 bytes in a region of size 10 [-Wstringop-overflow=]
     2280 |         wdb_osinfo_insert(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version",
          |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2281 |                           "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname",
          |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2282 |                           "release", "version", "os_release", "os_display_version", "checksum", false, "hexdigest", 1);
          |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_syscollector.c:2280:9: note: referencing argument 21 of type ‘char *’
    In file included from /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_syscollector.c:10:
    /root/repos/wazuh/src/wazuh_db/wdb.h:751:5: note: in a call to function ‘wdb_osinfo_insert’
      751 | int wdb_osinfo_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * hostname, const char * architecture, const char * os_name, const char * os_version, const char * os_codename, const char * os_major, const char * os_minor, const char * os_patch, const char * os_build, const char * os_platform, const char * sysname, const char * release, const char * version, const char * os_release, const char * os_display_version, const char * checksum, const bool replace, os_sha1 hexdigest, int triaged);
          |     ^~~~~~~~~~~~~~~~~
    Scanning dependencies of target test_logtest-config
    Scanning dependencies of target test_log
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_syscollector.c: In function ‘test_wdb_osinfo_insert_success’:
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_syscollector.c:2354:9: warning: ‘wdb_osinfo_insert’ accessing 41 bytes in a region of size 10 [-Wstringop-overflow=]
     2354 |         wdb_osinfo_insert(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version",
          |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2355 |                           "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname",
          |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2356 |                           "release", "version", "os_release", "os_display_version", "checksum", false, "hexdigest", 1);
          |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_syscollector.c:2354:9: note: referencing argument 21 of type ‘char *’
    In file included from /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_syscollector.c:10:
    /root/repos/wazuh/src/wazuh_db/wdb.h:751:5: note: in a call to function ‘wdb_osinfo_insert’
      751 | int wdb_osinfo_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * hostname, const char * architecture, const char * os_name, const char * os_version, const char * os_codename, const char * os_major, const char * os_minor, const char * os_patch, const char * os_build, const char * os_platform, const char * sysname, const char * release, const char * version, const char * os_release, const char * os_display_version, const char * checksum, const bool replace, os_sha1 hexdigest, int triaged);
      
      
      In file included from /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_integrity.c:13:
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_integrity.c: In function ‘test_wdbi_checksum_range_wbs_null’:
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_integrity.c:183:27: warning: ‘wdbi_checksum_range’ accessing 41 bytes in a region of size 1 [-Wstringop-overflow=]
      183 |     expect_assert_failure(wdbi_checksum_range(NULL, 0, "test_begin", "test_end", ""));
          |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_integrity.c:183:27: note: referencing argument 5 of type ‘char *’
    In file included from /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_integrity.c:17:
    /root/repos/wazuh/src/headers/../wazuh_db/wdb.h:1462:5: note: in a call to function ‘wdbi_checksum_range’
     1462 | int wdbi_checksum_range(wdb_t * wdb, wdb_component_t component, const char * begin, const char * end, os_sha1 hexdigest);
     
     In file included from /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_integrity.c:13:
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_integrity.c: In function ‘test_wdbi_checksum_wbs_null’:
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_integrity.c:129:27: warning: ‘wdbi_checksum’ accessing 41 bytes in a region of size 1 [-Wstringop-overflow=]
      129 |     expect_assert_failure(wdbi_checksum(NULL, 0, ""));
          |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_integrity.c:129:27: note: referencing argument 3 of type ‘char *’
    In file included from /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_integrity.c:17:
    /root/repos/wazuh/src/headers/../wazuh_db/wdb.h:1460:5: note: in a call to function ‘wdbi_checksum’
     1460 | int wdbi_checksum(wdb_t * wdb, wdb_component_t component, os_sha1 hexdigest);
     
     
      21%] Building C object analysisd/CMakeFiles/test_mitre.dir/test_mitre.c.o
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_syscollector.c:2203:9: warning: ‘wdb_osinfo_insert’ accessing 41 bytes in a region of size 10 [-Wstringop-overflow=]
     2203 |         wdb_osinfo_insert(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version",
          |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2204 |                           "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname",
          |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2205 |                           "release", "version", "os_release", "os_display_version", "checksum", false, "hexdigest", 1);
          |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_syscollector.c:2203:9: note: referencing argument 21 of type ‘char *’
    In file included from /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_syscollector.c:10:
    /root/repos/wazuh/src/wazuh_db/wdb.h:751:5: note: in a call to function ‘wdb_osinfo_insert’
      751 | int wdb_osinfo_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * hostname, const char * architecture, const char * os_name, const char * os_version, const char * os_codename, const char * os_major, const char * os_minor, const char * os_patch, const char * os_build, const char * os_platform, const char * sysname, const char * release, const char * version, const char * os_release, const char * os_display_version, const char * checksum, const bool replace, os_sha1 hexdigest, int triaged);
          |     ^~~~~~~~~~~~~~~~~
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_syscollector.c: In function ‘test_wdb_osinfo_insert_sql_fail’:
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_syscollector.c:2280:9: warning: ‘wdb_osinfo_insert’ accessing 41 bytes in a region of size 10 [-Wstringop-overflow=]
     2280 |         wdb_osinfo_insert(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version",
          |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2281 |                           "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname",
          |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2282 |                           "release", "version", "os_release", "os_display_version", "checksum", false, "hexdigest", 1);
          |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_syscollector.c:2280:9: note: referencing argument 21 of type ‘char *’
    In file included from /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_syscollector.c:10:
    /root/repos/wazuh/src/wazuh_db/wdb.h:751:5: note: in a call to function ‘wdb_osinfo_insert’
      751 | int wdb_osinfo_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * hostname, const char * architecture, const char * os_name, const char * os_version, const char * os_codename, const char * os_major, const char * os_minor, const char * os_patch, const char * os_build, const char * os_platform, const char * sysname, const char * release, const char * version, const char * os_release, const char * os_display_version, const char * checksum, const bool replace, os_sha1 hexdigest, int triaged);
          |     ^~~~~~~~~~~~~~~~~
    Scanning dependencies of target test_logtest-config
    Scanning dependencies of target test_log
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_syscollector.c: In function ‘test_wdb_osinfo_insert_success’:
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_syscollector.c:2354:9: warning: ‘wdb_osinfo_insert’ accessing 41 bytes in a region of size 10 [-Wstringop-overflow=]
     2354 |         wdb_osinfo_insert(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version",
          |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2355 |                           "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname",
          |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2356 |                           "release", "version", "os_release", "os_display_version", "checksum", false, "hexdigest", 1);
          |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_syscollector.c:2354:9: note: referencing argument 21 of type ‘char *’
    In file included from /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_syscollector.c:10:
    /root/repos/wazuh/src/wazuh_db/wdb.h:751:5: note: in a call to function ‘wdb_osinfo_insert’
      751 | int wdb_osinfo_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * hostname, const char * architecture, const char * os_name, const char * os_version, const char * os_codename, const char * os_major, const char * os_minor, const char * os_patch, const char * os_build, const char * os_platform, const char * sysname, const char * release, const char * version, const char * os_release, const char * os_display_version, const char * checksum, const bool replace, os_sha1 hexdigest, int triaged);
      
      /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_global.c:886:16: warning: ‘wdb_global_get_groups_integrity’ accessing 41 bytes in a region of size 1 [-Wstringop-overflow=]
      886 |     j_result = wdb_global_get_groups_integrity(data->wdb, "");
          |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_global.c:886:16: note: referencing argument 2 of type ‘char *’
    In file included from /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_global.c:9:
    /root/repos/wazuh/src/wazuh_db/wdb.h:2036:8: note: in a call to function ‘wdb_global_get_groups_integrity’
     2036 | cJSON* wdb_global_get_groups_integrity(wdb_t *wdb, os_sha1 hash);
          |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_global.c: In function ‘test_wdb_global_get_groups_integrity_synced’:
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_global.c:906:16: warning: ‘wdb_global_get_groups_integrity’ accessing 41 bytes in a region of size 1 [-Wstringop-overflow=]
      906 |     j_result = wdb_global_get_groups_integrity(data->wdb, "");
          |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_global.c:906:16: note: referencing argument 2 of type ‘char *’
    In file included from /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_global.c:9:
    /root/repos/wazuh/src/wazuh_db/wdb.h:2036:8: note: in a call to function ‘wdb_global_get_groups_integrity’
     2036 | cJSON* wdb_global_get_groups_integrity(wdb_t *wdb, os_sha1 hash);
          |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
</details>

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors