### PR TITLE
Improve OS info log unavailable for Vulnerability Detector

### DIFF
--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -12,7 +12,7 @@
 #define INFO_MESSAGES_H
 
 /* Vulnerability-Detector info messages*/
-#define VU_NO_OSINFO_AG       "(5700): Unable to get the OS information for agent '%.3d'. It may not have the OS inventory enabled."
+#define VU_NO_OSINFO_AG       "(5700): Unable to get the OS information for agent '%.3d'. Inventory data may not yet be synchronized."
 
 /* File integrity monitoring info messages*/
 #define FIM_DAEMON_STARTED                  "(6000): Starting daemon..."

--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -11,6 +11,9 @@
 #ifndef INFO_MESSAGES_H
 #define INFO_MESSAGES_H
 
+/* Vulnerability-Detector info messages*/
+#define VU_NO_OSINFO_AG       "(5700): Unable to get the OS information for agent '%.3d'. It may not have the OS inventory enabled."
+
 /* File integrity monitoring info messages*/
 #define FIM_DAEMON_STARTED                  "(6000): Starting daemon..."
 #define FIM_DISABLED                        "(6001): File integrity monitoring disabled."

--- a/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
@@ -49,9 +49,6 @@ void test_wdb_get_sys_osinfo_error_sql_execution(void ** state)
     will_return(__wrap_wdbc_query_parse_json, 0);
     will_return(__wrap_wdbc_query_parse_json, NULL);
 
-    // Handling result
-    expect_string(__wrap__minfo, formatted_msg, "Agents DB (1): No OS information available.");
-
     //Cleaning  memory
     expect_function_call(__wrap_cJSON_Delete);
 

--- a/src/wazuh_db/helpers/wdb_agents_helpers.c
+++ b/src/wazuh_db/helpers/wdb_agents_helpers.c
@@ -34,7 +34,6 @@ cJSON* wdb_get_agent_sys_osinfo(int id,
     cJSON* result = wdbc_query_parse_json(sock?sock:&aux_sock, wdbquery, wdboutput, WDBOUTPUT_SIZE);
 
     if (!result || !result->child) {
-        minfo("Agents DB (%d): No OS information available.", id);
         cJSON_Delete(result);
         result = NULL;
     }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5443,6 +5443,7 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
 
         // Getting sys_osinfo data from agent database
         if (j_osinfo = wdb_get_agent_sys_osinfo(id, &sock), !j_osinfo) {
+            mtinfo(WM_VULNDETECTOR_LOGTAG, VU_NO_OSINFO_AG, id);
             goto next;
         }
 


### PR DESCRIPTION
|Related issue|
|---|
|#13768|

## Description

In this PR, the changes proposed in the issue description #13768 have been applied to make it easier to recognize the problem and to provide a better context.

## Configuration options

In the configuration, to cause the issue and show the log, it is only necessary to **enable** _Vulnerability Detector_ in the manager and **disable** _Syscollector_ in the agent.

This way, the manager will not have the necessary information from the agent and will display the log message.

- Agent:
```xml
  <!-- System inventory -->
  <wodle name="syscollector">
    <disabled>yes</disabled>
    <interval>1h</interval>
    <scan_on_start>yes</scan_on_start>
    <hardware>yes</hardware>
    <os>yes</os>
    <network>yes</network>
    <packages>yes</packages>
    <ports all="no">yes</ports>
    <processes>yes</processes>

    <!-- Database synchronization settings -->
    <synchronization>
      <max_eps>10</max_eps>
    </synchronization>
  </wodle>
```

## Logs/Alerts example

Previously, the log was displayed as follows:
```
wazuh-modulesd INFO: Agents DB (1): No OS information available.
```

Whereas now, the new log would appear with exactly the same problem, but showing the following message:
```
wazuh-modulesd:vulnerability-detector: INFO: (5700): Unable to get the OS information for agent '001'. It may not have the OS inventory enabled.
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [ ] Added unit tests (for new features)
