### PR TITLE
FIMDB: Add option for RSync minSyncInterval feature

### DIFF
--- a/architecture/FIM/db/class.puml
+++ b/architecture/FIM/db/class.puml
@@ -176,7 +176,7 @@ package "db.hpp" <<Folder>> #DDDDDD{
 }
 package "db.h" <<Folder>> #DDDDDD{
     interface db {
-        void fim_db_init(int, int, fim_sync_callback_t, logging_callback_t, int, int,bool)
+        void fim_db_init(int, int, fim_sync_callback_t, logging_callback_t, int, uint32_t int,bool)
         void fim_run_integrity()
         void fim_sync_push_msg(const char*)
         TXN_HANDLE fim_db_transaction_start(const char*, result_callback_t, void*)

--- a/architecture/FIM/db/class.puml
+++ b/architecture/FIM/db/class.puml
@@ -176,7 +176,7 @@ package "db.hpp" <<Folder>> #DDDDDD{
 }
 package "db.h" <<Folder>> #DDDDDD{
     interface db {
-        void fim_db_init(int, int, fim_sync_callback_t, logging_callback_t, int, uint32_t int,bool)
+        void fim_db_init(int, int, fim_sync_callback_t, logging_callback_t, int, uint32_t, int,bool)
         void fim_run_integrity()
         void fim_sync_push_msg(const char*)
         TXN_HANDLE fim_db_transaction_start(const char*, result_callback_t, void*)

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1234,6 +1234,11 @@ static void parse_synchronization(syscheck_config * syscheck, XML_NODE node) {
             mwarn(XML_INVELEM, node[i]->element);
         }
     }
+
+    if (syscheck->min_sync_interval >= syscheck->sync_interval) {
+        mwarn("Synchronization min_interval is higher or equal than synchronization interval. " \
+              "Synchronization may be ommitted.");
+    }
 }
 
 int read_data_unit(const char *content) {

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1236,8 +1236,7 @@ static void parse_synchronization(syscheck_config * syscheck, XML_NODE node) {
     }
 
     if (syscheck->min_sync_interval >= syscheck->sync_interval) {
-        mwarn("Synchronization min_interval is higher or equal than synchronization interval. " \
-              "Synchronization may be ommitted.");
+        mwarn("Sync min_interval value higher than interval. Some synchronization turns can be skipped.");
     }
 }
 

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -114,7 +114,7 @@ int initialize_syscheck_configuration(syscheck_config *syscheck) {
 #endif
     syscheck->prefilter_cmd                   = NULL;
     syscheck->sync_interval                   = 300;
-    syscheck->min_sync_interval               = 10;
+    syscheck->min_sync_interval               = 60;
     syscheck->sync_max_eps                    = 10;
     syscheck->max_eps                         = 100;
     syscheck->max_files_per_second            = 0;

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -114,6 +114,7 @@ int initialize_syscheck_configuration(syscheck_config *syscheck) {
 #endif
     syscheck->prefilter_cmd                   = NULL;
     syscheck->sync_interval                   = 300;
+    syscheck->min_sync_interval               = 10;
     syscheck->sync_max_eps                    = 10;
     syscheck->max_eps                         = 100;
     syscheck->max_files_per_second            = 0;
@@ -1177,6 +1178,7 @@ static void parse_synchronization(syscheck_config * syscheck, XML_NODE node) {
     const char *xml_sync_queue_size = "queue_size";
     const char *xml_max_eps = "max_eps";
     const char *xml_registry_enabled = "registry_enabled";
+    const char *xml_min_sync_interval = "min_interval";
 
     for (int i = 0; node[i]; i++) {
         if (strcmp(node[i]->element, xml_enabled) == 0) {
@@ -1220,6 +1222,14 @@ static void parse_synchronization(syscheck_config * syscheck, XML_NODE node) {
                 syscheck->enable_registry_synchronization = r;
             }
 #endif
+        } else if (strcmp(node[i]->element, xml_min_sync_interval) == 0) {
+            uint32_t interval = strtoul(node[i]->content, NULL, 10);
+
+            if (errno == ERANGE) {
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
+            } else {
+                syscheck->min_sync_interval = interval;
+            }
         } else {
             mwarn(XML_INVELEM, node[i]->element);
         }

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -404,6 +404,7 @@ typedef struct _config {
     OSMatch **nodiff_regex;                            /* regex of files/dirs to never output diff */
 
     long sync_interval;                                /* Synchronization interval (seconds) */
+    uint32_t min_sync_interval;                        /* Minimum interval for synchronization process */
     long sync_max_eps;                                 /* Maximum events per second for synchronization messages. */
     int max_eps;                                       /* Maximum events per second. */
 

--- a/src/syscheckd/src/config.c
+++ b/src/syscheckd/src/config.c
@@ -479,6 +479,8 @@ cJSON *getSyscheckConfig(void) {
 #endif
     cJSON_AddNumberToObject(synchronization, "interval", syscheck.sync_interval);
     cJSON_AddNumberToObject(synchronization, "max_eps", syscheck.sync_max_eps);
+    cJSON_AddNumberToObject(synchronization, "min_interval", syscheck.min_sync_interval);
+
     cJSON_AddItemToObject(syscfg, "synchronization", synchronization);
 
     cJSON_AddNumberToObject(syscfg, "max_eps", syscheck.max_eps);

--- a/src/syscheckd/src/db/include/db.h
+++ b/src/syscheckd/src/db/include/db.h
@@ -35,7 +35,8 @@ extern "C" {
  * @param sync_interval Interval when the synchronization will be performed.
  * @param sync_callback Callback to send the synchronization messages.
  * @param log_callback Callback to perform logging operations.
- * @param file_limit Maximum number of files to be monitored
+ * @param file_limit Maximum number of files to be monitored.
+ * @param min_sync_interval_time Minimum interval for synchronization process.
  * @param value_limit Maximum number of registry values to be monitored.
  * @param sync_registry_enable Flag to enable the registry synchronization.
  *
@@ -46,6 +47,7 @@ FIMDBErrorCode fim_db_init(int storage,
                            fim_sync_callback_t sync_callback,
                            logging_callback_t log_callback,
                            int file_limit,
+                           uint32_t min_sync_interval_time,
                            int value_limit,
                            bool sync_registry_enabled);
 

--- a/src/syscheckd/src/db/include/db.hpp
+++ b/src/syscheckd/src/db/include/db.hpp
@@ -79,6 +79,7 @@ class EXPORTED DB final
         * @param callbackSyncRegistryWrapper Callback sync registry values.
         * @param callbackLogWrapper Callback to log lines.
         * @param fileLimit File limit.
+        * @param minSyncIntervalTime Minimum interval for synchronization process.
         * @param valueLimit Registry value limit.
         * @param syncRegistryEnabled Flag to enable/disable the registry sync mechanism.
         */
@@ -88,6 +89,7 @@ class EXPORTED DB final
                   std::function<void(const std::string&)> callbackSyncRegistryWrapper,
                   std::function<void(modules_log_level_t, const std::string&)> callbackLogWrapper,
                   int fileLimit,
+                  const uint32_t minSyncIntervalTime,
                   int valueLimit,
                   bool syncRegistryEnabled);
 

--- a/src/syscheckd/src/db/src/db.cpp
+++ b/src/syscheckd/src/db/src/db.cpp
@@ -29,6 +29,7 @@ void DB::init(const int storage,
               std::function<void(const std::string&)> callbackSyncRegistryWrapper,
               std::function<void(modules_log_level_t, const std::string&)> callbackLogWrapper,
               const int fileLimit,
+              const uint32_t minSyncIntervalTime,
               const int valueLimit,
               bool syncRegistryEnabled)
 {
@@ -48,6 +49,7 @@ void DB::init(const int storage,
                            dbsyncHandler,
                            rsyncHandler,
                            fileLimit,
+                           minSyncIntervalTime,
                            valueLimit,
                            syncRegistryEnabled);
 }
@@ -116,6 +118,7 @@ FIMDBErrorCode fim_db_init(int storage,
                            fim_sync_callback_t sync_callback,
                            logging_callback_t log_callback,
                            int file_limit,
+                           uint32_t min_sync_interval_time,
                            int value_limit,
                            bool sync_registry_enabled)
 {
@@ -215,6 +218,7 @@ FIMDBErrorCode fim_db_init(int storage,
                             callbackSyncRegistryWrapper,
                             callbackLogWrapper,
                             file_limit,
+                            min_sync_interval_time,
                             value_limit,
                             sync_registry_enabled);
         retVal = FIMDBErrorCode::FIMDB_OK;

--- a/src/syscheckd/src/db/src/fimDB.cpp
+++ b/src/syscheckd/src/db/src/fimDB.cpp
@@ -24,6 +24,7 @@ void FIMDB::registerRSync()
         FIMDBCreator<OS_TYPE>::registerRsync(m_rsyncHandler,
                                              m_dbsyncHandler->handle(),
                                              m_syncFileMessageFunction,
+                                             m_minSyncIntervalTime,
                                              m_syncRegistryMessageFunction,
                                              m_syncRegistryEnabled);
     }
@@ -52,6 +53,7 @@ void FIMDB::init(unsigned int syncInterval,
                  std::shared_ptr<DBSync> dbsyncHandler,
                  std::shared_ptr<RemoteSync> rsyncHandler,
                  const int fileLimit,
+                 const uint32_t minSyncIntervalTime,
                  const int registryLimit,
                  const bool syncRegistryEnabled)
 {
@@ -66,6 +68,7 @@ void FIMDB::init(unsigned int syncInterval,
     std::shared_lock<std::shared_timed_mutex> lock(m_handlersMutex);
     FIMDBCreator<OS_TYPE>::setLimits(m_dbsyncHandler, fileLimit, registryLimit);
     m_syncRegistryEnabled = syncRegistryEnabled;
+    m_minSyncIntervalTime = minSyncIntervalTime;
 }
 
 void FIMDB::removeItem(const nlohmann::json& item)

--- a/src/syscheckd/src/db/src/fimDB.hpp
+++ b/src/syscheckd/src/db/src/fimDB.hpp
@@ -121,7 +121,9 @@ class FIMDB
          * @param dbsyncHandler Pointer to a dbsync handler.
          * @param rsyncHandler Pointer to a rsync handler.
          * @param fileLimit Maximun number of file entries in database.
+         * @param minSyncIntervalTime Minimum interval for synchronization process.
          * @param registryLimit Maximun number of registry values entries in database (only for Windows).
+         * @param syncRegistryEnabled Flag to specify if the synchronization for registries is enabled (only for Windows).
          */
         void init(unsigned int syncInterval,
                   std::function<void(const std::string&)> callbackSyncFileWrapper,
@@ -130,6 +132,7 @@ class FIMDB
                   std::shared_ptr<DBSync> dbsyncHandler,
                   std::shared_ptr<RemoteSync> rsyncHandler,
                   int fileLimit,
+                  const uint32_t minSyncIntervalTime,
                   int registryLimit = 0,
                   bool syncRegistryEnabled = true);
 
@@ -255,6 +258,7 @@ class FIMDB
         std::thread                                                             m_integrityThread;
         std::shared_timed_mutex                                                 m_handlersMutex;
         bool                                                                    m_syncRegistryEnabled;
+        uint32_t                                                                m_minSyncIntervalTime;
 
         /**
         * @brief Function that executes the synchronization of the databases with the manager

--- a/src/syscheckd/src/db/src/fimDBSpecialization.h
+++ b/src/syscheckd/src/db/src/fimDBSpecialization.h
@@ -17,122 +17,85 @@
 #include "encodingWindowsHelper.h"
 #include "fimDBSpecializationWindows.hpp"
 
-
-constexpr auto FIM_FILE_SYNC_CONFIG_STATEMENT
+static auto fileSyncConfig
 {
-    R"(
-    {
-        "decoder_type":"JSON_RANGE",
-        "table":"file_entry",
-        "component":"fim_file",
-        "index":"path",
-        "checksum_field":"checksum",
-        "last_event":"last_event",
-        "no_data_query_json": {
-                "row_filter":"WHERE path BETWEEN '?' and '?' ORDER BY path",
-                "column_list":["*"],
-                "distinct_opt":false,
-                "order_by_opt":""
-        },
-        "count_range_query_json": {
-                "row_filter":"WHERE path BETWEEN '?' and '?' ORDER BY path",
-                "count_field_name":"count",
-                "column_list":["count(*) AS count "],
-                "distinct_opt":false,
-                "order_by_opt":""
-        },
-        "row_data_query_json": {
-                "row_filter":"WHERE path ='?'",
-                "column_list":["*"],
-                "distinct_opt":false,
-                "order_by_opt":""
-        },
-        "range_checksum_query_json": {
-                "row_filter":"WHERE path BETWEEN '?' and '?' ORDER BY path",
-                "column_list":["*"],
-                "distinct_opt":false,
-                "order_by_opt":""
-        }
-    }
-    )"
+    RegisterConfiguration::builder().decoderType("JSON_RANGE")
+    .table("file_entry")
+    .component("fim_file")
+    .index("path")
+    .checksumField("checksum")
+    .lastEvent("last_event")
+    .noData(QueryParameter::builder().rowFilter("WHERE path BETWEEN '?' and '?' ORDER BY path")
+            .columnList({"*"})
+            .distinctOpt(false)
+            .orderByOpt(""))
+    .countRange(QueryParameter::builder().rowFilter("WHERE path BETWEEN '?' and '?' ORDER BY path")
+            .countFieldName("count")
+            .columnList({"count(*) AS count"})
+            .distinctOpt(false)
+            .orderByOpt(""))
+    .rowData(QueryParameter::builder().rowFilter("WHERE path = '?'")
+            .columnList({"*"})
+            .distinctOpt(false)
+            .orderByOpt(""))
+    .rangeChecksum(QueryParameter::builder().rowFilter("WHERE path BETWEEN '?' and '?' ORDER BY path")
+            .columnList({"*"})
+            .distinctOpt(false)
+            .orderByOpt(""))
 };
 
-constexpr auto FIM_REGISTRY_SYNC_CONFIG_STATEMENT
+static auto registryKeySyncConfig
 {
-    R"(
-    {
-        "decoder_type":"JSON_RANGE",
-        "table":"registry_key",
-        "component":"fim_registry_key",
-        "index":"hash_full_path",
-        "last_event":"last_event",
-        "checksum_field":"checksum",
-        "no_data_query_json": {
-                "row_filter":"WHERE hash_full_path BETWEEN '?' and '?' ORDER BY hash_full_path",
-                "column_list":["*"],
-                "distinct_opt":false,
-                "order_by_opt":""
-        },
-        "count_range_query_json": {
-                "row_filter":"WHERE hash_full_path BETWEEN '?' and '?' ORDER BY hash_full_path",
-                "count_field_name":"count",
-                "column_list":["count(*) AS count "],
-                "distinct_opt":false,
-                "order_by_opt":""
-        },
-        "row_data_query_json": {
-                "row_filter":"WHERE hash_full_path ='?'",
-                "column_list":["*"],
-                "distinct_opt":false,
-                "order_by_opt":""
-        },
-        "range_checksum_query_json": {
-                "row_filter":"WHERE hash_full_path BETWEEN '?' and '?' ORDER BY hash_full_path",
-                "column_list":["*"],
-                "distinct_opt":false,
-                "order_by_opt":""
-        }
-    }
-    )"
+    RegisterConfiguration::builder().decoderType("JSON_RANGE")
+    .table("registry_key")
+    .component("fim_registry_key")
+    .index("hash_full_path")
+    .checksumField("checksum")
+    .lastEvent("last_event")
+    .noData(QueryParameter::builder().rowFilter("WHERE hash_full_path BETWEEN '?' and '?' ORDER BY hash_full_path")
+            .columnList({"*"})
+            .distinctOpt(false)
+            .orderByOpt(""))
+    .countRange(QueryParameter::builder().rowFilter("WHERE hash_full_path BETWEEN '?' and '?' ORDER BY hash_full_path")
+            .countFieldName("count")
+            .columnList({"count(*) AS count"})
+            .distinctOpt(false)
+            .orderByOpt(""))
+    .rowData(QueryParameter::builder().rowFilter("WHERE hash_full_path = '?'")
+            .columnList({"*"})
+            .distinctOpt(false)
+            .orderByOpt(""))
+    .rangeChecksum(QueryParameter::builder().rowFilter("WHERE hash_full_path BETWEEN '?' and '?' ORDER BY hash_full_path")
+            .columnList({"*"})
+            .distinctOpt(false)
+            .orderByOpt(""))
 };
 
-constexpr auto FIM_VALUE_SYNC_CONFIG_STATEMENT
+static auto registryValueSyncConfig
 {
-    R"(
-    {
-        "decoder_type":"JSON_RANGE",
-        "table":"registry_data",
-        "component":"fim_registry_value",
-        "index":"hash_full_path",
-        "last_event":"last_event",
-        "checksum_field":"checksum",
-        "no_data_query_json": {
-                "row_filter":"WHERE hash_full_path BETWEEN '?' and '?' ORDER BY hash_full_path",
-                "column_list":["*"],
-                "distinct_opt":false,
-                "order_by_opt":""
-        },
-        "count_range_query_json": {
-                "row_filter":"WHERE hash_full_path BETWEEN '?' and '?' ORDER BY hash_full_path",
-                "count_field_name":"count",
-                "column_list":["count(*) AS count "],
-                "distinct_opt":false,
-                "order_by_opt":""
-        },
-        "row_data_query_json": {
-                "row_filter":"WHERE hash_full_path ='?'",
-                "column_list":["*"],
-                "distinct_opt":false,
-                "order_by_opt":""
-        },
-        "range_checksum_query_json": {
-                "row_filter":"WHERE hash_full_path BETWEEN '?' and '?' ORDER BY hash_full_path",
-                "column_list":["*"],
-                "distinct_opt":false,
-                "order_by_opt":""
-        }
-    }
-    )"
+    RegisterConfiguration::builder().decoderType("JSON_RANGE")
+    .table("registry_data")
+    .component("fim_registry_value")
+    .index("hash_full_path")
+    .checksumField("checksum")
+    .lastEvent("last_event")
+    .noData(QueryParameter::builder().rowFilter("WHERE hash_full_path BETWEEN '?' and '?' ORDER BY hash_full_path")
+            .columnList({"*"})
+            .distinctOpt(false)
+            .orderByOpt(""))
+    .countRange(QueryParameter::builder().rowFilter("WHERE hash_full_path BETWEEN '?' and '?' ORDER BY hash_full_path")
+            .countFieldName("count")
+            .columnList({"count(*) AS count"})
+            .distinctOpt(false)
+            .orderByOpt(""))
+    .rowData(QueryParameter::builder().rowFilter("WHERE hash_full_path = '?'")
+            .columnList({"*"})
+            .distinctOpt(false)
+            .orderByOpt(""))
+    .rangeChecksum(QueryParameter::builder().rowFilter("WHERE hash_full_path BETWEEN '?' and '?' ORDER BY hash_full_path")
+            .columnList({"*"})
+            .distinctOpt(false)
+            .orderByOpt(""))
 };
 
 /* Statement related to files items. Defines everything necessary to perform the synchronization loop */
@@ -265,6 +228,7 @@ class FIMDBCreator final
         static void registerRsync(__attribute__((unused)) std::shared_ptr<RemoteSync> RSyncHandler,
                                   __attribute__((unused)) const RSYNC_HANDLE& handle,
                                   __attribute__((unused)) std::function<void(const std::string&)> syncFileMessageFunction,
+                                  __attribute__((unused)) const uint32_t syncMinInterval,
                                   __attribute__((unused)) std::function<void(const std::string&)> syncRegistryMessageFunction,
                                   __attribute__((unused)) const bool syncRegistryEnabled)
         {
@@ -320,24 +284,28 @@ class FIMDBCreator<OSType::WINDOWS> final
         static void registerRsync(std::shared_ptr<RemoteSync> RSyncHandler,
                                   const RSYNC_HANDLE& handle,
                                   std::function<void(const std::string&)> syncFileMessageFunction,
-                                  __attribute__((unused)) std::function<void(const std::string&)> syncRegistryMessageFunction,
+                                  const uint32_t syncMinInterval,
+                                  std::function<void(const std::string&)> syncRegistryMessageFunction,
                                   const bool syncRegistryEnabled)
         {
+            fileSyncConfig.minimalSyncIntervalTime(syncMinInterval);
             RSyncHandler->registerSyncID(FIM_COMPONENT_FILE,
                                         handle,
-                                        nlohmann::json::parse(FIM_FILE_SYNC_CONFIG_STATEMENT),
+                                        fileSyncConfig.config(),
                                         syncFileMessageFunction);
 
             if (syncRegistryEnabled)
             {
-
+                registryKeySyncConfig.minimalSyncIntervalTime(syncMinInterval);
                 RSyncHandler->registerSyncID(FIM_COMPONENT_REGISTRY_KEY,
                                             handle,
-                                            nlohmann::json::parse(FIM_REGISTRY_SYNC_CONFIG_STATEMENT),
+                                            registryKeySyncConfig.config(),
                                             syncRegistryMessageFunction);
+
+                registryValueSyncConfig.minimalSyncIntervalTime(syncMinInterval);
                 RSyncHandler->registerSyncID(FIM_COMPONENT_REGISTRY_VALUE,
                                             handle,
-                                            nlohmann::json::parse(FIM_VALUE_SYNC_CONFIG_STATEMENT),
+                                            registryValueSyncConfig.config(),
                                             syncRegistryMessageFunction);
             }
 
@@ -389,12 +357,14 @@ class FIMDBCreator<OSType::OTHERS> final
         static void registerRsync(std::shared_ptr<RemoteSync> RSyncHandler,
                                   const RSYNC_HANDLE& handle,
                                   std::function<void(const std::string&)> syncFileMessageFunction,
+                                  const uint32_t syncMinInterval,
                                   __attribute__((unused)) std::function<void(const std::string&)> syncRegistryMessageFunction,
                                   __attribute__((unused)) const bool syncRegistryEnabled)
         {
+            fileSyncConfig.minimalSyncIntervalTime(syncMinInterval);
             RSyncHandler->registerSyncID(FIM_COMPONENT_FILE,
                                         handle,
-                                        nlohmann::json::parse(FIM_FILE_SYNC_CONFIG_STATEMENT),
+                                        fileSyncConfig.config(),
                                         syncFileMessageFunction);
         }
 

--- a/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
@@ -37,6 +37,8 @@ const auto insertRegistryValueStatement = R"({
     }
 )"_json;
 
+const auto minSyncInterval { 10 };
+
 void transaction_callback(ReturnTypeCallback resultType, const cJSON* result_json, void* user_data)
 {
     fim_txn_context_s *event_data = (fim_txn_context_s *) user_data;
@@ -218,8 +220,9 @@ TEST(DBTest, TestInvalidFimLimit)
                     300,
                     mockSyncMessage,
                     mockLoggingFunction,
-                    -1,
                     100000,
+                    minSyncInterval,
+                    -1,
                     true)
     };
     ASSERT_EQ(result, FIMDB_ERR);
@@ -240,6 +243,7 @@ TEST(DBTest, TestValidFimLimit)
                     mockSyncMessage,
                     mockLoggingFunction,
                     100,
+                    minSyncInterval,
                     100000,
                     true)
     };

--- a/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
@@ -220,7 +220,7 @@ TEST(DBTest, TestInvalidFimLimit)
                     300,
                     mockSyncMessage,
                     mockLoggingFunction,
-                    100000,
+                    -1,
                     minSyncInterval,
                     -1,
                     true)

--- a/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.h
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.h
@@ -85,7 +85,7 @@ class DBTestFixture : public testing::Test {
                         mockSyncMessage,
                         mockLoggingFunction,
                         MAX_FILE_LIMIT,
-                        0,
+                        10,
                         100000,
                         true);
 

--- a/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.h
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.h
@@ -85,6 +85,7 @@ class DBTestFixture : public testing::Test {
                         mockSyncMessage,
                         mockLoggingFunction,
                         MAX_FILE_LIMIT,
+                        0,
                         100000,
                         true);
 

--- a/src/syscheckd/src/db/tests/db/dbItem/FileItem/CMakeLists.txt
+++ b/src/syscheckd/src/db/tests/db/dbItem/FileItem/CMakeLists.txt
@@ -32,6 +32,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         sqlite3
         cjson
         -static-libgcc -static-libstdc++
+        rsync
+        dbsync
     )
 else()
     target_link_libraries(fileitem_unit_test
@@ -47,6 +49,8 @@ else()
         sqlite3
         cjson
         dl
+        rsync
+        dbsync
     )
 endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 

--- a/src/syscheckd/src/db/tests/db/dbItem/RegistryKey/CMakeLists.txt
+++ b/src/syscheckd/src/db/tests/db/dbItem/RegistryKey/CMakeLists.txt
@@ -34,6 +34,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         crypto
         ws2_32
         crypt32
+        rsync
+        dbsync
         -static-libgcc -static-libstdc++
     )
 else()
@@ -51,6 +53,8 @@ else()
         cjson
         crypto
         ssl
+        rsync
+        dbsync
         dl
     )
 endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")

--- a/src/syscheckd/src/db/tests/db/dbItem/RegistryValue/CMakeLists.txt
+++ b/src/syscheckd/src/db/tests/db/dbItem/RegistryValue/CMakeLists.txt
@@ -35,6 +35,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         ws2_32
         crypt32
         -static-libgcc -static-libstdc++
+        rsync
+        dbsync
     )
 else()
     target_link_libraries(registryvalue_unit_test
@@ -52,6 +54,8 @@ else()
         crypto
         ssl
         dl
+        rsync
+        dbsync
     )
 endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 

--- a/src/syscheckd/src/db/testtool/main.cpp
+++ b/src/syscheckd/src/db/testtool/main.cpp
@@ -50,6 +50,7 @@ int main(int argc, const char* argv[])
             const auto fileLimit{ jsonConfigFile.at("file_limit").get<const uint32_t>() };
             const auto registryLimit{ jsonConfigFile.at("registry_limit").get<const uint32_t>() };
             const bool syncRegistryEnabled { jsonConfigFile.at("registry_sync") };
+            const auto minSyncInterval{ jsonConfigFile.at("min_sync_interval").get<const uint32_t>() };
 
             std::function<void(const std::string&)> callbackSyncFileWrapper
             {
@@ -83,6 +84,7 @@ int main(int argc, const char* argv[])
                                     callbackSyncRegistryWrapper,
                                     callbackLogWrapper,
                                     fileLimit,
+                                    minSyncInterval,
                                     registryLimit,
                                     syncRegistryEnabled);
 

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -83,6 +83,7 @@ void fim_initialize() {
                                          fim_send_sync_state,
                                          loggingFunction,
                                          syscheck.db_entry_file_limit,
+                                         syscheck.min_sync_interval,
                                          0,
                                          false);
 #else
@@ -91,6 +92,7 @@ void fim_initialize() {
                                          fim_send_sync_state,
                                          loggingFunction,
                                          syscheck.db_entry_file_limit,
+                                         syscheck.min_sync_interval,
                                          syscheck.db_entry_registry_limit,
                                          syscheck.enable_registry_synchronization);
 #endif

--- a/src/unit_tests/syscheckd/test_config.c
+++ b/src/unit_tests/syscheckd/test_config.c
@@ -606,7 +606,7 @@ void test_getSyscheckConfig_no_directories(void **state)
     assert_int_equal(process_priority->valueint, 10);
 
     cJSON *synchronization = cJSON_GetObjectItem(sys_items, "synchronization");
-    assert_int_equal(cJSON_GetArraySize(synchronization), 4);
+    assert_int_equal(cJSON_GetArraySize(synchronization), 5);
     cJSON *enabled = cJSON_GetObjectItem(synchronization, "enabled");
     assert_string_equal(cJSON_GetStringValue(enabled), "yes");
     cJSON *interval = cJSON_GetObjectItem(synchronization, "interval");

--- a/src/unit_tests/syscheckd/test_syscheck.c
+++ b/src/unit_tests/syscheckd/test_syscheck.c
@@ -51,6 +51,7 @@ static int setup_syscheck_config(void **state) {
 
     syscheck_conf->database_store            = FIM_DB_DISK;
     syscheck_conf->sync_interval             = 300;
+    syscheck_conf->min_sync_interval         = 10;
     syscheck_conf->db_entry_file_limit       = 100000;
 #ifdef WIN32
     syscheck_conf->db_entry_registry_limit   = 100000;
@@ -102,12 +103,14 @@ void test_fim_initialize(void **state)
     expect_wrapper_fim_db_init(syscheck_conf->database_store,
                                syscheck_conf->sync_interval,
                                syscheck_conf->db_entry_file_limit,
+                               syscheck_conf->min_sync_interval,
                                syscheck_conf->db_entry_registry_limit,
                                1);
 #else
     expect_wrapper_fim_db_init(syscheck_conf->database_store,
                                syscheck_conf->sync_interval,
                                syscheck_conf->db_entry_file_limit,
+                               syscheck_conf->min_sync_interval,
                                0,
                                0);
 #endif

--- a/src/unit_tests/syscheckd/test_syscheck.c
+++ b/src/unit_tests/syscheckd/test_syscheck.c
@@ -51,7 +51,7 @@ static int setup_syscheck_config(void **state) {
 
     syscheck_conf->database_store            = FIM_DB_DISK;
     syscheck_conf->sync_interval             = 300;
-    syscheck_conf->min_sync_interval         = 10;
+    syscheck_conf->min_sync_interval         = 60;
     syscheck_conf->db_entry_file_limit       = 100000;
 #ifdef WIN32
     syscheck_conf->db_entry_registry_limit   = 100000;
@@ -197,7 +197,7 @@ void test_Start_win32_Syscheck_corrupted_config_file(void **state) {
 
     will_return(__wrap_rootcheck_init, 1);
 
-    expect_wrapper_fim_db_init(0, 300, 100000, 100000, 1);
+    expect_wrapper_fim_db_init(0, 300, 100000, 60, 100000, 1);
     expect_function_call(__wrap_os_wait);
     expect_function_call(__wrap_start_daemon);
     assert_int_equal(Start_win32_Syscheck(), 0);
@@ -223,7 +223,7 @@ void test_Start_win32_Syscheck_syscheck_disabled_1(void **state) {
 
     will_return(__wrap_rootcheck_init, 0);
 
-    expect_wrapper_fim_db_init(0, 300, 100000, 100000, 1);
+    expect_wrapper_fim_db_init(0, 300, 100000, 60, 100000, 1);
     expect_string(__wrap__minfo, formatted_msg, FIM_FILE_SIZE_LIMIT_DISABLED);
 
     expect_string(__wrap__minfo, formatted_msg, FIM_DISK_QUOTA_LIMIT_DISABLED);
@@ -253,7 +253,7 @@ void test_Start_win32_Syscheck_syscheck_disabled_2(void **state) {
 
     will_return(__wrap_rootcheck_init, 0);
 
-    expect_wrapper_fim_db_init(0, 300, 100000, 100000, 1);
+    expect_wrapper_fim_db_init(0, 300, 100000, 60, 100000, 1);
     expect_string(__wrap__minfo, formatted_msg, FIM_FILE_SIZE_LIMIT_DISABLED);
 
     expect_string(__wrap__minfo, formatted_msg, FIM_DISK_QUOTA_LIMIT_DISABLED);
@@ -323,7 +323,7 @@ void test_Start_win32_Syscheck_dirs_and_registry(void **state) {
 
     expect_string(__wrap__minfo, formatted_msg, "(6004): No diff for file: 'Diff'");
 
-    expect_wrapper_fim_db_init(0, 300, 100000, 100000, 1);
+    expect_wrapper_fim_db_init(0, 300, 100000, 60, 100000, 1);
     snprintf(info_msg, OS_MAXSTR, "Started (pid: %d).", getpid());
     expect_string(__wrap__minfo, formatted_msg, info_msg);
 
@@ -371,7 +371,7 @@ void test_Start_win32_Syscheck_whodata_active(void **state) {
 
     expect_string(__wrap__minfo, formatted_msg, "(6003): Monitoring path: 'c:\\dir1', with options 'whodata'.");
 
-    expect_wrapper_fim_db_init(0, 300, 100000, 100000, 1);
+    expect_wrapper_fim_db_init(0, 300, 100000, 60, 100000, 1);
     expect_string(__wrap__minfo, formatted_msg, FIM_FILE_SIZE_LIMIT_DISABLED);
 
     expect_string(__wrap__minfo, formatted_msg, FIM_DISK_QUOTA_LIMIT_DISABLED);

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
@@ -42,11 +42,13 @@ FIMDBErrorCode __wrap_fim_db_init(int storage,
                                   __attribute__((unused)) fim_sync_callback_t sync_callback,
                                   __attribute__((unused)) logging_callback_t log_callback,
                                   int file_limit,
+                                  uint32_t min_sync_interval,
                                   int value_limit,
                                   int sync_registry_enable) {
     check_expected(storage);
     check_expected(sync_interval);
     check_expected(file_limit);
+    check_expected(min_sync_interval);
     check_expected(value_limit);
     check_expected(sync_registry_enable);
 
@@ -56,11 +58,13 @@ FIMDBErrorCode __wrap_fim_db_init(int storage,
 void expect_wrapper_fim_db_init(int storage,
                                 int sync_interval,
                                 int file_limit,
+                                uint32_t min_sync_interval,
                                 int value_limit,
                                 int sync_registry_enable) {
     expect_value(__wrap_fim_db_init, storage, storage);
     expect_value(__wrap_fim_db_init, sync_interval, sync_interval);
     expect_value(__wrap_fim_db_init, file_limit, file_limit);
+    expect_value(__wrap_fim_db_init, min_sync_interval, min_sync_interval);
     expect_value(__wrap_fim_db_init, value_limit, value_limit);
     expect_value(__wrap_fim_db_init, sync_registry_enable, sync_registry_enable);
 

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
@@ -44,12 +44,14 @@ FIMDBErrorCode __wrap_fim_db_init(int storage,
                                   fim_sync_callback_t sync_callback,
                                   logging_callback_t log_callback,
                                   int file_limit,
+                                  uint32_t min_sync_interval,
                                   int value_limit,
                                   int sync_registry_enable);
 
 void expect_wrapper_fim_db_init(int storage,
                                 int sync_interval,
                                 int file_limit,
+                                uint32_t min_sync_interval,
                                 int value_limit,
                                 int sync_registry_enable);
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #13641 | 

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR adds a new option for FIM to set the RSync minSyncInterval in order to avoid the synchronization overlapping that was experienced while executing the stress tests.
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
```xml
  <syscheck>
    <!-- Database synchronization settings -->
    <synchronization>
      <enabled>yes</enabled>
      <min_interval>x</min_interval>
      <interval>5m</interval>
      <max_eps>10</max_eps>
    </synchronization>
  </syscheck>
```

The new option is called `min_interval` inside the `synchronization` block and the default value is 10 seconds.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [X] Source installation
- [X] Source upgrade


<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
