### PR TITLE
Fix possible NULL dereference in wm_exec.c

### DIFF
--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -80,8 +80,10 @@ int wm_exec(char *command, char **output, int *status, int secs, const char * ad
         }
 
         char *new_env = getenv("PATH");
-        mdebug1("New 'PATH' environment variable set: '%s'", new_env);
-        free(new_path);
+        if (new_env != NULL) {
+            mdebug1("New 'PATH' environment variable set: '%s'", new_env);
+        }
+        os_free(new_path);
     }
 
     sinfo.cb = sizeof(STARTUPINFO);
@@ -348,8 +350,8 @@ int wm_exec(char *command, char **output, int *exitcode, int secs, const char * 
             char *new_env = getenv("PATH");
             if (new_env != NULL) {
                 mdebug1("New 'PATH' environment variable set: '%s'", new_env);
-                free(new_path);
             }
+            os_free(new_path);
         }
 
         argv = w_strtok(command);

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -346,8 +346,10 @@ int wm_exec(char *command, char **output, int *exitcode, int secs, const char * 
             }
 
             char *new_env = getenv("PATH");
-            mdebug1("New 'PATH' environment variable set: '%s'", new_env);
-            free(new_path);
+            if (new_env != NULL) {
+                mdebug1("New 'PATH' environment variable set: '%s'", new_env);
+                free(new_path);
+            }
         }
 
         argv = w_strtok(command);


### PR DESCRIPTION
|Related issue|
|---|
| Closes #13923|

## Description
This PR aims to fix a possible NULL dereference in case `getenv` fails.

https://github.com/wazuh/wazuh/blob/a2158a34e844fdca545abdc5af0d0a477ab6db0c/src/wazuh_modules/wm_exec.c#L347-L350

## Configuration options
No errors are raised 

## Logs/Alerts example
No errors are raised using scan-build 14 after the fix:
```
make[1]: Leaving directory '/home/antoniomanuelfr/vagrant/share/wazuh/src'

Done building agent

scan-build: Analysis run complete.
scan-build: Removing directory '/tmp/scan-build-2022-06-20-153811-44255-1' because it contains no reports.
scan-build: No bugs found.
```
<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
