### PR TITLE
Fix remoted not updating total bytes sent by UDP

### DIFF
--- a/src/remoted/sendmsg.c
+++ b/src/remoted/sendmsg.c
@@ -116,7 +116,7 @@ int send_msg(const char *agent_id, const char *msg, ssize_t msg_length)
         /* UDP mode, send the message */
         bytes_sent = sendto(logr.udp_sock, crypt_msg, msg_size, 0, (struct sockaddr *)&keys.keyentries[key_id]->peer_info, logr.peer_size);
         error = errno;
-        retval = (bytes_sent == msg_size ? 0 : -1);
+        retval = bytes_sent == msg_size ? 0 : -1;
     } else if (keys.keyentries[key_id]->sock >= 0) {
         /* TCP mode, enqueue the message in the send buffer */
         if (retval = nb_queue(&netbuffer_send, keys.keyentries[key_id]->sock, crypt_msg, msg_size), !retval) {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #13953|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR fixes issue #13953 passing to the function `rem_add_send()` the actual number of bytes sent through udp in function `send_msg()`.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report

<!-- Depending on the affected OS -->
- [x] Added unit tests (for new features)