### PR TITLE
Fix agent auto-restart when shared configuration changes

### DIFF
--- a/src/active-response/restart.sh
+++ b/src/active-response/restart.sh
@@ -41,26 +41,6 @@ if [ "$TYPE" = "manager" ]; then
     fi
 fi
 
-if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
-    touch ${PWD}/var/run/.restart
-    # Making sure to stop Wazuh even if the service is not active
-    systemctl is-active --quiet wazuh-$TYPE
-    if [ $? -ne 0 ]; then
-        ${PWD}/bin/wazuh-control stop
-    fi
-    systemctl restart wazuh-$TYPE
-    rm -f ${PWD}/var/run/.restart
-elif command -v service > /dev/null 2>&1; then
-    touch ${PWD}/var/run/.restart
-    # Making sure to stop Wazuh even if the service is not active
-    service wazuh-$TYPE status > /dev/null 2>&1
-    if [ $? -ne 0 ]; then
-        ${PWD}/bin/wazuh-control stop
-    fi
-    service wazuh-$TYPE restart
-    rm -f ${PWD}/var/run/.restart
-else
-    ${PWD}/bin/wazuh-control restart
-fi
+${PWD}/bin/wazuh-control restart
 
 exit $?;


### PR DESCRIPTION
On RHEL 9 on containers, service links to systemctl but that's unavailable.

|Related issue|
|---|
|Closes #13602|

This PR aims to let the Active Response script `restart.sh` behave just like `restart-wazuh`: simply call `wazuh-control restart`, no matter the underlying service manager.

## Tests

- [x] The agent is able to restart on an RHEL 9 based container after a shared configuration change.

