### PR TITLE
Upgrade click and clickclick to latest version (8.1.3 and 20.10.2)

### DIFF
--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -17,8 +17,8 @@ certifi==2020.4.5.1
 cffi==1.14.4
 chardet==3.0.4
 charset-normalizer==2.0.4
-Click==7.0
-clickclick==1.2.2
+click==8.1.3
+clickclick==20.10.2
 connexion==2.6.0
 cryptography==3.3.2
 Cython==0.29.21


### PR DESCRIPTION
|Related issue|
|---|
|#13743|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

In this PR we have upgraded the version of "click" and "clickclick" to `8.1.3` and `20.10.2` respectively, thus fixing the detected vulnerability.