### PR TITLE
Windows packages installation date retrieving fallback

### DIFF
--- a/src/data_provider/src/osinfo/sysOsInfoWin.cpp
+++ b/src/data_provider/src/osinfo/sysOsInfoWin.cpp
@@ -8,6 +8,7 @@
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
  */
+#include <winsock2.h>
 #include <windows.h>
 #include <versionhelpers.h>
 #include <sysinfoapi.h>

--- a/src/data_provider/src/packages/appxWindowsWrapper.h
+++ b/src/data_provider/src/packages/appxWindowsWrapper.h
@@ -234,15 +234,7 @@ class AppxWindowsWrapper final : public IPackageWrapper
 
                 if (installTimeRegistry.qword("InstallTime", value))
                 {
-
-                    // Format of value is 18-digit LDAP/FILETIME timestamps.
-                    // 18-digit LDAP/FILETIME timestamps -> Epoch/Unix time
-                    // (value/10000000ULL) - 11644473600ULL
-                    const time_t time {static_cast<long int>((value / 10000000ULL) - WINDOWS_UNIX_EPOCH_DIFF_SECONDS)};
-                    char formatString[20] = {0};
-
-                    std::strftime(formatString, sizeof(formatString), "%Y/%m/%d %H:%M:%S", std::localtime(&time));
-                    installTime.assign(formatString);
+                    installTime = Utils::buildTimestamp(value);
                 }
             }
             catch (...)

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -347,6 +347,10 @@ static void getPackagesFromReg(const HKEY key, const std::string& subKey, std::f
                 {
                     install_time = value;
                 }
+                else
+                {
+                    packageReg.creationDateKey(install_time);
+                }
 
                 if (packageReg.string("InstallLocation", value))
                 {

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -349,7 +349,7 @@ static void getPackagesFromReg(const HKEY key, const std::string& subKey, std::f
                 }
                 else
                 {
-                    packageReg.keyModificationDate(install_time);
+                    install_time = packageReg.keyModificationDate();
                 }
 
                 if (packageReg.string("InstallLocation", value))

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -349,7 +349,7 @@ static void getPackagesFromReg(const HKEY key, const std::string& subKey, std::f
                 }
                 else
                 {
-                    packageReg.creationDateKey(install_time);
+                    packageReg.keyModificationDate(install_time);
                 }
 
                 if (packageReg.string("InstallLocation", value))

--- a/src/shared_modules/utils/encodingWindowsHelper.h
+++ b/src/shared_modules/utils/encodingWindowsHelper.h
@@ -15,6 +15,7 @@
 #ifndef _ENCODING_WINDOWS_HELPER_H
 #define _ENCODING_WINDOWS_HELPER_H
 
+#include <winsock2.h>
 #include <windows.h>
 #include <string>
 #include <memory>

--- a/src/shared_modules/utils/registryHelper.h
+++ b/src/shared_modules/utils/registryHelper.h
@@ -201,9 +201,9 @@ namespace Utils
                 return ret;
             }
 
-            bool keyModificationDate(std::string& time) const
+            std::string keyModificationDate() const
             {
-                auto ret {false};
+                std::string ret { };
                 FILETIME lastModificationTime { };
                 auto result
                 {
@@ -212,14 +212,13 @@ namespace Utils
 
                 if (ERROR_SUCCESS == result)
                 {
-                    ULARGE_INTEGER fileTime {};
+                    ULARGE_INTEGER time { };
 
-                    fileTime.LowPart = lastModificationTime.dwLowDateTime;
-                    fileTime.HighPart = lastModificationTime.dwHighDateTime;
+                    time.LowPart = lastModificationTime.dwLowDateTime;
+                    time.HighPart = lastModificationTime.dwHighDateTime;
 
                     // Use structure values to build 18-digit LDAP/FILETIME number
-                    time = Utils::buildTimestamp(fileTime.QuadPart);
-                    ret = true;
+                    ret = Utils::buildTimestamp(time.QuadPart);
                 }
 
                 return ret;

--- a/src/shared_modules/utils/registryHelper.h
+++ b/src/shared_modules/utils/registryHelper.h
@@ -212,11 +212,13 @@ namespace Utils
 
                 if (ERROR_SUCCESS == result)
                 {
-                    unsigned long long fileTime { lastModificationTime.dwHighDateTime };
+                    ULARGE_INTEGER fileTime {};
+
+                    fileTime.LowPart = lastModificationTime.dwLowDateTime;
+                    fileTime.HighPart = lastModificationTime.dwHighDateTime;
 
                     // Use structure values to build 18-digit LDAP/FILETIME number
-                    fileTime = fileTime << sizeof(lastModificationTime.dwHighDateTime)*8 | lastModificationTime.dwLowDateTime;
-                    time = Utils::buildTimestamp(fileTime);
+                    time = Utils::buildTimestamp(fileTime.QuadPart);
                     ret = true;
                 }
 

--- a/src/shared_modules/utils/registryHelper.h
+++ b/src/shared_modules/utils/registryHelper.h
@@ -203,7 +203,7 @@ namespace Utils
 
             std::string keyModificationDate() const
             {
-                std::string ret { };
+                std::string ret;
                 FILETIME lastModificationTime { };
                 auto result
                 {

--- a/src/shared_modules/utils/registryHelper.h
+++ b/src/shared_modules/utils/registryHelper.h
@@ -205,7 +205,7 @@ namespace Utils
             {
                 std::string ret;
                 FILETIME lastModificationTime { };
-                auto result
+                const auto result
                 {
                     RegQueryInfoKey(m_registryKey, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, &lastModificationTime)
                 };

--- a/src/shared_modules/utils/registryHelper.h
+++ b/src/shared_modules/utils/registryHelper.h
@@ -15,6 +15,8 @@
 #define _REGISTRY_HELPER_H
 
 #include <string>
+#include <sstream>
+#include <iomanip>
 #include <windows.h>
 #include <winreg.h>
 #include <cstdio>
@@ -194,6 +196,37 @@ namespace Utils
                 catch (...)
                 {
                     ret = false;
+                }
+
+                return ret;
+            }
+
+            bool creationDateKey(std::string& time) const
+            {
+                auto ret {false};
+                FILETIME lastWirteTime { };
+                SYSTEMTIME userTime { };
+                auto result
+                {
+                    RegQueryInfoKey(m_registryKey, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, &lastWirteTime)
+                };
+
+                if (ERROR_SUCCESS == result)
+                {
+                    // Convert data of structure in readable format
+                    if (FileTimeToSystemTime(&lastWirteTime, &userTime))
+                    {
+                        std::stringstream value;
+
+                        value << std::setfill('0') << std::setw(4) << userTime.wYear << "/";
+                        value << std::setfill('0') << std::setw(2) << userTime.wMonth << "/";
+                        value << std::setfill('0') << std::setw(2) << userTime.wDay << " ";
+                        value << std::setfill('0') << std::setw(2) << userTime.wHour << ":";
+                        value << std::setfill('0') << std::setw(2) << userTime.wMinute << ":";
+                        value << std::setfill('0') << std::setw(2) << userTime.wSecond;
+                        time = value.str();
+                        ret = true;
+                    }
                 }
 
                 return ret;

--- a/src/shared_modules/utils/windowsHelper.h
+++ b/src/shared_modules/utils/windowsHelper.h
@@ -251,12 +251,10 @@ namespace Utils
         // 18-digit LDAP/FILETIME timestamps -> Epoch/Unix time
         // (value/10000000ULL) - 11644473600ULL
         const time_t epochTIme { static_cast<long int> ((time / 10000000ULL) - WINDOWS_UNIX_EPOCH_DIFF_SECONDS) };
-        std::string ret;
         char formatString[20] = {0};
 
         std::strftime(formatString, sizeof(formatString), "%Y/%m/%d %H:%M:%S", std::localtime(&epochTIme));
-        ret.assign(formatString);
-        return ret;
+        return formatString;
     }
 
     class NetworkWindowsHelper final

--- a/src/shared_modules/utils/windowsHelper.h
+++ b/src/shared_modules/utils/windowsHelper.h
@@ -20,6 +20,7 @@
 #include <system_error>
 #include <winsock2.h>
 #include <windows.h>
+#include <time.h>
 #include <ws2tcpip.h>
 #include <iphlpapi.h>
 #include <versionhelpers.h>
@@ -243,6 +244,21 @@ namespace Utils
         }
 
         return serialNumber;
+    }
+
+    static std::string buildTimestamp(const unsigned long long time)
+    {
+
+        // Format of value is 18-digit LDAP/FILETIME timestamps.
+        // 18-digit LDAP/FILETIME timestamps -> Epoch/Unix time
+        // (value/10000000ULL) - 11644473600ULL
+        const time_t epochTIme { static_cast<long int> ((time / 10000000ULL) - WINDOWS_UNIX_EPOCH_DIFF_SECONDS) };
+        std::string ret;
+        char formatString[20] = {0};
+
+        std::strftime(formatString, sizeof(formatString), "%Y/%m/%d %H:%M:%S", std::localtime(&epochTIme));
+        ret.assign(formatString);
+        return ret;
     }
 
     class NetworkWindowsHelper final

--- a/src/shared_modules/utils/windowsHelper.h
+++ b/src/shared_modules/utils/windowsHelper.h
@@ -175,7 +175,6 @@ namespace Utils
         return ret;
     }
 
-
     /* Reference: https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_2.6.0.pdf */
     static std::string getSerialNumberFromSmbios(const BYTE* rawData, const DWORD rawDataSize)
     {
@@ -246,9 +245,8 @@ namespace Utils
         return serialNumber;
     }
 
-    static std::string buildTimestamp(const unsigned long long time)
+    static std::string buildTimestamp(const ULONGLONG time)
     {
-
         // Format of value is 18-digit LDAP/FILETIME timestamps.
         // 18-digit LDAP/FILETIME timestamps -> Epoch/Unix time
         // (value/10000000ULL) - 11644473600ULL


### PR DESCRIPTION
|Related issue|
|---|
|#10703|


## Description

This PR aims to get the installation time of the package when the queried registry doesn't have the `InstallDate` field. Currently, the data provider gets the installation time from the `InstallDate` field and if `time_install` doesn't exist it will be empty, after the change this field will never be empty. The approach is to get the last modification date of the registry.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors