### PR TITLE
Fix permission error in JSON alert

### DIFF
--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -346,7 +346,7 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf, bool force_full_log, OSList * li
                 if (old_perm = win_perm_to_json(lf->fields[FIM_PERM_BEFORE].value), old_perm) {
                     cJSON_AddItemToObject(file_diff, "win_perm_before", old_perm);
                 } else {
-                    smwarn(list_msg, "The old permissions could not be added to the JSON alert.");
+                    smwarn(list_msg, "The old permissions of the Windows event could not be added to the JSON alert.");
                 }
             } else {
                 cJSON_AddStringToObject(file_diff, "perm_before", lf->fields[FIM_PERM_BEFORE].value);

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -346,7 +346,7 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf, bool force_full_log, OSList * li
                 if (old_perm = win_perm_to_json(lf->fields[FIM_PERM_BEFORE].value), old_perm) {
                     cJSON_AddItemToObject(file_diff, "win_perm_before", old_perm);
                 } else {
-                    smerror(list_msg, "The old permissions could not be added to the JSON alert.");
+                    smwarn(list_msg, "The old permissions could not be added to the JSON alert.");
                 }
             } else {
                 cJSON_AddStringToObject(file_diff, "perm_before", lf->fields[FIM_PERM_BEFORE].value);

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1517,7 +1517,7 @@ cJSON *win_perm_to_json(char *perms) {
         char *username = perm_node;
         perm_node = strchr(perm_node, '(');
         if (!perm_node) {
-            mdebug2("Uncontrolled condition when parsing a Windows permission from '%s'. Skip permission", username);
+            mdebug1("Uncontrolled condition when parsing the username from '%s'. Skipping permission.", username);
             continue;
         }
         *(perm_node++) = '\0';
@@ -1532,7 +1532,7 @@ cJSON *win_perm_to_json(char *perms) {
         char *perm_type = perm_node;
         perm_node = strchr(perm_node, ')');
         if (!perm_node) {
-            mdebug2("Uncontrolled condition when parsing a Windows permission from '%s'. Skip permission", perm_type);
+            mdebug1("Uncontrolled condition when parsing the permission type from '%s'. Skipping permission.", perm_type);
             continue;
         }
         *(perm_node++) = '\0';

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1510,6 +1510,9 @@ cJSON *win_perm_to_json(char *perms) {
         if (perms_it) {
             *(perms_it++) = '\0';
         }
+        else {
+            continue;
+        }
 
         while (*perm_node == ' ') perm_node++;
 
@@ -1517,7 +1520,7 @@ cJSON *win_perm_to_json(char *perms) {
         char *username = perm_node;
         perm_node = strchr(perm_node, '(');
         if (!perm_node) {
-            goto error;
+            continue;
         }
         *(perm_node++) = '\0';
         {
@@ -1531,7 +1534,7 @@ cJSON *win_perm_to_json(char *perms) {
         char *perm_type = perm_node;
         perm_node = strchr(perm_node, ')');
         if (!perm_node) {
-            goto error;
+            continue;
         }
         *(perm_node++) = '\0';
 

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1510,9 +1510,6 @@ cJSON *win_perm_to_json(char *perms) {
         if (perms_it) {
             *(perms_it++) = '\0';
         }
-        else {
-            continue;
-        }
 
         while (*perm_node == ' ') perm_node++;
 
@@ -1520,6 +1517,7 @@ cJSON *win_perm_to_json(char *perms) {
         char *username = perm_node;
         perm_node = strchr(perm_node, '(');
         if (!perm_node) {
+            mdebug2("Uncontrolled condition when parsing a Windows permission from '%s'. Skip permission", username);
             continue;
         }
         *(perm_node++) = '\0';
@@ -1534,6 +1532,7 @@ cJSON *win_perm_to_json(char *perms) {
         char *perm_type = perm_node;
         perm_node = strchr(perm_node, ')');
         if (!perm_node) {
+            mdebug2("Uncontrolled condition when parsing a Windows permission from '%s'. Skip permission", perm_type);
             continue;
         }
         *(perm_node++) = '\0';
@@ -1612,6 +1611,12 @@ cJSON *win_perm_to_json(char *perms) {
     }
 
     free(perms_cpy);
+    if(cJSON_GetArraySize(perms_json) == 0)
+    {
+        cJSON_Delete(perms_json);
+        return NULL;
+    }
+
     return perms_json;
 error:
     mdebug1("Uncontrolled condition when parsing a Windows permission from '%s'.", perms);

--- a/src/unit_tests/shared/test_syscheck_op.c
+++ b/src/unit_tests/shared/test_syscheck_op.c
@@ -3234,8 +3234,8 @@ static void test_win_perm_to_json_malformed_permission_1(void **state) {
     will_return(__wrap_cJSON_CreateArray, __real_cJSON_CreateArray());
 
     will_return_always(__wrap_wstr_split, 1);  // use real wstr_split
-    expect_string(__wrap__mdebug2, formatted_msg,
-        "Uncontrolled condition when parsing a Windows permission from 'fourth '. Skip permission");
+    expect_string(__wrap__mdebug1, formatted_msg,
+        "Uncontrolled condition when parsing the username from 'fourth '. Skipping permission.");
     output = win_perm_to_json(input);
 
     *state = output;
@@ -3330,8 +3330,8 @@ static void test_win_perm_to_json_malformed_permission_2(void **state) {
     will_return(__wrap_cJSON_CreateArray, __real_cJSON_CreateArray());
 
     will_return_always(__wrap_wstr_split, 1);  // use real wstr_split
-    expect_string(__wrap__mdebug2, formatted_msg,
-        "Uncontrolled condition when parsing a Windows permission from 'error'. Skip permission");
+    expect_string(__wrap__mdebug1, formatted_msg,
+        "Uncontrolled condition when parsing the permission type from 'error'. Skipping permission.");
     output = win_perm_to_json(input);
 
     *state = output;
@@ -3478,8 +3478,8 @@ static void test_win_perm_to_json_incorrect_permission_format(void **state) {
 
     will_return(__wrap_cJSON_CreateArray, __real_cJSON_CreateArray());
 
-    expect_string(__wrap__mdebug2, formatted_msg,
-        "Uncontrolled condition when parsing a Windows permission from 'This format is incorrect'. Skip permission");
+    expect_string(__wrap__mdebug1, formatted_msg,
+        "Uncontrolled condition when parsing the username from 'This format is incorrect'. Skipping permission.");
 
     output = win_perm_to_json(input);
 
@@ -3491,8 +3491,8 @@ static void test_win_perm_to_json_incorrect_permission_format_2(void **state) {
 
     will_return(__wrap_cJSON_CreateArray, __real_cJSON_CreateArray());
 
-    expect_string(__wrap__mdebug2, formatted_msg,
-        "Uncontrolled condition when parsing a Windows permission from 'too'. Skip permission");
+    expect_string(__wrap__mdebug1, formatted_msg,
+        "Uncontrolled condition when parsing the permission type from 'too'. Skipping permission.");
 
     output = win_perm_to_json(input);
 


### PR DESCRIPTION
|Issue|
|---|
| Closes #12073  |

## Description

When `FIM` is run on Windows logs with a malformed permission, the `analysisd` module generates a log message and discards this permission. This PR is to add changes to this behavior, right now the module `analysisd` reads permissions and discard only malformed permissions.

## Logs/Alerts example
[Syscheck stress test result](https://github.com/wazuh/wazuh/issues/12007),

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [x] Run stress test ([result](https://github.com/wazuh/wazuh/issues/12073#issuecomment-1165931629))
- [x] Add unit tests to new code

