### PR TITLE
Fix segmentation fault in Vuln Detector when scanning Windows agents

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2170,13 +2170,13 @@ int wm_vuldet_process_agent_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd
             published = (char *)sqlite3_column_text(stmt, 5);
             last_mod = (char *)sqlite3_column_text(stmt, 6);
 
-            os_strdup(cve, report->cve);
-            os_strdup(cwe, report->cwe);
-            os_strdup(assigner, report->assigner);
-            os_strdup(description, report->rationale);
-            os_strdup(cve_version, report->cve_version);
-            os_strdup(published, report->published);
-            os_strdup(last_mod, report->updated);
+            w_strdup(cve, report->cve);
+            w_strdup(cwe, report->cwe);
+            w_strdup(assigner, report->assigner);
+            w_strdup(description, report->rationale);
+            w_strdup(cve_version, report->cve_version);
+            w_strdup(published, report->published);
+            w_strdup(last_mod, report->updated);
 
         } else {
             goto error;


### PR DESCRIPTION
|Related issue|
|---|
|Fixes #13612|

This PR aims to fix the segmentation fault reported at #13612, when reporting a vulnerability whose CWE reference is null (according to the NVD feed). This problem happens when scanning agents running on Windows.

We're handling possible null values at parameters:
- CWE reference.
- Rationale.
- Version.

## Tests

- [x] This case is no longer reproducible on 4.2.6.
- [x] This case is no longer reproducible on 4.3.1.
- [x] Run scan-build.