### PR TITLE
Office365 integration scan messages enrichment

### DIFF
--- a/src/unit_tests/wazuh_modules/office365/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/office365/CMakeLists.txt
@@ -13,7 +13,7 @@ list(APPEND tests_names "test_wm_office365")
 list(APPEND tests_flags "-Wl,--wrap,_mwarn -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mtinfo -Wl,--wrap,_mterror\
                         -Wl,--wrap,_mtwarn -Wl,--wrap,_mtdebug1 -Wl,--wrap,_mtdebug2 -Wl,--wrap,access -Wl,--wrap,wurl_http_request \
                         -Wl,--wrap,wurl_free_response -Wl,--wrap,wm_sendmsg -Wl,--wrap,strftime -Wl,--wrap,gmtime_r \
-                        -Wl,--wrap,wm_state_io -Wl,--wrap,time -Wl,--wrap,StartMQ ${DEBUG_OP_WRAPPERS}")
+                        -Wl,--wrap,wm_state_io -Wl,--wrap,time -Wl,--wrap,StartMQ ${DEBUG_OP_WRAPPERS} -Wl,--wrap,isDebug")
 
 list(APPEND use_shared_libs 1)
 

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -281,6 +281,10 @@ STATIC void wm_office365_execute_scan(wm_office365* office365_config, int initia
     wm_office365_subscription* next_subscription = NULL;
     wm_office365_subscription* current_subscription = NULL;
     wm_office365_fail *tenant_fail = NULL;
+    char start_time_str[80];
+    char end_time_str[80];
+    struct tm tm_start = { .tm_sec = 0 };
+    struct tm tm_end = { .tm_sec = 0 };
 
     while (current_auth != NULL)
     {
@@ -329,6 +333,13 @@ STATIC void wm_office365_execute_scan(wm_office365* office365_config, int initia
                 if (wm_state_io(tenant_state_name, WM_IO_WRITE, &tenant_state_struc, sizeof(tenant_state_struc)) < 0) {
                     mterror(WM_OFFICE365_LOGTAG, "Couldn't save running state.");
                 }
+                else if (isDebug()) {
+                    memset(start_time_str, '\0', 80);
+                    gmtime_r(&now, &tm_start);
+                    strftime(start_time_str, sizeof(start_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_start);
+                    mtdebug1(WM_OFFICE365_LOGTAG, "Bookmark updated to '%s' for tenant '%s' and subscription '%s', waiting '%ld' seconds to run first scan.",
+                        start_time_str, current_auth->tenant_id, current_subscription->subscription_name, office365_config->interval);
+                }
                 current_subscription = next_subscription;
                 continue;
             }
@@ -357,9 +368,7 @@ STATIC void wm_office365_execute_scan(wm_office365* office365_config, int initia
             end_time = now;
 
             while ((end_time - start_time) > 0) {
-                char start_time_str[80];
                 memset(start_time_str, '\0', 80);
-                struct tm tm_start = { .tm_sec = 0 };
                 gmtime_r(&start_time, &tm_start);
                 strftime(start_time_str, sizeof(start_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_start);
 
@@ -367,9 +376,7 @@ STATIC void wm_office365_execute_scan(wm_office365* office365_config, int initia
                     end_time = start_time + DAY_SEC;
                 }
 
-                char end_time_str[80];
                 memset(end_time_str, '\0', 80);
-                struct tm tm_end = { .tm_sec = 0 };
                 gmtime_r(&end_time, &tm_end);
                 strftime(end_time_str, sizeof(end_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_end);
 
@@ -460,6 +467,10 @@ STATIC void wm_office365_execute_scan(wm_office365* office365_config, int initia
                     tenant_state_struc.last_log_time = end_time;
                     if (wm_state_io(tenant_state_name, WM_IO_WRITE, &tenant_state_struc, sizeof(tenant_state_struc)) < 0) {
                         mterror(WM_OFFICE365_LOGTAG, "Couldn't save running state.");
+                    }
+                    else {
+                        mtdebug1(WM_OFFICE365_LOGTAG, "Bookmark updated to '%s' for tenant '%s' and subscription '%s', waiting '%ld' seconds to run next scan.",
+                            end_time_str, current_auth->tenant_id, current_subscription->subscription_name, office365_config->interval);
                     }
 
                     if (tenant_fail = wm_office365_get_fail_by_tenant_and_subscription(office365_config->fails,

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -283,8 +283,7 @@ STATIC void wm_office365_execute_scan(wm_office365* office365_config, int initia
     wm_office365_fail *tenant_fail = NULL;
     char start_time_str[80];
     char end_time_str[80];
-    struct tm tm_start = { .tm_sec = 0 };
-    struct tm tm_end = { .tm_sec = 0 };
+    struct tm tm_aux = { .tm_sec = 0 };
 
     while (current_auth != NULL)
     {
@@ -335,8 +334,8 @@ STATIC void wm_office365_execute_scan(wm_office365* office365_config, int initia
                 }
                 else if (isDebug()) {
                     memset(start_time_str, '\0', 80);
-                    gmtime_r(&now, &tm_start);
-                    strftime(start_time_str, sizeof(start_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_start);
+                    gmtime_r(&now, &tm_aux);
+                    strftime(start_time_str, sizeof(start_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_aux);
                     mtdebug1(WM_OFFICE365_LOGTAG, "Bookmark updated to '%s' for tenant '%s' and subscription '%s', waiting '%ld' seconds to run first scan.",
                         start_time_str, current_auth->tenant_id, current_subscription->subscription_name, office365_config->interval);
                 }
@@ -369,16 +368,16 @@ STATIC void wm_office365_execute_scan(wm_office365* office365_config, int initia
 
             while ((end_time - start_time) > 0) {
                 memset(start_time_str, '\0', 80);
-                gmtime_r(&start_time, &tm_start);
-                strftime(start_time_str, sizeof(start_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_start);
+                gmtime_r(&start_time, &tm_aux);
+                strftime(start_time_str, sizeof(start_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_aux);
 
                 if ((end_time - start_time) > DAY_SEC) {
                     end_time = start_time + DAY_SEC;
                 }
 
                 memset(end_time_str, '\0', 80);
-                gmtime_r(&end_time, &tm_end);
-                strftime(end_time_str, sizeof(end_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_end);
+                gmtime_r(&end_time, &tm_aux);
+                strftime(end_time_str, sizeof(end_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_aux);
 
                 memset(url, '\0', OS_SIZE_8192);
                 snprintf(url, OS_SIZE_8192 -1, WM_OFFICE365_API_CONTENT_BLOB_URL, current_auth->client_id, current_subscription->subscription_name,


### PR DESCRIPTION
|Related issue|Documentation|Manual Testing |
|---|---|---|
|https://github.com/wazuh/wazuh/issues/14091|[Documentation](https://github.com/wazuh/wazuh-documentation/pull/5373)|https://github.com/wazuh/wazuh-qa/issues/3049|


## Description
The goal of this change is encrease the information about how Office365 integration works. 
2 new messages are added, one when first scan runs, with the legend `Bookmark updated to '2022-06-16T18:21:58Z' for tenant <TenatanID> and subscription <SubscriptionID>, waiting '60' seconds to run first scan`, where the first date is the UTC date as the API request to Office365 server, and the `'60' seconds` are the interval time. Second message is similar than first, it only change the word `next` instead the word `first`, and it shows when bookmark is updated. `'2022-06-16T18:21:58Z' for tenant <TenatanID> and subscription <SubscriptionID>, waiting '60' seconds to run first scan`

## Configuration options
ossec.conf 

```
  <office365>
    <enabled>yes</enabled>
    <interval>1m</interval>
    <curl_max_size>1M</curl_max_size>
    <only_future_events>no</only_future_events>
    <api_auth>
        <tenant_id>tenant_id</tenant_id>
        <client_id>client_id</client_id>
        <client_secret>client_secret</client_secret>
    </api_auth>
    <subscriptions>
        <subscription>Audit.SharePoint</subscription>
        <subscription>Audit.AzureActiveDirectory</subscription>
        <subscription>Audit.Exchange</subscription>
        <subscription>Audit.General</subscription>
    </subscriptions>
  </office365>
```

## Logs example
```
2022/06/22 21:55:20 wazuh-modulesd:office365[142854] wm_office365.c:472 at wm_office365_execute_scan(): DEBUG: Bookmark updated to '2022-06-23T00:55:18Z' for tenant '0fea4e03-8146-453b-b889-54b4bd11565b' and subscription 'Audit.SharePoint', waiting '60' seconds to run next scan.
```

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)