### PR TITLE
Add check workers stability procedure

### DIFF
--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -180,9 +180,9 @@ async def print_health(config, more, filter_node):
                 msg2 += "        Status:\n"
                 msg2 += "            Agents reconnect:\n"
                 msg2 += f"                Current phase: {node_info['status']['agents_reconnect']['current_phase']}.\n"
-                msg2 += f"                Last workers stability check: " \
+                msg2 += f"                Last stability check: " \
                         f"{node_info['status']['agents_reconnect']['workers_stability']['last_workers_stability_check']}.\n"
-                msg2 += f"                Last register workers: " \
+                msg2 += f"                Last connected workers: " \
                         f"{node_info['status']['agents_reconnect']['workers_stability']['last_register_workers']}.\n"
                 msg2 += f"                Worker stability counter: " \
                         f"{node_info['status']['agents_reconnect']['workers_stability']['workers_stability_counter']}.\n"

--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -175,6 +175,19 @@ async def print_health(config, more, filter_node):
                     f"{node_info['status']['last_sync_agentgroups']['n_synced_chunks']}.\n"
             msg2 += f"                Permission to synchronize agent-groups: " \
                     f"{node_info['status']['sync_agent_groups_free']}.\n"
+        else:
+            if node_info['status']:
+                msg2 += "        Status:\n"
+                msg2 += "            Agents reconnect:\n"
+                msg2 += f"                Current phase: {node_info['status']['agents_reconnect']['current_phase']}.\n"
+                msg2 += f"                Last workers stability check: " \
+                        f"{node_info['status']['agents_reconnect']['workers_stability']['last_workers_stability_check']}.\n"
+                msg2 += f"                Last register workers: " \
+                        f"{node_info['status']['agents_reconnect']['workers_stability']['last_register_workers']}.\n"
+                msg2 += f"                Worker stability counter: " \
+                        f"{node_info['status']['agents_reconnect']['workers_stability']['workers_stability_counter']}.\n"
+                msg2 += f"                Worker stability threshold: " \
+                        f"{node_info['status']['agents_reconnect']['workers_stability']['workers_stability_threshold']}.\n"
 
     print(msg1)
     more and print(msg2)

--- a/framework/wazuh/core/cluster/agents_reconnect.py
+++ b/framework/wazuh/core/cluster/agents_reconnect.py
@@ -7,17 +7,17 @@ from wazuh.core.cluster.utils import setup_dynamic_logger
 from wazuh.core.common import DECIMALS_DATE_FORMAT
 
 
-class Agents_Reconnection_Phases(str, Enum):
-    no_started = "No started"
-    check_workers_stability = "Check workers stability"
-    check_previous_reconnections = "Check previous reconnections"
-    check_agents_balance = "Check agents balance"
-    reconnect_agents = "Reconnect agents"
-    balance_sleeping = "Sleeping"
-    halt = "Halt"
+class AgentsReconnectionPhases(str, Enum):
+    NOT_STARTED = "Not started"
+    CHECK_WORKERS_STABILITY = "Check workers stability"
+    CHECK_PREVIOUS_RECONNECTIONS = "Check previous reconnections"
+    CHECK_AGENTS_BALANCE = "Check agents balance"
+    RECONNECT_AGENTS = "Reconnect agents"
+    BALANCE_SLEEPING = "Sleeping"
+    HALT = "Halt"
 
 
-class Agents_reconnect:
+class AgentsReconnect:
     """Class that encapsulates everything related to the agent reconnection algorithm."""
 
     def __init__(self, logger, nodes, blacklisted_nodes, workers_stability_threshold) -> None:
@@ -39,14 +39,13 @@ class Agents_reconnect:
         self.balance_threshold = 3
 
         # General
-        self.current_phase = Agents_Reconnection_Phases.no_started
+        self.current_phase = AgentsReconnectionPhases.NOT_STARTED
 
         # Provisional
         self.posbalance_sleep = 60
 
     async def reset_counter(self) -> None:
-        """Resets all counters of the reconnection procedure.
-        """
+        """Reset all counters of the reconnection procedure."""
         self.balance_counter = 0
         self.workers_stability_counter = 0
 
@@ -61,8 +60,8 @@ class Agents_reconnect:
         stability : bool
         """
         logger = setup_dynamic_logger(
-            self.logger, Agents_Reconnection_Phases.check_workers_stability.value)
-        self.current_phase = Agents_Reconnection_Phases.check_workers_stability
+            self.logger, AgentsReconnectionPhases.CHECK_WORKERS_STABILITY.value)
+        self.current_phase = AgentsReconnectionPhases.CHECK_WORKERS_STABILITY
         if len(self.nodes) == 0:
             logger.info("No nodes to check. Skipping...")
             return False
@@ -91,7 +90,7 @@ class Agents_reconnect:
                     f"Counter: {self.workers_stability_counter}/{self.workers_stability_threshold}.")
         return False
 
-    def get_current_phase(self) -> Agents_Reconnection_Phases:
+    def get_current_phase(self) -> AgentsReconnectionPhases:
         """Return the current phase of the algorithm.
 
         Returns
@@ -101,7 +100,7 @@ class Agents_reconnect:
         return self.current_phase
 
     def get_workers_stability_info(self) -> dict:
-        """Returns the information related to the phase 'Workers stability'.
+        """Return the information related to the phase 'Workers stability'.
 
         Returns
         -------

--- a/framework/wazuh/core/cluster/agents_reconnect.py
+++ b/framework/wazuh/core/cluster/agents_reconnect.py
@@ -1,0 +1,127 @@
+import contextlib
+from enum import Enum
+from xmlrpc.client import Boolean
+
+from wazuh.core import utils
+from wazuh.core.cluster.utils import setup_dynamic_logger
+from wazuh.core.common import DECIMALS_DATE_FORMAT
+
+
+class Agents_Reconnection_Phases(str, Enum):
+    no_started = "No started"
+    check_workers_stability = "Check workers stability"
+    check_previous_reconnections = "Check previous reconnections"
+    check_agents_balance = "Check agents balance"
+    reconnect_agents = "Reconnect agents"
+    balance_sleeping = "Sleeping"
+    halt = "Halt"
+
+
+class Agents_reconnect:
+    """Class that encapsulates everything related to the agent reconnection algorithm."""
+
+    def __init__(self, logger, nodes, blacklisted_nodes, workers_stability_threshold) -> None:
+        # Logger
+        self.logger = logger
+
+        # Check workers stability
+        self.nodes = nodes.keys()
+        self.blacklisted_nodes = blacklisted_nodes
+        self.previous_workers = set()
+        self.workers_stability_counter = 0
+        self.workers_stability_threshold = workers_stability_threshold
+
+        # Timestamps
+        self.last_workers_stability_check = 0
+
+        # Check agents balance -> Provisional
+        self.balance_counter = 0
+        self.balance_threshold = 3
+
+        # General
+        self.current_phase = Agents_Reconnection_Phases.no_started
+
+        # Provisional
+        self.posbalance_sleep = 60
+
+    async def reset_counter(self) -> None:
+        """Resets all counters of the reconnection procedure.
+        """
+        self.balance_counter = 0
+        self.workers_stability_counter = 0
+
+    async def check_workers_stability(self) -> Boolean:
+        """Function in charge of determining whether an environment is stable.
+
+        To verify the stability, the function uses the consecutive verification
+        of the number of workers in the environment.
+
+        Returns
+        -------
+        stability : bool
+        """
+        logger = setup_dynamic_logger(
+            self.logger, Agents_Reconnection_Phases.check_workers_stability.value)
+        self.current_phase = Agents_Reconnection_Phases.check_workers_stability
+        if len(self.nodes) == 0:
+            logger.info("No nodes to check. Skipping...")
+            return False
+
+        current_worker_list = set(self.nodes) - self.blacklisted_nodes
+        logger.debug(f"Current detected workers: {current_worker_list}.")
+
+        if self.previous_workers == current_worker_list or len(self.previous_workers) == 0:
+            if self.workers_stability_counter < self.workers_stability_threshold:
+                self.workers_stability_counter += 1
+            if self.previous_workers == set():
+                self.previous_workers = current_worker_list
+        else:
+            logger.info("Workers changed, restarting workers stability phase.")
+            self.previous_workers = current_worker_list
+            await self.reset_counter()
+
+        self.last_workers_stability_check = utils.get_utc_now()
+        if self.workers_stability_counter >= self.workers_stability_threshold:
+            logger.info(f"Cluster is ready {self.workers_stability_counter}/{self.workers_stability_threshold}. "
+                        f"Workers stability phase finished at "
+                        f"{self.last_workers_stability_check.strftime(DECIMALS_DATE_FORMAT)}.")
+            return True
+
+        logger.info(f"Workers are not stable at this moment. "
+                    f"Counter: {self.workers_stability_counter}/{self.workers_stability_threshold}.")
+        return False
+
+    def get_current_phase(self) -> Agents_Reconnection_Phases:
+        """Return the current phase of the algorithm.
+
+        Returns
+        -------
+        result : dict
+        """
+        return self.current_phase
+
+    def get_workers_stability_info(self) -> dict:
+        """Returns the information related to the phase 'Workers stability'.
+
+        Returns
+        -------
+        result : dict
+        """
+        with contextlib.suppress(AttributeError):
+            self.last_workers_stability_check = self.last_workers_stability_check.strftime(DECIMALS_DATE_FORMAT)
+
+        return {
+            "workers_stability_counter": self.workers_stability_counter,
+            "workers_stability_threshold": self.workers_stability_threshold,
+            "last_workers_stability_check": self.last_workers_stability_check,
+            "last_register_workers": str(list(self.previous_workers))
+        }
+
+    def to_dict(self) -> dict:
+        """Returns the model properties as a dict.
+
+        Returns
+        -------
+        result : dict
+        """
+        NotImplementedError("Not implemented yet")

--- a/framework/wazuh/core/cluster/cluster.json
+++ b/framework/wazuh/core/cluster/cluster.json
@@ -100,7 +100,11 @@
             "agent_group_start_delay": 30,
             "check_worker_lastkeepalive": 60,
             "max_allowed_time_without_keepalive": 120,
-            "max_locked_integrity_time": 1000
+            "max_locked_integrity_time": 1000,
+            "areconn_workers_stability_delay": 30,
+            "areconn_workers_stability_time": 300,
+            "areconn_workers_stability_threshold": 3,
+            "areconn_posbalance_time": 600
         },
 
         "communication":{

--- a/framework/wazuh/core/cluster/control.py
+++ b/framework/wazuh/core/cluster/control.py
@@ -100,10 +100,7 @@ async def get_node(lc: local_client.LocalClient, filter_node=None, select=None):
     if isinstance(node_info_array, Exception):
         raise node_info_array
 
-    if len(node_info_array['items']) > 0:
-        return node_info_array['items'][0]
-    else:
-        return {}
+    return node_info_array['items'][0] if len(node_info_array['items']) > 0 else {}
 
 
 async def get_health(lc: local_client.LocalClient, filter_node=None):
@@ -112,7 +109,7 @@ async def get_health(lc: local_client.LocalClient, filter_node=None):
     Parameters
     ----------
     lc : LocalClient object
-        LocalClient with which to send the 'get_nodes' request.
+        LocalClient with which to send the 'get_health' request.
     filter_node : str, list
         Node to return.
 

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -19,7 +19,7 @@ from uuid import uuid4
 import wazuh.core.cluster.cluster
 from wazuh.core import cluster as metadata, common, exception, utils
 from wazuh.core.agent import Agent
-from wazuh.core.cluster import server, cluster, common as c_common
+from wazuh.core.cluster import agents_reconnect, server, cluster, common as c_common
 from wazuh.core.cluster.dapi import dapi
 from wazuh.core.cluster.utils import context_tag
 from wazuh.core.common import DECIMALS_DATE_FORMAT
@@ -246,7 +246,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         self.current_zip_limit = self.cluster_items['intervals']['communication']['max_zip_size']
 
     def to_dict(self):
-        """Get worker healthcheck information.
+        """Get master healthcheck information.
 
         Returns
         -------
@@ -1129,9 +1129,14 @@ class Master(server.AbstractServer):
         self.integrity_already_executed = []
         self.dapi = dapi.APIRequestQueue(server=self)
         self.sendsync = dapi.SendSyncRequestQueue(server=self)
-        self.tasks.extend([self.dapi.run, self.sendsync.run, self.file_status_update, self.agent_groups_update])
+        self.tasks.extend([self.dapi.run, self.sendsync.run, self.file_status_update, self.agent_groups_update,
+                           self.cluster_agents_reconnect_controller])
         # pending API requests waiting for a response
         self.pending_api_requests = {}
+
+        # Agents reconnect
+        self.agents_reconnect_enabled = True  # Provisional
+        self.agents_reconnect = None
 
     def to_dict(self) -> Dict:
         """Get master's healthcheck information.
@@ -1143,6 +1148,55 @@ class Master(server.AbstractServer):
         """
         return {'info': {'name': self.configuration['node_name'], 'type': self.configuration['node_type'],
                          'version': metadata.__version__, 'ip': self.configuration['nodes'][0]}}
+
+    def get_health_agents_reconnect(self) -> Dict:
+        """Get agents reconnect information.
+
+        Returns
+        -------
+        dict
+            Agents reconnect information.
+        """
+        master_status_info = None
+        if self.agents_reconnect:
+            master_status_info = {
+                "agents_reconnect": {
+                    "current_phase": self.agents_reconnect.get_current_phase(),
+                    "workers_stability": self.agents_reconnect.get_workers_stability_info()
+                }
+            }
+
+        return master_status_info
+
+    async def cluster_agents_reconnect_controller(self):
+        """Controller task in charge of maintaining agents balance in the cluster.
+        """
+        if not self.agents_reconnect_enabled:
+            return
+
+        logger = self.setup_task_logger("Agents reconnect")
+        logger.info("Cluster agents reconnection started.")
+
+        self.agents_reconnect = agents_reconnect.Agents_reconnect(
+            logger=logger, blacklisted_nodes={"master"}, nodes=self.clients,
+            workers_stability_threshold=self.cluster_items["intervals"]["master"]["areconn_workers_stability_threshold"]
+        )
+
+        logger.info(
+            f"Sleeping {self.cluster_items['intervals']['master']['areconn_workers_stability_delay']}s "
+            f"before starting the agent-groups task, waiting for the workers connection.")
+        await asyncio.sleep(self.cluster_items['intervals']['master']['areconn_workers_stability_delay'])
+
+        while True:
+            # Check workers stability
+            while not await self.agents_reconnect.check_workers_stability():
+                await asyncio.sleep(self.cluster_items["intervals"]["master"]["areconn_workers_stability_time"])
+
+            # Iteration complete. Sleeping phase
+            self.agents_reconnect.current_phase = agents_reconnect.Agents_Reconnection_Phases.balance_sleeping
+            logger.info(f"Iteration complete. Sleep during "
+                        f"{self.cluster_items['intervals']['master']['areconn_posbalance_time']} seconds.")
+            await asyncio.sleep(self.cluster_items["intervals"]["master"]["areconn_posbalance_time"])
 
     def get_agent_groups_info(self, client):
         """Check whether the updated group information is sent only once per worker.
@@ -1247,27 +1301,31 @@ class Master(server.AbstractServer):
         dict
             Dict object containing nodes information.
         """
-        workers_info = {key: val.to_dict() for key, val in self.clients.items()
-                        if filter_node is None or filter_node == {} or key in filter_node}
-        n_connected_nodes = len(workers_info)
+        nodes_info = {key: val.to_dict() for key, val in self.clients.items()
+                      if filter_node is None or filter_node == {} or key in filter_node}
+        n_connected_nodes = len(nodes_info)
         if filter_node is None or self.configuration['node_name'] in filter_node:
-            workers_info.update({self.configuration['node_name']: self.to_dict()})
+            nodes_info[self.configuration['node_name']] = self.to_dict()
 
         # Get active agents by node and format last keep alive date format
         active_agents = Agent.get_agents_overview(filters={'status': 'active', 'node_name': filter_node})['items']
         for agent in active_agents:
-            if (agent_node := agent["node_name"]) in workers_info.keys():
-                workers_info[agent_node]["info"]["n_active_agents"] = \
-                    workers_info[agent_node]["info"].get("n_active_agents", 0) + 1
-        for node_name in workers_info.keys():
-            if workers_info[node_name]["info"].get("n_active_agents") is None:
-                workers_info[node_name]["info"]["n_active_agents"] = 0
-            if workers_info[node_name]['info']['type'] != 'master':
-                workers_info[node_name]['status']['last_keep_alive'] = str(
-                    utils.get_date_from_timestamp(workers_info[node_name]['status']['last_keep_alive']
+            if (agent_node := agent["node_name"]) in nodes_info:
+                nodes_info[agent_node]["info"]["n_active_agents"] = \
+                    nodes_info[agent_node]["info"].get("n_active_agents", 0) + 1
+        for node_name in nodes_info:
+            if nodes_info[node_name]["info"].get("n_active_agents") is None:
+                nodes_info[node_name]["info"]["n_active_agents"] = 0
+            if nodes_info[node_name]['info']['type'] != 'master':
+                nodes_info[node_name]['status']['last_keep_alive'] = str(
+                    utils.get_date_from_timestamp(nodes_info[node_name]['status']['last_keep_alive']
                                                   ).strftime(DECIMALS_DATE_FORMAT))
 
-        return {"n_connected_nodes": n_connected_nodes, "nodes": workers_info}
+        # Get master agents reconnect process information
+        if self.agents_reconnect_enabled:
+            nodes_info["master-node"]["status"] = self.get_health_agents_reconnect()
+
+        return {"n_connected_nodes": n_connected_nodes, "nodes": nodes_info}
 
     def get_node(self) -> Dict:
         """Get basic information about the node.

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -1169,15 +1169,14 @@ class Master(server.AbstractServer):
         return master_status_info
 
     async def cluster_agents_reconnect_controller(self):
-        """Controller task in charge of maintaining agents balance in the cluster.
-        """
+        """Controller task in charge of maintaining agents balance in the cluster."""
         if not self.agents_reconnect_enabled:
             return
 
         logger = self.setup_task_logger("Agents reconnect")
         logger.info("Cluster agents reconnection started.")
 
-        self.agents_reconnect = agents_reconnect.Agents_reconnect(
+        self.agents_reconnect = agents_reconnect.AgentsReconnect(
             logger=logger, blacklisted_nodes={"master"}, nodes=self.clients,
             workers_stability_threshold=self.cluster_items["intervals"]["master"]["areconn_workers_stability_threshold"]
         )
@@ -1193,7 +1192,7 @@ class Master(server.AbstractServer):
                 await asyncio.sleep(self.cluster_items["intervals"]["master"]["areconn_workers_stability_time"])
 
             # Iteration complete. Sleeping phase
-            self.agents_reconnect.current_phase = agents_reconnect.Agents_Reconnection_Phases.balance_sleeping
+            self.agents_reconnect.current_phase = agents_reconnect.AgentsReconnectionPhases.BALANCE_SLEEPING
             logger.info(f"Iteration complete. Sleep during "
                         f"{self.cluster_items['intervals']['master']['areconn_posbalance_time']} seconds.")
             await asyncio.sleep(self.cluster_items["intervals"]["master"]["areconn_posbalance_time"])

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -349,12 +349,3 @@ async def forward_function(func: callable, f_kwargs: dict = None, request_type: 
                           is_async=False, wait_for_complete=True, logger=logger)
     pool = concurrent.futures.ThreadPoolExecutor()
     return pool.submit(run, dapi.distribute_function()).result()
-
-
-def setup_dynamic_logger(logger, subtag: str) -> logging.Logger:
-    """Generate a new logger child by concatenating the tag of the parent and the child into the name."""
-    tag = logger.name.split('.')[-1]
-    logger = logger.getChild(subtag)
-    logger.addFilter(ClusterFilter(tag=tag, subtag=f"{tag} - {subtag}"))
-
-    return logger

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -352,8 +352,7 @@ async def forward_function(func: callable, f_kwargs: dict = None, request_type: 
 
 
 def setup_dynamic_logger(logger, subtag: str) -> logging.Logger:
-    """Generates a new logger child by concatenating the tag of the parent and the child into the name.
-    """
+    """Generate a new logger child by concatenating the tag of the parent and the child into the name."""
     tag = logger.name.split('.')[-1]
     logger = logger.getChild(subtag)
     logger.addFilter(ClusterFilter(tag=tag, subtag=f"{tag} - {subtag}"))

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -349,3 +349,13 @@ async def forward_function(func: callable, f_kwargs: dict = None, request_type: 
                           is_async=False, wait_for_complete=True, logger=logger)
     pool = concurrent.futures.ThreadPoolExecutor()
     return pool.submit(run, dapi.distribute_function()).result()
+
+
+def setup_dynamic_logger(logger, subtag: str) -> logging.Logger:
+    """Generates a new logger child by concatenating the tag of the parent and the child into the name.
+    """
+    tag = logger.name.split('.')[-1]
+    logger = logger.getChild(subtag)
+    logger.addFilter(ClusterFilter(tag=tag, subtag=f"{tag} - {subtag}"))
+
+    return logger


### PR DESCRIPTION
|Related issue|
|---|
|#13796|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR closes #13796. In this PR we have added the mechanism in charge of controlling the stability of the Wazuh cluster. Here we can see the logs of this procedure:

### Cluster log
```
2022/06/20 10:43:24 INFO: [Master] [Agents reconnect] Cluster agents reconnection started.
2022/06/20 10:43:24 INFO: [Master] [Agents reconnect] Sleeping 30s before starting the agent-groups task, waiting for the workers connection.
2022/06/20 10:43:54 INFO: [Master] [Agents reconnect - Check workers stability] Workers are not stable at this moment. Counter: 1/3.
2022/06/20 10:44:04 INFO: [Master] [Agents reconnect - Check workers stability] Workers are not stable at this moment. Counter: 2/3.
2022/06/20 10:44:14 INFO: [Master] [Agents reconnect - Check workers stability] Cluster is ready 3/3. Workers stability phase finished at 2022-06-20T10:44:14.500539Z.
2022/06/20 10:44:14 INFO: [Master] [Agents reconnect] Iteration complete. Sleep during 60 seconds.
2022/06/20 10:45:14 INFO: [Master] [Agents reconnect - Check workers stability] Cluster is ready 3/3. Workers stability phase finished at 2022-06-20T10:45:14.505606Z.
2022/06/20 10:45:14 INFO: [Master] [Agents reconnect] Iteration complete. Sleep during 60 seconds.
```

### CLI
```
root@wazuh-master:/# /var/ossec/bin/cluster_control -i more
Cluster name: wazuh

Connected nodes (2):

    master-node (wazuh-master)
        Version: 4.4.0
        Type: master
        Active agents: 1
        Status:
            Agents reconnect:
                Current phase: Sleeping.
                Last workers stability check: 2022-06-20T10:49:14.518214Z.
                Last register workers: ['worker1', 'worker2'].
                Worker stability counter: 3.
                Worker stability threshold: 3.
```