### PR TITLE
Fix function to print cluster health of `cluster_control` CLI

### DIFF
--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -98,6 +98,9 @@ async def print_health(config, more, filter_node):
         return total_seconds
 
     lc = local_client.LocalClient()
+    if filter_node is None:
+        filter_node = await control.get_nodes(lc, filter_node=filter_node)
+        filter_node = [node['name'] for node in filter_node['items']]
     result = await control.get_health(lc, filter_node=filter_node)
     msg2 = ""
 

--- a/framework/scripts/tests/test_cluster_control.py
+++ b/framework/scripts/tests/test_cluster_control.py
@@ -78,6 +78,7 @@ async def test_print_nodes(local_client_mock, get_agents_mock, print_table_mock,
 @patch('builtins.print')
 @patch('scripts.cluster_control.get_utc_strptime')
 @patch('scripts.cluster_control.local_client.LocalClient', return_value='LocalClient return value')
+@patch('scripts.cluster_control.control.get_nodes', return_value={'items': [{'name': 'wazuh_worker'}]})
 @patch('scripts.cluster_control.control.get_health',
        return_value={'n_connected_nodes': '1',
                      'nodes': {'wazuh_worker2': {
@@ -96,66 +97,89 @@ async def test_print_nodes(local_client_mock, get_agents_mock, print_table_mock,
                                     'last_sync_agentgroups': {'date_start_master': '0', 'date_end_master': '0',
                                                               'n_synced_chunks': 0},
                                     'sync_agent_info_free': 'True', 'sync_agent_groups_free': 'True'}}}})
-async def test_print_health(get_health_mock, local_client_mock, get_utc_strptime_mock, print_mock):
+async def test_print_health(get_health_mock, get_nodes_mock, local_client_mock, get_utc_strptime_mock, print_mock):
     """Test if the current status of the cluster is properly printed."""
 
     def seconds_mock(time, format=None):
         """Auxiliary mock function."""
         return timedelta(seconds=int(time))
 
+    # Common variables
     config = {'name': 'cluster_name'}
     more = True
-    filter_node = 'wazuh_worker'
     worker_status = get_health_mock.return_value['nodes']['wazuh_worker2']['status']
     worker_info = get_health_mock.return_value['nodes']['wazuh_worker2']['info']
-
     get_utc_strptime_mock.side_effect = seconds_mock
-    await cluster_control.print_health(config=config, more=more, filter_node=filter_node)
-    print_mock.assert_has_calls([call(f"Cluster name: {config['name']}\n\n"
-                                      f"Connected nodes ({get_health_mock.return_value['n_connected_nodes']}):"),
-                                 call(f"\n    wazuh_worker2 ({worker_info['ip']})\n        "
-                                      f"Version: {worker_info['version']}\n        Type: {worker_info['type']}\n       "
-                                      f" Active agents: {worker_info['n_active_agents']}\n        Status:\n           "
-                                      f" Last keep Alive:\n                Last received: "
-                                      f"{worker_status['last_keep_alive']}.\n            Integrity check:\n           "
-                                      f"     Last integrity check: n/a "
-                                      f"({worker_status['last_check_integrity']['date_end_master']} - "
-                                      f"{worker_status['last_check_integrity']['date_start_master']}).\n               "
-                                      f" Permission to check integrity: {worker_status['sync_integrity_free']}.\n      "
-                                      f"      Integrity sync:\n                Last integrity synchronization: 1.0s "
-                                      f"({worker_status['last_sync_integrity']['date_start_master']} - "
-                                      f"{worker_status['last_sync_integrity']['date_end_master']}).\n                "
-                                      f"Synchronized files: Shared: "
-                                      f"{worker_status['last_sync_integrity']['total_files']['shared']} | Missing: "
-                                      f"{worker_status['last_sync_integrity']['total_files']['missing']} | Extra: "
-                                      f"{worker_status['last_sync_integrity']['total_files']['extra']}.\n            "
-                                      f"Agents-info:\n                Last synchronization: 0.001s ("
-                                      f"{worker_status['last_sync_agentinfo']['date_start_master']} - "
-                                      f"{worker_status['last_sync_agentinfo']['date_start_master']}).\n         "
-                                      f"       Number of synchronized chunks: "
-                                      f"{worker_status['last_sync_agentinfo']['n_synced_chunks']}.\n                "
-                                      f"Permission to synchronize agent-info: {worker_status['sync_agent_info_free']}.\n            "
-                                      f"Agent-groups:\n                Last synchronization: 0.001s ("
-                                      f"{worker_status['last_sync_agentgroups']['date_start_master']} - "
-                                      f"{worker_status['last_sync_agentgroups']['date_start_master']}).\n         "
-                                      f"       Number of synchronized chunks: "
-                                      f"{worker_status['last_sync_agentgroups']['n_synced_chunks']}.\n                "
-                                      f"Permission to synchronize agent-groups: {worker_status['sync_agent_groups_free']}.\n"
-                                      )])
 
-    local_client_mock.assert_called_once_with()
-    get_health_mock.assert_called_once_with(local_client_mock.return_value, filter_node=filter_node)
-    get_utc_strptime_mock.assert_has_calls(
-        [call(worker_status['last_sync_integrity']['date_end_master'], '%Y-%m-%dT%H:%M:%S.%fZ'),
-         call(worker_status['last_sync_integrity']['date_start_master'], '%Y-%m-%dT%H:%M:%S.%fZ'),
-         call(worker_status['last_sync_agentinfo']['date_end_master'], '%Y-%m-%dT%H:%M:%S.%fZ'),
-         call(worker_status['last_sync_agentinfo']['date_start_master'], '%Y-%m-%dT%H:%M:%S.%fZ'),
-         call(worker_status['last_sync_agentgroups']['date_end_master'], '%Y-%m-%dT%H:%M:%S.%fZ'),
-         call(worker_status['last_sync_agentgroups']['date_start_master'], '%Y-%m-%dT%H:%M:%S.%fZ')])
+    # Test cases 1 and 2
+    for filter_node in ['wazuh_worker', None]:
+        # Reset mocks
+        print_mock.reset_mock()
+        local_client_mock.reset_mock()
+        get_nodes_mock.reset_mock()
+        get_health_mock.reset_mock()
 
+        # Call print_health
+        await cluster_control.print_health(config=config, more=more, filter_node=filter_node)
+        print_mock.assert_has_calls([call(f"Cluster name: {config['name']}\n\n"
+                                          f"Connected nodes ({get_health_mock.return_value['n_connected_nodes']}):"),
+                                     call(f"\n    wazuh_worker2 ({worker_info['ip']})\n        "
+                                          f"Version: {worker_info['version']}\n        "
+                                          f"Type: {worker_info['type']}\n       "
+                                          f" Active agents: {worker_info['n_active_agents']}\n        "
+                                          f"Status:\n           "
+                                          f" Last keep Alive:\n                Last received: "
+                                          f"{worker_status['last_keep_alive']}.\n            "
+                                          f"Integrity check:\n           "
+                                          f"     Last integrity check: n/a "
+                                          f"({worker_status['last_check_integrity']['date_end_master']} - "
+                                          f"{worker_status['last_check_integrity']['date_start_master']})."
+                                          f"\n                Permission to check integrity: "
+                                          f"{worker_status['sync_integrity_free']}.\n            "
+                                          f"Integrity sync:\n                Last integrity synchronization: 1.0s "
+                                          f"({worker_status['last_sync_integrity']['date_start_master']} - "
+                                          f"{worker_status['last_sync_integrity']['date_end_master']})."
+                                          f"\n                Synchronized files: Shared: "
+                                          f"{worker_status['last_sync_integrity']['total_files']['shared']} | Missing: "
+                                          f"{worker_status['last_sync_integrity']['total_files']['missing']} | Extra: "
+                                          f"{worker_status['last_sync_integrity']['total_files']['extra']}."
+                                          f"\n            Agents-info:\n                Last synchronization: 0.001s ("
+                                          f"{worker_status['last_sync_agentinfo']['date_start_master']} - "
+                                          f"{worker_status['last_sync_agentinfo']['date_start_master']}).\n         "
+                                          f"       Number of synchronized chunks: "
+                                          f"{worker_status['last_sync_agentinfo']['n_synced_chunks']}."
+                                          f"\n                Permission to synchronize agent-info: "
+                                          f"{worker_status['sync_agent_info_free']}.\n            "
+                                          f"Agent-groups:\n                Last synchronization: 0.001s ("
+                                          f"{worker_status['last_sync_agentgroups']['date_start_master']} - "
+                                          f"{worker_status['last_sync_agentgroups']['date_start_master']}).\n         "
+                                          f"       Number of synchronized chunks: "
+                                          f"{worker_status['last_sync_agentgroups']['n_synced_chunks']}."
+                                          f"\n                Permission to synchronize agent-groups: "
+                                          f"{worker_status['sync_agent_groups_free']}.\n"
+                                          )])
+
+        # Common assertions
+        local_client_mock.assert_called_once()
+        get_utc_strptime_mock.assert_has_calls(
+            [call(worker_status['last_sync_integrity']['date_end_master'], '%Y-%m-%dT%H:%M:%S.%fZ'),
+             call(worker_status['last_sync_integrity']['date_start_master'], '%Y-%m-%dT%H:%M:%S.%fZ'),
+             call(worker_status['last_sync_agentinfo']['date_end_master'], '%Y-%m-%dT%H:%M:%S.%fZ'),
+             call(worker_status['last_sync_agentinfo']['date_start_master'], '%Y-%m-%dT%H:%M:%S.%fZ'),
+             call(worker_status['last_sync_agentgroups']['date_end_master'], '%Y-%m-%dT%H:%M:%S.%fZ'),
+             call(worker_status['last_sync_agentgroups']['date_start_master'], '%Y-%m-%dT%H:%M:%S.%fZ')])
+
+        # filter_node dependant assertions
+        filter_node and get_nodes_mock.assert_not_called()
+        filter_node or get_nodes_mock.assert_called_once()
+        get_health_mock.assert_called_once_with(
+            local_client_mock.return_value,
+            filter_node=filter_node or [get_nodes_mock.return_value['items'][0]['name']])
+
+    # Test case 3
     more = False
+    filter_node = 'wazuh_worker'
     print_mock.reset_mock()
-
     await cluster_control.print_health(config=config, more=more, filter_node=filter_node)
     print_mock.assert_called_once_with(f"Cluster name: {config['name']}\n\nLast completed synchronization for connected"
                                        f" nodes ({get_health_mock.return_value['n_connected_nodes']}):\n    "
@@ -286,22 +310,22 @@ def test_main(get_cluster_status_mock, read_config_mock, check_cluster_config, p
 
         assert exclusive_mock.exclusive == [{'action': 'store_const', 'const': 'list_agents', 'dest': None,
                                              'flag': '-a', 'help': 'List agents', 'name': '--list-agents',
-                                             'nargs': None,  'type': None}, {'action': 'store_const',
-                                                                             'const': 'list_nodes',
-                                                                             'dest': None, 'flag': '-l',
-                                                                             'help': 'List nodes',
-                                                                             'name': '--list-nodes', 'nargs': None,
-                                                                             'type': None}, {'action': 'store',
-                                                                                             'const': 'health',
-                                                                                             'dest': None,
-                                                                                             'flag': '-i',
-                                                                                             'help': 'Show cluster '
-                                                                                                     'health',
-                                                                                             'name': '--health',
-                                                                                             'nargs': '?',
-                                                                                             'type': None},
+                                             'nargs': None, 'type': None}, {'action': 'store_const',
+                                                                            'const': 'list_nodes',
+                                                                            'dest': None, 'flag': '-l',
+                                                                            'help': 'List nodes',
+                                                                            'name': '--list-nodes', 'nargs': None,
+                                                                            'type': None}, {'action': 'store',
+                                                                                            'const': 'health',
+                                                                                            'dest': None,
+                                                                                            'flag': '-i',
+                                                                                            'help': 'Show cluster '
+                                                                                                    'health',
+                                                                                            'name': '--health',
+                                                                                            'nargs': '?',
+                                                                                            'type': None},
                                             {'action': 'store_true', 'const': None, 'dest': None, 'flag': '-u',
-                                             'help': 'Show usage', 'name': '--usage', 'nargs': None,  'type': None}]
+                                             'help': 'Show usage', 'name': '--usage', 'nargs': None, 'type': None}]
 
         # Test the fifth condition
         get_cluster_status_mock.return_value['enabled'] = 'yes'


### PR DESCRIPTION
|Related issue|
|---|
| #13229  |



## Description

As it was said in the related issue's body, when executing `cluster_control -i more`, the number of active agents is not returned correctly.

```
# /var/ossec/bin/cluster_control -a
ID   NAME          IP          STATUS  VERSION       NODE NAME    
000  wazuh-master  127.0.0.1   active  Wazuh v4.4.0  master-node  
001  b4bd23874d25  172.20.0.5  active  Wazuh v4.4.0  master-node  
```

```
# /var/ossec/bin/cluster_control -i more
Cluster name: wazuh

Connected nodes (2):

    master-node (wazuh-master)
        Version: 4.4.0
        Type: master
        Active agents: 0

...
```


The `print_health` funciton of `cluster_control.py` has the following line:

```python
result = await control.get_health(lc, filter_node=filter_node)
```

where `filter_node` is `None`.

`get_health` function of `wazuh/core/cluster/control.py`:

```python
...
response = await lc.execute(command=b'get_health',
                                data=json.dumps(filter_node).encode(),
                                wait_for_complete=False)
...
```


The command is sent and processed in the `master.py` file.

The `get_health` function of `wazuh/core/cluster/master.py` is the one in charge of getting the nodes and synchronization information.

```python
 def get_health(self, filter_node) -> Dict:
        """Get nodes and synchronization information.

        Parameters
        ----------
        filter_node : dict
            Whether to filter by a node or return all health information.

        Returns
        -------
        dict
            Dict object containing nodes information.
        """
        workers_info = {key: val.to_dict() for key, val in self.clients.items()
                        if filter_node is None or filter_node == {} or key in filter_node}
        n_connected_nodes = len(workers_info)
        if filter_node is None or self.configuration['node_name'] in filter_node:
            workers_info.update({self.configuration['node_name']: self.to_dict()})

        # Get active agents by node and format last keep alive date format
        active_agents = Agent.get_agents_overview(filters={'status': 'active', 'node_name': filter_node})['items']
        for agent in active_agents:
            if (agent_node := agent["node_name"]) in workers_info.keys():
                workers_info[agent_node]["info"]["n_active_agents"] = \
                    workers_info[agent_node]["info"].get("n_active_agents", 0) + 1
        for node_name in workers_info.keys():
            if workers_info[node_name]["info"].get("n_active_agents") is None:
                workers_info[node_name]["info"]["n_active_agents"] = 0
            if workers_info[node_name]['info']['type'] != 'master':
                workers_info[node_name]['status']['last_keep_alive'] = str(
                    utils.get_date_from_timestamp(workers_info[node_name]['status']['last_keep_alive']
                                                  ).strftime(DECIMALS_DATE_FORMAT))

        return {"n_connected_nodes": n_connected_nodes, "nodes": workers_info}
```
        
As we said above, when calling `/var/ossec/bin/cluster-control -i more`, `filter_node` is `None`.

This issue is only present in the `cluster_control` CLI. When the `GET /cluster/healthcheck` endpoint is requested, `filter_node` is never `None`.

Therefore, the profiling and enhancement done in https://github.com/wazuh/wazuh/issues/10868 are valid and correct and the only bug is related to the `cluster_control` CLI.

The solution would be getting the nodes before sending the `get_health` command to the cluster. This will not really affect the CLI performance as it is a fast operation (as we commented in the profiling issue, getting the agents for each node is the slowest part of the use case).

After the changes,` cluster_control -i more` is working as expected:

```
# /var/ossec/bin/cluster_control -i more
Cluster name: wazuh

Connected nodes (2):

    master-node (wazuh-master)
        Version: 4.4.0
        Type: master
        Active agents: 1

    worker1 (172.20.0.6)
        Version: 4.4.0
        Type: worker
        Active agents: 1
        Status:
            Last keep Alive:
                Last received: 2022-06-09T11:51:52.699977Z.
            Integrity check:
                Last integrity check: 0.015s (2022-06-09T11:48:28.059867Z - 2022-06-09T11:48:28.074725Z).
                Permission to check integrity: True.
            Integrity sync:
                Last integrity synchronization: n/a (n/a - n/a).
                Synchronized files: Shared: 0 | Missing: 0 | Extra: 0.
            Agents-info:
                Last synchronization: 0.009s (2022-06-09T11:48:21.033541Z - 2022-06-09T11:48:21.042419Z).
                Number of synchronized chunks: 1.
                Permission to synchronize agent-info: True.
            Agent-groups:
                Last synchronization: n/a (n/a - n/a).
                Number of synchronized chunks: 0.
                Permission to synchronize agent-groups: True.

    worker2 (172.20.0.3)
        Version: 4.4.0
        Type: worker
        Active agents: 0
        Status:
            Last keep Alive:
                Last received: 2022-06-09T11:51:52.717191Z.
            Integrity check:
                Last integrity check: 0.014s (2022-06-09T11:48:28.062810Z - 2022-06-09T11:48:28.076360Z).
                Permission to check integrity: True.
            Integrity sync:
                Last integrity synchronization: n/a (n/a - n/a).
                Synchronized files: Shared: 0 | Missing: 0 | Extra: 0.
            Agents-info:
                Last synchronization: n/a (n/a - n/a).
                Number of synchronized chunks: 0.
                Permission to synchronize agent-info: True.
            Agent-groups:
                Last synchronization: n/a (n/a - n/a).
                Number of synchronized chunks: 0.
                Permission to synchronize agent-groups: True.
```