### PR TITLE
Update status code of WazuhClusterError API responses to 500

### DIFF
--- a/api/api/util.py
+++ b/api/api/util.py
@@ -10,9 +10,7 @@ from functools import wraps
 import six
 from connexion import ProblemException
 
-from wazuh.core.common import WAZUH_PATH
-from wazuh.core.exception import WazuhException, WazuhInternalError, WazuhError, WazuhPermissionError, \
-    WazuhResourceNotFound, WazuhTooManyRequests, WazuhNotAcceptable
+from wazuh.core import common, exception
 
 
 def serialize(item):
@@ -234,7 +232,7 @@ def to_relative_path(full_path):
     :return: Relative path
     :rtype: str
     """
-    return os.path.relpath(full_path, WAZUH_PATH)
+    return os.path.relpath(full_path, common.WAZUH_PATH)
 
 
 def _create_problem(exc: Exception, code=None):
@@ -254,26 +252,26 @@ def _create_problem(exc: Exception, code=None):
         ProblemException or `exc` exception type
     """
     ext = None
-    if isinstance(exc, WazuhException):
+    if isinstance(exc, exception.WazuhException):
         ext = remove_nones_to_dict({'remediation': exc.remediation,
                                     'code': exc.code,
                                     'dapi_errors': exc.dapi_errors if exc.dapi_errors != {} else None
                                     })
 
-    if isinstance(exc, WazuhInternalError):
-        raise ProblemException(status=500 if not code else code, type=exc.type, title=exc.title, detail=exc.message,
-                               ext=ext)
-    elif isinstance(exc, WazuhPermissionError):
+    if isinstance(exc, (exception.WazuhInternalError, exception.WazuhClusterError)):
+        raise ProblemException(status=500 if not code else code,
+                               type=exc.type, title=exc.title, detail=exc.message, ext=ext)
+    elif isinstance(exc, exception.WazuhPermissionError):
         raise ProblemException(status=403, type=exc.type, title=exc.title, detail=exc.message, ext=ext)
-    elif isinstance(exc, WazuhResourceNotFound):
+    elif isinstance(exc, exception.WazuhResourceNotFound):
         raise ProblemException(status=404, type=exc.type, title=exc.title, detail=exc.message, ext=ext)
-    elif isinstance(exc, WazuhTooManyRequests):
+    elif isinstance(exc, exception.WazuhTooManyRequests):
         raise ProblemException(status=429, type=exc.type, title=exc.title, detail=exc.message, ext=ext)
-    elif isinstance(exc, WazuhNotAcceptable):
+    elif isinstance(exc, exception.WazuhNotAcceptable):
         raise ProblemException(status=406, type=exc.type, title=exc.title, detail=exc.message, ext=ext)
-    elif isinstance(exc, WazuhError):
-        raise ProblemException(status=400 if not code else code, type=exc.type, title=exc.title, detail=exc.message,
-                               ext=ext)
+    elif isinstance(exc, exception.WazuhError):
+        raise ProblemException(status=400 if not code else code,
+                               type=exc.type, title=exc.title, detail=exc.message, ext=ext)
 
     raise exc
 
@@ -334,6 +332,7 @@ def deprecate_endpoint(link: str = ''):
     link : str
         Documentation related with this deprecation.
     """
+
     def add_deprecation_headers(func):
         @wraps(func)
         async def wrapper(*args, **kwargs):

--- a/api/api/util.py
+++ b/api/api/util.py
@@ -258,7 +258,7 @@ def _create_problem(exc: Exception, code=None):
                                     'dapi_errors': exc.dapi_errors if exc.dapi_errors != {} else None
                                     })
 
-    if isinstance(exc, (exception.WazuhInternalError, exception.WazuhClusterError)):
+    if isinstance(exc, exception.WazuhInternalError):
         raise ProblemException(status=500 if not code else code,
                                type=exc.type, title=exc.title, detail=exc.message, ext=ext)
     elif isinstance(exc, exception.WazuhPermissionError):

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -180,6 +180,12 @@ class DistributedAPI:
                 raise
             self.logger.error(f"{e.message}")
             return e
+        except exception.WazuhClusterError as e:
+            e.dapi_errors = self.get_error_info(e)
+            if self.debug:
+                raise
+            self.logger.error(f"{e.message}")
+            return e
         except exception.WazuhError as e:
             e.dapi_errors = self.get_error_info(e)
             return e
@@ -299,6 +305,12 @@ class DistributedAPI:
 
             self.debug_log(f"Time calculating request result: {time.time() - before:.3f}s")
             return data
+        except exception.WazuhClusterError as e:
+            e.dapi_errors = self.get_error_info(e)
+            self.logger.error(f"{e.message}")
+            if self.debug:
+                raise
+            return json.dumps(e, cls=c_common.WazuhJSONEncoder)
         except (exception.WazuhError, exception.WazuhResourceNotFound) as e:
             e.dapi_errors = self.get_error_info(e)
             if self.debug:

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -180,20 +180,14 @@ class DistributedAPI:
                 raise
             self.logger.error(f"{e.message}")
             return e
-        except exception.WazuhClusterError as e:
-            e.dapi_errors = self.get_error_info(e)
-            if self.debug:
-                raise
-            self.logger.error(f"{e.message}")
-            return e
-        except exception.WazuhError as e:
-            e.dapi_errors = self.get_error_info(e)
-            return e
         except exception.WazuhInternalError as e:
             e.dapi_errors = self.get_error_info(e)
             if self.debug:
                 raise
-            self.logger.error(f"{e.message}", exc_info=True)
+            self.logger.error(f"{e.message}", exc_info=not isinstance(e, exception.WazuhClusterError))
+            return e
+        except exception.WazuhError as e:
+            e.dapi_errors = self.get_error_info(e)
             return e
         except Exception as e:
             if self.debug:
@@ -389,8 +383,8 @@ class DistributedAPI:
         result = {node: {'error': error_message}
                   }
 
-        # Give log path only in case of WazuhInternalError or WazuhClusterError
-        if isinstance(e, (exception.WazuhInternalError, exception.WazuhClusterError)):
+        # Give log path only in case of WazuhInternalError
+        if isinstance(e, exception.WazuhInternalError):
             log_filename = None
             for h in self.logger.handlers or self.logger.parent.handlers:
                 if hasattr(h, 'baseFilename'):

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -309,12 +309,6 @@ class DistributedAPI:
             if self.debug:
                 raise
             return json.dumps(e, cls=c_common.WazuhJSONEncoder)
-        except exception.WazuhClusterError as e:
-            e.dapi_errors = self.get_error_info(e)
-            self.logger.error(f"{e.message}")
-            if self.debug:
-                raise
-            return json.dumps(e, cls=c_common.WazuhJSONEncoder)
         except (exception.WazuhError, exception.WazuhResourceNotFound) as e:
             e.dapi_errors = self.get_error_info(e)
             if self.debug:

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -389,8 +389,8 @@ class DistributedAPI:
         result = {node: {'error': error_message}
                   }
 
-        # Give log path only in case of WazuhInternalError
-        if not isinstance(e, exception.WazuhError):
+        # Give log path only in case of WazuhInternalError or WazuhClusterError
+        if isinstance(e, (exception.WazuhInternalError, exception.WazuhClusterError)):
             log_filename = None
             for h in self.logger.handlers or self.logger.parent.handlers:
                 if hasattr(h, 'baseFilename'):

--- a/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
@@ -64,9 +64,18 @@ def raise_if_exc_routine(dapi_kwargs, expected_error=None):
             assert False, f'Unexpected exception: {e.ext}'
 
 
+class TestingLoggerParent:
+    """Class used to create the parent attribute of TestingLogger objects."""
+    def __init__(self):
+        self.handlers = []
+
+
 class TestingLogger:
+    """Class used to create custom Logger objects for testing purposes."""
     def __init__(self, logger_name):
         self.name = logger_name
+        self.handlers = []
+        self.parent = TestingLoggerParent()
 
     def error(self, message):
         pass

--- a/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
@@ -7,8 +7,7 @@ import logging
 import os
 import sys
 from asyncio import TimeoutError
-from typing import Iterator
-from unittest.mock import patch, MagicMock
+from unittest.mock import call, MagicMock, patch
 
 import pytest
 from connexion import ProblemException
@@ -65,6 +64,20 @@ def raise_if_exc_routine(dapi_kwargs, expected_error=None):
             assert False, f'Unexpected exception: {e.ext}'
 
 
+class TestingLogger:
+    def __init__(self, logger_name):
+        self.name = logger_name
+
+    def error(self, message):
+        pass
+
+    def debug(self, message):
+        pass
+
+    def debug2(self, message):
+        pass
+
+
 @pytest.mark.parametrize('kwargs', [
     {'f_kwargs': {'select': ['id']}, 'rbac_permissions': {'mode': 'black'}, 'nodes': ['worker1'],
      'basic_services': ('wazuh-modulesd', 'wazuh-db'), 'request_type': 'local_master'},
@@ -88,16 +101,6 @@ def test_DistributedAPI(install_type_mock, kwargs):
 
 def test_DistributedAPI_debug_log():
     """Check that error messages are correctly sent to the logger in the DistributedAPI class."""
-    class TestingLogger:
-        def __init__(self, logger_name):
-            self.name = logger_name
-
-        def debug(self, message):
-            pass
-
-        def debug2(self, message):
-            pass
-
     logger_ = TestingLogger(logger_name="wazuh-api")
     message = "Testing debug2"
     with patch.object(logger_, "debug2") as debug2_mock:
@@ -251,7 +254,7 @@ def test_DistributedAPI_local_request_errors():
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.check_wazuh_status', side_effect=None)
 @patch('asyncio.wait_for', new=AsyncMock(return_value='Testing'))
 def test_DistributedAPI_local_request(mock_local_request):
-    """Test `local_request` method from class DistributedAPI and check the behaviour when an error raise."""
+    """Test `local_request` method from class DistributedAPI and check the behaviour when an error raises."""
     dapi_kwargs = {'f': manager.status, 'logger': logger}
     raise_if_exc_routine(dapi_kwargs=dapi_kwargs)
 
@@ -305,10 +308,30 @@ def test_DistributedAPI_local_request(mock_local_request):
         except Exception as e:
             assert type(e) == KeyError
 
+    testing_logger = TestingLogger('test')
+    exc_code = 3000
+    cluster_exc = WazuhClusterError(exc_code)
+    with patch('asyncio.wait_for', new=AsyncMock(side_effect=cluster_exc)):
+        with patch.object(TestingLogger, "error") as logger_error_mock:
+            # Test WazuhClusterError caught in execute_local_request and ProblemException raised
+            dapi_kwargs = {'f': manager.status, 'logger': testing_logger}
+            raise_if_exc_routine(dapi_kwargs=dapi_kwargs, expected_error=exc_code)
+
+            # Test WazuhClusterError is raised when using debug in execute_local_request and distribute_function
+            dapi = DistributedAPI(f=manager.status, logger=testing_logger, debug=True)
+            try:
+                raise_if_exc(loop.run_until_complete(dapi.distribute_function()))
+            except WazuhClusterError as e:
+                assert e.dapi_errors == dapi.get_error_info(e)
+
+            # Test the logger `error` method was called for both distribute_function calls
+            logger_error_mock.assert_has_calls([call(f"{cluster_exc.message}"), call(f"{cluster_exc.message}")])
+
 
 @patch("asyncio.get_running_loop")
 def test_DistributedAPI_get_client(loop_mock):
     """Test get_client function from DistributedAPI."""
+
     class Node:
         def __init__(self):
             self.cluster_items = {"cluster_items": ["worker1", "worker2"]}
@@ -514,6 +537,7 @@ def test_APIRequestQueue_init(queue_mock):
 @patch("asyncio.get_event_loop")
 async def test_APIRequestQueue_run(loop_mock, import_module_mock):
     """Test `APIRequestQueue.run` function."""
+
     class DistributedAPI_mock:
         def __init__(self):
             pass
@@ -577,6 +601,7 @@ async def test_APIRequestQueue_run(loop_mock, import_module_mock):
 @patch("asyncio.get_event_loop")
 async def test_SendSyncRequestQueue_run(loop_mock):
     """Test `SendSyncRequestQueue.run` function."""
+
     class NodeMock:
         async def send_request(self, command, data):
             pass

--- a/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
@@ -334,7 +334,8 @@ def test_DistributedAPI_local_request(mock_local_request):
                 assert e.dapi_errors == dapi.get_error_info(e)
 
             # Test the logger `error` method was called for both distribute_function calls
-            logger_error_mock.assert_has_calls([call(f"{cluster_exc.message}"), call(f"{cluster_exc.message}")])
+            logger_error_mock.assert_has_calls([call(f"{cluster_exc.message}", exc_info=False),
+                                                call(f"{cluster_exc.message}", exc_info=False)])
 
 
 @patch("asyncio.get_running_loop")

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -699,6 +699,14 @@ class WazuhInternalError(WazuhException):
         self._ids = set() if ids is None else set(ids)
 
 
+class WazuhClusterError(WazuhInternalError):
+    """
+    This type of exception is raised inside the cluster.
+    """
+    _default_type = "about:blank"
+    _default_title = "Wazuh Cluster Error"
+
+
 class WazuhError(WazuhException):
     """
     This type of exception is raised as a controlled response to a bad request from user
@@ -755,14 +763,6 @@ class WazuhPermissionError(WazuhError):
     """
     _default_type = "about:blank"
     _default_title = "Permission Denied"
-
-
-class WazuhClusterError(WazuhError):
-    """
-    This type of exception is raised inside the cluster.
-    """
-    _default_type = "about:blank"
-    _default_title = "Wazuh Cluster Error"
 
 
 class WazuhResourceNotFound(WazuhError):


### PR DESCRIPTION
|Related issue|
|---|
|  #10364 |


## Description

This PR closes #10364.

After the investigation done in the related issue's comments, all the WazuhClusterError responses will be treated as server-side errors. Therefore, they will have status code 500.

I have used auxiliary variables to raise the `WazuhClusterError` exceptions by hand. In the following example, these variables were added to the `framework/wazuh/core/cluster/control.py` file.

Note: ignore the times taken by the API, they are high due to debugger breakpoints.

**BEFORE CHANGES:**

Request:

`GET /cluster/nodes
`

Response:

```
{
  "title": "Wazuh Cluster Error",
  "detail": "Timeout sending request",
  "remediation": "Please, try to make the request again",
  "dapi_errors": {
    "master-node": {
      "error": "Timeout sending request"
    }
  },
  "error": 3020
}
```

api.log


```
2022/05/31 15:00:53 INFO: wazuh 172.18.0.1 "GET /cluster/nodes" with parameters {} and body {} done in 20.795s: 400
```

**AFTER CHANGES**

Request:

`GET /cluster/nodes
`

Response (EDIT: I have also added the log path to Wazuh cluster errors. See https://github.com/wazuh/wazuh/pull/13646#issuecomment-1143279799):

```
{
  "title": "Wazuh Cluster Error",
  "detail": "Timeout sending request",
  "remediation": "Please, try to make the request again",
  "dapi_errors": {
    "master-node": {
      "error": "Timeout sending request"
    }
  },
  "error": 3020
}
```

api.log

```
2022/05/31 15:19:20 ERROR: Timeout sending request
2022/05/31 15:19:30 INFO: wazuh 172.18.0.1 "GET /cluster/nodes" with parameters {} and body {} done in 13.148s: 500
```


