### PR TITLE
Abort the enrollment process if the manager couldn't be verified.

### DIFF
--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -26,7 +26,7 @@
 extern int w_enrollment_concat_src_ip(char *buff, const char* sender_ip, const int use_src_ip);
 extern void w_enrollment_concat_group(char *buff, const char* centralized_group);
 extern void w_enrollment_concat_key(char *buff, keyentry* key_entry);
-extern void w_enrollment_verify_ca_certificate(const SSL *ssl, const char *ca_cert, const char *hostname);
+extern int w_enrollment_verify_ca_certificate(const SSL *ssl, const char *ca_cert, const char *hostname);
 extern int w_enrollment_connect(w_enrollment_ctx *cfg, const char * server_address);
 extern int w_enrollment_send_message(w_enrollment_ctx *cfg);
 extern int w_enrollment_store_key_entry(const char* keys);
@@ -415,7 +415,8 @@ void test_w_enrollment_verify_ca_certificate_null_connection(void **state) {
 void test_w_enrollment_verify_ca_certificate_no_certificate(void **state) {
     SSL *ssl = *state;
     expect_string(__wrap__mdebug1, formatted_msg, "Registering agent to unverified manager");
-    w_enrollment_verify_ca_certificate(ssl, NULL, "hostname");
+    int retval = w_enrollment_verify_ca_certificate(ssl, NULL, "hostname");
+    assert_int_equal(retval, 0);
 }
 
 void test_verificy_ca_certificate_invalid_certificate(void **state) {
@@ -427,7 +428,8 @@ void test_verificy_ca_certificate_invalid_certificate(void **state) {
 
     expect_string(__wrap__minfo, formatted_msg, "Verifying manager's certificate");
     expect_string(__wrap__merror, formatted_msg, "Unable to verify server certificate");
-    w_enrollment_verify_ca_certificate(ssl, "BAD_CERTIFICATE", "hostname");
+    int retval = w_enrollment_verify_ca_certificate(ssl, "BAD_CERTIFICATE", "hostname");
+    assert_int_equal(retval, 1);
 }
 
 void test_verificy_ca_certificate_valid_certificate(void **state) {
@@ -439,7 +441,9 @@ void test_verificy_ca_certificate_valid_certificate(void **state) {
 
     expect_string(__wrap__minfo, formatted_msg, "Verifying manager's certificate");
     expect_string(__wrap__minfo, formatted_msg, "Manager has been verified successfully");
-    w_enrollment_verify_ca_certificate(ssl, "GOOD_CERTIFICATE", "hostname");
+    int retval = w_enrollment_verify_ca_certificate(ssl, "GOOD_CERTIFICATE", "hostname");
+    assert_int_equal(retval, 0);
+
 }
 
 /**********************************************/


### PR DESCRIPTION
|Related issue|
|---|
|Closes #13772|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR aims to change the behavior of the enrollment process when the manager certificate couldn't be validated. Previously, an error message was triggered but the agent was enrolled nevertheless. 


## Configuration options
To enable the manager verification on the agent, I followed this [guide from the documentation 
](https://documentation.wazuh.com/current/user-manual/agent-enrollment/security-options/manager-identity-verification.html)

## Logs/Alerts example
### Previous behavior
```
2022/06/17 09:30:51 wazuh-agentd: INFO: Requesting a key from server: 10.2.0.18
2022/06/17 09:30:51 wazuh-agentd: INFO: Verifying manager's certificate
2022/06/17 09:30:51 wazuh-agentd: ERROR: Unable to verify server certificate
2022/06/17 09:30:51 wazuh-agentd: INFO: Using password specified on file: /var/ossec/etc/authd.pass
2022/06/17 09:30:51 wazuh-agentd: INFO: Using agent name as: ubuntuagent
2022/06/17 09:30:51 wazuh-agentd: INFO: Waiting for server reply
2022/06/17 09:30:51 wazuh-agentd: INFO: Valid key received
2022/06/17 09:30:51 wazuh-agentd: INFO: Waiting 20 seconds before server connection
2022/06/17 09:31:11 wazuh-agentd: INFO: (1410): Reading authentication keys file.
2022/06/17 09:31:11 wazuh-agentd: INFO: Closing connection to server ([10.2.0.18]:1514/tcp).
2022/06/17 09:31:11 wazuh-agentd: INFO: Trying to connect to server ([10.2.0.18]:1514/tcp).
2022/06/17 09:31:11 wazuh-agentd: INFO: (4102): Connected to the server ([10.2.0.18]:1514/tcp).
2022/06/17 09:31:14 sca: INFO: Evaluation finished for policy '/var/ossec/ruleset/sca/cis_ubuntu20-04.yml
```

### New behavior
```
2022/06/17 09:33:10 wazuh-agentd: INFO: Requesting a key from server: 10.2.0.18
2022/06/17 09:33:10 wazuh-agentd: INFO: Verifying manager's certificate
2022/06/17 09:33:10 wazuh-agentd: ERROR: Unable to verify server certificate
2022/06/17 09:33:10 wazuh-agentd: INFO: Requesting a key from server: 10.2.0.18
2022/06/17 09:33:10 wazuh-agentd: INFO: Verifying manager's certificate
2022/06/17 09:33:10 wazuh-agentd: ERROR: Unable to verify server certificate
2022/06/17 09:33:20 wazuh-agentd: INFO: Requesting a key from server: 10.2.0.18
2022/06/17 09:33:20 wazuh-agentd: INFO: Verifying manager's certificate
2022/06/17 09:33:20 wazuh-agentd: ERROR: Unable to verify server certificate
2022/06/17 09:33:20 wazuh-agentd: INFO: Requesting a key from server: 10.2.0.18
2022/06/17 09:33:20 wazuh-agentd: INFO: Verifying manager's certificate
2022/06/17 09:33:20 wazuh-agentd: ERROR: Unable to verify server certificate
```
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [X] Source upgrade
<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory