### PR TITLE
Fix segmentation fault in Vuln Detector when scanning Windows agents

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2088,13 +2088,13 @@ int wm_vuldet_report_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd_report
             published = (char *)sqlite3_column_text(stmt, 5);
             last_mod = (char *)sqlite3_column_text(stmt, 6);
 
-            os_strdup(cve, report->cve);
-            os_strdup(cwe, report->cwe);
-            os_strdup(assigner, report->assigner);
-            os_strdup(description, report->rationale);
-            os_strdup(cve_version, report->cve_version);
-            os_strdup(published, report->published);
-            os_strdup(last_mod, report->updated);
+            w_strdup(cve, report->cve);
+            w_strdup(cwe, report->cwe);
+            w_strdup(assigner, report->assigner);
+            w_strdup(description, report->rationale);
+            w_strdup(cve_version, report->cve_version);
+            w_strdup(published, report->published);
+            w_strdup(last_mod, report->updated);
         } else {
             goto error;
         }


### PR DESCRIPTION
|Related issue|
|---|
|#13612|

This PR aims to port the fix to the segmentation fault reported at #13612 to version 3.13.

## Tests

- [x] This case is no longer reproducible on 3.13.
- [x] Run scan-build.