### PR TITLE
Fix random text truncated for generic password.

### DIFF
--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -391,3 +391,59 @@ w_err_t w_auth_validate_groups(const char *groups, char *response) {
     os_free(tmp_groups);
     return ret;
 }
+
+char *w_generate_random_pass()
+{
+    int rand1;
+    int rand2;
+    char *rand3;
+    char *rand4;
+    os_md5 md1;
+    os_md5 md3;
+    os_md5 md4;
+    char *fstring = NULL;
+    char *str1 = NULL;
+    int time_value = (int)time(NULL);
+
+    rand1 = os_random();
+    rand2 = os_random();
+
+    rand3 = GetRandomNoise();
+    rand4 = GetRandomNoise();
+
+    OS_MD5_Str(rand3, -1, md3);
+    OS_MD5_Str(rand4, -1, md4);
+
+    const int requested_size = snprintf(NULL,
+                                        0,
+                                        "%d%d%s%d%s%s",
+                                        time_value,
+                                        rand1,
+                                        getuname(),
+                                        rand2,
+                                        md3,
+                                        md4);
+
+    if (requested_size > 0) {
+        os_calloc(requested_size + 1, sizeof(char), str1);
+        const int requested_size_assignation = snprintf(str1,
+                                                        requested_size + 1,
+                                                        "%d%d%s%d%s%s",
+                                                        time_value,
+                                                        rand1,
+                                                        getuname(),
+                                                        rand2,
+                                                        md3,
+                                                        md4);
+
+        if (requested_size_assignation > 0 && requested_size_assignation == requested_size) {
+            OS_MD5_Str(str1, -1, md1);
+            fstring = strdup(md1);
+        }
+    }
+
+    free(rand3);
+    free(rand4);
+    os_free(str1);
+    return(fstring);
+}

--- a/src/os_auth/auth.h
+++ b/src/os_auth/auth.h
@@ -171,6 +171,14 @@ w_err_t w_auth_add_agent(char *response,
                          char **id,
                          char **key);
 
+/**
+ * @brief Returns a MD5 hash of some random data collected from different sources.
+ *        The result must be freed by the caller.
+ *
+ * @return const char* The resulting hash or NULL on error.
+ */
+char *w_generate_random_pass();
+
 extern char shost[512];
 extern keystore keys;
 extern volatile int write_pending;
@@ -178,5 +186,7 @@ extern volatile int running;
 extern pthread_mutex_t mutex_keys;
 extern pthread_cond_t cond_pending;
 extern authd_config_t config;
+
+
 
 #endif /* AUTHD_H */

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -109,6 +109,7 @@ char *__generatetmppass()
     os_md5 md4;
     char *fstring = NULL;
     char *str1 = NULL;
+    int time_value = (int)time(NULL);
 
     rand1 = os_random();
     rand2 = os_random();
@@ -119,10 +120,10 @@ char *__generatetmppass()
     OS_MD5_Str(rand3, -1, md3);
     OS_MD5_Str(rand4, -1, md4);
 
-    const int requested_size = snprintf(str1,
+    const int requested_size = snprintf(NULL,
                                         0,
                                         "%d%d%s%d%s%s",
-                                        (int)time(0),
+                                        time_value,
                                         rand1,
                                         getuname(),
                                         rand2,
@@ -134,7 +135,7 @@ char *__generatetmppass()
         const int requested_size_assignation = snprintf(str1,
                                                         requested_size + 1,
                                                         "%d%d%s%d%s%s",
-                                                        (int)time(0),
+                                                        time_value,
                                                         rand1,
                                                         getuname(),
                                                         rand2,

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -97,63 +97,6 @@ static void help_authd(char * home_path)
     exit(1);
 }
 
-/* Generates a random and temporary shared pass to be used by the agents. */
-char *__generatetmppass()
-{
-    int rand1;
-    int rand2;
-    char *rand3;
-    char *rand4;
-    os_md5 md1;
-    os_md5 md3;
-    os_md5 md4;
-    char *fstring = NULL;
-    char *str1 = NULL;
-    int time_value = (int)time(NULL);
-
-    rand1 = os_random();
-    rand2 = os_random();
-
-    rand3 = GetRandomNoise();
-    rand4 = GetRandomNoise();
-
-    OS_MD5_Str(rand3, -1, md3);
-    OS_MD5_Str(rand4, -1, md4);
-
-    const int requested_size = snprintf(NULL,
-                                        0,
-                                        "%d%d%s%d%s%s",
-                                        time_value,
-                                        rand1,
-                                        getuname(),
-                                        rand2,
-                                        md3,
-                                        md4);
-
-    if (requested_size > 0) {
-        os_calloc(requested_size + 1, sizeof(char), str1);
-        const int requested_size_assignation = snprintf(str1,
-                                                        requested_size + 1,
-                                                        "%d%d%s%d%s%s",
-                                                        time_value,
-                                                        rand1,
-                                                        getuname(),
-                                                        rand2,
-                                                        md3,
-                                                        md4);
-
-        if (requested_size_assignation > 0 && requested_size_assignation == requested_size) {
-            OS_MD5_Str(str1, -1, md1);
-            fstring = strdup(md1);
-        }
-    }
-
-    free(rand3);
-    free(rand4);
-    os_free(str1);
-    return(fstring);
-}
-
 /* Function to use with SSL on non blocking socket,
  * to know if SSL operation failed for good
  */
@@ -493,7 +436,7 @@ int main(int argc, char **argv)
                 minfo("Accepting connections on port %hu. Using password specified on file: %s", config.port, AUTHD_PASS);
             } else {
                 /* Getting temporary pass. */
-                if (authpass = __generatetmppass(), authpass) {
+                if (authpass = w_generate_random_pass(), authpass) {
                     minfo("Accepting connections on port %hu. Random password chosen for agent authentication: %s", config.port, authpass);
                 } else {
                     merror_exit("Unable to generate random password. Exiting.");

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -145,11 +145,7 @@ char *__generatetmppass()
         if (requested_size_assignation > 0 && requested_size_assignation == requested_size) {
             OS_MD5_Str(str1, -1, md1);
             fstring = strdup(md1);
-        } else {
-            merror("Error generating random string for auth password.");
         }
-    } else {
-        merror("Error requesting size of random string for auth password.");
     }
 
     free(rand3);
@@ -497,11 +493,10 @@ int main(int argc, char **argv)
                 minfo("Accepting connections on port %hu. Using password specified on file: %s", config.port, AUTHD_PASS);
             } else {
                 /* Getting temporary pass. */
-                authpass = __generatetmppass();
-                if (authpass) {
+                if (authpass = __generatetmppass(), authpass) {
                     minfo("Accepting connections on port %hu. Random password chosen for agent authentication: %s", config.port, authpass);
                 } else {
-                    minfo("Accepting connections on port %hu. No password generated.", config.port);
+                    merror_exit("Unable to generate random password. Exiting.");
                 }
             }
         } else {

--- a/src/unit_tests/os_auth/CMakeLists.txt
+++ b/src/unit_tests/os_auth/CMakeLists.txt
@@ -36,6 +36,9 @@ list(APPEND os_auth_names "test_auth_add")
 list(APPEND os_auth_flags "${DEBUG_OP_WRAPPERS}")
 list(APPEND os_auth_names "test_ssl")
 list(APPEND os_auth_flags "-Wl,--wrap,SSL_read -Wl,--wrap=SSL_new")
+list(APPEND os_auth_names "test_auth")
+list(APPEND os_auth_flags "${DEBUG_OP_WRAPPERS} \
+                           -Wl,--wrap,os_random -Wl,--wrap,GetRandomNoise -Wl,--wrap,getuname -Wl,--wrap,time")
 
 list(LENGTH os_auth_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/os_auth/test_auth.c
+++ b/src/unit_tests/os_auth/test_auth.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "os_err.h"
+#include "shared.h"
+#include "../../os_auth/auth.h"
+#include "../../headers/sec.h"
+#include "../../addagent/manage_agents.h"
+
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+#include "../wrappers/wazuh/os_auth/os_auth_wrappers.h"
+#include "../wrappers/wazuh/shared/randombytes_wrappers.h"
+
+/* tests */
+
+static void test_w_generate_random_pass_success(void **state) {
+    char* result = NULL;
+
+    will_return(__wrap_os_random, 146557);
+    will_return(__wrap_os_random, 314159);
+    will_return(__wrap_GetRandomNoise, strdup("Wazuh"));
+    will_return(__wrap_GetRandomNoise, strdup("The Open Source Security Platform"));
+    will_return(__wrap_time, 1655254875);
+    will_return_always(__wrap_getuname, "Linux |ubuntu-focal |5.4.0-92-generic |#103-Ubuntu SMP Fri Nov 26 16:13:00 UTC 2021 "
+                                        "|x86_64 [Ubuntu|ubuntu: 20.04.2 LTS (Focal Fossa)] - Wazuh v4.3.4");
+
+    result = w_generate_random_pass();
+
+    assert_string_equal(result, "6e0d9a4188ac9de8fa695bd96e276090");
+    os_free(result);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_w_generate_random_pass_success),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.c
@@ -204,3 +204,11 @@ int __wrap_w_fseek(FILE *x, int64_t pos, __attribute__((unused)) int mode) {
     check_expected(pos);
     return mock_type(int);
 }
+
+char *__wrap_GetRandomNoise() {
+    return mock_ptr_type(char*);
+}
+
+const char *__wrap_getuname() {
+    return mock_ptr_type(char*);
+}

--- a/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.h
@@ -78,6 +78,10 @@ int __wrap_UnmergeFiles(const char *finalpath, const char *optdir, int mode);
 long long __wrap_get_UTC_modification_time(const char *file_path);
 #endif
 
+char *__wrap_GetRandomNoise();
+
+const char *__wrap_getuname();
+
 #endif
 int64_t __wrap_w_ftell (FILE *x);
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #13774 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

It was found that after enabling the password authentication for **authd** and letting it generate a random password (without writing one to `etc/authd.pass`), the following message is printed

```
2022/06/07 11:46:35 wazuh-authd[27962] string_op.c:1045 at os_snprintf(): WARNING: String may be truncated because it is too long.
```

The method in charge of generating this random password is `__generatetmppass()`. We can see that it gets the `uname` of the system as an intermediate step and this string is truncated during the process

![warning](https://user-images.githubusercontent.com/65046601/172415184-57f86cc1-0eba-41bc-9a0a-4d2b85c539a3.png)

This WARNING message doesn't affect the password generation, it's just an harmless message.

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer

- [x] Added unit tests (for new features)
