### PR TITLE
Properly handle AR information when overwriting a rule

### DIFF
--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -433,21 +433,7 @@ int OS_AddRuleInfo(RuleNode *r_node, RuleInfo *newrule, int sid, OSList* log_msg
 
             r_node->ruleinfo->compiled_rule = newrule->compiled_rule;
 
-            if (r_node->ruleinfo->ar) {
-                for (int i = 0; r_node->ruleinfo->ar[i]; i++) {
-                    os_free(r_node->ruleinfo->ar[i]->name);
-                    os_free(r_node->ruleinfo->ar[i]->command);
-                    os_free(r_node->ruleinfo->ar[i]->agent_id);
-                    os_free(r_node->ruleinfo->ar[i]->rules_id);
-                    os_free(r_node->ruleinfo->ar[i]->rules_group);
-                    os_free(r_node->ruleinfo->ar[i]->ar_cmd->name);
-                    os_free(r_node->ruleinfo->ar[i]->ar_cmd->executable);
-                    os_free(r_node->ruleinfo->ar[i]->ar_cmd->extra_args);
-                    os_free(r_node->ruleinfo->ar[i]->ar_cmd);
-                    os_free(r_node->ruleinfo->ar[i]);
-                }
-                os_free(r_node->ruleinfo->ar);
-            }
+            os_free(r_node->ruleinfo->ar);
             r_node->ruleinfo->ar = newrule->ar;
 
             os_free(r_node->ruleinfo->file);

--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -672,21 +672,7 @@ void os_remove_ruleinfo(RuleInfo *ruleinfo) {
         os_free(ruleinfo->if_matched_group);
     }
 
-    if (ruleinfo->ar) {
-        for (int i = 0; ruleinfo->ar[i]; i++) {
-            os_free(ruleinfo->ar[i]->name);
-            os_free(ruleinfo->ar[i]->command);
-            os_free(ruleinfo->ar[i]->agent_id);
-            os_free(ruleinfo->ar[i]->rules_id);
-            os_free(ruleinfo->ar[i]->rules_group);
-            os_free(ruleinfo->ar[i]->ar_cmd->name);
-            os_free(ruleinfo->ar[i]->ar_cmd->executable);
-            os_free(ruleinfo->ar[i]->ar_cmd->extra_args);
-            os_free(ruleinfo->ar[i]->ar_cmd);
-            os_free(ruleinfo->ar[i]);
-        }
-        os_free(ruleinfo->ar);
-    }
+    os_free(ruleinfo->ar);
     os_free(ruleinfo->file);
     free_strarray(ruleinfo->same_fields);
     free_strarray(ruleinfo->not_same_fields);

--- a/src/unit_tests/analysisd/test_rule_list.c
+++ b/src/unit_tests/analysisd/test_rule_list.c
@@ -27,7 +27,40 @@ int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, OSList* log_msg);
 
 /* setup/teardown */
 
+static int setup_AR(void **state) {
+    active_response *ar_info;
+    os_calloc(1, sizeof(active_response), ar_info);
 
+    os_strdup("test_ar_name", ar_info->name);
+    os_strdup("test_ar_command", ar_info->command);
+    os_strdup("test_ar_agent_id", ar_info->agent_id);
+    os_strdup("test_ar_rules_id", ar_info->rules_id);
+    os_strdup("test_ar_rules_group", ar_info->rules_group);
+    os_calloc(1, sizeof(ar_command), ar_info->ar_cmd);
+    os_strdup("test_ar_command_name", ar_info->ar_cmd->name);
+    os_strdup("test_ar_command_executable", ar_info->ar_cmd->executable);
+    os_strdup("test_ar_command_extra_args", ar_info->ar_cmd->extra_args);
+
+    *state = ar_info;
+    return OS_SUCCESS;
+}
+
+static int teardown_AR(void **state) {
+    active_response *ar_info = *state;
+
+    os_free(ar_info->name);
+    os_free(ar_info->command);
+    os_free(ar_info->agent_id);
+    os_free(ar_info->rules_id);
+    os_free(ar_info->rules_group);
+    os_free(ar_info->ar_cmd->name);
+    os_free(ar_info->ar_cmd->executable);
+    os_free(ar_info->ar_cmd->extra_args);
+    os_free(ar_info->ar_cmd);
+    os_free(ar_info);
+
+    return OS_SUCCESS;
+}
 
 /* wraps */
 
@@ -170,16 +203,7 @@ void test_os_remove_ruleinfo_OK(void **state)
     os_calloc(1, sizeof(RuleInfoDetail), ruleinfo->info_details);
 
     os_calloc(2, sizeof(active_response*), ruleinfo->ar);
-    os_calloc(1, sizeof(active_response), ruleinfo->ar[0]);
-    os_strdup("test_ar_name", ruleinfo->ar[0]->name);
-    os_strdup("test_ar_command", ruleinfo->ar[0]->command);
-    os_strdup("test_ar_agent_id", ruleinfo->ar[0]->agent_id);
-    os_strdup("test_ar_rules_id", ruleinfo->ar[0]->rules_id);
-    os_strdup("testtest_ar_rules_group", ruleinfo->ar[0]->rules_group);
-    os_calloc(1, sizeof(ar_command), ruleinfo->ar[0]->ar_cmd);
-    os_strdup("test_ar_command_name", ruleinfo->ar[0]->ar_cmd->name);
-    os_strdup("test_ar_command_executable", ruleinfo->ar[0]->ar_cmd->executable);
-    os_strdup("test_ar_command_extra_args", ruleinfo->ar[0]->ar_cmd->extra_args);
+    ruleinfo->ar[0] = *state;
     os_calloc(1, sizeof(ListRule), ruleinfo->lists);
 
     os_calloc(2, sizeof(char*), ruleinfo->same_fields);
@@ -239,16 +263,7 @@ void test_os_remove_rules_list_OK(void **state)
     os_calloc(1, sizeof(RuleInfoDetail), node->ruleinfo->info_details);
 
     os_calloc(2, sizeof(active_response*), node->ruleinfo->ar);
-    os_calloc(1, sizeof(active_response), node->ruleinfo->ar[0]);
-    os_strdup("test_ar_name", node->ruleinfo->ar[0]->name);
-    os_strdup("test_ar_command", node->ruleinfo->ar[0]->command);
-    os_strdup("test_ar_agent_id", node->ruleinfo->ar[0]->agent_id);
-    os_strdup("test_ar_rules_id", node->ruleinfo->ar[0]->rules_id);
-    os_strdup("testtest_ar_rules_group", node->ruleinfo->ar[0]->rules_group);
-    os_calloc(1, sizeof(ar_command), node->ruleinfo->ar[0]->ar_cmd);
-    os_strdup("test_ar_command_name", node->ruleinfo->ar[0]->ar_cmd->name);
-    os_strdup("test_ar_command_executable", node->ruleinfo->ar[0]->ar_cmd->executable);
-    os_strdup("test_ar_command_extra_args", node->ruleinfo->ar[0]->ar_cmd->extra_args);
+    node->ruleinfo->ar[0] = *state;
     os_calloc(1, sizeof(ListRule), node->ruleinfo->lists);
 
     os_calloc(2, sizeof(char*), node->ruleinfo->same_fields);
@@ -296,9 +311,9 @@ int main(void)
         cmocka_unit_test(test_os_remove_rulenode_child),
         // Tests os_remove_ruleinfo
         cmocka_unit_test(test_os_remove_ruleinfo_NULL),
-        cmocka_unit_test(test_os_remove_ruleinfo_OK),
+        cmocka_unit_test_setup_teardown(test_os_remove_ruleinfo_OK, setup_AR, teardown_AR),
         // Tests os_remove_rules_list
-        cmocka_unit_test(test_os_remove_rules_list_OK)
+        cmocka_unit_test_setup_teardown(test_os_remove_rules_list_OK, setup_AR, teardown_AR)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #13576|

## Description
We found two cases when analysisd couldn't start because of the relationship between the rules and the active response:
- When overwriting a rule, the AR information was deallocated, causing invalid reads in later steps. e81f881f1ea40a7895699e9efa04e4884e8f487d
- If a rule was skipped (maybe because of a missing list), the AR information was also freed, causing invalid reads in later steps. fd082f6455a47f7a3844ca3e06e90e8b21884fd9 

This PR aims to fix these two problems by removing the release of the AR information in these cases.

## Configuration options
### Case 1
- Create the following rule file `/var/ossec/etc/rules/0270-web_appsec_rules_edit.xml`:
```xml
<group name="web,appsec,attack,">
  <rule id="31533" level="9" frequency="50" timeframe="5" overwrite="yes">
    <if_matched_sid>31530</if_matched_sid>
    <same_source_ip/>
    <description>Local - High amount of POST requests in a small period of time (likely bot) (50/5s).</description>
    <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SI.4,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
  </rule>
</group>
```
- Add an active response:
```xml
<active-response>
  <disabled>no</disabled>
  <command>firewall-drop</command>
  <location>defined-agent</location>
  <agent_id>001</agent_id>
  <rules_id>550</rules_id>
  <level>10</level>
  <timeout>1</timeout>
</active-response>
```

### Case 2
- Create the following file `000-local_rules.xml`: 
```xml
<group name="local,">
  <rule id="100000" level="10">
    <decoded_as>json</decoded_as>
    <match>TEST</match>
    <description>Rule to bind AR</description>
  </rule>
  <rule id="100001" level="10">
    <decoded_as>json</decoded_as>
    <match>TEST1</match>
    <description>Rule to bind AR</description>
  </rule>
  <rule id="100002" level="10">
    <decoded_as>json</decoded_as>
    <match>TEST2</match>
    <description>Rule to overwrite</description>
  </rule>
  <rule id="100002" level="0" overwrite="yes">
    <decoded_as>json</decoded_as>
    <match>TEST2</match>
    <description>Overwrite rule</description>
  </rule>
  <rule id="100003" level="4">
    <if_sid>100001</if_sid>
    <match>TEST</match>
    <description>Rule to force the fail</description>
  </rule>
  <rule id="100004" level="4">
    <if_sid>100003</if_sid>
    <match>TEST</match>
    <description>Rule to force the fail</description>
  </rule>
</group>
```
- Add an active response:
```xml
<active-response>
  <disabled>no</disabled>
  <command>firewall-drop</command>
  <location>defined-agent</location>
  <agent_id>001</agent_id>
  <rules_id>550</rules_id>
  <level>10</level>
  <timeout>1</timeout>
</active-response>
```
## Logs/Alerts example
### Case 1
```
root@ubuntumanager:/var/ossec# valgrind --leak-check=full wazuh-analysisd -t
==3236== Memcheck, a memory error detector
==3236== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==3236== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==3236== Command: wazuh-analysisd -t
==3236== 
==3236== HEAP SUMMARY:
==3236==     in use at exit: 19,341,892 bytes in 111,716 blocks
==3236==   total heap usage: 772,208 allocs, 660,492 frees, 2,501,848,272 bytes allocated
==3236== 
==3236== LEAK SUMMARY:
==3236==    definitely lost: 0 bytes in 0 blocks
==3236==    indirectly lost: 0 bytes in 0 blocks
==3236==      possibly lost: 0 bytes in 0 blocks
==3236==    still reachable: 19,341,892 bytes in 111,716 blocks
==3236==         suppressed: 0 bytes in 0 blocks
==3236== Reachable blocks (those to which a pointer was found) are not shown.
==3236== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==3236== 
==3236== For lists of detected and suppressed errors, rerun with: -s
==3236== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
==3236== could not unlink /tmp/vgdb-pipe-from-vgdb-to-3236-by-root-on-???
==3236== could not unlink /tmp/vgdb-pipe-to-vgdb-from-3236-by-root-on-???
==3236== could not unlink /tmp/vgdb-pipe-shared-mem-vgdb-3236-by-root-on-???
```
### Case 2
```
root@ubuntumanager:/var/ossec# valgrind --leak-check=full wazuh-analysisd -t
==3227== Memcheck, a memory error detector
==3227== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==3227== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==3227== Command: wazuh-analysisd -t
==3227== 
2022/05/27 14:37:49 wazuh-analysisd: WARNING: (7611): Category was not found. Invalid 'category'. Rule '100000' will be ignored.
2022/05/27 14:37:49 wazuh-analysisd: WARNING: (7611): Category was not found. Invalid 'category'. Rule '100001' will be ignored.
2022/05/27 14:37:49 wazuh-analysisd: WARNING: (7611): Category was not found. Invalid 'category'. Rule '100002' will be ignored.
2022/05/27 14:37:49 wazuh-analysisd: WARNING: (7613): Rule ID '100002' does not exist but 'overwrite' is set to 'yes'. Still, the rule will be loaded.
2022/05/27 14:37:49 wazuh-analysisd: WARNING: (7611): Category was not found. Invalid 'category'. Rule '100002' will be ignored.
2022/05/27 14:37:49 wazuh-analysisd: WARNING: (7606): Signature ID '100001' was not found. Invalid 'if_sid'. Rule '100003' will be ignored.
2022/05/27 14:37:49 wazuh-analysisd: WARNING: (7606): Signature ID '100003' was not found. Invalid 'if_sid'. Rule '100004' will be ignored.
==3227== 
==3227== HEAP SUMMARY:
==3227==     in use at exit: 19,339,030 bytes in 111,703 blocks
==3227==   total heap usage: 772,534 allocs, 660,831 frees, 2,503,069,590 bytes allocated
==3227== 
==3227== LEAK SUMMARY:
==3227==    definitely lost: 0 bytes in 0 blocks
==3227==    indirectly lost: 0 bytes in 0 blocks
==3227==      possibly lost: 0 bytes in 0 blocks
==3227==    still reachable: 19,339,030 bytes in 111,703 blocks
==3227==         suppressed: 0 bytes in 0 blocks
==3227== Reachable blocks (those to which a pointer was found) are not shown.
==3227== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==3227== 
==3227== For lists of detected and suppressed errors, rerun with: -s
==3227== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
==3227== could not unlink /tmp/vgdb-pipe-from-vgdb-to-3227-by-root-on-???
==3227== could not unlink /tmp/vgdb-pipe-to-vgdb-from-3227-by-root-on-???
==3227== could not unlink /tmp/vgdb-pipe-shared-mem-vgdb-3227-by-root-on-???
root@ubuntumanager:/var/ossec# 
```

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer