### PR TITLE
Fix GeoIP compilation

### DIFF
--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -320,9 +320,9 @@ int OS_AddRuleInfo(RuleNode *r_node, RuleInfo *newrule, int sid, OSList* log_msg
             w_free_expression_t(&r_node->ruleinfo->dstip);
             r_node->ruleinfo->dstip = newrule->dstip;
 #ifdef LIBGEOIP_ENABLED
-            w_free_expression_t(&ruleinfo->srcgeoip);
+            w_free_expression_t(&r_node->ruleinfo->srcgeoip);
             r_node->ruleinfo->srcgeoip = newrule->srcgeoip;
-            w_free_expression_t(&ruleinfo->dstgeoip);
+            w_free_expression_t(&r_node->ruleinfo->dstgeoip);
             r_node->ruleinfo->dstgeoip = newrule->dstgeoip;
 #endif
             w_free_expression_t(&r_node->ruleinfo->srcport);


### PR DESCRIPTION
|Related issue|
|---|
|#13680|


## Description

When fixing the overwrite option of the rules (#13439), we forgot to change the frees and allocation of the geoip members of the event when using the USE_GEOIP=yes compile flag. 

This:

https://github.com/wazuh/wazuh/blob/fd082f6455a47f7a3844ca3e06e90e8b21884fd9/src/analysisd/rules_list.c#L322-L327

Should be:
```cpp
#ifdef LIBGEOIP_ENABLED
            w_free_expression_t(&r_node->ruleinfo->srcgeoip);
            r_node->ruleinfo->srcgeoip = newrule->srcgeoip;
            w_free_expression_t(&r_node->ruleinfo->dstgeoip);
            r_node->ruleinfo->dstgeoip = newrule->dstgeoip;
#endif
```

## Configuration options

```
USE_GEOIP=yes ./install.sh`
```
## Instalation log


```
   CC wazuh-authd
    CC wazuh-logtest-legacy
    CC wazuh-analysisd
make[1]: Leaving directory '/root/repos/wazuh/src'
make settings
make[1]: Entering directory '/root/repos/wazuh/src'
grep: /etc/redhat-release: No such file or directory

General settings:
    TARGET:             server
    V:                  
    DEBUG:              y
    DEBUGAD             
    INSTALLDIR:         /var/ossec
    DATABASE:           
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/15
    EXTERNAL_SRC_ONLY:  
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_ZEROMQ:         no
    USE_GEOIP:          yes
    USE_PRELUDE:        no
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        yes
    USE_AUDIT:          yes
    DISABLE_SYSC:       no
    DISABLE_CISCAT:     no
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DENABLE_SYSC -DENABLE_CISCAT -DENABLE_AUDIT -DLIBGEOIP_ENABLED
Compiler:
    CFLAGS            -pthread -Iexternal/libdb/build_unix/ -Iexternal/pacman/lib/libalpm/ -Iexternal/libarchive/libarchive -Wl,--start-group -Iexternal/audit-userspace/lib -g  -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DENABLE_SYSC -DENABLE_CISCAT -DENABLE_AUDIT -DLIBGEOIP_ENABLED -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Ishared_modules/common -Ishared_modules/dbsync/include -Ishared_modules/rsync/include -Iwazuh_modules/syscollector/include  -Idata_provider/include  -Iexternal/libpcre2/include 
    LDFLAGS           '-Wl,-rpath,/../lib' -pthread -lrt -ldl  -Lshared_modules/dbsync/build/lib -Lshared_modules/rsync/build/lib  -Lwazuh_modules/syscollector/build/lib -Ldata_provider/build/lib
    LIBS              -lrt -ldl -lm  -lGeoIP
    CC                cc
    MAKE              make
make[1]: Leaving directory '/root/repos/wazuh/src'

Done building server
```


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors