### PR TITLE
Update GET /mitre/software timeout and API integration tests after the MITRE DB update

### DIFF
--- a/api/api/controllers/mitre_controller.py
+++ b/api/api/controllers/mitre_controller.py
@@ -14,7 +14,7 @@ from wazuh.core.cluster.dapi.dapi import DistributedAPI
 logger = logging.getLogger('wazuh-api')
 
 MITRE_TECHNIQUES_TIMEOUT = 30
-MITRE_SOFTWARE_TIMEOUT = 15
+MITRE_SOFTWARE_TIMEOUT = 20
 
 
 async def get_metadata(request, pretty=False, wait_for_complete=False):

--- a/api/api/controllers/test/test_mitre_controller.py
+++ b/api/api/controllers/test/test_mitre_controller.py
@@ -171,7 +171,7 @@ async def test_get_software(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_r
                                       wait_for_complete=False,
                                       logger=ANY,
                                       rbac_permissions=mock_request['token_info']['rbac_policies'],
-                                      api_timeout=15)
+                                      api_timeout=20)
 
     mock_exc.assert_called_once_with(mock_dfunc.return_value)
     mock_remove.assert_called_once_with(f_kwargs)

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -256,9 +256,12 @@ def test_save_response_data_mitre(response, fields):
 
 
 def test_validate_mitre(response, data, index=0):
+    data = data.replace('"', '\\"')  # Escape " character in data
     data = json.loads(data.replace("'", '"'))
     for element in data:
         for k, v in element.items():
+            if isinstance(v, str):
+                v = v.replace('\\"', '"')  # Remove \\ characters used to escape "
             assert v == response.json()['data']['affected_items'][index][k]
 
 

--- a/api/test/integration/test_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_mitre_endpoints.tavern.yaml
@@ -544,7 +544,7 @@ stages:
         error: 0
         data:
           failed_items: []
-          total_affected_items: 3
+          total_affected_items: 2
           total_failed_items: 0
       verify_response_with:
         function: tavern_utils:test_validate_search
@@ -607,7 +607,7 @@ stages:
             - <<: *references_response
               id: "attack-pattern--01a5a209-b94c-450b-b7f9-946497d91055"
           failed_items: []
-          total_affected_items: 6
+          total_affected_items: 4
           total_failed_items: 0
 
   - name: Filter references using q parameter (complex query)
@@ -628,11 +628,8 @@ stages:
             - <<: *references_response
               source: "Wikipedia pwdump"
               type: "software"
-            - <<: *references_response
-              source: "Wikipedia FTP"
-              type: "software"
           failed_items: []
-          total_affected_items: 3
+          total_affected_items: 2
           total_failed_items: 0
 
 ---


### PR DESCRIPTION
|Related issue|
|---|
| #13788  |



## Description

This PR closes https://github.com/wazuh/wazuh/issues/13788.

BEFORE the MITRE DB update, these are the MITRE endpoints response times measured in a low-specs host. These times were taken in https://github.com/wazuh/wazuh/issues/13426. 

```
GET /mitre/groups -> 0m3.036s
GET /mitre/metadata -> 0m0.144s
GET /mitre/mitigations -> 0m1.359s
GET /mitre/references -> 0m0.348s
GET /mitre/software -> 0m14.826s:
GET /mitre/tactics -> 0m0.184s
GET /mitre/techniques -> 0m29.792s
```

AFTER the MITRE DB update, these are the MITRE endpoints response times (measured in a low-spec host, average of 3 response times each):

```
GET /mitre/groups -> 3.885s
GET /mitre/metadata -> 1.11s
GET /mitre/mitigations -> 1.98s
GET /mitre/references -> 1.125s
GET /mitre/software -> 17.255s
GET /mitre/tactics -> 0.82s
GET /mitre/techniques -> 27.225s
```


As it can be seen, the GET /mitre/software endpoint is slightly slower than it used to be. The GET /mitre/techniques endpoint is a bit faster. The rest of the endpoints' response times do not matter as they are still under the default timeout value (10s).

After talking with the team, we have decided to increase the GET /mitre/software timeout **from 15 to 20** to avoid possible API timeouts.

Apart from this change, the pull request also updates the MITRE API integration tests and unit tests.


**Configuration examples after the timeout value change (ref: https://github.com/wazuh/wazuh/pull/13550#issue-1242989629):**

For the **default** intervals > **request_timeout**, all the API requests will have timeout = 10 but MITRE techniques and software endpoints that will have 30 and 20. 

For intervals > **request_timeout = 12**, all the API requests will have timeout = 12 but MITRE techniques and software endpoints that will have 30 and 20. 

For intervals > **request_timeout = 23**, all the API requests will have timeout = 23 but MITRE techniques endpoint that will have 30. 

For intervals > **request_timeout = 35**, all the API requests will have timeout = 35.

