### PR TITLE
Modify Amazon Linux 2 SCA policy to resolve rule and condition on control 1.5.2

### DIFF
--- a/ruleset/sca/amazon/cis_amazon_linux_2.yml
+++ b/ruleset/sca/amazon/cis_amazon_linux_2.yml
@@ -557,9 +557,9 @@ checks:
       - pci_dss: ["2.2.4"]
       - nist_800_53: ["CM.1"]
       - tsc: ["CC5.2"]
-    condition: any
+    condition: all
     rules:
-      - 'c:sh -c "journalctl | grep \"protection: active\"" -> r:protection: active'
+      - 'c:sh -c "journalctl | grep \"protection: \" | tail -1" -> r:protection: active'
       - 'not c:sh -c "[[ -n $(grep noexec[0-9]*=off /proc/cmdline) || -z $(grep -E -i \" (pae|nx) \" /proc/cpuinfo) || -n $(grep \"\\sNX\\s.*\\sprotection:\\s\" /var/log/dmesg | grep -v active) ]] && echo \"NX Protection is not active\"" -> r:^NX Protection is not active$'
 
   # 1.5.3 Ensure address space layout randomization (ASLR) is enabled.


### PR DESCRIPTION
|Related issue|
|---|
| fixes  #13744 |

## Changes and actions.

- [x] Modified condition to all in control 1.5.2
- [x] Modified rule command 

The new condition and rule
```
    condition: all
    rules:
      - 'c:sh -c "journalctl | grep \"protection: \" | tail -1" -> r:protection: active'
      - 'not c:sh -c "[[ -n $(grep noexec[0-9]*=off /proc/cmdline) || -z $(grep -E -i \" (pae|nx) \" /proc/cpuinfo) || -n $(grep \"\\sNX\\s.*\\sprotection:\\s\" /var/log/dmesg | grep -v active) ]] && echo \"NX Protection is not active\"" -> r:^NX Protection is not active$'

```