### PR TITLE
Prevent Agentd from resetting its configuration on client block re-definition

### DIFF
--- a/src/client-agent/config.c
+++ b/src/client-agent/config.c
@@ -41,6 +41,11 @@ int ClientConf(const char *cfgfile)
     agt->events_persec = 500;
     agt->flags.auto_restart = 1;
     agt->crypto_method = W_METH_AES;
+    agt->notify_time = 0;
+    agt->max_time_reconnect_try = 0;
+    agt->force_reconnect_interval = 0;
+    agt->main_ip_update_interval = 0;
+    agt->server_count = 0;
 
     os_calloc(1, sizeof(wlabel_t), agt->labels);
     modules |= CCLIENT;

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -45,12 +45,6 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
     const char *xml_protocol = "protocol";
 
     agent * logr = (agent *)d1;
-    logr->notify_time = 0;
-    logr->max_time_reconnect_try = 0;
-    logr->force_reconnect_interval = 0;
-    logr->main_ip_update_interval = 0;
-    logr->rip_id = 0;
-    logr->server_count = 0;
 
     for (i = 0; node[i]; i++) {
         rip = NULL;


### PR DESCRIPTION
|Related issue|
|---|
|Closes #13583|

This PR aims to prevent the agent from resetting its configuration state when parsing multiple `<client>` stanzas.

For instance:

```xml
<ossec_config>
  <client>
    <server>
      <address>groovy</address>
    </server>
    <notify_time>15</notify_time>
    <time-reconnect>45</time-reconnect>
  </client>
  <client>
    <enrollment>
      <agent_name>Rock</agent_name>
    </enrollment>
    <server>
      <address>groovy</address>
    </server>
  </client>
  <client>
    <enrollment>
      <groups>group1</groups>
    </enrollment>
  </client>
</ossec_config>
```

We expect the agent:
- [x] Resolve the FQDN (`groovy` in the example).
- [x] `notify_time` set to 15.
- [x] `time-reconnect` set to 45.
- [x] The agent must enroll as "Rock".
- [x] The agent must enroll with group set to "group1".

## Extra tests
- [x] Define multiple `<server>` in many `<client>` blocks.
- [x] Declare `<enrollment>` multiple times.
- [ ] Use the legacy block `<address>` (outside `<server>`).
- [x] Declare fixed IP and FQDN addresses.
- [x] Test on Valgrind or AddressSanitizer.
- [x] Scan-build.