### PR TITLE
Fix Vulnerability Detector for Windows 8.1 and Windows 8

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5823,7 +5823,8 @@ int wm_vuldet_generate_win_cpe(scan_agent *agent) {
     const char *ws_ver = NULL;
     char *ver_aux = NULL;
 
-    if (!agent->os_release && agent->dist_ver != FEED_WS2012 && agent->dist_ver != FEED_WS2012R2) {
+    if (!agent->os_release && agent->dist_ver != FEED_WS2012 && agent->dist_ver != FEED_WS2012R2 &&
+        agent->dist_ver != FEED_W81) {
         mtwarn(WM_VULNDETECTOR_LOGTAG, VU_OSINFO_DISABLED, atoi(agent->agent_id));
     }
 
@@ -5863,7 +5864,6 @@ int wm_vuldet_generate_win_cpe(scan_agent *agent) {
         break;
         case FEED_W81:
             win_pr = PR_WIN81;
-            win_upd = ver_aux;
         break;
         case FEED_W10:
             win_pr = PR_WIN10;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5824,7 +5824,7 @@ int wm_vuldet_generate_win_cpe(scan_agent *agent) {
     char *ver_aux = NULL;
 
     if (!agent->os_release && agent->dist_ver != FEED_WS2012 && agent->dist_ver != FEED_WS2012R2 &&
-        agent->dist_ver != FEED_W81) {
+        agent->dist_ver != FEED_W8 && agent->dist_ver != FEED_W81) {
         mtwarn(WM_VULNDETECTOR_LOGTAG, VU_OSINFO_DISABLED, atoi(agent->agent_id));
     }
 
@@ -5860,7 +5860,6 @@ int wm_vuldet_generate_win_cpe(scan_agent *agent) {
         break;
         case FEED_W8:
             win_pr = PR_WIN8;
-            win_upd = ver_aux;
         break;
         case FEED_W81:
             win_pr = PR_WIN81;


### PR DESCRIPTION
|Related issue|
|---|
|#13939|


## Description

This PR aims to fix Vulnerability Detector for Wazuh Agents running on Windows 8.1 and Windows 8.

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] The data flow works as expected (agent-manager-api-app)
