### PR TITLE
Manage affected agents after removing groups properly

### DIFF
--- a/framework/scripts/agent_groups.py
+++ b/framework/scripts/agent_groups.py
@@ -125,9 +125,9 @@ def remove_group(group_id, quiet=False):
         if data['total_affected_items'] == 0:
             print(list(data['failed_items'].keys())[0])
         else:
-            affected_agents = data['dikt']['affected_agents']
+            affected_agents = next(iter(data['affected_items'][0].values()))
             msg = f'Group {group_id} removed.'
-            if not affected_agents:
+            if len(affected_agents) == 0:
                 msg += "\nNo affected agents."
             else:
                 msg += "\nAffected agents: {0}.".format(', '.join(affected_agents))


### PR DESCRIPTION
|Related issue|
|---|
|closes #13593 |


## Description

As it was reported in the issue, we were trying to access a dictionary key which does not exist when removing agent groups using the CLI.

This was due to the profiling done in https://github.com/wazuh/wazuh/pull/9046, leading to an outdated code block.

## Manual tests

### Removing an empty group

```shellsession
root@wazuh-master:/var/ossec/bin# ./agent_groups -a -g test_groups -q
Group 'test_groups' created.
root@wazuh-master:/var/ossec/bin# 
root@wazuh-master:/var/ossec/bin# ./agent_groups -l
Groups (2):
  default (1)
  test_groups (0)
Unassigned agents: 0.
root@wazuh-master:/var/ossec/bin# 
root@wazuh-master:/var/ossec/bin# ./agent_groups -r -g test_groups -q
Group test_groups removed.
No affected agents.
root@wazuh-master:/var/ossec/bin# 
```

### Removing a group with an agent assigned to it

```shellsession
root@wazuh-master:/var/ossec/bin# ./agent_groups -a -g test_groups -q
Group 'test_groups' created.
root@wazuh-master:/var/ossec/bin# ./agent_groups -a -i 001 -g test_groups -q
Group 'test_groups' added to agent '001'.
root@wazuh-master:/var/ossec/bin# 
root@wazuh-master:/var/ossec/bin# ./agent_groups -l
Groups (2):
  default (1)
  test_groups (1)
Unassigned agents: 0.
root@wazuh-master:/var/ossec/bin# 
root@wazuh-master:/var/ossec/bin# ./agent_groups -r -g test_groups -q
Group test_groups removed.
Affected agents: 001.
root@wazuh-master:/var/ossec/bin#
```

Regards,
Víctor