### PR TITLE
Fixes a segfault at OS_Regex_execute

### DIFF
--- a/ruleset/testing/ruleset/test_osregex_regex_decoders.xml
+++ b/ruleset/testing/ruleset/test_osregex_regex_decoders.xml
@@ -1,3 +1,30 @@
+
+<!--
+  OS_Regex realloc test: Should be the first test in the logtest session
+-->
+<decoder name="osregex_realloc_test">
+    <program_name>osregex_realloc_test</program_name>
+</decoder>
+
+<!-- OS_Regex realloc test: Initialize the regex_dinamic_size -->
+<decoder name="osregex_realloc_test">
+  <parent>osregex_realloc_test</parent>
+  <regex>fieldx=(\w+)</regex>
+  <order>f0</order>
+</decoder>
+
+<!-- OS_Regex realloc test: realloc the regex_dinamic_size -->
+<decoder name="osregex_realloc_test">
+  <parent>osregex_realloc_test</parent>
+  <regex>field_A1=(\w+)|field_A2=(\w+)|field_A3=(\w+)|field_A4=(\w+)|field_A5=(\w+)</regex>
+  <regex>field_A6=(\w+)|field_A7=(\w+)|field_A8=(\w+)|field_A9=(\w+)|field_A10=(\w+)</regex>
+  <regex>field_A11=(\w+)|field_A12=(\w+)|field_A13=(\w+)|field_A14=(\w+)|field_A15=(\w+)</regex>
+  <regex>field_A16=(\w+)|field_A17=(\w+)|field_A18=(\w+)|field_A19=(\w+)|field_A20=(\w+)|</regex>
+  <regex>field1=(\w+) field2=(\w+) field3=(\w+) field4=(\w+) field5=(\w+) field5=(\w+) </regex>
+  <regex>field6=(\w+) field7=(\w+) field8=(\w+) field9=(\w+) field10=(\w+)</regex>
+  <order>f1,f2,f3,f4,f5,f55,f6,f7,f8,f9,f10</order>
+</decoder>
+
 <!-- action tests -->
 <decoder name="test_osregex_3">
   <program_name>^test_osregex_3$</program_name>

--- a/ruleset/testing/ruleset/test_osregex_regex_rules.xml
+++ b/ruleset/testing/ruleset/test_osregex_regex_rules.xml
@@ -219,4 +219,22 @@
     <description>Testing OSREGEX data negation</description>
   </rule>
 
+  <!-- Dec 25 20:45:02 MyHost osregex_realloc_test[12345]: fieldx=0 field1=1 field2=2 field3=3 field4=4 field5=5 field5=5 field6=6 field7=7 field8=8 field9=9 field10=10 -->
+  <rule id="999733" level="3">
+    <decoded_as>osregex_realloc_test</decoded_as>
+    <field name="f0">0</field>
+    <field name="f1">1</field>
+    <field name="f2">2</field>
+    <field name="f3">3</field>
+    <field name="f4">4</field>
+    <field name="f5">5</field>
+    <field name="f55">5</field>
+    <field name="f6">6</field>
+    <field name="f7">7</field>
+    <field name="f8">8</field>
+    <field name="f9">9</field>
+    <field name="f10">10</field>
+    <description>Testing OSREGEX realloc</description>
+  </rule>
+
 </group>

--- a/ruleset/testing/tests/test_osregex_regex.ini
+++ b/ruleset/testing/tests/test_osregex_regex.ini
@@ -1,3 +1,9 @@
+[osregex:test_osregex:realloc]
+log 1 pass = Dec 25 20:45:02 MyHost osregex_realloc_test[12345]: fieldx=0 field1=1 field2=2 field3=3 field4=4 field5=5 field5=5 field6=6 field7=7 field8=8 field9=9 field10=10
+rule = 999733
+alert = 3
+decoder = osregex_realloc_test
+
 [osregex:test_osregex_3:action]
 log 1 pass = Dec 19 17:20:08 ubuntu test_osregex_3[12345]:test_action action_example_1*
 rule = 999706

--- a/src/os_regex/os_regex_execute.c
+++ b/src/os_regex/os_regex_execute.c
@@ -60,20 +60,23 @@ const char *OSRegex_Execute_ex(const char *str, OSRegex *reg, regex_matching *re
     if (external_context && prts_str) {
         if (str_sizes->prts_str_alloc_size < reg->d_size.prts_str_alloc_size) {
             os_realloc(*prts_str, reg->d_size.prts_str_alloc_size, *prts_str);
-            memset((void*)*prts_str + str_sizes->prts_str_alloc_size, 0, reg->d_size.prts_str_alloc_size - str_sizes->prts_str_alloc_size);
-            str_sizes->prts_str_alloc_size = reg->d_size.prts_str_alloc_size;
+            memset((void *) *prts_str + str_sizes->prts_str_alloc_size, 0,
+                   reg->d_size.prts_str_alloc_size - str_sizes->prts_str_alloc_size);
             if (!str_sizes->prts_str_size) {
-                os_calloc(str_sizes->prts_str_alloc_size, sizeof(int), str_sizes->prts_str_size);
+                os_calloc(1, reg->d_size.prts_str_alloc_size, str_sizes->prts_str_size);
             } else {
-                os_realloc(str_sizes->prts_str_size, str_sizes->prts_str_alloc_size * sizeof(int), str_sizes->prts_str_size);
+                os_realloc(str_sizes->prts_str_size, reg->d_size.prts_str_alloc_size, str_sizes->prts_str_size);
+                memset((void *) str_sizes->prts_str_size + str_sizes->prts_str_alloc_size, 0,
+                       reg->d_size.prts_str_alloc_size - str_sizes->prts_str_alloc_size);
             }
+            str_sizes->prts_str_alloc_size = reg->d_size.prts_str_alloc_size;
         }
 
         if (reg->d_size.prts_str_size) {
             // It is a pattern from which to extract substrings
             for (i = 0; reg->d_size.prts_str_size[i]; i++) {
                 if (!str_sizes->prts_str_size[i]) {
-                    os_calloc(reg->d_size.prts_str_size[i], sizeof(char *), (*prts_str)[i]);
+                    os_calloc(1, reg->d_size.prts_str_size[i], (*prts_str)[i]);
                     str_sizes->prts_str_size[i] = reg->d_size.prts_str_size[i];
                 } else if (str_sizes->prts_str_size[i] < reg->d_size.prts_str_size[i]) {
                     os_realloc((*prts_str)[i], reg->d_size.prts_str_size[i], (*prts_str)[i]);

--- a/src/unit_tests/os_regex/CMakeLists.txt
+++ b/src/unit_tests/os_regex/CMakeLists.txt
@@ -22,17 +22,22 @@ target_link_libraries(OS_REGEX_O ${WAZUHLIB} ${WAZUHEXT} -lpthread)
 # Generate os_regex tests
 list(APPEND os_regex_names "test_os_regex")
 list(APPEND os_regex_flags " ")
+list(APPEND os_regex_def " ")
 
 # OS_Regex execute, regex_matching
 list(APPEND os_regex_names "test_os_regex_execute")
 list(APPEND os_regex_flags " ")
+set(JSON_PATH_TEST "${CMAKE_CURRENT_SOURCE_DIR}/test_os_regex_execute.json")
+list(APPEND os_regex_def "JSON_PATH_TEST=\"${JSON_PATH_TEST}\"")
 
 # Compiling tests
 list(LENGTH os_regex_names count)
 math(EXPR count "${count} - 1")
+
 foreach(counter RANGE ${count})
     list(GET os_regex_names ${counter} test_name)
     list(GET os_regex_flags ${counter} test_flags)
+    list(GET os_regex_def ${counter} test_macro)
 
     add_executable(${test_name} ${test_name}.c)
 
@@ -43,6 +48,13 @@ foreach(counter RANGE ${count})
         OS_REGEX_O
         ${TEST_DEPS}
     )
+
+    if(NOT test_macro STREQUAL " ")
+    target_compile_definitions(
+        ${test_name} PRIVATE
+        ${test_macro}
+    )
+    endif()
 
     if(NOT test_flags STREQUAL " ")
         target_link_libraries(

--- a/src/unit_tests/os_regex/CMakeLists.txt
+++ b/src/unit_tests/os_regex/CMakeLists.txt
@@ -23,6 +23,10 @@ target_link_libraries(OS_REGEX_O ${WAZUHLIB} ${WAZUHEXT} -lpthread)
 list(APPEND os_regex_names "test_os_regex")
 list(APPEND os_regex_flags " ")
 
+# OS_Regex execute, regex_matching
+list(APPEND os_regex_names "test_os_regex_execute")
+list(APPEND os_regex_flags " ")
+
 # Compiling tests
 list(LENGTH os_regex_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/os_regex/test_os_regex_execute.c
+++ b/src/unit_tests/os_regex/test_os_regex_execute.c
@@ -248,7 +248,7 @@ void exec_test_case(test_case_parameters * test_case, regex_matching * matching_
 // Load test cases from a JSON file
 cJSON * readFile() {
 
-    const size_t buffer_size = 65535;
+    const size_t buffer_size = 65535*2;
     char * raw_json_file = calloc(buffer_size, sizeof(char));
 
     // Open the file

--- a/src/unit_tests/os_regex/test_os_regex_execute.c
+++ b/src/unit_tests/os_regex/test_os_regex_execute.c
@@ -21,7 +21,7 @@
  */
 struct _result_test
 {
-    unsigned int expected_failed_tests; ///< Expected failed tests count
+    unsigned int expected_failed_tests;       ///< Expected failed tests count
     unsigned int failed_tests_count;          ///< Failed tests count
     unsigned int executed_tests_suite_count;  ///< Executed tests suit count
     unsigned int executed_unit_test_count;    ///< Executed tests suit count
@@ -40,6 +40,34 @@ typedef struct test_case_parameters {
 } test_case_parameters;
 
 typedef test_case_parameters ** batch_test;
+
+static inline void print_os_regex_test_parameters(const test_case_parameters * test)
+{
+    printf("*********************************\n");
+    printf("Test description:\n");
+    printf("\t%s\n", (test->description != NULL) ? test->description : "This unit test has no description.");
+    printf("\n");
+    printf("Is the result ignored? %s\n", (test->ignore_result) ? "yes" : "no");
+    printf("\n");
+    printf("Pattern:\n");
+    printf("\t\"%s\"\n", test->pattern);
+    printf("\n");
+    printf("Log:\n");
+    printf("\t\"%s\"\n", test->log);
+    printf("\n");
+    printf("Expected end matching string:\n");
+    printf("\t\"%s\"\n", (test->end_match != NULL) ? test->end_match : "");
+    printf("\n");
+    printf("Expected capture groups:\n");
+    if(test->captured_groups != NULL)
+    {
+        for(int i = 0; *(test->captured_groups+i) != NULL; i++) {
+            printf("\t\"%s\"\n", *(test->captured_groups+i));
+        }
+    }
+    printf("\n");
+    printf("*********************************\n");
+}
 
 /**
  * @brief Execute a test case for OS_Regex_Execute()*
@@ -63,7 +91,7 @@ void exec_test_case(test_case_parameters * test_case, regex_matching * matching_
         result.failed_tests_count++;
 
         if (!test_case->ignore_result) {
-            // --------- print
+            print_os_regex_test_parameters(test_case);
             if(match_retval != NULL) {
                 printf("Error: regex '%s' should not match '%s' but it does.\n", test_case->pattern, test_case->log);
             } else {
@@ -81,7 +109,7 @@ void exec_test_case(test_case_parameters * test_case, regex_matching * matching_
     // Check if the last character matched is equal to the expected one
     bool strcmp_matched = (strcmp(match_retval, test_case->end_match) == 0);
     if (!test_case->ignore_result) {
-        // ---- Print test case
+        print_os_regex_test_parameters(test_case);
         assert_string_equal(match_retval, test_case->end_match);
     } else if (!strcmp_matched) {
         result.failed_tests_count++;
@@ -99,7 +127,7 @@ void exec_test_case(test_case_parameters * test_case, regex_matching * matching_
             if (!test_case->ignore_result) {
                 // Only print on fail test case
                 // Without this print is really hard to found the buggy line
-                // --------- Print del testcase printf("Fail on test);
+                print_os_regex_test_parameters(test_case);
                 if (expected_str != NULL) {
                     printf("The group: '%s' cannot be found\n", expected_str);
                 } else if (actual_str != NULL) {
@@ -116,7 +144,7 @@ void exec_test_case(test_case_parameters * test_case, regex_matching * matching_
         if (expected_str != NULL) {
             bool strcmp_group_matched = (strcmp(expected_str, actual_str) == 0);
             if (!test_case->ignore_result) {
-                // --------- Print del testcase printf("Fail on test);
+                print_os_regex_test_parameters(test_case);
                 assert_string_equal(expected_str, actual_str);
             } else if (!strcmp_group_matched) {
                 result.failed_tests_count++;

--- a/src/unit_tests/os_regex/test_os_regex_execute.c
+++ b/src/unit_tests/os_regex/test_os_regex_execute.c
@@ -31,15 +31,16 @@ struct _result_test
  * @brief Unit test definition for OS_Regex_Execute()
  */
 typedef struct test_case_parameters {
+    char * description;      ///< Test description
+    bool ignore_result;      ///< Ignore result (for tests with known failures)
     char * pattern;          ///< Regex pattern
     char * log;              ///< Log to match with the pattern
     char * end_match;        ///< Expected end match string (NULL if not matched)
     char ** captured_groups; ///< Expected captured groups (NULL if not captured)
-    char * description;      ///< Test description
-    bool ignore_result;      ///< Ignore result (for tests with known failures)
 } test_case_parameters;
 
 typedef test_case_parameters ** batch_test;
+
 
 static inline void print_os_regex_test_parameters(const test_case_parameters * test)
 {
@@ -109,7 +110,9 @@ void exec_test_case(test_case_parameters * test_case, regex_matching * matching_
     // Check if the last character matched is equal to the expected one
     bool strcmp_matched = (strcmp(match_retval, test_case->end_match) == 0);
     if (!test_case->ignore_result) {
-        print_os_regex_test_parameters(test_case);
+        if (!strcmp_matched) {
+            print_os_regex_test_parameters(test_case);
+        }
         assert_string_equal(match_retval, test_case->end_match);
     } else if (!strcmp_matched) {
         result.failed_tests_count++;
@@ -144,7 +147,9 @@ void exec_test_case(test_case_parameters * test_case, regex_matching * matching_
         if (expected_str != NULL) {
             bool strcmp_group_matched = (strcmp(expected_str, actual_str) == 0);
             if (!test_case->ignore_result) {
-                print_os_regex_test_parameters(test_case);
+                if (!strcmp_group_matched) {
+                    print_os_regex_test_parameters(test_case);
+                }
                 assert_string_equal(expected_str, actual_str);
             } else if (!strcmp_group_matched) {
                 result.failed_tests_count++;

--- a/src/unit_tests/os_regex/test_os_regex_execute.c
+++ b/src/unit_tests/os_regex/test_os_regex_execute.c
@@ -5,20 +5,27 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../../external/cJSON/cJSON.h"
 #include "../../os_regex/os_regex.h"
 #include "../../os_regex/os_regex_internal.h"
 #include "../wrappers/common.h"
+
+#ifndef JSON_PATH_TEST
+#define JSON_PATH_TEST ""
+#endif
 
 // Helpers
 /**
  * @brief Unit test definition for OS_Regex_Execute()
  */
 typedef struct test_case_parameters {
-    const char * pattern;          ///< Regex pattern
-    const char * log;              ///< Log to match with the pattern
-    const char * end_match;        ///< Expected end match string (NULL if not matched)
-    const char ** captured_groups; ///< Expected captured groups (NULL if not captured)
+    char * pattern;          ///< Regex pattern
+    char * log;              ///< Log to match with the pattern
+    char * end_match;        ///< Expected end match string (NULL if not matched)
+    char ** captured_groups; ///< Expected captured groups (NULL if not captured)
 } test_case_parameters;
+
+typedef test_case_parameters ** batch_test;
 
 /**
  * @brief Execute a test case for OS_Regex_Execute()*
@@ -80,62 +87,215 @@ void exec_test_case(test_case_parameters * test_case, regex_matching * matching_
     free(regex);
 }
 
+// Load test cases from a JSON file
+cJSON * readFile() {
+
+    const size_t buffer_size = 65535;
+    char * raw_json_file = calloc(buffer_size, sizeof(char));
+
+    // Open the file
+    FILE * fp = fopen(JSON_PATH_TEST, "r");
+    if (fp == NULL) {
+        printf("Error: cannot open file  '%s'\n", JSON_PATH_TEST);
+    }
+    assert_non_null(fp);
+
+    // Load test suite
+    size_t read_bytes = fread(raw_json_file, sizeof(char), buffer_size, fp);
+    if (read_bytes == 0) {
+        printf("Error: cannot read file  '%s'\n", JSON_PATH_TEST);
+    }
+    fclose(fp);
+    assert_int_not_equal(read_bytes, 0);
+
+    // Parse the file
+    cJSON * json_file = cJSON_Parse(raw_json_file);
+    if (json_file == NULL) {
+        printf("Error: cannot parse file  '%s'\n", JSON_PATH_TEST);
+    }
+    assert_non_null(json_file);
+
+    free(raw_json_file);
+    return json_file;
+}
+
+/**
+ * @brief Load a test case from a JSON object
+ *
+ * JSON oject structure:
+ * {
+ *  "pattern": "regex pattern",
+ *  "log": "log to match with the pattern",
+ *  "end_match": "expected end match string (NULL if not matched)",
+ *  "captured_groups": ["captured group 1", "captured group 2", ...]
+ * }
+ * @param json_test_case JSON object containing the test case
+ * @return Test case definition
+ */
+
+test_case_parameters * load_test_case(cJSON * json_test_case) {
+
+    // create a test_case_parameters
+    test_case_parameters * test_case = calloc(1, sizeof(test_case_parameters));
+    assert_non_null(test_case);
+
+    // pattern
+    cJSON * j_pattern = cJSON_GetObjectItemCaseSensitive(json_test_case, "pattern");
+    assert_non_null(j_pattern);
+    assert_true(cJSON_IsString(j_pattern));
+    test_case->pattern = strdup(cJSON_GetStringValue(j_pattern));
+
+    // log
+    cJSON * j_log = cJSON_GetObjectItemCaseSensitive(json_test_case, "log");
+    assert_non_null(j_log);
+    assert_true(cJSON_IsString(j_log));
+    test_case->log = strdup(cJSON_GetStringValue(j_log));
+
+    // end_match
+    cJSON * j_end_match = cJSON_GetObjectItemCaseSensitive(json_test_case, "end_match");
+    assert_non_null(j_end_match);
+    if (cJSON_IsNull(j_end_match)) {
+        test_case->end_match = NULL;
+    } else {
+        assert_true(cJSON_IsString(j_end_match));
+        test_case->end_match = strdup(cJSON_GetStringValue(j_end_match));
+    }
+
+    // captured_groups
+    cJSON * j_captured_groups = cJSON_GetObjectItemCaseSensitive(json_test_case, "captured_groups");
+    assert_non_null(j_captured_groups);
+    assert_true(cJSON_IsArray(j_captured_groups));
+    int i = 0;
+    do {
+
+        cJSON * j_captured_group = cJSON_GetArrayItem(j_captured_groups, i);
+        if (j_captured_group == NULL) {
+            break;
+        }
+
+        assert_true(cJSON_IsString(j_captured_group));
+        test_case->captured_groups = realloc(test_case->captured_groups, sizeof(char *) * (i + 2));
+
+        test_case->captured_groups[i] = strdup(cJSON_GetStringValue(j_captured_group));
+        test_case->captured_groups[i + 1] = NULL;
+
+    } while (++i);
+
+    return test_case;
+}
+
+/**
+ * @brief Free a test case
+ * @param test_case Test case to free
+ */
+void free_test_case_parameters(test_case_parameters * test_case) {
+
+    free(test_case->pattern);
+    free(test_case->log);
+    if (test_case->end_match != NULL) {
+        free(test_case->end_match);
+    }
+    if (test_case->captured_groups != NULL) {
+        for (int i = 0; test_case->captured_groups[i] != NULL; i++) {
+            free(test_case->captured_groups[i]);
+        }
+        free(test_case->captured_groups);
+    }
+    free(test_case);
+}
+
+/**
+ * @brief Load batch of test from a JSON array
+ *
+ * @param json_batch array of batch test
+ * @return test_case_parameters** batch of test
+ */
+batch_test load_batch_test_case(cJSON * json_batch) {
+
+    batch_test batch = NULL;
+
+    int i = 0; // test index
+    while (TRUE) {
+        batch = realloc(batch, sizeof(test_case_parameters) * (i + 2));
+        batch[i] = NULL;
+        batch[i + 1] = NULL;
+
+        cJSON * json_test_case = cJSON_GetArrayItem(json_batch, i);
+        if (json_test_case == NULL) {
+            break;
+        }
+        assert_true(cJSON_IsObject(json_test_case));
+        batch[i] = load_test_case(json_test_case);
+        assert_non_null(batch[i]);
+        i++;
+    };
+    return batch;
+}
+
+/**
+ * @brief Free a batch of test
+ * @param batch Batch of test to free
+ */
+void free_batch_test_case(batch_test batch) {
+    for (int i = 0; batch[i] != NULL; i++) {
+        free_test_case_parameters(batch[i]);
+    }
+    free(batch);
+}
+
+/**
+ * @brief Execute a batch of test, all batch test shared the same regex_matching structure
+ *
+ * @param batch array of test case
+ */
+void exectute_batch_test(batch_test batch) {
+    regex_matching regex_match = {0};
+    // Execute a batch of test cases
+    for (int case_id = 0; batch[case_id] != NULL; case_id++) {
+        exec_test_case(batch[case_id], &regex_match);
+    }
+    OSRegex_free_regex_matching(&regex_match);
+}
 /*
  * Test definitions
  * Each batch of test, define a group of unit tests. This unit test shared the regex_matching structure.
  * This structure is used to store the results of the match.
- * 
+ *
  * All batch test should be register in the test_suite array;
  */
-
-// Batch 1
-test_case_parameters batchTest_1[] = {
-    // Check X
-    {.pattern = "^(\\d+)-(\\d+)-(\\d+) (\\d+):(\\d+):(\\d\\d)$",
-     .log = "2018-01-01 00:00:00",
-     //.end_match = "0",
-     .end_match = NULL,
-     .captured_groups = (const char *[]){"2018", "01", "01", "00", "00", "00", NULL}},
-    // Check X
-    {.pattern = "^hi (\\w\\w\\w\\w\\w)",
-     .log = "hi wazuh",
-     .end_match = "h",
-     .captured_groups = (const char *[]){"wazuh", NULL}},
-    // Check X
-    {.pattern = "^(\\w+) (\\w+) (\\w+) (\\w+) (\\w+) (\\w+) (\\w+) (\\w+) (\\w+) (\\w+)",
-     .log = "f1 f2 f3 f4 f5 f6 f7 f8 f9 f10",
-     //.end_match = "0",
-     .end_match = NULL,
-     .captured_groups = (const char *[]){"f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10", NULL}},
-    // End of check
-    {0}};
-// Batch 2
-test_case_parameters batchTest_2[] = {
-    // Check X
-    {.pattern = "^hi (\\w+).",
-     .log = "hi wazuh.bye",
-     .end_match = ".bye",
-     .captured_groups = (const char *[]){"wazuh", NULL}},
-    // End of check
-    {0}};
-
-test_case_parameters * test_suite[] = {batchTest_1, batchTest_2, NULL};
 
 void test_regex_execute_regex_matching(void ** state) {
     (void) state;
     unsigned char test = 0;
 
-    regex_matching regex_match = {0};
+    // Load tests suite
+    cJSON * json_file = readFile();
+    assert_true(cJSON_IsArray(json_file));
 
-    for (int batch_id = 0; test_suite[batch_id] != NULL; batch_id++) {
-        memset(&regex_match, 0, sizeof(regex_matching));
-        // Execute a batch of test cases
-        for (int case_id = 0; test_suite[batch_id][case_id].pattern != NULL; case_id++) {
-            exec_test_case(&test_suite[batch_id][case_id], &regex_match);
+    // Load the suite of tests
+    int i = 0;
+    while (TRUE) {
+        // Get test suite
+        cJSON * json_suite = cJSON_GetArrayItem(json_file, i);
+        if (json_suite == NULL) {
+            break;
         }
-        OSRegex_free_regex_matching(&regex_match);
+        assert_true(cJSON_IsObject(json_suite));
+        // Get batch of test
+        cJSON * j_batch = cJSON_GetObjectItemCaseSensitive(json_suite, "batch_test");
+        assert_non_null(j_batch);
+        assert_true(cJSON_IsArray(j_batch));
+
+        batch_test batch = load_batch_test_case(j_batch);
+        assert_non_null(batch);
+
+        // Exceute the batch of test
+        exectute_batch_test(batch);
+        free_batch_test_case(batch);
+        i++;
     }
 
+    cJSON_Delete(json_file);
 }
 
 int main(void) {

--- a/src/unit_tests/os_regex/test_os_regex_execute.c
+++ b/src/unit_tests/os_regex/test_os_regex_execute.c
@@ -1,0 +1,115 @@
+
+#include <setjmp.h>
+#include <stdio.h>
+#include <cmocka.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../os_regex/os_regex.h"
+#include "../../os_regex/os_regex_internal.h"
+#include "../wrappers/common.h"
+
+// Helpers
+/**
+ * @brief Unit test definition for OS_Regex_Execute()
+ */
+typedef struct test_case_parameters {
+    const char * pattern;          ///< Regex pattern
+    const char * log;              ///< Log to match with the pattern
+    const char * end_match;        ///< Expected end match string (NULL if not matched)
+    const char ** captured_groups; ///< Expected captured groups (NULL if not captured)
+} test_case_parameters;
+
+/**
+ * @brief Execute a test case for OS_Regex_Execute()*
+ * @param test_case Test case definition
+ * @param matching_result Pointer to the matching_result structure to fill with the results of the match
+ */
+void exec_test_case(test_case_parameters * test_case, regex_matching * matching_result) {
+
+    // Compile & match
+    OSRegex * regex = calloc(1, sizeof(OSRegex));
+    const char * match_retval = NULL;
+
+    OSRegex_Compile(test_case->pattern, regex, OS_RETURN_SUBSTRING);
+    match_retval = OSRegex_Execute_ex(test_case->log, regex, matching_result);
+
+    // Check results
+    assert_non_null(match_retval); // The regex should match
+
+    // If the end_match field is defined on the test, then it needs to be checked.
+    // Otherwise, it is because there is a know bug and so it make no sense to check it.
+    if (test_case->end_match != NULL) {
+        assert_string_equal(match_retval, test_case->end_match);
+    }
+
+    // Check the captured groups
+    int i = 0;
+    do {
+        const char * exp_str = test_case->captured_groups != NULL ? test_case->captured_groups[i] : NULL;
+        const char * act_str = matching_result->sub_strings[i];
+
+        // All capture groups must be compared, that is, logical XOR
+        int parity = (!(exp_str == NULL) == !(act_str == NULL));
+
+        if (!parity) {
+            // Only print on fail test case
+            // Without this print is really hard to found the buggy line
+            printf("Fail on regex: '%s', with log: '%s'\n", test_case->pattern, test_case->log);
+            if (exp_str != NULL) {
+                printf("The group: '%s' cannot be found\n", exp_str);
+            } else if (act_str != NULL) {
+                printf("The group: '%s' was found, but not compared\n", act_str);
+            }
+        }
+        assert_true(parity);
+
+        // Check the captured groups
+        if (exp_str != NULL) {
+            assert_string_equal(exp_str, act_str);
+        } else {
+            break;
+        }
+    } while (++i, test_case->captured_groups[i]);
+
+    OSRegex_FreePattern(regex);
+    free(regex);
+}
+
+// Tests
+
+void test_regex_execute_regex_matching(void ** state) {
+    (void) state;
+    unsigned char test = 0;
+
+    regex_matching regex_match = {0};
+    memset(&regex_match, 0, sizeof(regex_matching));
+
+    // Create a test case
+    test_case_parameters t1 = {.pattern = "^hi (\\w\\w\\w\\w\\w)",
+                               .log = "hi wazuh",
+                               .end_match = "h",
+                               .captured_groups = (const char *[]){"wazuh", NULL}};
+
+    test_case_parameters t2 = {.pattern = "^(\\w+) (\\w+) (\\w+) (\\w+) (\\w+) (\\w+) (\\w+) (\\w+) (\\w+) (\\w+)",
+                               .log = "f1 f2 f3 f4 f5 f6 f7 f8 f9 f10",
+                               //.end_match = "0", 
+                               .end_match = NULL,
+                               .captured_groups =
+                                   (const char *[]){"f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10", NULL}};
+
+    // Exectute a test case (A group of test cases can be shared the same regex_matching)
+    exec_test_case(&t1, &regex_match);
+    exec_test_case(&t2, &regex_match);
+
+
+    OSRegex_free_regex_matching(&regex_match);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_regex_execute_regex_matching),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/os_regex/test_os_regex_execute.c
+++ b/src/unit_tests/os_regex/test_os_regex_execute.c
@@ -113,6 +113,7 @@ void exec_test_case(test_case_parameters * test_case, regex_matching * matching_
         if (!test_case->ignore_result) {
             assert_false(true);
         }
+        free(regex);
         return;
     }
 

--- a/src/unit_tests/os_regex/test_os_regex_execute.c
+++ b/src/unit_tests/os_regex/test_os_regex_execute.c
@@ -248,15 +248,19 @@ void exec_test_case(test_case_parameters * test_case, regex_matching * matching_
 // Load test cases from a JSON file
 cJSON * readFile() {
 
-    const size_t buffer_size = 65535*2;
-    char * raw_json_file = calloc(buffer_size, sizeof(char));
-
     // Open the file
     FILE * fp = fopen(JSON_PATH_TEST, "r");
     if (fp == NULL) {
         printf("Error: cannot open file  '%s'\n", JSON_PATH_TEST);
     }
     assert_non_null(fp);
+
+    // Calculate the file size for allocation of the buffer
+    assert_int_equal(fseek(fp, 0, SEEK_END), 0);
+    const size_t buffer_size = ftell(fp) + 1;
+    assert_int_equal(fseek(fp, 0, SEEK_SET), 0);
+
+    char * raw_json_file = calloc(buffer_size, sizeof(char));
 
     // Load test suite
     size_t read_bytes = fread(raw_json_file, sizeof(char), buffer_size, fp);

--- a/src/unit_tests/os_regex/test_os_regex_execute.c
+++ b/src/unit_tests/os_regex/test_os_regex_execute.c
@@ -165,7 +165,7 @@ void exec_test_case(test_case_parameters * test_case, regex_matching * matching_
         }
 
         if (print_on_error) {
-            printf("DEBUG (ERROR): the last matched is '%s', but the expected one is '%s'.\n", match_retval,
+            printf("DEBUG (ERROR): the last matched remanent string is '%s', but the expected one is '%s'.\n", match_retval,
                    test_case->end_match);
         }
         // Only stop if the test is not ignored
@@ -473,7 +473,7 @@ void test_regex_execute_regex_matching(void ** state) {
         - Failed tests are added (Increases)
         - Bugs are fixed (Decreases)
     */
-    result.expected_failed_tests = 5; ///< Number of tests that ignore the results and fail.
+    result.expected_failed_tests = 211; ///< Number of tests that ignore the results and fail.
 
     // Load tests suite
     cJSON * json_file = readFile();
@@ -531,7 +531,7 @@ void test_regex_execute_regex_matching(void ** state) {
     //
     printf("[ OS_REGEX ] --------------------------------\n");
 
-    // assert_int_equal(result.expected_failed_tests, result.failed_tests_count);
+    assert_int_equal(result.expected_failed_tests, result.failed_tests_count);
 }
 
 int main(void) {

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -60,7 +60,7 @@
         "batch_test": [
             {
                 "description": "\\w test: Includes all letters, digits, @ and _ characters.",
-                "__knowIssue:": "The pattern was designed this way due to know issue. Workaround for '(\\w+)' pattern",
+                "__knownIssue:": "The pattern was designed this way due to know issue. Workaround for '(\\w+)' pattern",
                 "pattern": "(\\w+\\w)$",
                 "log": "\t\r !\"#$%&()*+,./:;<=>?[\\]^`{|}~0123456789_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
                 "end_match": "z",
@@ -70,7 +70,7 @@
             },
             {
                 "description": "\\d test: Only digits.",
-                "__knowIssue:": "The pattern was designed this way due to know issue. Workaround for '(\\d+)' pattern",
+                "__knownIssue:": "The pattern was designed this way due to know issue. Workaround for '(\\d+)' pattern",
                 "pattern": "(\\d+\\d)$",
                 "log": "\t\r !\"#$%&()*+,./:;<=>?[\\]^`{|}~_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
                 "end_match": "9",
@@ -98,7 +98,7 @@
             },
             {
                 "description": "\\p test: symbols characters '()*+,-.:;<=>?[]!\"'#$%&|{}'.",
-                "__knowIssue:": "The pattern was designed this way due to know issue. Workaround for '(\\p+)' pattern",
+                "__knownIssue:": "The pattern was designed this way due to know issue. Workaround for '(\\p+)' pattern",
                 "pattern": "(\\p+\\p)$",
                 "log": "\r\t /\\^`~_@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789()*+,-.:;<=>?[]!\"'#$%&|{}",
                 "end_match": "}",
@@ -108,7 +108,7 @@
             },
             {
                 "description": "\\W test: Anything not \\w.",
-                "__knowIssue:": "The pattern was designed this way due to know issue. Workaround for '(\\W+)' pattern",
+                "__knownIssue:": "The pattern was designed this way due to know issue. Workaround for '(\\W+)' pattern",
                 "pattern": "(\\W+\\W)$",
                 "log": "0123456789_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz\t\r !\"#$%&()*+,./:;<=>?[\\]^`{|}~",
                 "end_match": "~",
@@ -118,7 +118,7 @@
             },
             {
                 "description": "\\D test: Anything not \\d.",
-                "__knowIssue:": "The pattern was designed this way due to know issue. Workaround for '(\\D+)' pattern",
+                "__knownIssue:": "The pattern was designed this way due to know issue. Workaround for '(\\D+)' pattern",
                 "pattern": "(\\D+\\D)$",
                 "log": "0123456789_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz\t !\"#$%&()*+,./:;<=>?[\\]^`{|}~",
                 "end_match": "~",
@@ -128,7 +128,7 @@
             },
             {
                 "description": "\\S test: Anything not \\s.",
-                "__knowIssue:": "The pattern was designed this way due to know issue. Workaround for '(\\S+)' pattern",
+                "__knownIssue:": "The pattern was designed this way due to know issue. Workaround for '(\\S+)' pattern",
                 "pattern": "(\\S+\\S)$",
                 "log": " \r\t!\"#$%&()*+,./:;<=>?[\\]^`{|}~_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
                 "end_match": "9",
@@ -138,7 +138,7 @@
             },
             {
                 "description": "\\. test: Anything",
-                "__knowIssue:": "The pattern was designed this way due to know issue. Workaround for '(\\S+)' pattern",
+                "__knownIssue:": "The pattern was designed this way due to know issue. Workaround for '(\\S+)' pattern",
                 "pattern": "(\\.+\\.)$",
                 "log": " \r\t!\"#$%&()*+,./:;<=>?[\\]^`{|}~_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
                 "end_match": "9",
@@ -171,7 +171,7 @@
                 "description": "[+]",
                 "pattern": "(\\d+)",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "debug": false,
                 "log": "asd_12_qwe",
                 "end_match": "2_qwe",
@@ -183,7 +183,7 @@
                 "description": "[+]",
                 "pattern": "(\\d+)",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "log": "asd_123_qwe",
                 "end_match": "3_qwe",
                 "captured_groups": [
@@ -216,7 +216,7 @@
                 "skip_test": true,
                 "pattern": "(\\d*)",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "log": "asd_12_qwe",
                 "end_match": "2_qwe",
                 "captured_groups": [
@@ -228,7 +228,7 @@
                 "skip_test": true,
                 "pattern": "(\\d*)",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "log": "asd_123_qwe",
                 "end_match": "3_qwe",
                 "captured_groups": [
@@ -243,7 +243,7 @@
             {
                 "description": "Using the '\\p+' token to test matching all the special characters with capture group. Note: the character '\\' is not captured by the token '\\p'.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "(\\p+)",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -270,7 +270,7 @@
             {
                 "description": "Using the '\\p*' token to test matching all the special characters without capture group. Note: the character '\\' is not captured by the token '\\p'.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are \\p*",
                 "log": "Special characters are $()|<\\",
                 "end_match": "<\\",
@@ -295,7 +295,7 @@
             {
                 "description": "Using the '\\.*' token to test matching the character '\\' with capture group.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "Backslash character is (\\.*)",
                 "log": "Backslash character is \\",
                 "end_match": "\\",
@@ -306,7 +306,7 @@
             {
                 "description": "Using the '\\.*' token to test matching the character '\\' without capture group.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "Backslash character is \\.*",
                 "log": "Backslash character is \\",
                 "end_match": "\\",
@@ -315,7 +315,7 @@
             {
                 "description": "Using the '\\t+' token to test NOT matching all the special characters with capture group.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are (\\t+)",
                 "log": "Special characters are $()|<\\",
                 "end_match": " $()|<\\",
@@ -326,7 +326,7 @@
             {
                 "description": "Using the '\\t+' token to test NOT matching all the special characters without capture group.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are \\t+",
                 "log": "Special characters are $()|<\\",
                 "end_match": " $()|<\\",
@@ -351,7 +351,7 @@
             {
                 "description": "Using the '\\d+' token to test NOT matching all the special characters with capture group.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are (\\d+)",
                 "log": "Special characters are $()|<\\",
                 "end_match": " $()|<\\",
@@ -362,7 +362,7 @@
             {
                 "description": "Using the '\\d+' token to test NOT matching all the special characters without capture group.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are \\d+",
                 "log": "Special characters are $()|<\\",
                 "end_match": " $()|<\\",
@@ -371,7 +371,7 @@
             {
                 "description": "Using the '\\d*' token to test NOT matching all the special characters with capture group.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are (\\d*)",
                 "log": "Special characters are $()|<\\",
                 "end_match": " $()|<\\",
@@ -382,7 +382,7 @@
             {
                 "description": "Using the '\\d*' token to test NOT matching all the special characters without capture group.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are \\d*",
                 "log": "Special characters are $()|<\\",
                 "end_match": " $()|<\\",
@@ -391,7 +391,7 @@
             {
                 "description": "Using the '\\D+' token to test matching all the special characters with capture group.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are (\\D+)",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -402,7 +402,7 @@
             {
                 "description": "Using the '\\D+' token to test matching all the special characters without capture group.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are \\D+",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -411,7 +411,7 @@
             {
                 "description": "Using the '\\D*' token to test matching all the special characters with capture group.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are (\\D*)",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -422,7 +422,7 @@
             {
                 "description": "Using the '\\D*' token to test matching all the special characters without capture group.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are \\D*",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -431,7 +431,7 @@
             {
                 "description": "Using the '\\w+' token to test NOT matching all the special characters with capture group.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are (\\w+)",
                 "log": "Special characters are $()|<\\",
                 "end_match": " $()|<\\",
@@ -442,7 +442,7 @@
             {
                 "description": "Using the '\\w+' token to test NOT matching all the special characters without capture group.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are \\w+",
                 "log": "Special characters are $()|<\\",
                 "end_match": " $()|<\\",
@@ -467,7 +467,7 @@
             {
                 "description": "Using the '\\W+' token to test matching all the special characters with capture group.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are (\\W+)",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -478,7 +478,7 @@
             {
                 "description": "Using the '\\W+' token to test matching all the special characters without capture group.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are \\W+",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -487,7 +487,7 @@
             {
                 "description": "Using the '\\W*' token to test matching all the special characters with capture group.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are (\\W*)",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -498,7 +498,7 @@
             {
                 "description": "Using the '\\W*' token to test matching all the special characters without capture group.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are \\W*",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -507,7 +507,7 @@
             {
                 "description": "Using the '\\S+' token to test matching all the special characters with capture group.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are (\\S+)",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -518,7 +518,7 @@
             {
                 "description": "Using the '\\S+' token to test matching all the special characters without capture group.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are \\S+",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -527,7 +527,7 @@
             {
                 "description": "Using the '\\S*' token to test matching all the special characters with capture group.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are (\\S*)",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -538,7 +538,7 @@
             {
                 "description": "Using the '\\S*' token to test matching all the special characters without capture group.",
                 "ignore_result": true,
-                "__knowIssue": "Link github issue ####",
+                "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are \\S*",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -806,6 +806,515 @@
                 "pattern": "\\d\\d\\d\\d$|(\\d\\d\\d\\d)$",
                 "log": "2020",
                 "end_match": "0",
+                "captured_groups": []
+            }
+        ]
+    },
+    {
+        "description": "[Functionality] Corner cases. This tests have shown that OS Regex is not working as expected.",
+        "batch_test": [
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. Without capture group.",
+                "ignore_result": true,
+                "pattern": "Pattern \\w+ \\d+",
+                "log": "Pattern Wazuh 123",
+                "end_match": "3",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. With capture group.",
+                "ignore_result": true,
+                "pattern": "Pattern (\\w+ \\d+)",
+                "log": "Pattern Wazuh 123",
+                "end_match": "3",
+                "captured_groups": [
+                    "Wazuh 123"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. Without capture group.",
+                "ignore_result": true,
+                "pattern": "^Pattern \\w+ \\d+",
+                "log": "Pattern Wazuh 123",
+                "end_match": "3",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. With capture group.",
+                "ignore_result": true,
+                "pattern": "^Pattern (\\w+ \\d+)",
+                "log": "Pattern Wazuh 123",
+                "end_match": "3",
+                "captured_groups": [
+                    "Wazuh 123"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. Without capture group.",
+                "ignore_result": true,
+                "pattern": "Pattern \\w+ \\d+$",
+                "log": "Pattern Wazuh 123",
+                "end_match": "3",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. With capture group.",
+                "ignore_result": true,
+                "pattern": "Pattern (\\w+ \\d+)$",
+                "log": "Pattern Wazuh 123",
+                "end_match": "3",
+                "captured_groups": [
+                    "Wazuh 123"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1'). Without capture group.",
+                "ignore_result": true,
+                "pattern": "Pattern \\w* \\d*",
+                "log": "Pattern Wazuh 123",
+                "end_match": "3",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1'). With capture group.",
+                "ignore_result": true,
+                "pattern": "Pattern (\\w* \\d*)",
+                "log": "Pattern Wazuh 123",
+                "end_match": "3",
+                "captured_groups": [
+                    "Wazuh 123"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1'). Without capture group.",
+                "ignore_result": true,
+                "pattern": "^Pattern \\w* \\d*",
+                "log": "Pattern Wazuh 123",
+                "end_match": "3",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1'). With capture group.",
+                "ignore_result": true,
+                "pattern": "^Pattern (\\w* \\d*)",
+                "log": "Pattern Wazuh 123",
+                "end_match": "3",
+                "captured_groups": [
+                    "Wazuh 123"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1'). Without capture group.",
+                "ignore_result": true,
+                "pattern": "Pattern \\w* \\d*$",
+                "log": "Pattern Wazuh 123",
+                "end_match": "3",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1'). With capture group.",
+                "ignore_result": true,
+                "pattern": "Pattern (\\w* \\d*)$",
+                "log": "Pattern Wazuh 123",
+                "end_match": "3",
+                "captured_groups": [
+                    "Wazuh 123"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. Without capture group.",
+                "ignore_result": true,
+                "pattern": "Subpattern 1: \\d+|Subpattern 2: \\d+",
+                "log": "Subpattern 2: 123",
+                "end_match": "3",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. With capture group.",
+                "ignore_result": true,
+                "pattern": "Subpattern 1: (\\d+)|Subpattern 2: (\\d+)",
+                "log": "Subpattern 2: 123",
+                "end_match": "3",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3'). Without capture group.",
+                "ignore_result": true,
+                "pattern": "\\d+",
+                "log": "123subpattern",
+                "end_match": "3subpattern",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. Without capture group.",
+                "ignore_result": true,
+                "pattern": "\\d+",
+                "log": "123",
+                "end_match": "3",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. With capture group.",
+                "ignore_result": true,
+                "pattern": "(\\d+)",
+                "log": "123subpattern",
+                "end_match": "3subpattern",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3'). Without capture group.",
+                "ignore_result": true,
+                "pattern": "\\d*",
+                "log": "123subpattern",
+                "end_match": "3subpattern",
+                "captured_groups": []
+            },
+            {
+                "description": "With capture group the case works well.",
+                "pattern": "(\\d*)",
+                "log": "123subpattern",
+                "end_match": "3subpattern",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. Without capture group.",
+                "ignore_result": true,
+                "pattern": "^\\d+",
+                "log": "123",
+                "end_match": "3",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. With capture group.",
+                "ignore_result": true,
+                "pattern": "^(\\d+)",
+                "log": "123",
+                "end_match": "3",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. Without capture group.",
+                "ignore_result": true,
+                "pattern": "^\\d*",
+                "log": "123",
+                "end_match": "3",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. With capture group.",
+                "ignore_result": true,
+                "pattern": "^(\\d*)",
+                "log": "123",
+                "end_match": "3",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3'). Without capture group.",
+                "ignore_result": true,
+                "pattern": "^\\d+",
+                "log": "123subpattern",
+                "end_match": "3subpattern",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. With capture group.",
+                "ignore_result": true,
+                "pattern": "^(\\d+)",
+                "log": "123subpattern",
+                "end_match": "3subpattern",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3'). Without capture group.",
+                "ignore_result": true,
+                "pattern": "^\\d*",
+                "log": "123subpattern",
+                "end_match": "3subpattern",
+                "captured_groups": []
+            },
+            {
+                "description": "With capture group the case works well.",
+                "pattern": "^(\\d*)",
+                "log": "123subpattern",
+                "end_match": "3subpattern",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. Without capture group.",
+                "ignore_result": true,
+                "pattern": "\\d+$",
+                "log": "123",
+                "end_match": "3",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. With capture group.",
+                "ignore_result": true,
+                "pattern": "(\\d+)$",
+                "log": "123",
+                "end_match": "3",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. Without capture group.",
+                "ignore_result": true,
+                "pattern": "\\d*$",
+                "log": "123",
+                "end_match": "3",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. With capture group.",
+                "ignore_result": true,
+                "pattern": "(\\d*)$",
+                "log": "123",
+                "end_match": "3",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. Without capture group.",
+                "ignore_result": true,
+                "pattern": "\\d+$",
+                "log": "log123",
+                "end_match": "3",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. With capture group.",
+                "ignore_result": true,
+                "pattern": "(\\d+)$",
+                "log": "log123",
+                "end_match": "3",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "It should match but it doesn't.",
+                "ignore_result": true,
+                "pattern": "\\d*$",
+                "log": "log123",
+                "end_match": "3",
+                "captured_groups": []
+            },
+            {
+                "description": "It should match but it doesn't.",
+                "ignore_result": true,
+                "pattern": "(\\d*)$",
+                "log": "log123",
+                "end_match": "3",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "Consecutive capture groups (without something in between) do not match.",
+                "ignore_result": true,
+                "pattern": "(\\D+)(\\d+)",
+                "log": "Test123",
+                "end_match": "3",
+                "captured_groups": [
+                    "Test", "123"
+                ]
+            },
+            {
+                "description": "Consecutive capture groups (without something in between) do not match.",
+                "ignore_result": true,
+                "pattern": "(\\d+)(\\D+)",
+                "log": "123Test",
+                "end_match": "t",
+                "captured_groups": [
+                    "123", "Test"
+                ]
+            },
+            {
+                "description": "Consecutive capture groups (without something in between) do not match.",
+                "ignore_result": true,
+                "pattern": "(\\D*)(\\d*)",
+                "log": "Test123",
+                "end_match": "3",
+                "captured_groups": [
+                    "Test", "123"
+                ]
+            },
+            {
+                "description": "Consecutive capture groups (without something in between) do not match.",
+                "ignore_result": true,
+                "pattern": "(\\d*)(\\D*)",
+                "log": "123Test",
+                "end_match": "t",
+                "captured_groups": [
+                    "123", "Test"
+                ]
+            },
+            {
+                "description": "Consecutive capture groups (without something in between) do not match. The same regex without capture group does match.",
+                "__knownIssue:": "In this case, the returned value is pointing to the '1' when it should be pointing to '3'.",
+                "ignore_result": true,
+                "pattern": "\\D+\\d+",
+                "log": "Test123",
+                "end_match": "3",
+                "captured_groups": []
+            },
+            {
+                "description": "Consecutive capture groups (without something in between) do not match. The same regex without capture group does match.",
+                "__knownIssue:": "In this case, the returned value is pointing to 'T' when it should be pointing to 't'.",
+                "ignore_result": true,
+                "pattern": "\\d+\\D+",
+                "log": "1234Test",
+                "end_match": "t",
+                "captured_groups": []
+            },
+            {
+                "description": "Consecutive capture groups (without something in between) do not match.",
+                "__knownIssue:": "In this case, the returned value is pointing to the 't' when it should be pointing to '3'.",
+                "ignore_result": true,
+                "pattern": "\\D*\\d*",
+                "log": "Test123",
+                "end_match": "3",
+                "captured_groups": []
+            },
+            {
+                "description": "Consecutive capture groups (without something in between) do not match.",
+                "__knownIssue:": "In this case, the returned value is pointing to the '3' when it should be pointing to 't'.",
+                "ignore_result": true,
+                "pattern": "\\d*\\D*",
+                "log": "123Test",
+                "end_match": "t",
+                "captured_groups": []
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "When there are 4 more optional tokens than characters to match, the regex doesn't match.",
+                "ignore_result": true,
+                "pattern": "\\w*\\w*\\w*\\w*\\w*\\w*",
+                "log": "xy",
+                "end_match": "y",
+                "captured_groups": []
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "In this case, with 4 extra optional tokens inside a capture group, it does match.",
+                "pattern": "(\\w*\\w*\\d*\\w*\\d*\\w*)",
+                "log": "xy",
+                "end_match": "y",
+                "captured_groups": [
+                    "xy"
+                ]
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "In this case, with 10 extra optional tokens inside a capture group, it does match.",
+                "pattern": "(\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*)",
+                "log": "xy",
+                "end_match": "y",
+                "captured_groups": [
+                    "xy"
+                ]
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "In this case, with only 3 extra optional tokens, it does match. TODO",
+                "ignore_result": true,
+                "pattern": "\\p*\\w*\\d*\\w*\\d*\\w*",
+                "log": "xy",
+                "end_match": "y",
+                "captured_groups": []
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "In this case, with only 3 extra optional tokens, it does match.",
+                "pattern": "\\w*\\w*\\w*\\w*\\w*",
+                "log": "xy",
+                "end_match": "y",
+                "captured_groups": []
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "In this case there are 2 exceding optional tokens, the regex doesn't match.",
+                "ignore_result": true,
+                "pattern": "xyz\\d*\\w*",
+                "log": "xyz",
+                "end_match": "z",
+                "captured_groups": []
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "In this case there are 2 exceding optional tokens inside a capture groupe, the regex doesn't match.",
+                "ignore_result": true,
+                "pattern": "xyz(\\d*\\w*)",
+                "log": "xyz",
+                "end_match": "z",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "In this case there is 1 exceding optional token inside a capture groupe, the regex does match but the expected group is not captured.",
+                "ignore_result": true,
+                "pattern": "xyz(\\w*)",
+                "log": "xyz",
+                "end_match": "z",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "In this case there are 2 exceding optional tokens inside a capture groupe, the regex doesn't match.",
+                "pattern": "xyz(\\w*)",
+                "log": "xyz ",
+                "end_match": "z ",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "In this case there are 2 exceding optional tokens inside a capture groupe, the regex doesn't match.",
+                "ignore_result": true,
+                "pattern": "xyz\\w*(\\w*)",
+                "log": "xyz",
+                "end_match": "z",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "In this case the regex does match.",
+                "pattern": "(xyz\\w*\\w*)",
+                "log": "xyz",
+                "end_match": "z",
+                "captured_groups": [
+                    "xyz"
+                ]
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "In this case the regex does match.",
+                "pattern": "\\d+\\w*\\w*",
+                "log": "123",
+                "end_match": "3",
                 "captured_groups": []
             }
         ]

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -275,5 +275,168 @@
                 "captured_groups": []
             }
         ]
+    },
+    {
+        "description": "[Functionality] Special characters. '^'",
+        "batch_test": [
+            {
+                "description": "'^' test: Start of string without digits. Dont match",
+                "pattern": "^(\\d+)",
+                "log": "hi digits",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "'^' test: Match without special caracter",
+                "pattern": "\\d+^\\d\\d\\d",
+                "ignore_result": false,
+                "log": "123^456",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "'^' test: Start of string.",
+                "ignore_result": true,
+                "pattern": "^(\\d+)",
+                "log": "1234",
+                "end_match": "4",
+                "captured_groups": []
+            },
+            {
+                "description": "'^' test: Start of string.",
+                "ignore_result": true,
+                "pattern": "^(\\d+)",
+                "log": "1234",
+                "end_match": "4",
+                "captured_groups": ["1234"]
+            },
+            {
+                "description": "'^' test: Start of string.",
+                "ignore_result": true,
+                "pattern": "^\\d+",
+                "log": "1234",
+                "end_match": "4",
+                "captured_groups": []
+            },
+            {
+                "description": "'^' test: Start of string.",
+                "ignore_result": true,
+                "pattern": "^\\d+",
+                "log": "1234",
+                "end_match": "4",
+                "captured_groups": []
+            },
+            {
+                "description": "'^' test: Start of string.",
+                "ignore_result": true,
+                "pattern": "^(\\d+)",
+                "log": "1234asd",
+                "end_match": "4asd",
+                "captured_groups": []
+            },
+            {
+                "description": "'^' test: Start of string.",
+                "ignore_result": true,
+                "pattern": "^(\\d+)",
+                "log": "1234asd",
+                "end_match": "4asd",
+                "captured_groups": ["1234"]
+            },
+            {
+                "description": "'^' test: Start of string.",
+                "ignore_result": true,
+                "pattern": "^\\d+",
+                "log": "1234asd",
+                "end_match": "4",
+                "captured_groups": []
+            },
+            {
+                "description": "'^' test: Start of string.",
+                "ignore_result": true,
+                "pattern": "^\\d+",
+                "log": "1234asd",
+                "end_match": "4",
+                "captured_groups": []
+            }
+        ]
+    },
+    {
+        "description": "[Functionality] Special characters. '$'",
+        "batch_test": [
+            {
+                "description": "'$' test: End of string. Without digits. Dont match",
+                "pattern": "(\\d+)$",
+                "log": "hi digits",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "'$' test: Match without special caracter",
+                "pattern": "\\d+$\\d\\d\\d",
+                "log": "123$456",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "'$' test: end of string.",
+                "pattern": "(\\d\\d\\d\\d)$",
+                "log": "1234",
+                "end_match": "4",
+                "captured_groups": ["1234"]
+            },
+            {
+                "description": "'$' test: Start of string.",
+                "pattern": "(\\d\\d)$",
+                "log": "1234",
+                "end_match": "4",
+                "captured_groups": ["34"]
+            },
+            {
+                "description": "'^' test: Start of string.",
+                "pattern": "\\d\\d\\d\\d$",
+                "log": "1234",
+                "end_match": "4",
+                "captured_groups": []
+            },
+            {
+                "description": "'^' test: Start of string.",
+                "ignore_result": true,
+                "pattern": "^\\d+",
+                "log": "1234",
+                "end_match": "4",
+                "captured_groups": []
+            },
+            {
+                "description": "'^' test: Start of string.",
+                "ignore_result": true,
+                "pattern": "^(\\d+)",
+                "log": "1234asd",
+                "end_match": "4asd",
+                "captured_groups": []
+            },
+            {
+                "description": "'^' test: Start of string.",
+                "ignore_result": true,
+                "pattern": "^(\\d+)",
+                "log": "1234asd",
+                "end_match": "4asd",
+                "captured_groups": ["1234"]
+            },
+            {
+                "description": "'$' test: End of string.",
+                "pattern": "\\D\\D$",
+                "log": "1234asd",
+                "end_match": "d",
+                "captured_groups": []
+            },
+            {
+                "description": "'$' test: End of string.",
+                "ignore_result": true,
+                "pattern": "\\D\\D$",
+                "log": "1234asd",
+                "end_match": "d",
+                "captured_groups": []
+            }
+        ]
     }
   ]

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -137,12 +137,13 @@
             },
             {
                 "description": "[*] It should not match since there are no characters of the type `\\d`.",
-                "pattern": "(\\d*)",
+                "__toDo": "Remove initial spaces at pattern and log after fixing this case",
+                "pattern": " (\\d*)",
                 "debug": true,
                 "ignore_result": true,
-                "log": "asd_ _qwe",
-                "end_match": " ",
-                "captured_groups": []
+                "log": " asd_ _qwe",
+                "end_match": " asd_ _qwe",
+                "captured_groups": [ "" ]
             }
         ]
     }

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -178,5 +178,102 @@
                 ]
             }
         ]
+    },
+    {
+        "description": "[Functionality] Special characters escaping (\\$ \\( \\) \\\\ \\| \\<)",
+        "batch_test": [
+            {
+                "description": "Using the '\\p+' token to test matching all the special characters with capture group. Note: the character '\\' is not captured by the token '\\p'.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "pattern": "(\\p+)",
+                "log": "Special characters are $()|<\\",
+                "end_match": "\\",
+                "captured_groups": [ "$()|<" ]
+            },
+            {
+                "description": "Using the '\\p+' token to test matching all the special characters without capture group. Note: the character '\\' is not captured by the token '\\p'.",
+                "pattern": "\\p+",
+                "log": "Special characters are $()|<\\",
+                "end_match": "\\",
+                "captured_groups": []
+            },
+            {
+                "description": "Using the '\\p*' token to test matching all the special characters with capture group. Note: the character '\\' is not captured by the token '\\p'.",
+                "pattern": "Special characters are (\\p*)",
+                "log": "Special characters are $()|<\\",
+                "end_match": "<\\",
+                "captured_groups": [ "$()|<" ]
+            },
+            {
+                "description": "Using the '\\p*' token to test matching all the special characters without capture group. Note: the character '\\' is not captured by the token '\\p'.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "pattern": "Special characters are \\p*",
+                "log": "Special characters are $()|<\\",
+                "end_match": "<\\",
+                "captured_groups": []
+            },
+            {
+                "description": "Using the '\\.+' token to test matching the character '\\' with capture group.",
+                "pattern": "Backslash character is (\\.+)",
+                "log": "Backslash character is \\",
+                "end_match": "\\",
+                "captured_groups": [ "\\" ]
+            },
+            {
+                "description": "Using the '\\.+' token to test matching the character '\\' without capture group.",
+                "pattern": "Backslash character is \\.+",
+                "log": "Backslash character is \\",
+                "end_match": "\\",
+                "captured_groups": []
+            },
+            {
+                "description": "Using the '\\.*' token to test matching the character '\\' with capture group.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "pattern": "Backslash character is (\\.*)",
+                "log": "Backslash character is \\",
+                "end_match": "\\",
+                "captured_groups": [ "\\" ]
+            },
+            {
+                "description": "Using the '\\.*' token to test matching the character '\\' without capture group.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "pattern": "Backslash character is \\.*",
+                "log": "Backslash character is \\",
+                "end_match": "\\",
+                "captured_groups": []
+            },
+            {
+                "description": "Using the '\\d*' token to test NOT matching all the special characters with capture group.",
+                "pattern": "Special characters are (\\d*)",
+                "log": "Special characters are $()|<\\",
+                "end_match": " $()|<\\",
+                "captured_groups": [ "" ]
+            },
+            {
+                "description": "Using the '\\d*' token to test NOT matching all the special characters without capture group.",
+                "pattern": "Special characters are \\d*",
+                "log": "Special characters are $()|<\\",
+                "end_match": " $()|<\\",
+                "captured_groups": []
+            },
+            {
+                "description": "Using the '\\w*' token to test NOT matching all the special characters with capture group.",
+                "pattern": "Special characters are (\\w*)",
+                "log": "Special characters are $()|<\\",
+                "end_match": " $()|<\\",
+                "captured_groups": [ "" ]
+            },
+            {
+                "description": "Using the '\\w*' token to test NOT matching all the special characters without capture group.",
+                "pattern": "Special characters are \\w*",
+                "log": "Special characters are $()|<\\",
+                "end_match": " $()|<\\",
+                "captured_groups": []
+            }
+        ]
     }
   ]

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -1,5 +1,47 @@
 [
     {
+        "description": "[Memory test] regex_matching alloc test: copy reg size.",
+        "batch_test": [
+            {
+                "description": "Create 20 patterns, 22 capture groups and match last.",
+                "__sub_string_size": "((36 gruopos x 2 know bug) + 1 null)  x 8 size = 584 bytes",
+                "__prts_main_array": " (20 pattern + 1 null)  x 8 size = 168 bytes",
+                "__prts_items_array": "size of array d_size->prts_str_size == size of array prts_str == prts_str_alloc_size = 168",
+                "__prts_items_array_1": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_2": "(4 group x2 + 1 null)  x 8 size = 72 bytes",
+                "__prts_items_array_3": "(5 group x2 + 1 null)  x 8 size = 88 bytes",
+                "__prts_items_array_4": "(6 group x2 + 1 null)  x 8 size = 104 bytes",
+                "__prts_items_array_5": "(7 group x2 + 1 null)  x 8 size = 120 bytes",
+                "__prts_items_array_6": "(8 group x2 + 1 null)  x 8 size = 136 bytes",
+                "__prts_items_array_7": "(9 group x2 + 1 null)  x 8 size = 152 bytes",
+                "__prts_items_array_8": "(10 group x2 + 1 null)  x 8 size = 168 bytes",
+                "__prts_items_array_9": "(11 group x2 + 1 null)  x 8 size = 184 bytes",
+                "__prts_items_array_10": "(12 group x2 + 1 null)  x 8 size = 200 bytes",
+                "__prts_items_array_11": "(13 group x2 + 1 null)  x 8 size = 216 bytes",
+                "__prts_items_array_12": "(14 group x2 + 1 null)  x 8 size = 232 bytes",
+                "__prts_items_array_13": "(15 group x2 + 1 null)  x 8 size = 248 bytes",
+                "__prts_items_array_14": "(16 group x2 + 1 null)  x 8 size = 264 bytes",
+                "__prts_items_array_15": "(17 group x2 + 1 null)  x 8 size = 280 bytes",
+                "__prts_items_array_16": "(18 group x2 + 1 null)  x 8 size = 296 bytes",
+                "__prts_items_array_17": "(19 group x2 + 1 null)  x 8 size = 312 bytes",
+                "__prts_items_array_18": "(20 group x2 + 1 null)  x 8 size = 328 bytes",
+                "__prts_items_array_19": "(21 group x2 + 1 null)  x 8 size = 344 bytes",
+                "__prts_items_array_20": "(36 group x2 + 1 null)  x 8 size = 584 bytes",
+                "__prts_items_array_21": "0x0",
+                "pattern": "^01cg field_01=(\\d+)|^04cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+)|^05cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+)|^06cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+)|^07cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+)|^08cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+)|^09cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+)|^10cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+)|^11cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+)|^12cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+) field_12=(\\d+)|^13cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+) field_12=(\\d+) field_13=(\\d+)|^14cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+) field_12=(\\d+) field_13=(\\d+) field_14=(\\d+)|^15cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+) field_12=(\\d+) field_13=(\\d+) field_14=(\\d+) field_15=(\\d+)|^16cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+) field_12=(\\d+) field_13=(\\d+) field_14=(\\d+) field_15=(\\d+) field_16=(\\d+)|^17cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+) field_12=(\\d+) field_13=(\\d+) field_14=(\\d+) field_15=(\\d+) field_16=(\\d+) field_17=(\\d+)|^18cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+) field_12=(\\d+) field_13=(\\d+) field_14=(\\d+) field_15=(\\d+) field_16=(\\d+) field_17=(\\d+) field_18=(\\d+)|^19cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+) field_12=(\\d+) field_13=(\\d+) field_14=(\\d+) field_15=(\\d+) field_16=(\\d+) field_17=(\\d+) field_18=(\\d+) field_19=(\\d+)|^20cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+) field_12=(\\d+) field_13=(\\d+) field_14=(\\d+) field_15=(\\d+) field_16=(\\d+) field_17=(\\d+) field_18=(\\d+) field_19=(\\d+) field_20=(\\d+)|^21cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+) field_12=(\\d+) field_13=(\\d+) field_14=(\\d+) field_15=(\\d+) field_16=(\\d+) field_17=(\\d+) field_18=(\\d+) field_19=(\\d+) field_20=(\\d+) field_21=(\\d+)|^36cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+) field_12=(\\d+) field_13=(\\d+) field_14=(\\d+) field_15=(\\d+) field_16=(\\d+) field_17=(\\d+) field_18=(\\d+) field_19=(\\d+) field_20=(\\d+) field_21=(\\d+) field_22=(\\d+) field_23=(\\d+) field_24=(\\d+) field_25=(\\d+) field_26=(\\d+) field_27=(\\d+) field_28=(\\d+) field_29=(\\d+) field_30=(\\d+) field_31=(\\d+) field_32=(\\d+) field_33=(\\d+) field_34=(\\d+) field_35=(\\d+) field_36=(\\d\\d\\d)",
+                "log": "36cg field_01=001 field_02=002 field_03=003 field_04=004 field_05=005 field_06=006 field_07=007 field_08=008 field_09=009 field_10=010 field_11=011 field_12=012 field_13=013 field_14=014 field_15=015 field_16=016 field_17=017 field_18=018 field_19=019 field_20=020 field_21=021 field_22=022 field_23=023 field_24=024 field_25=025 field_26=026 field_27=027 field_28=028 field_29=029 field_30=030 field_31=031 field_32=032 field_33=033 field_34=034 field_35=035 field_36=036",
+                "end_match": "6",
+                "captured_groups": [
+                    "001", "002","003","004","005","006","007","008",
+                    "009", "010","011","012","013","014","015","016",
+                    "017", "018","019","020","021","022","023","024",
+                    "025", "026","027","028","029","030","031","032",
+                    "033", "034","035","036"
+                ]
+            }
+        ]
+    },
+    {
         "description": "[Memory test] regex_matching expand test: Incremental capture groups and match last.",
         "batch_test": [
             {
@@ -17,7 +59,133 @@
                 ]
             },
             {
-                "description": "Resize x 20 patterns, 22 incremental capture groups and match last.",
+                "description": "Resize x 36 incremental capture groups and match.",
+                "__sub_string_size": "((36 gruopos x 2 know bug) + 1 null)  x 8 size = 584 bytes",
+                "__prts_main_array": " (1 pattern + 1 null)  x 8 size = 16 bytes",
+                "__prts_items_array": "size of array d_size->prts_str_size == size of array prts_str == prts_str_alloc_size = 16",
+                "__prts_items_array_1": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_2": "(4 group x2 + 1 null)  x 8 size = 72 bytes",
+                "__prts_items_array_3": "(5 group x2 + 1 null)  x 8 size = 88 bytes",
+                "__prts_items_array_4": "(6 group x2 + 1 null)  x 8 size = 104 bytes",
+                "__prts_items_array_5": "(7 group x2 + 1 null)  x 8 size = 120 bytes",
+                "__prts_items_array_6": "(8 group x2 + 1 null)  x 8 size = 136 bytes",
+                "__prts_items_array_7": "(9 group x2 + 1 null)  x 8 size = 152 bytes",
+                "__prts_items_array_8": "(10 group x2 + 1 null)  x 8 size = 168 bytes",
+                "__prts_items_array_9": "(11 group x2 + 1 null)  x 8 size = 184 bytes",
+                "__prts_items_array_10": "(12 group x2 + 1 null)  x 8 size = 200 bytes",
+                "__prts_items_array_11": "(13 group x2 + 1 null)  x 8 size = 216 bytes",
+                "__prts_items_array_12": "(14 group x2 + 1 null)  x 8 size = 232 bytes",
+                "__prts_items_array_13": "(15 group x2 + 1 null)  x 8 size = 248 bytes",
+                "__prts_items_array_14": "(16 group x2 + 1 null)  x 8 size = 264 bytes",
+                "__prts_items_array_15": "(17 group x2 + 1 null)  x 8 size = 280 bytes",
+                "__prts_items_array_16": "(18 group x2 + 1 null)  x 8 size = 296 bytes",
+                "__prts_items_array_17": "(19 group x2 + 1 null)  x 8 size = 312 bytes",
+                "__prts_items_array_18": "(20 group x2 + 1 null)  x 8 size = 328 bytes",
+                "__prts_items_array_19": "(21 group x2 + 1 null)  x 8 size = 344 bytes",
+                "__prts_items_array_20": "(36 group x2 + 1 null)  x 8 size = 584 bytes",
+                "__prts_items_array_21": "0x0",
+                "pattern": "^36cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+) field_12=(\\d+) field_13=(\\d+) field_14=(\\d+) field_15=(\\d+) field_16=(\\d+) field_17=(\\d+) field_18=(\\d+) field_19=(\\d+) field_20=(\\d+) field_21=(\\d+) field_22=(\\d+) field_23=(\\d+) field_24=(\\d+) field_25=(\\d+) field_26=(\\d+) field_27=(\\d+) field_28=(\\d+) field_29=(\\d+) field_30=(\\d+) field_31=(\\d+) field_32=(\\d+) field_33=(\\d+) field_34=(\\d+) field_35=(\\d+) field_36=(\\d\\d\\d)",
+                "log": "36cg field_01=001 field_02=002 field_03=003 field_04=004 field_05=005 field_06=006 field_07=007 field_08=008 field_09=009 field_10=010 field_11=011 field_12=012 field_13=013 field_14=014 field_15=015 field_16=016 field_17=017 field_18=018 field_19=019 field_20=020 field_21=021 field_22=022 field_23=023 field_24=024 field_25=025 field_26=026 field_27=027 field_28=028 field_29=029 field_30=030 field_31=031 field_32=032 field_33=033 field_34=034 field_35=035 field_36=036",
+                "end_match": "6",
+                "captured_groups": [
+                    "001", "002","003","004","005","006","007","008",
+                    "009", "010","011","012","013","014","015","016",
+                    "017", "018","019","020","021","022","023","024",
+                    "025", "026","027","028","029","030","031","032",
+                    "033", "034","035","036"
+                ]
+            }
+        ]
+    },
+    {
+        "description": "[Memory test] regex_matching expand test: Incremental patterns and match last.",
+        "batch_test": [
+            {
+                "description": "Inizialize regex matching with capture grup, min size (1 patter, 1 capture).",
+                "__sub_string_size": "((1 pattern x 2 know bug) + 1 null)  x 8 size = 24 bytes",
+                "__prts_main_array": " (1 pattern + 1 null)  x 8 size = 16 bytes",
+                "__prts_items_array": "size of array d_size->prts_str_size == size of array prts_str == prts_str_alloc_size = 16",
+                "__prts_items_array_1": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_array_2": "0x0",
+                "pattern": "hi (\\w+).",
+                "log": "Hi wazuh.",
+                "end_match": ".",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Resize x 38 incremental patterns and match last.",
+                "__sub_string_size": "((1 gruopos x 2 know bug) + 1 null)  x 8 size = 24 bytes",
+                "__prts_main_array": " (38 pattern + 1 null)  x 8 size = 312 bytes",
+                "__prts_items_array": "size of array d_size->prts_str_size == size of array prts_str == prts_str_alloc_size = 312",
+                "__prts_items_array_1": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_2": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_3": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_4": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_5": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_6": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_7": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_8": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_9": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_10": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_11": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_12": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_13": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_14": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_15": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_16": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_17": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_18": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_19": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_20": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_21": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_22": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_23": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_24": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_25": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_26": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_27": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_28": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_29": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_30": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_31": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_32": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_33": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_34": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_35": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_36": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_37": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_38": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_39": "0x0",
+                "pattern": "^01cg field_01=(\\d+)|^04cg field_01=(\\d+)|^05cg field_01=(\\d+)|^06cg field_01=(\\d+)|^07cg field_01=(\\d+)|^08cg field_01=(\\d+)|^09cg field_01=(\\d+)|^10cg field_01=(\\d+)|^11cg field_01=(\\d+)|^12cg field_01=(\\d+)|^13cg field_01=(\\d+)|^14cg field_01=(\\d+)|^15cg field_01=(\\d+)|^16cg field_01=(\\d+)|^17cg field_01=(\\d+)|^18cg field_01=(\\d+)|^19cg field_01=(\\d+)|^20cg field_01=(\\d+)|^21cg field_01=(\\d+)|^22cg field_01=(\\d+)|^23cg field_01=(\\d+)|^24cg field_01=(\\d+)|^25cg field_01=(\\d+)|^26cg field_01=(\\d+)|^27cg field_01=(\\d+)|^28cg field_01=(\\d+)|^29cg field_01=(\\d+)|^30cg field_01=(\\d+)|^31cg field_01=(\\d+)|^32cg field_01=(\\d+)|^33cg field_01=(\\d+)|^34cg field_01=(\\d+)|^35cg field_01=(\\d+)|^36cg field_01=(\\d+)|^37cg field_01=(\\d+)|^38cg field_01=(\\d\\d\\d)",
+                "log": "38cg field_01=001",
+                "end_match": "1",
+                "captured_groups": [
+                    "001"
+                ]
+            }
+        ]
+    },
+    {
+        "description": "[Memory test] regex_matching expand test: Incremental capture groups, patterns and match last.",
+        "batch_test": [
+            {
+                "description": "Inizialize regex matching with capture grup, min size (1 patter, 1 capture).",
+                "__sub_string_size": "((1 pattern x 2 know bug) + 1 null)  x 8 size = 24 bytes",
+                "__prts_main_array": " (1 pattern + 1 null)  x 8 size = 16 bytes",
+                "__prts_items_array": "size of array d_size->prts_str_size == size of array prts_str == prts_str_alloc_size = 16",
+                "__prts_items_array_1": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_array_2": "0x0",
+                "pattern": "hi (\\w+).",
+                "log": "Hi wazuh.",
+                "end_match": ".",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Resize x 20 patterns, 2236 incremental capture groups and match last.",
                 "__sub_string_size": "((36 gruopos x 2 know bug) + 1 null)  x 8 size = 584 bytes",
                 "__prts_main_array": " (20 pattern + 1 null)  x 8 size = 168 bytes",
                 "__prts_items_array": "size of array d_size->prts_str_size == size of array prts_str == prts_str_alloc_size = 168",

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -1,6 +1,6 @@
 [
     {
-        "test_suite_description": "Test a sigle patterns",
+        "description": "Test a sigle patterns",
         "batch_test": [
             {
                 "pattern": "^hi (\\w+).",
@@ -21,13 +21,13 @@
         ]
     },
     {
-        "test_suite_description": "Test a double patterns",
+        "description": "Test a double patterns",
         "batch_test": [
             {
-                "pattern": "^hi (\\w+)|^god bye (\\w+)$",
-                "log": "god bye wazuh",
-                "__end_match": "h",
-                "end_match": null,
+                "ignore_result" : true,
+                "pattern": "^hi (\\w+)|^good bye (\\w+)$",
+                "log": "good bye wazuh",
+                "end_match": "h",
                 "captured_groups": [
                     "wazuh"
                 ]
@@ -35,31 +35,31 @@
         ]
     },
     {
-        "test_suite_description": "Test a double patterns",
+        "description": "Test a double patterns",
         "batch_test": [
             {
+                "ignore_result" : true,
                 "pattern": "^hi (\\w+)|^god bye (\\w+)$",
                 "log": "god bye wazuh",
-                "__end_match": "h",
-                "end_match": null,
+                "end_match": "h",
                 "captured_groups": [
                     "wazuh"
                 ]
             },
             {
+                "ignore_result" : true,
                 "pattern": "^hi (\\w+)|^god bye (\\w+)$",
                 "log": "god bye wazuh",
-                "__end_match": "h",
-                "end_match": null,
+                "end_match": "h",
                 "captured_groups": [
                     "wazuh"
                 ]
             },
             {
+                "ignore_result" : true,
                 "pattern": "^hi (\\w+)|^god bye (\\w+)$",
                 "log": "god bye wazuh",
-                "__end_match": "h",
-                "end_match": null,
+                "end_match": "h",
                 "captured_groups": [
                     "wazuh"
                 ]

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -1,69 +1,149 @@
 [
     {
-        "description": "Test a sigle patterns",
+        "description": "[Functionality] Supported expression tests - Character Maps [\\w, \\d, \\s, \\W, \\D, \\S, \\p, \\t, \\.].",
         "batch_test": [
             {
-                "pattern": "^hi (\\w+).",
-                "log": "hi wazuh.bye",
-                "end_match": ".bye",
+                "description": "\\w test: Includes all letters, digits, @ and _ characters.",
+                "__knowIssue:": "The pattern was designed this way due to know issue. Workaround for '(\\w+)' pattern",
+                "pattern": "(\\w+\\w)$",
+                "log": "\t\r !\"#$%&()*+,./:;<=>?[\\]^`{|}~0123456789_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
+                "end_match": "z",
                 "captured_groups": [
-                    "wazuh"
+                    "0123456789_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
                 ]
             },
             {
-                "pattern": "^hi2 (\\w+).",
-                "log": "hi2 wazuh.bye",
-                "end_match": ".bye",
+                "description": "\\d test: Only digits.",
+                "__knowIssue:": "The pattern was designed this way due to know issue. Workaround for '(\\d+)' pattern",
+                "pattern": "(\\d+\\d)$",
+                "log": "\t\r !\"#$%&()*+,./:;<=>?[\\]^`{|}~_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+                "end_match": "9",
                 "captured_groups": [
-                    "wazuh"
+                    "0123456789"
+                ]
+            },
+            {
+                "description": "\\s test: space character ' '.",
+                "pattern": "(\\s+)",
+                "log": "\t\r!\"#$%&()*+,./:;<=>?[\\]^`{|}~_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 ",
+                "end_match": " ",
+                "captured_groups": [
+                    " "
+                ]
+            },
+            {
+                "description": "\\t test: tab character '\\t'.",
+                "pattern": "(\\t+)",
+                "log": "\r !\"#$%&()*+,./:;<=>?[\\]^`{|}~_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789\t",
+                "end_match": "\t",
+                "captured_groups": [
+                    "\t"
+                ]
+            },
+            {
+                "description": "\\p test: symbols characters '()*+,-.:;<=>?[]!\"'#$%&|{}'.",
+                "__knowIssue:": "The pattern was designed this way due to know issue. Workaround for '(\\p+)' pattern",
+                "pattern": "(\\p+\\p)$",
+                "log": "\r\t /\\^`~_@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789()*+,-.:;<=>?[]!\"'#$%&|{}",
+                "end_match": "}",
+                "captured_groups": [
+                    "()*+,-.:;<=>?[]!\"'#$%&|{}"
+                ]
+            },
+            {
+                "description": "\\W test: Anything not \\w.",
+                "__knowIssue:": "The pattern was designed this way due to know issue. Workaround for '(\\W+)' pattern",
+                "pattern": "(\\W+\\W)$",
+                "log": "0123456789_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz\t\r !\"#$%&()*+,./:;<=>?[\\]^`{|}~",
+                "end_match": "~",
+                "captured_groups": [
+                    "\t\r !\"#$%&()*+,./:;<=>?[\\]^`{|}~"
+                ]
+            },
+            {
+                "description": "\\D test: Anything not \\d.",
+                "__knowIssue:": "The pattern was designed this way due to know issue. Workaround for '(\\D+)' pattern",
+                "pattern": "(\\D+\\D)$",
+                "log": "0123456789_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz\t !\"#$%&()*+,./:;<=>?[\\]^`{|}~",
+                "end_match": "~",
+                "captured_groups": [
+                    "_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz\t !\"#$%&()*+,./:;<=>?[\\]^`{|}~"
+                ]
+            },
+            {
+                "description": "\\S test: Anything not \\s.",
+                "__knowIssue:": "The pattern was designed this way due to know issue. Workaround for '(\\S+)' pattern",
+                "pattern": "(\\S+\\S)$",
+                "log": " \r\t!\"#$%&()*+,./:;<=>?[\\]^`{|}~_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+                "end_match": "9",
+                "captured_groups": [
+                    "\r\t!\"#$%&()*+,./:;<=>?[\\]^`{|}~_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+                ]
+            },
+            {
+                "description": "\\. test: Anything",
+                "__knowIssue:": "The pattern was designed this way due to know issue. Workaround for '(\\S+)' pattern",
+                "pattern": "(\\.+\\.)$",
+                "log": " \r\t!\"#$%&()*+,./:;<=>?[\\]^`{|}~_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+                "end_match": "9",
+                "captured_groups": [
+                    " \r\t!\"#$%&()*+,./:;<=>?[\\]^`{|}~_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
                 ]
             }
         ]
     },
     {
-        "description": "Test a double patterns",
+        "description": "[Functionality] Modifiers (+ and *)",
         "batch_test": [
             {
-                "ignore_result" : true,
-                "pattern": "^hi (\\w+)|^good bye (\\w+)$",
-                "log": "good bye wazuh",
-                "end_match": "h",
-                "captured_groups": [
-                    "wazuh"
-                ]
-            }
-        ]
-    },
-    {
-        "description": "Test a double patterns",
-        "batch_test": [
+                "description": "[+] It should not match since there are no characters of the type `\\d`.",
+                "pattern": "(\\d+)",
+                "log": "asd_ _qwe",
+                "end_match": null,
+                "captured_groups": []
+            },
             {
-                "ignore_result" : true,
-                "pattern": "^hi (\\w+)|^god bye (\\w+)$",
-                "log": "god bye wazuh",
-                "end_match": "h",
+                "description": "[+] It should match one time",
+                "pattern": "(\\d+)",
+                "log": "asd_1_qwe",
+                "end_match": "1_qwe",
                 "captured_groups": [
-                    "wazuh"
+                    "1"
                 ]
             },
             {
-                "ignore_result" : true,
-                "pattern": "^hi (\\w+)|^god bye (\\w+)$",
-                "log": "god bye wazuh",
-                "end_match": "h",
+                "description" : "[+]",
+                "pattern": "(\\d+)",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "debug" : false,
+                "log": "asd_12_qwe",
+                "end_match": "2_qwe",
                 "captured_groups": [
-                    "wazuh"
+                    "12"
                 ]
             },
             {
-                "ignore_result" : true,
-                "pattern": "^hi (\\w+)|^god bye (\\w+)$",
-                "log": "god bye wazuh",
-                "end_match": "h",
+                "description" : "[+]",
+                "pattern": "(\\d+)",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "debug" : false,
+                "log": "asd_123_qwe",
+                "end_match": "3_qwe",
                 "captured_groups": [
-                    "wazuh"
+                    "123"
                 ]
+            },
+            {
+                "description": "[*] It should not match since there are no characters of the type `\\d`.",
+                "pattern": "(\\d*)",
+                "debug": true,
+                "ignore_result": true,
+                "log": "asd_ _qwe",
+                "end_match": " ",
+                "captured_groups": []
             }
         ]
     }
-]
+  ]

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -1,0 +1,69 @@
+[
+    {
+        "test_suite_description": "Test a sigle patterns",
+        "batch_test": [
+            {
+                "pattern": "^hi (\\w+).",
+                "log": "hi wazuh.bye",
+                "end_match": ".bye",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "pattern": "^hi2 (\\w+).",
+                "log": "hi2 wazuh.bye",
+                "end_match": ".bye",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            }
+        ]
+    },
+    {
+        "test_suite_description": "Test a double patterns",
+        "batch_test": [
+            {
+                "pattern": "^hi (\\w+)|^god bye (\\w+)$",
+                "log": "god bye wazuh",
+                "__end_match": "h",
+                "end_match": null,
+                "captured_groups": [
+                    "wazuh"
+                ]
+            }
+        ]
+    },
+    {
+        "test_suite_description": "Test a double patterns",
+        "batch_test": [
+            {
+                "pattern": "^hi (\\w+)|^god bye (\\w+)$",
+                "log": "god bye wazuh",
+                "__end_match": "h",
+                "end_match": null,
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "pattern": "^hi (\\w+)|^god bye (\\w+)$",
+                "log": "god bye wazuh",
+                "__end_match": "h",
+                "end_match": null,
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "pattern": "^hi (\\w+)|^god bye (\\w+)$",
+                "log": "god bye wazuh",
+                "__end_match": "h",
+                "end_match": null,
+                "captured_groups": [
+                    "wazuh"
+                ]
+            }
+        ]
+    }
+]

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -1,5 +1,61 @@
 [
     {
+        "description": "[Memory test] regex_matching expand test: Incremental capture groups and match last.",
+        "batch_test": [
+            {
+                "description": "Inizialize regex matching with capture grup, min size (1 patter, 1 capture).",
+                "__sub_string_size": "((1 pattern x 2 know bug) + 1 null)  x 8 size = 24 bytes",
+                "__prts_main_array": " (1 pattern + 1 null)  x 8 size = 16 bytes",
+                "__prts_items_array": "size of array d_size->prts_str_size == size of array prts_str == prts_str_alloc_size = 16",
+                "__prts_items_array_1": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_array_2": "0x0",
+                "pattern": "hi (\\w+).",
+                "log": "Hi wazuh.",
+                "end_match": ".",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Resize x 20 patterns, 22 incremental capture groups and match last.",
+                "__sub_string_size": "((36 gruopos x 2 know bug) + 1 null)  x 8 size = 584 bytes",
+                "__prts_main_array": " (20 pattern + 1 null)  x 8 size = 168 bytes",
+                "__prts_items_array": "size of array d_size->prts_str_size == size of array prts_str == prts_str_alloc_size = 168",
+                "__prts_items_array_1": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_items_array_2": "(4 group x2 + 1 null)  x 8 size = 72 bytes",
+                "__prts_items_array_3": "(5 group x2 + 1 null)  x 8 size = 88 bytes",
+                "__prts_items_array_4": "(6 group x2 + 1 null)  x 8 size = 104 bytes",
+                "__prts_items_array_5": "(7 group x2 + 1 null)  x 8 size = 120 bytes",
+                "__prts_items_array_6": "(8 group x2 + 1 null)  x 8 size = 136 bytes",
+                "__prts_items_array_7": "(9 group x2 + 1 null)  x 8 size = 152 bytes",
+                "__prts_items_array_8": "(10 group x2 + 1 null)  x 8 size = 168 bytes",
+                "__prts_items_array_9": "(11 group x2 + 1 null)  x 8 size = 184 bytes",
+                "__prts_items_array_10": "(12 group x2 + 1 null)  x 8 size = 200 bytes",
+                "__prts_items_array_11": "(13 group x2 + 1 null)  x 8 size = 216 bytes",
+                "__prts_items_array_12": "(14 group x2 + 1 null)  x 8 size = 232 bytes",
+                "__prts_items_array_13": "(15 group x2 + 1 null)  x 8 size = 248 bytes",
+                "__prts_items_array_14": "(16 group x2 + 1 null)  x 8 size = 264 bytes",
+                "__prts_items_array_15": "(17 group x2 + 1 null)  x 8 size = 280 bytes",
+                "__prts_items_array_16": "(18 group x2 + 1 null)  x 8 size = 296 bytes",
+                "__prts_items_array_17": "(19 group x2 + 1 null)  x 8 size = 312 bytes",
+                "__prts_items_array_18": "(20 group x2 + 1 null)  x 8 size = 328 bytes",
+                "__prts_items_array_19": "(21 group x2 + 1 null)  x 8 size = 344 bytes",
+                "__prts_items_array_20": "(36 group x2 + 1 null)  x 8 size = 584 bytes",
+                "__prts_items_array_21": "0x0",
+                "pattern": "^01cg field_01=(\\d+)|^04cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+)|^05cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+)|^06cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+)|^07cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+)|^08cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+)|^09cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+)|^10cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+)|^11cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+)|^12cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+) field_12=(\\d+)|^13cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+) field_12=(\\d+) field_13=(\\d+)|^14cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+) field_12=(\\d+) field_13=(\\d+) field_14=(\\d+)|^15cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+) field_12=(\\d+) field_13=(\\d+) field_14=(\\d+) field_15=(\\d+)|^16cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+) field_12=(\\d+) field_13=(\\d+) field_14=(\\d+) field_15=(\\d+) field_16=(\\d+)|^17cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+) field_12=(\\d+) field_13=(\\d+) field_14=(\\d+) field_15=(\\d+) field_16=(\\d+) field_17=(\\d+)|^18cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+) field_12=(\\d+) field_13=(\\d+) field_14=(\\d+) field_15=(\\d+) field_16=(\\d+) field_17=(\\d+) field_18=(\\d+)|^19cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+) field_12=(\\d+) field_13=(\\d+) field_14=(\\d+) field_15=(\\d+) field_16=(\\d+) field_17=(\\d+) field_18=(\\d+) field_19=(\\d+)|^20cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+) field_12=(\\d+) field_13=(\\d+) field_14=(\\d+) field_15=(\\d+) field_16=(\\d+) field_17=(\\d+) field_18=(\\d+) field_19=(\\d+) field_20=(\\d+)|^21cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+) field_12=(\\d+) field_13=(\\d+) field_14=(\\d+) field_15=(\\d+) field_16=(\\d+) field_17=(\\d+) field_18=(\\d+) field_19=(\\d+) field_20=(\\d+) field_21=(\\d+)|^36cg field_01=(\\d+) field_02=(\\d+) field_03=(\\d+) field_04=(\\d+) field_05=(\\d+) field_06=(\\d+) field_07=(\\d+) field_08=(\\d+) field_09=(\\d+) field_10=(\\d+) field_11=(\\d+) field_12=(\\d+) field_13=(\\d+) field_14=(\\d+) field_15=(\\d+) field_16=(\\d+) field_17=(\\d+) field_18=(\\d+) field_19=(\\d+) field_20=(\\d+) field_21=(\\d+) field_22=(\\d+) field_23=(\\d+) field_24=(\\d+) field_25=(\\d+) field_26=(\\d+) field_27=(\\d+) field_28=(\\d+) field_29=(\\d+) field_30=(\\d+) field_31=(\\d+) field_32=(\\d+) field_33=(\\d+) field_34=(\\d+) field_35=(\\d+) field_36=(\\d\\d\\d)",
+                "log": "36cg field_01=001 field_02=002 field_03=003 field_04=004 field_05=005 field_06=006 field_07=007 field_08=008 field_09=009 field_10=010 field_11=011 field_12=012 field_13=013 field_14=014 field_15=015 field_16=016 field_17=017 field_18=018 field_19=019 field_20=020 field_21=021 field_22=022 field_23=023 field_24=024 field_25=025 field_26=026 field_27=027 field_28=028 field_29=029 field_30=030 field_31=031 field_32=032 field_33=033 field_34=034 field_35=035 field_36=036",
+                "end_match": "6",
+                "captured_groups": [
+                    "001", "002","003","004","005","006","007","008",
+                    "009", "010","011","012","013","014","015","016",
+                    "017", "018","019","020","021","022","023","024",
+                    "025", "026","027","028","029","030","031","032",
+                    "033", "034","035","036"
+                ]
+            }
+        ]
+    },
+    {
         "description": "[Functionality] Supported expression tests - Character Maps [\\w, \\d, \\s, \\W, \\D, \\S, \\p, \\t, \\.].",
         "batch_test": [
             {

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -128,7 +128,6 @@
                 "pattern": "(\\d+)",
                 "ignore_result": true,
                 "__knowIssue": "Link github issue ####",
-                "debug" : false,
                 "log": "asd_123_qwe",
                 "end_match": "3_qwe",
                 "captured_groups": [
@@ -137,13 +136,46 @@
             },
             {
                 "description": "[*] It should not match since there are no characters of the type `\\d`.",
-                "__toDo": "Remove initial spaces at pattern and log after fixing this case",
-                "pattern": " (\\d*)",
-                "debug": true,
+                "skip_test": true,
+                "pattern": "(\\d*)",
                 "ignore_result": true,
                 "log": " asd_ _qwe",
                 "end_match": " asd_ _qwe",
                 "captured_groups": [ "" ]
+            },
+            {
+                "description": "[*] It should match one time",
+                "skip_test": true,
+                "pattern": "(\\d*)",
+                "log": "asd_1_qwe",
+                "end_match": "1_qwe",
+                "captured_groups": [
+                    "1"
+                ]
+            },
+            {
+                "description" : "[*]",
+                "skip_test": true,
+                "pattern": "(\\d*)",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "log": "asd_12_qwe",
+                "end_match": "2_qwe",
+                "captured_groups": [
+                    "12"
+                ]
+            },
+            {
+                "description" : "[+]",
+                "skip_test": true,
+                "pattern": "(\\d*)",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "log": "asd_123_qwe",
+                "end_match": "3_qwe",
+                "captured_groups": [
+                    "123"
+                ]
             }
         ]
     }

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -257,7 +257,65 @@
                 "captured_groups": []
             },
             {
+                "description": "Using the '\\t+' token to test NOT matching all the special characters with capture group.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "pattern": "Special characters are (\\t+)",
+                "log": "Special characters are $()|<\\",
+                "end_match": " $()|<\\",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Using the '\\t+' token to test NOT matching all the special characters without capture group.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "pattern": "Special characters are \\t+",
+                "log": "Special characters are $()|<\\",
+                "end_match": " $()|<\\",
+                "captured_groups": []
+            },
+            {
+                "description": "Using the '\\t*' token to test NOT matching all the special characters with capture group.",
+                "pattern": "Special characters are (\\t*)",
+                "log": "Special characters are $()|<\\",
+                "end_match": " $()|<\\",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Using the '\\t*' token to test NOT matching all the special characters without capture group.",
+                "pattern": "Special characters are \\t*",
+                "log": "Special characters are $()|<\\",
+                "end_match": " $()|<\\",
+                "captured_groups": []
+            },
+            {
+                "description": "Using the '\\d+' token to test NOT matching all the special characters with capture group.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "pattern": "Special characters are (\\d+)",
+                "log": "Special characters are $()|<\\",
+                "end_match": " $()|<\\",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Using the '\\d+' token to test NOT matching all the special characters without capture group.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "pattern": "Special characters are \\d+",
+                "log": "Special characters are $()|<\\",
+                "end_match": " $()|<\\",
+                "captured_groups": []
+            },
+            {
                 "description": "Using the '\\d*' token to test NOT matching all the special characters with capture group.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
                 "pattern": "Special characters are (\\d*)",
                 "log": "Special characters are $()|<\\",
                 "end_match": " $()|<\\",
@@ -267,7 +325,69 @@
             },
             {
                 "description": "Using the '\\d*' token to test NOT matching all the special characters without capture group.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
                 "pattern": "Special characters are \\d*",
+                "log": "Special characters are $()|<\\",
+                "end_match": " $()|<\\",
+                "captured_groups": []
+            },
+            {
+                "description": "Using the '\\D+' token to test matching all the special characters with capture group.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "pattern": "Special characters are (\\D+)",
+                "log": "Special characters are $()|<\\",
+                "end_match": "\\",
+                "captured_groups": [
+                    "$()|<\\"
+                ]
+            },
+            {
+                "description": "Using the '\\D+' token to test matching all the special characters without capture group.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "pattern": "Special characters are \\D+",
+                "log": "Special characters are $()|<\\",
+                "end_match": "\\",
+                "captured_groups": []
+            },
+            {
+                "description": "Using the '\\D*' token to test matching all the special characters with capture group.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "pattern": "Special characters are (\\D*)",
+                "log": "Special characters are $()|<\\",
+                "end_match": "\\",
+                "captured_groups": [
+                    "$()|<\\"
+                ]
+            },
+            {
+                "description": "Using the '\\D*' token to test matching all the special characters without capture group.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "pattern": "Special characters are \\D*",
+                "log": "Special characters are $()|<\\",
+                "end_match": "\\",
+                "captured_groups": []
+            },
+            {
+                "description": "Using the '\\w+' token to test NOT matching all the special characters with capture group.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "pattern": "Special characters are (\\w+)",
+                "log": "Special characters are $()|<\\",
+                "end_match": " $()|<\\",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Using the '\\w+' token to test NOT matching all the special characters without capture group.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "pattern": "Special characters are \\w+",
                 "log": "Special characters are $()|<\\",
                 "end_match": " $()|<\\",
                 "captured_groups": []
@@ -286,6 +406,86 @@
                 "pattern": "Special characters are \\w*",
                 "log": "Special characters are $()|<\\",
                 "end_match": " $()|<\\",
+                "captured_groups": []
+            },
+            {
+                "description": "Using the '\\W+' token to test matching all the special characters with capture group.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "pattern": "Special characters are (\\W+)",
+                "log": "Special characters are $()|<\\",
+                "end_match": "\\",
+                "captured_groups": [
+                    "$()|<\\"
+                ]
+            },
+            {
+                "description": "Using the '\\W+' token to test matching all the special characters without capture group.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "pattern": "Special characters are \\W+",
+                "log": "Special characters are $()|<\\",
+                "end_match": "\\",
+                "captured_groups": []
+            },
+            {
+                "description": "Using the '\\W*' token to test matching all the special characters with capture group.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "pattern": "Special characters are (\\W*)",
+                "log": "Special characters are $()|<\\",
+                "end_match": "\\",
+                "captured_groups": [
+                    "$()|<\\"
+                ]
+            },
+            {
+                "description": "Using the '\\W*' token to test matching all the special characters without capture group.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "pattern": "Special characters are \\W*",
+                "log": "Special characters are $()|<\\",
+                "end_match": "\\",
+                "captured_groups": []
+            },
+            {
+                "description": "Using the '\\S+' token to test matching all the special characters with capture group.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "pattern": "Special characters are (\\S+)",
+                "log": "Special characters are $()|<\\",
+                "end_match": "\\",
+                "captured_groups": [
+                    "$()|<\\"
+                ]
+            },
+            {
+                "description": "Using the '\\S+' token to test matching all the special characters without capture group.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "pattern": "Special characters are \\S+",
+                "log": "Special characters are $()|<\\",
+                "end_match": "\\",
+                "captured_groups": []
+            },
+            {
+                "description": "Using the '\\S*' token to test matching all the special characters with capture group.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "pattern": "Special characters are (\\S*)",
+                "log": "Special characters are $()|<\\",
+                "end_match": "\\",
+                "captured_groups": [
+                    "$()|<\\"
+                ]
+            },
+            {
+                "description": "Using the '\\S*' token to test matching all the special characters without capture group.",
+                "ignore_result": true,
+                "__knowIssue": "Link github issue ####",
+                "pattern": "Special characters are \\S*",
+                "log": "Special characters are $()|<\\",
+                "end_match": "\\",
                 "captured_groups": []
             }
         ]

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -112,11 +112,11 @@
                 ]
             },
             {
-                "description" : "[+]",
+                "description": "[+]",
                 "pattern": "(\\d+)",
                 "ignore_result": true,
                 "__knowIssue": "Link github issue ####",
-                "debug" : false,
+                "debug": false,
                 "log": "asd_12_qwe",
                 "end_match": "2_qwe",
                 "captured_groups": [
@@ -124,7 +124,7 @@
                 ]
             },
             {
-                "description" : "[+]",
+                "description": "[+]",
                 "pattern": "(\\d+)",
                 "ignore_result": true,
                 "__knowIssue": "Link github issue ####",
@@ -141,7 +141,9 @@
                 "ignore_result": true,
                 "log": " asd_ _qwe",
                 "end_match": " asd_ _qwe",
-                "captured_groups": [ "" ]
+                "captured_groups": [
+                    ""
+                ]
             },
             {
                 "description": "[*] It should match one time",
@@ -154,7 +156,7 @@
                 ]
             },
             {
-                "description" : "[*]",
+                "description": "[*]",
                 "skip_test": true,
                 "pattern": "(\\d*)",
                 "ignore_result": true,
@@ -166,7 +168,7 @@
                 ]
             },
             {
-                "description" : "[+]",
+                "description": "[+]",
                 "skip_test": true,
                 "pattern": "(\\d*)",
                 "ignore_result": true,
@@ -189,7 +191,9 @@
                 "pattern": "(\\p+)",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
-                "captured_groups": [ "$()|<" ]
+                "captured_groups": [
+                    "$()|<"
+                ]
             },
             {
                 "description": "Using the '\\p+' token to test matching all the special characters without capture group. Note: the character '\\' is not captured by the token '\\p'.",
@@ -203,7 +207,9 @@
                 "pattern": "Special characters are (\\p*)",
                 "log": "Special characters are $()|<\\",
                 "end_match": "<\\",
-                "captured_groups": [ "$()|<" ]
+                "captured_groups": [
+                    "$()|<"
+                ]
             },
             {
                 "description": "Using the '\\p*' token to test matching all the special characters without capture group. Note: the character '\\' is not captured by the token '\\p'.",
@@ -219,7 +225,9 @@
                 "pattern": "Backslash character is (\\.+)",
                 "log": "Backslash character is \\",
                 "end_match": "\\",
-                "captured_groups": [ "\\" ]
+                "captured_groups": [
+                    "\\"
+                ]
             },
             {
                 "description": "Using the '\\.+' token to test matching the character '\\' without capture group.",
@@ -235,7 +243,9 @@
                 "pattern": "Backslash character is (\\.*)",
                 "log": "Backslash character is \\",
                 "end_match": "\\",
-                "captured_groups": [ "\\" ]
+                "captured_groups": [
+                    "\\"
+                ]
             },
             {
                 "description": "Using the '\\.*' token to test matching the character '\\' without capture group.",
@@ -251,7 +261,9 @@
                 "pattern": "Special characters are (\\d*)",
                 "log": "Special characters are $()|<\\",
                 "end_match": " $()|<\\",
-                "captured_groups": [ "" ]
+                "captured_groups": [
+                    ""
+                ]
             },
             {
                 "description": "Using the '\\d*' token to test NOT matching all the special characters without capture group.",
@@ -265,7 +277,9 @@
                 "pattern": "Special characters are (\\w*)",
                 "log": "Special characters are $()|<\\",
                 "end_match": " $()|<\\",
-                "captured_groups": [ "" ]
+                "captured_groups": [
+                    ""
+                ]
             },
             {
                 "description": "Using the '\\w*' token to test NOT matching all the special characters without capture group.",
@@ -308,7 +322,9 @@
                 "pattern": "^(\\d+)",
                 "log": "1234",
                 "end_match": "4",
-                "captured_groups": ["1234"]
+                "captured_groups": [
+                    "1234"
+                ]
             },
             {
                 "description": "'^' test: Start of string.",
@@ -340,7 +356,9 @@
                 "pattern": "^(\\d+)",
                 "log": "1234asd",
                 "end_match": "4asd",
-                "captured_groups": ["1234"]
+                "captured_groups": [
+                    "1234"
+                ]
             },
             {
                 "description": "'^' test: Start of string.",
@@ -382,14 +400,18 @@
                 "pattern": "(\\d\\d\\d\\d)$",
                 "log": "1234",
                 "end_match": "4",
-                "captured_groups": ["1234"]
+                "captured_groups": [
+                    "1234"
+                ]
             },
             {
                 "description": "'$' test: Start of string.",
                 "pattern": "(\\d\\d)$",
                 "log": "1234",
                 "end_match": "4",
-                "captured_groups": ["34"]
+                "captured_groups": [
+                    "34"
+                ]
             },
             {
                 "description": "'^' test: Start of string.",
@@ -420,7 +442,9 @@
                 "pattern": "^(\\d+)",
                 "log": "1234asd",
                 "end_match": "4asd",
-                "captured_groups": ["1234"]
+                "captured_groups": [
+                    "1234"
+                ]
             },
             {
                 "description": "'$' test: End of string.",
@@ -438,5 +462,96 @@
                 "captured_groups": []
             }
         ]
+    },
+    {
+        "description": "[Functionality] Combine special characters. ['^', '$']",
+        "batch_test": [
+            {
+                "description": "Combine ^$ with non empty string",
+                "pattern": "^$",
+                "log": "hi digits",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Combine ^$ with empty string. Should be match",
+                "pattern": "^$",
+                "log": "",
+                "end_match": "",
+                "captured_groups": []
+            },
+            {
+                "description": "Combine ^$ with empty string. Should be match, and obtain an empty group",
+                "ignore_result": true,
+                "pattern": "^()$",
+                "log": "",
+                "end_match": "",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Combine ^$ with non empty string",
+                "pattern": "^$",
+                "log": "hi digits",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Combine ^$ with empty string. Should be match",
+                "pattern": "^$",
+                "log": "",
+                "end_match": "",
+                "captured_groups": []
+            },
+            {
+                "description": "Combine ^$ with empty string. Should be match, and obtain an empty group",
+                "ignore_result": true,
+                "pattern": "^()$",
+                "log": "",
+                "end_match": "",
+                "captured_groups": [
+                    ""
+                ]
+            }
+        ]
+    },
+    {
+        "description": "[Functionality] Special characters.  OR with flags ['^', '$','|']",
+        "batch_test": [
+            {
+                "description": "Only last subpattern with capture groups",
+                "ignore_result": true,
+                "pattern": "^$|^\\d|\\d$|\\s(\\w+\\w)",
+                "log": "^hi digits asd",
+                "end_match": "s asd",
+                "captured_groups": [
+                    "digits"
+                ]
+            },
+            {
+                "description": "Nothing to match",
+                "debug": true,
+                "pattern": "^$|^\\d|\\d$|\\s(\\w+)",
+                "log": "^hi*digits*asd$",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Only last subpattern with last",
+                "ignore_result": true,
+                "pattern": "^$|^\\d|\\d$|\\.+",
+                "log": "^hi digits asd&",
+                "end_match": "&",
+                "captured_groups": []
+            },
+            {
+                "description": "match with first",
+                "pattern": "\\d\\d\\d\\d$|(\\d\\d\\d\\d)$",
+                "log": "2020",
+                "end_match": "0",
+                "captured_groups": []
+            }
+        ]
     }
-  ]
+]

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -1,5 +1,360 @@
 [
     {
+        "description": "[Coverage] Lazy pattern, greedy match - backslash with '+' modifier. The next token does not include the map characters of the current token and has no modifier.",
+        "batch_test": [
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character",
+                "pattern": "\\w+\\s",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all",
+                "pattern": "\\w+\\s",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character + capture group.",
+                "pattern": "(\\w+)\\s",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Next token with blackslash.  ok_here == -1. Match all. 1 character + capture all.",
+                "pattern": "(\\w+\\s)",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all. Parcial capture group case.",
+                "pattern": "(\\w+)\\s",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character",
+                "pattern": "\\w+ ",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all",
+                "pattern": "\\w+ ",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character + capture group.",
+                "pattern": "(\\w+) ",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character + capture all.",
+                "pattern": "(\\w+ )",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all. Parcial capture group case.",
+                "pattern": "(\\w+) ",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all",
+                "pattern": "\\w+\\s1",
+                "log": "wazuh 1",
+                "end_match": "1",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character + capture group.",
+                "pattern": "(\\w+)\\s1",
+                "log": "w 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character + capture all.",
+                "pattern": "(\\w+\\s)1",
+                "log": "w 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Next token with blackslash. ok_here ==  -1. Match all. Parcial capture group case.",
+                "pattern": "(\\w+)\\s1",
+                "log": "wazuh 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match. 1 character",
+                "pattern": "\\w+\\s1",
+                "log": "w 123",
+                "end_match": "123",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match",
+                "pattern": "\\w+ 1",
+                "log": "wazuh 123",
+                "end_match": "123",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match. 1 character + capture group.",
+                "pattern": "(\\w+) 1",
+                "log": "w 123",
+                "end_match": "123",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match. 1 character + capture all.",
+                "pattern": "(\\w+ )1",
+                "log": "w 123",
+                "end_match": "123",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match. Parcial capture group case.",
+                "pattern": "(\\w+) 1",
+                "log": "wazuh 123",
+                "end_match": "123",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character (With flags).",
+                "pattern": "^\\w+\\s$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all (With flags).",
+                "pattern": "^\\w+\\s$",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character + capture group. (With flags).",
+                "pattern": "^(\\w+)\\s$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Next token with blackslash.  ok_here == -1. Match all. 1 character + capture all. (With flags).",
+                "pattern": "^(\\w+\\s)$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all. Parcial capture group case. (With flags).",
+                "pattern": "^(\\w+)\\s$",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character (With flags).",
+                "pattern": "^\\w+ $",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all (With flags).",
+                "pattern": "^\\w+ $",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character + capture group (With flags).",
+                "pattern": "^(\\w+) $",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character + capture all (With flags).",
+                "pattern": "^(\\w+ )$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all. Parcial capture group case (With flags).",
+                "pattern": "^(\\w+) $",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all. Ends pattern (With flags) before log.",
+                "debug" : true,
+                "ignore_result": true,
+                "pattern": "^\\w+ $",
+                "log": "wazuh -",
+                "end_match": null,
+                "captured_groups": [
+                ]
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all. Ends pattern (With flags and capture all) before log.",
+                "debug" : true,
+                "ignore_result": true,
+                "pattern": "^(\\w+ )$",
+                "log": "wazuh -",
+                "end_match": null,
+                "captured_groups": [
+                ]
+            }
+        ]
+    },
+    {
+        "description": "[Coverage] Regex, only backslash with '+' modifier.",
+        "batch_test": [
+            {
+                "description": "Without capture group, match all",
+                "ignore_result": true,
+                "debug": false,
+                "pattern": "\\w+",
+                "log": "wazuh",
+                "end_match": "h",
+                "captured_groups": []
+            },
+            {
+                "description": "With capture group, match all",
+                "ignore_result": true,
+                "debug": false,
+                "pattern": "(\\w+)",
+                "log": "wazuh",
+                "end_match": "h",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Without capture group, match all (And flags)",
+                "ignore_result": true,
+                "debug": false,
+                "pattern": "^\\w+$",
+                "log": "wazuh",
+                "end_match": "h",
+                "captured_groups": []
+            },
+            {
+                "description": "With capture group, match all (And flags)",
+                "ignore_result": true,
+                "debug": false,
+                "pattern": "^(\\w+)$",
+                "log": "wazuh",
+                "end_match": "h",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Without capture group, parcial match (And flags)",
+                "pattern": "^\\w+$",
+                "log": "wazuh ",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "With capture group, match all (And flags)",
+                "pattern": "^(\\w+)$",
+                "log": "wazuh ",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Without capture group, match one character.",
+                "pattern": "\\w+",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": []
+            },
+            {
+                "description": "With capture group, match one character.",
+                "pattern": "(\\w+)",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Without capture group, match all (And flags), match one character.",
+                "pattern": "^\\w+$",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": []
+            },
+            {
+                "description": "With capture group, match all (And flags), match one character.",
+                "pattern": "^(\\w+)$",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": [
+                    "w"
+                ]
+            }
+        ]
+    },
+    {
         "description": "[Coverage] Regex, only backslash with '+' modifier.",
         "batch_test": [
             {

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -1,5 +1,138 @@
 [
     {
+        "description": "[Coverage] Regex, only backslash with '*' modifier.",
+        "batch_test": [
+            {
+                "description": "Without capture group, match all",
+                "ignore_result": true,
+                "pattern": "\\w*",
+                "log": "wazuh",
+                "end_match": "h",
+                "captured_groups": []
+            },
+            {
+                "description": "Without capture group, match 0-0",
+                "ignore_result": true,
+                "__know_issue": "Return one byte before log starts ",
+                "skip_test": true,
+                "pattern": "\\d*",
+                "log": "wazuh",
+                "end_match": "wazuh",
+                "captured_groups": []
+            },
+            {
+                "description": "With capture group, match all",
+                "ignore_result": true,
+                "pattern": "(\\w*)",
+                "log": "wazuh",
+                "end_match": "h",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "With capture group, match 0-0",
+                "ignore_result": true,
+                "__know_issue": "Return one byte before log starts ",
+                "skip_test": true,
+                "pattern": "(\\d*)",
+                "log": "wazuh",
+                "end_match": "wazuh",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Without capture group, match all (And flags)",
+                "ignore_result": true,
+                "debug": false,
+                "pattern": "^\\w*$",
+                "log": "wazuh",
+                "end_match": "h",
+                "captured_groups": []
+            },
+            {
+                "description": "With capture group, match all (And flags)",
+                "ignore_result": true,
+                "pattern": "^(\\w*)$",
+                "log": "wazuh",
+                "end_match": "h",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Without capture group, parcial match (And flags)",
+                "pattern": "^\\w*$",
+                "log": "wazuh ",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "With capture group, match all (And flags)",
+                "pattern": "^(\\w*)$",
+                "log": "wazuh ",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Without capture group, match one character.",
+                "pattern": "\\w*",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": []
+            },
+            {
+                "description": "With capture group, match one character.",
+                "pattern": "(\\w*)",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Without capture group, match all (And flags), match one character.",
+                "pattern": "^\\w*$",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": []
+            },
+            {
+                "description": "With capture group, match all (And flags), match one character.",
+                "pattern": "^(\\w*)$",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Without capture group, empty (And flags)",
+                "ignore_result": true,
+                "__know_issue": "Return one byte before log starts ",
+                "pattern": "^\\w*$",
+                "log": "",
+                "end_match": "",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "With capture group, match 0-0. Empty string",
+                "ignore_result": true,
+                "__know_issue": "Return one byte before log starts ",
+                "skip_test": true,
+                "pattern": "(\\d*)",
+                "log": "",
+                "end_match": "",
+                "captured_groups": [
+                    ""
+                ]
+            }
+        ]
+    },
+    {
         "description": "[Coverage] Lazy pattern, greedy match - backslash with '+' modifier. st_error, error handling, parcial match and rewind.",
         "batch_test": [
             {
@@ -74,19 +207,19 @@
             },
             {
                 "description": "Save 6 token position, and restore the fifth. But the fifth should match with the next character.",
-                 "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+ \\w+6",
+                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+ \\w+6",
                 "ignore_result": true,
-                "__knowIssue":"#XXXX The stacktrace has a static size",
+                "__knowIssue": "#XXXX The stacktrace has a static size",
                 "log": "z1 x2 x3 x4 x5x5 x6",
                 "end_match": "6",
                 "captured_groups": []
             },
             {
                 "description": "Save 6 token position, and restore the sixth. But the sixth should match with the next character.",
-		"pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
+                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
                 "log": "z1 x2 x3 x4 x5 x6x6",
                 "ignore_result": true,
-                "__knowIssue":"#XXXX The stacktrace has a static size",
+                "__knowIssue": "#XXXX The stacktrace has a static size",
                 "end_match": "6",
                 "captured_groups": []
             }
@@ -114,14 +247,18 @@
                 "pattern": "(\\d+)\\w",
                 "log": "12",
                 "end_match": "2",
-                "captured_groups": ["1"]
+                "captured_groups": [
+                    "1"
+                ]
             },
             {
                 "description": "Min size: Minimum match with capture group",
                 "pattern": "\\d+(\\w)",
                 "log": "12",
                 "end_match": "2",
-                "captured_groups": ["2"]
+                "captured_groups": [
+                    "2"
+                ]
             },
             {
                 "description": "Lazy pattern: Move as fast as possible over the pattern",
@@ -138,7 +275,9 @@
                 "pattern": "(\\d+)\\w",
                 "log": "12345",
                 "end_match": "5",
-                "captured_groups": ["1"]
+                "captured_groups": [
+                    "1"
+                ]
             },
             {
                 "description": "Lazy pattern: Move as fast as possible over the pattern",
@@ -147,7 +286,9 @@
                 "pattern": "\\d+(\\w)",
                 "log": "12345",
                 "end_match": "5",
-                "captured_groups": ["5"]
+                "captured_groups": [
+                    "5"
+                ]
             },
             {
                 "description": "Min size: No match, no items in the log to consume (With flags).",
@@ -168,14 +309,18 @@
                 "pattern": "^(\\d+)\\w$",
                 "log": "12",
                 "end_match": "2",
-                "captured_groups": ["1"]
+                "captured_groups": [
+                    "1"
+                ]
             },
             {
                 "description": "Min size: Minimum match with capture group (With flags).",
                 "pattern": "^\\d+(\\w)$",
                 "log": "12",
                 "end_match": "2",
-                "captured_groups": ["2"]
+                "captured_groups": [
+                    "2"
+                ]
             },
             {
                 "description": "Lazy pattern: Move as fast as possible over the pattern (With flags).",
@@ -194,7 +339,9 @@
                 "pattern": "^(\\d+)\\w$",
                 "log": "12345",
                 "end_match": "5",
-                "captured_groups": ["1234"]
+                "captured_groups": [
+                    "1234"
+                ]
             },
             {
                 "description": "Lazy pattern: Move as fast as possible over the pattern (With flags).",
@@ -204,7 +351,9 @@
                 "pattern": "^\\d+(\\w)$",
                 "log": "12345",
                 "end_match": "5",
-                "captured_groups": ["5"]
+                "captured_groups": [
+                    "5"
+                ]
             },
             {
                 "description": "Lazy pattern: Move as fast as possible over the pattern (With flags).",
@@ -462,23 +611,21 @@
             },
             {
                 "description": "Next token without blackslash. ok_here == -1. Match all. Ends pattern (With flags) before log.",
-                "debug" : true,
+                "debug": true,
                 "ignore_result": true,
                 "pattern": "^\\w+ $",
                 "log": "wazuh -",
                 "end_match": null,
-                "captured_groups": [
-                ]
+                "captured_groups": []
             },
             {
                 "description": "Next token without blackslash. ok_here == -1. Match all. Ends pattern (With flags and capture all) before log.",
-                "debug" : true,
+                "debug": true,
                 "ignore_result": true,
                 "pattern": "^(\\w+ )$",
                 "log": "wazuh -",
                 "end_match": null,
-                "captured_groups": [
-                ]
+                "captured_groups": []
             }
         ]
     },

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -1,5 +1,98 @@
 [
     {
+        "description": "[Coverage] Lazy pattern, greedy match - backslash with '+' modifier. st_error, error handling, parcial match and rewind.",
+        "batch_test": [
+            {
+                "description": "Save 6 token position, and restore the first.",
+                "pattern": "\\w+_1 \\w+_2 \\w+_3 \\w+_4 \\w+_5 \\w+_6",
+                "log": "wa_11 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Save 6 token position, and restore the second.",
+                "pattern": "\\w+_1 \\w+_2 \\w+_3 \\w+_4 \\w+_5 \\w+_6",
+                "log": "wa_1 wa_22 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Save 6 token position, and restore the third.",
+                "pattern": "\\w+_1 \\w+_2 \\w+_3 \\w+_4 \\w+_5 \\w+_6",
+                "log": "wa_1 wa_2 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Save 6 token position, and restore the fourth.",
+                "pattern": "\\w+_1 \\w+_2 \\w+_3 \\w+_4 \\w+_5 \\w+_6",
+                "log": "wa_1 wa_2 wa_3 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Save 6 token position, and restore the fifth.",
+                "pattern": "\\w+_1 \\w+_2 \\w+_3 \\w+_4 \\w+_5 \\w+_6",
+                "log": "wa_1 wa_2 wa_3 wa_4 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Save 6 token position, and restore the sixth.",
+                "pattern": "\\w+_1 \\w+_2 \\w+_3 \\w+_4 \\w+_5 \\w+_6",
+                "log": "wa_1 wa_2 wa_3 wa_4 wa_5 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Save 6 token position, and restore the first. But the first should match with the next character.",
+                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
+                "log": "z1x1 x2 x3 x4 x5 x6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Save 6 token position, and restore the second. But the second should match with the next character.",
+                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
+                "log": "z1 x2x2 x3 x4 x5 x6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Save 6 token position, and restore the third. But the third should match with the next character.",
+                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
+                "log": "z1 x2x2 x3 x4 x5 x6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Save 6 token position, and restore the fourth. But the fourth should match with the next character.",
+                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
+                "log": "z1 x2 x3 x4x4 x5 x6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Save 6 token position, and restore the fifth. But the fifth should match with the next character.",
+                 "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+ \\w+6",
+                "ignore_result": true,
+                "__knowIssue":"#XXXX The stacktrace has a static size",
+                "log": "z1 x2 x3 x4 x5x5 x6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Save 6 token position, and restore the sixth. But the sixth should match with the next character.",
+		"pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
+                "log": "z1 x2 x3 x4 x5 x6x6",
+                "ignore_result": true,
+                "__knowIssue":"#XXXX The stacktrace has a static size",
+                "end_match": "6",
+                "captured_groups": []
+            }
+        ]
+    },
+    {
         "description": "[Coverage] Lazy pattern, greedy match - backslash with '+' modifier. The next token does include the map characters of the current token and has no modifier.",
         "batch_test": [
             {

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -94,6 +94,20 @@
                 ]
             },
             {
+                "description": "Match pattern but fail because log dont ends.",
+                "pattern": "hi wazuh$",
+                "log": "hi wazuh 123",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Match pattern (with group) but fail because log dont ends.",
+                "pattern": "(hi) (wazuh)$",
+                "log": "hi wazuh 123",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
                 "description": "Dont match at all .pattern[0] != '('.",
                 "pattern": "hi wazuh",
                 "log": "bye wazuh",

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -2586,6 +2586,15 @@
                 ]
             },
             {
+                "description": "This case matches.",
+                "pattern": "(\\d+)\\D* ",
+                "log": "123 ",
+                "end_match": " ",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
                 "ignore_result": true,
                 "pattern": "(\\d+)\\D*",
@@ -2867,6 +2876,99 @@
                     "xyz5xyz5",
                     "xyz6"
                 ]
+            },
+            {
+                "description": "This case has 3 (non-optional) tokens but it is capturing only 2 characters.",
+                "__knownIssue": "Capture groups could be either '04T15' or '4T15', depending on the (unpredictable) behavior of the greediness.",
+                "ignore_result": true,
+                "pattern": "(\\d+\\w\\d+)",
+                "log": "04T15",
+                "end_match": "5",
+                "captured_groups": [
+                    "04T15"
+                ]
+            },
+            {
+                "description": "This case should match but it does not.",
+                "ignore_result": true,
+                "pattern": "(-\\d+\\w\\d+:)",
+                "log": "-04T15:",
+                "end_match": ":",
+                "captured_groups": [
+                    "-04T15:"
+                ]
+            },
+            {
+                "description": "This case should match but it does not.",
+                "ignore_result": true,
+                "pattern": "-(\\d+\\w\\d+):",
+                "log": "-04T15:",
+                "end_match": ":",
+                "captured_groups": [
+                    "04T15"
+                ]
+            },
+            {
+                "description": "This case should match but it does not.",
+                "ignore_result": true,
+                "pattern": "-\\d+\\w\\d+:",
+                "log": "-04T15:",
+                "end_match": ":",
+                "captured_groups": []
+            },
+            {
+                "description": "This case matches.",
+                "__knownIssue": "Wrong end_match value.",
+                "ignore_result": true,
+                "pattern": "\\d+\\w\\d+",
+                "log": "04T15",
+                "end_match": "5",
+                "captured_groups": []
+            },
+            {
+                "description": "This case matches.",
+                "__knownIssue": "Wrong end_match value.",
+                "ignore_result": true,
+                "pattern": "(\\d+\\D\\d+)",
+                "log": "04T15",
+                "end_match": "5",
+                "captured_groups": [
+                    "04T15"
+                ]
+            },
+            {
+                "description": "This case matches.",
+                "pattern": "(-\\d+\\D\\d+:)",
+                "log": "-04T15:",
+                "end_match": ":",
+                "captured_groups": [
+                    "-04T15:"
+                ]
+            },
+            {
+                "description": "This case matches.",
+                "pattern": "-(\\d+\\D\\d+):",
+                "log": "-04T15:",
+                "end_match": ":",
+                "captured_groups": [
+                    "04T15"
+                ]
+            },
+            {
+                "description": "This case matches.",
+                "pattern": "-\\d+\\D\\d+:",
+                "log": "-04T15:",
+                "end_match": ":",
+                "captured_groups": []
+            },
+            {
+                "description": "This case matches.",
+                "__knownIssue": "Wrong end_match value.",
+                "ignore_result": true,
+                "pattern": "\\d+\\D\\d+",
+                "log": "04T15",
+                "end_match": "5",
+                "captured_groups": []
             }
         ]
     }

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -1,5 +1,392 @@
 [
     {
+        "description": "[Coverage] Lazy pattern, greedy match - backslash with '+' modifier. The next token does not include the map characters of the current token and has '+' modifier.",
+        "batch_test": [
+            {
+                "description": "Min size",
+                "pattern": "\\w+\\s+",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Min size. Capture all.",
+                "pattern": "(\\w+\\s+)",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Min size, with group",
+                "pattern": "(\\w+)\\s+",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": ["w"]
+            },
+            {
+                "description": "Other size",
+                "pattern": "\\w+\\s+",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Other size. With group",
+                "pattern": "(\\w+)\\s+",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": ["wazuh"]
+            },
+            {
+                "description": "Other size. With group",
+                "__know_issue": "Consecutive capture groups don't support. should match 'wazuh ' but it doesn't. But (\\w+)\\d*(\\s+) works",
+                "ignore_result": true,
+                "pattern": "(\\w+)(\\s+)",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": ["wazuh", " "]
+            },
+            {
+                "description": "2 groups no consecutive, and opcional",
+                "pattern": "(\\w+)\\d*(\\s+)",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": ["wazuh", " "]
+            },
+            {
+                "description": "2 groups no consecutive, and opcional",
+                "pattern": "(\\w+)\\d*(\\s+)",
+                "log": "wazuh123 ",
+                "end_match": " ",
+                "captured_groups": ["wazuh", " "]
+            },
+            {
+                "description": "2 groups no consecutive",
+                "pattern": "(\\w+)\\d+(\\s+)",
+                "log": "wazuh123 ",
+                "end_match": " ",
+                "captured_groups": ["wazuh", " "]
+            },
+            {
+                "description": "With literal at the end.",
+                "pattern": "\\w+\\s+1",
+                "log": "wazuh 1",
+                "end_match": "1",
+                "captured_groups": []
+            },
+            {
+                "description": "With literal at the end, 1 character + capture group.",
+                "pattern": "(\\w+)\\s+1",
+                "log": "w 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "With literal at the end, 1 character + capture all.",
+                "pattern": "(\\w+\\s+)1",
+                "log": "w 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "With literal at the end, 1 character + capture",
+                "pattern": " (\\w+)\\s+1",
+                "log": " wazuh 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Min size. Match all. 1 character (With flags).",
+                "pattern": "^\\w+\\s+$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all (With flags).",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "pattern": "^\\w+\\s+$",
+                "log": "wazuh  ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all. 1 character + capture group. (With flags).",
+                "pattern": "^(\\w+)\\s+$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Match all. 1 character + capture group. (With flags).",
+                "pattern": "^(\\w+)\\s+$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Next token with blackslash.  ok_here == -1. Match all. 1 character + capture all. (With flags).",
+                "pattern": "^(\\w+\\s+)$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Dont match.",
+                "pattern": "^\\w+\\s+$",
+                "log": "wazuh -",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Dont match.",
+                "pattern": "^(\\w+\\s+)$",
+                "log": "wazuh -",
+                "end_match": null,
+                "captured_groups": []
+            }
+        ]
+    },
+    {
+        "description": "[Coverage] Lazy pattern, greedy match - backslash with '+' modifier. The next token does include the map characters of the current token and has '*' modifier.",
+        "batch_test": [
+            {
+                "description": "Min size",
+                "pattern": "\\w+\\s*",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": []
+            },
+            {
+                "description": "Min size + opt.",
+                "pattern": "\\w+\\s*",
+                "__know_issue":"Err retval.",
+                "ignore_result": true,
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Min size. Capture all.",
+                "pattern": "(\\w+\\s*)",
+                "__know_issue": "The group: 'w' cannot be found",
+                "ignore_result": true,
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Min size. Capture all.",
+                "pattern": "(\\w+\\s*)",
+                "__know_issue": "The group: 'wazuh' cannot be found",
+                "ignore_result": true,
+                "log": "wazuh",
+                "end_match": "wazuh",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Min size + opt. Capture all.",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "pattern": "(\\w+\\s*)",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Min size, with group",
+                "pattern": "(\\w+)\\s*",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": ["w"]
+            },
+            {
+                "description": "Min size + opt, with group",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "pattern": "(\\w+)\\s*",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": ["w"]
+            },
+            {
+                "description": "Other size",
+                "pattern": "\\w+\\s*",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Other size. With group",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "pattern": "(\\w+\\s*)",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": ["wazuh "]
+            },
+            {
+                "description": "Other size. With group",
+                "__know_issue": "Consecutive capture groups don't support. should match 'wazuh ' but it doesn't. But (\\w+)\\d*(\\s+) works",
+                "ignore_result": true,
+                "pattern": "(\\w+)(\\s*)",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": ["wazuh", " "]
+            },
+            {
+                "description": "2 groups no consecutive, and opcional",
+                "pattern": "(\\w+)\\d+(\\s*)",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "log": "wazuh ",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "2 groups no consecutive, and opcional",
+                "pattern": "(\\w+)\\d+(\\s*)",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "log": "wazuh123 ",
+                "end_match": " ",
+                "captured_groups": ["wazuh", " "]
+            },
+            {
+                "description": "2 groups no consecutive",
+                "pattern": "(\\w+)\\d*(\\s*)",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "debug": false,
+                "log": "wazuh123 ",
+                "end_match": " ",
+                "captured_groups": ["wazuh", " "]
+            },
+            {
+                "description": "With literal at the end.",
+                "pattern": "\\w+\\s*1",
+                "log": "wazuh 1",
+                "end_match": "1",
+                "captured_groups": []
+            },
+            {
+                "description": "With literal at the end, 1 character + capture group.",
+                "pattern": "(\\w+)\\s*1",
+                "log": "w 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "With literal at the end, 1 character + capture all.",
+                "pattern": "(\\w+\\s*)1",
+                "log": "w 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "With literal at the end, 1 character + capture",
+                "pattern": " (\\w+)\\s*1",
+                "log": " wazuh 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Min size. Match all. 1 character (With flags).",
+                "pattern": "^\\w+\\s*$",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all (With flags).",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "pattern": "^\\w+\\s*$",
+                "log": "wazuh  ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all. 1 character + capture group. (With flags).",
+                "pattern": "^(\\w+)\\s*$",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Match all. 1 character + capture group. (With flags).",
+                "pattern": "^(\\w+)\\s*$",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Next token with blackslash.  ok_here == -1. Match all. 1 character + capture all. (With flags).",
+                "pattern": "^(\\w+\\s*)$",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Dont match.",
+                "pattern": "^\\w+\\s*$",
+                "log": "wazuh -",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Dont match.",
+                "pattern": "^(\\w+\\s*)$",
+                "log": "wazuh -",
+                "end_match": null,
+                "captured_groups": []
+            }
+        ]
+    },
+    {
         "description": "[Coverage] Lazy pattern, greedy match - backslash with '*' modifier. st_error, error handling, parcial match and rewind.",
         "batch_test": [
             {

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -420,7 +420,7 @@
                 ]
             },
             {
-                "description": "Using the '\\p+' token to test matching all the special characters without capture group. Note: the character '\\' is not captured by the token '\\p'.",
+                "description": "Using the '\\p+' token to test matching all the special characters w/o capture group. Note: the character '\\' is not captured by the token '\\p'.",
                 "pattern": "\\p+",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -436,7 +436,7 @@
                 ]
             },
             {
-                "description": "Using the '\\p*' token to test matching all the special characters without capture group. Note: the character '\\' is not captured by the token '\\p'.",
+                "description": "Using the '\\p*' token to test matching all the special characters w/o capture group. Note: the character '\\' is not captured by the token '\\p'.",
                 "ignore_result": true,
                 "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are \\p*",
@@ -454,7 +454,7 @@
                 ]
             },
             {
-                "description": "Using the '\\.+' token to test matching the character '\\' without capture group.",
+                "description": "Using the '\\.+' token to test matching the character '\\' w/o capture group.",
                 "pattern": "Backslash character is \\.+",
                 "log": "Backslash character is \\",
                 "end_match": "\\",
@@ -472,7 +472,7 @@
                 ]
             },
             {
-                "description": "Using the '\\.*' token to test matching the character '\\' without capture group.",
+                "description": "Using the '\\.*' token to test matching the character '\\' w/o capture group.",
                 "ignore_result": true,
                 "__knownIssue": "Link github issue ####",
                 "pattern": "Backslash character is \\.*",
@@ -492,7 +492,7 @@
                 ]
             },
             {
-                "description": "Using the '\\t+' token to test NOT matching all the special characters without capture group.",
+                "description": "Using the '\\t+' token to test NOT matching all the special characters w/o capture group.",
                 "ignore_result": true,
                 "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are \\t+",
@@ -510,7 +510,7 @@
                 ]
             },
             {
-                "description": "Using the '\\t*' token to test NOT matching all the special characters without capture group.",
+                "description": "Using the '\\t*' token to test NOT matching all the special characters w/o capture group.",
                 "pattern": "Special characters are \\t*",
                 "log": "Special characters are $()|<\\",
                 "end_match": " $()|<\\",
@@ -528,7 +528,7 @@
                 ]
             },
             {
-                "description": "Using the '\\d+' token to test NOT matching all the special characters without capture group.",
+                "description": "Using the '\\d+' token to test NOT matching all the special characters w/o capture group.",
                 "ignore_result": true,
                 "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are \\d+",
@@ -548,7 +548,7 @@
                 ]
             },
             {
-                "description": "Using the '\\d*' token to test NOT matching all the special characters without capture group.",
+                "description": "Using the '\\d*' token to test NOT matching all the special characters w/o capture group.",
                 "ignore_result": true,
                 "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are \\d*",
@@ -568,7 +568,7 @@
                 ]
             },
             {
-                "description": "Using the '\\D+' token to test matching all the special characters without capture group.",
+                "description": "Using the '\\D+' token to test matching all the special characters w/o capture group.",
                 "ignore_result": true,
                 "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are \\D+",
@@ -588,7 +588,7 @@
                 ]
             },
             {
-                "description": "Using the '\\D*' token to test matching all the special characters without capture group.",
+                "description": "Using the '\\D*' token to test matching all the special characters w/o capture group.",
                 "ignore_result": true,
                 "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are \\D*",
@@ -608,7 +608,7 @@
                 ]
             },
             {
-                "description": "Using the '\\w+' token to test NOT matching all the special characters without capture group.",
+                "description": "Using the '\\w+' token to test NOT matching all the special characters w/o capture group.",
                 "ignore_result": true,
                 "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are \\w+",
@@ -626,7 +626,7 @@
                 ]
             },
             {
-                "description": "Using the '\\w*' token to test NOT matching all the special characters without capture group.",
+                "description": "Using the '\\w*' token to test NOT matching all the special characters w/o capture group.",
                 "pattern": "Special characters are \\w*",
                 "log": "Special characters are $()|<\\",
                 "end_match": " $()|<\\",
@@ -644,7 +644,7 @@
                 ]
             },
             {
-                "description": "Using the '\\W+' token to test matching all the special characters without capture group.",
+                "description": "Using the '\\W+' token to test matching all the special characters w/o capture group.",
                 "ignore_result": true,
                 "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are \\W+",
@@ -664,7 +664,7 @@
                 ]
             },
             {
-                "description": "Using the '\\W*' token to test matching all the special characters without capture group.",
+                "description": "Using the '\\W*' token to test matching all the special characters w/o capture group.",
                 "ignore_result": true,
                 "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are \\W*",
@@ -684,7 +684,7 @@
                 ]
             },
             {
-                "description": "Using the '\\S+' token to test matching all the special characters without capture group.",
+                "description": "Using the '\\S+' token to test matching all the special characters w/o capture group.",
                 "ignore_result": true,
                 "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are \\S+",
@@ -704,7 +704,7 @@
                 ]
             },
             {
-                "description": "Using the '\\S*' token to test matching all the special characters without capture group.",
+                "description": "Using the '\\S*' token to test matching all the special characters w/o capture group.",
                 "ignore_result": true,
                 "__knownIssue": "Link github issue ####",
                 "pattern": "Special characters are \\S*",
@@ -982,7 +982,7 @@
         "description": "[Functionality] Corner cases. This tests have shown that OS Regex is not working as expected.",
         "batch_test": [
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. Without capture group.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
                 "ignore_result": true,
                 "pattern": "Pattern \\w+ \\d+",
                 "log": "Pattern Wazuh 123",
@@ -990,7 +990,7 @@
                 "captured_groups": []
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. With capture group.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
                 "ignore_result": true,
                 "pattern": "Pattern (\\w+ \\d+)",
                 "log": "Pattern Wazuh 123",
@@ -1000,7 +1000,7 @@
                 ]
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. Without capture group.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
                 "ignore_result": true,
                 "pattern": "^Pattern \\w+ \\d+",
                 "log": "Pattern Wazuh 123",
@@ -1008,7 +1008,7 @@
                 "captured_groups": []
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. With capture group.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
                 "ignore_result": true,
                 "pattern": "^Pattern (\\w+ \\d+)",
                 "log": "Pattern Wazuh 123",
@@ -1018,7 +1018,7 @@
                 ]
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. Without capture group.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
                 "ignore_result": true,
                 "pattern": "Pattern \\w+ \\d+$",
                 "log": "Pattern Wazuh 123",
@@ -1026,7 +1026,7 @@
                 "captured_groups": []
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. With capture group.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
                 "ignore_result": true,
                 "pattern": "Pattern (\\w+ \\d+)$",
                 "log": "Pattern Wazuh 123",
@@ -1036,7 +1036,7 @@
                 ]
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1'). Without capture group.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
                 "ignore_result": true,
                 "pattern": "Pattern \\w* \\d*",
                 "log": "Pattern Wazuh 123",
@@ -1044,7 +1044,7 @@
                 "captured_groups": []
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1'). With capture group.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
                 "ignore_result": true,
                 "pattern": "Pattern (\\w* \\d*)",
                 "log": "Pattern Wazuh 123",
@@ -1054,7 +1054,7 @@
                 ]
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1'). Without capture group.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
                 "ignore_result": true,
                 "pattern": "^Pattern \\w* \\d*",
                 "log": "Pattern Wazuh 123",
@@ -1062,7 +1062,7 @@
                 "captured_groups": []
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1'). With capture group.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
                 "ignore_result": true,
                 "pattern": "^Pattern (\\w* \\d*)",
                 "log": "Pattern Wazuh 123",
@@ -1072,7 +1072,7 @@
                 ]
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1'). Without capture group.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
                 "ignore_result": true,
                 "pattern": "Pattern \\w* \\d*$",
                 "log": "Pattern Wazuh 123",
@@ -1080,7 +1080,7 @@
                 "captured_groups": []
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1'). With capture group.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
                 "ignore_result": true,
                 "pattern": "Pattern (\\w* \\d*)$",
                 "log": "Pattern Wazuh 123",
@@ -1090,7 +1090,7 @@
                 ]
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. Without capture group.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
                 "ignore_result": true,
                 "pattern": "Subpattern 1: \\d+|Subpattern 2: \\d+",
                 "log": "Subpattern 2: 123",
@@ -1098,7 +1098,23 @@
                 "captured_groups": []
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. With capture group.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "ignore_result": true,
+                "pattern": "Subpattern 1: \\d+|^Subpattern 2: \\d+",
+                "log": "Subpattern 2: 123",
+                "end_match": "3",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "ignore_result": true,
+                "pattern": "Subpattern 1: \\d+|Subpattern 2: \\d+$",
+                "log": "Subpattern 2: 123",
+                "end_match": "3",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
                 "ignore_result": true,
                 "pattern": "Subpattern 1: (\\d+)|Subpattern 2: (\\d+)",
                 "log": "Subpattern 2: 123",
@@ -1108,7 +1124,27 @@
                 ]
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3'). Without capture group.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "ignore_result": true,
+                "pattern": "Subpattern 1: (\\d+)|^Subpattern 2: (\\d+)",
+                "log": "Subpattern 2: 123",
+                "end_match": "3",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "ignore_result": true,
+                "pattern": "Subpattern 1: (\\d+)|Subpattern 2: (\\d+)$",
+                "log": "Subpattern 2: 123",
+                "end_match": "3",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3').",
                 "ignore_result": true,
                 "pattern": "\\d+",
                 "log": "123subpattern",
@@ -1116,7 +1152,15 @@
                 "captured_groups": []
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. Without capture group.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "ignore_result": true,
+                "pattern": "\\d+",
+                "log": "subpattern123",
+                "end_match": "3",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
                 "ignore_result": true,
                 "pattern": "\\d+",
                 "log": "123",
@@ -1124,7 +1168,32 @@
                 "captured_groups": []
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. With capture group.",
+                "description": "Last matched character pointed (end_match) should be '9' but it is '1'.",
+                "ignore_result": true,
+                "pattern": "\\d+",
+                "log": "123456789",
+                "end_match": "9",
+                "captured_groups": []
+            },
+            {
+                "description": "This case works well.",
+                "pattern": "\\d+",
+                "log": "1",
+                "end_match": "1",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "ignore_result": true,
+                "pattern": "(\\d+)",
+                "log": "123",
+                "end_match": "3",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
                 "ignore_result": true,
                 "pattern": "(\\d+)",
                 "log": "123subpattern",
@@ -1134,12 +1203,67 @@
                 ]
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3'). Without capture group.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "ignore_result": true,
+                "pattern": "(\\d+)",
+                "log": "subpattern123",
+                "end_match": "3",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '9' but it is '1'.",
+                "ignore_result": true,
+                "pattern": "(\\d+)",
+                "log": "123456789",
+                "end_match": "9",
+                "captured_groups": [
+                    "123456789"
+                ]
+            },
+            {
+                "description": "This case works well.",
+                "pattern": "(\\d+)",
+                "log": "1",
+                "end_match": "1",
+                "captured_groups": [
+                    "1"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3').",
+                "ignore_result": true,
+                "pattern": "\\d*",
+                "log": "123",
+                "end_match": "3",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3').",
                 "ignore_result": true,
                 "pattern": "\\d*",
                 "log": "123subpattern",
                 "end_match": "3subpattern",
                 "captured_groups": []
+            },
+            {
+                "description": "This test overflows the heap buffer.",
+                "skip_test": true,
+                "pattern": "\\d*",
+                "log": "subpattern123",
+                "end_match": "3",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "ignore_result": true,
+                "pattern": "(\\d*)",
+                "log": "123",
+                "end_match": "3",
+                "captured_groups": [
+                    "123"
+                ]
             },
             {
                 "description": "With capture group the case works well.",
@@ -1151,7 +1275,17 @@
                 ]
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. Without capture group.",
+                "description": "This test overflows the heap buffer.",
+                "skip_test": true,
+                "pattern": "(\\d*)",
+                "log": "subpattern123",
+                "end_match": "3",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
                 "ignore_result": true,
                 "pattern": "^\\d+",
                 "log": "123",
@@ -1159,7 +1293,22 @@
                 "captured_groups": []
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. With capture group.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3').",
+                "ignore_result": true,
+                "pattern": "^\\d+",
+                "log": "123subpattern",
+                "end_match": "3subpattern",
+                "captured_groups": []
+            },
+            {
+                "description": "This test passes.",
+                "pattern": "^\\d+",
+                "log": "subpattern123",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
                 "ignore_result": true,
                 "pattern": "^(\\d+)",
                 "log": "123",
@@ -1169,7 +1318,24 @@
                 ]
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. Without capture group.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "ignore_result": true,
+                "pattern": "^(\\d+)",
+                "log": "123subpattern",
+                "end_match": "3subpattern",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "This test passes.",
+                "pattern": "^(\\d+)",
+                "log": "subpattern123",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
                 "ignore_result": true,
                 "pattern": "^\\d*",
                 "log": "123",
@@ -1177,7 +1343,23 @@
                 "captured_groups": []
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. With capture group.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3').",
+                "ignore_result": true,
+                "pattern": "^\\d*",
+                "log": "123subpattern",
+                "end_match": "3subpattern",
+                "captured_groups": []
+            },
+            {
+                "description": "This test overflows the heap buffer.",
+                "skip_test": true,
+                "pattern": "^\\d*",
+                "log": "subpattern123",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
                 "ignore_result": true,
                 "pattern": "^(\\d*)",
                 "log": "123",
@@ -1185,32 +1367,6 @@
                 "captured_groups": [
                     "123"
                 ]
-            },
-            {
-                "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3'). Without capture group.",
-                "ignore_result": true,
-                "pattern": "^\\d+",
-                "log": "123subpattern",
-                "end_match": "3subpattern",
-                "captured_groups": []
-            },
-            {
-                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. With capture group.",
-                "ignore_result": true,
-                "pattern": "^(\\d+)",
-                "log": "123subpattern",
-                "end_match": "3subpattern",
-                "captured_groups": [
-                    "123"
-                ]
-            },
-            {
-                "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3'). Without capture group.",
-                "ignore_result": true,
-                "pattern": "^\\d*",
-                "log": "123subpattern",
-                "end_match": "3subpattern",
-                "captured_groups": []
             },
             {
                 "description": "With capture group the case works well.",
@@ -1222,7 +1378,17 @@
                 ]
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. Without capture group.",
+                "description": "This test overflows the heap buffer.",
+                "skip_test": true,
+                "pattern": "^(\\d*)",
+                "log": "subpattern123",
+                "end_match": null,
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
                 "ignore_result": true,
                 "pattern": "\\d+$",
                 "log": "123",
@@ -1230,7 +1396,15 @@
                 "captured_groups": []
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. With capture group.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "ignore_result": true,
+                "pattern": "\\d+$",
+                "log": "log123",
+                "end_match": "3",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
                 "ignore_result": true,
                 "pattern": "(\\d+)$",
                 "log": "123",
@@ -1240,33 +1414,7 @@
                 ]
             },
             {
-                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. Without capture group.",
-                "ignore_result": true,
-                "pattern": "\\d*$",
-                "log": "123",
-                "end_match": "3",
-                "captured_groups": []
-            },
-            {
-                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. With capture group.",
-                "ignore_result": true,
-                "pattern": "(\\d*)$",
-                "log": "123",
-                "end_match": "3",
-                "captured_groups": [
-                    "123"
-                ]
-            },
-            {
-                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. Without capture group.",
-                "ignore_result": true,
-                "pattern": "\\d+$",
-                "log": "log123",
-                "end_match": "3",
-                "captured_groups": []
-            },
-            {
-                "description": "Last matched character pointed (end_match) should be '3' but it is '1'. With capture group.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
                 "ignore_result": true,
                 "pattern": "(\\d+)$",
                 "log": "log123",
@@ -1276,31 +1424,66 @@
                 ]
             },
             {
-                "description": "It should match but it doesn't.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
                 "ignore_result": true,
                 "pattern": "\\d*$",
-                "log": "log123",
+                "log": "123",
                 "end_match": "3",
                 "captured_groups": []
             },
             {
                 "description": "It should match but it doesn't.",
                 "ignore_result": true,
+                "pattern": "\\d*$",
+                "log": "pattern123",
+                "end_match": "3",
+                "captured_groups": []
+            },
+            {
+                "description": "This test passes.",
+                "pattern": "\\d*$",
+                "log": "123pattern",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "ignore_result": true,
                 "pattern": "(\\d*)$",
-                "log": "log123",
+                "log": "123",
                 "end_match": "3",
                 "captured_groups": [
                     "123"
                 ]
             },
             {
-                "description": "Consecutive capture groups (without something in between) do not match.",
+                "description": "It should match but it doesn't.",
+                "ignore_result": true,
+                "pattern": "(\\d*)$",
+                "log": "pattern123",
+                "end_match": "3",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "This test passes.",
+                "pattern": "(\\d*)$",
+                "log": "123pattern",
+                "end_match": null,
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Consecutive capture groups (without something in between) do not match when should.",
                 "ignore_result": true,
                 "pattern": "(\\D+)(\\d+)",
                 "log": "Test123",
                 "end_match": "3",
                 "captured_groups": [
-                    "Test", "123"
+                    "Test",
+                    "123"
                 ]
             },
             {
@@ -1310,7 +1493,8 @@
                 "log": "123Test",
                 "end_match": "t",
                 "captured_groups": [
-                    "123", "Test"
+                    "123",
+                    "Test"
                 ]
             },
             {
@@ -1320,7 +1504,8 @@
                 "log": "Test123",
                 "end_match": "3",
                 "captured_groups": [
-                    "Test", "123"
+                    "Test",
+                    "123"
                 ]
             },
             {
@@ -1330,12 +1515,12 @@
                 "log": "123Test",
                 "end_match": "t",
                 "captured_groups": [
-                    "123", "Test"
+                    "123",
+                    "Test"
                 ]
             },
             {
-                "description": "Consecutive capture groups (without something in between) do not match. The same regex without capture group does match.",
-                "__knownIssue:": "In this case, the returned value is pointing to the '1' when it should be pointing to '3'.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
                 "ignore_result": true,
                 "pattern": "\\D+\\d+",
                 "log": "Test123",
@@ -1343,17 +1528,15 @@
                 "captured_groups": []
             },
             {
-                "description": "Consecutive capture groups (without something in between) do not match. The same regex without capture group does match.",
-                "__knownIssue:": "In this case, the returned value is pointing to 'T' when it should be pointing to 't'.",
+                "description": "Last matched character pointed (end_match) should be 't' but it is 'T'.",
                 "ignore_result": true,
                 "pattern": "\\d+\\D+",
-                "log": "1234Test",
+                "log": "123Test",
                 "end_match": "t",
                 "captured_groups": []
             },
             {
-                "description": "Consecutive capture groups (without something in between) do not match.",
-                "__knownIssue:": "In this case, the returned value is pointing to the 't' when it should be pointing to '3'.",
+                "description": "Last matched character pointed (end_match) should be '3' but it is 't'.",
                 "ignore_result": true,
                 "pattern": "\\D*\\d*",
                 "log": "Test123",
@@ -1361,8 +1544,7 @@
                 "captured_groups": []
             },
             {
-                "description": "Consecutive capture groups (without something in between) do not match.",
-                "__knownIssue:": "In this case, the returned value is pointing to the '3' when it should be pointing to 't'.",
+                "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
                 "ignore_result": true,
                 "pattern": "\\d*\\D*",
                 "log": "123Test",
@@ -1380,8 +1562,28 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case, with 4 extra optional tokens inside a capture group, it does match.",
-                "pattern": "(\\w*\\w*\\d*\\w*\\d*\\w*)",
+                "__knownIssue:": "In this case, with extra optional tokens inside a capture group, it does match.",
+                "pattern": "(\\w*\\d*\\w*\\d*\\w*\\d*)",
+                "log": "xy",
+                "end_match": "y",
+                "captured_groups": [
+                    "xy"
+                ]
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "In this case, with extra optional tokens inside a capture group, it does match.",
+                "pattern": "^(\\w*\\d*\\w*\\d*\\w*\\d*)",
+                "log": "xy",
+                "end_match": "y",
+                "captured_groups": [
+                    "xy"
+                ]
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "In this case, with extra optional tokens inside a capture group, it does match.",
+                "pattern": "(\\w*\\d*\\w*\\d*\\w*\\d*)$",
                 "log": "xy",
                 "end_match": "y",
                 "captured_groups": [
@@ -1400,9 +1602,99 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case, with only 3 extra optional tokens, it does match. TODO",
+                "__knownIssue:": "In this case, with 10 extra optional tokens inside a capture group, it does match.",
+                "pattern": "^(\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*)",
+                "log": "xy",
+                "end_match": "y",
+                "captured_groups": [
+                    "xy"
+                ]
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "In this case, with 10 extra optional tokens inside a capture group, it does match.",
+                "pattern": "(\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*)$",
+                "log": "xy",
+                "end_match": "y",
+                "captured_groups": [
+                    "xy"
+                ]
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "In this case, with 3 extra optional tokens, it does NOT match.",
                 "ignore_result": true,
-                "pattern": "\\p*\\w*\\d*\\w*\\d*\\w*",
+                "pattern": "\\w*\\p*\\d*\\w*",
+                "log": "xy",
+                "end_match": "y",
+                "captured_groups": []
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "In this case, with 3 extra optional tokens, it does NOT match.",
+                "ignore_result": true,
+                "pattern": "^\\w*\\p*\\d*\\w*",
+                "log": "xy",
+                "end_match": "y",
+                "captured_groups": []
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "In this case, with 3 extra optional tokens, it does NOT match.",
+                "ignore_result": true,
+                "pattern": "\\w*\\p*\\d*\\w*$",
+                "log": "xy",
+                "end_match": "y",
+                "captured_groups": []
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "In this case, with 3 extra optional tokens inside a capture group, it does match.",
+                "pattern": "(\\w*\\p*\\d*\\w*)",
+                "log": "xy",
+                "end_match": "y",
+                "captured_groups": [
+                    "xy"
+                ]
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "In this case, with 3 extra optional tokens, it does NOT match.",
+                "ignore_result": true,
+                "pattern": "\\w*\\d*\\w*\\p*",
+                "log": "xy",
+                "end_match": "y",
+                "captured_groups": []
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "In this case, with 2 extra optional tokens, it does match.",
+                "pattern": "\\w*\\d*\\w*",
+                "log": "xy",
+                "end_match": "y",
+                "captured_groups": []
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "In this case, with 2 extra optional tokens, it does match.",
+                "pattern": "^\\w*\\d*\\w*",
+                "log": "xy",
+                "end_match": "y",
+                "captured_groups": []
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "In this case, with 2 extra optional tokens, it does match.",
+                "pattern": "\\w*\\d*\\w*$",
+                "log": "xy",
+                "end_match": "y",
+                "captured_groups": []
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__knownIssue:": "In this case, with 3 extra optional tokens, it does NOT match.",
+                "ignore_result": true,
+                "pattern": "\\w*\\d*\\p*\\w*",
                 "log": "xy",
                 "end_match": "y",
                 "captured_groups": []

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -2040,6 +2040,299 @@
                 "log": "123",
                 "end_match": "3",
                 "captured_groups": []
+            },
+            {
+                "description": "Capture group is not correctly obtained. It should be '123' but it is empty.",
+                "ignore_result": true,
+                "pattern": "(\\d+)\\D*",
+                "log": "123",
+                "end_match": "3",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
+                "ignore_result": true,
+                "pattern": "(\\d+)\\D*",
+                "log": "123Test",
+                "end_match": "t",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "Capture group is not correctly obtained. It should be '123' but it is empty.",
+                "ignore_result": true,
+                "pattern": "(\\d+)\\D*",
+                "log": "Test123",
+                "end_match": "3",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
+                "ignore_result": true,
+                "pattern": "\\d+(\\D*)",
+                "log": "123",
+                "end_match": "3",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
+                "ignore_result": true,
+                "pattern": "\\d+(\\D*)",
+                "log": "123Test",
+                "end_match": "t",
+                "captured_groups": [
+                    "Test"
+                ]
+            },
+            {
+                "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
+                "ignore_result": true,
+                "pattern": "\\d+(\\D*)",
+                "log": "Test123",
+                "end_match": "3",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
+                "ignore_result": true,
+                "pattern": "^\\d+(\\D*)",
+                "log": "123",
+                "end_match": "3",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
+                "ignore_result": true,
+                "pattern": "^\\d+(\\D*)",
+                "log": "123Test",
+                "end_match": "t",
+                "captured_groups": [
+                    "Test"
+                ]
+            },
+            {
+                "description": "This test passes.",
+                "pattern": "^\\d+(\\D*)",
+                "log": "Test123",
+                "end_match": null,
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
+                "ignore_result": true,
+                "pattern": "^(\\d+)\\D*",
+                "log": "123",
+                "end_match": "3",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
+                "ignore_result": true,
+                "pattern": "^(\\d+)\\D*",
+                "log": "123Test",
+                "end_match": "t",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "This test passes.",
+                "pattern": "^(\\d+)\\D*",
+                "log": "Test123",
+                "end_match": null,
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
+                "ignore_result": true,
+                "pattern": "\\d+(\\D*)$",
+                "log": "123",
+                "end_match": "3",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
+                "ignore_result": true,
+                "pattern": "\\d+(\\D*)$",
+                "log": "123Test",
+                "end_match": "t",
+                "captured_groups": [
+                    "Test"
+                ]
+            },
+            {
+                "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
+                "ignore_result": true,
+                "pattern": "\\d+(\\D*)$",
+                "log": "Test123",
+                "end_match": "3",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
+                "ignore_result": true,
+                "pattern": "(\\d+)\\D*$",
+                "log": "123",
+                "end_match": "3",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
+                "ignore_result": true,
+                "pattern": "(\\d+)\\D*$",
+                "log": "123Test",
+                "end_match": "t",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
+                "ignore_result": true,
+                "pattern": "(\\d+)\\D*$",
+                "log": "Test123",
+                "end_match": "3",
+                "captured_groups": [
+                    "123"
+                ]
+            },
+            {
+                "description": "Capture group is not correctly obtained.",
+                "ignore_result": true,
+                "pattern": "(\\d*)\\w*",
+                "log": "123",
+                "end_match": "3",
+                "captured_groups": [
+                    "1"
+                ]
+            },
+            {
+                "description": "Capture group is not correctly obtained.",
+                "ignore_result": true,
+                "pattern": "(\\d*)\\w*",
+                "log": "123Test",
+                "end_match": "3",
+                "captured_groups": [
+                    "1"
+                ]
+            },
+            {
+                "description": "Regex should match but does not.",
+                "__knownIssue": "Only 4 'recoverage' levels are allowed.",
+                "ignore_result": true,
+                "pattern": "(\\w+1) (\\w+2) (\\w+3) (\\w+4) (\\w+5)",
+                "log": "xyz1xyz1 xyz2xyz2 xyz3xyz3 xyz4xyz4 xyz5xyz5",
+                "end_match": "5",
+                "captured_groups": [
+                    "xyz1xyz1",
+                    "xyz2xyz2",
+                    "xyz3xyz3",
+                    "xyz4xyz4",
+                    "xyz5xyz5"
+                ]
+            },
+            {
+                "description": "This case matches.",
+                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5",
+                "log": "xyz1xyz1 xyz2xyz2 xyz3xyz3 xyz4xyz4 xyz5xyz5",
+                "end_match": "5xyz5",
+                "captured_groups": []
+            },
+            {
+                "description": "This case matches.",
+                "ignore_result": true,
+                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5$",
+                "log": "xyz1xyz1 xyz2xyz2 xyz3xyz3 xyz4xyz4 xyz5xyz5",
+                "end_match": "5",
+                "captured_groups": []
+            },
+            {
+                "description": "This case matches.",
+                "pattern": "(\\w+1) (\\w+2) (\\w+3) (\\w+4) (\\w+5)",
+                "log": "xyz1xyz1 xyz2xyz2 xyz3xyz3 xyz4xyz4 xyz5",
+                "end_match": "5",
+                "captured_groups": [
+                    "xyz1xyz1",
+                    "xyz2xyz2",
+                    "xyz3xyz3",
+                    "xyz4xyz4",
+                    "xyz5"
+                ]
+            },
+            {
+                "description": "Regex should match but does not.",
+                "ignore_result": true,
+                "pattern": "(\\w+1) (\\w+2) (\\w+3) (\\w+4) (\\w+5) (\\w+6)$",
+                "log": "xyz1xyz1 xyz2xyz2 xyz3xyz3 xyz4xyz4 xyz5 xyz6xyz6",
+                "end_match": "6",
+                "captured_groups": [
+                    "xyz1xyz1",
+                    "xyz2xyz2",
+                    "xyz3xyz3",
+                    "xyz4xyz4",
+                    "xyz5",
+                    "xyz6xyz6"
+                ]
+            },
+            {
+                "description": "Regex should match but does not.",
+                "ignore_result": true,
+                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6$",
+                "log": "xyz1xyz1 xyz2xyz2 xyz3xyz3 xyz4xyz4 xyz5 xyz6xyz6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "This case matches.",
+                "pattern": "(\\w+1) (\\w+2) (\\w+3) (\\w+4) (\\w+5) (\\w+6)$",
+                "log": "xyz1xyz1 xyz2xyz2 xyz3xyz3 xyz4xyz4 xyz5 xyz6",
+                "end_match": "6",
+                "captured_groups": [
+                    "xyz1xyz1",
+                    "xyz2xyz2",
+                    "xyz3xyz3",
+                    "xyz4xyz4",
+                    "xyz5",
+                    "xyz6"
+                ]
+            },
+            {
+                "description": "Regex should match but does not.",
+                "ignore_result": true,
+                "pattern": "(\\w+1) (\\w+2) (\\w+3) (\\w+4) (\\w+5) (\\w+6)$",
+                "log": "xyz1xyz1 xyz2xyz2 xyz3xyz3 xyz4xyz4 xyz5xyz5 xyz6",
+                "end_match": "6",
+                "captured_groups": [
+                    "xyz1xyz1",
+                    "xyz2xyz2",
+                    "xyz3xyz3",
+                    "xyz4xyz4",
+                    "xyz5xyz5",
+                    "xyz6"
+                ]
             }
         ]
     }

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -1,5 +1,142 @@
 [
     {
+        "description": "[Coverage] Lazy pattern, greedy match - backslash with '*' modifier. The next token does include the map characters of the current token and has no modifier.",
+        "batch_test": [
+            {
+                "description": "0 size: `\\d*` match 0-0",
+                "pattern": "\\d*\\w",
+                "log": "5",
+                "end_match": "5",
+                "captured_groups": []
+            },
+            {
+                "description": "0 size: `\\d*` match 0-0. With group",
+                "pattern": "(\\d*)\\w",
+                "log": "5",
+                "end_match": "5",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "\\w matches with '1' character",
+                "pattern": "\\d*\\w",
+                "log": "12",
+                "end_match": "12",
+                "captured_groups": []
+            },
+            {
+                "description": "\\w matches with '1' character",
+                "pattern": "(\\d*)\\w",
+                "log": "12",
+                "end_match": "12",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Min size: Minimum match with capture group",
+                "pattern": "\\d*(\\w)",
+                "log": "12",
+                "end_match": "12",
+                "captured_groups": [
+                    "1"
+                ]
+            },
+            {
+                "description": "Lazy pattern: Move as fast as possible over the pattern",
+                "pattern": "\\d*\\w",
+                "log": "12345",
+                "end_match": "12345",
+                "captured_groups": []
+            },
+            {
+                "description": "Lazy pattern: Move as fast as possible over the pattern, only capture the first character",
+                "pattern": "(\\d*)\\w",
+                "log": "12345",
+                "end_match": "12345",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Lazy pattern: Move as fast as possible over the pattern",
+                "pattern": "\\d*(\\w)",
+                "log": "12345",
+                "end_match": "12345",
+                "captured_groups": [
+                    "1"
+                ]
+            },
+            {
+                "description": "Min size: No match, no items in the log to consume (With flags).",
+                "pattern": "^\\d*\\d",
+                "log": "5",
+                "end_match": "5",
+                "captured_groups": []
+            },
+            {
+                "description": "Min size: No match, no items in the log to consume (With flags).",
+                "pattern": "^(\\d*)\\d",
+                "log": "5",
+                "end_match": "5",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Min size: Minimum match with capture group (With flags).",
+                "pattern": "^(\\d*)\\w$",
+                "log": "12",
+                "end_match": "2",
+                "captured_groups": [
+                    "1"
+                ]
+            },
+            {
+                "description": "Min size: Minimum match with capture group (With flags).",
+                "pattern": "^\\d*(\\w)$",
+                "log": "12",
+                "end_match": "2",
+                "captured_groups": [
+                    "2"
+                ]
+            },
+            {
+                "description": "Lazy pattern: Move as fast as possible over the pattern (With flags).",
+                "pattern": "^\\d*\\w$",
+                "log": "12345",
+                "end_match": "5",
+                "captured_groups": []
+            },
+            {
+                "description": "Lazy pattern: Move as fast as possible over the pattern, capture the first 4 character, because the $ flag.",
+                "pattern": "^(\\d*)\\w$",
+                "log": "12345",
+                "end_match": "5",
+                "captured_groups": [
+                    "1234"
+                ]
+            },
+            {
+                "description": "Lazy pattern: Move as fast as possible over the pattern (With flags).",
+                "pattern": "^\\d*(\\w)$",
+                "log": "12345",
+                "end_match": "5",
+                "captured_groups": [
+                    "5"
+                ]
+            },
+            {
+                "description": "Lazy pattern: Move as fast as possible over the pattern (With flags).",
+                "pattern": "^\\d*(\\w)$",
+                "log": "12345&&&&&&&",
+                "end_match": null,
+                "captured_groups": []
+            }
+        ]
+    },
+    {
         "description": "[Coverage] Lazy pattern, greedy match - backslash with '*' modifier. The next token does not include the map characters of the current token and has no modifier.",
         "batch_test": [
             {
@@ -295,7 +432,6 @@
             },
             {
                 "description": "Without capture group, match 0-0",
-                "ignore_result": true,
                 "__know_issue": "Return one byte before log starts ",
                 "skip_test": true,
                 "pattern": "\\d*",
@@ -546,31 +682,26 @@
             {
                 "description": "Lazy pattern: Move as fast as possible over the pattern",
                 "pattern": "\\d+\\w",
-                "ignore_result": true,
                 "log": "12345",
-                "end_match": "5",
+                "end_match": "2345",
                 "captured_groups": []
             },
             {
                 "description": "Lazy pattern: Move as fast as possible over the pattern, only capture the first character",
-                "ignore_result": true,
-                "__know_issue": "regex returns the pointer to '2' character. ",
                 "pattern": "(\\d+)\\w",
                 "log": "12345",
-                "end_match": "5",
+                "end_match": "2345",
                 "captured_groups": [
                     "1"
                 ]
             },
             {
                 "description": "Lazy pattern: Move as fast as possible over the pattern",
-                "ignore_result": true,
-                "__know_issue": "regex returns the pointer to '2' character. ",
                 "pattern": "\\d+(\\w)",
                 "log": "12345",
-                "end_match": "5",
+                "end_match": "2345",
                 "captured_groups": [
-                    "5"
+                    "2"
                 ]
             },
             {
@@ -608,16 +739,12 @@
             {
                 "description": "Lazy pattern: Move as fast as possible over the pattern (With flags).",
                 "pattern": "^\\d+\\w$",
-                "ignore_result": true,
-                "debug": true,
                 "log": "12345",
                 "end_match": "5",
                 "captured_groups": []
             },
             {
                 "description": "Lazy pattern: Move as fast as possible over the pattern, capture the first 4 character, because the $ flag.",
-                "ignore_result": true,
-                "debug": true,
                 "__know_issue": "regex returns the pointer to '2' character. ",
                 "pattern": "^(\\d+)\\w$",
                 "log": "12345",
@@ -628,9 +755,6 @@
             },
             {
                 "description": "Lazy pattern: Move as fast as possible over the pattern (With flags).",
-                "ignore_result": true,
-                "debug": true,
-                "__know_issue": "regex returns the pointer to '2' character. ",
                 "pattern": "^\\d+(\\w)$",
                 "log": "12345",
                 "end_match": "5",
@@ -640,9 +764,6 @@
             },
             {
                 "description": "Lazy pattern: Move as fast as possible over the pattern (With flags).",
-                "ignore_result": true,
-                "debug": true,
-                "__know_issue": "regex returns the pointer to '2' character. ",
                 "pattern": "^\\d+(\\w)$",
                 "log": "12345&&&&&&&",
                 "end_match": null,
@@ -894,8 +1015,6 @@
             },
             {
                 "description": "Next token without blackslash. ok_here == -1. Match all. Ends pattern (With flags) before log.",
-                "debug": true,
-                "ignore_result": true,
                 "pattern": "^\\w+ $",
                 "log": "wazuh -",
                 "end_match": null,
@@ -903,8 +1022,6 @@
             },
             {
                 "description": "Next token without blackslash. ok_here == -1. Match all. Ends pattern (With flags and capture all) before log.",
-                "debug": true,
-                "ignore_result": true,
                 "pattern": "^(\\w+ )$",
                 "log": "wazuh -",
                 "end_match": null,

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -1,5 +1,288 @@
 [
     {
+        "description": "[Coverage] Lazy pattern, greedy match - backslash with '*' modifier. The next token does not include the map characters of the current token and has no modifier.",
+        "batch_test": [
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character",
+                "pattern": "\\w*\\s",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all",
+                "pattern": "\\w*\\s",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character * capture group.",
+                "pattern": "(\\w*)\\s",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match 0-0. 1 character * capture group.",
+                "pattern": "(\\w*)\\s",
+                "log": " ",
+                "end_match": " ",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Next token with blackslash.  ok_here == -1. Match all. 1 character * capture all.",
+                "pattern": "(\\w*\\s)",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Next token with blackslash.  ok_here == -1. Match all. 1 character * capture all.",
+                "pattern": "(\\w*\\s)",
+                "log": " ",
+                "end_match": " ",
+                "captured_groups": [
+                    " "
+                ]
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all. Parcial capture group case.",
+                "pattern": "(\\w*)\\s",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character",
+                "pattern": "\\w* ",
+                "log": " ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character",
+                "pattern": "\\w* ",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all",
+                "pattern": "\\w* ",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character * capture group.",
+                "pattern": "(\\w*) ",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character * capture all.",
+                "pattern": "(\\w* )",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all. Parcial capture group case.",
+                "pattern": "(\\w*) ",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all",
+                "pattern": "\\w*\\s1",
+                "log": "wazuh 1",
+                "end_match": "1",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character * capture group.",
+                "pattern": "(\\w*)\\s1",
+                "log": "w 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character * capture all.",
+                "pattern": "(\\w*\\s)1",
+                "log": "w 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Next token with blackslash. ok_here ==  -1. Match all. Parcial capture group case.",
+                "pattern": "(\\w*)\\s1",
+                "log": "wazuh 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match. 1 character",
+                "pattern": "\\w*\\s1",
+                "log": "w 123",
+                "end_match": "123",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match",
+                "pattern": "\\w* 1",
+                "log": "wazuh 123",
+                "end_match": "123",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match. 1 character * capture group.",
+                "pattern": "(\\w*) 1",
+                "log": "w 123",
+                "end_match": "123",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match. 1 character * capture all.",
+                "pattern": "(\\w* )1",
+                "log": "w 123",
+                "end_match": "123",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match. Parcial capture group case.",
+                "pattern": "(\\w*) 1",
+                "log": "wazuh 123",
+                "end_match": "123",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character (With flags).",
+                "pattern": "^\\w*\\s$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all (With flags).",
+                "pattern": "^\\w*\\s$",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character * capture group. (With flags).",
+                "pattern": "^(\\w*)\\s$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Next token with blackslash.  ok_here == -1. Match all. 1 character * capture all. (With flags).",
+                "pattern": "^(\\w*\\s)$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all. Parcial capture group case. (With flags).",
+                "pattern": "^(\\w*)\\s$",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character (With flags).",
+                "pattern": "^\\w* $",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all (With flags).",
+                "pattern": "^\\w* $",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character * capture group (With flags).",
+                "pattern": "^(\\w*) $",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character * capture all (With flags).",
+                "pattern": "^(\\w* )$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all. Parcial capture group case (With flags).",
+                "pattern": "^(\\w*) $",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all. Ends pattern (With flags) before log.",
+                "pattern": "^\\w* $",
+                "log": "wazuh -",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Next token without blackslash. ok_here == -1. Match all. Ends pattern (With flags and capture all) before log.",
+                "pattern": "^(\\w* )$",
+                "log": "wazuh -",
+                "end_match": null,
+                "captured_groups": []
+            }
+        ]
+    },
+    {
         "description": "[Coverage] Regex, only backslash with '*' modifier.",
         "batch_test": [
             {

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -1,5 +1,96 @@
 [
     {
+        "description": "[Coverage] Regex, only backslash with '+' modifier.",
+        "batch_test": [
+            {
+                "description": "Without capture group, match all",
+                "ignore_result": true,
+                "debug": false,
+                "pattern": "\\w+",
+                "log": "wazuh",
+                "end_match": "h",
+                "captured_groups": []
+            },
+            {
+                "description": "With capture group, match all",
+                "ignore_result": true,
+                "debug": false,
+                "pattern": "(\\w+)",
+                "log": "wazuh",
+                "end_match": "h",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Without capture group, match all (And flags)",
+                "ignore_result": true,
+                "debug": false,
+                "pattern": "^\\w+$",
+                "log": "wazuh",
+                "end_match": "h",
+                "captured_groups": []
+            },
+            {
+                "description": "With capture group, match all (And flags)",
+                "ignore_result": true,
+                "debug": false,
+                "pattern": "^(\\w+)$",
+                "log": "wazuh",
+                "end_match": "h",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Without capture group, parcial match (And flags)",
+                "pattern": "^\\w+$",
+                "log": "wazuh ",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "With capture group, match all (And flags)",
+                "pattern": "^(\\w+)$",
+                "log": "wazuh ",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Without capture group, match one character.",
+                "pattern": "\\w+",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": []
+            },
+            {
+                "description": "With capture group, match one character.",
+                "pattern": "(\\w+)",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Without capture group, match all (And flags), match one character.",
+                "pattern": "^\\w+$",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": []
+            },
+            {
+                "description": "With capture group, match all (And flags), match one character.",
+                "pattern": "^(\\w+)$",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": [
+                    "w"
+                ]
+            }
+        ]
+    },
+    {
         "description": "[Coverage] Regex, only backslash without modifiers ('*', '+')",
         "batch_test": [
             {

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -2843,9 +2843,47 @@
         "description": "[Functionality] Special characters escaping (\\$ \\( \\) \\\\ \\| \\<)",
         "batch_test": [
             {
+                "description": "Using the '\\p+' token to test matching all the special characters with capture group.",
+                "ignore_result": true,
+                "__known_issue": "Bad end_match. Link github issue ####.",
+                "pattern": "\\p+",
+                "log": "$()|<",
+                "end_match": "<",
+                "captured_groups": []
+            },
+            {
+                "description": "Using the '\\p+' token to test matching all the special characters with capture group.",
+                "ignore_result": true,
+                "__known_issue": "Bad end_match. Link github issue ####.",
+                "pattern": "(\\p+)",
+                "log": "$()|<",
+                "end_match": "<",
+                "captured_groups": [
+                    "$()|<"
+                ]
+            },
+            {
+                "description": "Using all the tokens conditionally, except '\\p' and '\\.', to test matching all the special characters.",
+                "ignore_result": true,
+                "__known_issue": "Bad end_match. Link github issue ####.",
+                "pattern": "\\w*\\d*\\s*\\t*\\W*\\D*\\S*",
+                "log": "$()|<",
+                "end_match": "<",
+                "captured_groups": []
+            },
+            {
+                "description": "Using all the tokens conditionally, except '\\p' and '\\.', to test matching all the special characters.",
+                "ignore_result": true,
+                "__known_issue": "Bad end_match. Link github issue ####.",
+                "pattern": "\\w+|\\d+|\\s+|\\t+|\\W+|\\D+|\\S+|\\p+",
+                "log": "$()|<",
+                "end_match": "<",
+                "captured_groups": []
+            },
+            {
                 "description": "Using the '\\p+' token to test matching all the special characters with capture group. Note: the character '\\' is not captured by the token '\\p'.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "(\\p+)",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -2872,7 +2910,7 @@
             {
                 "description": "Using the '\\p*' token to test matching all the special characters w/o capture group. Note: the character '\\' is not captured by the token '\\p'.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "Special characters are \\p*",
                 "log": "Special characters are $()|<\\",
                 "end_match": "<\\",
@@ -2897,7 +2935,7 @@
             {
                 "description": "Using the '\\.*' token to test matching the character '\\' with capture group.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "Backslash character is (\\.*)",
                 "log": "Backslash character is \\",
                 "end_match": "\\",
@@ -2908,7 +2946,7 @@
             {
                 "description": "Using the '\\.*' token to test matching the character '\\' w/o capture group.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "Backslash character is \\.*",
                 "log": "Backslash character is \\",
                 "end_match": "\\",
@@ -2917,7 +2955,7 @@
             {
                 "description": "Using the '\\t+' token to test NOT matching all the special characters with capture group.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "Special characters are (\\t+)",
                 "log": "Special characters are $()|<\\",
                 "end_match": " $()|<\\",
@@ -2928,7 +2966,7 @@
             {
                 "description": "Using the '\\t+' token to test NOT matching all the special characters w/o capture group.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "Special characters are \\t+",
                 "log": "Special characters are $()|<\\",
                 "end_match": " $()|<\\",
@@ -2953,7 +2991,7 @@
             {
                 "description": "Using the '\\d+' token to test NOT matching all the special characters with capture group.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "Special characters are (\\d+)",
                 "log": "Special characters are $()|<\\",
                 "end_match": " $()|<\\",
@@ -2964,7 +3002,7 @@
             {
                 "description": "Using the '\\d+' token to test NOT matching all the special characters w/o capture group.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "Special characters are \\d+",
                 "log": "Special characters are $()|<\\",
                 "end_match": " $()|<\\",
@@ -2973,7 +3011,7 @@
             {
                 "description": "Using the '\\d*' token to test NOT matching all the special characters with capture group.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "Special characters are (\\d*)",
                 "log": "Special characters are $()|<\\",
                 "end_match": " $()|<\\",
@@ -2984,7 +3022,7 @@
             {
                 "description": "Using the '\\d*' token to test NOT matching all the special characters w/o capture group.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "Special characters are \\d*",
                 "log": "Special characters are $()|<\\",
                 "end_match": " $()|<\\",
@@ -2993,7 +3031,7 @@
             {
                 "description": "Using the '\\D+' token to test matching all the special characters with capture group.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "Special characters are (\\D+)",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -3004,7 +3042,7 @@
             {
                 "description": "Using the '\\D+' token to test matching all the special characters w/o capture group.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "Special characters are \\D+",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -3013,7 +3051,7 @@
             {
                 "description": "Using the '\\D*' token to test matching all the special characters with capture group.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "Special characters are (\\D*)",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -3024,7 +3062,7 @@
             {
                 "description": "Using the '\\D*' token to test matching all the special characters w/o capture group.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "Special characters are \\D*",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -3033,7 +3071,7 @@
             {
                 "description": "Using the '\\w+' token to test NOT matching all the special characters with capture group.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "Special characters are (\\w+)",
                 "log": "Special characters are $()|<\\",
                 "end_match": " $()|<\\",
@@ -3044,7 +3082,7 @@
             {
                 "description": "Using the '\\w+' token to test NOT matching all the special characters w/o capture group.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "Special characters are \\w+",
                 "log": "Special characters are $()|<\\",
                 "end_match": " $()|<\\",
@@ -3069,7 +3107,7 @@
             {
                 "description": "Using the '\\W+' token to test matching all the special characters with capture group.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "Special characters are (\\W+)",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -3080,7 +3118,7 @@
             {
                 "description": "Using the '\\W+' token to test matching all the special characters w/o capture group.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "Special characters are \\W+",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -3089,7 +3127,7 @@
             {
                 "description": "Using the '\\W*' token to test matching all the special characters with capture group.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "Special characters are (\\W*)",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -3100,7 +3138,7 @@
             {
                 "description": "Using the '\\W*' token to test matching all the special characters w/o capture group.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "Special characters are \\W*",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -3109,7 +3147,7 @@
             {
                 "description": "Using the '\\S+' token to test matching all the special characters with capture group.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "Special characters are (\\S+)",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -3120,7 +3158,7 @@
             {
                 "description": "Using the '\\S+' token to test matching all the special characters w/o capture group.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "Special characters are \\S+",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -3129,7 +3167,7 @@
             {
                 "description": "Using the '\\S*' token to test matching all the special characters with capture group.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "Special characters are (\\S*)",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -3140,7 +3178,7 @@
             {
                 "description": "Using the '\\S*' token to test matching all the special characters w/o capture group.",
                 "ignore_result": true,
-                "__knownIssue": "Link github issue ####",
+                "__known_issue": "Link github issue ####",
                 "pattern": "Special characters are \\S*",
                 "log": "Special characters are $()|<\\",
                 "end_match": "\\",
@@ -3987,7 +4025,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "When there are 4 more optional tokens than characters to match, the regex doesn't match.",
+                "__known_issue:": "When there are 4 more optional tokens than characters to match, the regex doesn't match.",
                 "ignore_result": true,
                 "pattern": "\\w*\\w*\\w*\\w*\\w*\\w*",
                 "log": "xy",
@@ -3996,7 +4034,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case, with extra optional tokens inside a capture group, it does match.",
+                "__known_issue:": "In this case, with extra optional tokens inside a capture group, it does match.",
                 "pattern": "(\\w*\\d*\\w*\\d*\\w*\\d*)",
                 "log": "xy",
                 "end_match": "y",
@@ -4006,7 +4044,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case, with extra optional tokens inside a capture group, it does match.",
+                "__known_issue:": "In this case, with extra optional tokens inside a capture group, it does match.",
                 "pattern": "^(\\w*\\d*\\w*\\d*\\w*\\d*)",
                 "log": "xy",
                 "end_match": "y",
@@ -4016,7 +4054,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case, with extra optional tokens inside a capture group, it does match.",
+                "__known_issue:": "In this case, with extra optional tokens inside a capture group, it does match.",
                 "pattern": "(\\w*\\d*\\w*\\d*\\w*\\d*)$",
                 "log": "xy",
                 "end_match": "y",
@@ -4026,7 +4064,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case, with 10 extra optional tokens inside a capture group, it does match.",
+                "__known_issue:": "In this case, with 10 extra optional tokens inside a capture group, it does match.",
                 "pattern": "(\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*)",
                 "log": "xy",
                 "end_match": "y",
@@ -4036,7 +4074,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case, with 10 extra optional tokens inside a capture group, it does match.",
+                "__known_issue:": "In this case, with 10 extra optional tokens inside a capture group, it does match.",
                 "pattern": "^(\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*)",
                 "log": "xy",
                 "end_match": "y",
@@ -4046,7 +4084,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case, with 10 extra optional tokens inside a capture group, it does match.",
+                "__known_issue:": "In this case, with 10 extra optional tokens inside a capture group, it does match.",
                 "pattern": "(\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*)$",
                 "log": "xy",
                 "end_match": "y",
@@ -4056,7 +4094,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case, with 3 extra optional tokens, it does NOT match.",
+                "__known_issue:": "In this case, with 3 extra optional tokens, it does NOT match.",
                 "ignore_result": true,
                 "pattern": "\\w*\\p*\\d*\\w*",
                 "log": "xy",
@@ -4065,7 +4103,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case, with 3 extra optional tokens, it does NOT match.",
+                "__known_issue:": "In this case, with 3 extra optional tokens, it does NOT match.",
                 "ignore_result": true,
                 "pattern": "^\\w*\\p*\\d*\\w*",
                 "log": "xy",
@@ -4074,7 +4112,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case, with 3 extra optional tokens, it does NOT match.",
+                "__known_issue:": "In this case, with 3 extra optional tokens, it does NOT match.",
                 "ignore_result": true,
                 "pattern": "\\w*\\p*\\d*\\w*$",
                 "log": "xy",
@@ -4083,7 +4121,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case, with 3 extra optional tokens inside a capture group, it does match.",
+                "__known_issue:": "In this case, with 3 extra optional tokens inside a capture group, it does match.",
                 "pattern": "(\\w*\\p*\\d*\\w*)",
                 "log": "xy",
                 "end_match": "y",
@@ -4093,7 +4131,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case, with 3 extra optional tokens, it does NOT match.",
+                "__known_issue:": "In this case, with 3 extra optional tokens, it does NOT match.",
                 "ignore_result": true,
                 "pattern": "\\w*\\d*\\w*\\p*",
                 "log": "xy",
@@ -4102,7 +4140,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case, with 2 extra optional tokens, it does match.",
+                "__known_issue:": "In this case, with 2 extra optional tokens, it does match.",
                 "pattern": "\\w*\\d*\\w*",
                 "log": "xy",
                 "end_match": "y",
@@ -4110,7 +4148,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case, with 2 extra optional tokens, it does match.",
+                "__known_issue:": "In this case, with 2 extra optional tokens, it does match.",
                 "pattern": "^\\w*\\d*\\w*",
                 "log": "xy",
                 "end_match": "y",
@@ -4118,7 +4156,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case, with 2 extra optional tokens, it does match.",
+                "__known_issue:": "In this case, with 2 extra optional tokens, it does match.",
                 "pattern": "\\w*\\d*\\w*$",
                 "log": "xy",
                 "end_match": "y",
@@ -4126,7 +4164,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case, with 3 extra optional tokens, it does NOT match.",
+                "__known_issue:": "In this case, with 3 extra optional tokens, it does NOT match.",
                 "ignore_result": true,
                 "pattern": "\\w*\\d*\\p*\\w*",
                 "log": "xy",
@@ -4135,7 +4173,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case, with only 3 extra optional tokens, it does match.",
+                "__known_issue:": "In this case, with only 3 extra optional tokens, it does match.",
                 "pattern": "\\w*\\w*\\w*\\w*\\w*",
                 "log": "xy",
                 "end_match": "y",
@@ -4143,7 +4181,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case there are 2 exceding optional tokens, the regex doesn't match.",
+                "__known_issue:": "In this case there are 2 exceding optional tokens, the regex doesn't match.",
                 "ignore_result": true,
                 "pattern": "xyz\\d*\\w*",
                 "log": "xyz",
@@ -4152,7 +4190,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case there are 2 exceding optional tokens inside a capture groupe, the regex doesn't match.",
+                "__known_issue:": "In this case there are 2 exceding optional tokens inside a capture groupe, the regex doesn't match.",
                 "ignore_result": true,
                 "pattern": "xyz(\\d*\\w*)",
                 "log": "xyz",
@@ -4163,7 +4201,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case there is 1 exceding optional token inside a capture groupe, the regex does match but the expected group is not captured.",
+                "__known_issue:": "In this case there is 1 exceding optional token inside a capture groupe, the regex does match but the expected group is not captured.",
                 "ignore_result": true,
                 "pattern": "xyz(\\w*)",
                 "log": "xyz",
@@ -4174,7 +4212,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case there are 2 exceding optional tokens inside a capture groupe, the regex doesn't match.",
+                "__known_issue:": "In this case there are 2 exceding optional tokens inside a capture groupe, the regex doesn't match.",
                 "pattern": "xyz(\\w*)",
                 "log": "xyz ",
                 "end_match": "z ",
@@ -4184,7 +4222,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case there are 2 exceding optional tokens inside a capture groupe, the regex doesn't match.",
+                "__known_issue:": "In this case there are 2 exceding optional tokens inside a capture groupe, the regex doesn't match.",
                 "ignore_result": true,
                 "pattern": "xyz\\w*(\\w*)",
                 "log": "xyz",
@@ -4195,7 +4233,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case the regex does match.",
+                "__known_issue:": "In this case the regex does match.",
                 "pattern": "(xyz\\w*\\w*)",
                 "log": "xyz",
                 "end_match": "z",
@@ -4205,7 +4243,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__knownIssue:": "In this case the regex does match.",
+                "__known_issue:": "In this case the regex does match.",
                 "pattern": "\\d+\\w*\\w*",
                 "log": "123",
                 "end_match": "3",
@@ -4420,7 +4458,7 @@
             },
             {
                 "description": "Regex should match but does not.",
-                "__knownIssue": "Only 4 'recoverage' levels are allowed.",
+                "__known_issue": "Only 4 'recoverage' levels are allowed.",
                 "ignore_result": true,
                 "pattern": "(\\w+1) (\\w+2) (\\w+3) (\\w+4) (\\w+5)",
                 "log": "xyz1xyz1 xyz2xyz2 xyz3xyz3 xyz4xyz4 xyz5xyz5",
@@ -4514,8 +4552,71 @@
                 ]
             },
             {
+                "description": "Regex should match but does not.",
+                "ignore_result": true,
+                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
+                "log": "z1 x2 x3 x4 x5x5 x6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Regex should match but does not.",
+                "ignore_result": true,
+                "pattern": "(\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6)",
+                "log": "z1 x2 x3 x4 x5x5 x6",
+                "end_match": "6",
+                "captured_groups": [
+                    "z1 x2 x3 x4 x5x5 x6"
+                ]
+            },
+            {
+                "description": "Regex should match but does not.",
+                "ignore_result": true,
+                "pattern": "(\\w+1) (\\w+2) (\\w+3) (\\w+4) (\\w+5) (\\w+6)",
+                "log": "z1 x2 x3 x4 x5x5 x6",
+                "end_match": "6",
+                "captured_groups": [
+                    "z1",
+                    "x2",
+                    "x3",
+                    "x4",
+                    "x5x5",
+                    "x6"
+                ]
+            },
+            {
+                "description": "This case matches.",
+                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
+                "log": "z1 x2 x3 x4x4 x5 x6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "This case matches.",
+                "pattern": "(\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6)",
+                "log": "z1 x2 x3 x4x4 x5 x6",
+                "end_match": "6",
+                "captured_groups": [
+                    "z1 x2 x3 x4x4 x5 x6"
+                ]
+            },
+            {
+                "description": "This case matches.",
+                "pattern": "(\\w+1) (\\w+2) (\\w+3) (\\w+4) (\\w+5) (\\w+6)",
+                "log": "z1 x2 x3 x4x4 x5 x6",
+                "end_match": "6",
+                "captured_groups": [
+                    "z1",
+                    "x2",
+                    "x3",
+                    "x4x4",
+                    "x5",
+                    "x6"
+                ]
+            },
+            {
                 "description": "This case has 3 (non-optional) tokens but it is capturing only 2 characters.",
-                "__knownIssue": "Capture groups could be either '04T15' or '4T15', depending on the (unpredictable) behavior of the greediness.",
+                "__known_issue": "Capture groups could be either '04T15' or '4T15', depending on the (unpredictable) behavior of the greediness.",
                 "ignore_result": true,
                 "pattern": "(\\d+\\w\\d+)",
                 "log": "04T15",
@@ -4554,7 +4655,7 @@
             },
             {
                 "description": "This case matches.",
-                "__knownIssue": "Wrong end_match value.",
+                "__known_issue": "Wrong end_match value.",
                 "ignore_result": true,
                 "pattern": "\\d+\\w\\d+",
                 "log": "04T15",
@@ -4563,7 +4664,7 @@
             },
             {
                 "description": "This case matches.",
-                "__knownIssue": "Wrong end_match value.",
+                "__known_issue": "Wrong end_match value.",
                 "ignore_result": true,
                 "pattern": "(\\d+\\D\\d+)",
                 "log": "04T15",
@@ -4599,12 +4700,174 @@
             },
             {
                 "description": "This case matches.",
-                "__knownIssue": "Wrong end_match value.",
+                "__known_issue": "Wrong end_match value.",
                 "ignore_result": true,
                 "pattern": "\\d+\\D\\d+",
                 "log": "04T15",
                 "end_match": "5",
                 "captured_groups": []
+            },
+            {
+                "description": "Empty regex should not match but it does.",
+                "ignore_result": true,
+                "pattern": "",
+                "log": "Test",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "This case does not match, which is correct.",
+                "pattern": "()",
+                "log": "Test",
+                "end_match": null,
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be 't' but it is '1'",
+                "ignore_result": true,
+                "pattern": "\\.+",
+                "log": "123 test",
+                "end_match": "t",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be 't' but it is '1'",
+                "ignore_result": true,
+                "pattern": "\\.+$",
+                "log": "123 test",
+                "end_match": "t",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be 't' but it is '1'",
+                "ignore_result": true,
+                "pattern": "^\\.+",
+                "log": "123 test",
+                "end_match": "t",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be 't' but it is '1'",
+                "ignore_result": true,
+                "pattern": "^\\.+$",
+                "log": "123 test",
+                "end_match": "t",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be 't' but it is '1'",
+                "ignore_result": true,
+                "pattern": "^(\\.+)$",
+                "log": "123 test",
+                "end_match": "t",
+                "captured_groups": [
+                    "123 test"
+                ]
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '~' but it is '_'",
+                "ignore_result": true,
+                "pattern": "\\.+",
+                "log": "_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 \r\t!\"#$%&()*+,./:;<=>?[\\]^`{|}~",
+                "end_match": "~",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '~' but it is '_'",
+                "ignore_result": true,
+                "pattern": "^\\.+$",
+                "log": "_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 \r\t!\"#$%&()*+,./:;<=>?[\\]^`{|}~",
+                "end_match": "~",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '~' but it is '_'",
+                "ignore_result": true,
+                "pattern": "\\.+$",
+                "log": "_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 \r\t!\"#$%&()*+,./:;<=>?[\\]^`{|}~",
+                "end_match": "~",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '~' but it is '_'",
+                "ignore_result": true,
+                "pattern": "^\\.+",
+                "log": "_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 \r\t!\"#$%&()*+,./:;<=>?[\\]^`{|}~",
+                "end_match": "~",
+                "captured_groups": []
+            },
+            {
+                "description": "Last matched character pointed (end_match) should be '~' but it is '_'",
+                "ignore_result": true,
+                "pattern": "^(\\.+)$",
+                "log": "_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 \r\t!\"#$%&()*+,./:;<=>?[\\]^`{|}~",
+                "end_match": "~",
+                "captured_groups": [
+                    "_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 \r\t!\"#$%&()*+,./:;<=>?[\\]^`{|}~"
+                ]
+            }
+        ]
+    },
+    {
+        "description": "[Functionality] Complementary cases.",
+        "batch_test": [
+            {
+                "pattern": "\\(\\)",
+                "log": "()",
+                "end_match": ")",
+                "captured_groups": []
+            },
+            {
+                "pattern": "(\\(\\))",
+                "log": "()",
+                "end_match": ")",
+                "captured_groups": [
+                    "()"
+                ]
+            },
+            {
+                "pattern": "\\\\",
+                "log": "\\",
+                "end_match": "\\",
+                "captured_groups": []
+            },
+            {
+                "pattern": "(\\\\)",
+                "log": "\\",
+                "end_match": "\\",
+                "captured_groups": [
+                    "\\"
+                ]
+            },
+            {
+                "pattern": "\\(\\\\\\)",
+                "log": "(\\)",
+                "end_match": ")",
+                "captured_groups": []
+            },
+            {
+                "pattern": "(\\(\\\\\\))",
+                "log": "(\\)",
+                "end_match": ")",
+                "captured_groups": [
+                    "(\\)"
+                ]
+            },
+            {
+                "pattern": "123 \\W*",
+                "log": "123 test",
+                "end_match": " test",
+                "captured_groups": []
+            },
+            {
+                "pattern": "123 (\\W*)",
+                "log": "123 test",
+                "end_match": " test",
+                "captured_groups": [
+                    ""
+                ]
             }
         ]
     }

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -1,5 +1,454 @@
 [
     {
+        "description": "[Coverage] Lazy pattern, greedy match - backslash with '*' modifier. The next token does not include the map characters of the current token and has '+' modifier.",
+        "batch_test": [
+            {
+                "description": "Min size",
+                "pattern": "\\w*\\s+",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Min size. Capture all.",
+                "pattern": "(\\w*\\s+)",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Min size, with group",
+                "pattern": "(\\w*)\\s+",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Other size",
+                "pattern": "\\w*\\s+",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Other size. With group",
+                "pattern": "(\\w*)\\s+",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Other size. With group",
+                "__know_issue": "Consecutive capture groups don't support. should match 'wazuh ' but it doesn't. But (\\w+)\\d*(\\s+) works",
+                "ignore_result": true,
+                "pattern": "(\\w*)(\\s+)",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
+            },
+            {
+                "description": "2 groups no consecutive, and opcional",
+                "pattern": "(\\w*)\\d*(\\s+)",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
+            },
+            {
+                "description": "2 groups no consecutive, and opcional",
+                "pattern": "(\\w*)\\d*(\\s+)",
+                "log": "wazuh123 ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
+            },
+            {
+                "description": "2 groups no consecutive",
+                "pattern": "(\\w*)\\d+(\\s+)",
+                "log": "wazuh123 ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
+            },
+            {
+                "description": "2 groups no consecutive, and opcional",
+                "pattern": "(\\w*)\\d*(\\s*)",
+                "__know_issue": "Err retval.",
+                "ignore_result": true,
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
+            },
+            {
+                "description": "2 groups no consecutive, and opcional",
+                "pattern": "(\\w*)\\d*(\\s*)",
+                "__know_issue": "Err retval.",
+                "ignore_result": true,
+                "log": "wazuh123 ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
+            },
+            {
+                "description": "2 groups no consecutive",
+                "pattern": "(\\w*)\\d+(\\s*)",
+                "__know_issue": "Err retval.",
+                "ignore_result": true,
+                "log": "wazuh123 ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
+            },
+            {
+                "description": "With literal at the end.",
+                "pattern": "\\w*\\s+1",
+                "log": "wazuh 1",
+                "end_match": "1",
+                "captured_groups": []
+            },
+            {
+                "description": "With literal at the end, 1 character + capture group.",
+                "pattern": "(\\w*)\\s+1",
+                "log": "w 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "With literal at the end, 1 character + capture all.",
+                "pattern": "(\\w*\\s+)1",
+                "log": "w 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "With literal at the end, 1 character + capture",
+                "pattern": " (\\w*)\\s+1",
+                "log": " wazuh 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Min size. Match all. 1 character (With flags).",
+                "pattern": "^\\w*\\s+$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all (With flags).",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "pattern": "^\\w*\\s+$",
+                "log": "wazuh  ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all. 1 character + capture group. (With flags).",
+                "pattern": "^(\\w*)\\s+$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Match all. 1 character + capture group. (With flags).",
+                "pattern": "^(\\w*)\\s+$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Next token with blackslash.  ok_here == -1. Match all. 1 character + capture all. (With flags).",
+                "pattern": "^(\\w*\\s+)$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Dont match.",
+                "pattern": "^\\w*\\s+$",
+                "log": "wazuh -",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Dont match.",
+                "pattern": "^(\\w*\\s+)$",
+                "log": "wazuh -",
+                "end_match": null,
+                "captured_groups": []
+            }
+        ]
+    },
+    {
+        "description": "[Coverage] Lazy pattern, greedy match - backslash with '*' modifier. The next token does include the map characters of the current token and has '*' modifier.",
+        "batch_test": [
+            {
+                "description": "Min size",
+                "pattern": "\\w*\\s*",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": []
+            },
+            {
+                "description": "Min size + opt.",
+                "pattern": "\\w*\\s*",
+                "__know_issue": "Err retval.",
+                "ignore_result": true,
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Min size. Capture all.",
+                "pattern": "(\\w*\\s*)",
+                "__know_issue": "The group: 'w' cannot be found",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Min size. Capture all.",
+                "pattern": "(\\w*\\s*)",
+                "log": "wazuh",
+                "end_match": "h",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Min size + opt. Capture all.",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "pattern": "(\\w*\\s*)",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Min size, with group",
+                "pattern": "(\\w*)\\s*",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Min size + opt, with group",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "pattern": "(\\w*)\\s*",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Other size",
+                "pattern": "\\w*\\s*",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Other size. With group",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "pattern": "(\\w*\\s*)",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh "
+                ]
+            },
+            {
+                "description": "Other size. With group",
+                "__know_issue": "Consecutive capture groups don't support. should match 'wazuh ' but it doesn't. But (\\w+)\\d*(\\s+) works",
+                "ignore_result": true,
+                "pattern": "(\\w*)(\\s*)",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
+            },
+            {
+                "description": "2 groups no consecutive, and opcional",
+                "pattern": "(\\w*)\\d+(\\s*)",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "log": "wazuh ",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "2 groups no consecutive, and opcional",
+                "pattern": "(\\w*)\\d+(\\s*)",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "log": "wazuh123 ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
+            },
+            {
+                "description": "2 groups no consecutive",
+                "pattern": "(\\w*)\\d*(\\s*)",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "log": "wazuh123 ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
+            },
+            {
+                "description": "With literal at the end.",
+                "pattern": "\\w*\\s*1",
+                "log": "wazuh 1",
+                "end_match": "1",
+                "captured_groups": []
+            },
+            {
+                "description": "With literal at the end, 1 character + capture group.",
+                "pattern": "(\\w*)\\s*1",
+                "log": "w 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "With literal at the end, 1 character + capture all.",
+                "pattern": "(\\w*\\s*)1",
+                "log": "w 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "With literal at the end, 1 character + capture",
+                "pattern": " (\\w*)\\s*1",
+                "log": " wazuh 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Min size. Match all. 1 character (With flags).",
+                "pattern": "^\\w*\\s*$",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Next token with blackslash. ok_here == -1. Match all (With flags).",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "pattern": "^\\w*\\s*$",
+                "log": "wazuh  ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all. 1 character + capture group. (With flags).",
+                "pattern": "^(\\w*)\\s*$",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Match all. 1 character + capture group. (With flags).",
+                "pattern": "^(\\w*)\\s*$",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Next token with blackslash.  ok_here == -1. Match all. 1 character + capture all. (With flags).",
+                "pattern": "^(\\w*\\s*)$",
+                "ignore_result": true,
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Dont match.",
+                "pattern": "^\\w*\\s*$",
+                "log": "wazuh -",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Dont match.",
+                "pattern": "^(\\w*\\s*)$",
+                "log": "wazuh -",
+                "end_match": null,
+                "captured_groups": []
+            }
+        ]
+    },
+    {
         "description": "[Coverage] Lazy pattern, greedy match - backslash with '+' modifier. The next token does not include the map characters of the current token and has '+' modifier.",
         "batch_test": [
             {
@@ -23,7 +472,9 @@
                 "pattern": "(\\w+)\\s+",
                 "log": "w ",
                 "end_match": " ",
-                "captured_groups": ["w"]
+                "captured_groups": [
+                    "w"
+                ]
             },
             {
                 "description": "Other size",
@@ -37,7 +488,9 @@
                 "pattern": "(\\w+)\\s+",
                 "log": "wazuh ",
                 "end_match": " ",
-                "captured_groups": ["wazuh"]
+                "captured_groups": [
+                    "wazuh"
+                ]
             },
             {
                 "description": "Other size. With group",
@@ -46,28 +499,40 @@
                 "pattern": "(\\w+)(\\s+)",
                 "log": "wazuh ",
                 "end_match": " ",
-                "captured_groups": ["wazuh", " "]
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
             },
             {
                 "description": "2 groups no consecutive, and opcional",
                 "pattern": "(\\w+)\\d*(\\s+)",
                 "log": "wazuh ",
                 "end_match": " ",
-                "captured_groups": ["wazuh", " "]
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
             },
             {
                 "description": "2 groups no consecutive, and opcional",
                 "pattern": "(\\w+)\\d*(\\s+)",
                 "log": "wazuh123 ",
                 "end_match": " ",
-                "captured_groups": ["wazuh", " "]
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
             },
             {
                 "description": "2 groups no consecutive",
                 "pattern": "(\\w+)\\d+(\\s+)",
                 "log": "wazuh123 ",
                 "end_match": " ",
-                "captured_groups": ["wazuh", " "]
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
             },
             {
                 "description": "With literal at the end.",
@@ -175,7 +640,7 @@
             {
                 "description": "Min size + opt.",
                 "pattern": "\\w+\\s*",
-                "__know_issue":"Err retval.",
+                "__know_issue": "Err retval.",
                 "ignore_result": true,
                 "log": "w ",
                 "end_match": " ",
@@ -197,8 +662,9 @@
                 "pattern": "(\\w+\\s*)",
                 "__know_issue": "The group: 'wazuh' cannot be found",
                 "ignore_result": true,
+                "debug": false,
                 "log": "wazuh",
-                "end_match": "wazuh",
+                "end_match": "h",
                 "captured_groups": [
                     "wazuh"
                 ]
@@ -219,7 +685,9 @@
                 "pattern": "(\\w+)\\s*",
                 "log": "w",
                 "end_match": "w",
-                "captured_groups": ["w"]
+                "captured_groups": [
+                    "w"
+                ]
             },
             {
                 "description": "Min size + opt, with group",
@@ -228,7 +696,9 @@
                 "pattern": "(\\w+)\\s*",
                 "log": "w ",
                 "end_match": " ",
-                "captured_groups": ["w"]
+                "captured_groups": [
+                    "w"
+                ]
             },
             {
                 "description": "Other size",
@@ -246,7 +716,9 @@
                 "pattern": "(\\w+\\s*)",
                 "log": "wazuh ",
                 "end_match": " ",
-                "captured_groups": ["wazuh "]
+                "captured_groups": [
+                    "wazuh "
+                ]
             },
             {
                 "description": "Other size. With group",
@@ -255,7 +727,10 @@
                 "pattern": "(\\w+)(\\s*)",
                 "log": "wazuh ",
                 "end_match": " ",
-                "captured_groups": ["wazuh", " "]
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
             },
             {
                 "description": "2 groups no consecutive, and opcional",
@@ -273,7 +748,10 @@
                 "__know_issue": "Err retval.",
                 "log": "wazuh123 ",
                 "end_match": " ",
-                "captured_groups": ["wazuh", " "]
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
             },
             {
                 "description": "2 groups no consecutive",
@@ -283,7 +761,10 @@
                 "debug": false,
                 "log": "wazuh123 ",
                 "end_match": " ",
-                "captured_groups": ["wazuh", " "]
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
             },
             {
                 "description": "With literal at the end.",

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -1,5 +1,162 @@
 [
     {
+        "description": "[Coverage] Regex, only charmap without backslash",
+        "batch_test": [
+            {
+                "description": "Match between pattern and regex. pattern[0] != '('.",
+                "pattern": "hi wazuh",
+                "log": "hi wazuh",
+                "end_match": "h",
+                "captured_groups": []
+            },
+            {
+                "description": "Match between pattern and regex. With capture group",
+                "pattern": "(hi) (wazuh)",
+                "log": "hi wazuh",
+                "end_match": "h",
+                "captured_groups": [
+                    "hi",
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Dont match at all .pattern[0] != '('.",
+                "pattern": "hi wazuh",
+                "log": "bye wazuh",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "match with prefix.",
+                "pattern": "(hi) (wazuh)",
+                "log": "prefixhi wazuh",
+                "end_match": "h",
+                "captured_groups": [
+                    "hi",
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "match with sufix.",
+                "pattern": "(hi) (wazuh)",
+                "log": "fixhi wazuhsub",
+                "end_match": "hsub",
+                "captured_groups": [
+                    "hi",
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "match with continue capture group.",
+                "ignore_result": true,
+                "__knownIssue:": "The capture groups cannot be adjacent to each other",
+                "pattern": "(hi)(wazuh)",
+                "log": "hiwazuh",
+                "end_match": "h",
+                "captured_groups": [
+                    "hi",
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "match with continue capture group and context",
+                "ignore_result": true,
+                "__knownIssue:": "The capture groups cannot be adjacent to each other",
+                "pattern": "(hi)(wazuh)",
+                "log": "prefixhiwazuhsub",
+                "end_match": "hsub",
+                "captured_groups": [
+                    "hi",
+                    "wazuh"
+                ]
+            }
+        ]
+    },
+    {
+        "description": "[Coverage] Regex, only charmap + END/BEGIN flags and st_error without backslash",
+        "batch_test": [
+            {
+                "description": "Pattern ends and the END_SET is set. (ENDOFFILE(pt) true)",
+                "pattern": "hi wazuh",
+                "log": "hi wazuh",
+                "end_match": "h",
+                "captured_groups": []
+            },
+            {
+                "description": "Empty pattern END_SET and BEGIN_SET are set.",
+                "pattern": "^$",
+                "log": "hi wazuh",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Empty pattern END_SET and BEGIN_SET are set.",
+                "ignore_result": true,
+                "__knownIssue:": "empty group?",
+                "pattern": "(^$)",
+                "log": "",
+                "end_match": "",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Empty pattern END_SET and BEGIN_SET are set.",
+                "ignore_result": true,
+                "__knownIssue:": "empty group?",
+                "pattern": "^()$",
+                "log": "",
+                "end_match": "",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Pattern ends and the END_SET is not set.",
+                "pattern": "hi wazuh",
+                "log": "hi wazuh!",
+                "end_match": "h!",
+                "captured_groups": []
+            },
+            {
+                "description": "partially matched and then backward (st error test).",
+                "pattern": "(hi) (wazuh)",
+                "log": "XX hi wa hi wazuhXX",
+                "end_match": "hXX",
+                "captured_groups": [
+                    "hi",
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "partially matched and then return (st error + BEGIN_SET test).",
+                "pattern": "^(hi) (wazuh)",
+                "log": "hi wa hi wazuhXX",
+                "end_match": null,
+                "captured_groups": []
+            }
+        ]
+    },
+    {
+        "description": "[Coverage] Loop on all sub patterns without capture groups",
+        "batch_test": [
+            {
+                "description": "Loop on all sub patterns, without match",
+                "pattern": "^hi|bye$|^$",
+                "log": "123456",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Loop on all sub patterns, match",
+                "pattern": "^hi|bye$|^$|\\w+\\d.|\\p*",
+                "log": "123456.",
+                "end_match": ".",
+                "captured_groups": []
+            }
+        ]
+    },
+    {
         "description": "[Memory test] regex_matching alloc test: copy reg size.",
         "batch_test": [
             {
@@ -32,11 +189,42 @@
                 "log": "36cg field_01=001 field_02=002 field_03=003 field_04=004 field_05=005 field_06=006 field_07=007 field_08=008 field_09=009 field_10=010 field_11=011 field_12=012 field_13=013 field_14=014 field_15=015 field_16=016 field_17=017 field_18=018 field_19=019 field_20=020 field_21=021 field_22=022 field_23=023 field_24=024 field_25=025 field_26=026 field_27=027 field_28=028 field_29=029 field_30=030 field_31=031 field_32=032 field_33=033 field_34=034 field_35=035 field_36=036",
                 "end_match": "6",
                 "captured_groups": [
-                    "001", "002","003","004","005","006","007","008",
-                    "009", "010","011","012","013","014","015","016",
-                    "017", "018","019","020","021","022","023","024",
-                    "025", "026","027","028","029","030","031","032",
-                    "033", "034","035","036"
+                    "001",
+                    "002",
+                    "003",
+                    "004",
+                    "005",
+                    "006",
+                    "007",
+                    "008",
+                    "009",
+                    "010",
+                    "011",
+                    "012",
+                    "013",
+                    "014",
+                    "015",
+                    "016",
+                    "017",
+                    "018",
+                    "019",
+                    "020",
+                    "021",
+                    "022",
+                    "023",
+                    "024",
+                    "025",
+                    "026",
+                    "027",
+                    "028",
+                    "029",
+                    "030",
+                    "031",
+                    "032",
+                    "033",
+                    "034",
+                    "035",
+                    "036"
                 ]
             }
         ]
@@ -88,11 +276,56 @@
                 "log": "36cg field_01=001 field_02=002 field_03=003 field_04=004 field_05=005 field_06=006 field_07=007 field_08=008 field_09=009 field_10=010 field_11=011 field_12=012 field_13=013 field_14=014 field_15=015 field_16=016 field_17=017 field_18=018 field_19=019 field_20=020 field_21=021 field_22=022 field_23=023 field_24=024 field_25=025 field_26=026 field_27=027 field_28=028 field_29=029 field_30=030 field_31=031 field_32=032 field_33=033 field_34=034 field_35=035 field_36=036",
                 "end_match": "6",
                 "captured_groups": [
-                    "001", "002","003","004","005","006","007","008",
-                    "009", "010","011","012","013","014","015","016",
-                    "017", "018","019","020","021","022","023","024",
-                    "025", "026","027","028","029","030","031","032",
-                    "033", "034","035","036"
+                    "001",
+                    "002",
+                    "003",
+                    "004",
+                    "005",
+                    "006",
+                    "007",
+                    "008",
+                    "009",
+                    "010",
+                    "011",
+                    "012",
+                    "013",
+                    "014",
+                    "015",
+                    "016",
+                    "017",
+                    "018",
+                    "019",
+                    "020",
+                    "021",
+                    "022",
+                    "023",
+                    "024",
+                    "025",
+                    "026",
+                    "027",
+                    "028",
+                    "029",
+                    "030",
+                    "031",
+                    "032",
+                    "033",
+                    "034",
+                    "035",
+                    "036"
+                ]
+            },
+            {
+                "description": "Go back to 1 pattern and 1 capture groups.",
+                "__sub_string_size": "((1 pattern x 2 know bug) + 1 null)  x 8 size = 24 bytes",
+                "__prts_main_array": " (1 pattern + 1 null)  x 8 size = 16 bytes",
+                "__prts_items_array": "size of array d_size->prts_str_size == size of array prts_str == prts_str_alloc_size = 16",
+                "__prts_items_array_1": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
+                "__prts_array_2": "0x0",
+                "pattern": "hi (\\w+).",
+                "log": "Hi wazuh.",
+                "end_match": ".",
+                "captured_groups": [
+                    "wazuh"
                 ]
             }
         ]
@@ -101,7 +334,7 @@
         "description": "[Memory test] regex_matching expand test: Incremental patterns and match last.",
         "batch_test": [
             {
-                "description": "Inizialize regex matching with capture grup, min size (1 patter, 1 capture).",
+                "description": "Inizialize regex matching with a capture group, min size (1 patter, 1 capture).",
                 "__sub_string_size": "((1 pattern x 2 know bug) + 1 null)  x 8 size = 24 bytes",
                 "__prts_main_array": " (1 pattern + 1 null)  x 8 size = 16 bytes",
                 "__prts_items_array": "size of array d_size->prts_str_size == size of array prts_str == prts_str_alloc_size = 16",
@@ -168,7 +401,7 @@
         ]
     },
     {
-        "description": "[Memory test] regex_matching expand test: Incremental capture groups, patterns and match last.",
+        "description": "[Memory test] regex_matching expand test: Incremental capture groups and patterns, then match last.",
         "batch_test": [
             {
                 "description": "Inizialize regex matching with capture grup, min size (1 patter, 1 capture).",
@@ -214,11 +447,42 @@
                 "log": "36cg field_01=001 field_02=002 field_03=003 field_04=004 field_05=005 field_06=006 field_07=007 field_08=008 field_09=009 field_10=010 field_11=011 field_12=012 field_13=013 field_14=014 field_15=015 field_16=016 field_17=017 field_18=018 field_19=019 field_20=020 field_21=021 field_22=022 field_23=023 field_24=024 field_25=025 field_26=026 field_27=027 field_28=028 field_29=029 field_30=030 field_31=031 field_32=032 field_33=033 field_34=034 field_35=035 field_36=036",
                 "end_match": "6",
                 "captured_groups": [
-                    "001", "002","003","004","005","006","007","008",
-                    "009", "010","011","012","013","014","015","016",
-                    "017", "018","019","020","021","022","023","024",
-                    "025", "026","027","028","029","030","031","032",
-                    "033", "034","035","036"
+                    "001",
+                    "002",
+                    "003",
+                    "004",
+                    "005",
+                    "006",
+                    "007",
+                    "008",
+                    "009",
+                    "010",
+                    "011",
+                    "012",
+                    "013",
+                    "014",
+                    "015",
+                    "016",
+                    "017",
+                    "018",
+                    "019",
+                    "020",
+                    "021",
+                    "022",
+                    "023",
+                    "024",
+                    "025",
+                    "026",
+                    "027",
+                    "028",
+                    "029",
+                    "030",
+                    "031",
+                    "032",
+                    "033",
+                    "034",
+                    "035",
+                    "036"
                 ]
             }
         ]

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -1,5 +1,79 @@
 [
     {
+        "description": "[Coverage] Regex, only backslash without modifiers ('*', '+')",
+        "batch_test": [
+            {
+                "description": "Without capture group, match all",
+                "pattern": "\\w\\w\\s\\S\\S\\S\\S\\S",
+                "log": "hi wazuh",
+                "end_match": "h",
+                "captured_groups": []
+            },
+            {
+                "description": "Without capture group, parcial match",
+                "pattern": "\\w\\w\\s\\S\\S\\S\\S\\S",
+                "log": "hi waz",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Without capture group, parcial match and then match all",
+                "pattern": "\\w\\w\\s\\S\\S\\S\\S\\S",
+                "log": "hi waz hi wazu.",
+                "end_match": ".",
+                "captured_groups": []
+            },
+            {
+                "description": "With capture group, match all",
+                "pattern": "\\w(\\w\\s\\S)\\S(\\S\\S\\S)",
+                "log": "hi wazuh",
+                "end_match": "h",
+                "captured_groups": [
+                    "i w",
+                    "zuh"
+                ]
+            },
+            {
+                "description": "With capture group, parcial match",
+                "pattern": "(\\w\\w)\\s\\S\\S\\S\\S\\S",
+                "log": "hi waz",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "With capture group, parcial match and then match all",
+                "pattern": "(\\w\\w)\\s(\\S\\S\\S\\S\\S)",
+                "log": "hi waz hi wazuh.",
+                "end_match": "h.",
+                "captured_groups": [
+                    "hi",
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "With capture group, parcial match and then match all",
+                "__knownIssue:": "The capture groups cannot be adjacent to each other",
+                "ignore_result": true,
+                "pattern": "(\\w\\w\\s)(\\S\\S\\S\\S\\S)",
+                "log": "hi waz hi wazuh.",
+                "end_match": "h.",
+                "captured_groups": [
+                    "hi ",
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "With capture group, parcial match and then match all (1 group)",
+                "pattern": "(\\w\\w\\s\\S\\S\\S\\S\\S)\\p$",
+                "log": "hi waz hi wazuh.",
+                "end_match": ".",
+                "captured_groups": [
+                    "hi wazuh"
+                ]
+            }
+        ]
+    },
+    {
         "description": "[Coverage] Regex, only charmap without backslash",
         "batch_test": [
             {

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -1,5 +1,98 @@
 [
     {
+        "description": "[Coverage] Lazy pattern, greedy match - backslash with '*' modifier. st_error, error handling, parcial match and rewind.",
+        "batch_test": [
+            {
+                "description": "Save 6 token position, and restore the first.",
+                "pattern": "\\w*_1 \\w*_2 \\w*_3 \\w*_4 \\w*_5 \\w*_6",
+                "log": "wa_11 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Save 6 token position, and restore the second.",
+                "pattern": "\\w*_1 \\w*_2 \\w*_3 \\w*_4 \\w*_5 \\w*_6",
+                "log": "wa_1 wa_22 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Save 6 token position, and restore the third.",
+                "pattern": "\\w*_1 \\w*_2 \\w*_3 \\w*_4 \\w*_5 \\w*_6",
+                "log": "wa_1 wa_2 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Save 6 token position, and restore the fourth.",
+                "pattern": "\\w*_1 \\w*_2 \\w*_3 \\w*_4 \\w*_5 \\w*_6",
+                "log": "wa_1 wa_2 wa_3 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Save 6 token position, and restore the fifth.",
+                "pattern": "\\w*_1 \\w*_2 \\w*_3 \\w*_4 \\w*_5 \\w*_6",
+                "log": "wa_1 wa_2 wa_3 wa_4 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Save 6 token position, and restore the sixth.",
+                "pattern": "\\w*_1 \\w*_2 \\w*_3 \\w*_4 \\w*_5 \\w*_6",
+                "log": "wa_1 wa_2 wa_3 wa_4 wa_5 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Save 6 token position, and restore the first. But the first should match with the next character.",
+                "pattern": "\\w*1 \\w*2 \\w*3 \\w*4 \\w*5 \\w*6",
+                "log": "z1x1 x2 x3 x4 x5 x6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Save 6 token position, and restore the second. But the second should match with the next character.",
+                "pattern": "\\w*1 \\w*2 \\w*3 \\w*4 \\w*5 \\w*6",
+                "log": "z1 x2x2 x3 x4 x5 x6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Save 6 token position, and restore the third. But the third should match with the next character.",
+                "pattern": "\\w*1 \\w*2 \\w*3 \\w*4 \\w*5 \\w*6",
+                "log": "z1 x2x2 x3 x4 x5 x6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Save 6 token position, and restore the fourth. But the fourth should match with the next character.",
+                "pattern": "\\w*1 \\w*2 \\w*3 \\w*4 \\w*5 \\w*6",
+                "log": "z1 x2 x3 x4x4 x5 x6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Save 6 token position, and restore the fifth. But the fifth should match with the next character.",
+                "pattern": "\\w*1 \\w*2 \\w*3 \\w*4 \\w*5 \\w*6",
+                "__knowIssue": "#XXXX The stacktrace has a static size",
+                "ignore_result": true,
+                "log": "z1 x2 x3 x4 x5x5 x6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Save 6 token position, and restore the sixth. But the sixth should match with the next character.",
+                "pattern": "\\w*1 \\w*2 \\w*3 \\w*4 \\w*5 \\w*6",
+                "log": "z1 x2 x3 x4 x5 x6x6",
+                "__knowIssue": "#XXXX The stacktrace has a static size",
+                "ignore_result": true,
+                "end_match": "6",
+                "captured_groups": []
+            }
+        ]
+    },
+    {
         "description": "[Coverage] Lazy pattern, greedy match - backslash with '*' modifier. The next token does include the map characters of the current token and has no modifier.",
         "batch_test": [
             {
@@ -626,7 +719,7 @@
             },
             {
                 "description": "Save 6 token position, and restore the fifth. But the fifth should match with the next character.",
-                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+ \\w+6",
+                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
                 "ignore_result": true,
                 "__knowIssue": "#XXXX The stacktrace has a static size",
                 "log": "z1 x2 x3 x4 x5x5 x6",

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -1,5 +1,131 @@
 [
     {
+        "description": "[Coverage] Lazy pattern, greedy match - backslash with '+' modifier. The next token does include the map characters of the current token and has no modifier.",
+        "batch_test": [
+            {
+                "description": "Min size: No match, no items in the log to consume",
+                "pattern": "\\d+\\d",
+                "log": "5",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Min size: No match, no items in the log to consume",
+                "pattern": "(\\d+)\\d",
+                "log": "5",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Min size: Minimum match with capture group",
+                "pattern": "(\\d+)\\w",
+                "log": "12",
+                "end_match": "2",
+                "captured_groups": ["1"]
+            },
+            {
+                "description": "Min size: Minimum match with capture group",
+                "pattern": "\\d+(\\w)",
+                "log": "12",
+                "end_match": "2",
+                "captured_groups": ["2"]
+            },
+            {
+                "description": "Lazy pattern: Move as fast as possible over the pattern",
+                "pattern": "\\d+\\w",
+                "ignore_result": true,
+                "log": "12345",
+                "end_match": "5",
+                "captured_groups": []
+            },
+            {
+                "description": "Lazy pattern: Move as fast as possible over the pattern, only capture the first character",
+                "ignore_result": true,
+                "__know_issue": "regex returns the pointer to '2' character. ",
+                "pattern": "(\\d+)\\w",
+                "log": "12345",
+                "end_match": "5",
+                "captured_groups": ["1"]
+            },
+            {
+                "description": "Lazy pattern: Move as fast as possible over the pattern",
+                "ignore_result": true,
+                "__know_issue": "regex returns the pointer to '2' character. ",
+                "pattern": "\\d+(\\w)",
+                "log": "12345",
+                "end_match": "5",
+                "captured_groups": ["5"]
+            },
+            {
+                "description": "Min size: No match, no items in the log to consume (With flags).",
+                "pattern": "^\\d+\\d",
+                "log": "5",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Min size: No match, no items in the log to consume (With flags).",
+                "pattern": "^(\\d+)\\d",
+                "log": "5",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Min size: Minimum match with capture group (With flags).",
+                "pattern": "^(\\d+)\\w$",
+                "log": "12",
+                "end_match": "2",
+                "captured_groups": ["1"]
+            },
+            {
+                "description": "Min size: Minimum match with capture group (With flags).",
+                "pattern": "^\\d+(\\w)$",
+                "log": "12",
+                "end_match": "2",
+                "captured_groups": ["2"]
+            },
+            {
+                "description": "Lazy pattern: Move as fast as possible over the pattern (With flags).",
+                "pattern": "^\\d+\\w$",
+                "ignore_result": true,
+                "debug": true,
+                "log": "12345",
+                "end_match": "5",
+                "captured_groups": []
+            },
+            {
+                "description": "Lazy pattern: Move as fast as possible over the pattern, capture the first 4 character, because the $ flag.",
+                "ignore_result": true,
+                "debug": true,
+                "__know_issue": "regex returns the pointer to '2' character. ",
+                "pattern": "^(\\d+)\\w$",
+                "log": "12345",
+                "end_match": "5",
+                "captured_groups": ["1234"]
+            },
+            {
+                "description": "Lazy pattern: Move as fast as possible over the pattern (With flags).",
+                "ignore_result": true,
+                "debug": true,
+                "__know_issue": "regex returns the pointer to '2' character. ",
+                "pattern": "^\\d+(\\w)$",
+                "log": "12345",
+                "end_match": "5",
+                "captured_groups": ["5"]
+            },
+            {
+                "description": "Lazy pattern: Move as fast as possible over the pattern (With flags).",
+                "ignore_result": true,
+                "debug": true,
+                "__know_issue": "regex returns the pointer to '2' character. ",
+                "pattern": "^\\d+(\\w)$",
+                "log": "12345&&&&&&&",
+                "end_match": null,
+                "captured_groups": []
+            }
+        ]
+    },
+    {
         "description": "[Coverage] Lazy pattern, greedy match - backslash with '+' modifier. The next token does not include the map characters of the current token and has no modifier.",
         "batch_test": [
             {
@@ -259,97 +385,6 @@
                 "log": "wazuh -",
                 "end_match": null,
                 "captured_groups": [
-                ]
-            }
-        ]
-    },
-    {
-        "description": "[Coverage] Regex, only backslash with '+' modifier.",
-        "batch_test": [
-            {
-                "description": "Without capture group, match all",
-                "ignore_result": true,
-                "debug": false,
-                "pattern": "\\w+",
-                "log": "wazuh",
-                "end_match": "h",
-                "captured_groups": []
-            },
-            {
-                "description": "With capture group, match all",
-                "ignore_result": true,
-                "debug": false,
-                "pattern": "(\\w+)",
-                "log": "wazuh",
-                "end_match": "h",
-                "captured_groups": [
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "Without capture group, match all (And flags)",
-                "ignore_result": true,
-                "debug": false,
-                "pattern": "^\\w+$",
-                "log": "wazuh",
-                "end_match": "h",
-                "captured_groups": []
-            },
-            {
-                "description": "With capture group, match all (And flags)",
-                "ignore_result": true,
-                "debug": false,
-                "pattern": "^(\\w+)$",
-                "log": "wazuh",
-                "end_match": "h",
-                "captured_groups": [
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "Without capture group, parcial match (And flags)",
-                "pattern": "^\\w+$",
-                "log": "wazuh ",
-                "end_match": null,
-                "captured_groups": []
-            },
-            {
-                "description": "With capture group, match all (And flags)",
-                "pattern": "^(\\w+)$",
-                "log": "wazuh ",
-                "end_match": null,
-                "captured_groups": []
-            },
-            {
-                "description": "Without capture group, match one character.",
-                "pattern": "\\w+",
-                "log": "w",
-                "end_match": "w",
-                "captured_groups": []
-            },
-            {
-                "description": "With capture group, match one character.",
-                "pattern": "(\\w+)",
-                "log": "w",
-                "end_match": "w",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Without capture group, match all (And flags), match one character.",
-                "pattern": "^\\w+$",
-                "log": "w",
-                "end_match": "w",
-                "captured_groups": []
-            },
-            {
-                "description": "With capture group, match all (And flags), match one character.",
-                "pattern": "^(\\w+)$",
-                "log": "w",
-                "end_match": "w",
-                "captured_groups": [
-                    "w"
                 ]
             }
         ]

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -1350,21 +1350,25 @@
             },
             {
                 "description": "Match 0-0 and capture all",
-                "__known_issue:": "If the pattern has only one token that has the quantifier '*' and it is inside a capture group, when the log is empty, it matches correctly, returning the pointer to the end of the string but does not capture the empty group as expected.",
+                "__known_issue:": "If the pattern has only one token that has the quantifier '*' and it is inside a capture group, when the log is empty, it matches correctly, returning the pointer to the end of the string but does not capture the empty group as expected. BUG 6 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(\\w*)",
                 "log": "",
                 "end_match": "",
-                "captured_groups": [ "" ]
+                "captured_groups": [
+                    ""
+                ]
             },
             {
                 "description": "Match 0-0 with flags and capture all",
-                "__known_issue:": "If the pattern has only one token that has the quantifier '*' and it is inside a capture group, when the log is empty, it matches correctly, returning the pointer to the end of the string but does not capture the empty group as expected.",
+                "__known_issue:": "If the pattern has only one token that has the quantifier '*' and it is inside a capture group, when the log is empty, it matches correctly, returning the pointer to the end of the string but does not capture the empty group as expected. BUG 6 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "^(\\w*)$",
                 "log": "",
                 "end_match": "",
-                "captured_groups": [ "" ]
+                "captured_groups": [
+                    ""
+                ]
             }
         ]
     },
@@ -2115,7 +2119,7 @@
             {
                 "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
                 "ignore_result": true,
-                "debug":false,
+                "debug": false,
                 "pattern": "(\\w*)(\\s*)",
                 "log": "",
                 "end_match": "",
@@ -3490,6 +3494,7 @@
         "batch_test": [
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "Pattern \\w+ \\d+",
                 "log": "Pattern Wazuh 123",
@@ -3498,6 +3503,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "Pattern (\\w+ \\d+)",
                 "log": "Pattern Wazuh 123",
@@ -3508,6 +3514,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "^Pattern \\w+ \\d+",
                 "log": "Pattern Wazuh 123",
@@ -3516,6 +3523,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "^Pattern (\\w+ \\d+)",
                 "log": "Pattern Wazuh 123",
@@ -3526,6 +3534,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "Pattern \\w+ \\d+$",
                 "log": "Pattern Wazuh 123",
@@ -3534,6 +3543,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "Pattern (\\w+ \\d+)$",
                 "log": "Pattern Wazuh 123",
@@ -3544,6 +3554,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "Pattern \\w* \\d*",
                 "log": "Pattern Wazuh 123",
@@ -3552,6 +3563,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "Pattern (\\w* \\d*)",
                 "log": "Pattern Wazuh 123",
@@ -3562,6 +3574,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "^Pattern \\w* \\d*",
                 "log": "Pattern Wazuh 123",
@@ -3570,6 +3583,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "^Pattern (\\w* \\d*)",
                 "log": "Pattern Wazuh 123",
@@ -3580,6 +3594,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "Pattern \\w* \\d*$",
                 "log": "Pattern Wazuh 123",
@@ -3588,6 +3603,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "Pattern (\\w* \\d*)$",
                 "log": "Pattern Wazuh 123",
@@ -3598,6 +3614,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "Subpattern 1: \\d+|Subpattern 2: \\d+",
                 "log": "Subpattern 2: 123",
@@ -3606,6 +3623,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "Subpattern 1: \\d+|^Subpattern 2: \\d+",
                 "log": "Subpattern 2: 123",
@@ -3614,6 +3632,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "Subpattern 1: \\d+|Subpattern 2: \\d+$",
                 "log": "Subpattern 2: 123",
@@ -3622,6 +3641,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "Subpattern 1: (\\d+)|Subpattern 2: (\\d+)",
                 "log": "Subpattern 2: 123",
@@ -3632,6 +3652,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "Subpattern 1: (\\d+)|^Subpattern 2: (\\d+)",
                 "log": "Subpattern 2: 123",
@@ -3642,6 +3663,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "Subpattern 1: (\\d+)|Subpattern 2: (\\d+)$",
                 "log": "Subpattern 2: 123",
@@ -3652,6 +3674,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3').",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\d+",
                 "log": "123subpattern",
@@ -3660,6 +3683,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\d+",
                 "log": "subpattern123",
@@ -3668,6 +3692,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\d+",
                 "log": "123",
@@ -3676,6 +3701,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '9' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\d+",
                 "log": "123456789",
@@ -3691,6 +3717,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(\\d+)",
                 "log": "123",
@@ -3701,6 +3728,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(\\d+)",
                 "log": "123subpattern",
@@ -3711,6 +3739,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(\\d+)",
                 "log": "subpattern123",
@@ -3721,6 +3750,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '9' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(\\d+)",
                 "log": "123456789",
@@ -3740,6 +3770,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3').",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\d*",
                 "log": "123",
@@ -3748,6 +3779,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3').",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\d*",
                 "log": "123subpattern",
@@ -3756,6 +3788,7 @@
             },
             {
                 "description": "This test overflows the heap buffer.",
+                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/wazuh/wazuh/issues/14249",
                 "skip_test": true,
                 "pattern": "\\d*",
                 "log": "subpattern123",
@@ -3764,6 +3797,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(\\d*)",
                 "log": "123",
@@ -3783,16 +3817,18 @@
             },
             {
                 "description": "This test overflows the heap buffer.",
+                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/wazuh/wazuh/issues/14249",
                 "skip_test": true,
                 "pattern": "(\\d*)",
                 "log": "subpattern123",
-                "end_match": "3",
+                "end_match": "subpattern123",
                 "captured_groups": [
-                    "123"
+                    ""
                 ]
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "^\\d+",
                 "log": "123",
@@ -3801,6 +3837,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3').",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "^\\d+",
                 "log": "123subpattern",
@@ -3816,6 +3853,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "^(\\d+)",
                 "log": "123",
@@ -3826,6 +3864,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "^(\\d+)",
                 "log": "123subpattern",
@@ -3843,6 +3882,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "^\\d*",
                 "log": "123",
@@ -3852,6 +3892,7 @@
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3').",
                 "ignore_result": true,
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "pattern": "^\\d*",
                 "log": "123subpattern",
                 "end_match": "3subpattern",
@@ -3859,6 +3900,7 @@
             },
             {
                 "description": "This test overflows the heap buffer.",
+                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/wazuh/wazuh/issues/14249",
                 "skip_test": true,
                 "pattern": "^\\d*",
                 "log": "subpattern123",
@@ -3868,6 +3910,7 @@
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
                 "ignore_result": true,
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "pattern": "^(\\d*)",
                 "log": "123",
                 "end_match": "3",
@@ -3887,6 +3930,7 @@
             {
                 "description": "This test overflows the heap buffer.",
                 "skip_test": true,
+                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/wazuh/wazuh/issues/14249",
                 "pattern": "^(\\d*)",
                 "log": "subpattern123",
                 "end_match": null,
@@ -3896,6 +3940,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\d+$",
                 "log": "123",
@@ -3904,6 +3949,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\d+$",
                 "log": "log123",
@@ -3912,6 +3958,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(\\d+)$",
                 "log": "123",
@@ -3922,6 +3969,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(\\d+)$",
                 "log": "log123",
@@ -3932,6 +3980,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\d*$",
                 "log": "123",
@@ -3965,6 +4014,7 @@
             },
             {
                 "description": "It should match but it doesn't.",
+                "__known_issue:": "When the regex is a backlashed token with the '*' quantifier follow by the flag '$' (end of string) and the string does not start with a character that belongs to the character map of such a token, then it does not match as expected. BUG 7 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(\\d*)$",
                 "log": "pattern123",
@@ -3984,6 +4034,7 @@
             },
             {
                 "description": "Consecutive capture groups (without something in between) do not match when should.",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(\\D+)(\\d+)",
                 "log": "Test123",
@@ -3995,6 +4046,7 @@
             },
             {
                 "description": "Consecutive capture groups (without something in between) do not match.",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(\\d+)(\\D+)",
                 "log": "123Test",
@@ -4006,6 +4058,7 @@
             },
             {
                 "description": "Consecutive capture groups (without something in between) do not match.",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(\\D*)(\\d*)",
                 "log": "Test123",
@@ -4017,6 +4070,7 @@
             },
             {
                 "description": "Consecutive capture groups (without something in between) do not match.",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(\\d*)(\\D*)",
                 "log": "123Test",
@@ -4028,6 +4082,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\D+\\d+",
                 "log": "Test123",
@@ -4036,6 +4091,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is 'T'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\d+\\D+",
                 "log": "123Test",
@@ -4044,6 +4100,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is 't'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\D*\\d*",
                 "log": "Test123",
@@ -4052,6 +4109,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\d*\\D*",
                 "log": "123Test",
@@ -4060,7 +4118,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "When there are 4 more optional tokens than characters to match, the regex doesn't match.",
+                "__known_issue:": "When there are 4 more optional tokens than characters to match, the regex doesn't match. BUG 8 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\w*\\w*\\w*\\w*\\w*\\w*",
                 "log": "xy",
@@ -4129,7 +4187,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "In this case, with 3 extra optional tokens, it does NOT match.",
+                "__known_issue:": "With 3 optional tokens do not match that do not mach, it does NOT match.",
                 "ignore_result": true,
                 "pattern": "\\w*\\p*\\d*\\w*",
                 "log": "xy",
@@ -4138,7 +4196,34 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "In this case, with 3 extra optional tokens, it does NOT match.",
+                "__known_issue": "When there are 3 tokens with the quantifier '*' consecutively, under certain circumstances, the regex does not match even though it should. BUG 8 of issue: http://#XXXX",
+                "ignore_result": true,
+                "pattern": "\\w*\\p*\\d*\\w*",
+                "log": "xy55",
+                "end_match": "5",
+                "captured_groups": []
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__known_issue": "When there are 3 tokens with the quantifier '*' consecutively, under certain circumstances, the regex does not match even though it should. BUG 8 of issue: http://#XXXX",
+                "ignore_result": true,
+                "pattern": "\\w+\\p*\\d*\\w*",
+                "log": "xy55",
+                "end_match": "5",
+                "captured_groups": []
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "pattern": "(\\w*)\\p*\\d*\\w*",
+                "log": "xy",
+                "end_match": "y",
+                "captured_groups": [
+                    "xy"
+                ]
+            },
+            {
+                "description": "Tokens with optional quantifier (*) should always match, but they don't.",
+                "__known_issue": "When there are 3 tokens with the quantifier '*' consecutively, under certain circumstances, the regex does not match even though it should. BUG 8 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "^\\w*\\p*\\d*\\w*",
                 "log": "xy",
@@ -4147,7 +4232,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "In this case, with 3 extra optional tokens, it does NOT match.",
+                "__known_issue": "When there are 3 tokens with the quantifier '*' consecutively, under certain circumstances, the regex does not match even though it should. BUG 8 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\w*\\p*\\d*\\w*$",
                 "log": "xy",
@@ -4199,7 +4284,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "In this case, with 3 extra optional tokens, it does NOT match.",
+                "__known_issue": "When there are 3 tokens with the quantifier '*' consecutively, under certain circumstances, the regex does not match even though it should. BUG 8 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\w*\\d*\\p*\\w*",
                 "log": "xy",
@@ -4216,7 +4301,8 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "In this case there are 2 exceding optional tokens, the regex doesn't match.",
+                "__known_issue": "Maybe related with bug 9 or 8. BUG 10 of issue: http://#XXXX",
+                "__known_issue_2": "In this case there are 2 exceding optional tokens, the regex doesn't match.",
                 "ignore_result": true,
                 "pattern": "xyz\\d*\\w*",
                 "log": "xyz",
@@ -4225,7 +4311,8 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "In this case there are 2 exceding optional tokens inside a capture groupe, the regex doesn't match.",
+                "__known_issue": "Maybe related with bug 9 or 8. BUG 10 of issue: http://#XXXX",
+                "__known_issue_2": "In this case there are 2 exceding optional tokens inside a capture groupe, the regex doesn't match.",
                 "ignore_result": true,
                 "pattern": "xyz(\\d*\\w*)",
                 "log": "xyz",
@@ -4236,7 +4323,8 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "In this case there is 1 exceding optional token inside a capture groupe, the regex does match but the expected group is not captured.",
+                "__known_issue": "May related with bug 5. BUG 11 of issue: http://#XXXX",
+                "__known_issue:_2": "In this case there is 1 exceding optional token inside a capture groupe, the regex does match but the expected group is not captured.",
                 "ignore_result": true,
                 "pattern": "xyz(\\w*)",
                 "log": "xyz",
@@ -4258,6 +4346,7 @@
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
                 "__known_issue:": "In this case there are 2 exceding optional tokens inside a capture groupe, the regex doesn't match.",
+                "__known_issue": "May related with bug 5. BUG 11 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "xyz\\w*(\\w*)",
                 "log": "xyz",
@@ -4287,6 +4376,7 @@
             {
                 "description": "Capture group is not correctly obtained. It should be '123' but it is empty.",
                 "ignore_result": true,
+                "__known_issue": "BUG 12 of issue: http://#XXXX",
                 "pattern": "(\\d+)\\D*",
                 "log": "123",
                 "end_match": "3",
@@ -4305,6 +4395,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(\\d+)\\D*",
                 "log": "123Test",
@@ -4315,6 +4406,7 @@
             },
             {
                 "description": "Capture group is not correctly obtained. It should be '123' but it is empty.",
+                "__known_issue": "BUG 12 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(\\d+)\\D*",
                 "log": "Test123",
@@ -4325,6 +4417,7 @@
             },
             {
                 "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
+                "__known_issue": "BUG 12 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\d+(\\D*)",
                 "log": "123",
@@ -4336,6 +4429,7 @@
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
                 "ignore_result": true,
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "pattern": "\\d+(\\D*)",
                 "log": "123Test",
                 "end_match": "t",
@@ -4345,6 +4439,7 @@
             },
             {
                 "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
+                "__known_issue": "BUG 12 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\d+(\\D*)",
                 "log": "Test123",
@@ -4356,6 +4451,7 @@
             {
                 "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
                 "ignore_result": true,
+                "__known_issue": "BUG 12 of issue: http://#XXXX",
                 "pattern": "^\\d+(\\D*)",
                 "log": "123",
                 "end_match": "3",
@@ -4366,6 +4462,7 @@
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
                 "ignore_result": true,
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "pattern": "^\\d+(\\D*)",
                 "log": "123Test",
                 "end_match": "t",
@@ -4384,6 +4481,7 @@
             },
             {
                 "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
+                "__known_issue": "BUG 12 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "^(\\d+)\\D*",
                 "log": "123",
@@ -4394,6 +4492,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "^(\\d+)\\D*",
                 "log": "123Test",
@@ -4413,6 +4512,7 @@
             },
             {
                 "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
+                "__known_issue": "BUG 12 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\d+(\\D*)$",
                 "log": "123",
@@ -4423,6 +4523,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\d+(\\D*)$",
                 "log": "123Test",
@@ -4433,6 +4534,7 @@
             },
             {
                 "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
+                "__known_issue": "BUG 12 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\d+(\\D*)$",
                 "log": "Test123",
@@ -4443,6 +4545,7 @@
             },
             {
                 "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
+                "__known_issue": "BUG 12 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(\\d+)\\D*$",
                 "log": "123",
@@ -4453,6 +4556,7 @@
             },
             {
                 "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
+                "__known_issue": "BUG 12 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(\\d+)\\D*$",
                 "log": "123Test",
@@ -4463,6 +4567,7 @@
             },
             {
                 "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
+                "__known_issue": "BUG 12 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(\\d+)\\D*$",
                 "log": "Test123",
@@ -4473,6 +4578,7 @@
             },
             {
                 "description": "Capture group is not correctly obtained.",
+                "__known_issue": "BUG 12 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(\\d*)\\w*",
                 "log": "123",
@@ -4483,6 +4589,7 @@
             },
             {
                 "description": "Capture group is not correctly obtained.",
+                "__known_issue": "BUG 12 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(\\d*)\\w*",
                 "log": "123Test",
@@ -4493,7 +4600,8 @@
             },
             {
                 "description": "Regex should match but does not.",
-                "__known_issue": "Only 4 'recoverage' levels are allowed.",
+                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
+                "__known_issue_2": "Only 4 'recoverage' levels are allowed.",
                 "ignore_result": true,
                 "pattern": "(\\w+1) (\\w+2) (\\w+3) (\\w+4) (\\w+5)",
                 "log": "xyz1xyz1 xyz2xyz2 xyz3xyz3 xyz4xyz4 xyz5xyz5",
@@ -4514,7 +4622,8 @@
                 "captured_groups": []
             },
             {
-                "description": "This case matches.",
+                "description": "This case does not match.",
+                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5$",
                 "log": "xyz1xyz1 xyz2xyz2 xyz3xyz3 xyz4xyz4 xyz5xyz5",
@@ -4537,6 +4646,7 @@
             {
                 "description": "Regex should match but does not.",
                 "ignore_result": true,
+                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
                 "pattern": "(\\w+1) (\\w+2) (\\w+3) (\\w+4) (\\w+5) (\\w+6)$",
                 "log": "xyz1xyz1 xyz2xyz2 xyz3xyz3 xyz4xyz4 xyz5 xyz6xyz6",
                 "end_match": "6",
@@ -4552,6 +4662,7 @@
             {
                 "description": "Regex should match but does not.",
                 "ignore_result": true,
+                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
                 "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6$",
                 "log": "xyz1xyz1 xyz2xyz2 xyz3xyz3 xyz4xyz4 xyz5 xyz6xyz6",
                 "end_match": "6",
@@ -4575,6 +4686,7 @@
                 "description": "Regex should match but does not.",
                 "ignore_result": true,
                 "pattern": "(\\w+1) (\\w+2) (\\w+3) (\\w+4) (\\w+5) (\\w+6)$",
+                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
                 "log": "xyz1xyz1 xyz2xyz2 xyz3xyz3 xyz4xyz4 xyz5xyz5 xyz6",
                 "end_match": "6",
                 "captured_groups": [
@@ -4590,6 +4702,7 @@
                 "description": "Regex should match but does not.",
                 "ignore_result": true,
                 "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
+                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
                 "log": "z1 x2 x3 x4 x5x5 x6",
                 "end_match": "6",
                 "captured_groups": []
@@ -4598,6 +4711,7 @@
                 "description": "Regex should match but does not.",
                 "ignore_result": true,
                 "pattern": "(\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6)",
+                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
                 "log": "z1 x2 x3 x4 x5x5 x6",
                 "end_match": "6",
                 "captured_groups": [
@@ -4606,6 +4720,7 @@
             },
             {
                 "description": "Regex should match but does not.",
+                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(\\w+1) (\\w+2) (\\w+3) (\\w+4) (\\w+5) (\\w+6)",
                 "log": "z1 x2 x3 x4 x5x5 x6",
@@ -4651,7 +4766,8 @@
             },
             {
                 "description": "This case has 3 (non-optional) tokens but it is capturing only 2 characters.",
-                "__known_issue": "Capture groups could be either '04T15' or '4T15', depending on the (unpredictable) behavior of the greediness.",
+                "__known_issue": "BUG 13 of issue: http://#XXXX",
+                "__known_issue_2": "Capture groups could be either '04T15' or '4T15', depending on the (unpredictable) behavior of the greediness.",
                 "ignore_result": true,
                 "pattern": "(\\d+\\w\\d+)",
                 "log": "04T15",
@@ -4662,6 +4778,7 @@
             },
             {
                 "description": "This case should match but it does not.",
+                "__known_issue": "Related BUG 13 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(-\\d+\\w\\d+:)",
                 "log": "-04T15:",
@@ -4672,6 +4789,7 @@
             },
             {
                 "description": "This case should match but it does not.",
+                "__known_issue": "Related BUG 13 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "-(\\d+\\w\\d+):",
                 "log": "-04T15:",
@@ -4681,6 +4799,7 @@
                 ]
             },
             {
+                "__known_issue": "Related BUG 13 of issue: http://#XXXX",
                 "description": "This case should match but it does not.",
                 "ignore_result": true,
                 "pattern": "-\\d+\\w\\d+:",
@@ -4690,7 +4809,8 @@
             },
             {
                 "description": "This case matches.",
-                "__known_issue": "Wrong end_match value.",
+                "__known_issue": "Related BUG 13 of issue: http://#XXXX",
+                "__known_issue_2": "Wrong end_match value.",
                 "ignore_result": true,
                 "pattern": "\\d+\\w\\d+",
                 "log": "04T15",
@@ -4699,7 +4819,8 @@
             },
             {
                 "description": "This case matches.",
-                "__known_issue": "Wrong end_match value.",
+                "__known_issue": "Related BUG 13 of issue: http://#XXXX",
+                "__known_issue_2": "Wrong end_match value.",
                 "ignore_result": true,
                 "pattern": "(\\d+\\D\\d+)",
                 "log": "04T15",
@@ -4743,6 +4864,19 @@
                 "captured_groups": []
             },
             {
+                "description": "This case matches.",
+                "__known_issue": "Related BUG 13 of issue: http://#XXXX",
+                "__known_issue_2": "Wrong end_match value.",
+                "ignore_result": true,
+                "debug": true,
+                "pattern": "(\\d+\\D\\d+)",
+                "log": "04T15",
+                "end_match": "5",
+                "captured_groups": [
+                    "04T15"
+                ]
+            },
+            {
                 "description": "Empty regex should not match but it does.",
                 "ignore_result": true,
                 "pattern": "",
@@ -4762,13 +4896,15 @@
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '1'",
                 "ignore_result": true,
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "pattern": "\\.+",
-                "log": "123 test",
+                "log": "123 Test",
                 "end_match": "t",
                 "captured_groups": []
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '1'",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\.+$",
                 "log": "123 test",
@@ -4777,6 +4913,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '1'",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "^\\.+",
                 "log": "123 test",
@@ -4785,6 +4922,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '1'",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "^\\.+$",
                 "log": "123 test",
@@ -4793,6 +4931,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '1'",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "^(\\.+)$",
                 "log": "123 test",
@@ -4803,6 +4942,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '~' but it is '_'",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "\\.+",
                 "log": "_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 \r\t!\"#$%&()*+,./:;<=>?[\\]^`{|}~",
@@ -4811,6 +4951,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '~' but it is '_'",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "^\\.+$",
                 "log": "_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 \r\t!\"#$%&()*+,./:;<=>?[\\]^`{|}~",
@@ -4835,6 +4976,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '~' but it is '_'",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "^(\\.+)$",
                 "log": "_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 \r\t!\"#$%&()*+,./:;<=>?[\\]^`{|}~",

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -1,16 +1,1799 @@
 [
     {
-        "description": "[Coverage] Lazy pattern, greedy match - backslash with '*' modifier. The next token does not include the map characters of the current token and has '+' modifier.",
+        "description": "[Functionality] Charmap without backslashed tokens.",
         "batch_test": [
             {
-                "description": "Min size",
+                "description": "Literal match. Match all.",
+                "pattern": "hi wazuh",
+                "log": "hi wazuh",
+                "end_match": "h",
+                "captured_groups": []
+            },
+            {
+                "description": "Literal match. Match all, with capture groups.",
+                "pattern": "(hi) (wazuh)",
+                "log": "hi wazuh",
+                "end_match": "h",
+                "captured_groups": [
+                    "hi",
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Literal match, with the end flag. It does not match.",
+                "pattern": "hi wazuh$",
+                "log": "hi wazuh 123",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Literal match, with groups and the end flag. It does not match.",
+                "pattern": "(hi) (wazuh)$",
+                "log": "hi wazuh 123",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Dont match at all.",
+                "pattern": "hi wazuh",
+                "log": "bye wazuh",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Match with prefix and group.",
+                "pattern": "(hi) (wazuh)",
+                "log": "prefixhi wazuh",
+                "end_match": "h",
+                "captured_groups": [
+                    "hi",
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Match with sufix and group.",
+                "pattern": "(hi) (wazuh)",
+                "log": "fixhi wazuhsub",
+                "end_match": "hsub",
+                "captured_groups": [
+                    "hi",
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Match with adjacent capture groups.",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "ignore_result": true,
+                "pattern": "(hi)(wazuh)",
+                "log": "hiwazuh",
+                "end_match": "h",
+                "captured_groups": [
+                    "hi",
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Match with adjacent capture groups and context.",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "ignore_result": true,
+                "pattern": "(hi)(wazuh)",
+                "log": "prefixhiwazuhsub",
+                "end_match": "hsub",
+                "captured_groups": [
+                    "hi",
+                    "wazuh"
+                ]
+            }
+        ]
+    },
+    {
+        "description": "[Functionality] Charmap + END/BEGIN flags and st_error without backslashed tokens.",
+        "batch_test": [
+            {
+                "description": "Regex match all and the END_SET is set.",
+                "pattern": "hi wazuh$",
+                "log": "hi wazuh",
+                "end_match": "h",
+                "captured_groups": []
+            },
+            {
+                "description": "Empty pattern END_SET and BEGIN_SET are set.",
+                "pattern": "^$",
+                "log": "hi wazuh",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Empty pattern END_SET and BEGIN_SET are set.",
+                "__known_issue:": "It should match but does not, it is not possible to check if a log is empty. BUG 2 of issue: http://#XXXX",
+                "ignore_result": true,
+                "pattern": "^$",
+                "log": "",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Empty pattern END_SET and BEGIN_SET are set.",
+                "__known_issue:": "It should match but does not, it is not possible to check if a log is empty. BUG 2 of issue: http://#XXXX",
+                "ignore_result": true,
+                "pattern": "(^$)",
+                "log": "",
+                "end_match": "",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Empty pattern END_SET and BEGIN_SET are set.",
+                "__known_issue:": "It should match but does not, it is not possible to check if a log is empty. BUG 2 of issue: http://#XXXX",
+                "ignore_result": true,
+                "pattern": "^()$",
+                "log": "",
+                "end_match": "",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Pattern ends and the END_SET is not set.",
+                "pattern": "hi wazuh",
+                "log": "hi wazuh!",
+                "end_match": "h!",
+                "captured_groups": []
+            },
+            {
+                "description": "Partial match and then re-match ('st_error' test).",
+                "pattern": "(hi) (wazuh)",
+                "log": "XX hi wa hi wazuhXX",
+                "end_match": "hXX",
+                "captured_groups": [
+                    "hi",
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Partial match and then re-match ('st_error' + BEGIN_SET test).",
+                "pattern": "^(hi) (wazuh)",
+                "log": "hi wa hi wazuhXX",
+                "end_match": null,
+                "captured_groups": []
+            }
+        ]
+    },
+    {
+        "description": "[Functionality] Only backslashed tokens without quantifiers ('*', '+').",
+        "batch_test": [
+            {
+                "description": "Match all.",
+                "pattern": "\\w\\w\\s\\S\\S\\S\\S\\S",
+                "log": "hi wazuh",
+                "end_match": "h",
+                "captured_groups": []
+            },
+            {
+                "description": "Parcial match and fail",
+                "pattern": "\\w\\w\\s\\S\\S\\S\\S\\S",
+                "log": "hi waz",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Parcial match and fail and then re-match",
+                "pattern": "\\w\\w\\s\\S\\S\\S\\S\\S",
+                "log": "hi waz hi wazu.",
+                "end_match": ".",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all with capture groups.",
+                "pattern": "\\w(\\w\\s\\S)\\S(\\S\\S\\S)",
+                "log": "hi wazuh",
+                "end_match": "h",
+                "captured_groups": [
+                    "i w",
+                    "zuh"
+                ]
+            },
+            {
+                "description": "Parcial match and fail  with capture group.",
+                "pattern": "(\\w\\w)\\s\\S\\S\\S\\S\\S",
+                "log": "hi waz",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Parcial match and fail but then re-match with capture group.",
+                "pattern": "(\\w\\w)\\s(\\S\\S\\S\\S\\S)",
+                "log": "hi waz hi wazuh.",
+                "end_match": "h.",
+                "captured_groups": [
+                    "hi",
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Parcial match and fail but then re-match with adjacent capture group.",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "ignore_result": true,
+                "pattern": "(\\w\\w\\s)(\\S\\S\\S\\S\\S)",
+                "log": "hi waz hi wazuh.",
+                "end_match": "h.",
+                "captured_groups": [
+                    "hi ",
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Parcial match and fail but then re-match with one capture group.",
+                "pattern": "(\\w\\w\\s\\S\\S\\S\\S\\S)\\p$",
+                "log": "hi waz hi wazuh.",
+                "end_match": ".",
+                "captured_groups": [
+                    "hi wazuh"
+                ]
+            }
+        ]
+    },
+    {
+        "description": "[Functionality] Only backslashed tokens with the '+' quantifier.",
+        "batch_test": [
+            {
+                "description": "Match all.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "ignore_result": true,
+                "pattern": "\\w+",
+                "log": "wazuh",
+                "end_match": "h",
+                "captured_groups": []
+            },
+            {
+                "description": "Mach all with capture group.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "ignore_result": true,
+                "pattern": "(\\w+)",
+                "log": "wazuh",
+                "end_match": "h",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Mach all with capture group and flags.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "ignore_result": true,
+                "debug": false,
+                "pattern": "^\\w+$",
+                "log": "wazuh",
+                "end_match": "h",
+                "captured_groups": []
+            },
+            {
+                "description": "Mach all with capture group and flags.",
+                "ignore_result": true,
+                "debug": false,
+                "pattern": "^(\\w+)$",
+                "log": "wazuh",
+                "end_match": "h",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Parcial match and fail, with flags.",
+                "pattern": "^\\w+$",
+                "log": "wazuh ",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Parcial match and fail with capture group and flags.",
+                "pattern": "^(\\w+)$",
+                "log": "wazuh ",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Match one character.",
+                "pattern": "\\w+",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": []
+            },
+            {
+                "description": "Match one character, with capture group.",
+                "pattern": "(\\w+)",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Match one character and flags.",
+                "pattern": "^\\w+$",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": []
+            },
+            {
+                "description": "Match one character, with capture group and flags",
+                "pattern": "^(\\w+)$",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": [
+                    "w"
+                ]
+            }
+        ]
+    },
+    {
+        "description": "[Functionality] Lazy-Greedy behavior duality: Regex composed by a backslashed token with a '+' quantifier followed by a token that has no quantifier, where the last token does not include the charmap of the first one.",
+        "batch_test": [
+            {
+                "description": "Minimun log to match all, with backslashed token.",
+                "pattern": "\\w+\\s",
+                "log": "X ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all, with backslashed token.",
+                "pattern": "\\w+\\s",
+                "log": "Wazuh ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Minimun log to match all with capture group, with backslashed token.",
+                "pattern": "(\\w+)\\s",
+                "log": "X ",
+                "end_match": " ",
+                "captured_groups": [
+                    "X"
+                ]
+            },
+            {
+                "description": "Minimun log to match and capture all, with backslashed token.",
+                "pattern": "(\\w+\\s)",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Match all, capture the first token, with backslashed token.",
+                "pattern": "(\\w+)\\s",
+                "log": "Wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "Wazuh"
+                ]
+            },
+            {
+                "description": "Minimun log to match all.",
+                "pattern": "\\w+ ",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all.",
+                "pattern": "\\w+ ",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Minimun log to match all with capture group.",
+                "pattern": "(\\w+) ",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Minimun log to match and capture all.",
+                "pattern": "(\\w+ )",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Match all and capture the first word.",
+                "pattern": "(\\w+) ",
+                "log": "Wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "Wazuh"
+                ]
+            },
+            {
+                "description": "Match all, with a literal at the end.",
+                "pattern": "\\w+\\s1",
+                "log": "wazuh 1",
+                "end_match": "1",
+                "captured_groups": []
+            },
+            {
+                "description": "Minimun log to match all, with a literal at the end, capture the first word.",
+                "pattern": "(\\w+)\\s1",
+                "log": "w 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Match all, with a literal at the end, capture the first word and the second token (space).",
+                "pattern": "(\\w+\\s)1",
+                "log": "w 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Match all, with a literal at the end, capture the first word.",
+                "pattern": "(\\w+)\\s1",
+                "log": "wazuh 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Match, with a postfix.",
+                "pattern": "\\w+\\s1",
+                "log": "w 123",
+                "end_match": "123",
+                "captured_groups": []
+            },
+            {
+                "description": "Match, with a postfix and a literal space",
+                "pattern": "\\w+ 1",
+                "log": "wazuh 123",
+                "end_match": "123",
+                "captured_groups": []
+            },
+            {
+                "description": "Match, with a postfix and a literal space, capture the first token.",
+                "pattern": "(\\w+) 1",
+                "log": "w 123",
+                "end_match": "123",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Match, with a postfix and a literal space, capture the first token and the space.",
+                "pattern": "(\\w+ )1",
+                "log": "w 123",
+                "end_match": "123",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Match, with a postfix and a literal space, capture the first token.",
+                "pattern": "(\\w+) 1",
+                "log": "wazuh 123",
+                "end_match": "123",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Match, with a postfix and a literal space, capture the first token and the space..",
+                "pattern": "^\\w+\\s$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all with flags.",
+                "pattern": "^\\w+\\s$",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all with flags and capture the first token",
+                "pattern": "^(\\w+)\\s$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Match and capture all with flags.",
+                "pattern": "^(\\w+\\s)$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Match all with backslashed token and flags.",
+                "pattern": "^(\\w+)\\s$",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Match minimum log with flags.",
+                "pattern": "^\\w+ $",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all with flags.",
+                "pattern": "^\\w+ $",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Match minimum log with flags and capture the first token.",
+                "pattern": "^(\\w+) $",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Match minimum log with flags and capture all.",
+                "pattern": "^(\\w+ )$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Match minimum log with flags and capture the first token.",
+                "pattern": "^(\\w+) $",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Fail match becouse of flags.",
+                "pattern": "^\\w+ $",
+                "log": "wazuh -",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Fail match becouse of flags.",
+                "pattern": "^(\\w+ )$",
+                "log": "wazuh -",
+                "end_match": null,
+                "captured_groups": []
+            }
+        ]
+    },
+    {
+        "description": "[Functionality] Lazy-Greedy behavior duality: Regex composed by a backslashed token with a '+' quantifier followed by a token that has no quantifier, where the last token does include the charmap of the first one.",
+        "batch_test": [
+            {
+                "description": "Minimun log to match all, with backslashed token.",
+                "pattern": "\\d+\\d",
+                "log": "5",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Match all, with backslashed token.",
+                "pattern": "(\\d+)\\d",
+                "log": "5",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Minimun log to match all with capture group, with backslashed token.",
+                "pattern": "(\\d+)\\w",
+                "log": "12",
+                "end_match": "2",
+                "captured_groups": [
+                    "1"
+                ]
+            },
+            {
+                "description": "Minimun log to match and capture all, with backslashed token.",
+                "pattern": "\\d+(\\w)",
+                "log": "12",
+                "end_match": "2",
+                "captured_groups": [
+                    "2"
+                ]
+            },
+            {
+                "description": "Match all, with backslashed token.",
+                "pattern": "\\d+\\w",
+                "log": "12345",
+                "end_match": "2345",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all, capture the first token, with backslashed token.",
+                "pattern": "(\\d+)\\w",
+                "log": "12345",
+                "end_match": "2345",
+                "captured_groups": [
+                    "1"
+                ]
+            },
+            {
+                "description": "Match all, capture the second token, with backslashed token.",
+                "pattern": "\\d+(\\w)",
+                "log": "12345",
+                "end_match": "2345",
+                "captured_groups": [
+                    "2"
+                ]
+            },
+            {
+                "description": "No match, no item to consume.",
+                "pattern": "^\\d+\\d",
+                "log": "5",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "No match, no item to consume.",
+                "pattern": "^(\\d+)\\d",
+                "log": "5",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Match all, capture the first token with flags.",
+                "pattern": "^(\\d+)\\w$",
+                "log": "12",
+                "end_match": "2",
+                "captured_groups": [
+                    "1"
+                ]
+            },
+            {
+                "description": "Match all, capture the second token with flags.",
+                "pattern": "^\\d+(\\w)$",
+                "log": "12",
+                "end_match": "2",
+                "captured_groups": [
+                    "2"
+                ]
+            },
+            {
+                "description": "Match all with flags.",
+                "pattern": "^\\d+\\w$",
+                "log": "12345",
+                "end_match": "5",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all with flags.",
+                "pattern": "^(\\d+)\\w$",
+                "log": "12345",
+                "end_match": "5",
+                "captured_groups": [
+                    "1234"
+                ]
+            },
+            {
+                "description": "Match all with flags and capture the second token.",
+                "pattern": "^\\d+(\\w)$",
+                "log": "12345",
+                "end_match": "5",
+                "captured_groups": [
+                    "5"
+                ]
+            },
+            {
+                "description": "Dont match with flags.",
+                "pattern": "^\\d+(\\w)$",
+                "log": "12345&&&&&&&",
+                "end_match": null,
+                "captured_groups": []
+            }
+        ]
+    },
+    {
+        "description": "[Functionality] Lazy-Greedy behavior duality: Regex composed by a backslashed token with a '+' quantifier followed by a token that has the '+' quantifier, where the last token does not include the charmap of the first one.",
+        "batch_test": [
+            {
+                "description": "Minimun log to match all.",
+                "pattern": "\\w+\\s+",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Minimun log to match all, with capture all.",
+                "pattern": "(\\w+\\s+)",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Minimun log to match all, capture the first token.",
+                "pattern": "(\\w+)\\s+",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Minimun log to match all, capture the second token.",
+                "pattern": "\\w+(\\s+)",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    " "
+                ]
+            },
+            {
+                "description": "Match all.",
+                "pattern": "\\w+\\s+",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all with group.",
+                "pattern": "(\\w+)\\s+",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Match all with consecutive group.",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "ignore_result": true,
+                "pattern": "(\\w+)(\\s+)",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
+            },
+            {
+                "description": "Match all with no consecutive group and opcional.",
+                "pattern": "(\\w+)\\d*(\\s+)",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
+            },
+            {
+                "description": "Match all with no consecutive group and opcional",
+                "pattern": "(\\w+)\\d*(\\s+)",
+                "log": "wazuh123 ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
+            },
+            {
+                "description": "Match all with no consecutive group.",
+                "pattern": "(\\w+)\\d+(\\s+)",
+                "log": "wazuh123 ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
+            },
+            {
+                "description": "Match all with literal at the end.",
+                "pattern": "\\w+\\s+1",
+                "log": "wazuh 1",
+                "end_match": "1",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all, 1 character with literal at the end and capture the first token.",
+                "pattern": "(\\w+)\\s+1",
+                "log": "w 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Match all, 1 character with literal at the end and no capture the literal.",
+                "pattern": "(\\w+\\s+)1",
+                "log": "w 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Match all with literal at the end and capture the first token.",
+                "pattern": " (\\w+)\\s+1",
+                "log": " wazuh 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Minimun log to match all, with flags.",
+                "pattern": "^\\w+\\s+$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all, with flags.",
+                "ignore_result": true,
+                "__know_issue": "Err retval.",
+                "pattern": "^\\w+\\s+$",
+                "log": "wazuh  ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Minimun log to match all, with flags and capture the first token.",
+                "pattern": "^(\\w+)\\s+$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Minimun log to match all, with flags and capture the second token.",
+                "pattern": "^\\w+(\\s+)$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    " "
+                ]
+            },
+            {
+                "description": "Minimun log to match all, with flags and capture all.",
+                "pattern": "^(\\w+\\s+)$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Dont match.",
+                "pattern": "^\\w+\\s+$",
+                "log": "wazuh -",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Dont match.",
+                "pattern": "^(\\w+\\s+)$",
+                "log": "wazuh -",
+                "end_match": null,
+                "captured_groups": []
+            }
+        ]
+    },
+    {
+        "description": "[Functionality] Lazy-Greedy behavior duality: Regex composed by a backslashed token with a '+' quantifier followed by a token that has the '*' quantifier, where the last token does include the charmap of the first one.",
+        "batch_test": [
+            {
+                "description": "Minimun log to match all.",
+                "pattern": "\\w+\\s*",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": []
+            },
+            {
+                "description": "Minimun log to match all and patter with a optional token.",
+                "pattern": "\\w+\\s*",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "ignore_result": true,
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Minimun log to match all and capture all.",
+                "pattern": "(\\w+\\s*)",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "ignore_result": true,
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Match all and capture all.",
+                "pattern": "(\\w+\\s*)",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "ignore_result": true,
+                "debug": false,
+                "log": "wazuh",
+                "end_match": "h",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Minimun log with optional token to match and capture all.",
+                "ignore_result": true,
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "pattern": "(\\w+\\s*)",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Minimun log to match and capture the first token.",
+                "pattern": "(\\w+)\\s*",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "inimun log with optional token to match and capture the first token.",
+                "ignore_result": true,
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "pattern": "(\\w+)\\s*",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Match all.",
+                "pattern": "\\w+\\s*",
+                "ignore_result": true,
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all, capture all.",
+                "ignore_result": true,
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "pattern": "(\\w+\\s*)",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh "
+                ]
+            },
+            {
+                "description": "Match all with no consecutive group.",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "ignore_result": true,
+                "pattern": "(\\w+)(\\s*)",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
+            },
+            {
+                "description": "Match all with no consecutive group and opcional.",
+                "pattern": "(\\w+)\\d+(\\s*)",
+                "ignore_result": true,
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "log": "wazuh ",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Match all with no consecutive group and opcional.",
+                "pattern": "(\\w+)\\d+(\\s*)",
+                "ignore_result": true,
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "log": "wazuh123 ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
+            },
+            {
+                "description": "Match all with no consecutive group and opcional.",
+                "pattern": "(\\w+)\\d*(\\s*)",
+                "ignore_result": true,
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "debug": false,
+                "log": "wazuh123 ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh",
+                    " "
+                ]
+            },
+            {
+                "description": "Match all with literal at the end.",
+                "pattern": "\\w+\\s*1",
+                "log": "wazuh 1",
+                "end_match": "1",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all with literal at the end, 1 character and capture the first token.",
+                "pattern": "(\\w+)\\s*1",
+                "log": "w 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Match all with literal at the end, 1 character and capture the first token and te optional.",
+                "pattern": "(\\w+\\s*)1",
+                "log": "w 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Match all with literal at the end and capture the first token.",
+                "pattern": " (\\w+)\\s*1",
+                "log": " wazuh 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Minimun log to match all, with flags.",
+                "pattern": "^\\w+\\s*$",
+                "ignore_result": true,
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all, with flags.",
+                "ignore_result": true,
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "pattern": "^\\w+\\s*$",
+                "log": "wazuh  ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Minimun log to match all, with flags and capture the first token.",
+                "pattern": "^(\\w+)\\s*$",
+                "ignore_result": true,
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Minimun log to match all, with flags and capture the first token.",
+                "pattern": "^(\\w+)\\s*$",
+                "ignore_result": true,
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Minimun log to match all, with flags and capture all.",
+                "pattern": "^(\\w+\\s*)$",
+                "ignore_result": true,
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Dont match.",
+                "pattern": "^\\w+\\s*$",
+                "log": "wazuh -",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Dont match.",
+                "pattern": "^(\\w+\\s*)$",
+                "log": "wazuh -",
+                "end_match": null,
+                "captured_groups": []
+            }
+        ]
+    },
+    {
+        "description": "[Functionality] Lazy-Greedy behavior duality: Regex composed by backslashed tokens with '*' quantifiers. Test the 'st_error', 'pt_error[]' and 'pt_error_str[]' for parcial matches and rewind.",
+        "batch_test": [
+            {
+                "description": "Saves and restores the first position error.",
+                "pattern": "\\w+_1 \\w+_2 \\w+_3 \\w+_4 \\w+_5 \\w+_6",
+                "log": "wa_11 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Saves and restores the second position error.",
+                "pattern": "\\w+_1 \\w+_2 \\w+_3 \\w+_4 \\w+_5 \\w+_6",
+                "log": "wa_1 wa_22 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Saves and restores the third position error.",
+                "pattern": "\\w+_1 \\w+_2 \\w+_3 \\w+_4 \\w+_5 \\w+_6",
+                "log": "wa_1 wa_2 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Saves and restores the fourth position error.",
+                "pattern": "\\w+_1 \\w+_2 \\w+_3 \\w+_4 \\w+_5 \\w+_6",
+                "log": "wa_1 wa_2 wa_3 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Saves and restores the fifth position error.",
+                "pattern": "\\w+_1 \\w+_2 \\w+_3 \\w+_4 \\w+_5 \\w+_6",
+                "log": "wa_1 wa_2 wa_3 wa_4 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Saves and restores the sixth position error.",
+                "pattern": "\\w+_1 \\w+_2 \\w+_3 \\w+_4 \\w+_5 \\w+_6",
+                "log": "wa_1 wa_2 wa_3 wa_4 wa_5 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Saves and restores the first position error. But the first should match with the next character.",
+                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
+                "log": "z1x1 x2 x3 x4 x5 x6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Saves and restores the second position error. But the second should match with the next character.",
+                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
+                "log": "z1 x2x2 x3 x4 x5 x6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Saves and restores the third position error. But the third should match with the next character.",
+                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
+                "log": "z1 x2x2 x3 x4 x5 x6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Saves and restores the fourth position error. But the fourth should match with the next character.",
+                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
+                "log": "z1 x2 x3 x4x4 x5 x6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Saves and restores the fifth position error. But the fifth should match with the next character.",
+                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
+                "ignore_result": true,
+                "__known_issue:": "It should match but does not, as the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
+                "log": "z1 x2 x3 x4 x5x5 x6",
+                "end_match": "6",
+                "captured_groups": []
+            },
+            {
+                "description": "Saves and restores the sixth position error. But the sixth should match with the next character.",
+                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
+                "log": "z1 x2 x3 x4 x5 x6x6",
+                "ignore_result": true,
+                "__known_issue:": "It should match but does not, as the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
+                "end_match": "6",
+                "captured_groups": []
+            }
+        ]
+    },
+    {
+        "description": "[Functionality] Only backslashed tokens with the '*' quantifier.",
+        "batch_test": [
+            {
+                "description": "Match all.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "ignore_result": true,
+                "pattern": "\\w*",
+                "log": "wazuh",
+                "end_match": "h",
+                "captured_groups": []
+            },
+            {
+                "description": "Match 0-0",
+                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG 4 Issue: https://github.com/wazuh/wazuh/issues/14249",
+                "skip_test": true,
+                "pattern": "\\d*",
+                "log": "wazuh",
+                "end_match": "wazuh",
+                "captured_groups": []
+            },
+            {
+                "description": "Mach all with capture group.",
+                "ignore_result": true,
+                "pattern": "(\\w*)",
+                "log": "wazuh",
+                "end_match": "h",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Match 0-0, with capture group",
+                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/wazuh/wazuh/issues/14249",
+                "skip_test": true,
+                "pattern": "(\\d*)",
+                "log": "wazuh",
+                "end_match": "wazuh",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Mach all with capture group and flags.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "ignore_result": true,
+                "debug": false,
+                "pattern": "^\\w*$",
+                "log": "wazuh",
+                "end_match": "h",
+                "captured_groups": []
+            },
+            {
+                "description": "With capture group, match all (And flags)",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "ignore_result": true,
+                "pattern": "^(\\w*)$",
+                "log": "wazuh",
+                "end_match": "h",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Parcial match and fail, with flags.",
+                "pattern": "^\\w*$",
+                "log": "wazuh ",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Parcial match and fail, with flags and capture group.",
+                "pattern": "^(\\w*)$",
+                "log": "wazuh ",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "description": "Match one character.",
+                "pattern": "\\w*",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": []
+            },
+            {
+                "description": "Match one character with capture group.",
+                "pattern": "(\\w*)",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Match one character and flags.",
+                "pattern": "^\\w*$",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": []
+            },
+            {
+                "description": "Match one character, with group and flags.",
+                "pattern": "^(\\w*)$",
+                "log": "w",
+                "end_match": "w",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Match 0-0 with flags.",
+                "debug": true,
+                "pattern": "^\\w*$",
+                "log": "",
+                "end_match": "",
+                "captured_groups": []
+            },
+            {
+                "description": "Match 0-0 and capture all",
+                "__known_issue:": "If the pattern has only one token that has the quantifier '*' and it is inside a capture group, when the log is empty, it matches correctly, returning the pointer to the end of the string but does not capture the empty group as expected.",
+                "ignore_result": true,
+                "pattern": "(\\w*)",
+                "log": "",
+                "end_match": "",
+                "captured_groups": [ "" ]
+            },
+            {
+                "description": "Match 0-0 with flags and capture all",
+                "__known_issue:": "If the pattern has only one token that has the quantifier '*' and it is inside a capture group, when the log is empty, it matches correctly, returning the pointer to the end of the string but does not capture the empty group as expected.",
+                "ignore_result": true,
+                "pattern": "^(\\w*)$",
+                "log": "",
+                "end_match": "",
+                "captured_groups": [ "" ]
+            }
+        ]
+    },
+    {
+        "description": "[Functionality] Lazy-Greedy behavior duality: Regex composed by a backslashed token with a '*' quantifier followed by a token that has no quantifier, where the last token does not include the charmap of the first one.er.",
+        "batch_test": [
+            {
+                "description": "Match 1 character.",
+                "pattern": "\\w*\\s",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all.",
+                "pattern": "\\w*\\s",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Match 1 character with capture group.",
+                "pattern": "(\\w*)\\s",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Minimun log to match all, with backslashed token and capture group",
+                "pattern": "(\\w*)\\s",
+                "log": " ",
+                "end_match": " ",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Match all, with backslashed token and capture all",
+                "pattern": "(\\w*\\s)",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Minimun log to match all, with backslashed token and capture all.",
+                "pattern": "(\\w*\\s)",
+                "log": " ",
+                "end_match": " ",
+                "captured_groups": [
+                    " "
+                ]
+            },
+            {
+                "description": "Mtch all, with backslashed token and capture the first token.",
+                "pattern": "(\\w*)\\s",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Minimun log to match all, with literal token.",
+                "pattern": "\\w* ",
+                "log": " ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all, with 1 character and literal token.",
+                "pattern": "\\w* ",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all with literal.",
+                "pattern": "\\w* ",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all, with literal token and capture the first token.",
+                "pattern": "(\\w*) ",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Match all, with literal token and capture all.",
+                "pattern": "(\\w* )",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Match all, with literal token and capture the first token.",
+                "pattern": "(\\w*) ",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Match all, with literal token.",
+                "pattern": "\\w*\\s1",
+                "log": "wazuh 1",
+                "end_match": "1",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all, with backlashed token and capture the first token.",
+                "pattern": "(\\w*)\\s1",
+                "log": "w 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Match all, with backlashed token and capture the first token.",
+                "pattern": "(\\w*\\s)1",
+                "log": "w 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Match all, with backlashed token and capture the first token.",
+                "pattern": "(\\w*)\\s1",
+                "log": "wazuh 1",
+                "end_match": "1",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Match, with backlashed token and literal.",
+                "pattern": "\\w*\\s1",
+                "log": "w 123",
+                "end_match": "123",
+                "captured_groups": []
+            },
+            {
+                "description": "Match, with liteals token.",
+                "pattern": "\\w* 1",
+                "log": "wazuh 123",
+                "end_match": "123",
+                "captured_groups": []
+            },
+            {
+                "description": "Match, with liteals token and capture the first.",
+                "pattern": "(\\w*) 1",
+                "log": "w 123",
+                "end_match": "123",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Match, with liteals token and capture the first token and literal.",
+                "pattern": "(\\w* )1",
+                "log": "w 123",
+                "end_match": "123",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Match, with liteals token and capture the first token.",
+                "pattern": "(\\w*) 1",
+                "log": "wazuh 123",
+                "end_match": "123",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Match all with backlashed token and flags.",
+                "pattern": "^\\w*\\s$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all with backlashed token and flags.",
+                "pattern": "^\\w*\\s$",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all with backlashed token, flags and capture the first group.",
+                "pattern": "^(\\w*)\\s$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Match all with backlashed token, flags and capture all.",
+                "pattern": "^(\\w*\\s)$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "description": "Match all with backlashed token and flags.",
+                "pattern": "^(\\w*)\\s$",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "description": "Match all with liteal token and flags.",
+                "pattern": "^\\w* $",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all with literal token and flags.",
+                "pattern": "^\\w* $",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all with literal token, flags and capture the first.",
+                "pattern": "^(\\w*) $",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w"
+                ]
+            },
+            {
+                "description": "Match all with literal token and flags.",
+                "pattern": "^(\\w* )$",
+                "log": "w ",
+                "end_match": " ",
+                "captured_groups": [
+                    "w "
+                ]
+            },
+            {
+                "pattern": "^(\\w*) $",
+                "log": "wazuh ",
+                "end_match": " ",
+                "captured_groups": [
+                    "wazuh"
+                ]
+            },
+            {
+                "pattern": "^\\w* $",
+                "log": "wazuh -",
+                "end_match": null,
+                "captured_groups": []
+            },
+            {
+                "pattern": "^(\\w* )$",
+                "log": "wazuh -",
+                "end_match": null,
+                "captured_groups": []
+            }
+        ]
+    },
+    {
+        "description": "[Functionality] Lazy-Greedy behavior duality: Regex composed by a backslashed token with a '*' quantifier followed by a token that has no quantifier, where the last token does include the charmap of the first one.",
+        "batch_test": [
+            {
+                "description": "Match all. 0-0 and backlashed token.",
+                "pattern": "\\d*\\w",
+                "log": "5",
+                "end_match": "5",
+                "captured_groups": []
+            },
+            {
+                "description": "Match all. 0-0 and backlashed token and capture group.",
+                "pattern": "(\\d*)\\w",
+                "log": "5",
+                "end_match": "5",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "\\w matches with '1' character",
+                "pattern": "\\d*\\w",
+                "log": "12",
+                "end_match": "12",
+                "captured_groups": []
+            },
+            {
+                "description": "\\w matches with '1' character",
+                "pattern": "(\\d*)\\w",
+                "log": "12",
+                "end_match": "12",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Matches and capture group.",
+                "pattern": "\\d*(\\w)",
+                "log": "12",
+                "end_match": "12",
+                "captured_groups": [
+                    "1"
+                ]
+            },
+            {
+                "description": "Matches with nothing (0-0) and \\w matches to the first number.",
+                "pattern": "\\d*\\w",
+                "log": "12345",
+                "end_match": "12345",
+                "captured_groups": []
+            },
+            {
+                "description": "Matches with nothing (0-0) and \\w matches to the first number.",
+                "pattern": "(\\d*)\\w",
+                "log": "12345",
+                "end_match": "12345",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "description": "Matches with nothing (0-0) and \\w matches to the first number.",
+                "pattern": "\\d*(\\w)",
+                "log": "12345",
+                "end_match": "12345",
+                "captured_groups": [
+                    "1"
+                ]
+            },
+            {
+                "description": "Matches with nothing (0-0) and \\d matches to the first number.",
+                "pattern": "^\\d*\\d",
+                "log": "5",
+                "end_match": "5",
+                "captured_groups": []
+            },
+            {
+                "description": "Matches with nothing (0-0) and \\d matches to the first number.",
+                "pattern": "^(\\d*)\\d",
+                "log": "5",
+                "end_match": "5",
+                "captured_groups": [
+                    ""
+                ]
+            },
+            {
+                "pattern": "^(\\d*)\\w$",
+                "log": "12",
+                "end_match": "2",
+                "captured_groups": [
+                    "1"
+                ]
+            },
+            {
+                "pattern": "^\\d*(\\w)$",
+                "log": "12",
+                "end_match": "2",
+                "captured_groups": [
+                    "2"
+                ]
+            },
+            {
+                "description": "Matches with nothing (0-0) and \\d matches to the last number.",
+                "pattern": "^\\d*\\w$",
+                "log": "12345",
+                "end_match": "5",
+                "captured_groups": []
+            },
+            {
+                "description": "Matches with nothing (0-0) and \\d matches to the last number.",
+                "pattern": "^(\\d*)\\w$",
+                "log": "12345",
+                "end_match": "5",
+                "captured_groups": [
+                    "1234"
+                ]
+            },
+            {
+                "description": "Matches with nothing (0-0) and \\d matches to the last number.",
+                "pattern": "^\\d*(\\w)$",
+                "log": "12345",
+                "end_match": "5",
+                "captured_groups": [
+                    "5"
+                ]
+            },
+            {
+                "description": "Dont match.",
+                "pattern": "^\\d*(\\w)$",
+                "log": "12345&&&&&&&",
+                "end_match": null,
+                "captured_groups": []
+            }
+        ]
+    },
+    {
+        "description": "[Functionality] Lazy-Greedy behavior duality: Regex composed by a backslashed token with a '*' quantifier followed by a token that has the '+' quantifier, where the last token does not include the charmap of the first one.",
+        "batch_test": [
+            {
                 "pattern": "\\w*\\s+",
                 "log": "w ",
                 "end_match": " ",
                 "captured_groups": []
             },
             {
-                "description": "Min size. Capture all.",
+                "description": "Capture all.",
                 "pattern": "(\\w*\\s+)",
                 "log": "w ",
                 "end_match": " ",
@@ -19,7 +1802,6 @@
                 ]
             },
             {
-                "description": "Min size, with group",
                 "pattern": "(\\w*)\\s+",
                 "log": "w ",
                 "end_match": " ",
@@ -28,14 +1810,12 @@
                 ]
             },
             {
-                "description": "Other size",
                 "pattern": "\\w*\\s+",
                 "log": "wazuh ",
                 "end_match": " ",
                 "captured_groups": []
             },
             {
-                "description": "Other size. With group",
                 "pattern": "(\\w*)\\s+",
                 "log": "wazuh ",
                 "end_match": " ",
@@ -44,8 +1824,7 @@
                 ]
             },
             {
-                "description": "Other size. With group",
-                "__know_issue": "Consecutive capture groups don't support. should match 'wazuh ' but it doesn't. But (\\w+)\\d*(\\s+) works",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(\\w*)(\\s+)",
                 "log": "wazuh ",
@@ -56,7 +1835,7 @@
                 ]
             },
             {
-                "description": "2 groups no consecutive, and opcional",
+                "description": "2 no consecutive groups, and opcional.",
                 "pattern": "(\\w*)\\d*(\\s+)",
                 "log": "wazuh ",
                 "end_match": " ",
@@ -66,7 +1845,7 @@
                 ]
             },
             {
-                "description": "2 groups no consecutive, and opcional",
+                "description": "2 no consecutive groups, and opcional.",
                 "pattern": "(\\w*)\\d*(\\s+)",
                 "log": "wazuh123 ",
                 "end_match": " ",
@@ -88,7 +1867,7 @@
             {
                 "description": "2 groups no consecutive, and opcional",
                 "pattern": "(\\w*)\\d*(\\s*)",
-                "__know_issue": "Err retval.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "log": "wazuh ",
                 "end_match": " ",
@@ -100,7 +1879,7 @@
             {
                 "description": "2 groups no consecutive, and opcional",
                 "pattern": "(\\w*)\\d*(\\s*)",
-                "__know_issue": "Err retval.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "log": "wazuh123 ",
                 "end_match": " ",
@@ -112,7 +1891,7 @@
             {
                 "description": "2 groups no consecutive",
                 "pattern": "(\\w*)\\d+(\\s*)",
-                "__know_issue": "Err retval.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "log": "wazuh123 ",
                 "end_match": " ",
@@ -122,14 +1901,12 @@
                 ]
             },
             {
-                "description": "With literal at the end.",
                 "pattern": "\\w*\\s+1",
                 "log": "wazuh 1",
                 "end_match": "1",
                 "captured_groups": []
             },
             {
-                "description": "With literal at the end, 1 character + capture group.",
                 "pattern": "(\\w*)\\s+1",
                 "log": "w 1",
                 "end_match": "1",
@@ -138,7 +1915,6 @@
                 ]
             },
             {
-                "description": "With literal at the end, 1 character + capture all.",
                 "pattern": "(\\w*\\s+)1",
                 "log": "w 1",
                 "end_match": "1",
@@ -147,7 +1923,6 @@
                 ]
             },
             {
-                "description": "With literal at the end, 1 character + capture",
                 "pattern": " (\\w*)\\s+1",
                 "log": " wazuh 1",
                 "end_match": "1",
@@ -156,23 +1931,20 @@
                 ]
             },
             {
-                "description": "Min size. Match all. 1 character (With flags).",
                 "pattern": "^\\w*\\s+$",
                 "log": "w ",
                 "end_match": " ",
                 "captured_groups": []
             },
             {
-                "description": "Next token with blackslash. ok_here == -1. Match all (With flags).",
                 "ignore_result": true,
-                "__know_issue": "Err retval.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "pattern": "^\\w*\\s+$",
                 "log": "wazuh  ",
                 "end_match": " ",
                 "captured_groups": []
             },
             {
-                "description": "Match all. 1 character + capture group. (With flags).",
                 "pattern": "^(\\w*)\\s+$",
                 "log": "w ",
                 "end_match": " ",
@@ -181,7 +1953,6 @@
                 ]
             },
             {
-                "description": "Match all. 1 character + capture group. (With flags).",
                 "pattern": "^(\\w*)\\s+$",
                 "log": "w ",
                 "end_match": " ",
@@ -190,7 +1961,6 @@
                 ]
             },
             {
-                "description": "Next token with blackslash.  ok_here == -1. Match all. 1 character + capture all. (With flags).",
                 "pattern": "^(\\w*\\s+)$",
                 "log": "w ",
                 "end_match": " ",
@@ -215,28 +1985,24 @@
         ]
     },
     {
-        "description": "[Coverage] Lazy pattern, greedy match - backslash with '*' modifier. The next token does include the map characters of the current token and has '*' modifier.",
+        "description": "[Functionality] Lazy-Greedy behavior duality: Regex composed by a backslashed token with a '+' quantifier followed by a token that has the '*' quantifier, where the last token does include the charmap of the first one.",
         "batch_test": [
             {
-                "description": "Min size",
                 "pattern": "\\w*\\s*",
                 "log": "w",
                 "end_match": "w",
                 "captured_groups": []
             },
             {
-                "description": "Min size + opt.",
                 "pattern": "\\w*\\s*",
-                "__know_issue": "Err retval.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "log": "w ",
                 "end_match": " ",
                 "captured_groups": []
             },
             {
-                "description": "Min size. Capture all.",
                 "pattern": "(\\w*\\s*)",
-                "__know_issue": "The group: 'w' cannot be found",
                 "log": "w",
                 "end_match": "w",
                 "captured_groups": [
@@ -244,7 +2010,17 @@
                 ]
             },
             {
-                "description": "Min size. Capture all.",
+                "pattern": "(\\w*\\s*)",
+                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/wazuh/wazuh/issues/14249",
+                "__known_issue_2:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "skip_test": true,
+                "log": " ",
+                "end_match": " ",
+                "captured_groups": [
+                    " "
+                ]
+            },
+            {
                 "pattern": "(\\w*\\s*)",
                 "log": "wazuh",
                 "end_match": "h",
@@ -253,9 +2029,9 @@
                 ]
             },
             {
-                "description": "Min size + opt. Capture all.",
                 "ignore_result": true,
-                "__know_issue": "Err retval.",
+                "debug": false,
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "pattern": "(\\w*\\s*)",
                 "log": "w ",
                 "end_match": " ",
@@ -273,9 +2049,8 @@
                 ]
             },
             {
-                "description": "Min size + opt, with group",
                 "ignore_result": true,
-                "__know_issue": "Err retval.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "pattern": "(\\w*)\\s*",
                 "log": "w ",
                 "end_match": " ",
@@ -284,10 +2059,10 @@
                 ]
             },
             {
-                "description": "Other size",
                 "pattern": "\\w*\\s*",
                 "ignore_result": true,
-                "__know_issue": "Err retval.",
+                "debug": false,
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "log": "wazuh ",
                 "end_match": " ",
                 "captured_groups": []
@@ -295,7 +2070,8 @@
             {
                 "description": "Other size. With group",
                 "ignore_result": true,
-                "__know_issue": "Err retval.",
+                "debug": false,
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "pattern": "(\\w*\\s*)",
                 "log": "wazuh ",
                 "end_match": " ",
@@ -304,8 +2080,7 @@
                 ]
             },
             {
-                "description": "Other size. With group",
-                "__know_issue": "Consecutive capture groups don't support. should match 'wazuh ' but it doesn't. But (\\w+)\\d*(\\s+) works",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
                 "ignore_result": true,
                 "pattern": "(\\w*)(\\s*)",
                 "log": "wazuh ",
@@ -316,10 +2091,44 @@
                 ]
             },
             {
-                "description": "2 groups no consecutive, and opcional",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "ignore_result": true,
+                "pattern": "(\\w*)(\\s*)",
+                "log": " ",
+                "end_match": " ",
+                "captured_groups": [
+                    "",
+                    " "
+                ]
+            },
+            {
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "ignore_result": true,
+                "pattern": "(\\w*)(\\s*)",
+                "log": "w",
+                "end_match": " ",
+                "captured_groups": [
+                    "",
+                    " "
+                ]
+            },
+            {
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "ignore_result": true,
+                "debug":false,
+                "pattern": "(\\w*)(\\s*)",
+                "log": "",
+                "end_match": "",
+                "captured_groups": [
+                    "",
+                    ""
+                ]
+            },
+            {
+                "description": "2 groups no consecutive, and opcional.",
                 "pattern": "(\\w*)\\d+(\\s*)",
                 "ignore_result": true,
-                "__know_issue": "Err retval.",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
                 "log": "wazuh ",
                 "end_match": null,
                 "captured_groups": []
@@ -328,7 +2137,7 @@
                 "description": "2 groups no consecutive, and opcional",
                 "pattern": "(\\w*)\\d+(\\s*)",
                 "ignore_result": true,
-                "__know_issue": "Err retval.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "log": "wazuh123 ",
                 "end_match": " ",
                 "captured_groups": [
@@ -340,7 +2149,7 @@
                 "description": "2 groups no consecutive",
                 "pattern": "(\\w*)\\d*(\\s*)",
                 "ignore_result": true,
-                "__know_issue": "Err retval.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "log": "wazuh123 ",
                 "end_match": " ",
                 "captured_groups": [
@@ -349,14 +2158,12 @@
                 ]
             },
             {
-                "description": "With literal at the end.",
                 "pattern": "\\w*\\s*1",
                 "log": "wazuh 1",
                 "end_match": "1",
                 "captured_groups": []
             },
             {
-                "description": "With literal at the end, 1 character + capture group.",
                 "pattern": "(\\w*)\\s*1",
                 "log": "w 1",
                 "end_match": "1",
@@ -365,7 +2172,6 @@
                 ]
             },
             {
-                "description": "With literal at the end, 1 character + capture all.",
                 "pattern": "(\\w*\\s*)1",
                 "log": "w 1",
                 "end_match": "1",
@@ -374,7 +2180,6 @@
                 ]
             },
             {
-                "description": "With literal at the end, 1 character + capture",
                 "pattern": " (\\w*)\\s*1",
                 "log": " wazuh 1",
                 "end_match": "1",
@@ -383,28 +2188,25 @@
                 ]
             },
             {
-                "description": "Min size. Match all. 1 character (With flags).",
                 "pattern": "^\\w*\\s*$",
                 "ignore_result": true,
-                "__know_issue": "Err retval.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "log": "w ",
                 "end_match": " ",
                 "captured_groups": []
             },
             {
-                "description": "Next token with blackslash. ok_here == -1. Match all (With flags).",
                 "ignore_result": true,
-                "__know_issue": "Err retval.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "pattern": "^\\w*\\s*$",
                 "log": "wazuh  ",
                 "end_match": " ",
                 "captured_groups": []
             },
             {
-                "description": "Match all. 1 character + capture group. (With flags).",
                 "pattern": "^(\\w*)\\s*$",
                 "ignore_result": true,
-                "__know_issue": "Err retval.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "log": "w ",
                 "end_match": " ",
                 "captured_groups": [
@@ -412,10 +2214,9 @@
                 ]
             },
             {
-                "description": "Match all. 1 character + capture group. (With flags).",
                 "pattern": "^(\\w*)\\s*$",
                 "ignore_result": true,
-                "__know_issue": "Err retval.",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "log": "w ",
                 "end_match": " ",
                 "captured_groups": [
@@ -423,8 +2224,8 @@
                 ]
             },
             {
-                "description": "Next token with blackslash.  ok_here == -1. Match all. 1 character + capture all. (With flags).",
                 "pattern": "^(\\w*\\s*)$",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
                 "ignore_result": true,
                 "log": "w ",
                 "end_match": " ",
@@ -449,1860 +2250,94 @@
         ]
     },
     {
-        "description": "[Coverage] Lazy pattern, greedy match - backslash with '+' modifier. The next token does not include the map characters of the current token and has '+' modifier.",
+        "description": "[Functionality] Lazy-Greedy behavior duality: Regex composed by backslashed tokens with '*' quantifiers. Test the 'st_error', 'pt_error[]' and 'pt_error_str[]' for parcial matches and rewind.",
         "batch_test": [
             {
-                "description": "Min size",
-                "pattern": "\\w+\\s+",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Min size. Capture all.",
-                "pattern": "(\\w+\\s+)",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w "
-                ]
-            },
-            {
-                "description": "Min size, with group",
-                "pattern": "(\\w+)\\s+",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Other size",
-                "pattern": "\\w+\\s+",
-                "log": "wazuh ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Other size. With group",
-                "pattern": "(\\w+)\\s+",
-                "log": "wazuh ",
-                "end_match": " ",
-                "captured_groups": [
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "Other size. With group",
-                "__know_issue": "Consecutive capture groups don't support. should match 'wazuh ' but it doesn't. But (\\w+)\\d*(\\s+) works",
-                "ignore_result": true,
-                "pattern": "(\\w+)(\\s+)",
-                "log": "wazuh ",
-                "end_match": " ",
-                "captured_groups": [
-                    "wazuh",
-                    " "
-                ]
-            },
-            {
-                "description": "2 groups no consecutive, and opcional",
-                "pattern": "(\\w+)\\d*(\\s+)",
-                "log": "wazuh ",
-                "end_match": " ",
-                "captured_groups": [
-                    "wazuh",
-                    " "
-                ]
-            },
-            {
-                "description": "2 groups no consecutive, and opcional",
-                "pattern": "(\\w+)\\d*(\\s+)",
-                "log": "wazuh123 ",
-                "end_match": " ",
-                "captured_groups": [
-                    "wazuh",
-                    " "
-                ]
-            },
-            {
-                "description": "2 groups no consecutive",
-                "pattern": "(\\w+)\\d+(\\s+)",
-                "log": "wazuh123 ",
-                "end_match": " ",
-                "captured_groups": [
-                    "wazuh",
-                    " "
-                ]
-            },
-            {
-                "description": "With literal at the end.",
-                "pattern": "\\w+\\s+1",
-                "log": "wazuh 1",
-                "end_match": "1",
-                "captured_groups": []
-            },
-            {
-                "description": "With literal at the end, 1 character + capture group.",
-                "pattern": "(\\w+)\\s+1",
-                "log": "w 1",
-                "end_match": "1",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "With literal at the end, 1 character + capture all.",
-                "pattern": "(\\w+\\s+)1",
-                "log": "w 1",
-                "end_match": "1",
-                "captured_groups": [
-                    "w "
-                ]
-            },
-            {
-                "description": "With literal at the end, 1 character + capture",
-                "pattern": " (\\w+)\\s+1",
-                "log": " wazuh 1",
-                "end_match": "1",
-                "captured_groups": [
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "Min size. Match all. 1 character (With flags).",
-                "pattern": "^\\w+\\s+$",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all (With flags).",
-                "ignore_result": true,
-                "__know_issue": "Err retval.",
-                "pattern": "^\\w+\\s+$",
-                "log": "wazuh  ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Match all. 1 character + capture group. (With flags).",
-                "pattern": "^(\\w+)\\s+$",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Match all. 1 character + capture group. (With flags).",
-                "pattern": "^(\\w+)\\s+$",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Next token with blackslash.  ok_here == -1. Match all. 1 character + capture all. (With flags).",
-                "pattern": "^(\\w+\\s+)$",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w "
-                ]
-            },
-            {
-                "description": "Dont match.",
-                "pattern": "^\\w+\\s+$",
-                "log": "wazuh -",
-                "end_match": null,
-                "captured_groups": []
-            },
-            {
-                "description": "Dont match.",
-                "pattern": "^(\\w+\\s+)$",
-                "log": "wazuh -",
-                "end_match": null,
-                "captured_groups": []
-            }
-        ]
-    },
-    {
-        "description": "[Coverage] Lazy pattern, greedy match - backslash with '+' modifier. The next token does include the map characters of the current token and has '*' modifier.",
-        "batch_test": [
-            {
-                "description": "Min size",
-                "pattern": "\\w+\\s*",
-                "log": "w",
-                "end_match": "w",
-                "captured_groups": []
-            },
-            {
-                "description": "Min size + opt.",
-                "pattern": "\\w+\\s*",
-                "__know_issue": "Err retval.",
-                "ignore_result": true,
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Min size. Capture all.",
-                "pattern": "(\\w+\\s*)",
-                "__know_issue": "The group: 'w' cannot be found",
-                "ignore_result": true,
-                "log": "w",
-                "end_match": "w",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Min size. Capture all.",
-                "pattern": "(\\w+\\s*)",
-                "__know_issue": "The group: 'wazuh' cannot be found",
-                "ignore_result": true,
-                "debug": false,
-                "log": "wazuh",
-                "end_match": "h",
-                "captured_groups": [
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "Min size + opt. Capture all.",
-                "ignore_result": true,
-                "__know_issue": "Err retval.",
-                "pattern": "(\\w+\\s*)",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w "
-                ]
-            },
-            {
-                "description": "Min size, with group",
-                "pattern": "(\\w+)\\s*",
-                "log": "w",
-                "end_match": "w",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Min size + opt, with group",
-                "ignore_result": true,
-                "__know_issue": "Err retval.",
-                "pattern": "(\\w+)\\s*",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Other size",
-                "pattern": "\\w+\\s*",
-                "ignore_result": true,
-                "__know_issue": "Err retval.",
-                "log": "wazuh ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Other size. With group",
-                "ignore_result": true,
-                "__know_issue": "Err retval.",
-                "pattern": "(\\w+\\s*)",
-                "log": "wazuh ",
-                "end_match": " ",
-                "captured_groups": [
-                    "wazuh "
-                ]
-            },
-            {
-                "description": "Other size. With group",
-                "__know_issue": "Consecutive capture groups don't support. should match 'wazuh ' but it doesn't. But (\\w+)\\d*(\\s+) works",
-                "ignore_result": true,
-                "pattern": "(\\w+)(\\s*)",
-                "log": "wazuh ",
-                "end_match": " ",
-                "captured_groups": [
-                    "wazuh",
-                    " "
-                ]
-            },
-            {
-                "description": "2 groups no consecutive, and opcional",
-                "pattern": "(\\w+)\\d+(\\s*)",
-                "ignore_result": true,
-                "__know_issue": "Err retval.",
-                "log": "wazuh ",
-                "end_match": null,
-                "captured_groups": []
-            },
-            {
-                "description": "2 groups no consecutive, and opcional",
-                "pattern": "(\\w+)\\d+(\\s*)",
-                "ignore_result": true,
-                "__know_issue": "Err retval.",
-                "log": "wazuh123 ",
-                "end_match": " ",
-                "captured_groups": [
-                    "wazuh",
-                    " "
-                ]
-            },
-            {
-                "description": "2 groups no consecutive",
-                "pattern": "(\\w+)\\d*(\\s*)",
-                "ignore_result": true,
-                "__know_issue": "Err retval.",
-                "debug": false,
-                "log": "wazuh123 ",
-                "end_match": " ",
-                "captured_groups": [
-                    "wazuh",
-                    " "
-                ]
-            },
-            {
-                "description": "With literal at the end.",
-                "pattern": "\\w+\\s*1",
-                "log": "wazuh 1",
-                "end_match": "1",
-                "captured_groups": []
-            },
-            {
-                "description": "With literal at the end, 1 character + capture group.",
-                "pattern": "(\\w+)\\s*1",
-                "log": "w 1",
-                "end_match": "1",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "With literal at the end, 1 character + capture all.",
-                "pattern": "(\\w+\\s*)1",
-                "log": "w 1",
-                "end_match": "1",
-                "captured_groups": [
-                    "w "
-                ]
-            },
-            {
-                "description": "With literal at the end, 1 character + capture",
-                "pattern": " (\\w+)\\s*1",
-                "log": " wazuh 1",
-                "end_match": "1",
-                "captured_groups": [
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "Min size. Match all. 1 character (With flags).",
-                "pattern": "^\\w+\\s*$",
-                "ignore_result": true,
-                "__know_issue": "Err retval.",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all (With flags).",
-                "ignore_result": true,
-                "__know_issue": "Err retval.",
-                "pattern": "^\\w+\\s*$",
-                "log": "wazuh  ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Match all. 1 character + capture group. (With flags).",
-                "pattern": "^(\\w+)\\s*$",
-                "ignore_result": true,
-                "__know_issue": "Err retval.",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Match all. 1 character + capture group. (With flags).",
-                "pattern": "^(\\w+)\\s*$",
-                "ignore_result": true,
-                "__know_issue": "Err retval.",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Next token with blackslash.  ok_here == -1. Match all. 1 character + capture all. (With flags).",
-                "pattern": "^(\\w+\\s*)$",
-                "ignore_result": true,
-                "__know_issue": "Err retval.",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w "
-                ]
-            },
-            {
-                "description": "Dont match.",
-                "pattern": "^\\w+\\s*$",
-                "log": "wazuh -",
-                "end_match": null,
-                "captured_groups": []
-            },
-            {
-                "description": "Dont match.",
-                "pattern": "^(\\w+\\s*)$",
-                "log": "wazuh -",
-                "end_match": null,
-                "captured_groups": []
-            }
-        ]
-    },
-    {
-        "description": "[Coverage] Lazy pattern, greedy match - backslash with '*' modifier. st_error, error handling, parcial match and rewind.",
-        "batch_test": [
-            {
-                "description": "Save 6 token position, and restore the first.",
+                "description": "Saves and restores the first position error.",
                 "pattern": "\\w*_1 \\w*_2 \\w*_3 \\w*_4 \\w*_5 \\w*_6",
                 "log": "wa_11 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
                 "end_match": "6",
                 "captured_groups": []
             },
             {
-                "description": "Save 6 token position, and restore the second.",
+                "description": "Saves and restores the second position error.",
                 "pattern": "\\w*_1 \\w*_2 \\w*_3 \\w*_4 \\w*_5 \\w*_6",
                 "log": "wa_1 wa_22 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
                 "end_match": "6",
                 "captured_groups": []
             },
             {
-                "description": "Save 6 token position, and restore the third.",
+                "description": "Saves and restores the third position error.",
                 "pattern": "\\w*_1 \\w*_2 \\w*_3 \\w*_4 \\w*_5 \\w*_6",
                 "log": "wa_1 wa_2 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
                 "end_match": "6",
                 "captured_groups": []
             },
             {
-                "description": "Save 6 token position, and restore the fourth.",
+                "description": "Saves and restores the fourth position error.",
                 "pattern": "\\w*_1 \\w*_2 \\w*_3 \\w*_4 \\w*_5 \\w*_6",
                 "log": "wa_1 wa_2 wa_3 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
                 "end_match": "6",
                 "captured_groups": []
             },
             {
-                "description": "Save 6 token position, and restore the fifth.",
+                "description": "Saves and restores the fifth position error.",
                 "pattern": "\\w*_1 \\w*_2 \\w*_3 \\w*_4 \\w*_5 \\w*_6",
                 "log": "wa_1 wa_2 wa_3 wa_4 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
                 "end_match": "6",
                 "captured_groups": []
             },
             {
-                "description": "Save 6 token position, and restore the sixth.",
+                "description": "Saves and restores the sixth position error.",
                 "pattern": "\\w*_1 \\w*_2 \\w*_3 \\w*_4 \\w*_5 \\w*_6",
                 "log": "wa_1 wa_2 wa_3 wa_4 wa_5 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
                 "end_match": "6",
                 "captured_groups": []
             },
             {
-                "description": "Save 6 token position, and restore the first. But the first should match with the next character.",
+                "description": "Saves and restores the first position error. But the first should match with the next character.",
                 "pattern": "\\w*1 \\w*2 \\w*3 \\w*4 \\w*5 \\w*6",
                 "log": "z1x1 x2 x3 x4 x5 x6",
                 "end_match": "6",
                 "captured_groups": []
             },
             {
-                "description": "Save 6 token position, and restore the second. But the second should match with the next character.",
+                "description": "Saves and restores the second position error. But the second should match with the next character.",
                 "pattern": "\\w*1 \\w*2 \\w*3 \\w*4 \\w*5 \\w*6",
                 "log": "z1 x2x2 x3 x4 x5 x6",
                 "end_match": "6",
                 "captured_groups": []
             },
             {
-                "description": "Save 6 token position, and restore the third. But the third should match with the next character.",
+                "description": "Saves and restores the  third position error. But the third should match with the next character.",
                 "pattern": "\\w*1 \\w*2 \\w*3 \\w*4 \\w*5 \\w*6",
                 "log": "z1 x2x2 x3 x4 x5 x6",
                 "end_match": "6",
                 "captured_groups": []
             },
             {
-                "description": "Save 6 token position, and restore the fourth. But the fourth should match with the next character.",
+                "description": "Saves and restores the fourth position error. But the fourth should match with the next character.",
                 "pattern": "\\w*1 \\w*2 \\w*3 \\w*4 \\w*5 \\w*6",
                 "log": "z1 x2 x3 x4x4 x5 x6",
                 "end_match": "6",
                 "captured_groups": []
             },
             {
-                "description": "Save 6 token position, and restore the fifth. But the fifth should match with the next character.",
+                "description": "Saves and restores the fifth position error. But the fifth should match with the next character.",
                 "pattern": "\\w*1 \\w*2 \\w*3 \\w*4 \\w*5 \\w*6",
-                "__knowIssue": "#XXXX The stacktrace has a static size",
+                "__known_issue:": "It should match but does not, as the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
                 "ignore_result": true,
                 "log": "z1 x2 x3 x4 x5x5 x6",
                 "end_match": "6",
                 "captured_groups": []
             },
             {
-                "description": "Save 6 token position, and restore the sixth. But the sixth should match with the next character.",
+                "description": "Saves and restores the sixth position error. But the sixth should match with the next character.",
                 "pattern": "\\w*1 \\w*2 \\w*3 \\w*4 \\w*5 \\w*6",
                 "log": "z1 x2 x3 x4 x5 x6x6",
-                "__knowIssue": "#XXXX The stacktrace has a static size",
+                "__known_issue:": "It should match but does not, as the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
                 "ignore_result": true,
                 "end_match": "6",
-                "captured_groups": []
-            }
-        ]
-    },
-    {
-        "description": "[Coverage] Lazy pattern, greedy match - backslash with '*' modifier. The next token does include the map characters of the current token and has no modifier.",
-        "batch_test": [
-            {
-                "description": "0 size: `\\d*` match 0-0",
-                "pattern": "\\d*\\w",
-                "log": "5",
-                "end_match": "5",
-                "captured_groups": []
-            },
-            {
-                "description": "0 size: `\\d*` match 0-0. With group",
-                "pattern": "(\\d*)\\w",
-                "log": "5",
-                "end_match": "5",
-                "captured_groups": [
-                    ""
-                ]
-            },
-            {
-                "description": "\\w matches with '1' character",
-                "pattern": "\\d*\\w",
-                "log": "12",
-                "end_match": "12",
-                "captured_groups": []
-            },
-            {
-                "description": "\\w matches with '1' character",
-                "pattern": "(\\d*)\\w",
-                "log": "12",
-                "end_match": "12",
-                "captured_groups": [
-                    ""
-                ]
-            },
-            {
-                "description": "Min size: Minimum match with capture group",
-                "pattern": "\\d*(\\w)",
-                "log": "12",
-                "end_match": "12",
-                "captured_groups": [
-                    "1"
-                ]
-            },
-            {
-                "description": "Lazy pattern: Move as fast as possible over the pattern",
-                "pattern": "\\d*\\w",
-                "log": "12345",
-                "end_match": "12345",
-                "captured_groups": []
-            },
-            {
-                "description": "Lazy pattern: Move as fast as possible over the pattern, only capture the first character",
-                "pattern": "(\\d*)\\w",
-                "log": "12345",
-                "end_match": "12345",
-                "captured_groups": [
-                    ""
-                ]
-            },
-            {
-                "description": "Lazy pattern: Move as fast as possible over the pattern",
-                "pattern": "\\d*(\\w)",
-                "log": "12345",
-                "end_match": "12345",
-                "captured_groups": [
-                    "1"
-                ]
-            },
-            {
-                "description": "Min size: No match, no items in the log to consume (With flags).",
-                "pattern": "^\\d*\\d",
-                "log": "5",
-                "end_match": "5",
-                "captured_groups": []
-            },
-            {
-                "description": "Min size: No match, no items in the log to consume (With flags).",
-                "pattern": "^(\\d*)\\d",
-                "log": "5",
-                "end_match": "5",
-                "captured_groups": [
-                    ""
-                ]
-            },
-            {
-                "description": "Min size: Minimum match with capture group (With flags).",
-                "pattern": "^(\\d*)\\w$",
-                "log": "12",
-                "end_match": "2",
-                "captured_groups": [
-                    "1"
-                ]
-            },
-            {
-                "description": "Min size: Minimum match with capture group (With flags).",
-                "pattern": "^\\d*(\\w)$",
-                "log": "12",
-                "end_match": "2",
-                "captured_groups": [
-                    "2"
-                ]
-            },
-            {
-                "description": "Lazy pattern: Move as fast as possible over the pattern (With flags).",
-                "pattern": "^\\d*\\w$",
-                "log": "12345",
-                "end_match": "5",
-                "captured_groups": []
-            },
-            {
-                "description": "Lazy pattern: Move as fast as possible over the pattern, capture the first 4 character, because the $ flag.",
-                "pattern": "^(\\d*)\\w$",
-                "log": "12345",
-                "end_match": "5",
-                "captured_groups": [
-                    "1234"
-                ]
-            },
-            {
-                "description": "Lazy pattern: Move as fast as possible over the pattern (With flags).",
-                "pattern": "^\\d*(\\w)$",
-                "log": "12345",
-                "end_match": "5",
-                "captured_groups": [
-                    "5"
-                ]
-            },
-            {
-                "description": "Lazy pattern: Move as fast as possible over the pattern (With flags).",
-                "pattern": "^\\d*(\\w)$",
-                "log": "12345&&&&&&&",
-                "end_match": null,
-                "captured_groups": []
-            }
-        ]
-    },
-    {
-        "description": "[Coverage] Lazy pattern, greedy match - backslash with '*' modifier. The next token does not include the map characters of the current token and has no modifier.",
-        "batch_test": [
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character",
-                "pattern": "\\w*\\s",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all",
-                "pattern": "\\w*\\s",
-                "log": "wazuh ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character * capture group.",
-                "pattern": "(\\w*)\\s",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match 0-0. 1 character * capture group.",
-                "pattern": "(\\w*)\\s",
-                "log": " ",
-                "end_match": " ",
-                "captured_groups": [
-                    ""
-                ]
-            },
-            {
-                "description": "Next token with blackslash.  ok_here == -1. Match all. 1 character * capture all.",
-                "pattern": "(\\w*\\s)",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w "
-                ]
-            },
-            {
-                "description": "Next token with blackslash.  ok_here == -1. Match all. 1 character * capture all.",
-                "pattern": "(\\w*\\s)",
-                "log": " ",
-                "end_match": " ",
-                "captured_groups": [
-                    " "
-                ]
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all. Parcial capture group case.",
-                "pattern": "(\\w*)\\s",
-                "log": "wazuh ",
-                "end_match": " ",
-                "captured_groups": [
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character",
-                "pattern": "\\w* ",
-                "log": " ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character",
-                "pattern": "\\w* ",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all",
-                "pattern": "\\w* ",
-                "log": "wazuh ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character * capture group.",
-                "pattern": "(\\w*) ",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character * capture all.",
-                "pattern": "(\\w* )",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w "
-                ]
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all. Parcial capture group case.",
-                "pattern": "(\\w*) ",
-                "log": "wazuh ",
-                "end_match": " ",
-                "captured_groups": [
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all",
-                "pattern": "\\w*\\s1",
-                "log": "wazuh 1",
-                "end_match": "1",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character * capture group.",
-                "pattern": "(\\w*)\\s1",
-                "log": "w 1",
-                "end_match": "1",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character * capture all.",
-                "pattern": "(\\w*\\s)1",
-                "log": "w 1",
-                "end_match": "1",
-                "captured_groups": [
-                    "w "
-                ]
-            },
-            {
-                "description": "Next token with blackslash. ok_here ==  -1. Match all. Parcial capture group case.",
-                "pattern": "(\\w*)\\s1",
-                "log": "wazuh 1",
-                "end_match": "1",
-                "captured_groups": [
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match. 1 character",
-                "pattern": "\\w*\\s1",
-                "log": "w 123",
-                "end_match": "123",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match",
-                "pattern": "\\w* 1",
-                "log": "wazuh 123",
-                "end_match": "123",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match. 1 character * capture group.",
-                "pattern": "(\\w*) 1",
-                "log": "w 123",
-                "end_match": "123",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match. 1 character * capture all.",
-                "pattern": "(\\w* )1",
-                "log": "w 123",
-                "end_match": "123",
-                "captured_groups": [
-                    "w "
-                ]
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match. Parcial capture group case.",
-                "pattern": "(\\w*) 1",
-                "log": "wazuh 123",
-                "end_match": "123",
-                "captured_groups": [
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character (With flags).",
-                "pattern": "^\\w*\\s$",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all (With flags).",
-                "pattern": "^\\w*\\s$",
-                "log": "wazuh ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character * capture group. (With flags).",
-                "pattern": "^(\\w*)\\s$",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Next token with blackslash.  ok_here == -1. Match all. 1 character * capture all. (With flags).",
-                "pattern": "^(\\w*\\s)$",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w "
-                ]
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all. Parcial capture group case. (With flags).",
-                "pattern": "^(\\w*)\\s$",
-                "log": "wazuh ",
-                "end_match": " ",
-                "captured_groups": [
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character (With flags).",
-                "pattern": "^\\w* $",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all (With flags).",
-                "pattern": "^\\w* $",
-                "log": "wazuh ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character * capture group (With flags).",
-                "pattern": "^(\\w*) $",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character * capture all (With flags).",
-                "pattern": "^(\\w* )$",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w "
-                ]
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all. Parcial capture group case (With flags).",
-                "pattern": "^(\\w*) $",
-                "log": "wazuh ",
-                "end_match": " ",
-                "captured_groups": [
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all. Ends pattern (With flags) before log.",
-                "pattern": "^\\w* $",
-                "log": "wazuh -",
-                "end_match": null,
-                "captured_groups": []
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all. Ends pattern (With flags and capture all) before log.",
-                "pattern": "^(\\w* )$",
-                "log": "wazuh -",
-                "end_match": null,
-                "captured_groups": []
-            }
-        ]
-    },
-    {
-        "description": "[Coverage] Regex, only backslash with '*' modifier.",
-        "batch_test": [
-            {
-                "description": "Without capture group, match all",
-                "ignore_result": true,
-                "pattern": "\\w*",
-                "log": "wazuh",
-                "end_match": "h",
-                "captured_groups": []
-            },
-            {
-                "description": "Without capture group, match 0-0",
-                "__know_issue": "Return one byte before log starts ",
-                "skip_test": true,
-                "pattern": "\\d*",
-                "log": "wazuh",
-                "end_match": "wazuh",
-                "captured_groups": []
-            },
-            {
-                "description": "With capture group, match all",
-                "ignore_result": true,
-                "pattern": "(\\w*)",
-                "log": "wazuh",
-                "end_match": "h",
-                "captured_groups": [
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "With capture group, match 0-0",
-                "ignore_result": true,
-                "__know_issue": "Return one byte before log starts ",
-                "skip_test": true,
-                "pattern": "(\\d*)",
-                "log": "wazuh",
-                "end_match": "wazuh",
-                "captured_groups": [
-                    ""
-                ]
-            },
-            {
-                "description": "Without capture group, match all (And flags)",
-                "ignore_result": true,
-                "debug": false,
-                "pattern": "^\\w*$",
-                "log": "wazuh",
-                "end_match": "h",
-                "captured_groups": []
-            },
-            {
-                "description": "With capture group, match all (And flags)",
-                "ignore_result": true,
-                "pattern": "^(\\w*)$",
-                "log": "wazuh",
-                "end_match": "h",
-                "captured_groups": [
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "Without capture group, parcial match (And flags)",
-                "pattern": "^\\w*$",
-                "log": "wazuh ",
-                "end_match": null,
-                "captured_groups": []
-            },
-            {
-                "description": "With capture group, match all (And flags)",
-                "pattern": "^(\\w*)$",
-                "log": "wazuh ",
-                "end_match": null,
-                "captured_groups": []
-            },
-            {
-                "description": "Without capture group, match one character.",
-                "pattern": "\\w*",
-                "log": "w",
-                "end_match": "w",
-                "captured_groups": []
-            },
-            {
-                "description": "With capture group, match one character.",
-                "pattern": "(\\w*)",
-                "log": "w",
-                "end_match": "w",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Without capture group, match all (And flags), match one character.",
-                "pattern": "^\\w*$",
-                "log": "w",
-                "end_match": "w",
-                "captured_groups": []
-            },
-            {
-                "description": "With capture group, match all (And flags), match one character.",
-                "pattern": "^(\\w*)$",
-                "log": "w",
-                "end_match": "w",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Without capture group, empty (And flags)",
-                "ignore_result": true,
-                "__know_issue": "Return one byte before log starts ",
-                "pattern": "^\\w*$",
-                "log": "",
-                "end_match": "",
-                "captured_groups": [
-                    ""
-                ]
-            },
-            {
-                "description": "With capture group, match 0-0. Empty string",
-                "ignore_result": true,
-                "__know_issue": "Return one byte before log starts ",
-                "skip_test": true,
-                "pattern": "(\\d*)",
-                "log": "",
-                "end_match": "",
-                "captured_groups": [
-                    ""
-                ]
-            }
-        ]
-    },
-    {
-        "description": "[Coverage] Lazy pattern, greedy match - backslash with '+' modifier. st_error, error handling, parcial match and rewind.",
-        "batch_test": [
-            {
-                "description": "Save 6 token position, and restore the first.",
-                "pattern": "\\w+_1 \\w+_2 \\w+_3 \\w+_4 \\w+_5 \\w+_6",
-                "log": "wa_11 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
-                "end_match": "6",
-                "captured_groups": []
-            },
-            {
-                "description": "Save 6 token position, and restore the second.",
-                "pattern": "\\w+_1 \\w+_2 \\w+_3 \\w+_4 \\w+_5 \\w+_6",
-                "log": "wa_1 wa_22 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
-                "end_match": "6",
-                "captured_groups": []
-            },
-            {
-                "description": "Save 6 token position, and restore the third.",
-                "pattern": "\\w+_1 \\w+_2 \\w+_3 \\w+_4 \\w+_5 \\w+_6",
-                "log": "wa_1 wa_2 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
-                "end_match": "6",
-                "captured_groups": []
-            },
-            {
-                "description": "Save 6 token position, and restore the fourth.",
-                "pattern": "\\w+_1 \\w+_2 \\w+_3 \\w+_4 \\w+_5 \\w+_6",
-                "log": "wa_1 wa_2 wa_3 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
-                "end_match": "6",
-                "captured_groups": []
-            },
-            {
-                "description": "Save 6 token position, and restore the fifth.",
-                "pattern": "\\w+_1 \\w+_2 \\w+_3 \\w+_4 \\w+_5 \\w+_6",
-                "log": "wa_1 wa_2 wa_3 wa_4 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
-                "end_match": "6",
-                "captured_groups": []
-            },
-            {
-                "description": "Save 6 token position, and restore the sixth.",
-                "pattern": "\\w+_1 \\w+_2 \\w+_3 \\w+_4 \\w+_5 \\w+_6",
-                "log": "wa_1 wa_2 wa_3 wa_4 wa_5 wa_1 wa_2 wa_3 wa_4 wa_5 wa_6",
-                "end_match": "6",
-                "captured_groups": []
-            },
-            {
-                "description": "Save 6 token position, and restore the first. But the first should match with the next character.",
-                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
-                "log": "z1x1 x2 x3 x4 x5 x6",
-                "end_match": "6",
-                "captured_groups": []
-            },
-            {
-                "description": "Save 6 token position, and restore the second. But the second should match with the next character.",
-                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
-                "log": "z1 x2x2 x3 x4 x5 x6",
-                "end_match": "6",
-                "captured_groups": []
-            },
-            {
-                "description": "Save 6 token position, and restore the third. But the third should match with the next character.",
-                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
-                "log": "z1 x2x2 x3 x4 x5 x6",
-                "end_match": "6",
-                "captured_groups": []
-            },
-            {
-                "description": "Save 6 token position, and restore the fourth. But the fourth should match with the next character.",
-                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
-                "log": "z1 x2 x3 x4x4 x5 x6",
-                "end_match": "6",
-                "captured_groups": []
-            },
-            {
-                "description": "Save 6 token position, and restore the fifth. But the fifth should match with the next character.",
-                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
-                "ignore_result": true,
-                "__knowIssue": "#XXXX The stacktrace has a static size",
-                "log": "z1 x2 x3 x4 x5x5 x6",
-                "end_match": "6",
-                "captured_groups": []
-            },
-            {
-                "description": "Save 6 token position, and restore the sixth. But the sixth should match with the next character.",
-                "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
-                "log": "z1 x2 x3 x4 x5 x6x6",
-                "ignore_result": true,
-                "__knowIssue": "#XXXX The stacktrace has a static size",
-                "end_match": "6",
-                "captured_groups": []
-            }
-        ]
-    },
-    {
-        "description": "[Coverage] Lazy pattern, greedy match - backslash with '+' modifier. The next token does include the map characters of the current token and has no modifier.",
-        "batch_test": [
-            {
-                "description": "Min size: No match, no items in the log to consume",
-                "pattern": "\\d+\\d",
-                "log": "5",
-                "end_match": null,
-                "captured_groups": []
-            },
-            {
-                "description": "Min size: No match, no items in the log to consume",
-                "pattern": "(\\d+)\\d",
-                "log": "5",
-                "end_match": null,
-                "captured_groups": []
-            },
-            {
-                "description": "Min size: Minimum match with capture group",
-                "pattern": "(\\d+)\\w",
-                "log": "12",
-                "end_match": "2",
-                "captured_groups": [
-                    "1"
-                ]
-            },
-            {
-                "description": "Min size: Minimum match with capture group",
-                "pattern": "\\d+(\\w)",
-                "log": "12",
-                "end_match": "2",
-                "captured_groups": [
-                    "2"
-                ]
-            },
-            {
-                "description": "Lazy pattern: Move as fast as possible over the pattern",
-                "pattern": "\\d+\\w",
-                "log": "12345",
-                "end_match": "2345",
-                "captured_groups": []
-            },
-            {
-                "description": "Lazy pattern: Move as fast as possible over the pattern, only capture the first character",
-                "pattern": "(\\d+)\\w",
-                "log": "12345",
-                "end_match": "2345",
-                "captured_groups": [
-                    "1"
-                ]
-            },
-            {
-                "description": "Lazy pattern: Move as fast as possible over the pattern",
-                "pattern": "\\d+(\\w)",
-                "log": "12345",
-                "end_match": "2345",
-                "captured_groups": [
-                    "2"
-                ]
-            },
-            {
-                "description": "Min size: No match, no items in the log to consume (With flags).",
-                "pattern": "^\\d+\\d",
-                "log": "5",
-                "end_match": null,
-                "captured_groups": []
-            },
-            {
-                "description": "Min size: No match, no items in the log to consume (With flags).",
-                "pattern": "^(\\d+)\\d",
-                "log": "5",
-                "end_match": null,
-                "captured_groups": []
-            },
-            {
-                "description": "Min size: Minimum match with capture group (With flags).",
-                "pattern": "^(\\d+)\\w$",
-                "log": "12",
-                "end_match": "2",
-                "captured_groups": [
-                    "1"
-                ]
-            },
-            {
-                "description": "Min size: Minimum match with capture group (With flags).",
-                "pattern": "^\\d+(\\w)$",
-                "log": "12",
-                "end_match": "2",
-                "captured_groups": [
-                    "2"
-                ]
-            },
-            {
-                "description": "Lazy pattern: Move as fast as possible over the pattern (With flags).",
-                "pattern": "^\\d+\\w$",
-                "log": "12345",
-                "end_match": "5",
-                "captured_groups": []
-            },
-            {
-                "description": "Lazy pattern: Move as fast as possible over the pattern, capture the first 4 character, because the $ flag.",
-                "__know_issue": "regex returns the pointer to '2' character. ",
-                "pattern": "^(\\d+)\\w$",
-                "log": "12345",
-                "end_match": "5",
-                "captured_groups": [
-                    "1234"
-                ]
-            },
-            {
-                "description": "Lazy pattern: Move as fast as possible over the pattern (With flags).",
-                "pattern": "^\\d+(\\w)$",
-                "log": "12345",
-                "end_match": "5",
-                "captured_groups": [
-                    "5"
-                ]
-            },
-            {
-                "description": "Lazy pattern: Move as fast as possible over the pattern (With flags).",
-                "pattern": "^\\d+(\\w)$",
-                "log": "12345&&&&&&&",
-                "end_match": null,
-                "captured_groups": []
-            }
-        ]
-    },
-    {
-        "description": "[Coverage] Lazy pattern, greedy match - backslash with '+' modifier. The next token does not include the map characters of the current token and has no modifier.",
-        "batch_test": [
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character",
-                "pattern": "\\w+\\s",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all",
-                "pattern": "\\w+\\s",
-                "log": "wazuh ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character + capture group.",
-                "pattern": "(\\w+)\\s",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Next token with blackslash.  ok_here == -1. Match all. 1 character + capture all.",
-                "pattern": "(\\w+\\s)",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w "
-                ]
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all. Parcial capture group case.",
-                "pattern": "(\\w+)\\s",
-                "log": "wazuh ",
-                "end_match": " ",
-                "captured_groups": [
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character",
-                "pattern": "\\w+ ",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all",
-                "pattern": "\\w+ ",
-                "log": "wazuh ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character + capture group.",
-                "pattern": "(\\w+) ",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character + capture all.",
-                "pattern": "(\\w+ )",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w "
-                ]
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all. Parcial capture group case.",
-                "pattern": "(\\w+) ",
-                "log": "wazuh ",
-                "end_match": " ",
-                "captured_groups": [
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all",
-                "pattern": "\\w+\\s1",
-                "log": "wazuh 1",
-                "end_match": "1",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character + capture group.",
-                "pattern": "(\\w+)\\s1",
-                "log": "w 1",
-                "end_match": "1",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character + capture all.",
-                "pattern": "(\\w+\\s)1",
-                "log": "w 1",
-                "end_match": "1",
-                "captured_groups": [
-                    "w "
-                ]
-            },
-            {
-                "description": "Next token with blackslash. ok_here ==  -1. Match all. Parcial capture group case.",
-                "pattern": "(\\w+)\\s1",
-                "log": "wazuh 1",
-                "end_match": "1",
-                "captured_groups": [
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match. 1 character",
-                "pattern": "\\w+\\s1",
-                "log": "w 123",
-                "end_match": "123",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match",
-                "pattern": "\\w+ 1",
-                "log": "wazuh 123",
-                "end_match": "123",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match. 1 character + capture group.",
-                "pattern": "(\\w+) 1",
-                "log": "w 123",
-                "end_match": "123",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match. 1 character + capture all.",
-                "pattern": "(\\w+ )1",
-                "log": "w 123",
-                "end_match": "123",
-                "captured_groups": [
-                    "w "
-                ]
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match. Parcial capture group case.",
-                "pattern": "(\\w+) 1",
-                "log": "wazuh 123",
-                "end_match": "123",
-                "captured_groups": [
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character (With flags).",
-                "pattern": "^\\w+\\s$",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all (With flags).",
-                "pattern": "^\\w+\\s$",
-                "log": "wazuh ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all. 1 character + capture group. (With flags).",
-                "pattern": "^(\\w+)\\s$",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Next token with blackslash.  ok_here == -1. Match all. 1 character + capture all. (With flags).",
-                "pattern": "^(\\w+\\s)$",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w "
-                ]
-            },
-            {
-                "description": "Next token with blackslash. ok_here == -1. Match all. Parcial capture group case. (With flags).",
-                "pattern": "^(\\w+)\\s$",
-                "log": "wazuh ",
-                "end_match": " ",
-                "captured_groups": [
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character (With flags).",
-                "pattern": "^\\w+ $",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all (With flags).",
-                "pattern": "^\\w+ $",
-                "log": "wazuh ",
-                "end_match": " ",
-                "captured_groups": []
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character + capture group (With flags).",
-                "pattern": "^(\\w+) $",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all. 1 character + capture all (With flags).",
-                "pattern": "^(\\w+ )$",
-                "log": "w ",
-                "end_match": " ",
-                "captured_groups": [
-                    "w "
-                ]
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all. Parcial capture group case (With flags).",
-                "pattern": "^(\\w+) $",
-                "log": "wazuh ",
-                "end_match": " ",
-                "captured_groups": [
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all. Ends pattern (With flags) before log.",
-                "pattern": "^\\w+ $",
-                "log": "wazuh -",
-                "end_match": null,
-                "captured_groups": []
-            },
-            {
-                "description": "Next token without blackslash. ok_here == -1. Match all. Ends pattern (With flags and capture all) before log.",
-                "pattern": "^(\\w+ )$",
-                "log": "wazuh -",
-                "end_match": null,
-                "captured_groups": []
-            }
-        ]
-    },
-    {
-        "description": "[Coverage] Regex, only backslash with '+' modifier.",
-        "batch_test": [
-            {
-                "description": "Without capture group, match all",
-                "ignore_result": true,
-                "debug": false,
-                "pattern": "\\w+",
-                "log": "wazuh",
-                "end_match": "h",
-                "captured_groups": []
-            },
-            {
-                "description": "With capture group, match all",
-                "ignore_result": true,
-                "debug": false,
-                "pattern": "(\\w+)",
-                "log": "wazuh",
-                "end_match": "h",
-                "captured_groups": [
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "Without capture group, match all (And flags)",
-                "ignore_result": true,
-                "debug": false,
-                "pattern": "^\\w+$",
-                "log": "wazuh",
-                "end_match": "h",
-                "captured_groups": []
-            },
-            {
-                "description": "With capture group, match all (And flags)",
-                "ignore_result": true,
-                "debug": false,
-                "pattern": "^(\\w+)$",
-                "log": "wazuh",
-                "end_match": "h",
-                "captured_groups": [
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "Without capture group, parcial match (And flags)",
-                "pattern": "^\\w+$",
-                "log": "wazuh ",
-                "end_match": null,
-                "captured_groups": []
-            },
-            {
-                "description": "With capture group, match all (And flags)",
-                "pattern": "^(\\w+)$",
-                "log": "wazuh ",
-                "end_match": null,
-                "captured_groups": []
-            },
-            {
-                "description": "Without capture group, match one character.",
-                "pattern": "\\w+",
-                "log": "w",
-                "end_match": "w",
-                "captured_groups": []
-            },
-            {
-                "description": "With capture group, match one character.",
-                "pattern": "(\\w+)",
-                "log": "w",
-                "end_match": "w",
-                "captured_groups": [
-                    "w"
-                ]
-            },
-            {
-                "description": "Without capture group, match all (And flags), match one character.",
-                "pattern": "^\\w+$",
-                "log": "w",
-                "end_match": "w",
-                "captured_groups": []
-            },
-            {
-                "description": "With capture group, match all (And flags), match one character.",
-                "pattern": "^(\\w+)$",
-                "log": "w",
-                "end_match": "w",
-                "captured_groups": [
-                    "w"
-                ]
-            }
-        ]
-    },
-    {
-        "description": "[Coverage] Regex, only backslash without modifiers ('*', '+')",
-        "batch_test": [
-            {
-                "description": "Without capture group, match all",
-                "pattern": "\\w\\w\\s\\S\\S\\S\\S\\S",
-                "log": "hi wazuh",
-                "end_match": "h",
-                "captured_groups": []
-            },
-            {
-                "description": "Without capture group, parcial match",
-                "pattern": "\\w\\w\\s\\S\\S\\S\\S\\S",
-                "log": "hi waz",
-                "end_match": null,
-                "captured_groups": []
-            },
-            {
-                "description": "Without capture group, parcial match and then match all",
-                "pattern": "\\w\\w\\s\\S\\S\\S\\S\\S",
-                "log": "hi waz hi wazu.",
-                "end_match": ".",
-                "captured_groups": []
-            },
-            {
-                "description": "With capture group, match all",
-                "pattern": "\\w(\\w\\s\\S)\\S(\\S\\S\\S)",
-                "log": "hi wazuh",
-                "end_match": "h",
-                "captured_groups": [
-                    "i w",
-                    "zuh"
-                ]
-            },
-            {
-                "description": "With capture group, parcial match",
-                "pattern": "(\\w\\w)\\s\\S\\S\\S\\S\\S",
-                "log": "hi waz",
-                "end_match": null,
-                "captured_groups": []
-            },
-            {
-                "description": "With capture group, parcial match and then match all",
-                "pattern": "(\\w\\w)\\s(\\S\\S\\S\\S\\S)",
-                "log": "hi waz hi wazuh.",
-                "end_match": "h.",
-                "captured_groups": [
-                    "hi",
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "With capture group, parcial match and then match all",
-                "__knownIssue:": "The capture groups cannot be adjacent to each other",
-                "ignore_result": true,
-                "pattern": "(\\w\\w\\s)(\\S\\S\\S\\S\\S)",
-                "log": "hi waz hi wazuh.",
-                "end_match": "h.",
-                "captured_groups": [
-                    "hi ",
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "With capture group, parcial match and then match all (1 group)",
-                "pattern": "(\\w\\w\\s\\S\\S\\S\\S\\S)\\p$",
-                "log": "hi waz hi wazuh.",
-                "end_match": ".",
-                "captured_groups": [
-                    "hi wazuh"
-                ]
-            }
-        ]
-    },
-    {
-        "description": "[Coverage] Regex, only charmap without backslash",
-        "batch_test": [
-            {
-                "description": "Match between pattern and regex. pattern[0] != '('.",
-                "pattern": "hi wazuh",
-                "log": "hi wazuh",
-                "end_match": "h",
-                "captured_groups": []
-            },
-            {
-                "description": "Match between pattern and regex. With capture group",
-                "pattern": "(hi) (wazuh)",
-                "log": "hi wazuh",
-                "end_match": "h",
-                "captured_groups": [
-                    "hi",
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "Match pattern but fail because log dont ends.",
-                "pattern": "hi wazuh$",
-                "log": "hi wazuh 123",
-                "end_match": null,
-                "captured_groups": []
-            },
-            {
-                "description": "Match pattern (with group) but fail because log dont ends.",
-                "pattern": "(hi) (wazuh)$",
-                "log": "hi wazuh 123",
-                "end_match": null,
-                "captured_groups": []
-            },
-            {
-                "description": "Dont match at all .pattern[0] != '('.",
-                "pattern": "hi wazuh",
-                "log": "bye wazuh",
-                "end_match": null,
-                "captured_groups": []
-            },
-            {
-                "description": "match with prefix.",
-                "pattern": "(hi) (wazuh)",
-                "log": "prefixhi wazuh",
-                "end_match": "h",
-                "captured_groups": [
-                    "hi",
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "match with sufix.",
-                "pattern": "(hi) (wazuh)",
-                "log": "fixhi wazuhsub",
-                "end_match": "hsub",
-                "captured_groups": [
-                    "hi",
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "match with continue capture group.",
-                "ignore_result": true,
-                "__knownIssue:": "The capture groups cannot be adjacent to each other",
-                "pattern": "(hi)(wazuh)",
-                "log": "hiwazuh",
-                "end_match": "h",
-                "captured_groups": [
-                    "hi",
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "match with continue capture group and context",
-                "ignore_result": true,
-                "__knownIssue:": "The capture groups cannot be adjacent to each other",
-                "pattern": "(hi)(wazuh)",
-                "log": "prefixhiwazuhsub",
-                "end_match": "hsub",
-                "captured_groups": [
-                    "hi",
-                    "wazuh"
-                ]
-            }
-        ]
-    },
-    {
-        "description": "[Coverage] Regex, only charmap + END/BEGIN flags and st_error without backslash",
-        "batch_test": [
-            {
-                "description": "Pattern ends and the END_SET is set. (ENDOFFILE(pt) true)",
-                "pattern": "hi wazuh",
-                "log": "hi wazuh",
-                "end_match": "h",
-                "captured_groups": []
-            },
-            {
-                "description": "Empty pattern END_SET and BEGIN_SET are set.",
-                "pattern": "^$",
-                "log": "hi wazuh",
-                "end_match": null,
-                "captured_groups": []
-            },
-            {
-                "description": "Empty pattern END_SET and BEGIN_SET are set.",
-                "ignore_result": true,
-                "__knownIssue:": "empty group?",
-                "pattern": "(^$)",
-                "log": "",
-                "end_match": "",
-                "captured_groups": [
-                    ""
-                ]
-            },
-            {
-                "description": "Empty pattern END_SET and BEGIN_SET are set.",
-                "ignore_result": true,
-                "__knownIssue:": "empty group?",
-                "pattern": "^()$",
-                "log": "",
-                "end_match": "",
-                "captured_groups": [
-                    ""
-                ]
-            },
-            {
-                "description": "Pattern ends and the END_SET is not set.",
-                "pattern": "hi wazuh",
-                "log": "hi wazuh!",
-                "end_match": "h!",
-                "captured_groups": []
-            },
-            {
-                "description": "partially matched and then backward (st error test).",
-                "pattern": "(hi) (wazuh)",
-                "log": "XX hi wa hi wazuhXX",
-                "end_match": "hXX",
-                "captured_groups": [
-                    "hi",
-                    "wazuh"
-                ]
-            },
-            {
-                "description": "partially matched and then return (st error + BEGIN_SET test).",
-                "pattern": "^(hi) (wazuh)",
-                "log": "hi wa hi wazuhXX",
-                "end_match": null,
                 "captured_groups": []
             }
         ]
@@ -2751,7 +2786,7 @@
         ]
     },
     {
-        "description": "[Functionality] Modifiers (+ and *)",
+        "description": "[Functionality] quantifiers (+ and *)",
         "batch_test": [
             {
                 "description": "[+] It should not match since there are no characters of the type `\\d`.",

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -62,7 +62,7 @@
             },
             {
                 "description": "Match with adjacent capture groups.",
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(hi)(Wazuh)",
                 "log": "hiWazuh",
@@ -74,7 +74,7 @@
             },
             {
                 "description": "Match with adjacent capture groups and context.",
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(hi)(Wazuh)",
                 "log": "prefixhiWazuhsub",
@@ -105,7 +105,7 @@
             },
             {
                 "description": "Empty pattern END_SET and BEGIN_SET are set.",
-                "__known_issue:": "It should match but does not, it is not possible to check if a log is empty.",
+                "__known_issue": "It should match but does not, it is not possible to check if a log is empty.",
                 "pattern": "^$",
                 "log": "",
                 "end_match": "",
@@ -113,7 +113,7 @@
             },
             {
                 "description": "Empty pattern END_SET and BEGIN_SET are set.",
-                "__known_issue:": "It should match but does not, it is not possible to check if a log is empty.",
+                "__known_issue": "It should match but does not, it is not possible to check if a log is empty.",
                 "ignore_result": true,
                 "pattern": "(^$)",
                 "log": "",
@@ -124,7 +124,7 @@
             },
             {
                 "description": "Empty pattern END_SET and BEGIN_SET are set.",
-                "__known_issue:": "It should match but does not, it is not possible to check if a log is empty. BUG 2 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, it is not possible to check if a log is empty. BUG 2 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^()$",
                 "log": "",
@@ -212,7 +212,7 @@
             },
             {
                 "description": "Parcial match and fail but then re-match with adjacent capture group.",
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\w\\w\\s)(\\S\\S\\S\\S\\S)",
                 "log": "hi Waz hi Wazuh.",
@@ -238,7 +238,7 @@
         "batch_test": [
             {
                 "description": "Match all.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\w+",
                 "log": "Wazuh",
@@ -247,7 +247,7 @@
             },
             {
                 "description": "Mach all with capture group.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\w+)",
                 "log": "Wazuh",
@@ -258,7 +258,7 @@
             },
             {
                 "description": "Mach all with capture group and flags.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "debug": false,
                 "pattern": "^\\w+$",
@@ -764,7 +764,7 @@
             },
             {
                 "description": "Match all with consecutive group.",
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\w+)(\\s+)",
                 "log": "Wazuh ",
@@ -910,7 +910,7 @@
             {
                 "description": "Minimun log to match all and patter with a optional token.",
                 "pattern": "\\w+\\s*",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "log": "w ",
                 "end_match": " ",
@@ -919,7 +919,7 @@
             {
                 "description": "Minimun log to match all and capture all.",
                 "pattern": "(\\w+\\s*)",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "log": "w",
                 "end_match": "w",
@@ -930,7 +930,7 @@
             {
                 "description": "Match all and capture all.",
                 "pattern": "(\\w+\\s*)",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "debug": false,
                 "log": "Wazuh",
@@ -942,7 +942,7 @@
             {
                 "description": "Minimun log with optional token to match and capture all.",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "(\\w+\\s*)",
                 "log": "w ",
                 "end_match": " ",
@@ -962,7 +962,7 @@
             {
                 "description": "inimun log with optional token to match and capture the first token.",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "(\\w+)\\s*",
                 "log": "w ",
                 "end_match": " ",
@@ -974,7 +974,7 @@
                 "description": "Match all.",
                 "pattern": "\\w+\\s*",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": []
@@ -982,7 +982,7 @@
             {
                 "description": "Match all, capture all.",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "(\\w+\\s*)",
                 "log": "Wazuh ",
                 "end_match": " ",
@@ -992,7 +992,7 @@
             },
             {
                 "description": "Match all with no consecutive group.",
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\w+)(\\s*)",
                 "log": "Wazuh ",
@@ -1006,7 +1006,7 @@
                 "description": "Match all with no consecutive group and opcional.",
                 "pattern": "(\\w+)\\d+(\\s*)",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "Wazuh ",
                 "end_match": null,
                 "captured_groups": []
@@ -1015,7 +1015,7 @@
                 "description": "Match all with no consecutive group and opcional.",
                 "pattern": "(\\w+)\\d+(\\s*)",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "Wazuh123 ",
                 "end_match": " ",
                 "captured_groups": [
@@ -1027,7 +1027,7 @@
                 "description": "Match all with no consecutive group and opcional.",
                 "pattern": "(\\w+)\\d*(\\s*)",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "debug": false,
                 "log": "Wazuh123 ",
                 "end_match": " ",
@@ -1074,7 +1074,7 @@
                 "description": "Minimun log to match all, with flags.",
                 "pattern": "^\\w+\\s*$",
                 "ignore_result": true,
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "w ",
                 "end_match": " ",
                 "captured_groups": []
@@ -1082,7 +1082,7 @@
             {
                 "description": "Match all, with flags.",
                 "ignore_result": true,
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "^\\w+\\s*$",
                 "log": "Wazuh  ",
                 "end_match": " ",
@@ -1092,7 +1092,7 @@
                 "description": "Minimun log to match all, with flags and capture the first token.",
                 "pattern": "^(\\w+)\\s*$",
                 "ignore_result": true,
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "w ",
                 "end_match": " ",
                 "captured_groups": [
@@ -1103,7 +1103,7 @@
                 "description": "Minimun log to match all, with flags and capture the first token.",
                 "pattern": "^(\\w+)\\s*$",
                 "ignore_result": true,
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "w ",
                 "end_match": " ",
                 "captured_groups": [
@@ -1114,7 +1114,7 @@
                 "description": "Minimun log to match all, with flags and capture all.",
                 "pattern": "^(\\w+\\s*)$",
                 "ignore_result": true,
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "w ",
                 "end_match": " ",
                 "captured_groups": [
@@ -1214,7 +1214,7 @@
                 "description": "Saves and restores the fifth position error. But the fifth should match with the next character.",
                 "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
                 "ignore_result": true,
-                "__known_issue:": "It should match but does not, as the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, as the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "z1 x2 x3 x4 x5x5 x6",
                 "end_match": "6",
                 "captured_groups": []
@@ -1224,7 +1224,7 @@
                 "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
                 "log": "z1 x2 x3 x4 x5 x6x6",
                 "ignore_result": true,
-                "__known_issue:": "It should match but does not, as the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, as the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "end_match": "6",
                 "captured_groups": []
             }
@@ -1235,7 +1235,7 @@
         "batch_test": [
             {
                 "description": "Match all.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\w*",
                 "log": "Wazuh",
@@ -1244,7 +1244,7 @@
             },
             {
                 "description": "Match 0-0",
-                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG 4 Issue: https://github.com/Wazuh/Wazuh/issues/14249",
+                "__known_issue": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG 4 Issue: https://github.com/Wazuh/Wazuh/issues/14249",
                 "skip_test": true,
                 "pattern": "\\d*",
                 "log": "Wazuh",
@@ -1263,7 +1263,7 @@
             },
             {
                 "description": "Match 0-0, with capture group",
-                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/Wazuh/Wazuh/issues/14249",
+                "__known_issue": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/Wazuh/Wazuh/issues/14249",
                 "skip_test": true,
                 "pattern": "(\\d*)",
                 "log": "Wazuh",
@@ -1274,7 +1274,7 @@
             },
             {
                 "description": "Mach all with capture group and flags.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "debug": false,
                 "pattern": "^\\w*$",
@@ -1284,7 +1284,7 @@
             },
             {
                 "description": "With capture group, match all (And flags)",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^(\\w*)$",
                 "log": "Wazuh",
@@ -1349,7 +1349,7 @@
             },
             {
                 "description": "Match 0-0 and capture all",
-                "__known_issue:": "If the pattern has only one token that has the quantifier '*' and it is inside a capture group, when the log is empty, it matches correctly, returning the pointer to the end of the string but does not capture the empty group as expected. BUG 5 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "If the pattern has only one token that has the quantifier '*' and it is inside a capture group, when the log is empty, it matches correctly, returning the pointer to the end of the string but does not capture the empty group as expected. BUG 5 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\w*)",
                 "log": "",
@@ -1360,7 +1360,7 @@
             },
             {
                 "description": "Match 0-0 with flags and capture all",
-                "__known_issue:": "If the pattern has only one token that has the quantifier '*' and it is inside a capture group, when the log is empty, it matches correctly, returning the pointer to the end of the string but does not capture the empty group as expected. BUG 5 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "If the pattern has only one token that has the quantifier '*' and it is inside a capture group, when the log is empty, it matches correctly, returning the pointer to the end of the string but does not capture the empty group as expected. BUG 5 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^(\\w*)$",
                 "log": "",
@@ -1827,7 +1827,7 @@
                 ]
             },
             {
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\w*)(\\s+)",
                 "log": "Wazuh ",
@@ -1870,7 +1870,7 @@
             {
                 "description": "2 groups no consecutive, and opcional",
                 "pattern": "(\\w*)\\d*(\\s*)",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "log": "Wazuh ",
                 "end_match": " ",
@@ -1882,7 +1882,7 @@
             {
                 "description": "2 groups no consecutive, and opcional",
                 "pattern": "(\\w*)\\d*(\\s*)",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "log": "Wazuh123 ",
                 "end_match": " ",
@@ -1894,7 +1894,7 @@
             {
                 "description": "2 groups no consecutive",
                 "pattern": "(\\w*)\\d+(\\s*)",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "log": "Wazuh123 ",
                 "end_match": " ",
@@ -1941,7 +1941,7 @@
             },
             {
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "^\\w*\\s+$",
                 "log": "Wazuh  ",
                 "end_match": " ",
@@ -1998,7 +1998,7 @@
             },
             {
                 "pattern": "\\w*\\s*",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "log": "w ",
                 "end_match": " ",
@@ -2014,7 +2014,7 @@
             },
             {
                 "pattern": "(\\w*\\s*)",
-                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/Wazuh/Wazuh/issues/14249",
+                "__known_issue": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/Wazuh/Wazuh/issues/14249",
                 "__known_issue_2:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "skip_test": true,
                 "log": " ",
@@ -2034,7 +2034,7 @@
             {
                 "ignore_result": true,
                 "debug": false,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "(\\w*\\s*)",
                 "log": "w ",
                 "end_match": " ",
@@ -2053,7 +2053,7 @@
             },
             {
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "(\\w*)\\s*",
                 "log": "w ",
                 "end_match": " ",
@@ -2065,7 +2065,7 @@
                 "pattern": "\\w*\\s*",
                 "ignore_result": true,
                 "debug": false,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": []
@@ -2074,7 +2074,7 @@
                 "description": "Other size. With group",
                 "ignore_result": true,
                 "debug": false,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "(\\w*\\s*)",
                 "log": "Wazuh ",
                 "end_match": " ",
@@ -2083,7 +2083,7 @@
                 ]
             },
             {
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\w*)(\\s*)",
                 "log": "Wazuh ",
@@ -2094,7 +2094,7 @@
                 ]
             },
             {
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\w*)(\\s*)",
                 "log": " ",
@@ -2105,7 +2105,7 @@
                 ]
             },
             {
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\w*)(\\s*)",
                 "log": "w",
@@ -2116,7 +2116,7 @@
                 ]
             },
             {
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "debug": false,
                 "pattern": "(\\w*)(\\s*)",
@@ -2131,7 +2131,7 @@
                 "description": "2 groups no consecutive, and opcional.",
                 "pattern": "(\\w*)\\d+(\\s*)",
                 "ignore_result": true,
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "Wazuh ",
                 "end_match": null,
                 "captured_groups": []
@@ -2140,7 +2140,7 @@
                 "description": "2 groups no consecutive, and opcional",
                 "pattern": "(\\w*)\\d+(\\s*)",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "Wazuh123 ",
                 "end_match": " ",
                 "captured_groups": [
@@ -2152,7 +2152,7 @@
                 "description": "2 groups no consecutive",
                 "pattern": "(\\w*)\\d*(\\s*)",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "Wazuh123 ",
                 "end_match": " ",
                 "captured_groups": [
@@ -2193,14 +2193,14 @@
             {
                 "pattern": "^\\w*\\s*$",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "w ",
                 "end_match": " ",
                 "captured_groups": []
             },
             {
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "^\\w*\\s*$",
                 "log": "Wazuh  ",
                 "end_match": " ",
@@ -2209,7 +2209,7 @@
             {
                 "pattern": "^(\\w*)\\s*$",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "w ",
                 "end_match": " ",
                 "captured_groups": [
@@ -2219,7 +2219,7 @@
             {
                 "pattern": "^(\\w*)\\s*$",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "w ",
                 "end_match": " ",
                 "captured_groups": [
@@ -2228,7 +2228,7 @@
             },
             {
                 "pattern": "^(\\w*\\s*)$",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "log": "w ",
                 "end_match": " ",
@@ -2328,7 +2328,7 @@
             {
                 "description": "Saves and restores the fifth position error. But the fifth should match with the next character.",
                 "pattern": "\\w*1 \\w*2 \\w*3 \\w*4 \\w*5 \\w*6",
-                "__known_issue:": "It should match but does not, as the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, as the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "log": "z1 x2 x3 x4 x5x5 x6",
                 "end_match": "6",
@@ -2338,7 +2338,7 @@
                 "description": "Saves and restores the sixth position error. But the sixth should match with the next character.",
                 "pattern": "\\w*1 \\w*2 \\w*3 \\w*4 \\w*5 \\w*6",
                 "log": "z1 x2 x3 x4 x5 x6x6",
-                "__known_issue:": "It should match but does not, as the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, as the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "end_match": "6",
                 "captured_groups": []
@@ -3493,7 +3493,7 @@
         "batch_test": [
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Pattern \\w+ \\d+",
                 "log": "Pattern Wazuh 123",
@@ -3502,7 +3502,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Pattern (\\w+ \\d+)",
                 "log": "Pattern Wazuh 123",
@@ -3513,7 +3513,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^Pattern \\w+ \\d+",
                 "log": "Pattern Wazuh 123",
@@ -3522,7 +3522,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^Pattern (\\w+ \\d+)",
                 "log": "Pattern Wazuh 123",
@@ -3533,7 +3533,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Pattern \\w+ \\d+$",
                 "log": "Pattern Wazuh 123",
@@ -3542,7 +3542,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Pattern (\\w+ \\d+)$",
                 "log": "Pattern Wazuh 123",
@@ -3553,7 +3553,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Pattern \\w* \\d*",
                 "log": "Pattern Wazuh 123",
@@ -3562,7 +3562,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Pattern (\\w* \\d*)",
                 "log": "Pattern Wazuh 123",
@@ -3573,7 +3573,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^Pattern \\w* \\d*",
                 "log": "Pattern Wazuh 123",
@@ -3582,7 +3582,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^Pattern (\\w* \\d*)",
                 "log": "Pattern Wazuh 123",
@@ -3593,7 +3593,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Pattern \\w* \\d*$",
                 "log": "Pattern Wazuh 123",
@@ -3602,7 +3602,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Pattern (\\w* \\d*)$",
                 "log": "Pattern Wazuh 123",
@@ -3613,7 +3613,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Subpattern 1: \\d+|Subpattern 2: \\d+",
                 "log": "Subpattern 2: 123",
@@ -3622,7 +3622,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Subpattern 1: \\d+|^Subpattern 2: \\d+",
                 "log": "Subpattern 2: 123",
@@ -3631,7 +3631,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Subpattern 1: \\d+|Subpattern 2: \\d+$",
                 "log": "Subpattern 2: 123",
@@ -3640,7 +3640,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Subpattern 1: (\\d+)|Subpattern 2: (\\d+)",
                 "log": "Subpattern 2: 123",
@@ -3651,7 +3651,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Subpattern 1: (\\d+)|^Subpattern 2: (\\d+)",
                 "log": "Subpattern 2: 123",
@@ -3662,7 +3662,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Subpattern 1: (\\d+)|Subpattern 2: (\\d+)$",
                 "log": "Subpattern 2: 123",
@@ -3673,7 +3673,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3').",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d+",
                 "log": "123subpattern",
@@ -3682,7 +3682,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d+",
                 "log": "subpattern123",
@@ -3691,7 +3691,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d+",
                 "log": "123",
@@ -3700,7 +3700,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '9' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d+",
                 "log": "123456789",
@@ -3716,7 +3716,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d+)",
                 "log": "123",
@@ -3727,7 +3727,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d+)",
                 "log": "123subpattern",
@@ -3738,7 +3738,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d+)",
                 "log": "subpattern123",
@@ -3749,7 +3749,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '9' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d+)",
                 "log": "123456789",
@@ -3769,7 +3769,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3').",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d*",
                 "log": "123",
@@ -3778,7 +3778,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3').",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d*",
                 "log": "123subpattern",
@@ -3787,7 +3787,7 @@
             },
             {
                 "description": "This test overflows the heap buffer.",
-                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/Wazuh/Wazuh/issues/14249",
+                "__known_issue": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/Wazuh/Wazuh/issues/14249",
                 "skip_test": true,
                 "pattern": "\\d*",
                 "log": "subpattern123",
@@ -3796,7 +3796,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d*)",
                 "log": "123",
@@ -3816,7 +3816,7 @@
             },
             {
                 "description": "This test overflows the heap buffer.",
-                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/Wazuh/Wazuh/issues/14249",
+                "__known_issue": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/Wazuh/Wazuh/issues/14249",
                 "skip_test": true,
                 "pattern": "(\\d*)",
                 "log": "subpattern123",
@@ -3827,7 +3827,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^\\d+",
                 "log": "123",
@@ -3836,7 +3836,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3').",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^\\d+",
                 "log": "123subpattern",
@@ -3852,7 +3852,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^(\\d+)",
                 "log": "123",
@@ -3863,7 +3863,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^(\\d+)",
                 "log": "123subpattern",
@@ -3881,7 +3881,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^\\d*",
                 "log": "123",
@@ -3891,7 +3891,7 @@
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3').",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "^\\d*",
                 "log": "123subpattern",
                 "end_match": "3subpattern",
@@ -3899,7 +3899,7 @@
             },
             {
                 "description": "This test overflows the heap buffer.",
-                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/Wazuh/Wazuh/issues/14249",
+                "__known_issue": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/Wazuh/Wazuh/issues/14249",
                 "skip_test": true,
                 "pattern": "^\\d*",
                 "log": "subpattern123",
@@ -3909,7 +3909,7 @@
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "^(\\d*)",
                 "log": "123",
                 "end_match": "3",
@@ -3929,7 +3929,7 @@
             {
                 "description": "This test overflows the heap buffer.",
                 "skip_test": true,
-                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/Wazuh/Wazuh/issues/14249",
+                "__known_issue": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/Wazuh/Wazuh/issues/14249",
                 "pattern": "^(\\d*)",
                 "log": "subpattern123",
                 "end_match": null,
@@ -3939,7 +3939,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d+$",
                 "log": "123",
@@ -3948,7 +3948,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d+$",
                 "log": "log123",
@@ -3957,7 +3957,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d+)$",
                 "log": "123",
@@ -3968,7 +3968,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d+)$",
                 "log": "log123",
@@ -3979,7 +3979,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d*$",
                 "log": "123",
@@ -4013,7 +4013,7 @@
             },
             {
                 "description": "It should match but it doesn't.",
-                "__known_issue:": "When the regex is a backlashed token with the '*' quantifier follow by the flag '$' (end of string) and the string does not start with a character that belongs to the character map of such a token, then it does not match as expected. BUG 7 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "When the regex is a backlashed token with the '*' quantifier follow by the flag '$' (end of string) and the string does not start with a character that belongs to the character map of such a token, then it does not match as expected. BUG 7 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d*)$",
                 "log": "pattern123",
@@ -4024,7 +4024,7 @@
             },
             {
                 "description": "This test passes.",
-                "__known_issue:": "When the regex is a backlashed token with the '*' quantifier follow by the flag '$' (end of string) and the string does not start with a character that belongs to the character map of such a token, then it does not match as expected. BUG 7 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "When the regex is a backlashed token with the '*' quantifier follow by the flag '$' (end of string) and the string does not start with a character that belongs to the character map of such a token, then it does not match as expected. BUG 7 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d*)$",
                 "log": "123pattern",
@@ -4035,7 +4035,7 @@
             },
             {
                 "description": "Consecutive capture groups (without something in between) do not match when should.",
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\D+)(\\d+)",
                 "log": "Test123",
@@ -4047,7 +4047,7 @@
             },
             {
                 "description": "Consecutive capture groups (without something in between) do not match.",
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d+)(\\D+)",
                 "log": "123Test",
@@ -4059,7 +4059,7 @@
             },
             {
                 "description": "Consecutive capture groups (without something in between) do not match.",
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\D*)(\\d*)",
                 "log": "Test123",
@@ -4071,7 +4071,7 @@
             },
             {
                 "description": "Consecutive capture groups (without something in between) do not match.",
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d*)(\\D*)",
                 "log": "123Test",
@@ -4083,7 +4083,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\D+\\d+",
                 "log": "Test123",
@@ -4092,7 +4092,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is 'T'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d+\\D+",
                 "log": "123Test",
@@ -4101,7 +4101,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is 't'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\D*\\d*",
                 "log": "Test123",
@@ -4110,7 +4110,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d*\\D*",
                 "log": "123Test",
@@ -4119,7 +4119,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "When there are 4 more optional tokens than characters to match, the regex doesn't match. BUG 8 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "When there are 4 more optional tokens than characters to match, the regex doesn't match. BUG 8 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\w*\\w*\\w*\\w*\\w*\\w*",
                 "log": "xy",
@@ -4128,7 +4128,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "In this case, with extra optional tokens inside a capture group, it does match.",
+                "__known_issue": "In this case, with extra optional tokens inside a capture group, it does match.",
                 "pattern": "(\\w*\\d*\\w*\\d*\\w*\\d*)",
                 "log": "xy",
                 "end_match": "y",
@@ -4138,7 +4138,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "In this case, with extra optional tokens inside a capture group, it does match.",
+                "__known_issue": "In this case, with extra optional tokens inside a capture group, it does match.",
                 "pattern": "^(\\w*\\d*\\w*\\d*\\w*\\d*)",
                 "log": "xy",
                 "end_match": "y",
@@ -4148,7 +4148,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "In this case, with extra optional tokens inside a capture group, it does match.",
+                "__known_issue": "In this case, with extra optional tokens inside a capture group, it does match.",
                 "pattern": "(\\w*\\d*\\w*\\d*\\w*\\d*)$",
                 "log": "xy",
                 "end_match": "y",
@@ -4158,7 +4158,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "In this case, with 10 extra optional tokens inside a capture group, it does match.",
+                "__known_issue": "In this case, with 10 extra optional tokens inside a capture group, it does match.",
                 "pattern": "(\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*)",
                 "log": "xy",
                 "end_match": "y",
@@ -4168,7 +4168,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "In this case, with 10 extra optional tokens inside a capture group, it does match.",
+                "__known_issue": "In this case, with 10 extra optional tokens inside a capture group, it does match.",
                 "pattern": "^(\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*)",
                 "log": "xy",
                 "end_match": "y",
@@ -4178,7 +4178,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "In this case, with 10 extra optional tokens inside a capture group, it does match.",
+                "__known_issue": "In this case, with 10 extra optional tokens inside a capture group, it does match.",
                 "pattern": "(\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*\\w*)$",
                 "log": "xy",
                 "end_match": "y",
@@ -4188,7 +4188,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "With 3 optional tokens do not match that do not mach, it does NOT match.",
+                "__known_issue": "With 3 optional tokens do not match that do not mach, it does NOT match.",
                 "ignore_result": true,
                 "pattern": "\\w*\\p*\\d*\\w*",
                 "log": "xy",
@@ -4242,7 +4242,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "In this case, with 3 extra optional tokens inside a capture group, it does match.",
+                "__known_issue": "In this case, with 3 extra optional tokens inside a capture group, it does match.",
                 "pattern": "(\\w*\\p*\\d*\\w*)",
                 "log": "xy",
                 "end_match": "y",
@@ -4252,7 +4252,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "In this case, with 3 extra optional tokens, it does NOT match.",
+                "__known_issue": "In this case, with 3 extra optional tokens, it does NOT match.",
                 "ignore_result": true,
                 "pattern": "\\w*\\d*\\w*\\p*",
                 "log": "xy",
@@ -4261,7 +4261,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "In this case, with 2 extra optional tokens, it does match.",
+                "__known_issue": "In this case, with 2 extra optional tokens, it does match.",
                 "pattern": "\\w*\\d*\\w*",
                 "log": "xy",
                 "end_match": "y",
@@ -4269,7 +4269,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "In this case, with 2 extra optional tokens, it does match.",
+                "__known_issue": "In this case, with 2 extra optional tokens, it does match.",
                 "pattern": "^\\w*\\d*\\w*",
                 "log": "xy",
                 "end_match": "y",
@@ -4277,7 +4277,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "In this case, with 2 extra optional tokens, it does match.",
+                "__known_issue": "In this case, with 2 extra optional tokens, it does match.",
                 "pattern": "\\w*\\d*\\w*$",
                 "log": "xy",
                 "end_match": "y",
@@ -4294,7 +4294,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "In this case, with only 3 extra optional tokens, it does match.",
+                "__known_issue": "In this case, with only 3 extra optional tokens, it does match.",
                 "pattern": "\\w*\\w*\\w*\\w*\\w*",
                 "log": "xy",
                 "end_match": "y",
@@ -4325,7 +4325,7 @@
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
                 "__known_issue": "May related with bug 5. BUG 11 of issue: https://github.com/wazuh/wazuh/issues/14420",
-                "__known_issue:_2": "In this case there is 1 exceding optional token inside a capture groupe, the regex does match but the expected group is not captured.",
+                "__known_issue_2": "In this case there is 1 exceding optional token inside a capture groupe, the regex does match but the expected group is not captured.",
                 "ignore_result": true,
                 "pattern": "xyz(\\w*)",
                 "log": "xyz",
@@ -4336,7 +4336,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "In this case there are 2 exceding optional tokens inside a capture groupe, the regex doesn't match.",
+                "__known_issue": "In this case there are 2 exceding optional tokens inside a capture groupe, the regex doesn't match.",
                 "pattern": "xyz(\\w*)",
                 "log": "xyz ",
                 "end_match": "z ",
@@ -4346,7 +4346,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "In this case there are 2 exceding optional tokens inside a capture groupe, the regex doesn't match.",
+                "__known_issue": "In this case there are 2 exceding optional tokens inside a capture groupe, the regex doesn't match.",
                 "__known_issue": "May related with bug 5. BUG 11 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "xyz\\w*(\\w*)",
@@ -4358,7 +4358,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "In this case the regex does match.",
+                "__known_issue": "In this case the regex does match.",
                 "pattern": "(xyz\\w*\\w*)",
                 "log": "xyz",
                 "end_match": "z",
@@ -4368,7 +4368,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "In this case the regex does match.",
+                "__known_issue": "In this case the regex does match.",
                 "pattern": "\\d+\\w*\\w*",
                 "log": "123",
                 "end_match": "3",
@@ -4396,7 +4396,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d+)\\D*",
                 "log": "123Test",
@@ -4430,7 +4430,7 @@
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "\\d+(\\D*)",
                 "log": "123Test",
                 "end_match": "t",
@@ -4463,7 +4463,7 @@
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "^\\d+(\\D*)",
                 "log": "123Test",
                 "end_match": "t",
@@ -4493,7 +4493,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^(\\d+)\\D*",
                 "log": "123Test",
@@ -4524,7 +4524,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d+(\\D*)$",
                 "log": "123Test",
@@ -4601,7 +4601,7 @@
             },
             {
                 "description": "Regex should match but does not.",
-                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "__known_issue_2": "Only 4 'recoverage' levels are allowed.",
                 "ignore_result": true,
                 "pattern": "(\\w+1) (\\w+2) (\\w+3) (\\w+4) (\\w+5)",
@@ -4617,7 +4617,7 @@
             },
             {
                 "description": "Regex should match but does not.",
-                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "__known_issue_2": "Only 4 'recoverage' levels are allowed.",
                 "ignore_result": true,
                 "pattern": "(\\w+#) (\\w+#) (\\w+#) (\\w+#) (\\w+#) (\\w+#)",
@@ -4641,7 +4641,7 @@
             },
             {
                 "description": "This case does not match.",
-                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5$",
                 "log": "xyz1xyz1 xyz2xyz2 xyz3xyz3 xyz4xyz4 xyz5xyz5",
@@ -4664,7 +4664,7 @@
             {
                 "description": "Regex should match but does not.",
                 "ignore_result": true,
-                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "(\\w+1) (\\w+2) (\\w+3) (\\w+4) (\\w+5) (\\w+6)$",
                 "log": "xyz1xyz1 xyz2xyz2 xyz3xyz3 xyz4xyz4 xyz5 xyz6xyz6",
                 "end_match": "6",
@@ -4680,7 +4680,7 @@
             {
                 "description": "Regex should match but does not.",
                 "ignore_result": true,
-                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6$",
                 "log": "xyz1xyz1 xyz2xyz2 xyz3xyz3 xyz4xyz4 xyz5 xyz6xyz6",
                 "end_match": "6",
@@ -4704,7 +4704,7 @@
                 "description": "Regex should match but does not.",
                 "ignore_result": true,
                 "pattern": "(\\w+1) (\\w+2) (\\w+3) (\\w+4) (\\w+5) (\\w+6)$",
-                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "xyz1xyz1 xyz2xyz2 xyz3xyz3 xyz4xyz4 xyz5xyz5 xyz6",
                 "end_match": "6",
                 "captured_groups": [
@@ -4720,7 +4720,7 @@
                 "description": "Regex should match but does not.",
                 "ignore_result": true,
                 "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
-                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "z1 x2 x3 x4 x5x5 x6",
                 "end_match": "6",
                 "captured_groups": []
@@ -4729,7 +4729,7 @@
                 "description": "Regex should match but does not.",
                 "ignore_result": true,
                 "pattern": "(\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6)",
-                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "z1 x2 x3 x4 x5x5 x6",
                 "end_match": "6",
                 "captured_groups": [
@@ -4738,7 +4738,7 @@
             },
             {
                 "description": "Regex should match but does not.",
-                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\w+1) (\\w+2) (\\w+3) (\\w+4) (\\w+5) (\\w+6)",
                 "log": "z1 x2 x3 x4 x5x5 x6",
@@ -4913,7 +4913,7 @@
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '1'",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "\\.+",
                 "log": "123 Test",
                 "end_match": "t",
@@ -4921,7 +4921,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '1'",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\.+$",
                 "log": "123 test",
@@ -4930,7 +4930,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '1'",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^\\.+",
                 "log": "123 test",
@@ -4939,7 +4939,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '1'",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^\\.+$",
                 "log": "123 test",
@@ -4948,7 +4948,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '1'",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^(\\.+)$",
                 "log": "123 test",
@@ -4959,7 +4959,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '~' but it is '_'",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\.+",
                 "log": "_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 \r\t!\"#$%&()*+,./:;<=>?[\\]^`{|}~",
@@ -4968,7 +4968,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '~' but it is '_'",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^\\.+$",
                 "log": "_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 \r\t!\"#$%&()*+,./:;<=>?[\\]^`{|}~",
@@ -4993,7 +4993,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '~' but it is '_'",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^(\\.+)$",
                 "log": "_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 \r\t!\"#$%&()*+,./:;<=>?[\\]^`{|}~",

--- a/src/unit_tests/os_regex/test_os_regex_execute.json
+++ b/src/unit_tests/os_regex/test_os_regex_execute.json
@@ -4,84 +4,84 @@
         "batch_test": [
             {
                 "description": "Literal match. Match all.",
-                "pattern": "hi wazuh",
-                "log": "hi wazuh",
+                "pattern": "hi Wazuh",
+                "log": "hi Wazuh",
                 "end_match": "h",
                 "captured_groups": []
             },
             {
                 "description": "Literal match. Match all, with capture groups.",
-                "pattern": "(hi) (wazuh)",
-                "log": "hi wazuh",
+                "pattern": "(hi) (Wazuh)",
+                "log": "hi Wazuh",
                 "end_match": "h",
                 "captured_groups": [
                     "hi",
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
                 "description": "Literal match, with the end flag. It does not match.",
-                "pattern": "hi wazuh$",
-                "log": "hi wazuh 123",
+                "pattern": "hi Wazuh$",
+                "log": "hi Wazuh 123",
                 "end_match": null,
                 "captured_groups": []
             },
             {
                 "description": "Literal match, with groups and the end flag. It does not match.",
-                "pattern": "(hi) (wazuh)$",
-                "log": "hi wazuh 123",
+                "pattern": "(hi) (Wazuh)$",
+                "log": "hi Wazuh 123",
                 "end_match": null,
                 "captured_groups": []
             },
             {
                 "description": "Dont match at all.",
-                "pattern": "hi wazuh",
-                "log": "bye wazuh",
+                "pattern": "hi Wazuh",
+                "log": "bye Wazuh",
                 "end_match": null,
                 "captured_groups": []
             },
             {
                 "description": "Match with prefix and group.",
-                "pattern": "(hi) (wazuh)",
-                "log": "prefixhi wazuh",
+                "pattern": "(hi) (Wazuh)",
+                "log": "prefixhi Wazuh",
                 "end_match": "h",
                 "captured_groups": [
                     "hi",
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
                 "description": "Match with sufix and group.",
-                "pattern": "(hi) (wazuh)",
-                "log": "fixhi wazuhsub",
+                "pattern": "(hi) (Wazuh)",
+                "log": "fixhi Wazuhsub",
                 "end_match": "hsub",
                 "captured_groups": [
                     "hi",
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
                 "description": "Match with adjacent capture groups.",
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
-                "pattern": "(hi)(wazuh)",
-                "log": "hiwazuh",
+                "pattern": "(hi)(Wazuh)",
+                "log": "hiWazuh",
                 "end_match": "h",
                 "captured_groups": [
                     "hi",
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
                 "description": "Match with adjacent capture groups and context.",
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
-                "pattern": "(hi)(wazuh)",
-                "log": "prefixhiwazuhsub",
+                "pattern": "(hi)(Wazuh)",
+                "log": "prefixhiWazuhsub",
                 "end_match": "hsub",
                 "captured_groups": [
                     "hi",
-                    "wazuh"
+                    "Wazuh"
                 ]
             }
         ]
@@ -91,30 +91,29 @@
         "batch_test": [
             {
                 "description": "Regex match all and the END_SET is set.",
-                "pattern": "hi wazuh$",
-                "log": "hi wazuh",
+                "pattern": "hi Wazuh$",
+                "log": "hi Wazuh",
                 "end_match": "h",
                 "captured_groups": []
             },
             {
                 "description": "Empty pattern END_SET and BEGIN_SET are set.",
                 "pattern": "^$",
-                "log": "hi wazuh",
+                "log": "hi Wazuh",
                 "end_match": null,
                 "captured_groups": []
             },
             {
                 "description": "Empty pattern END_SET and BEGIN_SET are set.",
-                "__known_issue:": "It should match but does not, it is not possible to check if a log is empty. BUG 2 of issue: http://#XXXX",
-                "ignore_result": true,
+                "__known_issue:": "It should match but does not, it is not possible to check if a log is empty.",
                 "pattern": "^$",
                 "log": "",
-                "end_match": null,
+                "end_match": "",
                 "captured_groups": []
             },
             {
                 "description": "Empty pattern END_SET and BEGIN_SET are set.",
-                "__known_issue:": "It should match but does not, it is not possible to check if a log is empty. BUG 2 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, it is not possible to check if a log is empty.",
                 "ignore_result": true,
                 "pattern": "(^$)",
                 "log": "",
@@ -125,7 +124,7 @@
             },
             {
                 "description": "Empty pattern END_SET and BEGIN_SET are set.",
-                "__known_issue:": "It should match but does not, it is not possible to check if a log is empty. BUG 2 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, it is not possible to check if a log is empty. BUG 2 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^()$",
                 "log": "",
@@ -136,25 +135,25 @@
             },
             {
                 "description": "Pattern ends and the END_SET is not set.",
-                "pattern": "hi wazuh",
-                "log": "hi wazuh!",
+                "pattern": "hi Wazuh",
+                "log": "hi Wazuh!",
                 "end_match": "h!",
                 "captured_groups": []
             },
             {
                 "description": "Partial match and then re-match ('st_error' test).",
-                "pattern": "(hi) (wazuh)",
-                "log": "XX hi wa hi wazuhXX",
+                "pattern": "(hi) (Wazuh)",
+                "log": "XX hi Wa hi WazuhXX",
                 "end_match": "hXX",
                 "captured_groups": [
                     "hi",
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
                 "description": "Partial match and then re-match ('st_error' + BEGIN_SET test).",
-                "pattern": "^(hi) (wazuh)",
-                "log": "hi wa hi wazuhXX",
+                "pattern": "^(hi) (Wazuh)",
+                "log": "hi Wa hi WazuhXX",
                 "end_match": null,
                 "captured_groups": []
             }
@@ -166,70 +165,70 @@
             {
                 "description": "Match all.",
                 "pattern": "\\w\\w\\s\\S\\S\\S\\S\\S",
-                "log": "hi wazuh",
+                "log": "hi Wazuh",
                 "end_match": "h",
                 "captured_groups": []
             },
             {
                 "description": "Parcial match and fail",
                 "pattern": "\\w\\w\\s\\S\\S\\S\\S\\S",
-                "log": "hi waz",
+                "log": "hi Waz",
                 "end_match": null,
                 "captured_groups": []
             },
             {
                 "description": "Parcial match and fail and then re-match",
                 "pattern": "\\w\\w\\s\\S\\S\\S\\S\\S",
-                "log": "hi waz hi wazu.",
+                "log": "hi Waz hi Wazu.",
                 "end_match": ".",
                 "captured_groups": []
             },
             {
                 "description": "Match all with capture groups.",
                 "pattern": "\\w(\\w\\s\\S)\\S(\\S\\S\\S)",
-                "log": "hi wazuh",
+                "log": "hi Wazuh",
                 "end_match": "h",
                 "captured_groups": [
-                    "i w",
+                    "i W",
                     "zuh"
                 ]
             },
             {
                 "description": "Parcial match and fail  with capture group.",
                 "pattern": "(\\w\\w)\\s\\S\\S\\S\\S\\S",
-                "log": "hi waz",
+                "log": "hi Waz",
                 "end_match": null,
                 "captured_groups": []
             },
             {
                 "description": "Parcial match and fail but then re-match with capture group.",
                 "pattern": "(\\w\\w)\\s(\\S\\S\\S\\S\\S)",
-                "log": "hi waz hi wazuh.",
+                "log": "hi Waz hi Wazuh.",
                 "end_match": "h.",
                 "captured_groups": [
                     "hi",
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
                 "description": "Parcial match and fail but then re-match with adjacent capture group.",
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\w\\w\\s)(\\S\\S\\S\\S\\S)",
-                "log": "hi waz hi wazuh.",
+                "log": "hi Waz hi Wazuh.",
                 "end_match": "h.",
                 "captured_groups": [
                     "hi ",
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
                 "description": "Parcial match and fail but then re-match with one capture group.",
                 "pattern": "(\\w\\w\\s\\S\\S\\S\\S\\S)\\p$",
-                "log": "hi waz hi wazuh.",
+                "log": "hi Waz hi Wazuh.",
                 "end_match": ".",
                 "captured_groups": [
-                    "hi wazuh"
+                    "hi Wazuh"
                 ]
             }
         ]
@@ -239,31 +238,31 @@
         "batch_test": [
             {
                 "description": "Match all.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\w+",
-                "log": "wazuh",
+                "log": "Wazuh",
                 "end_match": "h",
                 "captured_groups": []
             },
             {
                 "description": "Mach all with capture group.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\w+)",
-                "log": "wazuh",
+                "log": "Wazuh",
                 "end_match": "h",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
                 "description": "Mach all with capture group and flags.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "debug": false,
                 "pattern": "^\\w+$",
-                "log": "wazuh",
+                "log": "Wazuh",
                 "end_match": "h",
                 "captured_groups": []
             },
@@ -272,23 +271,23 @@
                 "ignore_result": true,
                 "debug": false,
                 "pattern": "^(\\w+)$",
-                "log": "wazuh",
+                "log": "Wazuh",
                 "end_match": "h",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
                 "description": "Parcial match and fail, with flags.",
                 "pattern": "^\\w+$",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": null,
                 "captured_groups": []
             },
             {
                 "description": "Parcial match and fail with capture group and flags.",
                 "pattern": "^(\\w+)$",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": null,
                 "captured_groups": []
             },
@@ -380,7 +379,7 @@
             {
                 "description": "Match all.",
                 "pattern": "\\w+ ",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": []
             },
@@ -414,7 +413,7 @@
             {
                 "description": "Match all, with a literal at the end.",
                 "pattern": "\\w+\\s1",
-                "log": "wazuh 1",
+                "log": "Wazuh 1",
                 "end_match": "1",
                 "captured_groups": []
             },
@@ -439,10 +438,10 @@
             {
                 "description": "Match all, with a literal at the end, capture the first word.",
                 "pattern": "(\\w+)\\s1",
-                "log": "wazuh 1",
+                "log": "Wazuh 1",
                 "end_match": "1",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
@@ -455,7 +454,7 @@
             {
                 "description": "Match, with a postfix and a literal space",
                 "pattern": "\\w+ 1",
-                "log": "wazuh 123",
+                "log": "Wazuh 123",
                 "end_match": "123",
                 "captured_groups": []
             },
@@ -480,10 +479,10 @@
             {
                 "description": "Match, with a postfix and a literal space, capture the first token.",
                 "pattern": "(\\w+) 1",
-                "log": "wazuh 123",
+                "log": "Wazuh 123",
                 "end_match": "123",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
@@ -496,7 +495,7 @@
             {
                 "description": "Match all with flags.",
                 "pattern": "^\\w+\\s$",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": []
             },
@@ -521,10 +520,10 @@
             {
                 "description": "Match all with backslashed token and flags.",
                 "pattern": "^(\\w+)\\s$",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
@@ -537,7 +536,7 @@
             {
                 "description": "Match all with flags.",
                 "pattern": "^\\w+ $",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": []
             },
@@ -562,23 +561,23 @@
             {
                 "description": "Match minimum log with flags and capture the first token.",
                 "pattern": "^(\\w+) $",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
                 "description": "Fail match becouse of flags.",
                 "pattern": "^\\w+ $",
-                "log": "wazuh -",
+                "log": "Wazuh -",
                 "end_match": null,
                 "captured_groups": []
             },
             {
                 "description": "Fail match becouse of flags.",
                 "pattern": "^(\\w+ )$",
-                "log": "wazuh -",
+                "log": "Wazuh -",
                 "end_match": null,
                 "captured_groups": []
             }
@@ -750,65 +749,65 @@
             {
                 "description": "Match all.",
                 "pattern": "\\w+\\s+",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": []
             },
             {
                 "description": "Match all with group.",
                 "pattern": "(\\w+)\\s+",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
                 "description": "Match all with consecutive group.",
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\w+)(\\s+)",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh",
+                    "Wazuh",
                     " "
                 ]
             },
             {
                 "description": "Match all with no consecutive group and opcional.",
                 "pattern": "(\\w+)\\d*(\\s+)",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh",
+                    "Wazuh",
                     " "
                 ]
             },
             {
                 "description": "Match all with no consecutive group and opcional",
                 "pattern": "(\\w+)\\d*(\\s+)",
-                "log": "wazuh123 ",
+                "log": "Wazuh123 ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh",
+                    "Wazuh",
                     " "
                 ]
             },
             {
                 "description": "Match all with no consecutive group.",
                 "pattern": "(\\w+)\\d+(\\s+)",
-                "log": "wazuh123 ",
+                "log": "Wazuh123 ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh",
+                    "Wazuh",
                     " "
                 ]
             },
             {
                 "description": "Match all with literal at the end.",
                 "pattern": "\\w+\\s+1",
-                "log": "wazuh 1",
+                "log": "Wazuh 1",
                 "end_match": "1",
                 "captured_groups": []
             },
@@ -833,10 +832,10 @@
             {
                 "description": "Match all with literal at the end and capture the first token.",
                 "pattern": " (\\w+)\\s+1",
-                "log": " wazuh 1",
+                "log": " Wazuh 1",
                 "end_match": "1",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
@@ -851,7 +850,7 @@
                 "ignore_result": true,
                 "__know_issue": "Err retval.",
                 "pattern": "^\\w+\\s+$",
-                "log": "wazuh  ",
+                "log": "Wazuh  ",
                 "end_match": " ",
                 "captured_groups": []
             },
@@ -885,14 +884,14 @@
             {
                 "description": "Dont match.",
                 "pattern": "^\\w+\\s+$",
-                "log": "wazuh -",
+                "log": "Wazuh -",
                 "end_match": null,
                 "captured_groups": []
             },
             {
                 "description": "Dont match.",
                 "pattern": "^(\\w+\\s+)$",
-                "log": "wazuh -",
+                "log": "Wazuh -",
                 "end_match": null,
                 "captured_groups": []
             }
@@ -911,7 +910,7 @@
             {
                 "description": "Minimun log to match all and patter with a optional token.",
                 "pattern": "\\w+\\s*",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "log": "w ",
                 "end_match": " ",
@@ -920,7 +919,7 @@
             {
                 "description": "Minimun log to match all and capture all.",
                 "pattern": "(\\w+\\s*)",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "log": "w",
                 "end_match": "w",
@@ -931,19 +930,19 @@
             {
                 "description": "Match all and capture all.",
                 "pattern": "(\\w+\\s*)",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "debug": false,
-                "log": "wazuh",
+                "log": "Wazuh",
                 "end_match": "h",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
                 "description": "Minimun log with optional token to match and capture all.",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "(\\w+\\s*)",
                 "log": "w ",
                 "end_match": " ",
@@ -963,7 +962,7 @@
             {
                 "description": "inimun log with optional token to match and capture the first token.",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "(\\w+)\\s*",
                 "log": "w ",
                 "end_match": " ",
@@ -975,31 +974,31 @@
                 "description": "Match all.",
                 "pattern": "\\w+\\s*",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
-                "log": "wazuh ",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": []
             },
             {
                 "description": "Match all, capture all.",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "(\\w+\\s*)",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh "
+                    "Wazuh "
                 ]
             },
             {
                 "description": "Match all with no consecutive group.",
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\w+)(\\s*)",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh",
+                    "Wazuh",
                     " "
                 ]
             },
@@ -1007,8 +1006,8 @@
                 "description": "Match all with no consecutive group and opcional.",
                 "pattern": "(\\w+)\\d+(\\s*)",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
-                "log": "wazuh ",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "log": "Wazuh ",
                 "end_match": null,
                 "captured_groups": []
             },
@@ -1016,11 +1015,11 @@
                 "description": "Match all with no consecutive group and opcional.",
                 "pattern": "(\\w+)\\d+(\\s*)",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
-                "log": "wazuh123 ",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "log": "Wazuh123 ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh",
+                    "Wazuh",
                     " "
                 ]
             },
@@ -1028,19 +1027,19 @@
                 "description": "Match all with no consecutive group and opcional.",
                 "pattern": "(\\w+)\\d*(\\s*)",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "debug": false,
-                "log": "wazuh123 ",
+                "log": "Wazuh123 ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh",
+                    "Wazuh",
                     " "
                 ]
             },
             {
                 "description": "Match all with literal at the end.",
                 "pattern": "\\w+\\s*1",
-                "log": "wazuh 1",
+                "log": "Wazuh 1",
                 "end_match": "1",
                 "captured_groups": []
             },
@@ -1065,17 +1064,17 @@
             {
                 "description": "Match all with literal at the end and capture the first token.",
                 "pattern": " (\\w+)\\s*1",
-                "log": " wazuh 1",
+                "log": " Wazuh 1",
                 "end_match": "1",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
                 "description": "Minimun log to match all, with flags.",
                 "pattern": "^\\w+\\s*$",
                 "ignore_result": true,
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "w ",
                 "end_match": " ",
                 "captured_groups": []
@@ -1083,9 +1082,9 @@
             {
                 "description": "Match all, with flags.",
                 "ignore_result": true,
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "^\\w+\\s*$",
-                "log": "wazuh  ",
+                "log": "Wazuh  ",
                 "end_match": " ",
                 "captured_groups": []
             },
@@ -1093,7 +1092,7 @@
                 "description": "Minimun log to match all, with flags and capture the first token.",
                 "pattern": "^(\\w+)\\s*$",
                 "ignore_result": true,
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "w ",
                 "end_match": " ",
                 "captured_groups": [
@@ -1104,7 +1103,7 @@
                 "description": "Minimun log to match all, with flags and capture the first token.",
                 "pattern": "^(\\w+)\\s*$",
                 "ignore_result": true,
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "w ",
                 "end_match": " ",
                 "captured_groups": [
@@ -1115,7 +1114,7 @@
                 "description": "Minimun log to match all, with flags and capture all.",
                 "pattern": "^(\\w+\\s*)$",
                 "ignore_result": true,
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "w ",
                 "end_match": " ",
                 "captured_groups": [
@@ -1125,14 +1124,14 @@
             {
                 "description": "Dont match.",
                 "pattern": "^\\w+\\s*$",
-                "log": "wazuh -",
+                "log": "Wazuh -",
                 "end_match": null,
                 "captured_groups": []
             },
             {
                 "description": "Dont match.",
                 "pattern": "^(\\w+\\s*)$",
-                "log": "wazuh -",
+                "log": "Wazuh -",
                 "end_match": null,
                 "captured_groups": []
             }
@@ -1215,7 +1214,7 @@
                 "description": "Saves and restores the fifth position error. But the fifth should match with the next character.",
                 "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
                 "ignore_result": true,
-                "__known_issue:": "It should match but does not, as the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, as the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "z1 x2 x3 x4 x5x5 x6",
                 "end_match": "6",
                 "captured_groups": []
@@ -1225,7 +1224,7 @@
                 "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
                 "log": "z1 x2 x3 x4 x5 x6x6",
                 "ignore_result": true,
-                "__known_issue:": "It should match but does not, as the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, as the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "end_match": "6",
                 "captured_groups": []
             }
@@ -1236,75 +1235,75 @@
         "batch_test": [
             {
                 "description": "Match all.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\w*",
-                "log": "wazuh",
+                "log": "Wazuh",
                 "end_match": "h",
                 "captured_groups": []
             },
             {
                 "description": "Match 0-0",
-                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG 4 Issue: https://github.com/wazuh/wazuh/issues/14249",
+                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG 4 Issue: https://github.com/Wazuh/Wazuh/issues/14249",
                 "skip_test": true,
                 "pattern": "\\d*",
-                "log": "wazuh",
-                "end_match": "wazuh",
+                "log": "Wazuh",
+                "end_match": "Wazuh",
                 "captured_groups": []
             },
             {
                 "description": "Mach all with capture group.",
                 "ignore_result": true,
                 "pattern": "(\\w*)",
-                "log": "wazuh",
+                "log": "Wazuh",
                 "end_match": "h",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
                 "description": "Match 0-0, with capture group",
-                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/wazuh/wazuh/issues/14249",
+                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/Wazuh/Wazuh/issues/14249",
                 "skip_test": true,
                 "pattern": "(\\d*)",
-                "log": "wazuh",
-                "end_match": "wazuh",
+                "log": "Wazuh",
+                "end_match": "Wazuh",
                 "captured_groups": [
                     ""
                 ]
             },
             {
                 "description": "Mach all with capture group and flags.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "debug": false,
                 "pattern": "^\\w*$",
-                "log": "wazuh",
+                "log": "Wazuh",
                 "end_match": "h",
                 "captured_groups": []
             },
             {
                 "description": "With capture group, match all (And flags)",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^(\\w*)$",
-                "log": "wazuh",
+                "log": "Wazuh",
                 "end_match": "h",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
                 "description": "Parcial match and fail, with flags.",
                 "pattern": "^\\w*$",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": null,
                 "captured_groups": []
             },
             {
                 "description": "Parcial match and fail, with flags and capture group.",
                 "pattern": "^(\\w*)$",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": null,
                 "captured_groups": []
             },
@@ -1350,7 +1349,7 @@
             },
             {
                 "description": "Match 0-0 and capture all",
-                "__known_issue:": "If the pattern has only one token that has the quantifier '*' and it is inside a capture group, when the log is empty, it matches correctly, returning the pointer to the end of the string but does not capture the empty group as expected. BUG 6 of issue: http://#XXXX",
+                "__known_issue:": "If the pattern has only one token that has the quantifier '*' and it is inside a capture group, when the log is empty, it matches correctly, returning the pointer to the end of the string but does not capture the empty group as expected. BUG 5 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\w*)",
                 "log": "",
@@ -1361,7 +1360,7 @@
             },
             {
                 "description": "Match 0-0 with flags and capture all",
-                "__known_issue:": "If the pattern has only one token that has the quantifier '*' and it is inside a capture group, when the log is empty, it matches correctly, returning the pointer to the end of the string but does not capture the empty group as expected. BUG 6 of issue: http://#XXXX",
+                "__known_issue:": "If the pattern has only one token that has the quantifier '*' and it is inside a capture group, when the log is empty, it matches correctly, returning the pointer to the end of the string but does not capture the empty group as expected. BUG 5 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^(\\w*)$",
                 "log": "",
@@ -1385,7 +1384,7 @@
             {
                 "description": "Match all.",
                 "pattern": "\\w*\\s",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": []
             },
@@ -1428,10 +1427,10 @@
             {
                 "description": "Mtch all, with backslashed token and capture the first token.",
                 "pattern": "(\\w*)\\s",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
@@ -1451,7 +1450,7 @@
             {
                 "description": "Match all with literal.",
                 "pattern": "\\w* ",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": []
             },
@@ -1476,16 +1475,16 @@
             {
                 "description": "Match all, with literal token and capture the first token.",
                 "pattern": "(\\w*) ",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
                 "description": "Match all, with literal token.",
                 "pattern": "\\w*\\s1",
-                "log": "wazuh 1",
+                "log": "Wazuh 1",
                 "end_match": "1",
                 "captured_groups": []
             },
@@ -1510,10 +1509,10 @@
             {
                 "description": "Match all, with backlashed token and capture the first token.",
                 "pattern": "(\\w*)\\s1",
-                "log": "wazuh 1",
+                "log": "Wazuh 1",
                 "end_match": "1",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
@@ -1526,7 +1525,7 @@
             {
                 "description": "Match, with liteals token.",
                 "pattern": "\\w* 1",
-                "log": "wazuh 123",
+                "log": "Wazuh 123",
                 "end_match": "123",
                 "captured_groups": []
             },
@@ -1551,10 +1550,10 @@
             {
                 "description": "Match, with liteals token and capture the first token.",
                 "pattern": "(\\w*) 1",
-                "log": "wazuh 123",
+                "log": "Wazuh 123",
                 "end_match": "123",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
@@ -1567,7 +1566,7 @@
             {
                 "description": "Match all with backlashed token and flags.",
                 "pattern": "^\\w*\\s$",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": []
             },
@@ -1592,10 +1591,10 @@
             {
                 "description": "Match all with backlashed token and flags.",
                 "pattern": "^(\\w*)\\s$",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
@@ -1608,7 +1607,7 @@
             {
                 "description": "Match all with literal token and flags.",
                 "pattern": "^\\w* $",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": []
             },
@@ -1632,21 +1631,21 @@
             },
             {
                 "pattern": "^(\\w*) $",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
                 "pattern": "^\\w* $",
-                "log": "wazuh -",
+                "log": "Wazuh -",
                 "end_match": null,
                 "captured_groups": []
             },
             {
                 "pattern": "^(\\w* )$",
-                "log": "wazuh -",
+                "log": "Wazuh -",
                 "end_match": null,
                 "captured_groups": []
             }
@@ -1815,98 +1814,98 @@
             },
             {
                 "pattern": "\\w*\\s+",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": []
             },
             {
                 "pattern": "(\\w*)\\s+",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\w*)(\\s+)",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh",
+                    "Wazuh",
                     " "
                 ]
             },
             {
                 "description": "2 no consecutive groups, and opcional.",
                 "pattern": "(\\w*)\\d*(\\s+)",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh",
+                    "Wazuh",
                     " "
                 ]
             },
             {
                 "description": "2 no consecutive groups, and opcional.",
                 "pattern": "(\\w*)\\d*(\\s+)",
-                "log": "wazuh123 ",
+                "log": "Wazuh123 ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh",
+                    "Wazuh",
                     " "
                 ]
             },
             {
                 "description": "2 groups no consecutive",
                 "pattern": "(\\w*)\\d+(\\s+)",
-                "log": "wazuh123 ",
+                "log": "Wazuh123 ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh",
+                    "Wazuh",
                     " "
                 ]
             },
             {
                 "description": "2 groups no consecutive, and opcional",
                 "pattern": "(\\w*)\\d*(\\s*)",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh",
+                    "Wazuh",
                     " "
                 ]
             },
             {
                 "description": "2 groups no consecutive, and opcional",
                 "pattern": "(\\w*)\\d*(\\s*)",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
-                "log": "wazuh123 ",
+                "log": "Wazuh123 ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh",
+                    "Wazuh",
                     " "
                 ]
             },
             {
                 "description": "2 groups no consecutive",
                 "pattern": "(\\w*)\\d+(\\s*)",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
-                "log": "wazuh123 ",
+                "log": "Wazuh123 ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh",
+                    "Wazuh",
                     " "
                 ]
             },
             {
                 "pattern": "\\w*\\s+1",
-                "log": "wazuh 1",
+                "log": "Wazuh 1",
                 "end_match": "1",
                 "captured_groups": []
             },
@@ -1928,10 +1927,10 @@
             },
             {
                 "pattern": " (\\w*)\\s+1",
-                "log": " wazuh 1",
+                "log": " Wazuh 1",
                 "end_match": "1",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
@@ -1942,9 +1941,9 @@
             },
             {
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "^\\w*\\s+$",
-                "log": "wazuh  ",
+                "log": "Wazuh  ",
                 "end_match": " ",
                 "captured_groups": []
             },
@@ -1975,14 +1974,14 @@
             {
                 "description": "Dont match.",
                 "pattern": "^\\w*\\s+$",
-                "log": "wazuh -",
+                "log": "Wazuh -",
                 "end_match": null,
                 "captured_groups": []
             },
             {
                 "description": "Dont match.",
                 "pattern": "^(\\w*\\s+)$",
-                "log": "wazuh -",
+                "log": "Wazuh -",
                 "end_match": null,
                 "captured_groups": []
             }
@@ -1999,7 +1998,7 @@
             },
             {
                 "pattern": "\\w*\\s*",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "log": "w ",
                 "end_match": " ",
@@ -2015,8 +2014,8 @@
             },
             {
                 "pattern": "(\\w*\\s*)",
-                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/wazuh/wazuh/issues/14249",
-                "__known_issue_2:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/Wazuh/Wazuh/issues/14249",
+                "__known_issue_2:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "skip_test": true,
                 "log": " ",
                 "end_match": " ",
@@ -2026,16 +2025,16 @@
             },
             {
                 "pattern": "(\\w*\\s*)",
-                "log": "wazuh",
+                "log": "Wazuh",
                 "end_match": "h",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
                 "ignore_result": true,
                 "debug": false,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "(\\w*\\s*)",
                 "log": "w ",
                 "end_match": " ",
@@ -2054,7 +2053,7 @@
             },
             {
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "(\\w*)\\s*",
                 "log": "w ",
                 "end_match": " ",
@@ -2066,8 +2065,8 @@
                 "pattern": "\\w*\\s*",
                 "ignore_result": true,
                 "debug": false,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
-                "log": "wazuh ",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": []
             },
@@ -2075,27 +2074,27 @@
                 "description": "Other size. With group",
                 "ignore_result": true,
                 "debug": false,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "(\\w*\\s*)",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh "
+                    "Wazuh "
                 ]
             },
             {
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\w*)(\\s*)",
-                "log": "wazuh ",
+                "log": "Wazuh ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh",
+                    "Wazuh",
                     " "
                 ]
             },
             {
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\w*)(\\s*)",
                 "log": " ",
@@ -2106,7 +2105,7 @@
                 ]
             },
             {
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\w*)(\\s*)",
                 "log": "w",
@@ -2117,7 +2116,7 @@
                 ]
             },
             {
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "debug": false,
                 "pattern": "(\\w*)(\\s*)",
@@ -2132,8 +2131,8 @@
                 "description": "2 groups no consecutive, and opcional.",
                 "pattern": "(\\w*)\\d+(\\s*)",
                 "ignore_result": true,
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
-                "log": "wazuh ",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "log": "Wazuh ",
                 "end_match": null,
                 "captured_groups": []
             },
@@ -2141,11 +2140,11 @@
                 "description": "2 groups no consecutive, and opcional",
                 "pattern": "(\\w*)\\d+(\\s*)",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
-                "log": "wazuh123 ",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "log": "Wazuh123 ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh",
+                    "Wazuh",
                     " "
                 ]
             },
@@ -2153,17 +2152,17 @@
                 "description": "2 groups no consecutive",
                 "pattern": "(\\w*)\\d*(\\s*)",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
-                "log": "wazuh123 ",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "log": "Wazuh123 ",
                 "end_match": " ",
                 "captured_groups": [
-                    "wazuh",
+                    "Wazuh",
                     " "
                 ]
             },
             {
                 "pattern": "\\w*\\s*1",
-                "log": "wazuh 1",
+                "log": "Wazuh 1",
                 "end_match": "1",
                 "captured_groups": []
             },
@@ -2185,32 +2184,32 @@
             },
             {
                 "pattern": " (\\w*)\\s*1",
-                "log": " wazuh 1",
+                "log": " Wazuh 1",
                 "end_match": "1",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
                 "pattern": "^\\w*\\s*$",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "w ",
                 "end_match": " ",
                 "captured_groups": []
             },
             {
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "^\\w*\\s*$",
-                "log": "wazuh  ",
+                "log": "Wazuh  ",
                 "end_match": " ",
                 "captured_groups": []
             },
             {
                 "pattern": "^(\\w*)\\s*$",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "w ",
                 "end_match": " ",
                 "captured_groups": [
@@ -2220,7 +2219,7 @@
             {
                 "pattern": "^(\\w*)\\s*$",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "w ",
                 "end_match": " ",
                 "captured_groups": [
@@ -2229,7 +2228,7 @@
             },
             {
                 "pattern": "^(\\w*\\s*)$",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "log": "w ",
                 "end_match": " ",
@@ -2240,14 +2239,14 @@
             {
                 "description": "Dont match.",
                 "pattern": "^\\w*\\s*$",
-                "log": "wazuh -",
+                "log": "Wazuh -",
                 "end_match": null,
                 "captured_groups": []
             },
             {
                 "description": "Dont match.",
                 "pattern": "^(\\w*\\s*)$",
-                "log": "wazuh -",
+                "log": "Wazuh -",
                 "end_match": null,
                 "captured_groups": []
             }
@@ -2329,7 +2328,7 @@
             {
                 "description": "Saves and restores the fifth position error. But the fifth should match with the next character.",
                 "pattern": "\\w*1 \\w*2 \\w*3 \\w*4 \\w*5 \\w*6",
-                "__known_issue:": "It should match but does not, as the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, as the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "log": "z1 x2 x3 x4 x5x5 x6",
                 "end_match": "6",
@@ -2339,7 +2338,7 @@
                 "description": "Saves and restores the sixth position error. But the sixth should match with the next character.",
                 "pattern": "\\w*1 \\w*2 \\w*3 \\w*4 \\w*5 \\w*6",
                 "log": "z1 x2 x3 x4 x5 x6x6",
-                "__known_issue:": "It should match but does not, as the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, as the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "end_match": "6",
                 "captured_groups": []
@@ -2449,10 +2448,10 @@
                 "__prts_items_array_1": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
                 "__prts_array_2": "0x0",
                 "pattern": "hi (\\w+).",
-                "log": "Hi wazuh.",
+                "log": "Hi Wazuh.",
                 "end_match": ".",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
@@ -2531,10 +2530,10 @@
                 "__prts_items_array_1": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
                 "__prts_array_2": "0x0",
                 "pattern": "hi (\\w+).",
-                "log": "Hi wazuh.",
+                "log": "Hi Wazuh.",
                 "end_match": ".",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             }
         ]
@@ -2550,10 +2549,10 @@
                 "__prts_items_array_1": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
                 "__prts_array_2": "0x0",
                 "pattern": "hi (\\w+).",
-                "log": "Hi wazuh.",
+                "log": "Hi Wazuh.",
                 "end_match": ".",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
@@ -2620,10 +2619,10 @@
                 "__prts_items_array_1": "(1 group x2 + 1 null)  x 8 size = 24 bytes",
                 "__prts_array_2": "0x0",
                 "pattern": "hi (\\w+).",
-                "log": "Hi wazuh.",
+                "log": "Hi Wazuh.",
                 "end_match": ".",
                 "captured_groups": [
-                    "wazuh"
+                    "Wazuh"
                 ]
             },
             {
@@ -3494,7 +3493,7 @@
         "batch_test": [
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Pattern \\w+ \\d+",
                 "log": "Pattern Wazuh 123",
@@ -3503,7 +3502,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Pattern (\\w+ \\d+)",
                 "log": "Pattern Wazuh 123",
@@ -3514,7 +3513,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^Pattern \\w+ \\d+",
                 "log": "Pattern Wazuh 123",
@@ -3523,7 +3522,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^Pattern (\\w+ \\d+)",
                 "log": "Pattern Wazuh 123",
@@ -3534,7 +3533,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Pattern \\w+ \\d+$",
                 "log": "Pattern Wazuh 123",
@@ -3543,7 +3542,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Pattern (\\w+ \\d+)$",
                 "log": "Pattern Wazuh 123",
@@ -3554,7 +3553,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Pattern \\w* \\d*",
                 "log": "Pattern Wazuh 123",
@@ -3563,7 +3562,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Pattern (\\w* \\d*)",
                 "log": "Pattern Wazuh 123",
@@ -3574,7 +3573,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^Pattern \\w* \\d*",
                 "log": "Pattern Wazuh 123",
@@ -3583,7 +3582,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^Pattern (\\w* \\d*)",
                 "log": "Pattern Wazuh 123",
@@ -3594,7 +3593,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Pattern \\w* \\d*$",
                 "log": "Pattern Wazuh 123",
@@ -3603,7 +3602,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is ' ' (before the '1').",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Pattern (\\w* \\d*)$",
                 "log": "Pattern Wazuh 123",
@@ -3614,7 +3613,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Subpattern 1: \\d+|Subpattern 2: \\d+",
                 "log": "Subpattern 2: 123",
@@ -3623,7 +3622,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Subpattern 1: \\d+|^Subpattern 2: \\d+",
                 "log": "Subpattern 2: 123",
@@ -3632,7 +3631,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Subpattern 1: \\d+|Subpattern 2: \\d+$",
                 "log": "Subpattern 2: 123",
@@ -3641,7 +3640,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Subpattern 1: (\\d+)|Subpattern 2: (\\d+)",
                 "log": "Subpattern 2: 123",
@@ -3652,7 +3651,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Subpattern 1: (\\d+)|^Subpattern 2: (\\d+)",
                 "log": "Subpattern 2: 123",
@@ -3663,7 +3662,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "Subpattern 1: (\\d+)|Subpattern 2: (\\d+)$",
                 "log": "Subpattern 2: 123",
@@ -3674,7 +3673,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3').",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d+",
                 "log": "123subpattern",
@@ -3683,7 +3682,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d+",
                 "log": "subpattern123",
@@ -3692,7 +3691,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d+",
                 "log": "123",
@@ -3701,7 +3700,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '9' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d+",
                 "log": "123456789",
@@ -3717,7 +3716,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d+)",
                 "log": "123",
@@ -3728,7 +3727,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d+)",
                 "log": "123subpattern",
@@ -3739,7 +3738,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d+)",
                 "log": "subpattern123",
@@ -3750,7 +3749,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '9' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d+)",
                 "log": "123456789",
@@ -3770,7 +3769,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3').",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d*",
                 "log": "123",
@@ -3779,7 +3778,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3').",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d*",
                 "log": "123subpattern",
@@ -3788,7 +3787,7 @@
             },
             {
                 "description": "This test overflows the heap buffer.",
-                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/wazuh/wazuh/issues/14249",
+                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/Wazuh/Wazuh/issues/14249",
                 "skip_test": true,
                 "pattern": "\\d*",
                 "log": "subpattern123",
@@ -3797,7 +3796,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d*)",
                 "log": "123",
@@ -3817,7 +3816,7 @@
             },
             {
                 "description": "This test overflows the heap buffer.",
-                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/wazuh/wazuh/issues/14249",
+                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/Wazuh/Wazuh/issues/14249",
                 "skip_test": true,
                 "pattern": "(\\d*)",
                 "log": "subpattern123",
@@ -3828,7 +3827,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^\\d+",
                 "log": "123",
@@ -3837,7 +3836,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3').",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^\\d+",
                 "log": "123subpattern",
@@ -3853,7 +3852,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^(\\d+)",
                 "log": "123",
@@ -3864,7 +3863,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^(\\d+)",
                 "log": "123subpattern",
@@ -3882,7 +3881,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^\\d*",
                 "log": "123",
@@ -3892,7 +3891,7 @@
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is 's' (After '3').",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "^\\d*",
                 "log": "123subpattern",
                 "end_match": "3subpattern",
@@ -3900,7 +3899,7 @@
             },
             {
                 "description": "This test overflows the heap buffer.",
-                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/wazuh/wazuh/issues/14249",
+                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/Wazuh/Wazuh/issues/14249",
                 "skip_test": true,
                 "pattern": "^\\d*",
                 "log": "subpattern123",
@@ -3910,7 +3909,7 @@
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "^(\\d*)",
                 "log": "123",
                 "end_match": "3",
@@ -3930,7 +3929,7 @@
             {
                 "description": "This test overflows the heap buffer.",
                 "skip_test": true,
-                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/wazuh/wazuh/issues/14249",
+                "__known_issue:": "When the regex consists only of tokens with '*' quantifiers, then it always matches. When it matches having 0 matching characters, then it returns the pointer poiting to one byte before the beginning of the string. BUG Issue: https://github.com/Wazuh/Wazuh/issues/14249",
                 "pattern": "^(\\d*)",
                 "log": "subpattern123",
                 "end_match": null,
@@ -3940,7 +3939,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d+$",
                 "log": "123",
@@ -3949,7 +3948,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d+$",
                 "log": "log123",
@@ -3958,7 +3957,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d+)$",
                 "log": "123",
@@ -3969,7 +3968,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d+)$",
                 "log": "log123",
@@ -3980,7 +3979,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d*$",
                 "log": "123",
@@ -4014,7 +4013,7 @@
             },
             {
                 "description": "It should match but it doesn't.",
-                "__known_issue:": "When the regex is a backlashed token with the '*' quantifier follow by the flag '$' (end of string) and the string does not start with a character that belongs to the character map of such a token, then it does not match as expected. BUG 7 of issue: http://#XXXX",
+                "__known_issue:": "When the regex is a backlashed token with the '*' quantifier follow by the flag '$' (end of string) and the string does not start with a character that belongs to the character map of such a token, then it does not match as expected. BUG 7 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d*)$",
                 "log": "pattern123",
@@ -4025,16 +4024,18 @@
             },
             {
                 "description": "This test passes.",
+                "__known_issue:": "When the regex is a backlashed token with the '*' quantifier follow by the flag '$' (end of string) and the string does not start with a character that belongs to the character map of such a token, then it does not match as expected. BUG 7 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "ignore_result": true,
                 "pattern": "(\\d*)$",
                 "log": "123pattern",
-                "end_match": null,
+                "end_match": "",
                 "captured_groups": [
                     ""
                 ]
             },
             {
                 "description": "Consecutive capture groups (without something in between) do not match when should.",
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\D+)(\\d+)",
                 "log": "Test123",
@@ -4046,7 +4047,7 @@
             },
             {
                 "description": "Consecutive capture groups (without something in between) do not match.",
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d+)(\\D+)",
                 "log": "123Test",
@@ -4058,7 +4059,7 @@
             },
             {
                 "description": "Consecutive capture groups (without something in between) do not match.",
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\D*)(\\d*)",
                 "log": "Test123",
@@ -4070,7 +4071,7 @@
             },
             {
                 "description": "Consecutive capture groups (without something in between) do not match.",
-                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, adjacent capture groups are not supported. BUG 1 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d*)(\\D*)",
                 "log": "123Test",
@@ -4082,7 +4083,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is '1'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\D+\\d+",
                 "log": "Test123",
@@ -4091,7 +4092,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is 'T'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d+\\D+",
                 "log": "123Test",
@@ -4100,7 +4101,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '3' but it is 't'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\D*\\d*",
                 "log": "Test123",
@@ -4109,7 +4110,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d*\\D*",
                 "log": "123Test",
@@ -4118,7 +4119,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue:": "When there are 4 more optional tokens than characters to match, the regex doesn't match. BUG 8 of issue: http://#XXXX",
+                "__known_issue:": "When there are 4 more optional tokens than characters to match, the regex doesn't match. BUG 8 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\w*\\w*\\w*\\w*\\w*\\w*",
                 "log": "xy",
@@ -4196,7 +4197,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue": "When there are 3 tokens with the quantifier '*' consecutively, under certain circumstances, the regex does not match even though it should. BUG 8 of issue: http://#XXXX",
+                "__known_issue": "When there are 3 tokens with the quantifier '*' consecutively, under certain circumstances, the regex does not match even though it should. BUG 8 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\w*\\p*\\d*\\w*",
                 "log": "xy55",
@@ -4205,7 +4206,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue": "When there are 3 tokens with the quantifier '*' consecutively, under certain circumstances, the regex does not match even though it should. BUG 8 of issue: http://#XXXX",
+                "__known_issue": "When there are 3 tokens with the quantifier '*' consecutively, under certain circumstances, the regex does not match even though it should. BUG 8 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\w+\\p*\\d*\\w*",
                 "log": "xy55",
@@ -4223,7 +4224,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue": "When there are 3 tokens with the quantifier '*' consecutively, under certain circumstances, the regex does not match even though it should. BUG 8 of issue: http://#XXXX",
+                "__known_issue": "When there are 3 tokens with the quantifier '*' consecutively, under certain circumstances, the regex does not match even though it should. BUG 8 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^\\w*\\p*\\d*\\w*",
                 "log": "xy",
@@ -4232,7 +4233,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue": "When there are 3 tokens with the quantifier '*' consecutively, under certain circumstances, the regex does not match even though it should. BUG 8 of issue: http://#XXXX",
+                "__known_issue": "When there are 3 tokens with the quantifier '*' consecutively, under certain circumstances, the regex does not match even though it should. BUG 8 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\w*\\p*\\d*\\w*$",
                 "log": "xy",
@@ -4284,7 +4285,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue": "When there are 3 tokens with the quantifier '*' consecutively, under certain circumstances, the regex does not match even though it should. BUG 8 of issue: http://#XXXX",
+                "__known_issue": "When there are 3 tokens with the quantifier '*' consecutively, under certain circumstances, the regex does not match even though it should. BUG 8 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\w*\\d*\\p*\\w*",
                 "log": "xy",
@@ -4301,7 +4302,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue": "Maybe related with bug 9 or 8. BUG 10 of issue: http://#XXXX",
+                "__known_issue": "Maybe related with bug 9 or 8. BUG 10 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "__known_issue_2": "In this case there are 2 exceding optional tokens, the regex doesn't match.",
                 "ignore_result": true,
                 "pattern": "xyz\\d*\\w*",
@@ -4311,7 +4312,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue": "Maybe related with bug 9 or 8. BUG 10 of issue: http://#XXXX",
+                "__known_issue": "Maybe related with bug 9 or 8. BUG 10 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "__known_issue_2": "In this case there are 2 exceding optional tokens inside a capture groupe, the regex doesn't match.",
                 "ignore_result": true,
                 "pattern": "xyz(\\d*\\w*)",
@@ -4323,7 +4324,7 @@
             },
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
-                "__known_issue": "May related with bug 5. BUG 11 of issue: http://#XXXX",
+                "__known_issue": "May related with bug 5. BUG 11 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "__known_issue:_2": "In this case there is 1 exceding optional token inside a capture groupe, the regex does match but the expected group is not captured.",
                 "ignore_result": true,
                 "pattern": "xyz(\\w*)",
@@ -4346,7 +4347,7 @@
             {
                 "description": "Tokens with optional quantifier (*) should always match, but they don't.",
                 "__known_issue:": "In this case there are 2 exceding optional tokens inside a capture groupe, the regex doesn't match.",
-                "__known_issue": "May related with bug 5. BUG 11 of issue: http://#XXXX",
+                "__known_issue": "May related with bug 5. BUG 11 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "xyz\\w*(\\w*)",
                 "log": "xyz",
@@ -4376,7 +4377,7 @@
             {
                 "description": "Capture group is not correctly obtained. It should be '123' but it is empty.",
                 "ignore_result": true,
-                "__known_issue": "BUG 12 of issue: http://#XXXX",
+                "__known_issue": "BUG 12 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "(\\d+)\\D*",
                 "log": "123",
                 "end_match": "3",
@@ -4395,7 +4396,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d+)\\D*",
                 "log": "123Test",
@@ -4406,7 +4407,7 @@
             },
             {
                 "description": "Capture group is not correctly obtained. It should be '123' but it is empty.",
-                "__known_issue": "BUG 12 of issue: http://#XXXX",
+                "__known_issue": "BUG 12 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d+)\\D*",
                 "log": "Test123",
@@ -4417,7 +4418,7 @@
             },
             {
                 "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
-                "__known_issue": "BUG 12 of issue: http://#XXXX",
+                "__known_issue": "BUG 12 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d+(\\D*)",
                 "log": "123",
@@ -4429,7 +4430,7 @@
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "\\d+(\\D*)",
                 "log": "123Test",
                 "end_match": "t",
@@ -4439,7 +4440,7 @@
             },
             {
                 "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
-                "__known_issue": "BUG 12 of issue: http://#XXXX",
+                "__known_issue": "BUG 12 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d+(\\D*)",
                 "log": "Test123",
@@ -4451,7 +4452,7 @@
             {
                 "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
                 "ignore_result": true,
-                "__known_issue": "BUG 12 of issue: http://#XXXX",
+                "__known_issue": "BUG 12 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "^\\d+(\\D*)",
                 "log": "123",
                 "end_match": "3",
@@ -4462,7 +4463,7 @@
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "^\\d+(\\D*)",
                 "log": "123Test",
                 "end_match": "t",
@@ -4481,7 +4482,7 @@
             },
             {
                 "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
-                "__known_issue": "BUG 12 of issue: http://#XXXX",
+                "__known_issue": "BUG 12 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^(\\d+)\\D*",
                 "log": "123",
@@ -4492,7 +4493,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^(\\d+)\\D*",
                 "log": "123Test",
@@ -4512,7 +4513,7 @@
             },
             {
                 "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
-                "__known_issue": "BUG 12 of issue: http://#XXXX",
+                "__known_issue": "BUG 12 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d+(\\D*)$",
                 "log": "123",
@@ -4523,7 +4524,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '3'.",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d+(\\D*)$",
                 "log": "123Test",
@@ -4534,7 +4535,7 @@
             },
             {
                 "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
-                "__known_issue": "BUG 12 of issue: http://#XXXX",
+                "__known_issue": "BUG 12 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\d+(\\D*)$",
                 "log": "Test123",
@@ -4545,7 +4546,7 @@
             },
             {
                 "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
-                "__known_issue": "BUG 12 of issue: http://#XXXX",
+                "__known_issue": "BUG 12 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d+)\\D*$",
                 "log": "123",
@@ -4556,7 +4557,7 @@
             },
             {
                 "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
-                "__known_issue": "BUG 12 of issue: http://#XXXX",
+                "__known_issue": "BUG 12 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d+)\\D*$",
                 "log": "123Test",
@@ -4567,7 +4568,7 @@
             },
             {
                 "description": "Capture group is not correctly obtained. It should be an empty group but it is null.",
-                "__known_issue": "BUG 12 of issue: http://#XXXX",
+                "__known_issue": "BUG 12 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d+)\\D*$",
                 "log": "Test123",
@@ -4578,7 +4579,7 @@
             },
             {
                 "description": "Capture group is not correctly obtained.",
-                "__known_issue": "BUG 12 of issue: http://#XXXX",
+                "__known_issue": "BUG 12 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d*)\\w*",
                 "log": "123",
@@ -4589,7 +4590,7 @@
             },
             {
                 "description": "Capture group is not correctly obtained.",
-                "__known_issue": "BUG 12 of issue: http://#XXXX",
+                "__known_issue": "BUG 12 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\d*)\\w*",
                 "log": "123Test",
@@ -4600,7 +4601,7 @@
             },
             {
                 "description": "Regex should match but does not.",
-                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "__known_issue_2": "Only 4 'recoverage' levels are allowed.",
                 "ignore_result": true,
                 "pattern": "(\\w+1) (\\w+2) (\\w+3) (\\w+4) (\\w+5)",
@@ -4615,6 +4616,23 @@
                 ]
             },
             {
+                "description": "Regex should match but does not.",
+                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
+                "__known_issue_2": "Only 4 'recoverage' levels are allowed.",
+                "ignore_result": true,
+                "pattern": "(\\w+#) (\\w+#) (\\w+#) (\\w+#) (\\w+#) (\\w+#)",
+                "log": "a# b# c# d#d# e# f#",
+                "end_match": "#",
+                "captured_groups": [
+                    "a#",
+                    "b#",
+                    "c#",
+                    "d#d#",
+                    "e#",
+                    "f#"
+                ]
+            },
+            {
                 "description": "This case matches.",
                 "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5",
                 "log": "xyz1xyz1 xyz2xyz2 xyz3xyz3 xyz4xyz4 xyz5xyz5",
@@ -4623,7 +4641,7 @@
             },
             {
                 "description": "This case does not match.",
-                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5$",
                 "log": "xyz1xyz1 xyz2xyz2 xyz3xyz3 xyz4xyz4 xyz5xyz5",
@@ -4646,7 +4664,7 @@
             {
                 "description": "Regex should match but does not.",
                 "ignore_result": true,
-                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "(\\w+1) (\\w+2) (\\w+3) (\\w+4) (\\w+5) (\\w+6)$",
                 "log": "xyz1xyz1 xyz2xyz2 xyz3xyz3 xyz4xyz4 xyz5 xyz6xyz6",
                 "end_match": "6",
@@ -4662,7 +4680,7 @@
             {
                 "description": "Regex should match but does not.",
                 "ignore_result": true,
-                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6$",
                 "log": "xyz1xyz1 xyz2xyz2 xyz3xyz3 xyz4xyz4 xyz5 xyz6xyz6",
                 "end_match": "6",
@@ -4686,7 +4704,7 @@
                 "description": "Regex should match but does not.",
                 "ignore_result": true,
                 "pattern": "(\\w+1) (\\w+2) (\\w+3) (\\w+4) (\\w+5) (\\w+6)$",
-                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "xyz1xyz1 xyz2xyz2 xyz3xyz3 xyz4xyz4 xyz5xyz5 xyz6",
                 "end_match": "6",
                 "captured_groups": [
@@ -4702,7 +4720,7 @@
                 "description": "Regex should match but does not.",
                 "ignore_result": true,
                 "pattern": "\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6",
-                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "z1 x2 x3 x4 x5x5 x6",
                 "end_match": "6",
                 "captured_groups": []
@@ -4711,7 +4729,7 @@
                 "description": "Regex should match but does not.",
                 "ignore_result": true,
                 "pattern": "(\\w+1 \\w+2 \\w+3 \\w+4 \\w+5 \\w+6)",
-                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "log": "z1 x2 x3 x4 x5x5 x6",
                 "end_match": "6",
                 "captured_groups": [
@@ -4720,7 +4738,7 @@
             },
             {
                 "description": "Regex should match but does not.",
-                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: http://#XXXX",
+                "__known_issue:": "It should match but does not, the states stack is limited to 4 states. BUG 6 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(\\w+1) (\\w+2) (\\w+3) (\\w+4) (\\w+5) (\\w+6)",
                 "log": "z1 x2 x3 x4 x5x5 x6",
@@ -4766,7 +4784,7 @@
             },
             {
                 "description": "This case has 3 (non-optional) tokens but it is capturing only 2 characters.",
-                "__known_issue": "BUG 13 of issue: http://#XXXX",
+                "__known_issue": "BUG 13 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "__known_issue_2": "Capture groups could be either '04T15' or '4T15', depending on the (unpredictable) behavior of the greediness.",
                 "ignore_result": true,
                 "pattern": "(\\d+\\w\\d+)",
@@ -4778,7 +4796,7 @@
             },
             {
                 "description": "This case should match but it does not.",
-                "__known_issue": "Related BUG 13 of issue: http://#XXXX",
+                "__known_issue": "Related BUG 13 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "(-\\d+\\w\\d+:)",
                 "log": "-04T15:",
@@ -4789,7 +4807,7 @@
             },
             {
                 "description": "This case should match but it does not.",
-                "__known_issue": "Related BUG 13 of issue: http://#XXXX",
+                "__known_issue": "Related BUG 13 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "-(\\d+\\w\\d+):",
                 "log": "-04T15:",
@@ -4799,7 +4817,7 @@
                 ]
             },
             {
-                "__known_issue": "Related BUG 13 of issue: http://#XXXX",
+                "__known_issue": "Related BUG 13 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "description": "This case should match but it does not.",
                 "ignore_result": true,
                 "pattern": "-\\d+\\w\\d+:",
@@ -4809,7 +4827,7 @@
             },
             {
                 "description": "This case matches.",
-                "__known_issue": "Related BUG 13 of issue: http://#XXXX",
+                "__known_issue": "Related BUG 13 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "__known_issue_2": "Wrong end_match value.",
                 "ignore_result": true,
                 "pattern": "\\d+\\w\\d+",
@@ -4819,7 +4837,7 @@
             },
             {
                 "description": "This case matches.",
-                "__known_issue": "Related BUG 13 of issue: http://#XXXX",
+                "__known_issue": "Related BUG 13 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "__known_issue_2": "Wrong end_match value.",
                 "ignore_result": true,
                 "pattern": "(\\d+\\D\\d+)",
@@ -4865,10 +4883,9 @@
             },
             {
                 "description": "This case matches.",
-                "__known_issue": "Related BUG 13 of issue: http://#XXXX",
+                "__known_issue": "Related BUG 13 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "__known_issue_2": "Wrong end_match value.",
                 "ignore_result": true,
-                "debug": true,
                 "pattern": "(\\d+\\D\\d+)",
                 "log": "04T15",
                 "end_match": "5",
@@ -4896,7 +4913,7 @@
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '1'",
                 "ignore_result": true,
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "pattern": "\\.+",
                 "log": "123 Test",
                 "end_match": "t",
@@ -4904,7 +4921,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '1'",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\.+$",
                 "log": "123 test",
@@ -4913,7 +4930,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '1'",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^\\.+",
                 "log": "123 test",
@@ -4922,7 +4939,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '1'",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^\\.+$",
                 "log": "123 test",
@@ -4931,7 +4948,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be 't' but it is '1'",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^(\\.+)$",
                 "log": "123 test",
@@ -4942,7 +4959,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '~' but it is '_'",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "\\.+",
                 "log": "_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 \r\t!\"#$%&()*+,./:;<=>?[\\]^`{|}~",
@@ -4951,7 +4968,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '~' but it is '_'",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^\\.+$",
                 "log": "_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 \r\t!\"#$%&()*+,./:;<=>?[\\]^`{|}~",
@@ -4976,7 +4993,7 @@
             },
             {
                 "description": "Last matched character pointed (end_match) should be '~' but it is '_'",
-                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: http://#XXXX",
+                "__known_issue:": "Matches but if the regex ends with a token with the quantifier '+' or '*', then it does not return the pointer to the last character matched, as it should be. BUG 3 of issue: https://github.com/wazuh/wazuh/issues/14420",
                 "ignore_result": true,
                 "pattern": "^(\\.+)$",
                 "log": "_-@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 \r\t!\"#$%&()*+,./:;<=>?[\\]^`{|}~",

--- a/src/unit_tests/os_regex/test_os_regex_execute.md
+++ b/src/unit_tests/os_regex/test_os_regex_execute.md
@@ -35,6 +35,7 @@ The `unit tests` are also JSON objects that have a format similar to the followi
 {
   "description" : "Optional description of the unit test",
   "ignore_result" : false,
+  "debug": false,
   "pattern": "^Some pattern in a (\\w+) ",
   "log": "Some pattern in a Wazuh log.",
   "end_match": " log.",
@@ -47,6 +48,7 @@ The `unit tests` are also JSON objects that have a format similar to the followi
 Where:
 - `description` (string/optional): Unit test description.
 - `ignore_result` (bool/optional): If true, the test is executed but if it fails then such failures are ignored. This allows having tests for known buggy cases.
+- `debug` (bool/optional): If true, it prints a verbose description of the errors.
 - `pattern` (string) : OS Regex pattern.
 - `log` (string): Log to be analyzed.
 - `end_match` (string): When the regex matches, it should return a pointer to the last matched character. This parameter would be the string that is conformed starting from this character to the end of the log.

--- a/src/unit_tests/os_regex/test_os_regex_execute.md
+++ b/src/unit_tests/os_regex/test_os_regex_execute.md
@@ -1,0 +1,53 @@
+# os_regex_execute tests framework
+
+The `test suites` set of **os_regex_execute** is defined in [test_os_regex_execute.json](test_os_regex_execute.json) as an array as follows:
+
+```json
+[
+    test_suite_1,
+    test_suite_2,
+    .
+    .
+    .
+    test_suite_n
+]
+```
+
+Each `test suite` uses a [regex_matching](https://github.com/wazuh/wazuh/blob/v4.3.5/src/os_regex/os_regex.h#L45-L49) structure, which is initially empty and is shared between its `unit tests`, allowing to test the memory usage. These suites are JSON objects with the following structure:
+
+```json
+{
+  "description": "Here it should be explained what is the functionality or use case that is being tested.",
+  "batch_test": [
+           UT_1,
+           UT_2,
+           .
+           .
+           .
+           UT_m
+  ]
+}
+```
+
+Where `batch_test` contains a `unit tests` array grouped by functionality.
+The `unit tests` are also JSON objects that have a format similar to the following one:
+```json
+{
+  "description" : "Optional description of the unit test",
+  "ignore_result" : false,
+  "pattern": "^Some pattern in a (\\w+) ",
+  "log": "Some pattern in a Wazuh log.",
+  "end_match": " log.",
+  "captured_groups": [
+    "Wazuh"
+  ]
+}
+```
+
+Where:
+- `description` (string/optional): Unit test description.
+- `ignore_result` (bool/optional): If true, the test is executed but if it fails then such failures are ignored. This allows having tests for known buggy cases.
+- `pattern` (string) : OS Regex pattern.
+- `log` (string): Log to be analyzed.
+- `end_match` (string): When the regex matches, it should return a pointer to the last matched character. This parameter would be the string that is conformed starting from this character to the end of the log.
+- `captured_groups`: An array with the expected capture groups.

--- a/src/unit_tests/os_regex/test_os_regex_execute.md
+++ b/src/unit_tests/os_regex/test_os_regex_execute.md
@@ -33,8 +33,9 @@ Where `batch_test` contains a `unit tests` array grouped by functionality.
 The `unit tests` are also JSON objects that have a format similar to the following one:
 ```json
 {
-  "description" : "Optional description of the unit test",
-  "ignore_result" : false,
+  "description": "Optional description of the unit test",
+  "skip_test": false,
+  "ignore_result": false,
   "debug": false,
   "pattern": "^Some pattern in a (\\w+) ",
   "log": "Some pattern in a Wazuh log.",
@@ -47,7 +48,8 @@ The `unit tests` are also JSON objects that have a format similar to the followi
 
 Where:
 - `description` (string/optional): Unit test description.
-- `ignore_result` (bool/optional): If true, the test is executed but if it fails then such failures are ignored. This allows having tests for known buggy cases.
+- `skip_test` (bool/optional): If true, the test is skipped. This allows developing tests that should work but are not, until fixed, given known buggy cases. This option is used in tests that produce segmentation faults or conditions that abort the tests and can not be handled.
+- `ignore_result` (bool/optional): If true, the test is executed but if it fails then such failures are ignored. This allows having tests for known buggy cases but prevents them to fail. This option is used in tests that fail but still can be bypassed.
 - `debug` (bool/optional): If true, it prints a verbose description of the errors.
 - `pattern` (string) : OS Regex pattern.
 - `log` (string): Log to be analyzed.


### PR DESCRIPTION
|Related issues|
|---|
|#13933|


## Description

When executing a regex (`OSRegex_Execute_ex`), a `regex_matching` structure can be passed as a parameter to store the results. This allows the execution of the same regex to be thread safe.
In addition to this, the structure can be mutated, increasing in size to meet the criteria of the regex to be executed. This allows the same structure to be used by different executions of different regexes.

This PR fixes the initial memory reservation of the structure elements and also the reallocation of some elements.
Also adds a testing framework for os_regex_execution with external os_regex_matching framework.
[How does the os_regex testing framework work?](https://github.com/wazuh/wazuh/blob/d376cb8d07c31f2ece86df6894f41c5dcf24341b/src/unit_tests/os_regex/test_os_regex_execute.md)


### Test suite output:
```
╭─root@200-u20-dev-manager ~/repos/wazuh/src/unit_tests/build ‹13933-fix-segfault-osregex-exec●› 
╰─# ./os_regex/test_os_regex_execute              
[==========] tests: Running 1 test(s).
[ RUN      ] test_regex_execute_regex_matching
[ OS_REGEX ] Testing suite: [Functionality] Charmap without backslashed tokens.
[ OS_REGEX ] Testing suite: [Functionality] Charmap + END/BEGIN flags and st_error without backslashed tokens.
[ OS_REGEX ] Testing suite: [Functionality] Only backslashed tokens without quantifiers ('*', '+').
[ OS_REGEX ] Testing suite: [Functionality] Only backslashed tokens with the '+' quantifier.
[ OS_REGEX ] Testing suite: [Functionality] Lazy-Greedy behavior duality: Regex composed by a backslashed token with a '+' quantifier followed by a token that has no quantifier, where the last token does not include the charmap of the first one.
[ OS_REGEX ] Testing suite: [Functionality] Lazy-Greedy behavior duality: Regex composed by a backslashed token with a '+' quantifier followed by a token that has no quantifier, where the last token does include the charmap of the first one.
[ OS_REGEX ] Testing suite: [Functionality] Lazy-Greedy behavior duality: Regex composed by a backslashed token with a '+' quantifier followed by a token that has the '+' quantifier, where the last token does not include the charmap of the first one.
[ OS_REGEX ] Testing suite: [Functionality] Lazy-Greedy behavior duality: Regex composed by a backslashed token with a '+' quantifier followed by a token that has the '*' quantifier, where the last token does include the charmap of the first one.
[ OS_REGEX ] Testing suite: [Functionality] Lazy-Greedy behavior duality: Regex composed by backslashed tokens with '*' quantifiers. Test the 'st_error', 'pt_error[]' and 'pt_error_str[]' for parcial matches and rewind.
[ OS_REGEX ] Testing suite: [Functionality] Only backslashed tokens with the '*' quantifier.
[ OS_REGEX ] Testing suite: [Functionality] Lazy-Greedy behavior duality: Regex composed by a backslashed token with a '*' quantifier followed by a token that has no quantifier, where the last token does not include the charmap of the first one.er.
[ OS_REGEX ] Testing suite: [Functionality] Lazy-Greedy behavior duality: Regex composed by a backslashed token with a '*' quantifier followed by a token that has no quantifier, where the last token does include the charmap of the first one.
[ OS_REGEX ] Testing suite: [Functionality] Lazy-Greedy behavior duality: Regex composed by a backslashed token with a '*' quantifier followed by a token that has the '+' quantifier, where the last token does not include the charmap of the first one.
[ OS_REGEX ] Testing suite: [Functionality] Lazy-Greedy behavior duality: Regex composed by a backslashed token with a '+' quantifier followed by a token that has the '*' quantifier, where the last token does include the charmap of the first one.
[ OS_REGEX ] Testing suite: [Functionality] Lazy-Greedy behavior duality: Regex composed by backslashed tokens with '*' quantifiers. Test the 'st_error', 'pt_error[]' and 'pt_error_str[]' for parcial matches and rewind.
[ OS_REGEX ] Testing suite: [Coverage] Loop on all sub patterns without capture groups
[ OS_REGEX ] Testing suite: [Memory test] regex_matching alloc test: copy reg size.
[ OS_REGEX ] Testing suite: [Memory test] regex_matching expand test: Incremental capture groups and match last.
[ OS_REGEX ] Testing suite: [Memory test] regex_matching expand test: Incremental patterns and match last.
[ OS_REGEX ] Testing suite: [Memory test] regex_matching expand test: Incremental capture groups and patterns, then match last.
[ OS_REGEX ] Testing suite: [Functionality] Supported expression tests - Character Maps [\w, \d, \s, \W, \D, \S, \p, \t, \.].
[ OS_REGEX ] Testing suite: [Functionality] quantifiers (+ and *)
[ OS_REGEX ] Testing suite: [Functionality] Special characters escaping (\$ \( \) \\ \| \<)
[ OS_REGEX ] Testing suite: [Functionality] Special characters. '^'
[ OS_REGEX ] Testing suite: [Functionality] Special characters. '$'
[ OS_REGEX ] Testing suite: [Functionality] Combine special characters. ['^', '$']
[ OS_REGEX ] Testing suite: [Functionality] Special characters.  OR with flags ['^', '$','|']
[ OS_REGEX ] Testing suite: [Functionality] Corner cases. This tests have shown that OS Regex is not working as expected.
[ OS_REGEX ] Testing suite: [Functionality] Complementary cases.
[ OS_REGEX ] --------------------------------
[ OS_REGEX ] >>> Amount of executed suites: 29
[ OS_REGEX ] >>> Amount of unit tests: 517
[ OS_REGEX ] >>> Amount of executed unit tests: 506
[ OS_REGEX ] >>> Amount of skipped unit tests: 11
[ OS_REGEX ] >>> Amount of failed unit tests: 211
[ OS_REGEX ] >>> Amount of errors found: 219
[ OS_REGEX ] --------------------------------
[       OK ] test_regex_execute_regex_matching
[==========] tests: 1 test(s) run.
[  PASSED  ] 1 test(s).
```


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors