### PR TITLE
Fix result access when removing group

### DIFF
--- a/framework/scripts/agent_groups.py
+++ b/framework/scripts/agent_groups.py
@@ -188,7 +188,7 @@ async def remove_group(group_id, quiet=False):
         if result.total_affected_items == 0:
             msg = list(result.failed_items.keys())[0]
         else:
-            affected_agents = next(iter(data['affected_items'][0].values()))
+            affected_agents = next(iter(result.affected_items[0].values()))
             msg = f'Group {group_id} removed.'
             if len(affected_agents) == 0:
                 msg += "\nNo affected agents."


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/13801|

This PR fixes an error introduced during the migration from 4.3 to 4.4 due to changes in AffectedItemsWazuhResult structure.

After the changes:

```
root@wazuh-master:/# /var/ossec/bin/agent_groups -ag david
Group 'david' created.

root@wazuh-master:/# /var/ossec/bin/agent_groups -ai 001 -g david
Group 'david' added to agent '001'.

root@wazuh-master:/# /var/ossec/bin/agent_groups -rg david 
Group david removed.
Affected agents: 001.
```