### PR TITLE
Feature/13841 tag parameter logs endpoints

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2450,42 +2450,8 @@ components:
             - warning
         tag:
           type: string
+          format: alphanumeric
           description: "Wazuh component that logged the event"
-          enum:
-            - agent_control
-            - wazuh-agentlessd
-            - wazuh-analysisd
-            - wazuh-authd
-            - wazuh-csyslogd
-            - wazuh-dbd
-            - wazuh-execd
-            - wazuh-integratord
-            - wazuh-maild
-            - wazuh-monitord
-            - wazuh-logcollector
-            - wazuh-remoted
-            - wazuh-reportd
-            - wazuh-rootcheck
-            - wazuh-syscheckd
-            - sca
-            - verify-agent-conf
-            - wazuh-db
-            - wazuh-modulesd
-            - wazuh-modulesd:agent-key-polling
-            - wazuh-modulesd:aws-s3
-            - wazuh-modulesd:azure-logs
-            - wazuh-modulesd:agent-upgrade
-            - wazuh-modulesd:task-manager
-            - wazuh-modulesd:ciscat
-            - wazuh-modulesd:control
-            - wazuh-modulesd:command
-            - wazuh-modulesd:database
-            - wazuh-modulesd:docker-listener
-            - wazuh-modulesd:download
-            - wazuh-modulesd:oscap
-            - wazuh-modulesd:osquery
-            - wazuh-modulesd:syscollector
-            - wazuh-modulesd:vulnerability-detector
         timestamp:
           type: string
           format: date-time
@@ -4710,37 +4676,7 @@ components:
       description: "Wazuh component that logged the event"
       schema:
         type: string
-        enum:
-        - wazuh-agentlessd
-        - wazuh-analysisd
-        - wazuh-authd
-        - wazuh-csyslogd
-        - wazuh-dbd
-        - wazuh-execd
-        - wazuh-integratord
-        - wazuh-maild
-        - wazuh-monitord
-        - wazuh-logcollector
-        - wazuh-remoted
-        - wazuh-reportd
-        - wazuh-rootcheck
-        - wazuh-syscheckd
-        - sca
-        - wazuh-db
-        - wazuh-modulesd
-        - wazuh-modulesd:agent-key-polling
-        - wazuh-modulesd:aws-s3
-        - wazuh-modulesd:azure-logs
-        - wazuh-modulesd:ciscat
-        - wazuh-modulesd:control
-        - wazuh-modulesd:command
-        - wazuh-modulesd:database
-        - wazuh-modulesd:docker-listener
-        - wazuh-modulesd:download
-        - wazuh-modulesd:oscap
-        - wazuh-modulesd:osquery
-        - wazuh-modulesd:syscollector
-        - wazuh-modulesd:vulnerability-detector
+        format: alphanumeric
     log_level:
       in: query
       name: level

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -1556,6 +1556,22 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
+  - name: Read logs with filters -> tag=wazuh-unknown-daemon {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        tag: wazuh-unknown-daemon
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: []
+          failed_items: []
+          total_affected_items: 0
+          total_failed_items: 0
+
   - name: Read logs with filters -> level=info, limit=1 {node_id}
     request:
       verify: False

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -17,7 +17,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - wazuh-agentlessd: !anystr
@@ -57,7 +57,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - compilation_date: !anystr
@@ -146,7 +146,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - alerts: !anything
@@ -183,7 +183,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - rootcheck:
@@ -206,7 +206,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - syscheck:
@@ -242,7 +242,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           affected_items: []
           failed_items:
@@ -284,7 +284,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - alerts: !anything
@@ -328,7 +328,7 @@ stages:
     response:
         status_code: 200
         json:
-          error: !anyint
+          error: 0
           data:
             affected_items:
               - averages: !anything
@@ -352,7 +352,7 @@ stages:
     response:
         status_code: 200
         json:
-          error: !anyint
+          error: 0
           data:
             affected_items:
               - Sun:
@@ -395,7 +395,7 @@ stages:
     response:
         status_code: 200
         json:
-          error: !anyint
+          error: 0
           data:
             affected_items:
               - total_events_decoded: !anyfloat
@@ -463,7 +463,7 @@ stages:
     response:
         status_code: 200
         json:
-          error: !anyint
+          error: 0
           data:
             affected_items:
               - queue_size: !anyfloat
@@ -495,7 +495,7 @@ stages:
     response:
         status_code: 200
         json:
-          error: !anyint
+          error: 0
           data:
             affected_items: !anything
             failed_items: []
@@ -515,7 +515,7 @@ stages:
     response:
         status_code: 200
         json:
-          error: !anyint
+          error: 0
           data:
             affected_items:
               - &manager_log
@@ -563,7 +563,7 @@ stages:
     response:
         status_code: 200
         json:
-          error: !anyint
+          error: 0
           data:
             affected_items:
               - <<: *manager_log
@@ -588,7 +588,7 @@ stages:
     response:
         status_code: 200
         json:
-          error: !anyint
+          error: 0
           data:
             affected_items:
               - <<: *manager_log
@@ -613,7 +613,7 @@ stages:
     response:
         status_code: 200
         json:
-          error: !anyint
+          error: 0
           data:
             affected_items:
               - <<: *manager_log
@@ -635,7 +635,7 @@ stages:
     response:
         status_code: 200
         json:
-          error: !anyint
+          error: 0
           data:
             affected_items:
               - <<: *manager_log
@@ -676,7 +676,26 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
+        data:
+          affected_items: []
+          failed_items: []
+          total_affected_items: 0
+          total_failed_items: 0
+
+  - name: Filter by non-existent tag
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        tag: wazuh-unknown-daemon
+    response:
+      status_code: 200
+      json:
+        error: 0
         data:
           affected_items: []
           failed_items: []
@@ -699,7 +718,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - sca: !anything
@@ -745,7 +764,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - node_name: !anystr
@@ -798,7 +817,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - name: !anystr
@@ -839,7 +858,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           affected_items: []
           failed_items:
@@ -865,7 +884,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - global: !anything
@@ -883,7 +902,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - active-response: !anything
@@ -902,7 +921,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - alerts: !anything
@@ -920,7 +939,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - command: !anything
@@ -938,7 +957,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - internal: !anything
@@ -956,7 +975,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - auth: !anything
@@ -974,7 +993,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - internal: !anything
@@ -992,7 +1011,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - localfile: !anything
@@ -1010,7 +1029,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           failed_items: []
@@ -1027,7 +1046,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - internal: !anything
@@ -1045,7 +1064,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - monitord: !anything
@@ -1063,7 +1082,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - remote: !anything
@@ -1081,7 +1100,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - internal: !anything
@@ -1099,7 +1118,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - syscheck: !anything
@@ -1117,7 +1136,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - rootcheck: !anything
@@ -1135,7 +1154,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - internal: !anything
@@ -1153,7 +1172,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - wmodules: !anything
@@ -1201,7 +1220,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - alerts:
@@ -1224,7 +1243,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           affected_items: []
           failed_items:
@@ -1248,7 +1267,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           affected_items: []
           failed_items:
@@ -1288,7 +1307,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - alerts:
@@ -1313,7 +1332,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - !anystr


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/13841 |



## Description

This PR closes https://github.com/wazuh/wazuh/issues/13841.

In this pull request, I have updated the API spec so the `tag` parameter of the logs endpoints is not an enum any longer.

#### Test results

```
test_cluster_endpoints.tavern.yaml 
	 45 passed, 47 warnings

test_manager_endpoints.tavern.yaml 
	 31 passed, 33 warnings
```
