### PR TITLE
Adapt min_interval option to parse time suffixes.

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1223,12 +1223,12 @@ static void parse_synchronization(syscheck_config * syscheck, XML_NODE node) {
             }
 #endif
         } else if (strcmp(node[i]->element, xml_min_sync_interval) == 0) {
-            uint32_t interval = strtoul(node[i]->content, NULL, 10);
+            long interval = w_parse_time(node[i]->content);
 
-            if (errno == ERANGE) {
+            if (interval < 0) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
-                syscheck->min_sync_interval = interval;
+                syscheck->min_sync_interval = (uint32_t) interval;
             }
         } else {
             mwarn(XML_INVELEM, node[i]->element);


### PR DESCRIPTION

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR aims to change the way the option `min_interval` is parsed in order to use time suffixes in the same way that the `interval option is parsed.` 
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

```xml
   <synchronization>
      <enabled>yes</enabled>
      <min_interval>20m</min_interval>
      <interval>5m</interval>
      <max_eps>10</max_eps>
    </synchronization>
</syscheck>

```

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example
```
ork timeout to 1.000000 sec.
2022/06/22 06:44:35 wazuh-db: INFO: Started (pid: 10696).
2022/06/22 06:44:36 wazuh-execd: INFO: Started (pid: 10720).
2022/06/22 06:44:36 wazuh-syscheckd: WARNING: Sync min_interval value higher than interval. Some synchronization turns can be skipped.
2022/06/22 06:44:36 rootcheck: INFO: Rootcheck disabled.
2022/06/22 06:44:36 wazuh-syscheckd: INFO: Started (pid: 10740).
2022/06/22 06:44:36 wazuh-syscheckd: INFO: (6003): Monitoring path: '/bin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2022/06/22 06:44:36 wazuh-syscheckd: INFO: (6003): Monito
```
<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [X] Source installation
- [X] Source upgrade