### PR TITLE
Fix DockerListener issue when the docker service is not running

### DIFF
--- a/wodles/docker-listener/DockerListener.py
+++ b/wodles/docker-listener/DockerListener.py
@@ -40,7 +40,7 @@ class DockerListener:
         self.wazuh_queue = '{0}/queue/sockets/queue'.format(self.wazuh_path)
         self.msg_header = "1:Wazuh-Docker:"
         # docker variables
-        self.client = docker.from_env()
+        self.client = None
         self.send_msg(json.dumps({self.field_debug_name: "Started"}))
         self.thread1 = threading.Thread(target=self.listen)
         self.thread2 = threading.Thread(target=self.listen)
@@ -80,6 +80,7 @@ class DockerListener:
         :return: True if Docker service is active or False if it is inactive.
         """
         try:
+            self.client = docker.from_env()
             self.client.ping()
             return True
         except Exception:


### PR DESCRIPTION
|Related issue|
|---|
| #13776 |

## Description

This PR updates the `DockerListener` integration to avoid crashes when attempting to run the module in a Wazuh agent with Python 3.6 having the Docker service stopped. This issue was not present in Wazuh managers as they use the embedded framework's Python.

The details about the root cause and how to reproduce the issue can be found [here](https://github.com/wazuh/wazuh/issues/13776#issuecomment-1155317008).

The manual testing performed to ensure everything works as expected after the changes can be found [here](https://github.com/wazuh/wazuh/issues/13776#issuecomment-1155351965) and [here](https://github.com/wazuh/wazuh/issues/13776#issuecomment-1155355835).