### PR TITLE
Use broadcast system in agent-groups send task

### DIFF
--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -666,10 +666,12 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         await sync_object.sync(start_time=start_time, chunks=local_agent_groups_information)
 
     async def send_agent_groups_information(self, groups_info):
-        """Send the group information to the worker node.
+        """Send group information to the worker node.
 
-        Each time we get data it will be sent.
-        A worker node cannot send two consecutive times the same group information.
+        Parameters
+        ----------
+        groups_info : list
+            Chunks of agent-groups data obtained in local db.
         """
         logger = self.task_loggers['Agent-groups send']
         try:
@@ -678,7 +680,6 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             await self.agent_groups.sync(start_time=self.send_agent_groups_status['date_start'], chunks=groups_info)
         except Exception as e:
             logger.error(f'Error sending agent-groups information to {self.name}: {e}')
-
 
     def set_date_end_master(self, logger):
         """Store the datetime when Integrity sync is completed and log 'Finished in' message.

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -665,7 +665,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         local_agent_groups_information = await sync_object.retrieve_information()
         await sync_object.sync(start_time=start_time, chunks=local_agent_groups_information)
 
-    async def send_agent_groups_information(self, groups_info):
+    async def send_agent_groups_information(self, groups_info: list):
         """Send group information to the worker node.
 
         Parameters
@@ -1010,10 +1010,7 @@ class Master(server.AbstractServer):
                          'version': metadata.__version__, 'ip': self.configuration['nodes'][0]}}
 
     async def agent_groups_update(self):
-        """Asynchronous task in charge of obtaining data related to agent-groups periodically.
-
-        It updates the local variable agent_groups_control
-        every self.cluster_items['intervals']['master']['sync_agent_groups'] seconds.
+        """Obtain and broadcast agent-groups data periodically.
 
         This information will only be sent to the worker nodes when it contains data.
         It looks like this: ['[{"data":[{"id":1,"group":["default","group1"]}]}]'].

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -198,12 +198,13 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         self.version = ""
         self.cluster_name = ""
         self.node_type = ""
-        self.agent_group_task = None
+
         # Dictionary to save loggers for each sync task.
         self.task_loggers = {}
         context_tag.set(self.tag)
         self.integrity = None
         self.agent_groups = None
+
         # Maximum zip size allowed when syncing Integrity files.
         self.current_zip_limit = self.cluster_items['intervals']['communication']['max_zip_size']
 
@@ -956,12 +957,6 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         """
         super().connection_lost(exc)
         self.logger.info("Cancelling pending tasks.")
-
-        # Cancel agent-groups task
-        try:
-            self.agent_group_task.cancel()
-        except AttributeError:
-            pass
 
         # Cancel all pending tasks
         for pending_task in self.sync_tasks.values():


### PR DESCRIPTION
|Related issue|
|---|
| Closes #13848 |

## Description

This PR replaces the old system for sending `agent-groups` information to all workers with the new broadcasting system developed in https://github.com/wazuh/wazuh/pull/13124.

Thanks to that, an endless loop in each MasterHandler is removed and replaced by an asynchronous queue that executes the desired function. 

`broadcast()` has been used instead of `broadcast_add()` and `broadcast_pop()`. This means that the master will periodically queue the agent_groups info, regardless of whether past iterations were successful or whether there is still previous information to be sent.

## Tests
The coverage of the updated modules remains the the same:
```
----------- coverage: platform linux, python 3.9.5-final-0 -----------
Name                                                      Stmts   Miss  Cover
-----------------------------------------------------------------------------
framework/wazuh/core/cluster/__init__.py                      5      0   100%
framework/wazuh/core/cluster/client.py                      146      1    99%
framework/wazuh/core/cluster/cluster.py                     265      1    99%
framework/wazuh/core/cluster/common.py                      665      2    99%
framework/wazuh/core/cluster/control.py                      69      1    99%
framework/wazuh/core/cluster/dapi/__init__.py                 0      0   100%
framework/wazuh/core/cluster/dapi/dapi.py                   388     22    94%
framework/wazuh/core/cluster/dapi/tests/test_dapi.py        390      6    98%
framework/wazuh/core/cluster/local_client.py                 95      0   100%
framework/wazuh/core/cluster/local_server.py                147      0   100%
framework/wazuh/core/cluster/master.py                      439      4    99%
framework/wazuh/core/cluster/server.py                      198      0   100%
framework/wazuh/core/cluster/tests/__init__.py                0      0   100%
framework/wazuh/core/cluster/tests/test_client.py           296      9    97%
framework/wazuh/core/cluster/tests/test_cluster.py          296      7    98%
framework/wazuh/core/cluster/tests/test_common.py          1094     38    97%
framework/wazuh/core/cluster/tests/test_control.py          102      0   100%
framework/wazuh/core/cluster/tests/test_local_client.py     166      0   100%
framework/wazuh/core/cluster/tests/test_local_server.py     374     11    97%
framework/wazuh/core/cluster/tests/test_master.py           985     39    96%
framework/wazuh/core/cluster/tests/test_server.py           409      5    99%
framework/wazuh/core/cluster/tests/test_utils.py            157      1    99%
framework/wazuh/core/cluster/tests/test_worker.py           779     14    98%
framework/wazuh/core/cluster/utils.py                       148      0   100%
framework/wazuh/core/cluster/worker.py                      351     12    97%
-----------------------------------------------------------------------------
TOTAL                                                      7964    173    98%
```
