### PR TITLE
Github integration scan messages enrichment

### DIFF
--- a/src/unit_tests/wazuh_modules/github/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/github/CMakeLists.txt
@@ -14,7 +14,8 @@ list(APPEND tests_flags "-Wl,--wrap,_mwarn -Wl,--wrap,_mdebug1 -Wl,--wrap,_merro
                         -Wl,--wrap,_mtwarn -Wl,--wrap,_mtdebug1 -Wl,--wrap,_mtdebug2 -Wl,--wrap,StartMQ -Wl,--wrap,sleep \
                         -Wl,--wrap,OS_IsValidIP -Wl,--wrap,OSMatch_Execute -Wl,--wrap,wm_sendmsg -Wl,--wrap,OSRegex_Compile \
                         -Wl,--wrap,wm_state_io -Wl,--wrap,OSRegex_Execute -Wl,--wrap,OSRegex_Execute_ex -Wl,--wrap,OSMatch_Compile \
-                        -Wl,--wrap,OSRegex_FreePattern -Wl,--wrap,wurl_http_request -Wl,--wrap,strftime -Wl,--wrap,gmtime_r")
+                        -Wl,--wrap,OSRegex_FreePattern -Wl,--wrap,wurl_http_request -Wl,--wrap,strftime -Wl,--wrap,gmtime_r \
+                        -Wl,--wrap,isDebug")
 list(APPEND use_shared_libs 1)
 
 list(APPEND shared_libs "../scheduling/wmodules_scheduling_helpers.h")

--- a/src/unit_tests/wazuh_modules/github/test_wm_github.c
+++ b/src/unit_tests/wazuh_modules/github/test_wm_github.c
@@ -29,6 +29,7 @@
 #include "../../wrappers/wazuh/wazuh_modules/wmodules_wrappers.h"
 #include "../../wrappers/wazuh/shared/url_wrappers.h"
 #include "../../wrappers/libc/time_wrappers.h"
+#include "../../wrappers/libc/time_wrappers.h"
 
 unsigned int __wrap_sleep(unsigned int __seconds) {
     check_expected(__seconds);
@@ -37,6 +38,10 @@ unsigned int __wrap_sleep(unsigned int __seconds) {
 
 unsigned int __wrap_gmtime_r(__attribute__ ((__unused__)) const time_t *t, __attribute__ ((__unused__)) struct tm *tm) {
     return mock_type(unsigned int);
+}
+
+int __wrap_isDebug() {
+    return mock();
 }
 
 ////////////////  test wm-github /////////////////
@@ -388,6 +393,20 @@ void test_github_execute_scan(void **state) {
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
     expect_string(__wrap__mtdebug1, formatted_msg, "Scanning organization: 'test_org'");
 
+    will_return(__wrap_isDebug, 1);
+
+#ifndef WIN32
+    will_return(__wrap_gmtime_r, 1);
+#endif
+
+    will_return(__wrap_strftime,"2021-05-07T11:24:56");
+    will_return(__wrap_strftime, 20);
+    will_return(__wrap_strftime,"2021-05-07T12:24:56Z");
+    will_return(__wrap_strftime, 20);
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to 2021-05-07T12:24:56Z, waiting to run first scan at 2021-05-07T11:24:56");
+
     expect_string(__wrap_wm_state_io, tag, "github-test_org-git");
     expect_value(__wrap_wm_state_io, op, WM_IO_READ);
     expect_any(__wrap_wm_state_io, state);
@@ -399,6 +418,20 @@ void test_github_execute_scan(void **state) {
     expect_any(__wrap_wm_state_io, state);
     expect_any(__wrap_wm_state_io, size);
     will_return(__wrap_wm_state_io, 1);
+
+    will_return(__wrap_isDebug, 1);
+
+#ifndef WIN32
+    will_return(__wrap_gmtime_r, 1);
+#endif
+
+    will_return(__wrap_strftime,"2021-05-07T11:24:56");
+    will_return(__wrap_strftime, 20);
+    will_return(__wrap_strftime,"2021-05-07T12:24:56Z");
+    will_return(__wrap_strftime, 20);
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to 2021-05-07T12:24:56Z, waiting to run first scan at 2021-05-07T11:24:56");
 
     expect_string(__wrap_wm_state_io, tag, "github-test_org-web");
     expect_value(__wrap_wm_state_io, op, WM_IO_READ);
@@ -612,6 +645,20 @@ void test_github_execute_scan_status_code_200_null(void **state) {
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:github");
     expect_string(__wrap__mterror, formatted_msg, "Couldn't save running state.");
 
+    will_return(__wrap_isDebug, 1);
+
+#ifndef WIN32
+    will_return(__wrap_gmtime_r, 1);
+#endif
+
+    will_return(__wrap_strftime,"2021-05-07T11:24:56");
+    will_return(__wrap_strftime, 20);
+    will_return(__wrap_strftime,"2021-05-07T12:24:56Z");
+    will_return(__wrap_strftime, 20);
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to 2021-05-07T12:24:56Z, waiting to run next scan at 2021-05-07T11:24:56");
+
     wm_github_execute_scan(data->github_config, initial_scan);
 }
 
@@ -674,6 +721,8 @@ void test_github_execute_scan_max_size_reached(void **state) {
     expect_any(__wrap_wm_state_io, state);
     expect_any(__wrap_wm_state_io, size);
     will_return(__wrap_wm_state_io, 1);
+
+    will_return(__wrap_isDebug, 0);
 
     wm_github_execute_scan(data->github_config, initial_scan);
 

--- a/src/unit_tests/wazuh_modules/github/test_wm_github.c
+++ b/src/unit_tests/wazuh_modules/github/test_wm_github.c
@@ -399,13 +399,11 @@ void test_github_execute_scan(void **state) {
     will_return(__wrap_gmtime_r, 1);
 #endif
 
-    will_return(__wrap_strftime,"2021-05-07T11:24:56");
-    will_return(__wrap_strftime, 20);
     will_return(__wrap_strftime,"2021-05-07T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to 2021-05-07T12:24:56Z, waiting to run first scan at 2021-05-07T11:24:56");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2021-05-07T12:24:56Z', waiting '10' seconds to run first scan");
 
     expect_string(__wrap_wm_state_io, tag, "github-test_org-git");
     expect_value(__wrap_wm_state_io, op, WM_IO_READ);
@@ -425,13 +423,11 @@ void test_github_execute_scan(void **state) {
     will_return(__wrap_gmtime_r, 1);
 #endif
 
-    will_return(__wrap_strftime,"2021-05-07T11:24:56");
-    will_return(__wrap_strftime, 20);
-    will_return(__wrap_strftime,"2021-05-07T12:24:56Z");
+    will_return(__wrap_strftime,"2021-05-07T11:24:56Z");
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to 2021-05-07T12:24:56Z, waiting to run first scan at 2021-05-07T11:24:56");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2021-05-07T11:24:56Z', waiting '10' seconds to run first scan");
 
     expect_string(__wrap_wm_state_io, tag, "github-test_org-web");
     expect_value(__wrap_wm_state_io, op, WM_IO_READ);
@@ -651,13 +647,11 @@ void test_github_execute_scan_status_code_200_null(void **state) {
     will_return(__wrap_gmtime_r, 1);
 #endif
 
-    will_return(__wrap_strftime,"2021-05-07T11:24:56");
-    will_return(__wrap_strftime, 20);
     will_return(__wrap_strftime,"2021-05-07T12:24:56Z");
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to 2021-05-07T12:24:56Z, waiting to run next scan at 2021-05-07T11:24:56");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2021-05-07T12:24:56Z', waiting '10' seconds to run next scan");
 
     wm_github_execute_scan(data->github_config, initial_scan);
 }

--- a/src/unit_tests/wazuh_modules/github/test_wm_github.c
+++ b/src/unit_tests/wazuh_modules/github/test_wm_github.c
@@ -641,17 +641,8 @@ void test_github_execute_scan_status_code_200_null(void **state) {
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:github");
     expect_string(__wrap__mterror, formatted_msg, "Couldn't save running state.");
 
-    will_return(__wrap_isDebug, 1);
-
-#ifndef WIN32
-    will_return(__wrap_gmtime_r, 1);
-#endif
-
-    will_return(__wrap_strftime,"2021-05-07T12:24:56Z");
-    will_return(__wrap_strftime, 20);
-
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2021-05-07T12:24:56Z', waiting '10' seconds to run next scan");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2021-05-07 12:34:56', waiting '10' seconds to run next scan");
 
     wm_github_execute_scan(data->github_config, initial_scan);
 }
@@ -716,7 +707,8 @@ void test_github_execute_scan_max_size_reached(void **state) {
     expect_any(__wrap_wm_state_io, size);
     will_return(__wrap_wm_state_io, 1);
 
-    will_return(__wrap_isDebug, 0);
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2021-05-07 12:34:56', waiting '10' seconds to run next scan");
 
     wm_github_execute_scan(data->github_config, initial_scan);
 

--- a/src/unit_tests/wazuh_modules/github/test_wm_github.c
+++ b/src/unit_tests/wazuh_modules/github/test_wm_github.c
@@ -402,7 +402,7 @@ void test_github_execute_scan(void **state) {
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2021-05-07T12:24:56Z', waiting '10' seconds to run first scan");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2021-05-07T12:24:56Z', waiting '10' seconds to run first scan.");
 
     expect_string(__wrap_wm_state_io, tag, "github-test_org-git");
     expect_value(__wrap_wm_state_io, op, WM_IO_READ);
@@ -426,7 +426,7 @@ void test_github_execute_scan(void **state) {
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2021-05-07T11:24:56Z', waiting '10' seconds to run first scan");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2021-05-07T11:24:56Z', waiting '10' seconds to run first scan.");
 
     expect_string(__wrap_wm_state_io, tag, "github-test_org-web");
     expect_value(__wrap_wm_state_io, op, WM_IO_READ);
@@ -681,7 +681,7 @@ void test_github_execute_scan_max_size_reached(void **state) {
     will_return(__wrap_gmtime_r, 1);
 #endif
 
-    will_return(__wrap_strftime,"2021-05-07 12:34:56");
+    will_return(__wrap_strftime,"2021-05-07T12:34:56Z");
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
@@ -704,7 +704,7 @@ void test_github_execute_scan_max_size_reached(void **state) {
     will_return(__wrap_wm_state_io, 1);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2021-05-07 12:34:56', waiting '10' seconds to run next scan");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2021-05-07T12:34:56Z', waiting '10' seconds to run next scan.");
 
     wm_github_execute_scan(data->github_config, initial_scan);
 

--- a/src/unit_tests/wazuh_modules/github/test_wm_github.c
+++ b/src/unit_tests/wazuh_modules/github/test_wm_github.c
@@ -640,9 +640,6 @@ void test_github_execute_scan_status_code_200_null(void **state) {
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:github");
     expect_string(__wrap__mterror, formatted_msg, "Couldn't save running state.");
 
-    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2021-05-07 12:34:56', waiting '10' seconds to run next scan");
-
     wm_github_execute_scan(data->github_config, initial_scan);
 }
 

--- a/src/unit_tests/wazuh_modules/github/test_wm_github.c
+++ b/src/unit_tests/wazuh_modules/github/test_wm_github.c
@@ -402,7 +402,7 @@ void test_github_execute_scan(void **state) {
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2021-05-07T12:24:56Z', waiting '10' seconds to run first scan.");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2021-05-07T12:24:56Z' for organization 'test_org' and event type 'git', waiting '10' seconds to run first scan.");
 
     expect_string(__wrap_wm_state_io, tag, "github-test_org-git");
     expect_value(__wrap_wm_state_io, op, WM_IO_READ);
@@ -426,7 +426,7 @@ void test_github_execute_scan(void **state) {
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2021-05-07T11:24:56Z', waiting '10' seconds to run first scan.");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2021-05-07T11:24:56Z' for organization 'test_org' and event type 'web', waiting '10' seconds to run first scan.");
 
     expect_string(__wrap_wm_state_io, tag, "github-test_org-web");
     expect_value(__wrap_wm_state_io, op, WM_IO_READ);
@@ -704,7 +704,7 @@ void test_github_execute_scan_max_size_reached(void **state) {
     will_return(__wrap_wm_state_io, 1);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2021-05-07T12:34:56Z', waiting '10' seconds to run next scan.");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2021-05-07T12:34:56Z' for organization 'test_org' and event type 'web', waiting '10' seconds to run next scan.");
 
     wm_github_execute_scan(data->github_config, initial_scan);
 

--- a/src/unit_tests/wazuh_modules/github/test_wm_github.c
+++ b/src/unit_tests/wazuh_modules/github/test_wm_github.c
@@ -29,7 +29,6 @@
 #include "../../wrappers/wazuh/wazuh_modules/wmodules_wrappers.h"
 #include "../../wrappers/wazuh/shared/url_wrappers.h"
 #include "../../wrappers/libc/time_wrappers.h"
-#include "../../wrappers/libc/time_wrappers.h"
 
 unsigned int __wrap_sleep(unsigned int __seconds) {
     check_expected(__seconds);

--- a/src/wazuh_modules/wm_github.c
+++ b/src/wazuh_modules/wm_github.c
@@ -253,7 +253,7 @@ STATIC void wm_github_execute_scan(wm_github *github_config, int initial_scan) {
 
                     if (wm_state_io(org_state_name, WM_IO_WRITE, &org_state_struc, sizeof(org_state_struc)) < 0) {
                         mterror(WM_GITHUB_LOGTAG, "Couldn't save running state.");
-                    } else if (isDebug() > 0) {
+                    } else if (isDebug()) {
                         memset(next_scan_time_str, '\0', 80);
                         next_scan_time = time(0) + github_config->interval;
                         localtime_r(&next_scan_time, &tm_next_scan);
@@ -365,7 +365,7 @@ STATIC void wm_github_execute_scan(wm_github *github_config, int initial_scan) {
                 } else {
                     org_state_struc.last_log_time = new_scan_time;
 
-                    if (isDebug() > 0) {
+                    if (isDebug()) {
                         memset(next_scan_time_str, '\0', 80);
                         next_scan_time = time(0) + github_config->interval;
                         localtime_r(&next_scan_time, &tm_next_scan);

--- a/src/wazuh_modules/wm_github.c
+++ b/src/wazuh_modules/wm_github.c
@@ -355,9 +355,11 @@ STATIC void wm_github_execute_scan(wm_github *github_config, int initial_scan) {
                     wm_github_scan_failure_action(&github_config->fails, current->org_name, event_types[event_types_it], error_msg, github_config->queue_fd);
                 } else {
                     org_state_struc.last_log_time = new_scan_time;
-                    mtdebug1(WM_GITHUB_LOGTAG, "Bookmark updated to '%s', waiting '%ld' seconds to run next scan", new_scan_time_str, github_config->interval);
                     if (wm_state_io(org_state_name, WM_IO_WRITE, &org_state_struc, sizeof(org_state_struc)) < 0) {
                         mterror(WM_GITHUB_LOGTAG, "Couldn't save running state.");
+                    } else {
+                        mtdebug1(WM_GITHUB_LOGTAG, "Bookmark updated to '%s', waiting '%ld' seconds to run next scan", new_scan_time_str, github_config->interval);
+
                     }
 
                     org_fail = wm_github_get_fail_by_org_and_type(github_config->fails, current->org_name, event_types[event_types_it]);

--- a/src/wazuh_modules/wm_github.c
+++ b/src/wazuh_modules/wm_github.c
@@ -252,7 +252,8 @@ STATIC void wm_github_execute_scan(wm_github *github_config, int initial_scan) {
                         memset(new_scan_time_str, '\0', 80);
                         gmtime_r(&new_scan_time, &tm_scan);
                         strftime(new_scan_time_str, sizeof(new_scan_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_scan);
-                        mtdebug1(WM_GITHUB_LOGTAG, "Bookmark updated to '%s', waiting '%ld' seconds to run first scan.", new_scan_time_str, github_config->interval);
+                        mtdebug1(WM_GITHUB_LOGTAG, "Bookmark updated to '%s' for organization '%s' and event type '%s', waiting '%ld' seconds to run first scan.",
+                            new_scan_time_str, current->org_name, event_types[event_types_it], github_config->interval);
                     }
                     continue;
                 }
@@ -356,7 +357,8 @@ STATIC void wm_github_execute_scan(wm_github *github_config, int initial_scan) {
                     if (wm_state_io(org_state_name, WM_IO_WRITE, &org_state_struc, sizeof(org_state_struc)) < 0) {
                         mterror(WM_GITHUB_LOGTAG, "Couldn't save running state.");
                     } else {
-                        mtdebug1(WM_GITHUB_LOGTAG, "Bookmark updated to '%s', waiting '%ld' seconds to run next scan.", new_scan_time_str, github_config->interval);
+                        mtdebug1(WM_GITHUB_LOGTAG, "Bookmark updated to '%s' for organization '%s' and event type '%s', waiting '%ld' seconds to run next scan.",
+                            new_scan_time_str, current->org_name, event_types[event_types_it], github_config->interval);
                     }
 
                     org_fail = wm_github_get_fail_by_org_and_type(github_config->fails, current->org_name, event_types[event_types_it]);

--- a/src/wazuh_modules/wm_github.c
+++ b/src/wazuh_modules/wm_github.c
@@ -355,15 +355,7 @@ STATIC void wm_github_execute_scan(wm_github *github_config, int initial_scan) {
                     wm_github_scan_failure_action(&github_config->fails, current->org_name, event_types[event_types_it], error_msg, github_config->queue_fd);
                 } else {
                     org_state_struc.last_log_time = new_scan_time;
-
-                    if (isDebug()) {
-                        memset(new_scan_time_str, '\0', 80);
-                        gmtime_r(&new_scan_time, &tm_scan);
-                        strftime(new_scan_time_str, sizeof(new_scan_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_scan);
-
-                        mtdebug1(WM_GITHUB_LOGTAG, "Bookmark updated to '%s', waiting '%ld' seconds to run next scan", new_scan_time_str, github_config->interval);
-                    }
-
+                    mtdebug1(WM_GITHUB_LOGTAG, "Bookmark updated to '%s', waiting '%ld' seconds to run next scan", new_scan_time_str, github_config->interval);
                     if (wm_state_io(org_state_name, WM_IO_WRITE, &org_state_struc, sizeof(org_state_struc)) < 0) {
                         mterror(WM_GITHUB_LOGTAG, "Couldn't save running state.");
                     }

--- a/src/wazuh_modules/wm_github.c
+++ b/src/wazuh_modules/wm_github.c
@@ -246,15 +246,13 @@ STATIC void wm_github_execute_scan(wm_github *github_config, int initial_scan) {
 
                 if (initial_scan && (!org_state_struc.last_log_time || github_config->only_future_events)) {
                     org_state_struc.last_log_time = new_scan_time;
-
                     if (wm_state_io(org_state_name, WM_IO_WRITE, &org_state_struc, sizeof(org_state_struc)) < 0) {
                         mterror(WM_GITHUB_LOGTAG, "Couldn't save running state.");
                     } else if (isDebug()) {
                         memset(new_scan_time_str, '\0', 80);
                         gmtime_r(&new_scan_time, &tm_scan);
                         strftime(new_scan_time_str, sizeof(new_scan_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_scan);
-
-                        mtdebug1(WM_GITHUB_LOGTAG, "Bookmark updated to '%s', waiting '%ld' seconds to run first scan", new_scan_time_str, github_config->interval);
+                        mtdebug1(WM_GITHUB_LOGTAG, "Bookmark updated to '%s', waiting '%ld' seconds to run first scan.", new_scan_time_str, github_config->interval);
                     }
                     continue;
                 }
@@ -358,8 +356,7 @@ STATIC void wm_github_execute_scan(wm_github *github_config, int initial_scan) {
                     if (wm_state_io(org_state_name, WM_IO_WRITE, &org_state_struc, sizeof(org_state_struc)) < 0) {
                         mterror(WM_GITHUB_LOGTAG, "Couldn't save running state.");
                     } else {
-                        mtdebug1(WM_GITHUB_LOGTAG, "Bookmark updated to '%s', waiting '%ld' seconds to run next scan", new_scan_time_str, github_config->interval);
-
+                        mtdebug1(WM_GITHUB_LOGTAG, "Bookmark updated to '%s', waiting '%ld' seconds to run next scan.", new_scan_time_str, github_config->interval);
                     }
 
                     org_fail = wm_github_get_fail_by_org_and_type(github_config->fails, current->org_name, event_types[event_types_it]);


### PR DESCRIPTION
|Related issue|Documentation|Testing Manual|
|---|---|---|
|https://github.com/wazuh/wazuh/issues/13784 https://github.com/wazuh/wazuh/issues/13943| [Documentation](https://github.com/wazuh/wazuh-documentation/pull/5357)| https://github.com/wazuh/wazuh-qa/issues/3013|

## Description
The goal of this change is encrease the information about how Github integration works. 
2 new messages are added, one when first scan runs, with the legend `Bookmark updated to '2022-06-16T18:21:58Z', waiting '60' seconds to run first scan`, where the first date is the UTC date as the API request to Github server, and the `'60' seconds` are the interval time. Second message is similar than first, it only change the word `next` instead the word `first`, and it shows when bookmark is updated. `Bookmark updated to '2022-06-16T18:21:58Z', waiting '60' seconds to run next scan`


## Configuration options
ossec.conf 

```
<github>
    <enabled>yes</enabled>
    <interval>1m</interval>
    <time_delay>30s</time_delay>
    <curl_max_size>1M</curl_max_size>
    <only_future_events>yes</only_future_events>
    <api_auth>
        <org_name>dummy</org_name>
        <api_token>dummy</api_token>
    </api_auth>
    <api_parameters>
        <event_type>all</event_type>
    </api_parameters>
</github>

```
## Logs

```
2022/06/16 15:22:28 wazuh-modulesd:github[303215] wm_github.c:225 at wm_github_execute_scan(): DEBUG: Scanning organization: 'binarybeast2022'
2022/06/16 15:22:28 wazuh-modulesd:github[303215] wm_github.c:257 at wm_github_execute_scan(): DEBUG: Bookmark updated to '2022-06-16T18:21:58Z', waiting '60' seconds to run first scan
2022/06/16 15:23:28 wazuh-modulesd:github[303215] wm_github.c:257 at wm_github_execute_scan(): DEBUG: Bookmark updated to '2022-06-16T18:22:58Z', waiting '60' seconds to run next scan

```

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
