### PR TITLE
Prevent OpenSSL library from cleaning up resources on wazuh-modulesd stop

### DIFF
--- a/src/shared/url.c
+++ b/src/shared/url.c
@@ -85,6 +85,7 @@ int wurl_get(const char * url, const char * dest, const char * header, const cha
     CURL *curl;
     FILE *fp;
     CURLcode res;
+    OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS | OPENSSL_INIT_ADD_ALL_DIGESTS | OPENSSL_INIT_LOAD_CONFIG | OPENSSL_INIT_NO_ATEXIT, NULL);
     curl = curl_easy_init();
     char errbuf[CURL_ERROR_SIZE];
     int old_mask;
@@ -318,6 +319,7 @@ int wurl_check_connection() {
 char * wurl_http_get(const char * url, size_t max_size, const long timeout) {
     CURL *curl;
     CURLcode res;
+    OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS | OPENSSL_INIT_ADD_ALL_DIGESTS | OPENSSL_INIT_LOAD_CONFIG | OPENSSL_INIT_NO_ATEXIT, NULL);
     curl = curl_easy_init();
     char errbuf[CURL_ERROR_SIZE];
 
@@ -439,6 +441,7 @@ curl_response* wurl_http_request(char *method, char **headers, const char* url, 
         return NULL;
     }
 
+    OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS | OPENSSL_INIT_ADD_ALL_DIGESTS | OPENSSL_INIT_LOAD_CONFIG | OPENSSL_INIT_NO_ATEXIT, NULL);
     CURL* curl = curl_easy_init();
 
     if (!curl) {

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
@@ -30,7 +30,7 @@ list(APPEND vulndetector_flags "-Wl,--wrap,_merror -Wl,--wrap,_mterror -Wl,--wra
                                 -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,OS_RecvSecureTCP -Wl,--wrap,close -Wl,--wrap,sqlite3_prepare_v2 \
                                 -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,sqlite3_bind_int -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_close_v2 \
                                 -Wl,--wrap,sqlite3_finalize -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_CreateArray \
-                                -Wl,--wrap,OPENSSL_init_ssl -Wl,--wrap,OPENSSL_init_crypto -Wl,--wrap,StartMQ -Wl,--wrap,SendMSG -Wl,--wrap,strerror \
+                                -Wl,--wrap,StartMQ -Wl,--wrap,SendMSG -Wl,--wrap,strerror \
                                 -Wl,--wrap,_mterror_exit -Wl,--wrap,sqlite3_column_text -Wl,--wrap,sqlite3_column_double \
                                 -Wl,--wrap,cJSON_Delete -Wl,--wrap,cJSON_AddItemToObject -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_CreateNumber \
                                 -Wl,--wrap,cJSON_CreateString -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_PrintUnformatted \
@@ -55,7 +55,7 @@ list(APPEND vulndetector_flags "-Wl,--wrap,_merror -Wl,--wrap,_mterror -Wl,--wra
                                 -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,OS_RecvSecureTCP -Wl,--wrap,close -Wl,--wrap,sqlite3_prepare_v2 \
                                 -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,sqlite3_bind_int -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_close_v2 \
                                 -Wl,--wrap,sqlite3_finalize -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_CreateArray \
-                                -Wl,--wrap,OPENSSL_init_ssl -Wl,--wrap,OPENSSL_init_crypto -Wl,--wrap,StartMQ -Wl,--wrap,SendMSG -Wl,--wrap,strerror \
+                                -Wl,--wrap,StartMQ -Wl,--wrap,SendMSG -Wl,--wrap,strerror \
                                 -Wl,--wrap,_mterror_exit -Wl,--wrap,c_isdigit -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fgets -Wl,--wrap,fwrite \
                                 -Wl,--wrap,OSRegex_Compile -Wl,--wrap,OSRegex_Execute,--wrap,fflush -Wl,--wrap,fprintf -Wl,--wrap,fread -Wl,--wrap,fseek \
                                 -Wl,--wrap,remove -Wl,--wrap,getpid -Wl,--wrap,fgetpos -Wl,--wrap=fgetc")

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -15,8 +15,6 @@
 
 #include "../../wrappers/common.h"
 #include "../../wrappers/externals/cJSON/cJSON_wrappers.h"
-#include "../../wrappers/externals/openssl/init_wrappers.h"
-#include "../../wrappers/externals/openssl/ssl_init_wrappers.h"
 #include "../../wrappers/externals/sqlite/sqlite3_wrappers.h"
 #include "../../wrappers/libc/stdio_wrappers.h"
 #include "../../wrappers/libc/string_wrappers.h"
@@ -497,9 +495,6 @@ static int setup_cve_report(void **state) {
     expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQ, type, WRITE);
     will_return(__wrap_StartMQ, 1);
-
-    will_return_always(__wrap_OPENSSL_init_ssl, 1);
-    will_return(__wrap_OPENSSL_init_crypto, 1);
 
     will_return(__wrap_OS_ReadXML, 1);
     will_return(__wrap_OS_GetOneContentforElement, "node01");
@@ -6424,9 +6419,6 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors
     expect_value(__wrap_StartMQ, type, WRITE);
     will_return(__wrap_StartMQ, 1);
 
-    will_return_always(__wrap_OPENSSL_init_ssl, 1);
-    will_return(__wrap_OPENSSL_init_crypto, 1);
-
     will_return(__wrap_OS_ReadXML, 1);
     will_return(__wrap_OS_GetOneContentforElement, "node01");
 
@@ -6777,9 +6769,6 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors
     expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQ, type, WRITE);
     will_return(__wrap_StartMQ, 1);
-
-    will_return_always(__wrap_OPENSSL_init_ssl, 1);
-    will_return(__wrap_OPENSSL_init_crypto, 1);
 
     will_return(__wrap_OS_ReadXML, 1);
     will_return(__wrap_OS_GetOneContentforElement, "node01");
@@ -19452,9 +19441,6 @@ void test_wm_vuldet_init_success(void **state)
     expect_value(__wrap_StartMQ, type, WRITE);
     will_return(__wrap_StartMQ, 1);
 
-    will_return_always(__wrap_OPENSSL_init_ssl, 1);
-    will_return(__wrap_OPENSSL_init_crypto, 1);
-
     will_return(__wrap_OS_ReadXML, 1);
     will_return(__wrap_OS_GetOneContentforElement, "node01");
 
@@ -20140,8 +20126,6 @@ void test_wm_vuldet_send_removed_cve_report_ip_assigned_success() {
     expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQ, type, WRITE);
     will_return(__wrap_StartMQ, 1);
-    will_return_always(__wrap_OPENSSL_init_ssl, 1);
-    will_return(__wrap_OPENSSL_init_crypto, 1);
     will_return(__wrap_OS_ReadXML, 1);
     will_return(__wrap_OS_GetOneContentforElement, "node01");
     wm_vuldet_init(vuldet);
@@ -20248,8 +20232,6 @@ void test_wm_vuldet_send_removed_cve_report_no_ip_success() {
     expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQ, type, WRITE);
     will_return(__wrap_StartMQ, 1);
-    will_return_always(__wrap_OPENSSL_init_ssl, 1);
-    will_return(__wrap_OPENSSL_init_crypto, 1);
     will_return(__wrap_OS_ReadXML, 1);
     will_return(__wrap_OS_GetOneContentforElement, "node01");
     wm_vuldet_init(vuldet);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -7788,20 +7788,6 @@ void wm_vuldet_init(wm_vuldet_t * vuldet) {
 
     vu_queue = &vuldet->queue_fd;
 
-    SSL_library_init();
-    SSL_load_error_strings();
-    OpenSSL_add_all_algorithms();
-
-
-    for (i = 0; SSL_library_init() < 0 && i < WM_MAX_ATTEMPTS; i++) {
-        sleep(WM_MAX_WAIT);
-    }
-
-    if (i == WM_MAX_ATTEMPTS) {
-        mterror(WM_VULNDETECTOR_LOGTAG, VU_SSL_LIBRARY_ERROR);
-        pthread_exit(NULL);
-    }
-
     if (!flags->run_on_start) {
         time_t time_sleep = vuldet->scan_interval;
         for (i = 0; i < OS_SUPP_SIZE; i++) {

--- a/src/wazuh_modules/wm_fluent.c
+++ b/src/wazuh_modules/wm_fluent.c
@@ -96,6 +96,7 @@ void * wm_fluent_main(wm_fluent_t * fluent) {
         pthread_exit(NULL);
     }
 
+    OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS | OPENSSL_INIT_ADD_ALL_DIGESTS | OPENSSL_INIT_LOAD_CONFIG | OPENSSL_INIT_NO_ATEXIT, NULL);
     SSL_load_error_strings();
     SSL_library_init();
 


### PR DESCRIPTION
|Related issue|
|---|
|Fixes #13805|

This PR aims to fix a crash in wazuh-modulesd that happens sometimes when the service gets stopped during a file download, such as a Vulnerability Detector feed.

This is caused by a race condition between a cleaning up function triggered by the OpenSSL initializer at the exit, and the Download module, which is still running after the cleaning up. This produces a use-after-free condition, that may lead to a segmentation fault.

Both the race condition and the call backtrace are described at #13805.

The trigger is set up by `OPENSSL_init_crypto()`, which is called by `OPENSSL_init_ssl()` (Vulnerability Detector and Fluent or by

|Module|Caller|Callee|
|---|---|---|
|Vulnerability Detector|`wm_vuldet_init()`|`OPENSSL_init_crypto()`|
|Fluent Forwarder|`wm_fluent_main()`|`OPENSSL_init_crypto()`|
|Agent Upgrade|`wurl_http_get()`|`curl_easy_init()`|
|GitHub Integration|`wurl_http_request()`|`curl_easy_init()`|
|Office365 Integration|`wurl_http_request()`|`curl_easy_init()`|

## Proposed fix

1. Remove the OpenSSL initialization at Vulnerability Detector, as it now uses the Download module.
2. Append a call to `OPENSSL_init_crypto()` manually on the remaining points, adding a flag to set up no exit triggers.

As we saw at https://github.com/wazuh/wazuh/issues/13805#issuecomment-1154158951, this is the actual call to `OPENSSL_init_crypto()` by Vulnerability Detector:

```c
OPENSSL_init_crypto (opts=76, settings=0x0)
```

```
76 = 0x4C
```

This matches:

```c
OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS | OPENSSL_INIT_ADD_ALL_DIGESTS | OPENSSL_INIT_LOAD_CONFIG, NULL);
```

So we're or-ing the flag `OPENSSL_INIT_NO_ATEXIT`.

## Tests

- [x] Running wazuh-modulesd and stopping it while Vulnerability Detector is downloading the RHEL feed does not let  ThreadSanitizer report further race conditions.
- [x] Explicitly calling `OPENSSL_init_crypto()` multiple times does not make AddressSanitizer report any memory leaks.