### PR TITLE
Update macOS codenames

### DIFF
--- a/src/data_provider/src/osinfo/sysOsParsers.cpp
+++ b/src/data_provider/src/osinfo/sysOsParsers.cpp
@@ -430,6 +430,9 @@ bool MacOsParser::parseUname(const std::string& in, nlohmann::json& output)
         {"17", "High Sierra"},
         {"18", "Mojave"},
         {"19", "Catalina"},
+        {"20", "Big Sur"},
+        {"21", "Monterey"},
+        {"22", "Ventura"},
     };
     constexpr auto PATTERN_MATCH{"[0-9]+"};
     std::string match;

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -374,6 +374,8 @@ const char *OSX_ReleaseName(int version) {
     /* 18 */ "Mojave",
     /* 19 */ "Catalina",
     /* 20 */ "Big Sur",
+    /* 21 */ "Monterey",
+    /* 22 */ "Ventura",
     };
 
     version -= 10;

--- a/src/unit_tests/shared/test_version_op.c
+++ b/src/unit_tests/shared/test_version_op.c
@@ -1441,7 +1441,9 @@ void test_OSX_ReleaseName(void **state) {
     assert_string_equal(OSX_ReleaseName(18), "Mojave");
     assert_string_equal(OSX_ReleaseName(19), "Catalina");
     assert_string_equal(OSX_ReleaseName(20), "Big Sur");
-    assert_string_equal(OSX_ReleaseName(21), "Unknown");
+    assert_string_equal(OSX_ReleaseName(21), "Monterey");
+    assert_string_equal(OSX_ReleaseName(22), "Ventura");
+    assert_string_equal(OSX_ReleaseName(23), "Unknown");
 }
 
 #endif


### PR DESCRIPTION
|Related issue|
|---|
|#13836|

## Description

This PR aims to add the latest macOS codename versions to Agent's codename retrieving mechanism and Sysinfo

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors