### PR TITLE
Avoids including update_time in task module responses when update_time is null.

### DIFF
--- a/src/unit_tests/wazuh_modules/task_manager/test_wm_task_manager_parsing.c
+++ b/src/unit_tests/wazuh_modules/task_manager/test_wm_task_manager_parsing.c
@@ -365,8 +365,7 @@ void test_wm_task_manager_parse_data_result_last_update_0(void **state)
     assert_null(cJSON_GetObjectItem(response, "error_msg"));
     assert_non_null(cJSON_GetObjectItem(response, "create_time"));
     assert_string_equal(cJSON_GetObjectItem(response, "create_time")->valuestring, "5/5/20 12:30:55.666");
-    assert_non_null(cJSON_GetObjectItem(response, "update_time"));
-    assert_string_equal(cJSON_GetObjectItem(response, "update_time")->valuestring, "0");
+    assert_null(cJSON_GetObjectItem(response, "update_time"));
 }
 
 void test_wm_task_manager_parse_data_result_no_last_update(void **state)

--- a/src/wazuh_modules/task_manager/wm_task_manager_parsing.c
+++ b/src/wazuh_modules/task_manager/wm_task_manager_parsing.c
@@ -397,8 +397,6 @@ void wm_task_manager_parse_data_result(cJSON *response, const char *node, const 
             timestamp = w_get_timestamp(tmp);
             cJSON_AddStringToObject(response, task_manager_json_keys[WM_TASK_LAST_UPDATE_TIME], timestamp);
             os_free(timestamp);
-        } else {
-            cJSON_AddStringToObject(response, task_manager_json_keys[WM_TASK_LAST_UPDATE_TIME], "0");
         }
     }
 }


### PR DESCRIPTION
|Related issue|
|---|
|#13503|

## Description

This PR avoids including update_time, if update_time is null or zero, in the task module's response when queried for an upgrade result.

After these changes, the task module's response is:

when update_time is null or zero:
``` json
[{"error":0,"message":"Success","agent":2,"task_id":10,"node":"node01","module":"upgrade_module","command":"upgrade","status":"In queue","create_time":"2022/06/01 16:10:38"}]
```

when update_time is greater than zero:
``` json
[{"error":0,"message":"Success","agent":2,"task_id":10,"node":"node01","module":"upgrade_module","command":"upgrade","status":"Updating","create_time":"2022/06/01 16:10:38","update_time":"2022/06/01 16:10:58"}]
```


## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
