### PR TITLE
Add changes to add Windows tests to RTR check

### DIFF
--- a/src/ci/utils.py
+++ b/src/ci/utils.py
@@ -31,6 +31,7 @@ HEADER_DIR = {
     'rtr':              "=============== Running RTR checks  ===============",
     'scanbuild':        "=============== Running Scanbuild   ===============",
     'tests':            "=============== Running Tests       ===============",
+    'winagentTests':    "=============== Running Windows Agent Tests =======",
     'testtool':         "=============== Running TEST TOOL   ===============",
     'valgrind':         "=============== Running Valgrind    ===============",
     'wintests':         "=============== Running TEST TOOL for Windows ====="


### PR DESCRIPTION
|EPIC|Component|
|---|---|
| https://github.com/wazuh/wazuh/issues/9103 | FIM |

|Issue|
|---|
| Closes #13677  | FIM |


## Description
Hello team, there is a project to add C++ Windows tests, I have added a new check in our RTR to be able to run Windows tests in Jenkins.
Regards

## Logs/Alerts example
When we run a RTR test, I have added a new  check which runs tests for Windows in c++
![image](https://user-images.githubusercontent.com/11745030/171959781-6a02add7-ab88-4dde-8ad7-b3fbd640a129.png)

## Tests
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report