### PR TITLE
Remove standalone references from API integration tests files

### DIFF
--- a/api/test/integration/README.md
+++ b/api/test/integration/README.md
@@ -56,34 +56,6 @@ finished. The execution of `api_test` is done automatically thanks to the `pytes
 In the `conftest.py` file, we can also find functions used to make the HTML report,
 configure [RBAC](#RBAC-API-integration-tests), etc.
 
-### Environment selection
-
-The Wazuh docker environment will have a different configuration depending on
-the [`pytest` mark](https://docs.pytest.org/en/6.2.x/mark.html) used to run the tests with.
-
-- If the `standalone` mark is specified, a Wazuh environment with **1 manager and 12 agents** will be built (no cluster)
-  .
-
-- If the `cluster` mark is specified, a Wazuh cluster setup with **3 managers and 12 agents** will be built.
-
-- If **no mark** is specified, a Wazuh cluster setup with **3 managers and 12 agents** will be built.
-
-The following table shows how these marks must be used with the `pytest` command and the environment they build:
-
-| Command                          | Environment                                          |  
-|----------------------------------|------------------------------------------------------|
-| `pytest TEST_NAME`               | Wazuh cluster environment                            |  
-| `pytest -m cluster TEST_NAME`    | Wazuh cluster environment                            |
-| `pytest -m standalone TEST_NAME` | Wazuh environment with cluster disabled (standalone) | 
-
-Apart from choosing the environment to be built, the marks are also used to filter the API integration test cases. By
-default, tests without the `standalone` or `cluster` marks, will have both of them implicitly. Test cases with **only
-standalone** can only be passed in a Wazuh environment with cluster disabled and cases with **only cluster** mark can
-only be passed in a Wazuh cluster environment.
-
-Talking about [RBAC API integration tests](#RBAC-API-integration-tests), they don't have any marks, so there is no need
-to specify one when running them. If a mark is specified, no tests will be run due to the filters. In other words,
-**RBAC tests are always going to be performed in the default cluster setup**.
 
 ## RBAC API integration tests
 
@@ -174,8 +146,6 @@ optional arguments:
                         Specify the keyword to filter tests out. Default None.
   -R {both,yes,no}, --rbac {both,yes,no}
                         Specify what to do with RBAC tests. Run everything, only RBAC ones or no RBAC. Default "both".
-  -m {both,standalone,cluster}, --mode {both,standalone,cluster}
-                        Specify where to pass API integration tests. Run tests in both environments, standalone environment or Wazuh cluster environment. Default "both".
   -i ITERATIONS, --iterations ITERATIONS
                         Specify how many times will every test be run. Default 1.
 ```

--- a/api/test/integration/env/base/manager/entrypoint.sh
+++ b/api/test/integration/env/base/manager/entrypoint.sh
@@ -8,14 +8,10 @@ for conf_file in /tmp_volume/configuration_files/*.conf; do
   python3 /tools/xml_parser.py /var/ossec/etc/ossec.conf $conf_file
 done
 
-if [ $4 == "standalone" ]; then
-  sed -i -e "/<cluster>/,/<\/cluster>/ s|<disabled>[a-z]\+</disabled>|<disabled>yes</disabled>|g" /var/ossec/etc/ossec.conf
-else
-  sed -i "s:<key>key</key>:<key>9d273b53510fef702b54a92e9cffc82e</key>:g" /var/ossec/etc/ossec.conf
-  sed -i "s:<node>NODE_IP</node>:<node>$1</node>:g" /var/ossec/etc/ossec.conf
-  sed -i "s:<node_name>node01</node_name>:<node_name>$2</node_name>:g" /var/ossec/etc/ossec.conf
-  sed -i "s:validate_responses=False:validate_responses=True:g" /var/ossec/api/scripts/wazuh-apid.py
-fi
+sed -i "s:<key>key</key>:<key>9d273b53510fef702b54a92e9cffc82e</key>:g" /var/ossec/etc/ossec.conf
+sed -i "s:<node>NODE_IP</node>:<node>$1</node>:g" /var/ossec/etc/ossec.conf
+sed -i "s:<node_name>node01</node_name>:<node_name>$2</node_name>:g" /var/ossec/etc/ossec.conf
+sed -i "s:validate_responses=False:validate_responses=True:g" /var/ossec/api/scripts/wazuh-apid.py
 
 if [ "$3" != "master" ]; then
     sed -i "s:<node_type>master</node_type>:<node_type>worker</node_type>:g" /var/ossec/etc/ossec.conf

--- a/api/test/integration/env/base/manager/manager.Dockerfile
+++ b/api/test/integration/env/base/manager/manager.Dockerfile
@@ -1,9 +1,5 @@
 FROM public.ecr.aws/o5x5t0j3/amd64/api_development:integration_test_wazuh-generic
 
-# ENV_MODE needs to be assigned to an environment variable as it is going to be used at run time (CMD)
-ARG ENV_MODE
-ENV ENV_MODE ${ENV_MODE}
-
 # INSTALL MANAGER
 ARG WAZUH_BRANCH
 
@@ -16,4 +12,4 @@ RUN /wazuh/install.sh
 COPY base/manager/entrypoint.sh /scripts/entrypoint.sh
 
 # HEALTHCHECK
-HEALTHCHECK --retries=900 --interval=1s --timeout=30s --start-period=30s CMD /var/ossec/framework/python/bin/python3 /tmp_volume/healthcheck/healthcheck.py ${ENV_MODE} || exit 1
+HEALTHCHECK --retries=900 --interval=1s --timeout=30s --start-period=30s CMD /var/ossec/framework/python/bin/python3 /tmp_volume/healthcheck/healthcheck.py || exit 1

--- a/api/test/integration/env/base/nginx-lb/entrypoint.sh
+++ b/api/test/integration/env/base/nginx-lb/entrypoint.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
 
-if [ $1 == "standalone" ]; then
-  # Remove workers upstream configurations (in upstream mycluster and upstream register)
-  sed -i -E '/wazuh-worker1|wazuh-worker2/d' /etc/nginx/nginx.conf;
-fi
-
 until service nginx start; do
   echo "nginx couldn´t start - sleeping for 1 second"
   sleep 1

--- a/api/test/integration/env/configurations/base/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/base/manager/healthcheck/healthcheck.py
@@ -5,4 +5,4 @@ from healthcheck_utils import get_manager_health_base
 
 
 if __name__ == "__main__":
-    exit(get_manager_health_base(env_mode=sys.argv[1] if len(sys.argv) > 1 else None))
+    exit(get_manager_health_base())

--- a/api/test/integration/env/configurations/experimental/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/experimental/manager/healthcheck/healthcheck.py
@@ -9,5 +9,4 @@ from healthcheck_utils import get_manager_health_base, check
 if __name__ == "__main__":
     # Workers are not needed in this test, so the exit code is set to 0 (healthy).
     exit(check(os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log"))
-         or get_manager_health_base(
-        env_mode=sys.argv[1] if len(sys.argv) > 1 else None)) if socket.gethostname() == 'wazuh-master' else exit(0)
+         or get_manager_health_base()) if socket.gethostname() == 'wazuh-master' else exit(0)

--- a/api/test/integration/env/configurations/syscheck/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/syscheck/manager/healthcheck/healthcheck.py
@@ -10,5 +10,4 @@ if __name__ == "__main__":
     # Workers are not needed in this test, so the exit code is set to 0 (healthy).
     exit(check(os.system(
         "grep -q 'wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log"))
-         or get_manager_health_base(
-        env_mode=sys.argv[1] if len(sys.argv) > 1 else None)) if socket.gethostname() == 'wazuh-master' else exit(0)
+         or get_manager_health_base()) if socket.gethostname() == 'wazuh-master' else exit(0)

--- a/api/test/integration/env/configurations/syscollector/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/syscollector/manager/healthcheck/healthcheck.py
@@ -10,5 +10,4 @@ if __name__ == "__main__":
     # Workers are not needed in this test, so the exit code is set to 0 (healthy).
     exit(check(os.system(
         "grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log"))
-         or get_manager_health_base(
-        env_mode=sys.argv[1] if len(sys.argv) > 1 else None)) if socket.gethostname() == 'wazuh-master' else exit(0)
+         or get_manager_health_base()) if socket.gethostname() == 'wazuh-master' else exit(0)

--- a/api/test/integration/env/configurations/vulnerability/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/vulnerability/manager/healthcheck/healthcheck.py
@@ -65,7 +65,7 @@ if __name__ == '__main__':
         agents_node = get_healthcheck_state()
 
     # Create a checks list with the manager health base at first
-    checks_list = [get_manager_health_base(env_mode=sys.argv[1] if len(sys.argv) > 1 else None)]
+    checks_list = [get_manager_health_base()]
 
     expected_log = "grep -q 'wazuh-modulesd:vulnerability-detector: INFO: (5471): Finished vulnerability assessment " \
                    "for agent '\\''{}'\\''' /var/ossec/logs/ossec.log"

--- a/api/test/integration/env/docker-compose.yml
+++ b/api/test/integration/env/docker-compose.yml
@@ -2,9 +2,6 @@ version: '3.7'
 
 services:
   wazuh-master:
-    profiles:
-      - standalone
-      - cluster
     build:
       context: .
       dockerfile: base/manager/manager.Dockerfile
@@ -20,11 +17,8 @@ services:
       - wazuh-master
       - master-node
       - master
-      - ${ENV_MODE}
 
   wazuh-worker1:
-    profiles:
-      - cluster
     build:
       context: .
       dockerfile: base/manager/manager.Dockerfile
@@ -40,8 +34,6 @@ services:
       - worker
 
   wazuh-worker2:
-    profiles:
-      - cluster
     build:
       context: .
       dockerfile: base/manager/manager.Dockerfile
@@ -57,9 +49,6 @@ services:
       - worker
 
   wazuh-agent1:
-    profiles:
-      - standalone
-      - cluster
     build:
       context: .
       dockerfile: base/agent/new.Dockerfile
@@ -76,9 +65,6 @@ services:
       - nginx-lb
 
   wazuh-agent2:
-    profiles:
-      - standalone
-      - cluster
     build:
       context: .
       dockerfile: base/agent/new.Dockerfile
@@ -96,9 +82,6 @@ services:
       - nginx-lb
 
   wazuh-agent3:
-    profiles:
-      - standalone
-      - cluster
     build:
       context: .
       dockerfile: base/agent/new.Dockerfile
@@ -116,9 +99,6 @@ services:
       - nginx-lb
 
   wazuh-agent4:
-    profiles:
-      - standalone
-      - cluster
     build:
       context: .
       dockerfile: base/agent/new.Dockerfile
@@ -136,9 +116,6 @@ services:
       - nginx-lb
 
   wazuh-agent5:
-    profiles:
-      - standalone
-      - cluster
     build:
       context: .
       dockerfile: base/agent/old.Dockerfile
@@ -157,9 +134,6 @@ services:
       - nginx-lb
 
   wazuh-agent6:
-    profiles:
-      - standalone
-      - cluster
     build:
       context: .
       dockerfile: base/agent/old.Dockerfile
@@ -178,9 +152,6 @@ services:
       - nginx-lb
 
   wazuh-agent7:
-    profiles:
-      - standalone
-      - cluster
     build:
       context: .
       dockerfile: base/agent/old.Dockerfile
@@ -199,9 +170,6 @@ services:
       - nginx-lb
 
   wazuh-agent8:
-    profiles:
-      - standalone
-      - cluster
     build:
       context: .
       dockerfile: base/agent/old.Dockerfile
@@ -220,12 +188,8 @@ services:
       - nginx-lb
 
   nginx-lb:
-    profiles:
-      - standalone
-      - cluster
     build:
       context: ./base/nginx-lb
     image: integration_test_nginx-lb
     entrypoint:
       - /scripts/entrypoint.sh
-      - ${ENV_MODE}

--- a/api/test/integration/env/tools/healthcheck_utils.py
+++ b/api/test/integration/env/tools/healthcheck_utils.py
@@ -96,20 +96,13 @@ def check(result):
         return 1
 
 
-def get_master_health(env_mode):
+def get_master_health():
     os.system("/var/ossec/bin/agent_control -ls > /tmp_volume/output.txt")
     os.system("/var/ossec/bin/wazuh-control status > /tmp_volume/daemons.txt")
 
     check0 = check(os.system("diff -q /tmp_volume/output.txt /tmp_volume/healthcheck/agent_control_check.txt"))
 
-    if env_mode == "standalone":
-        # If the environment is in standalone mode, the only difference is in the clusterd daemon
-        check1 = check(not
-                       (subprocess.run(['diff', '/tmp_volume/daemons.txt', '/tmp_volume/healthcheck/daemons_check.txt'],
-                                       stdout=subprocess.PIPE).stdout.decode('utf-8')
-                        == CHECK_CLUSTERD_DAEMON))
-    else:
-        check1 = check(os.system("diff -q /tmp_volume/daemons.txt /tmp_volume/healthcheck/daemons_check.txt"))
+    check1 = check(os.system("diff -q /tmp_volume/daemons.txt /tmp_volume/healthcheck/daemons_check.txt"))
 
     check2 = get_api_health()
 
@@ -121,9 +114,8 @@ def get_worker_health():
     return check(os.system("diff -q /tmp_volume/daemons.txt /tmp_volume/healthcheck/daemons_check.txt"))
 
 
-def get_manager_health_base(env_mode):
-    return get_master_health(
-        env_mode=env_mode) if socket.gethostname() == 'wazuh-master' else get_worker_health()
+def get_manager_health_base():
+    return get_master_health() if socket.gethostname() == 'wazuh-master' else get_worker_health()
 
 
 def get_api_health():

--- a/api/test/integration/env/tools/healthcheck_utils.py
+++ b/api/test/integration/env/tools/healthcheck_utils.py
@@ -2,7 +2,6 @@ import json
 import os
 import re
 import socket
-import subprocess
 import time
 
 # Configuration
@@ -19,9 +18,6 @@ LOGIN_URL = f"{BASE_URL}/security/user/authenticate"
 
 HEALTHCHECK_TOKEN_FILE = '/tmp_volume/healthcheck/healthcheck.token'
 OSSEC_LOG_PATH = '/var/ossec/logs/ossec.log'
-
-# Variable used to compare default daemons_check.txt with an output with cluster disabled
-CHECK_CLUSTERD_DAEMON = '1c1\n< wazuh-clusterd not running...\n---\n> wazuh-clusterd is running...\n'
 
 
 def get_login_header(user, password):

--- a/api/test/integration/pytest.ini
+++ b/api/test/integration/pytest.ini
@@ -2,6 +2,3 @@
 render_collapsed = True
 tavern-strict=json:off headers:off
 tavern-global-cfg=common.yaml
-markers =
-    standalone: mark a test to be passed in a Wazuh standalone environment.
-    cluster: mark a test to be passed in a Wazuh cluster environment.

--- a/api/test/integration/run_tests.py
+++ b/api/test/integration/run_tests.py
@@ -6,11 +6,6 @@ import subprocess
 
 PYTEST_COMMAND = 'pytest -vv'
 
-PYTEST_MARK_STANDALONE = '-m standalone'
-PYTEST_MARK_CLUSTER = '-m cluster'
-STANDALONE_SUFFIX = '_standalone'
-CLUSTER_SUFFIX = '_cluster'
-
 RESULTS_FOLDER = '_test_results'
 TESTS_PATH = os.path.dirname(os.path.abspath(__file__))
 
@@ -103,8 +98,6 @@ def collect_non_excluded_tests() -> list:
     done_tests = glob.glob(f'test_*')
     os.chdir(TESTS_PATH)
     collected_tests = sorted([test for test in glob.glob('test_*') if
-                              f"{test.rstrip('.tavern.yaml')}{STANDALONE_SUFFIX}" not in done_tests or
-                              f"{test.rstrip('.tavern.yaml')}{CLUSTER_SUFFIX}" not in done_tests or
                               f"{test.rstrip('.tavern.yaml')}" not in done_tests])
     print(f'Collected tests [{len(collected_tests)}]:')
     print('{}\n\n'.format(", ".join(collected_tests)))
@@ -112,7 +105,7 @@ def collect_non_excluded_tests() -> list:
     return collected_tests
 
 
-def run_tests(collected_tests: list, n_iterations: int = 1, mode: str = 'both'):
+def run_tests(collected_tests: list, n_iterations: int = 1):
     """Run a certain number of iterations of API integration tests.
 
     Parameters
@@ -121,9 +114,6 @@ def run_tests(collected_tests: list, n_iterations: int = 1, mode: str = 'both'):
         Collected API integration tests that are going to be run.
     n_iterations : int
         Number of iterations for the API integration tests to be run.
-    mode : str
-        Indicates the environment where the tests are going to be passed. The possible values are `both`, `standalone`,
-        and `cluster`.
     """
 
     def run_test(test: str, iteration: int, pytest_mark: str = None):
@@ -139,9 +129,7 @@ def run_tests(collected_tests: list, n_iterations: int = 1, mode: str = 'both'):
             Extra mark used to pass the API integration test in a cluster or standalone environment.
         """
         test_name = \
-            f'{test.rsplit(".")[0]}' \
-            f'{STANDALONE_SUFFIX if pytest_mark == PYTEST_MARK_STANDALONE else CLUSTER_SUFFIX if pytest_mark == PYTEST_MARK_CLUSTER else ""}' \
-            f'{iteration if iteration != 1 else ""}'
+            f'{test.rsplit(".")[0]}' f'{iteration if iteration != 1 else ""}'
         html_params = [f"--html={RESULTS_FOLDER}/html_reports/{test_name}.html", '--self-contained-html']
         with open(os.path.join(RESULTS_FOLDER, test_name), 'w') as f:
             command = PYTEST_COMMAND.split(' ') + html_params + [test]
@@ -154,25 +142,8 @@ def run_tests(collected_tests: list, n_iterations: int = 1, mode: str = 'both'):
     for test in collected_tests:
         for i in range(1, n_iterations + 1):
             iteration_info = f'[{i}/{n_iterations}]' if n_iterations > 1 else ''
-            if 'rbac' not in test:
-                if mode == 'standalone':
-                    # Run test with a standalone environment
-                    print(f'{test} - Standalone environment {iteration_info}')
-                    run_test(test=test, iteration=i, pytest_mark=PYTEST_MARK_STANDALONE)
-                elif mode == 'cluster':
-                    # Run test with a cluster environment
-                    print(f'{test} - Cluster environment {iteration_info}')
-                    run_test(test=test, iteration=i, pytest_mark=PYTEST_MARK_CLUSTER)
-                else:  # mode == 'both'
-                    # Run test with both environments
-                    print(f'{test} - Standalone environment {iteration_info}')
-                    run_test(test=test, iteration=i, pytest_mark=PYTEST_MARK_STANDALONE)
-                    print(f'{test} - Cluster environment {iteration_info}')
-                    run_test(test=test, iteration=i, pytest_mark=PYTEST_MARK_CLUSTER)
-            else:
-                # Run test with the default environment
-                print(f'{test} {iteration_info}')
-                run_test(test=test, iteration=i)
+            print(f'{test} {iteration_info}')
+            run_test(test=test, iteration=i)
 
 
 def get_results(filename: str = None):
@@ -187,14 +158,8 @@ def get_results(filename: str = None):
         calculate_result(filename)
     else:
         os.chdir(RESULTS_FOLDER)
-        for file in sorted(glob.glob('test_*_standalone*')):
-            print(f"{file} - Standalone environment")
-            calculate_result(file)
-        for file in sorted(glob.glob('test_*_cluster*')):
-            print(f"{file} - Cluster environment")
-            calculate_result(file)
-        for file in sorted(glob.glob('test_rbac*')):
-            print(file)
+        for file in sorted(glob.glob('test_*')):
+            print(f"{file}")
             calculate_result(file)
 
 
@@ -217,9 +182,6 @@ def get_script_arguments():
     parser.add_argument('-R', '--rbac', dest='rbac', default='both', choices=rbac_choices,
                         help='Specify what to do with RBAC tests. Run everything, only RBAC ones or no RBAC. Default '
                              '"both".', action='store')
-    parser.add_argument('-m', '--mode', dest='mode', default='both', choices=mode_choices,
-                        help='Specify where to pass API integration tests. Run tests in both environments, standalone '
-                             'environment or Wazuh cluster environment. Default "both".', action='store')
     parser.add_argument('-i', '--iterations', dest='iterations', default=1, type=int,
                         help='Specify how many times will every test be run. Default 1.', action='store')
 
@@ -234,11 +196,10 @@ if __name__ == '__main__':
     exclude = options.exclude
     results = options.results
     rbac_arg = options.rbac
-    mode_arg = options.mode
     iterations = options.iterations
 
     if results:
         get_results()
     else:
         tests = collect_non_excluded_tests() if exclude else collect_tests(test_list=tl, keyword=key, rbac=rbac_arg)
-        run_tests(collected_tests=tests, n_iterations=iterations, mode=mode_arg)
+        run_tests(collected_tests=tests, n_iterations=iterations)

--- a/api/test/integration/run_tests.py
+++ b/api/test/integration/run_tests.py
@@ -116,34 +116,17 @@ def run_tests(collected_tests: list, n_iterations: int = 1):
         Number of iterations for the API integration tests to be run.
     """
 
-    def run_test(test: str, iteration: int, pytest_mark: str = None):
-        """Run a single API integration test once.
-
-        Parameters
-        ----------
-        test : str
-            API integration test to be run.
-        iteration : int
-            Number indicating the iteration to be run.
-        pytest_mark : str
-            Extra mark used to pass the API integration test in a cluster or standalone environment.
-        """
-        test_name = \
-            f'{test.rsplit(".")[0]}' f'{iteration if iteration != 1 else ""}'
-        html_params = [f"--html={RESULTS_FOLDER}/html_reports/{test_name}.html", '--self-contained-html']
-        with open(os.path.join(RESULTS_FOLDER, test_name), 'w') as f:
-            command = PYTEST_COMMAND.split(' ') + html_params + [test]
-            if pytest_mark:
-                command += pytest_mark.split(' ')
-            subprocess.call(command, stdout=f)
-        get_results(filename=os.path.join(RESULTS_FOLDER, test_name))
-
     os.chdir(TESTS_PATH)
     for test in collected_tests:
         for i in range(1, n_iterations + 1):
             iteration_info = f'[{i}/{n_iterations}]' if n_iterations > 1 else ''
+            test_name = f'{test.rsplit(".")[0]}{i if i != 1 else ""}'
             print(f'{test} {iteration_info}')
-            run_test(test=test, iteration=i)
+            f = open(os.path.join(RESULTS_FOLDER, test_name), 'w')
+            html_params = [f"--html={RESULTS_FOLDER}/html_reports/{test_name}.html", '--self-contained-html']
+            subprocess.call(PYTEST_COMMAND.split(' ') + html_params + [test], stdout=f)
+            f.close()
+            get_results(filename=os.path.join(RESULTS_FOLDER, test_name))
 
 
 def get_results(filename: str = None):
@@ -159,7 +142,7 @@ def get_results(filename: str = None):
     else:
         os.chdir(RESULTS_FOLDER)
         for file in sorted(glob.glob('test_*')):
-            print(f"{file}")
+            print(file)
             calculate_result(file)
 
 

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -1990,9 +1990,6 @@ stages:
 ---
 test_name: GET /agents/{agent_id}/config/{component}/{configuration} (only cluster configuration)
 
-marks:
-  - cluster
-
 stages:
 
 - name: Request-Com-Cluster (Manager)

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -1,8 +1,6 @@
 ---
 test_name: GET /cluster/local/config
 
-marks:
-  - cluster
 stages:
 
   - name: Get cluster config
@@ -33,9 +31,6 @@ stages:
 
 ---
 test_name: GET /cluster/healthcheck
-
-marks:
-  - cluster
 
 stages:
 
@@ -112,9 +107,6 @@ stages:
 ---
 test_name: GET /cluster/local/info
 
-marks:
-  - cluster
-
 stages:
 
   - name: Get cluster node
@@ -138,9 +130,6 @@ stages:
 
 ---
 test_name: GET /cluster/nodes
-
-marks:
-  - cluster
 
 stages:
 
@@ -396,7 +385,6 @@ stages:
 test_name: GET /cluster/nodes
 
 marks:
-  - cluster
   - parametrize:
       key: node_id
       vals:
@@ -433,7 +421,6 @@ stages:
 test_name: GET /cluster/nodes select
 
 marks:
-  - cluster
   - parametrize:
       key: field
       vals:
@@ -465,9 +452,6 @@ stages:
 ---
 test_name: GET /cluster/status
 
-marks:
-  - cluster
-
 stages:
 
   - name: Get cluster status
@@ -486,9 +470,6 @@ stages:
 
 ---
 test_name: GET /cluster/{node_id}/configuration
-
-marks:
-  - cluster
 
 stages:
 
@@ -720,9 +701,6 @@ stages:
 ---
 test_name: GET /cluster/configuration/validation
 
-marks:
-  - cluster
-
 stages:
 
   - name: Request cluster validation
@@ -843,9 +821,6 @@ stages:
 ---
 test_name: GET /cluster/api/config
 
-marks:
-  - cluster
-
 stages:
 
   # GET /cluster/api/config
@@ -929,9 +904,6 @@ stages:
 
 ---
 test_name: GET /cluster/{node_id}/configuration/{component}/{configuration}
-
-marks:
-  - cluster
 
 stages:
 
@@ -1364,7 +1336,6 @@ stages:
 test_name: GET /cluster/{node_id}/info
 
 marks:
-  - cluster
   - parametrize:
       key: node_id
       vals:
@@ -1403,7 +1374,6 @@ stages:
 test_name: GET /cluster/{node_id}/logs
 
 marks:
-  - cluster
   - parametrize:
       key: node_id
       vals:
@@ -1621,7 +1591,6 @@ stages:
 test_name: GET /cluster/{node_id}/logs/summary
 
 marks:
-  - cluster
   - parametrize:
       key: node_id
       vals:
@@ -1652,7 +1621,6 @@ stages:
 test_name: GET /cluster/{node_id}/stats
 
 marks:
-  - cluster
   - parametrize:
       key: node_id
       vals:
@@ -1700,9 +1668,6 @@ stages:
 ---
 test_name: GET /cluster/wrong_node/stats
 
-marks:
-  - cluster
-
 stages:
 
   - name: Unexisting_node stats
@@ -1729,7 +1694,6 @@ stages:
 test_name: GET /cluster/{node_id}/stats/analysisd
 
 marks:
-  - cluster
   - parametrize:
       key: node_id
       vals:
@@ -1806,7 +1770,6 @@ stages:
 test_name: GET /cluster/{node_id}/stats/hourly
 
 marks:
-  - cluster
   - parametrize:
       key: node_id
       vals:
@@ -1839,7 +1802,6 @@ stages:
 test_name: GET /cluster/{node_id}/stats/remoted
 
 marks:
-  - cluster
   - parametrize:
       key: node_id
       vals:
@@ -1879,7 +1841,6 @@ stages:
 test_name: GET /cluster/{node_id}/stats/weekly
 
 marks:
-  - cluster
   - parametrize:
       key: node_id
       vals:
@@ -1931,7 +1892,6 @@ stages:
 test_name: GET /cluster/{node_id}/status
 
 marks:
-  - cluster
   - parametrize:
       key: node_id
       vals:
@@ -1960,9 +1920,6 @@ stages:
 
 ---
 test_name: PUT /cluster/restart
-
-marks:
-  - cluster
 
 stages:
 
@@ -2011,9 +1968,6 @@ stages:
 
 ---
 test_name: PUT /cluster/{node_id}/configuration
-
-marks:
-  - cluster
 
 stages:
 


### PR DESCRIPTION
|Related issue|
|---|
|closes #13764 |


## Description

This PR removes every reference to the standalone AIT from the code, tools and documentation.

## Tests performed

```
(ait-env) vicferpoy:~/Desktop/Git/wazuh/api/test/integration (feature/13764-remove-standalone-ait)$ python3 run_tests.py -r
test_cluster_endpoints
	 45 passed, 57 warnings

test_manager_endpoints
	 1 failed, 30 passed, 33 warnings

```
> The failing test is not related to this issue.

Regards,
Víctor