### PR TITLE
Limit rsync dispatch queue elements.

### DIFF
--- a/src/shared_modules/common/commonDefs.h
+++ b/src/shared_modules/common/commonDefs.h
@@ -120,4 +120,11 @@ typedef struct
  */
 typedef void((*log_fnc_t)(const char* msg));
 
+/**
+* @brief Definition to indicate the unlimited queue.
+*
+* @details It's used to define the unlimited queue size.
+*/
+#define UNLIMITED_QUEUE_SIZE 0
+
 #endif // _COMMON_DEFS_H_

--- a/src/shared_modules/rsync/include/rsync.h
+++ b/src/shared_modules/rsync/include/rsync.h
@@ -46,9 +46,10 @@ EXPORTED void rsync_teardown(void);
 /**
  * @brief Creates a new RSync instance.
  *
+ * @param max_queue_size Size of the message dispatch queue
  * @return Handle instance to be used for synchronization between the manager and the agent.
  */
-EXPORTED RSYNC_HANDLE rsync_create();
+EXPORTED RSYNC_HANDLE rsync_create(const size_t max_queue_size);
 
 /**
  * @brief Initializes the \p handle instance.

--- a/src/shared_modules/rsync/include/rsync.h
+++ b/src/shared_modules/rsync/include/rsync.h
@@ -46,7 +46,7 @@ EXPORTED void rsync_teardown(void);
 /**
  * @brief Creates a new RSync instance.
  *
- * @param max_queue_size Size of the message dispatch queue
+ * @param max_queue_size Size of the message dispatch queue, if the value is 0, it is unlimited.
  * @return Handle instance to be used for synchronization between the manager and the agent.
  */
 EXPORTED RSYNC_HANDLE rsync_create(const size_t max_queue_size);

--- a/src/shared_modules/rsync/include/rsync.hpp
+++ b/src/shared_modules/rsync/include/rsync.hpp
@@ -44,9 +44,9 @@ public:
     /**
      * @brief Remote sync initializes the instance.
      *
-     * @param maxQueueSize Maximum size of the queue, if the value is 0, it is unlimited.
+     * @param maxQueueSize Maximum size of the queue.
      */
-    RemoteSync(const size_t maxQueueSize = 0);
+    RemoteSync(const size_t maxQueueSize = UNLIMITED_QUEUE_SIZE);
 
     /**
      * @brief RSync Constructor.

--- a/src/shared_modules/rsync/include/rsync.hpp
+++ b/src/shared_modules/rsync/include/rsync.hpp
@@ -44,7 +44,7 @@ public:
     /**
      * @brief Remote sync initializes the instance.
      *
-     * @param maxQueueSize Maximum size of the queue.
+     * @param maxQueueSize Maximum size of the queue, if the value is 0, it is unlimited.
      */
     RemoteSync(const size_t maxQueueSize = 0);
 

--- a/src/shared_modules/rsync/include/rsync.hpp
+++ b/src/shared_modules/rsync/include/rsync.hpp
@@ -31,25 +31,27 @@
 
 using SyncCallbackData = const std::function<void(const std::string&)>;
 
-class EXPORTED RemoteSync 
+class EXPORTED RemoteSync
 {
 public:
     /**
     * @brief Initializes the shared library.
     *
-    * @param logFunction pointer to log function to be used by the rsync.
+    * @param logFunction Pointer to log function to be used by the rsync.
     */
     static void initialize(std::function<void(const std::string&)> logFunction);
 
     /**
-     * @brief Remote sync initializes the instance. 
+     * @brief Remote sync initializes the instance.
+     *
+     * @param maxQueueSize Maximum size of the queue.
      */
-    RemoteSync();
+    RemoteSync(const size_t maxQueueSize = 0);
 
     /**
      * @brief RSync Constructor.
      *
-     * @param handle     handle to point another rsync instance.
+     * @param handle Handle to point another rsync instance.
      *
      */
     RemoteSync(RSYNC_HANDLE handle);
@@ -67,7 +69,7 @@ public:
      * @param dbsyncHandle       DBSync handle to synchronize databases.
      * @param startConfiguration Statement used as a synchronization start.
      * @param callbackData       This callback is used to send sync information.
-     * 
+     *
      */
     virtual void startSync(const DBSYNC_HANDLE   dbsyncHandle,
                            const nlohmann::json& startConfiguration,
@@ -83,12 +85,12 @@ public:
      * @param callbackData       This callback is used to send sync information.
      *
      */
-    virtual void registerSyncID(const std::string&    messageHeaderID, 
+    virtual void registerSyncID(const std::string&    messageHeaderID,
                                 const DBSYNC_HANDLE   dbsyncHandle,
                                 const nlohmann::json& syncConfiguration,
                                 SyncCallbackData      callbackData);
     /**
-     * @brief Pushes the \p payload message within a queue to process it in an async 
+     * @brief Pushes the \p payload message within a queue to process it in an async
      *  dispatch queue.
      *
      * @param payload Message to be queued and processed.

--- a/src/shared_modules/rsync/src/rsync.cpp
+++ b/src/shared_modules/rsync/src/rsync.cpp
@@ -46,14 +46,14 @@ EXPORTED void rsync_teardown(void)
     RSyncImplementation::instance().release();
 }
 
-EXPORTED RSYNC_HANDLE rsync_create()
+EXPORTED RSYNC_HANDLE rsync_create(const size_t maxQueueSize)
 {
     RSYNC_HANDLE retVal{ nullptr };
     std::string errorMessage;
 
     try
     {
-        retVal = RSyncImplementation::instance().create();
+        retVal = RSyncImplementation::instance().create(maxQueueSize);
     }
     // LCOV_EXCL_START
     catch (...)
@@ -221,8 +221,8 @@ void RemoteSync::teardown()
     RSyncImplementation::instance().release();
 }
 
-RemoteSync::RemoteSync()
-    : m_handle { RSyncImplementation::instance().create() }
+RemoteSync::RemoteSync(const size_t maxQueueSize)
+    : m_handle { RSyncImplementation::instance().create(maxQueueSize) }
     , m_shouldBeRemoved{ true }
 
 { }

--- a/src/shared_modules/rsync/src/rsyncImplementation.h
+++ b/src/shared_modules/rsync/src/rsyncImplementation.h
@@ -87,7 +87,7 @@ namespace RSync
 
             void releaseContext(const RSYNC_HANDLE handle);
 
-            RSYNC_HANDLE create(const size_t maxQueueSize = 0);
+            RSYNC_HANDLE create(const size_t maxQueueSize = UNLIMITED_QUEUE_SIZE);
 
             void startRSync(const RSYNC_HANDLE handle,
                             const std::shared_ptr<DBSyncWrapper>& spDBSyncWrapper,

--- a/src/shared_modules/rsync/src/rsyncImplementation.h
+++ b/src/shared_modules/rsync/src/rsyncImplementation.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <mutex>
 #include <functional>
+#include <memory>
 #include "commonDefs.h"
 #include "json.hpp"
 #include "registrationController.hpp"
@@ -86,7 +87,7 @@ namespace RSync
 
             void releaseContext(const RSYNC_HANDLE handle);
 
-            RSYNC_HANDLE create();
+            RSYNC_HANDLE create(const size_t maxQueueSize = 0);
 
             void startRSync(const RSYNC_HANDLE handle,
                             const std::shared_ptr<DBSyncWrapper>& spDBSyncWrapper,
@@ -110,8 +111,10 @@ namespace RSync
             class RSyncContext final
             {
                 public:
-                    RSyncContext() = default;
-                    MsgDispatcher m_msgDispatcher;
+                    RSyncContext(const size_t maxQueueSize)
+                        : m_msgDispatcher { std::make_shared<MsgDispatcher>(maxQueueSize) }
+                    { }
+                    std::shared_ptr<MsgDispatcher> m_msgDispatcher;
             };
 
             std::shared_ptr<RSyncContext> remoteSyncContext(const RSYNC_HANDLE handle);

--- a/src/shared_modules/rsync/tests/interface/rsync_test.cpp
+++ b/src/shared_modules/rsync/tests/interface/rsync_test.cpp
@@ -35,7 +35,7 @@ constexpr auto SQL_STMT_INFO
     CREATE INDEX inode_index ON entry_path (inode_id);
     COMMIT;)"
 };
-constexpr size_t maxQueueSize {0};
+constexpr size_t maxQueueSize {UNLIMITED_QUEUE_SIZE};
 
 class CallbackMock
 {

--- a/src/shared_modules/rsync/tests/interface/rsync_test.cpp
+++ b/src/shared_modules/rsync/tests/interface/rsync_test.cpp
@@ -35,6 +35,7 @@ constexpr auto SQL_STMT_INFO
     CREATE INDEX inode_index ON entry_path (inode_id);
     COMMIT;)"
 };
+constexpr size_t maxQueueSize {0};
 
 class CallbackMock
 {
@@ -83,7 +84,7 @@ void RSyncTest::TearDown()
 
 TEST_F(RSyncTest, Initialization)
 {
-    const auto handle { rsync_create() };
+    const auto handle { rsync_create(maxQueueSize) };
     ASSERT_NE(nullptr, handle);
 }
 
@@ -92,7 +93,7 @@ TEST_F(RSyncTest, startSyncWithInvalidParams)
     const auto dbsyncHandle { dbsync_create(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, SQL_STMT_INFO) };
     ASSERT_NE(nullptr, dbsyncHandle);
 
-    const auto rsyncHandle { rsync_create() };
+    const auto rsyncHandle { rsync_create(maxQueueSize) };
     ASSERT_NE(nullptr, rsyncHandle);
 
     const auto startConfigStmt
@@ -113,7 +114,7 @@ TEST_F(RSyncTest, startSyncWithoutExtraParams)
     const auto dbsyncHandle { dbsync_create(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, SQL_STMT_INFO) };
     ASSERT_NE(nullptr, dbsyncHandle);
 
-    const auto rsyncHandle { rsync_create() };
+    const auto rsyncHandle { rsync_create(maxQueueSize) };
     ASSERT_NE(nullptr, rsyncHandle);
 
     const auto startConfigStmt
@@ -130,7 +131,7 @@ TEST_F(RSyncTest, startSyncWithBadSelectQuery)
     const auto dbsyncHandle { dbsync_create(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, SQL_STMT_INFO) };
     ASSERT_NE(nullptr, dbsyncHandle);
 
-    const auto rsyncHandle { rsync_create() };
+    const auto rsyncHandle { rsync_create(maxQueueSize) };
     ASSERT_NE(nullptr, rsyncHandle);
 
     const auto startConfigStmt
@@ -178,7 +179,7 @@ TEST_F(RSyncTest, startSyncWithIntegrityClear)
     const auto dbsyncHandle { dbsync_create(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql) };
     ASSERT_NE(nullptr, dbsyncHandle);
 
-    const auto rsyncHandle { rsync_create() };
+    const auto rsyncHandle { rsync_create(maxQueueSize) };
     ASSERT_NE(nullptr, rsyncHandle);
 
     const auto expectedResult1
@@ -265,7 +266,7 @@ TEST_F(RSyncTest, startSyncIntegrityGlobal)
     const auto dbsyncHandle { dbsync_create(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, SQL_STMT_INFO) };
     ASSERT_NE(nullptr, dbsyncHandle);
 
-    const auto rsyncHandle { rsync_create() };
+    const auto rsyncHandle { rsync_create(maxQueueSize) };
     ASSERT_NE(nullptr, rsyncHandle);
 
     const auto expectedResult1
@@ -350,14 +351,14 @@ TEST_F(RSyncTest, startSyncIntegrityGlobal)
 }
 TEST_F(RSyncTest, registerIncorrectSyncId)
 {
-    const auto handle { rsync_create() };
+    const auto handle { rsync_create(maxQueueSize) };
     ASSERT_EQ(-1, rsync_register_sync_id(handle, nullptr, nullptr, nullptr, {}));
 }
 
 TEST_F(RSyncTest, pushMessage)
 {
     const std::string buffer{"test buffer"};
-    const auto handle { rsync_create() };
+    const auto handle { rsync_create(maxQueueSize) };
     ASSERT_NE(0, rsync_push_message(handle, nullptr, 1000));
     ASSERT_NE(0, rsync_push_message(handle, reinterpret_cast<const void*>(0x1000), 0));
     ASSERT_EQ(0, rsync_push_message(handle, reinterpret_cast<const void*>(buffer.data()), buffer.size()));
@@ -370,7 +371,7 @@ TEST_F(RSyncTest, CloseWithoutInitialization)
 
 TEST_F(RSyncTest, CloseCorrectInitialization)
 {
-    const auto handle { rsync_create() };
+    const auto handle { rsync_create(maxQueueSize) };
     ASSERT_NE(nullptr, handle);
     EXPECT_EQ(0, rsync_close(handle));
 }
@@ -380,7 +381,7 @@ TEST_F(RSyncTest, RegisterAndPush)
     const auto handle_dbsync { dbsync_create(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, SQL_STMT_INFO) };
     ASSERT_NE(nullptr, handle_dbsync);
 
-    const auto handle_rsync { rsync_create() };
+    const auto handle_rsync { rsync_create(maxQueueSize) };
     ASSERT_NE(nullptr, handle_rsync);
 
     const auto expectedResult1
@@ -497,7 +498,7 @@ TEST_F(RSyncTest, RegisterIncorrectQueryAndPush)
     const auto handle_dbsync { dbsync_create(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, SQL_STMT_INFO) };
     ASSERT_NE(nullptr, handle_dbsync);
 
-    const auto handle_rsync { rsync_create() };
+    const auto handle_rsync { rsync_create(maxQueueSize) };
     ASSERT_NE(nullptr, handle_rsync);
 
     const auto registerConfigStmt

--- a/src/shared_modules/rsync/testtool/agentEmulator.cpp
+++ b/src/shared_modules/rsync/testtool/agentEmulator.cpp
@@ -44,9 +44,10 @@ static void callback(const ReturnTypeCallback /*type*/,
 AgentEmulator::AgentEmulator(const std::chrono::milliseconds updatePeriod,
                              const unsigned int maxDbItems,
                              const std::shared_ptr<SyncQueue>& outQueue,
-                             const std::string& dbFolder)
+                             const std::string& dbFolder,
+                             const size_t maxQueueSize)
     : m_agentId{ std::to_string(reinterpret_cast<unsigned long>(this)) }
-    , m_rsyncHandle{ rsync_create() }
+    , m_rsyncHandle{ rsync_create(maxQueueSize) }
     , m_dbSyncHandle{ createDbsyncHandle(dbFolder + m_agentId + ".db") }
     , m_config{ nullptr }//TODO: define config based on dbsync handle create statement
     , m_startConfig{ nullptr }//TODO: define config based on first/last sync information statement

--- a/src/shared_modules/rsync/testtool/agentEmulator.h
+++ b/src/shared_modules/rsync/testtool/agentEmulator.h
@@ -32,7 +32,8 @@ class AgentEmulator
         AgentEmulator(const std::chrono::milliseconds updatePeriod,
                       const unsigned int maxDbItems,
                       const std::shared_ptr<SyncQueue>& outQueue,
-                      const std::string& dbFolder);
+                      const std::string& dbFolder,
+                      const size_t maxQueueSize);
         ~AgentEmulator();
     private:
 

--- a/src/shared_modules/rsync/testtool/main.cpp
+++ b/src/shared_modules/rsync/testtool/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, const char* argv[])
             };
             const std::chrono::milliseconds syncPeriod{100};
             const auto maxDbItems{100};
-            const size_t maxQueueSize{0};
+            const size_t maxQueueSize{UNLIMITED_QUEUE_SIZE};
             AgentEmulator agent{syncPeriod, maxDbItems, syncQueue, args.outputFolder(), maxQueueSize};
             ManagerEmulator manager{syncQueue};
 
@@ -68,7 +68,7 @@ int main(int argc, const char* argv[])
 
             const auto& jsonConfigFile { nlohmann::json::parse(configFile) };
             const auto& jsonInputFile { nlohmann::json::parse(inputData) };
-            const size_t maxQueueSize{0};
+            const size_t maxQueueSize{UNLIMITED_QUEUE_SIZE};
             OneTimeSync otSync(jsonConfigFile,
                                jsonInputFile,
                                args.outputFolder(),

--- a/src/shared_modules/rsync/testtool/main.cpp
+++ b/src/shared_modules/rsync/testtool/main.cpp
@@ -39,7 +39,8 @@ int main(int argc, const char* argv[])
             };
             const std::chrono::milliseconds syncPeriod{100};
             const auto maxDbItems{100};
-            AgentEmulator agent{syncPeriod, maxDbItems, syncQueue, args.outputFolder()};
+            const size_t maxQueueSize{0};
+            AgentEmulator agent{syncPeriod, maxDbItems, syncQueue, args.outputFolder(), maxQueueSize};
             ManagerEmulator manager{syncQueue};
 
             while (getc(stdin) != 'q');
@@ -67,9 +68,11 @@ int main(int argc, const char* argv[])
 
             const auto& jsonConfigFile { nlohmann::json::parse(configFile) };
             const auto& jsonInputFile { nlohmann::json::parse(inputData) };
+            const size_t maxQueueSize{0};
             OneTimeSync otSync(jsonConfigFile,
                                jsonInputFile,
-                               args.outputFolder());
+                               args.outputFolder(),
+                               maxQueueSize);
             otSync.syncData();
             otSync.pushData();
             otSync.startSync();

--- a/src/shared_modules/rsync/testtool/oneTimeSync.cpp
+++ b/src/shared_modules/rsync/testtool/oneTimeSync.cpp
@@ -40,8 +40,9 @@ DBSYNC_HANDLE getDbsyncHandle(const nlohmann::json& config)
 
 OneTimeSync::OneTimeSync(const nlohmann::json& config,
                          const nlohmann::json& inputData,
-                         const std::string& outputFolder)
-    : m_rsyncHandle{ rsync_create() }
+                         const std::string& outputFolder,
+                         const size_t maxQueueSize)
+    : m_rsyncHandle{ rsync_create(maxQueueSize) }
     , m_dbSyncHandle{ getDbsyncHandle(config.at("dbsync")) }
     , m_inputData{ inputData }
     , m_outputFolder{ outputFolder }

--- a/src/shared_modules/rsync/testtool/oneTimeSync.h
+++ b/src/shared_modules/rsync/testtool/oneTimeSync.h
@@ -21,7 +21,8 @@ class OneTimeSync final
     public:
         OneTimeSync(const nlohmann::json& config,
                     const nlohmann::json& inputData,
-                    const std::string& outputFolder);
+                    const std::string& outputFolder,
+                    const size_t maxQueueSize);
         ~OneTimeSync();
         void syncData();
         void pushData();

--- a/src/shared_modules/utils/msgDispatcher.h
+++ b/src/shared_modules/utils/msgDispatcher.h
@@ -15,6 +15,7 @@
 #include <mutex>
 #include <functional>
 #include <utility>
+#include "commonDefs.h"
 #include "threadDispatcher.h"
 
 namespace Utils
@@ -32,7 +33,7 @@ namespace Utils
         , public RawValueDecoder
     {
         public:
-            MsgDispatcher(const size_t maxQueueSize = 0)
+            MsgDispatcher(const size_t maxQueueSize = UNLIMITED_QUEUE_SIZE)
                 : ThreadType
             {
                 std::bind(&DispatcherType::dispatch, this, std::placeholders::_1),

--- a/src/shared_modules/utils/msgDispatcher.h
+++ b/src/shared_modules/utils/msgDispatcher.h
@@ -34,11 +34,11 @@ namespace Utils
         public:
             MsgDispatcher(const size_t maxQueueSize = 0)
                 : ThreadType
-                {
-                    std::bind(&DispatcherType::dispatch, this, std::placeholders::_1),
-                    std::thread::hardware_concurrency(),
-                    maxQueueSize
-                }
+            {
+                std::bind(&DispatcherType::dispatch, this, std::placeholders::_1),
+                std::thread::hardware_concurrency(),
+                maxQueueSize
+            }
             {
             }
             // LCOV_EXCL_START

--- a/src/shared_modules/utils/msgDispatcher.h
+++ b/src/shared_modules/utils/msgDispatcher.h
@@ -32,8 +32,13 @@ namespace Utils
         , public RawValueDecoder
     {
         public:
-            MsgDispatcher()
-                : ThreadType{std::bind(&DispatcherType::dispatch, this, std::placeholders::_1)}
+            MsgDispatcher(const size_t maxQueueSize = 0)
+                : ThreadType
+                {
+                    std::bind(&DispatcherType::dispatch, this, std::placeholders::_1),
+                    std::thread::hardware_concurrency(),
+                    maxQueueSize
+                }
             {
             }
             // LCOV_EXCL_START

--- a/src/shared_modules/utils/pipelineNodesImp.h
+++ b/src/shared_modules/utils/pipelineNodesImp.h
@@ -31,7 +31,7 @@ namespace Utils
             {}
             ReadNode(Functor functor,
                      const unsigned int numberOfThreads)
-                : DispatcherType{ functor, numberOfThreads, 0 }
+                : DispatcherType{ functor, numberOfThreads, UNLIMITED_QUEUE_SIZE }
             {}
             // LCOV_EXCL_START
             ~ReadNode() = default;
@@ -63,7 +63,7 @@ namespace Utils
             {}
             ReadWriteNode(Functor functor,
                           const unsigned int numberOfThreads)
-                : DispatcherType{ std::bind(&RWNodeType::doTheWork, this, std::placeholders::_1), numberOfThreads, 0 }
+                : DispatcherType{ std::bind(&RWNodeType::doTheWork, this, std::placeholders::_1), numberOfThreads, UNLIMITED_QUEUE_SIZE }
                 , m_functor{functor}
             {}
             // LCOV_EXCL_START

--- a/src/shared_modules/utils/pipelineNodesImp.h
+++ b/src/shared_modules/utils/pipelineNodesImp.h
@@ -31,7 +31,7 @@ namespace Utils
             {}
             ReadNode(Functor functor,
                      const unsigned int numberOfThreads)
-                : DispatcherType{ functor, numberOfThreads }
+                : DispatcherType{ functor, numberOfThreads, 0 }
             {}
             // LCOV_EXCL_START
             ~ReadNode() = default;
@@ -63,7 +63,7 @@ namespace Utils
             {}
             ReadWriteNode(Functor functor,
                           const unsigned int numberOfThreads)
-                : DispatcherType{ std::bind(&RWNodeType::doTheWork, this, std::placeholders::_1), numberOfThreads }
+                : DispatcherType{ std::bind(&RWNodeType::doTheWork, this, std::placeholders::_1), numberOfThreads, 0 }
                 , m_functor{functor}
             {}
             // LCOV_EXCL_START

--- a/src/shared_modules/utils/tests/CMakeLists.txt
+++ b/src/shared_modules/utils/tests/CMakeLists.txt
@@ -16,11 +16,13 @@ set(CMAKE_CXX_FLAGS_DEBUG "-g --coverage")
 
 include_directories(${SRC_FOLDER}/)
 include_directories(${SRC_FOLDER}/headers/)
+include_directories(${SRC_FOLDER}/shared_modules/common/)
 include_directories(${SRC_FOLDER}/shared_modules/utils/)
 include_directories(${SRC_FOLDER}/external/googletest/googletest/include/)
 include_directories(${SRC_FOLDER}/external/googletest/googlemock/include/)
 include_directories(${SRC_FOLDER}/external/openssl/include/)
 include_directories(${SRC_FOLDER}/external/nlohmann/)
+include_directories(${SRC_FOLDER}/external/cJSON/)
 
 file(GLOB UTIL_CXX_UNITTEST_WINDOWS_SRC
     "windowsHelper_test.cpp"

--- a/src/shared_modules/utils/tests/threadDispatcher_test.cpp
+++ b/src/shared_modules/utils/tests/threadDispatcher_test.cpp
@@ -79,3 +79,29 @@ TEST_F(ThreadDispatcherTest, AsyncDispatcherCancel)
     dispatcher.rundown();
     EXPECT_EQ(0ul, dispatcher.size());
 }
+
+TEST_F(ThreadDispatcherTest, AsyncDispatcherQueue)
+{
+    constexpr auto NUMBER_OF_THREADS { 1ul };
+    constexpr auto MAX_QUEUE_SIZE { 5ull };
+    constexpr auto NUMBER_OF_ITEMS { 10 };
+
+    AsyncDispatcher<int, std::function<void(int)>> dispatcher
+    {
+        [](const int value)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(value));
+        }
+        , NUMBER_OF_THREADS
+        , MAX_QUEUE_SIZE
+    };
+
+    for (int i = 0; i < NUMBER_OF_ITEMS; ++i)
+    {
+        dispatcher.push(1000);
+    }
+
+    EXPECT_EQ(MAX_QUEUE_SIZE - NUMBER_OF_THREADS, dispatcher.size() - NUMBER_OF_THREADS);
+    dispatcher.cancel();
+}
+

--- a/src/shared_modules/utils/threadDispatcher.h
+++ b/src/shared_modules/utils/threadDispatcher.h
@@ -94,9 +94,9 @@ namespace Utils
                         m_queue.push
                         (
                             [value, this]()
-                            {
-                                this->m_functor(value);
-                            }
+                        {
+                            this->m_functor(value);
+                        }
                         );
                     }
                 }

--- a/src/shared_modules/utils/threadDispatcher.h
+++ b/src/shared_modules/utils/threadDispatcher.h
@@ -18,6 +18,12 @@
 #include <functional>
 #include <iostream>
 #include "threadSafeQueue.h"
+
+constexpr auto UNLIMITED_QUEUE_SIZE
+{
+    0
+};
+
 namespace Utils
 {
     // *
@@ -65,7 +71,7 @@ namespace Utils
     class AsyncDispatcher
     {
         public:
-            AsyncDispatcher(Functor functor, const unsigned int numberOfThreads = std::thread::hardware_concurrency(), const size_t maxQueueSize = 0)
+            AsyncDispatcher(Functor functor, const unsigned int numberOfThreads = std::thread::hardware_concurrency(), const size_t maxQueueSize = UNLIMITED_QUEUE_SIZE)
                 : m_functor{ functor }
                 , m_running{ true }
                 , m_numberOfThreads{ numberOfThreads }
@@ -89,7 +95,7 @@ namespace Utils
             {
                 if (m_running)
                 {
-                    if (0 == m_maxQueueSize || m_queue.size() < m_maxQueueSize)
+                    if (UNLIMITED_QUEUE_SIZE == m_maxQueueSize || m_queue.size() < m_maxQueueSize)
                     {
                         m_queue.push
                         (

--- a/src/shared_modules/utils/threadDispatcher.h
+++ b/src/shared_modules/utils/threadDispatcher.h
@@ -65,10 +65,11 @@ namespace Utils
     class AsyncDispatcher
     {
         public:
-            AsyncDispatcher(Functor functor, const unsigned int numberOfThreads = std::thread::hardware_concurrency())
+            AsyncDispatcher(Functor functor, const unsigned int numberOfThreads = std::thread::hardware_concurrency(), const size_t maxQueueSize = 0)
                 : m_functor{ functor }
                 , m_running{ true }
                 , m_numberOfThreads{ numberOfThreads }
+                , m_maxQueueSize { maxQueueSize }
             {
                 m_threads.reserve(m_numberOfThreads);
 
@@ -88,13 +89,16 @@ namespace Utils
             {
                 if (m_running)
                 {
-                    m_queue.push
-                    (
-                        [value, this]()
+                    if (0 == m_maxQueueSize || m_queue.size() < m_maxQueueSize)
                     {
-                        this->m_functor(value);
+                        m_queue.push
+                        (
+                            [value, this]()
+                            {
+                                this->m_functor(value);
+                            }
+                        );
                     }
-                    );
                 }
             }
 
@@ -171,13 +175,14 @@ namespace Utils
             std::vector<std::thread> m_threads;
             std::atomic_bool m_running;
             const unsigned int m_numberOfThreads;
+            const size_t m_maxQueueSize;
     };
 
     template <typename Input, typename Functor>
     class SyncDispatcher
     {
         public:
-            SyncDispatcher(Functor functor, const unsigned int /*numberOfThreads = 0*/)
+            SyncDispatcher(Functor functor, const unsigned int /*numberOfThreads = 0*/, const size_t /*maxQueueSize = 0*/)
                 : m_functor{functor}
                 , m_running{true}
             {

--- a/src/shared_modules/utils/threadDispatcher.h
+++ b/src/shared_modules/utils/threadDispatcher.h
@@ -18,11 +18,7 @@
 #include <functional>
 #include <iostream>
 #include "threadSafeQueue.h"
-
-constexpr auto UNLIMITED_QUEUE_SIZE
-{
-    0
-};
+#include "commonDefs.h"
 
 namespace Utils
 {
@@ -188,7 +184,7 @@ namespace Utils
     class SyncDispatcher
     {
         public:
-            SyncDispatcher(Functor functor, const unsigned int /*numberOfThreads = 0*/, const size_t /*maxQueueSize = 0*/)
+            SyncDispatcher(Functor functor, const unsigned int /*numberOfThreads = 0*/, const size_t /*maxQueueSize = UNLIMITED_QUEUE_SIZE*/)
                 : m_functor{functor}
                 , m_running{true}
             {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #13954  |

## Description
This issue aims to add an item-in-memory limit to rsync response queues.

This limit must be configurable in the rsync instance, for the module that wants to implement it.