### PR TITLE
Fix a segmentation fault at Wazuh DB when auto-upgrading databases

### DIFF
--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -436,7 +436,11 @@ void * run_up(__attribute__((unused)) void * args) {
 
         *(name++) = '\0';
         wdb = wdb_open_agent2(atoi(entry));
-        wdb_leave(wdb);
+
+        if (wdb != NULL) {
+            wdb_leave(wdb);
+        }
+
         free(entry);
 
         sleep(1);


### PR DESCRIPTION
|Related issue|
|---|
|Fixes #13657|

This PR aims to prevent Wazuh DB from crashing when trying to upgrade databases, which it does automatically.

### Behavior before this fix

If Wazuh DB cannot open any database (like _000.db_), the daemon will crash.

### Behavior after this fix

If Wazuh DB cannot open a database file, it will print an error like this:

```
2022/06/02 11:10:28 wazuh-db: ERROR: Couldn't create SQLite database 'queue/db/000.db'
2022/06/02 11:10:28 wazuh-db: ERROR: Couldn't open DB for agent '000'
```

## Tests

- [x] Wazuh DB no longer crashes when it cannot open a database file.
```sh
service wazuh-manager stop
chown root:root /var/ossec/queue/db/000.db
service wazuh-manager start
```

- [x] Scan-build