### PR TITLE
Adding new features to runtest.py

### DIFF
--- a/ruleset/testing/coverage.py
+++ b/ruleset/testing/coverage.py
@@ -7,11 +7,11 @@
 # Foundation
 
 import argparse
-from os import strerror
-from os import path as Path
-from os import listdir
-import errno
 import re
+import errno
+from os import path as Path
+from os import strerror
+from os import listdir
 
 
 def check_dir(path):

--- a/ruleset/testing/coverage.py
+++ b/ruleset/testing/coverage.py
@@ -69,7 +69,7 @@ def get_rule_ids(rules_path):
     for filename in listdir(rules_path):
         if Path.isfile(rules_path + filename):
             with open(rules_path + filename,'r') as rule_file:
-                ruleSet.update( {match for match in re.findall(rule_start_pattern, rule_file.read())} )
+                rule_set.update( {match for match in re.findall(rule_start_pattern, rule_file.read())} )
 
     return rule_set
 

--- a/ruleset/testing/coverage.py
+++ b/ruleset/testing/coverage.py
@@ -1,3 +1,11 @@
+#!/usr/bin/env python
+# Copyright (C) 2015, Wazuh Inc.
+#
+# This program is a free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation
+
 import argparse
 from os import strerror
 from os import path as Path

--- a/ruleset/testing/coverage.py
+++ b/ruleset/testing/coverage.py
@@ -73,6 +73,7 @@ def get_rule_ids(rules_path):
 
     return rule_set
 
+
 def get_parent_decoder_names(decoders_path):
     """
     Get a set with all parent decoder names found on given directory path.

--- a/ruleset/testing/coverage.py
+++ b/ruleset/testing/coverage.py
@@ -68,8 +68,8 @@ def get_rule_ids(rules_path):
 
     for filename in listdir(rules_path):
         if Path.isfile(rules_path + filename):
-            with open(rules_path + filename,'r') as rule_file:
-                rule_set.update( {match for match in re.findall(rule_start_pattern, rule_file.read())} )
+            with open(rules_path + filename, 'r') as rule_file:
+                rule_set.update({match for match in re.findall(rule_start_pattern, rule_file.read())})
 
     return rule_set
 

--- a/ruleset/testing/coverage.py
+++ b/ruleset/testing/coverage.py
@@ -1,0 +1,139 @@
+import argparse
+from os import strerror
+from os import path as Path
+from os import listdir
+import errno
+import re
+
+def checkDir(path):
+    """
+    Check if given path is a directory.
+
+    Parameters
+    ----------
+    path : str
+        The path to be checked.
+
+    Raises
+    ------
+    FileNotFoundError
+        If path doesn't exists.
+
+    NotADirectoryError
+        If path is not a directory.
+    """
+    if not Path.exists(path):
+        raise FileNotFoundError(errno.ENOENT, strerror(errno.ENOENT), path)
+
+    if not Path.isdir(path):
+        raise NotADirectoryError(errno.ENOTDIR, strerror(errno.ENOTDIR), path)
+
+def getRuleIds(rulesPath):
+    """
+    Get a set with all rule ids found on given directory path.
+
+    Parameters
+    ----------
+    rulesPath : str
+        Path of the directory with rule files.
+
+    Returns
+    -------
+    set
+        Set with all rule ids found. Empty set if none found.
+
+    Raises
+    ------
+    FileNotFoundError
+        If path doesn't exists.
+
+    NotADirectoryError
+        If path is not a directory.
+    """
+    checkDir(rulesPath)
+
+    ruleSet = set()
+
+    ruleStartPattern = re.compile(r'^\s*<rule\sid="(\d+)"', re.MULTILINE)
+
+    for filename in listdir(rulesPath):
+        if Path.isfile(rulesPath+filename):
+            with open(rulesPath+filename,'r') as ruleFile:
+                ruleSet.update( {match for match in re.findall(ruleStartPattern, ruleFile.read())} )
+
+    return ruleSet
+
+def getParentDecoderNames(decodersPath):
+    """
+    Get a set with all parent decoder names found on given directory path.
+
+    Parameters
+    ----------
+    decodersPath : str
+        Path of the directory with decoder files.
+
+    Returns
+    -------
+    set
+        Set with all parent decoder names found. Empty set if none found.
+
+    Raises
+    ------
+    FileNotFoundError
+        If path doesn't exists.
+
+    NotADirectoryError
+        If path is not a directory.
+    """
+    checkDir(decodersPath)
+
+    decoderSet = set()
+    decoderStartPattern = re.compile(r'^\s*<decoder\sname="(.+)">')
+    decoderEndPattern = re.compile(r'^\s*</decoder>')
+    parentDecoderPattern = re.compile(r'^\s*<parent>')
+
+    for filename in listdir(decodersPath):
+        if Path.isfile(decodersPath+filename):
+            with open(decodersPath+filename,'r') as decoderFile:
+                insideDecoder = False
+                parentFound = False
+                decoderName = None
+                for line in decoderFile:
+                    if not insideDecoder:
+                        decoderName = re.match(decoderStartPattern, line)
+                        if decoderName:
+                            insideDecoder = True
+                            decoderName = decoderName.group(1)
+                    elif not parentFound and re.match(parentDecoderPattern, line):
+                        parentFound = True
+                    elif re.match(decoderEndPattern, line):
+                        if not parentFound:
+                            decoderSet.add(decoderName)
+                        else:
+                            parentFound = False
+
+                        insideDecoder = False
+
+    return decoderSet
+
+
+def main(testsPath, rulesetPath, outputPath):
+    ruleSet = getRuleIds(rulesetPath + "rules/")
+    parentDecoderSet = getParentDecoderNames(rulesetPath + "decoders/")
+
+    print(len(ruleSet))
+    print(len(parentDecoderSet))
+
+if __name__ == "__main__":
+    # Console arguments definition
+    parser = argparse.ArgumentParser(
+        prog="mitre_mapping.py",
+        description='Script to update ruleset mitre mappings from csv file')
+
+    parser.add_argument("tests_path", help="path were ini test files are located")
+    parser.add_argument("ruleset_path", help="path were ruleset is located")
+    parser.add_argument("-o", "--output", help="output directory with coverage results", default=None)
+
+    args = parser.parse_args()
+    main(args.tests_path, args.ruleset_path, args.output)
+

--- a/ruleset/testing/coverage.py
+++ b/ruleset/testing/coverage.py
@@ -111,7 +111,7 @@ def get_parent_decoder_names(decoders_path):
                 decoder_name = None
                 for line in decoder_file:
                     if not inside_decoder:
-                        decoder_name = re.match(decoderStartPattern, line)
+                        decoder_name = re.match(decoder_start_pattern, line)
                         if decoder_name:
                             inside_decoder = True
                             decoder_name = decoder_name.group(1)

--- a/ruleset/testing/runtests.py
+++ b/ruleset/testing/runtests.py
@@ -182,10 +182,8 @@ class OssecTester(object):
             sys.stdout.flush()
         return did_pass
 
-    def run(self, selective_test=False, geoip=False, custom=False):
+    def run(self, selective_test=False, geoip=False):
         for aFile in os.listdir(self._test_path):
-            if re.match(r'^test_(.*?).ini$',aFile) and not custom:
-                continue
             aFile = os.path.join(self._test_path, aFile)
             if aFile.endswith(".ini"):
                 if selective_test and not aFile.endswith(selective_test):
@@ -263,8 +261,6 @@ if __name__ == "__main__":
                         help='Use -g or --geoip to enable geoip tests (default: False)')
     parser.add_argument('--testfile', '-t', action='store', type=str, dest='testfile',
                         help='Use -t or --testfile to pass the ini file to test')
-    parser.add_argument('--custom-ruleset', '-c', action='store_true', dest='custom',
-                        help='Use -c or --custom-ruleset to test custom rules and decoders')
     parser.add_argument('--skip-windows-eventchannel', '-s', action='store_false', dest='windows_tests',
                         help='Use -s or --skip-windows-eventchannel to avoid modifying windows event channel rules for testing.')
     args = parser.parse_args()
@@ -288,7 +284,7 @@ if __name__ == "__main__":
     restart_analysisd()
 
     OT = OssecTester(args.wazuh_home)
-    error = OT.run(selective_test, args.geoip, args.custom)
+    error = OT.run(selective_test, args.geoip)
 
     cleanDR()
     if args.windows_tests:

--- a/ruleset/testing/runtests.py
+++ b/ruleset/testing/runtests.py
@@ -49,6 +49,7 @@ def getWazuhInfo(wazuh_home):
 
     return wazuh_env_vars
 
+
 def provisionDR():
     base_dir = os.path.dirname(os.path.realpath(__file__))
     rules_dir = os.path.join(base_dir, "ruleset")
@@ -57,12 +58,13 @@ def provisionDR():
     for file in os.listdir(rules_dir):
         file_fullpath = os.path.join(rules_dir, file)
         if os.path.isfile(file_fullpath) and re.match(r'^test_(.*_)?rules.xml$',file):
-            shutil.copy2(file_fullpath , args.wazuh_home + "/etc/rules")
+            shutil.copy2(file_fullpath, args.wazuh_home + "/etc/rules")
 
     for file in os.listdir(decoders_dir):
         file_fullpath = os.path.join(decoders_dir, file)
         if os.path.isfile(file_fullpath) and re.match(r'^test_(.*_)?decoders.xml$',file):
-            shutil.copy2(file_fullpath , args.wazuh_home + "/etc/decoders")
+            shutil.copy2(file_fullpath, args.wazuh_home + "/etc/decoders")
+
 
 def cleanDR():
     rules_dir = args.wazuh_home + "/etc/rules"
@@ -78,9 +80,11 @@ def cleanDR():
         if os.path.isfile(file_fullpath) and re.match(r'^test_(.*_)?decoders.xml$',file):
             os.remove(file_fullpath)
 
+
 def restart_analysisd():
     print("Restarting wazuh-manager...")
     ret = os.system('systemctl restart wazuh-manager')
+
 
 def enable_win_eventlog_test_actions(tree):
     base_rule = tree.find('.//rule[@id="60000"]')
@@ -88,6 +92,7 @@ def enable_win_eventlog_test_actions(tree):
     base_rule.remove(base_rule.find(".//category"))
     decoded_as = ET.SubElement(base_rule,"decoded_as")
     decoded_as.text = "json"
+
 
 def disable_win_eventlog_test_actions(tree):
     base_rule = tree.find('.//rule[@id="60000"]')
@@ -97,6 +102,7 @@ def disable_win_eventlog_test_actions(tree):
     category = ET.SubElement(base_rule,"category")
     category.text = "ossec"
 
+
 def modify_win_eventlog_testing(action):
     win_base_rules_file = "/var/ossec/ruleset/rules/0575-win-base_rules.xml"
     actions = {"enable": enable_win_eventlog_test_actions, "disable": disable_win_eventlog_test_actions}
@@ -104,8 +110,10 @@ def modify_win_eventlog_testing(action):
     actions[action](tree)
     tree.write(win_base_rules_file)
 
+
 def enable_win_eventlog_tests():
     modify_win_eventlog_testing("enable")
+
 
 def disable_win_eventlog_tests():
     modify_win_eventlog_testing("disable")
@@ -135,7 +143,9 @@ def gather_failed_test_data(std_out, alert, rule, decoder, section, line_name):
 
     return failed_test
 
+
 class OssecTester(object):
+
     def __init__(self, bdir):
         self._error = False
         self._debug = False
@@ -185,6 +195,7 @@ class OssecTester(object):
             sys.stdout.flush()
         return test_status
 
+
     def run(self, selective_test=False, geoip=False):
         for a_ini_file in os.listdir(self._test_path):
             a_ini_file = os.path.join(self._test_path, a_ini_file)
@@ -215,6 +226,7 @@ class OssecTester(object):
                             self._execution_data[a_ini_file][self.runTest(value, rule, alert, decoder,t, name, negate=neg)]+=1
                 print("\n\n")
         return self._error
+
 
     def print_results(self):
         template = "|{: ^25}|{: ^10}|{: ^10}|{: ^10}|"
@@ -253,6 +265,7 @@ class OssecTester(object):
 def cleanup(*args):
     cleanDR()
     sys.exit(0)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='This script tests Wazuh rules.')

--- a/ruleset/testing/runtests.py
+++ b/ruleset/testing/runtests.py
@@ -153,7 +153,7 @@ class OssecTester(object):
         return cmd
 
     def runTest(self, log, rule, alert, decoder, section, name, negate=False):
-        did_pass = "failed"
+        test_status = "failed"
         self.tested_rules.add(rule)
         self.tested_decoders.add(decoder)
         p = subprocess.Popen(
@@ -181,22 +181,22 @@ class OssecTester(object):
             print(std_out)
         else:
             sys.stdout.write(".")
-            did_pass = "passed"
+            test_status = "passed"
             sys.stdout.flush()
-        return did_pass
+        return test_status
 
     def run(self, selective_test=False, geoip=False):
-        for aFile in os.listdir(self._test_path):
-            aFile = os.path.join(self._test_path, aFile)
-            if aFile.endswith(".ini"):
-                if selective_test and not aFile.endswith(selective_test):
+        for a_ini_file in os.listdir(self._test_path):
+            a_ini_file = os.path.join(self._test_path, a_ini_file)
+            if a_ini_file.endswith(".ini"):
+                if selective_test and not a_ini_file.endswith(selective_test):
                     continue
-                if geoip is False and aFile.endswith("geoip.ini"):
+                if geoip is False and a_ini_file.endswith("geoip.ini"):
                     continue
-                self._execution_data[aFile] = {"passed":0, "failed":0}
-                print("- [ File = %s ] ---------" % (aFile))
+                self._execution_data[a_ini_file] = {"passed":0, "failed":0}
+                print("- [ File = %s ] ---------" % (a_ini_file))
                 tGroup = ConfigParser.RawConfigParser(dict_type=MultiOrderedDict)
-                tGroup.read([aFile])
+                tGroup.read([a_ini_file])
                 tSections = tGroup.sections()
                 for t in tSections:
                     rule = tGroup.get(t, "rule")
@@ -212,9 +212,8 @@ class OssecTester(object):
                                 neg = True
                             else:
                                 neg = False
-                            self._execution_data[aFile][self.runTest(value, rule, alert, decoder,t, name, negate=neg)]+=1
-                print("")
-                print("")
+                            self._execution_data[a_ini_file][self.runTest(value, rule, alert, decoder,t, name, negate=neg)]+=1
+                print("\n\n")
         return self._error
 
     def print_results(self):
@@ -229,7 +228,6 @@ class OssecTester(object):
             print(template.format(test_name, passed_count, failed_count, status))
 
         if len(self._failed_tests):
-
             template = "|{: <10} |{: ^25}|{: ^25}|"
             print("\n\nFailing tests summary:")
             for failed_test in self._failed_tests:
@@ -291,7 +289,7 @@ if __name__ == "__main__":
 
     cleanDR()
     if args.windows_tests:
-            disable_win_eventlog_tests()
+        disable_win_eventlog_tests()
     restart_analysisd()
 
     rules = get_rule_ids("/var/ossec/ruleset/rules/")
@@ -303,7 +301,7 @@ if __name__ == "__main__":
     template = "|{: ^10}|{: ^10}|{: ^10}|{: ^10.2%}|"
     print(template.format("Rules", len(OT.tested_rules), len(rules), len(OT.tested_rules)/len(rules)))
     print(template.format("Decoders", len(OT.tested_decoders), len(decoders), len(OT.tested_decoders)/len(decoders)))
-    print("")
+    print("\n")
 
     OT.print_results()
 

--- a/ruleset/testing/runtests.py
+++ b/ruleset/testing/runtests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2015-2022, Wazuh Inc.
+# Copyright (C) 2015, Wazuh Inc.
 #
 # This program is a free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
@@ -57,12 +57,12 @@ def provisionDR():
 
     for file in os.listdir(rules_dir):
         file_fullpath = os.path.join(rules_dir, file)
-        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*?)_rules.xml$',file):
+        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*?_)rules.xml$',file):
             shutil.copy2(file_fullpath , args.wazuh_home + "/etc/rules")
 
     for file in os.listdir(decoders_dir):
         file_fullpath = os.path.join(decoders_dir, file)
-        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*?)_decoders.xml$',file):
+        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*?_)decoders.xml$',file):
             shutil.copy2(file_fullpath , args.wazuh_home + "/etc/decoders")
 
 def cleanDR():
@@ -71,12 +71,12 @@ def cleanDR():
 
     for file in os.listdir(rules_dir):
         file_fullpath = os.path.join(rules_dir, file)
-        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*?)_rules.xml$',file):
+        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*?_)rules.xml$',file):
             os.remove(file_fullpath)
 
     for file in os.listdir(decoders_dir):
         file_fullpath = os.path.join(decoders_dir, file)
-        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*?)_decoders.xml$',file):
+        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*?_)decoders.xml$',file):
             os.remove(file_fullpath)
 
 def restart_analysisd():

--- a/ruleset/testing/runtests.py
+++ b/ruleset/testing/runtests.py
@@ -21,8 +21,6 @@ import xml.etree.ElementTree as ET
 from coverage import getRuleIds
 from coverage import getParentDecoderNames
 
-rules_test_fname_pattern = re.compile('^test_(.*?)_rules.xml$')
-decoders_test_fname_pattern = re.compile('^test_(.*?)_decoders.xml$')
 
 class MultiOrderedDict(OrderedDict):
     def __setitem__(self, key, value):
@@ -57,12 +55,12 @@ def provisionDR():
 
     for file in os.listdir(rules_dir):
         file_fullpath = os.path.join(rules_dir, file)
-        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*?_)rules.xml$',file):
+        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*_)?rules.xml$',file):
             shutil.copy2(file_fullpath , args.wazuh_home + "/etc/rules")
 
     for file in os.listdir(decoders_dir):
         file_fullpath = os.path.join(decoders_dir, file)
-        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*?_)decoders.xml$',file):
+        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*_)?decoders.xml$',file):
             shutil.copy2(file_fullpath , args.wazuh_home + "/etc/decoders")
 
 def cleanDR():
@@ -71,12 +69,12 @@ def cleanDR():
 
     for file in os.listdir(rules_dir):
         file_fullpath = os.path.join(rules_dir, file)
-        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*?_)rules.xml$',file):
+        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*_)?rules.xml$',file):
             os.remove(file_fullpath)
 
     for file in os.listdir(decoders_dir):
         file_fullpath = os.path.join(decoders_dir, file)
-        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*?_)decoders.xml$',file):
+        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*_)?decoders.xml$',file):
             os.remove(file_fullpath)
 
 def restart_analysisd():

--- a/ruleset/testing/runtests.py
+++ b/ruleset/testing/runtests.py
@@ -116,13 +116,13 @@ def gather_failed_test_data(std_out, alert, rule, decoder, section, line_name):
                     "expected_rule" :  rule,
                     "expected_decoder" : decoder,
                     "section" : section,
-                    "line_name" : line_name}
+                    "line_name" : line_name,
+                    "actual_rule": "",
+                    "actual_level": "",
+                    "description": ""}
 
     if re.search(r'No decoder matched.', std_out):
         failed_test["actual_decoder"] = ""
-        failed_test["actual_rule"] = ""
-        failed_test["actual_level"] = ""
-        failed_test["description"] = ""
     else:
         decoder_search = re.search(r"Completed decoding.\n\tname:\s*\'(?P<decoder>[\w-]*)",std_out)
         failed_test["actual_decoder"] = decoder_search.group("decoder")
@@ -132,10 +132,6 @@ def gather_failed_test_data(std_out, alert, rule, decoder, section, line_name):
             failed_test["actual_rule"] = rule_search.group("rule_id")
             failed_test["actual_level"] = rule_search.group("level")
             failed_test["description"] = rule_search.group("description")
-        else:
-            failed_test["actual_rule"] = ""
-            failed_test["actual_level"] = ""
-            failed_test["description"] = ""
 
     return failed_test
 

--- a/ruleset/testing/runtests.py
+++ b/ruleset/testing/runtests.py
@@ -22,7 +22,6 @@ from coverage import get_rule_ids
 from coverage import get_parent_decoder_names
 
 
-
 class MultiOrderedDict(OrderedDict):
     def __setitem__(self, key, value):
         if isinstance(value, list) and key in self:
@@ -37,7 +36,7 @@ def getWazuhInfo(wazuh_home):
     try:
         proc = subprocess.Popen([wazuh_control, "info"], stdout=subprocess.PIPE)
         (stdout, stderr) = proc.communicate()
-    except:
+    except Exception as e:
         print("Seems like there is no Wazuh installation.")
         return None
 
@@ -57,12 +56,12 @@ def provisionDR():
 
     for file in os.listdir(rules_dir):
         file_fullpath = os.path.join(rules_dir, file)
-        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*_)?rules.xml$',file):
+        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*_)?rules.xml$', file):
             shutil.copy2(file_fullpath, args.wazuh_home + "/etc/rules")
 
     for file in os.listdir(decoders_dir):
         file_fullpath = os.path.join(decoders_dir, file)
-        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*_)?decoders.xml$',file):
+        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*_)?decoders.xml$', file):
             shutil.copy2(file_fullpath, args.wazuh_home + "/etc/decoders")
 
 
@@ -72,12 +71,12 @@ def cleanDR():
 
     for file in os.listdir(rules_dir):
         file_fullpath = os.path.join(rules_dir, file)
-        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*_)?rules.xml$',file):
+        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*_)?rules.xml$', file):
             os.remove(file_fullpath)
 
     for file in os.listdir(decoders_dir):
         file_fullpath = os.path.join(decoders_dir, file)
-        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*_)?decoders.xml$',file):
+        if os.path.isfile(file_fullpath) and re.match(r'^test_(.*_)?decoders.xml$', file):
             os.remove(file_fullpath)
 
 
@@ -90,16 +89,16 @@ def enable_win_eventlog_test_actions(tree):
     base_rule = tree.find('.//rule[@id="60000"]')
     base_rule.remove(base_rule.find(".//decoded_as"))
     base_rule.remove(base_rule.find(".//category"))
-    decoded_as = ET.SubElement(base_rule,"decoded_as")
+    decoded_as = ET.SubElement(base_rule, "decoded_as")
     decoded_as.text = "json"
 
 
 def disable_win_eventlog_test_actions(tree):
     base_rule = tree.find('.//rule[@id="60000"]')
     base_rule.remove(base_rule.find(".//decoded_as"))
-    decoded_as = ET.SubElement(base_rule,"decoded_as")
+    decoded_as = ET.SubElement(base_rule, "decoded_as")
     decoded_as.text = "windows_eventchannel"
-    category = ET.SubElement(base_rule,"category")
+    category = ET.SubElement(base_rule, "category")
     category.text = "ossec"
 
 
@@ -120,23 +119,23 @@ def disable_win_eventlog_tests():
 
 
 def gather_failed_test_data(std_out, alert, rule, decoder, section, line_name):
-    failed_test = {"expected_level" : alert,
-                    "expected_rule" :  rule,
-                    "expected_decoder" : decoder,
-                    "section" : section,
-                    "line_name" : line_name,
-                    "actual_rule": "",
-                    "actual_level": "",
-                    "description": ""}
+    failed_test = {"expected_level": alert,
+                   "expected_rule":  rule,
+                   "expected_decoder": decoder,
+                   "section": section,
+                   "line_name": line_name,
+                   "actual_rule": "",
+                   "actual_level": "",
+                   "description": ""}
 
     if re.search(r'No decoder matched.', std_out):
         failed_test["actual_decoder"] = ""
     else:
-        decoder_search = re.search(r"Completed decoding.\n\tname:\s*\'(?P<decoder>[\w-]*)",std_out)
+        decoder_search = re.search(r"Completed decoding.\n\tname:\s*\'(?P<decoder>[\w-]*)", std_out)
         failed_test["actual_decoder"] = decoder_search.group("decoder")
 
-        if re.search(r"Phase 3: Completed filtering \(rules\)",std_out):
-            rule_search = re.search(r"Completed filtering \(rules\)\.\n\tid:\s+\'(?P<rule_id>\d+)\W+level:\s*'(?P<level>\d+)\W+description:\s+'(?P<description>.*?)'",std_out)
+        if re.search(r"Phase 3: Completed filtering \(rules\)", std_out):
+            rule_search = re.search(r"Completed filtering \(rules\)\.\n\tid:\s+\'(?P<rule_id>\d+)\W+level:\s*'(?P<level>\d+)\W+description:\s+'(?P<description>.*?)'", std_out)
             failed_test["actual_rule"] = rule_search.group("rule_id")
             failed_test["actual_level"] = rule_search.group("level")
             failed_test["description"] = rule_search.group("description")
@@ -195,7 +194,6 @@ class OssecTester(object):
             sys.stdout.flush()
         return test_status
 
-
     def run(self, selective_test=False, geoip=False):
         for a_ini_file in os.listdir(self._test_path):
             a_ini_file = os.path.join(self._test_path, a_ini_file)
@@ -204,7 +202,7 @@ class OssecTester(object):
                     continue
                 if geoip is False and a_ini_file.endswith("geoip.ini"):
                     continue
-                self._execution_data[a_ini_file] = {"passed":0, "failed":0}
+                self._execution_data[a_ini_file] = {"passed": 0, "failed": 0}
                 print("- [ File = %s ] ---------" % (a_ini_file))
                 tGroup = ConfigParser.RawConfigParser(dict_type=MultiOrderedDict)
                 tGroup.read([a_ini_file])
@@ -223,10 +221,9 @@ class OssecTester(object):
                                 neg = True
                             else:
                                 neg = False
-                            self._execution_data[a_ini_file][self.runTest(value, rule, alert, decoder,t, name, negate=neg)]+=1
+                            self._execution_data[a_ini_file][self.runTest(value, rule, alert, decoder, t, name, negate=neg)] += 1
                 print("\n\n")
         return self._error
-
 
     def print_results(self):
         template = "|{: ^25}|{: ^10}|{: ^10}|{: ^10}|"
@@ -253,10 +250,10 @@ class OssecTester(object):
                     summary["summary"] = "Unexpected alert level. Expected: " + failed_test["expected_level"] + ". Got: " + failed_test["actual_level"]
 
                 print("----------------------------------------")
-                print("Failed test: "+failed_test["line_name"])
-                print("Summary: "+ summary)
-                print(template.format("","Expected","Result"))
-                print(template.format("------","------","------"))
+                print("Failed test: " + failed_test["line_name"])
+                print("Summary: " + summary)
+                print(template.format("", "Expected", "Result"))
+                print(template.format("------", "------", "------"))
                 print(template.format("Decoder", failed_test["expected_decoder"], failed_test["actual_decoder"]))
                 print(template.format("Rule", failed_test["expected_rule"], failed_test["actual_rule"]))
                 print(template.format("Level", failed_test["expected_level"], failed_test["actual_level"]))


### PR DESCRIPTION
|Related issue|
|---|
|#13555|



## Description

New features added to runtest.py:
* Windows event channel testing
* Better reporting capabilities




## Tests

|Component |  Tested  |  Total   | Coverage |
| -------- | -------- | -------- | -------- |
|  Rules   |   1171   |   4247   |  27.57%  |
| Decoders |    75    |   165    |  45.45%  |

|          File           |  Passed  |  Failed  |  Status  |
|        --------         | -------- | -------- | -------- |
|./tests/proftpd.ini      |    7     |    0     |   ✅    |
|./tests/exim.ini         |    7     |    0     |   ✅    |
|./tests/squid_rules.ini  |    2     |    0     |   ✅    |
|./tests/sysmon_eid_3.ini |    10    |    0     |   ✅    |
|./tests/checkpoint_smart1.ini|    18    |    0     |   ✅    |
|./tests/iptables.ini     |    8     |    0     |   ✅    |
|./tests/sysmon_eid_10.ini|    4     |    0     |   ✅    |
|./tests/SonicWall.ini    |    11    |    0     |   ✅    |
|./tests/panda_paps.ini   |    8     |    0     |   ✅    |
|./tests/fortiauth.ini    |    4     |    0     |   ✅    |
|./tests/openldap.ini     |    9     |    0     |   ✅    |
|./tests/f5_big_ip.ini    |    48    |    0     |   ✅    |
|./tests/sophos.ini       |    8     |    0     |   ✅    |
|./tests/opensmtpd.ini    |    7     |    0     |   ✅    |
|./tests/netscreen.ini    |    4     |    0     |   ✅    |
|./tests/rsh.ini          |    2     |    0     |   ✅    |
|./tests/arbor.ini        |    2     |    0     |   ✅    |
|./tests/web_rules.ini    |    10    |    0     |   ✅    |
|./tests/exchange.ini     |    2     |    0     |   ✅    |
|./tests/vuln_detector.ini|    2     |    0     |   ✅    |
|./tests/sysmon_eid_7.ini |    6     |    0     |   ✅    |
|./tests/cpanel.ini       |    7     |    0     |   ✅    |
|./tests/apparmor.ini     |    5     |    0     |   ✅    |
|./tests/pam.ini          |    5     |    0     |   ✅    |
|./tests/apache.ini       |    12    |    0     |   ✅    |
|./tests/fireeye.ini      |    3     |    0     |   ✅    |
|./tests/sysmon.ini       |    3     |    0     |   ✅    |
|./tests/dovecot.ini      |    15    |    0     |   ✅    |
|./tests/nginx.ini        |    12    |    0     |   ✅    |
|./tests/nextcloud.ini    |    8     |    0     |   ✅    |
|./tests/unbound.ini      |    0     |    0     |   ✅    |
|./tests/paloalto.ini     |    16    |    0     |   ✅    |
|./tests/sysmon_eid_13.ini|    7     |    0     |   ✅    |
|./tests/ossec.ini        |    5     |    0     |   ✅    |
|./tests/cisco_ftd.ini    |    42    |    0     |   ✅    |
|./tests/sysmon_eid_1.ini |    59    |    0     |   ✅    |
|./tests/github.ini       |   324    |    0     |   ✅    |
|./tests/fortimail.ini    |    6     |    0     |   ✅    |
|./tests/named.ini        |    5     |    0     |   ✅    |
|./tests/powershell.ini   |    32    |    0     |   ✅    |
|./tests/openvpn_ldap.ini |    2     |    0     |   ✅    |
|./tests/sysmon_eid_8.ini |    4     |    0     |   ✅    |
|./tests/cloudflare-waf.ini|    13    |    0     |   ✅    |
|./tests/huawei_usg.ini   |    3     |    0     |   ✅    |
|./tests/eset.ini         |    8     |    0     |   ✅    |
|./tests/gcp.ini          |    31    |    0     |   ✅    |
|./tests/samba.ini        |    4     |    0     |   ✅    |
|./tests/pfsense.ini      |    2     |    0     |   ✅    |
|./tests/cisco_asa.ini    |    88    |    0     |   ✅    |
|./tests/systemd.ini      |    2     |    0     |   ✅    |
|./tests/web_appsec.ini   |    31    |    0     |   ✅    |
|./tests/sysmon_eid_11.ini|    28    |    0     |   ✅    |
|./tests/cisco_ios.ini    |    17    |    0     |   ✅    |
|./tests/pix.ini          |    22    |    0     |   ✅    |
|./tests/php.ini          |    2     |    0     |   ✅    |
|./tests/office365.ini    |   128    |    0     |   ✅    |
|./tests/fortigate.ini    |    45    |    0     |   ✅    |
|./tests/audit_scp.ini    |    8     |    0     |   ✅    |
|./tests/win_application.ini|    0     |    0     |   ✅    |
|./tests/fortiddos.ini    |    1     |    0     |   ✅    |
|./tests/cimserver.ini    |    2     |    0     |   ✅    |
|./tests/freepbx.ini      |    6     |    0     |   ✅    |
|./tests/sshd.ini         |    47    |    0     |   ✅    |
|./tests/win_event_channel.ini|    8     |    0     |   ✅    |
|./tests/gitlab.ini       |    27    |    0     |   ✅    |
|./tests/glpi.ini         |    3     |    0     |   ✅    |
|./tests/api.ini          |    20    |    0     |   ✅    |
|./tests/dropbear.ini     |    3     |    0     |   ✅    |
|./tests/firewalld.ini    |    2     |    0     |   ✅    |
|./tests/mailscanner.ini  |    1     |    0     |   ✅    |
|./tests/owlh.ini         |    4     |    0     |   ✅    |
|./tests/sysmon_eid_20.ini|    2     |    0     |   ✅    |
|./tests/oscap.ini        |    32    |    0     |   ✅    |
|./tests/mcafee_epo.ini   |    1     |    0     |   ✅    |
|./tests/doas.ini         |    4     |    0     |   ✅    |
|./tests/junos.ini        |    3     |    0     |   ✅    |
|./tests/sudo.ini         |    8     |    0     |   ✅    |
|./tests/syslog.ini       |    6     |    0     |   ✅    |
|./tests/sophos_fw.ini    |    10    |    0     |   ✅    |
|./tests/vsftpd.ini       |    4     |    0     |   ✅    |
|./tests/postfix.ini      |    2     |    0     |   ✅    |
|./tests/modsecurity.ini  |    6     |    0     |   ✅    |
|./tests/su.ini           |    5     |    0     |   ✅    |
|./tests/kernel_usb.ini   |    6     |    0     |   ✅    |
|./tests/aws_s3_access.ini|    10    |    0     |   ✅    |
|./tests/auditd.ini       |    31    |    0     |   ✅    |
