### PR TITLE
Add empty string check before cleaning agents artifacts.

### DIFF
--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -596,7 +596,7 @@ void delete_sqlite(const char *id, const char *name)
 /* Delete diff folders */
 void delete_diff(const char *name)
 {
-    if (!name || *name == '\0') {
+    if (NULL == name || *name == '\0') {
         return;
     }
 

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -600,8 +600,7 @@ void delete_diff(const char *name)
         return;
     }
 
-    char tmp_folder[513];
-    tmp_folder[512] = '\0';
+    char tmp_folder[513] = {0};
     snprintf(tmp_folder, 512, "%s/%s",
              DIFF_DIR,
              name);

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -596,6 +596,10 @@ void delete_sqlite(const char *id, const char *name)
 /* Delete diff folders */
 void delete_diff(const char *name)
 {
+    if (!name || *name == '\0') {
+        return;
+    }
+
     char tmp_folder[513];
     tmp_folder[512] = '\0';
     snprintf(tmp_folder, 512, "%s/%s",

--- a/src/unit_tests/wazuh_modules/database/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/database/CMakeLists.txt
@@ -10,7 +10,8 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 
 list(APPEND wmdb_tests_names "test_wm_database")
 list(APPEND wmdb_tests_flags "-Wl,--wrap,wdb_set_agent_groups -Wl,--wrap,opendir -Wl,--wrap,readdir -Wl,--wrap,strerror -Wl,--wrap,unlink \
-                              -Wl,--wrap,closedir -Wl,--wrap,rmdir_ex -Wl,--wrap,getpid  -Wl,--wrap,w_is_single_node ${DEBUG_OP_WRAPPERS} ${STDIO_OP_WRAPPERS}")
+                              -Wl,--wrap,closedir -Wl,--wrap,rmdir_ex -Wl,--wrap,getpid  -Wl,--wrap,w_is_single_node -Wl,--wrap,_mterror \
+                              -Wl,--wrap,wdb_get_agent_name -Wl,--wrap,wdb_remove_agent_db -Wl,--wrap,wdbc_query_ex ${DEBUG_OP_WRAPPERS} ${STDIO_OP_WRAPPERS}")
 
 # Add extra compiling flags
 add_compile_options(-Wall)

--- a/src/unit_tests/wazuh_modules/database/test_wm_database.c
+++ b/src/unit_tests/wazuh_modules/database/test_wm_database.c
@@ -352,8 +352,14 @@ void test_sync_agents_artifacts_with_wdb_empty_agent_name(void **state) {
     expect_value(__wrap_wdb_get_agent_name, id, 1);
     will_return(__wrap_wdb_get_agent_name, agent_name);
 
+    will_return(__wrap_readdir, NULL);
+
     // wm_clean_agent_artifacts
     char *wdb_response = "{\"agents\":{\"001\":\"ok\"}}";
+
+    expect_value(__wrap_wdb_remove_agent_db, id, 1);
+    expect_string(__wrap_wdb_remove_agent_db, name, "centos");
+    will_return(__wrap_wdb_remove_agent_db, OS_SUCCESS);
 
     expect_value(__wrap_wdbc_query_ex, *sock, -1);
     expect_string(__wrap_wdbc_query_ex, query, "wazuhdb remove 1");
@@ -361,7 +367,11 @@ void test_sync_agents_artifacts_with_wdb_empty_agent_name(void **state) {
     will_return(__wrap_wdbc_query_ex, wdb_response);
     will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
 
-    will_return(__wrap_readdir, NULL);
+    char path[OS_MAXSTR] = {0};
+    snprintf(path, OS_MAXSTR, "%s/centos", DIFF_DIR);
+
+    expect_string(__wrap_rmdir_ex, name, path);
+    will_return(__wrap_rmdir_ex, OS_SUCCESS);
 
     sync_agents_artifacts_with_wdb(keys);
 

--- a/src/unit_tests/wazuh_modules/database/test_wm_database.c
+++ b/src/unit_tests/wazuh_modules/database/test_wm_database.c
@@ -347,7 +347,7 @@ void test_sync_agents_artifacts_with_wdb_empty_agent_name(void **state) {
     will_return(__wrap_opendir, (DIR *)1);
     will_return(__wrap_readdir, dir_ent);
 
-    char *agent_name;
+    char *agent_name = NULL;
     os_strdup("", agent_name);
     expect_value(__wrap_wdb_get_agent_name, id, 1);
     will_return(__wrap_wdb_get_agent_name, agent_name);
@@ -407,7 +407,7 @@ void test_sync_agents_artifacts_with_wdb_bad_file_name2(void **state) {
     will_return(__wrap_opendir, (DIR *)1);
     will_return(__wrap_readdir, dir_ent);
 
-    char *agent_name;
+    char *agent_name = NULL;
     os_strdup("", agent_name);
     expect_value(__wrap_wdb_get_agent_name, id, 1);
     will_return(__wrap_wdb_get_agent_name, agent_name);
@@ -444,7 +444,7 @@ void test_sync_agents_artifacts_with_wdb_agent_exists_in_db(void **state) {
     will_return(__wrap_opendir, (DIR *)1);
     will_return(__wrap_readdir, dir_ent);
 
-    char *agent_name;
+    char *agent_name = NULL;
     os_strdup("centos", agent_name);
     expect_value(__wrap_wdb_get_agent_name, id, 1);
     will_return(__wrap_wdb_get_agent_name, agent_name);

--- a/src/unit_tests/wazuh_modules/database/test_wm_database.c
+++ b/src/unit_tests/wazuh_modules/database/test_wm_database.c
@@ -379,6 +379,48 @@ void test_sync_agents_artifacts_with_wdb_empty_agent_name(void **state) {
     os_free(keys);
 }
 
+void test_sync_agents_artifacts_with_wdb_agent_name_with_special_characters(void **state) {
+    struct dirent *dir_ent = NULL;
+    keystore *keys = NULL;
+    os_calloc(1, sizeof(struct dirent), dir_ent);
+    os_calloc(1, sizeof(keystore), keys);
+    strcpy(dir_ent->d_name, "001-centos-agent.test.db");
+
+    will_return(__wrap_opendir, (DIR *)1);
+    will_return(__wrap_readdir, dir_ent);
+
+    char *agent_name = NULL;
+    os_strdup("", agent_name);
+    expect_value(__wrap_wdb_get_agent_name, id, 1);
+    will_return(__wrap_wdb_get_agent_name, agent_name);
+
+    will_return(__wrap_readdir, NULL);
+
+    // wm_clean_agent_artifacts
+    char *wdb_response = "{\"agents\":{\"001\":\"ok\"}}";
+
+    expect_value(__wrap_wdb_remove_agent_db, id, 1);
+    expect_string(__wrap_wdb_remove_agent_db, name, "centos-agent.test");
+    will_return(__wrap_wdb_remove_agent_db, OS_SUCCESS);
+
+    expect_value(__wrap_wdbc_query_ex, *sock, -1);
+    expect_string(__wrap_wdbc_query_ex, query, "wazuhdb remove 1");
+    expect_any(__wrap_wdbc_query_ex, len);
+    will_return(__wrap_wdbc_query_ex, wdb_response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    char path[OS_MAXSTR] = {0};
+    snprintf(path, OS_MAXSTR, "%s/centos-agent.test", DIFF_DIR);
+
+    expect_string(__wrap_rmdir_ex, name, path);
+    will_return(__wrap_rmdir_ex, OS_SUCCESS);
+
+    sync_agents_artifacts_with_wdb(keys);
+
+    os_free(dir_ent);
+    os_free(keys);
+}
+
 void test_sync_agents_artifacts_with_wdb_bad_file_name(void **state) {
     struct dirent *dir_ent = NULL;
     keystore *keys = NULL;
@@ -475,6 +517,7 @@ int main()
         // sync_agents_artifacts_with_wdb
         cmocka_unit_test_setup_teardown(test_sync_agents_artifacts_with_wdb_opendir_error, setup_wmdb, teardown_wmdb),
         cmocka_unit_test_setup_teardown(test_sync_agents_artifacts_with_wdb_empty_agent_name, setup_wmdb, teardown_wmdb),
+        cmocka_unit_test_setup_teardown(test_sync_agents_artifacts_with_wdb_agent_name_with_special_characters, setup_wmdb, teardown_wmdb),
         cmocka_unit_test_setup_teardown(test_sync_agents_artifacts_with_wdb_bad_file_name, setup_wmdb, teardown_wmdb),
         cmocka_unit_test_setup_teardown(test_sync_agents_artifacts_with_wdb_bad_file_name2, setup_wmdb, teardown_wmdb),
         cmocka_unit_test_setup_teardown(test_sync_agents_artifacts_with_wdb_agent_exists_in_db, setup_wmdb, teardown_wmdb),

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_helpers_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_helpers_wrappers.c
@@ -100,6 +100,8 @@ char* __wrap_wdb_get_agent_name(int id,
 
 int __wrap_wdb_remove_agent_db(int id, const char* name) {
     check_expected(id);
-    check_expected(name);
+    if (name) {
+        check_expected(name);
+    }
     return mock();
 }

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_helpers_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_helpers_wrappers.c
@@ -45,6 +45,25 @@ int* __wrap_wdb_get_all_agents(bool include_manager, __attribute__((unused)) int
     return mock_ptr_type(int*);
 }
 
+int __wrap_wdb_update_agent_keepalive(int id, const char *connection_status, const char *sync_status, __attribute__((unused)) int *sock) {
+    check_expected(id);
+    check_expected(connection_status);
+    check_expected(sync_status);
+    return mock();
+}
+
+int __wrap_wdb_update_agent_data(agent_info_data *agent_data, __attribute__((unused)) int *sock) {
+    check_expected(agent_data);
+    return mock();
+}
+
+int __wrap_wdb_update_agent_connection_status(int id, const char *connection_status, const char *sync_status, __attribute__((unused)) int *sock) {
+    check_expected(id);
+    check_expected(connection_status);
+    check_expected(sync_status);
+    return mock();
+}
+
 int __wrap_wdb_set_agent_groups_csv(int id,
                                     __attribute__((unused)) char *groups_csv,
                                     __attribute__((unused)) char *mode,
@@ -65,27 +84,22 @@ int __wrap_wdb_set_agent_groups(int id,
     return mock();
 }
 
-int __wrap_wdb_update_agent_keepalive(int id, const char *connection_status, const char *sync_status, __attribute__((unused)) int *sock) {
-    check_expected(id);
-    check_expected(connection_status);
-    check_expected(sync_status);
-    return mock();
-}
-
 char* __wrap_wdb_get_agent_group(int id,
                                  __attribute__((unused)) int *wdb_sock) {
     check_expected(id);
     return mock_type(char *);
 }
 
-int __wrap_wdb_update_agent_data(agent_info_data *agent_data, __attribute__((unused)) int *sock) {
-    check_expected(agent_data);
-    return mock();
+
+
+char* __wrap_wdb_get_agent_name(int id,
+                                __attribute__((unused)) int *wdb_sock) {
+    check_expected(id);
+    return mock_type(char *);
 }
 
-int __wrap_wdb_update_agent_connection_status(int id, const char *connection_status, const char *sync_status, __attribute__((unused)) int *sock) {
+int __wrap_wdb_remove_agent_db(int id, const char* name) {
     check_expected(id);
-    check_expected(connection_status);
-    check_expected(sync_status);
+    check_expected(name);
     return mock();
 }

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_helpers_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_helpers_wrappers.h
@@ -36,4 +36,8 @@ int __wrap_wdb_set_agent_groups(int id,
                                 __attribute__((unused)) int *sock);
 
 char* __wrap_wdb_get_agent_group(int id, int *wdb_sock);
+
+char* __wrap_wdb_get_agent_name(int id, __attribute__((unused)) int *wdb_sock);
+
+int __wrap_wdb_remove_agent_db(int id, const char* name);
 #endif

--- a/src/wazuh_db/helpers/wdb_global_helpers.c
+++ b/src/wazuh_db/helpers/wdb_global_helpers.c
@@ -1048,6 +1048,10 @@ int wdb_remove_agent_db(int id, const char * name) {
     char path[PATH_MAX];
     char path_aux[PATH_MAX];
 
+    if (!name || *name == '\0' || id == OS_INVALID) {
+        return OS_INVALID;
+    }
+
     snprintf(path, PATH_MAX, "%s/agents/%03d-%s.db", WDB_DIR, id, name);
 
     if (!remove(path)) {

--- a/src/wazuh_db/helpers/wdb_global_helpers.c
+++ b/src/wazuh_db/helpers/wdb_global_helpers.c
@@ -1048,7 +1048,7 @@ int wdb_remove_agent_db(int id, const char * name) {
     char path[PATH_MAX];
     char path_aux[PATH_MAX];
 
-    if (NULL == name || *name == '\0' || id == OS_INVALID) {
+    if (NULL == name || *name == '\0' || id <= 0) {
         return OS_INVALID;
     }
 

--- a/src/wazuh_db/helpers/wdb_global_helpers.c
+++ b/src/wazuh_db/helpers/wdb_global_helpers.c
@@ -1048,7 +1048,7 @@ int wdb_remove_agent_db(int id, const char * name) {
     char path[PATH_MAX];
     char path_aux[PATH_MAX];
 
-    if (!name || *name == '\0' || id == OS_INVALID) {
+    if (NULL == name || *name == '\0' || id == OS_INVALID) {
         return OS_INVALID;
     }
 

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -449,21 +449,15 @@ void sync_agents_artifacts_with_wdb() {
             if (agent_id > 0 && (agent_name = wdb_get_agent_name(agent_id, &wdb_wmdb_sock)) != NULL) {
                 if (*agent_name == '\0') {
                     // Getting name from database file
-                    char* agent_name_from_file = NULL;
-                    char* agent_name_from_file_start = NULL;
-                    os_strdup(end, agent_name_from_file);
-                    agent_name_from_file_start = agent_name_from_file;
+                    char* agent_name_from_file = end + 1;
                     char* substring = strchr(agent_name_from_file, '.');
                     if (substring) {
-                        agent_name_from_file++;
                         *substring = '\0';
                     } else {
-                        os_free(agent_name_from_file_start);
                         agent_name_from_file = NULL;
                     }
                     // Agent not found. Removing agent artifacts
                     wm_clean_agent_artifacts(agent_id, agent_name_from_file);
-                    os_free(agent_name_from_file_start);
                 }
                 os_free(agent_name);
             }

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -452,7 +452,7 @@ void sync_agents_artifacts_with_wdb() {
                     // Agent not found. Removing agent artifacts
                     // Getting agent name from end pointer (-agentname.db)
                     char* agent_name_from_file = end + 1;
-                    char* substring = strchr(agent_name_from_file, '.');
+                    char* substring = strrchr(agent_name_from_file, '.');
                     if (NULL != substring) {
                         *substring = '\0';
                     } else {

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -484,10 +484,8 @@ void wm_clean_agent_artifacts(int agent_id, const char* agent_name) {
     int result = OS_INVALID;
 
     // Removing legacy database
-    if (*agent_name != '\0') {
-        if (result = wdb_remove_agent_db(agent_id, agent_name), result) {
-            mtdebug1(WM_DATABASE_LOGTAG, "Could not remove the legacy DB of the agent %d.", agent_id);
-        }
+    if (result = wdb_remove_agent_db(agent_id, agent_name), result) {
+        mtdebug1(WM_DATABASE_LOGTAG, "Could not remove the legacy DB of the agent %d.", agent_id);
     }
 
     // Removing wazuh-db database
@@ -498,9 +496,7 @@ void wm_clean_agent_artifacts(int agent_id, const char* agent_name) {
         mtdebug1(WM_DATABASE_LOGTAG, "Could not remove the wazuh-db DB of the agent %d.", agent_id);
     }
 
-    if (*agent_name != '\0') {
-        delete_diff(agent_name);
-    }
+    delete_diff(agent_name);
 }
 
 // Clean dangling database files

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -451,8 +451,8 @@ void sync_agents_artifacts_with_wdb() {
                 if (*agent_name == '\0') {
                     // Agent not found. Removing agent artifacts
                     // Getting agent name from end pointer (-agentname.db)
-                    char* agent_name_from_file = end + 1;
-                    char* substring = strrchr(agent_name_from_file, '.');
+                    const char* agent_name_from_file = end + 1;
+                    char* const substring = strrchr(agent_name_from_file, '.');
                     if (NULL != substring) {
                         *substring = '\0';
                     } else {

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -443,20 +443,21 @@ void sync_agents_artifacts_with_wdb() {
 
     while ((dirent = readdir(dir)) != NULL) {
         char *end = NULL;
+        // File name pattern is XXX-agentname.db
         if (end = strchr(dirent->d_name, '-'), end) {
             int agent_id = (int)strtol(dirent->d_name, &end, 10);
             char *agent_name = NULL;
             if (agent_id > 0 && (agent_name = wdb_get_agent_name(agent_id, &wdb_wmdb_sock)) != NULL) {
                 if (*agent_name == '\0') {
-                    // Getting name from database file
+                    // Agent not found. Removing agent artifacts
+                    // Getting agent name from end pointer (-agentname.db)
                     char* agent_name_from_file = end + 1;
                     char* substring = strchr(agent_name_from_file, '.');
-                    if (substring) {
+                    if (NULL != substring) {
                         *substring = '\0';
                     } else {
                         agent_name_from_file = NULL;
                     }
-                    // Agent not found. Removing agent artifacts
                     wm_clean_agent_artifacts(agent_id, agent_name_from_file);
                 }
                 os_free(agent_name);

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -341,7 +341,6 @@ void sync_keys_with_wdb(keystore *keys) {
     unsigned int i;
 
     // Add new agents to the database
-
     for (i = 0; i < keys->keysize; i++) {
         entry = keys->keyentries[i];
         int id;
@@ -410,7 +409,6 @@ void sync_keys_with_agents_artifacts(keystore *keys) {
     unsigned int i;
 
     // Add new agents databases
-
     for (i = 0; i < keys->keysize; i++) {
         entry = keys->keyentries[i];
         int id;
@@ -472,8 +470,10 @@ void wm_clean_agent_artifacts(int agent_id, const char* agent_name) {
     int result = OS_INVALID;
 
     // Removing legacy database
-    if (result = wdb_remove_agent_db(agent_id, agent_name), result) {
-        mtdebug1(WM_DATABASE_LOGTAG, "Could not remove the legacy DB of the agent %d.", agent_id);
+    if (*agent_name != '\0') {
+        if (result = wdb_remove_agent_db(agent_id, agent_name), result) {
+            mtdebug1(WM_DATABASE_LOGTAG, "Could not remove the legacy DB of the agent %d.", agent_id);
+        }
     }
 
     // Removing wazuh-db database
@@ -484,7 +484,9 @@ void wm_clean_agent_artifacts(int agent_id, const char* agent_name) {
         mtdebug1(WM_DATABASE_LOGTAG, "Could not remove the wazuh-db DB of the agent %d.", agent_id);
     }
 
-    delete_diff(agent_name);
+    if (*agent_name != '\0') {
+        delete_diff(agent_name);
+    }
 }
 
 // Clean dangling database files

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -448,8 +448,22 @@ void sync_agents_artifacts_with_wdb() {
             char *agent_name = NULL;
             if (agent_id > 0 && (agent_name = wdb_get_agent_name(agent_id, &wdb_wmdb_sock)) != NULL) {
                 if (*agent_name == '\0') {
+                    // Getting name from database file
+                    char* agent_name_from_file = NULL;
+                    char* agent_name_from_file_start = NULL;
+                    os_strdup(end, agent_name_from_file);
+                    agent_name_from_file_start = agent_name_from_file;
+                    char* substring = strchr(agent_name_from_file, '.');
+                    if (substring) {
+                        agent_name_from_file++;
+                        *substring = '\0';
+                    } else {
+                        os_free(agent_name_from_file_start);
+                        agent_name_from_file = NULL;
+                    }
                     // Agent not found. Removing agent artifacts
-                    wm_clean_agent_artifacts(agent_id, agent_name);
+                    wm_clean_agent_artifacts(agent_id, agent_name_from_file);
+                    os_free(agent_name_from_file_start);
                 }
                 os_free(agent_name);
             }


### PR DESCRIPTION
|Related issue|
|---|
|#13875|

## Description

This PR fixes the deletion of the diff directory due to an empty agent name. 

![image](https://user-images.githubusercontent.com/13010397/174495739-c3c0995b-1e8e-4ec6-8fa6-c9e45a835cca.png)

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)