### PR TITLE
Fix maild to stringify any json array type

### DIFF
--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -752,11 +752,11 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
             body_size -= log_size;
         }
 
-        free(key);
+        os_free(key);
     }
     else if ((item->type & 0xFF) == cJSON_Array){
 
-        cJSON *json_array;
+        cJSON *json_item;
         int i = 0;
         log_size = strlen(item->string) + strlen(tab) + strlen(delimitator);
 
@@ -768,17 +768,17 @@ void PrintTable(cJSON *item, char *printed, size_t body_size, char *tab, int cou
             body_size -= log_size;
         }
 
-        while(json_array = cJSON_GetArrayItem(item, i), json_array){
-            key = cJSON_PrintUnformatted(json_array);
+        while(json_item = cJSON_GetArrayItem(item, i), json_item){
+            key = cJSON_PrintUnformatted(json_item);
             log_size = strlen(key) + strlen(space);
 
             if(body_size > log_size){
-                strncat(printed, json_array->valuestring, body_size);
+                strncat(printed, key, body_size);
                 strncat(printed, space, strlen(space));
                 body_size -= log_size;
             }
 
-            free(key);
+            os_free(key);
             i++;
         }
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/13678|

## Description

This PR aims to fix the bug reported on issue [#13679](https://github.com/wazuh/wazuh/issues/13678). The segmentation fault was produced on the following code block:
https://github.com/wazuh/wazuh/blob/ac1542bd91ccad0e65180550dc8f9768a2c5cbd2/src/os_maild/os_maild_client.c#L771-L783
As it can be seen, on line 776, a `valuestring` is expected to be obtained from the `json_array` structure (which is an item from the actual json array), but it can happen for such an item to be of another data type. In case this element does not contain an actual string, `valuestring` happens to be NULL.

The proposed solution would be to print any item as a string no matter its type.

## Configuration options
Maild configuration on the `ossec.conf` file:
```xml
  <global>
    <jsonout_output>yes</jsonout_output>
    <alerts_log>yes</alerts_log>
    <logall>no</logall>
    <logall_json>no</logall_json>
    <email_notification>yes</email_notification>
    <smtp_server>smtp_server_name</smtp_server>
    <email_from>no-reply@smtp_server_name.com</email_from>
    <email_to>somewhere@emailme.com</email_to>
    <email_log_source>alerts.json</email_log_source>
    <agents_disconnection_time>10m</agents_disconnection_time>
    <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
  </global>

  <email_alerts>
    <email_to>somewhere@emailme.com</email_to>
    <rule_id>100003</rule_id>
    <do_not_delay/>
  </email_alerts>
```

## Logs/Alerts example

The following log, which triggers the segfault, has to be appended at the end of the `alerts.json` file:

```json
{"timestamp":"2022-01-01T11:22:33.444+0000","rule":{"level":5,"description":"Test maild log with an objects array without a full_log field","id":"100100","firedtimes":1,"mail":true,"groups":["local","syslog","sshd"]},"agent":{"id":"000","name":"some-name"},"manager":{"name":"some-name"},"id":"1234567891.123456","decoder":{"name":"json"},"data":{"test_maild":"test_objects_array","objects_array":[{"test_key1":"test_str1","test_key2":"test_str2"},{"test_key3":"test_str3","test_key4":"test_str4"}]},"location":"stdin"}
```

## Tests

Wazuh-Maild has memleaks when loading the configuration. These leaks were present on 4.3 even before this PR was created:

[Valgrind report PR](https://github.com/wazuh/wazuh/files/8827662/Valgrind_PR.log)
[Valgrind report 4.3](https://github.com/wazuh/wazuh/files/8827661/Valgrind_4.3.log)

[Scan build report](https://github.com/wazuh/wazuh/files/8827687/scan-build-2022-06-02-195729-71981-1.zip)



<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors