### PR TITLE
Split configuration for FIMDB registry and file limits 

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1578,10 +1578,10 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
     const char *xml_database = "database";
     const char *xml_scantime = "scan_time";
     const char *xml_file_limit = "file_limit";
-    const char *xml_registry_limit = "registry_limit";
     const char *xml_enabled = "enabled";
     const char *xml_entries = "entries";
 #ifdef WIN32
+    const char *xml_registry_limit = "registry_limit";
 #endif
     const char *xml_ignore = "ignore";
     const char *xml_registry_ignore = "registry_ignore";

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -103,9 +103,6 @@ int initialize_syscheck_configuration(syscheck_config *syscheck) {
     syscheck->registry_limit_enabled          = true;
     syscheck->db_entry_registry_limit         = 100000;
     syscheck->realtime_change                 = 0;
-
-
-
     syscheck->registry                        = NULL;
     syscheck->key_ignore                      = NULL;
     syscheck->key_ignore_regex                = NULL;
@@ -1790,7 +1787,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                     syscheck->db_entry_registry_limit = atoi(children[j]->content);
 
                     if (syscheck->db_entry_registry_limit < 0) {
-                        mdebug2("Maximum value allowed for file_limit is '%d'", MAX_FILE_LIMIT);
+                        mdebug2("Maximum value allowed for registry_limit is '%d'", MAX_FILE_LIMIT);
                         syscheck->db_entry_registry_limit = MAX_FILE_LIMIT;
                     }
                 }

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -103,6 +103,9 @@ int initialize_syscheck_configuration(syscheck_config *syscheck) {
     syscheck->registry_limit_enabled          = true;
     syscheck->db_entry_registry_limit         = 100000;
     syscheck->realtime_change                 = 0;
+
+
+
     syscheck->registry                        = NULL;
     syscheck->key_ignore                      = NULL;
     syscheck->key_ignore_regex                = NULL;
@@ -1587,7 +1590,6 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
     const char *xml_registry_ignore = "registry_ignore";
 #ifdef WIN32
     const char *xml_registry_ignore_value = "registry_ignore_value";
-    const char *xml_db_entry_registry_limit = "registries";
 #endif
     const char *xml_auto_ignore = "auto_ignore"; // TODO: Deprecated since 3.11.0
     const char *xml_alert_new_files = "alert_new_files"; // TODO: Deprecated since 3.11.0

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -79,8 +79,8 @@ int initialize_syscheck_configuration(syscheck_config *syscheck) {
     syscheck->nodiff_regex                    = NULL;
     syscheck->scan_day                        = NULL;
     syscheck->scan_time                       = NULL;
-    syscheck->db_entry_limit_enabled          = true;
-    syscheck->db_entry_file_limit             = 100000;
+    syscheck->file_limit_enabled              = true;
+    syscheck->file_entry_limit                = 100000;
     syscheck->directories                     = OSList_Create();
 
     if (syscheck->directories == NULL) {
@@ -100,6 +100,7 @@ int initialize_syscheck_configuration(syscheck_config *syscheck) {
     syscheck->wdata.fd                        = NULL;
 #endif
 #ifdef WIN32
+    syscheck->registry_limit_enabled          = true
     syscheck->db_entry_registry_limit         = 100000;
     syscheck->realtime_change                 = 0;
     syscheck->registry                        = NULL;
@@ -1576,11 +1577,12 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
     const char *xml_scanday = "scan_day";
     const char *xml_database = "database";
     const char *xml_scantime = "scan_time";
-    const char *xml_file_limit = "file_limit"; // Deprecated
-    const char *xml_file_limit_entries = "entries"; // Deprecated
-    const char *xml_db_entry = "db_entry_limit";
-    const char *xml_db_entry_enabled = "enabled";
-    const char *xml_db_entry_file_limit = "files";
+    const char *xml_file_limit = "file_limit";
+    const char *xml_enabled = "enabled";
+    const char *xml_entries = "entries";
+#ifdef WIN32
+    const char *xml_registry_limit = "registry_limit";
+#endif
     const char *xml_ignore = "ignore";
     const char *xml_registry_ignore = "registry_ignore";
 #ifdef WIN32
@@ -1719,14 +1721,13 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
             if (!(children = OS_GetElementsbyNode(xml, node[i]))) {
                 continue;
             }
-            mwarn("file_limit block will be deprecated in future versions. Use db_entry_limit instead.");
             for(j = 0; children[j]; j++) {
-                if (strcmp(children[j]->element, xml_db_entry_enabled) == 0) {
+                if (strcmp(children[j]->element, xml_enabled) == 0) {
                     if (strcmp(children[j]->content, "yes") == 0) {
-                        syscheck->db_entry_limit_enabled = true;
+                        syscheck->file_limit_enabled = true;
                     }
                     else if (strcmp(children[j]->content, "no") == 0) {
-                        syscheck->db_entry_limit_enabled = false;
+                        syscheck->file_limit_enabled = false;
                     }
                     else {
                         merror(XML_VALUEERR, children[j]->element, children[j]->content);
@@ -1734,42 +1735,42 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                         return (OS_INVALID);
                     }
                 }
-                else if (strcmp(children[j]->element, xml_file_limit_entries) == 0) {
+                else if (strcmp(children[j]->element, xml_entries) == 0) {
                     if (!OS_StrIsNum(children[j]->content)) {
                         merror(XML_VALUEERR, children[j]->element, children[j]->content);
                         OS_ClearNode(children);
                         return (OS_INVALID);
                     }
 
-                    syscheck->db_entry_file_limit = atoi(children[j]->content);
+                    syscheck->file_entry_limit = atoi(children[j]->content);
 
-                    if (syscheck->db_entry_file_limit < 0) {
+                    if (syscheck->file_entry_limit < 0) {
                         mdebug2("Maximum value allowed for file_limit is '%d'", MAX_FILE_LIMIT);
-                        syscheck->db_entry_file_limit = MAX_FILE_LIMIT;
+                        syscheck->file_entry_limit = MAX_FILE_LIMIT;
                     }
                 }
             }
 
-            if (!syscheck->db_entry_limit_enabled) {
-                syscheck->db_entry_file_limit = 0;
+            if (!syscheck->file_limit_enabled) {
+                syscheck->file_entry_limit = 0;
             }
 
             OS_ClearNode(children);
         }
 
-        /* FIM dbsync entry limits */
-        else if (strcmp(node[i]->element, xml_db_entry) == 0) {
+#ifdef WIN32
+        // Get registry limit
+        else if (strcmp(node[i]->element, xml_registry_limit) == 0) {
             if (!(children = OS_GetElementsbyNode(xml, node[i]))) {
                 continue;
             }
-
             for(j = 0; children[j]; j++) {
-                if (strcmp(children[j]->element, xml_db_entry_enabled) == 0) {
+                if (strcmp(children[j]->element, xml_enabled) == 0) {
                     if (strcmp(children[j]->content, "yes") == 0) {
-                        syscheck->db_entry_limit_enabled = true;
+                        syscheck->registry_limit_enabled = true;
                     }
                     else if (strcmp(children[j]->content, "no") == 0) {
-                        syscheck->db_entry_limit_enabled = false;
+                        syscheck->registry_limit_enabled = false;
                     }
                     else {
                         merror(XML_VALUEERR, children[j]->element, children[j]->content);
@@ -1777,22 +1778,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                         return (OS_INVALID);
                     }
                 }
-                else if (strcmp(children[j]->element, xml_db_entry_file_limit) == 0) {
-                    if (!OS_StrIsNum(children[j]->content)) {
-                        merror(XML_VALUEERR, children[j]->element, children[j]->content);
-                        OS_ClearNode(children);
-                        return (OS_INVALID);
-                    }
-
-                    syscheck->db_entry_file_limit = atoi(children[j]->content);
-
-                    if (syscheck->db_entry_file_limit < 0) {
-                        mdebug2("Maximum value allowed for db_entry_file_limit is '%d'", MAX_FILE_LIMIT);
-                        syscheck->db_entry_file_limit = MAX_FILE_LIMIT;
-                    }
-                }
-#ifdef WIN32
-                else if (strcmp(children[j]->element, xml_db_entry_registry_limit) == 0) {
+                else if (strcmp(children[j]->element, xml_entries) == 0) {
                     if (!OS_StrIsNum(children[j]->content)) {
                         merror(XML_VALUEERR, children[j]->element, children[j]->content);
                         OS_ClearNode(children);
@@ -1802,22 +1788,19 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                     syscheck->db_entry_registry_limit = atoi(children[j]->content);
 
                     if (syscheck->db_entry_registry_limit < 0) {
-                        mdebug2("Maximum value allowed for db_entry_registry_limit is '%d'", MAX_FILE_LIMIT);
+                        mdebug2("Maximum value allowed for file_limit is '%d'", MAX_FILE_LIMIT);
                         syscheck->db_entry_registry_limit = MAX_FILE_LIMIT;
                     }
                 }
-#endif
             }
 
-            if (!syscheck->db_entry_limit_enabled) {
-                syscheck->db_entry_file_limit = 0;
-#ifdef WIN32
+            if (!syscheck->registry_limit_enabled) {
                 syscheck->db_entry_registry_limit = 0;
-#endif
             }
 
             OS_ClearNode(children);
         }
+#endif
 
         /* Get if xml_scan_on_start */
         else if (strcmp(node[i]->element, xml_scan_on_start) == 0) {

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -100,7 +100,7 @@ int initialize_syscheck_configuration(syscheck_config *syscheck) {
     syscheck->wdata.fd                        = NULL;
 #endif
 #ifdef WIN32
-    syscheck->registry_limit_enabled          = true
+    syscheck->registry_limit_enabled          = true;
     syscheck->db_entry_registry_limit         = 100000;
     syscheck->realtime_change                 = 0;
     syscheck->registry                        = NULL;
@@ -1578,10 +1578,10 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
     const char *xml_database = "database";
     const char *xml_scantime = "scan_time";
     const char *xml_file_limit = "file_limit";
+    const char *xml_registry_limit = "registry_limit";
     const char *xml_enabled = "enabled";
     const char *xml_entries = "entries";
 #ifdef WIN32
-    const char *xml_registry_limit = "registry_limit";
 #endif
     const char *xml_ignore = "ignore";
     const char *xml_registry_ignore = "registry_ignore";

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -385,7 +385,7 @@ typedef struct _config {
     char *scan_time;                                   /* run syscheck at this time */
 
     unsigned int file_limit_enabled;                   /* Enable FIM file entry max limits */
-    unsigned int file_entry_limit;                     /* maximum number of files to monitor */
+    int file_entry_limit;                              /* maximum number of files to monitor */
 
     char **ignore;                                     /* list of files/dirs to ignore */
     OSMatch **ignore_regex;                            /* regex of files/dirs to ignore */
@@ -411,7 +411,7 @@ typedef struct _config {
     /* Windows only registry checking */
 #ifdef WIN32
     unsigned int registry_limit_enabled;               /* Enable FIM registry entry max limits */
-    unsigned int db_entry_registry_limit;              /* maximum number of registries to monitor */
+    int db_entry_registry_limit;                       /* maximum number of registries to monitor */
     registry_ignore *key_ignore;                       /* List of registry keys to ignore */
     registry_ignore_regex *key_ignore_regex;           /* Regex of registry keys to ignore */
     registry_ignore *value_ignore;                     /* List of registry values to ignore*/

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -410,7 +410,7 @@ typedef struct _config {
 
     /* Windows only registry checking */
 #ifdef WIN32
-    unsigned int registry_limit_enabled                /* Enable FIM registry entry max limits */
+    unsigned int registry_limit_enabled;               /* Enable FIM registry entry max limits */
     unsigned int db_entry_registry_limit;              /* maximum number of registries to monitor */
     registry_ignore *key_ignore;                       /* List of registry keys to ignore */
     registry_ignore_regex *key_ignore_regex;           /* Regex of registry keys to ignore */

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -384,8 +384,8 @@ typedef struct _config {
     char *scan_day;                                    /* run syscheck on this day */
     char *scan_time;                                   /* run syscheck at this time */
 
-    unsigned int db_entry_limit_enabled;               /* Enable FIM entry max limits */
-    int db_entry_file_limit;                           /* maximum number of files to monitor */
+    unsigned int file_limit_enabled;                   /* Enable FIM file entry max limits */
+    unsigned int file_entry_limit;                     /* maximum number of files to monitor */
 
     char **ignore;                                     /* list of files/dirs to ignore */
     OSMatch **ignore_regex;                            /* regex of files/dirs to ignore */
@@ -410,7 +410,8 @@ typedef struct _config {
 
     /* Windows only registry checking */
 #ifdef WIN32
-    int db_entry_registry_limit;                       /* maximum number of registries to monitor */
+    unsigned int registry_limit_enabled                /* Enable FIM registry entry max limits */
+    unsigned int db_entry_registry_limit;              /* maximum number of registries to monitor */
     registry_ignore *key_ignore;                       /* List of registry keys to ignore */
     registry_ignore_regex *key_ignore_regex;           /* Regex of registry keys to ignore */
     registry_ignore *value_ignore;                     /* List of registry values to ignore*/

--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -247,7 +247,7 @@
 #define FIM_DELETE_DB_TRY                   "(6340): Failed to delete FIM database '%s'- %dº try."
 #define FIM_DELETE_DB                       "(6341): Failed to delete FIM database '%s'."
 #define FIM_FILE_LIMIT_VALUE                "(6342): Maximum number of files to be monitored: '%u'"
-#define FIM_FILE_LIMIT_UNLIMITED            "(6343): No limit set to maximum number of entries to be monitored"
+#define FIM_LIMIT_UNLIMITED                 "(6343): No limit set to maximum number of %s entries to be monitored"
 #define FIM_INOTIFY_WATCH_DELETED           "(6344): Inotify watch deleted for '%s'"
 #define FIM_NUM_WATCHES                     "(6345): Folders monitored with real-time engine: %u"
 #define FIM_REALTIME_CALLBACK               "(6346): Realtime watch deleted for '%s'"

--- a/src/syscheckd/src/config.c
+++ b/src/syscheckd/src/config.c
@@ -153,7 +153,7 @@ cJSON *getSyscheckConfig(void) {
     cJSON * registry_limit = cJSON_CreateObject();
     cJSON_AddStringToObject(registry_limit, "enabled", syscheck.registry_limit_enabled ? "yes" : "no");
     cJSON_AddNumberToObject(registry_limit, "entries", syscheck.db_entry_registry_limit);
-    cJSON_AddItemToObject(syscfg, "file_limit", registry_limit);
+    cJSON_AddItemToObject(syscfg, "registry_limit", registry_limit);
 #endif
 
     cJSON *diff = cJSON_CreateObject();

--- a/src/syscheckd/src/config.c
+++ b/src/syscheckd/src/config.c
@@ -145,13 +145,16 @@ cJSON *getSyscheckConfig(void) {
     if (syscheck.scan_time) cJSON_AddStringToObject(syscfg,"scan_time",syscheck.scan_time);
     cJSON_AddNumberToObject(syscfg, "max_files_per_second", syscheck.max_files_per_second);
 
-    cJSON * db_entry_limit = cJSON_CreateObject();
-    cJSON_AddStringToObject(db_entry_limit, "enabled", syscheck.db_entry_limit_enabled ? "yes" : "no");
-    cJSON_AddNumberToObject(db_entry_limit, "files", syscheck.db_entry_file_limit);
+    cJSON * file_limit = cJSON_CreateObject();
+    cJSON_AddStringToObject(file_limit, "enabled", syscheck.file_limit_enabled ? "yes" : "no");
+    cJSON_AddNumberToObject(file_limit, "entries", syscheck.file_entry_limit);
+    cJSON_AddItemToObject(syscfg, "file_limit", file_limit);
 #ifdef WIN32
-    cJSON_AddNumberToObject(db_entry_limit, "registries", syscheck.db_entry_registry_limit);
+    cJSON * registry_limit = cJSON_CreateObject();
+    cJSON_AddStringToObject(registry_limit, "enabled", syscheck.registry_limit_enabled ? "yes" : "no");
+    cJSON_AddNumberToObject(registry_limit, "entries", syscheck.db_entry_registry_limit);
+    cJSON_AddItemToObject(syscfg, "file_limit", registry_limit);
 #endif
-    cJSON_AddItemToObject(syscfg, "db_entry_limit", db_entry_limit);
 
     cJSON *diff = cJSON_CreateObject();
 

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -537,14 +537,14 @@ time_t fim_scan() {
 
     w_mutex_unlock(&syscheck.fim_scan_mutex);
 
-    if (syscheck.db_entry_limit_enabled) {
+    if (syscheck.file_limit_enabled) {
         nodes_count = fim_db_get_count_file_entry();
     }
 
     fim_db_transaction_deleted_rows(db_transaction_handle, transaction_callback, &txn_ctx);
     db_transaction_handle = NULL;
 
-    if (syscheck.db_entry_limit_enabled && (nodes_count >= syscheck.db_entry_file_limit)) {
+    if (syscheck.file_limit_enabled && (nodes_count >= syscheck.file_entry_limit)) {
         w_mutex_lock(&syscheck.fim_scan_mutex);
 
         db_transaction_handle = fim_db_transaction_start(FIMDB_FILE_TXN_TABLE, transaction_callback, &txn_ctx);
@@ -584,9 +584,9 @@ time_t fim_scan() {
     gettime(&end);
     end_of_scan = time(NULL);
 
-    if (syscheck.db_entry_limit_enabled) {
+    if (syscheck.file_limit_enabled) {
         int files_count = fim_db_get_count_file_entry();
-        fim_check_db_state(syscheck.db_entry_file_limit, files_count, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+        fim_check_db_state(syscheck.file_entry_limit, files_count, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 #ifdef WIN32
         fim_check_db_state(syscheck.db_entry_registry_limit,
                            fim_db_get_count_registry_key(),

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -587,7 +587,10 @@ time_t fim_scan() {
     if (syscheck.file_limit_enabled) {
         int files_count = fim_db_get_count_file_entry();
         fim_check_db_state(syscheck.file_entry_limit, files_count, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    }
+
 #ifdef WIN32
+    if (syscheck.registry_limit_enabled) {
         fim_check_db_state(syscheck.db_entry_registry_limit,
                            fim_db_get_count_registry_key(),
                            &_registry_key_state,
@@ -596,8 +599,8 @@ time_t fim_scan() {
                            fim_db_get_count_registry_data(),
                            &_registry_value_state,
                            FIMDB_REGISTRY_VALUE_TABLENAME);
-#endif
     }
+#endif
 
     if (_base_line == 0) {
         _base_line = 1;

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -252,14 +252,19 @@ void start_daemon()
 
     minfo(FIM_DAEMON_STARTED);
 
-    if (syscheck.db_entry_limit_enabled) {
-        mdebug2(FIM_FILE_LIMIT_VALUE, syscheck.db_entry_file_limit);
-#ifdef WIN32
-        mdebug2(FIM_REGISTRY_LIMIT_VALUE, syscheck.db_entry_registry_limit);
-#endif
+    if (syscheck.file_limit_enabled) {
+        mdebug2(FIM_FILE_LIMIT_VALUE, syscheck.file_entry_limit);
     } else {
-        mdebug2(FIM_FILE_LIMIT_UNLIMITED);
+        mdebug2(FIM_LIMIT_UNLIMITED, "file");
     }
+
+#ifdef WIN32
+    if (syscheck.registry_limit_enabled) {
+        mdebug2(FIM_REGISTRY_LIMIT_VALUE, syscheck.db_entry_registry_limit);
+    } else {
+        mdebug2(FIM_LIMIT_UNLIMITED, "registry");
+    }
+#endif
 
     // Create File integrity monitoring base-line
     minfo(FIM_FREQUENCY_TIME, syscheck.time);

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -82,7 +82,7 @@ void fim_initialize() {
                                          syscheck.sync_interval,
                                          fim_send_sync_state,
                                          loggingFunction,
-                                         syscheck.db_entry_file_limit,
+                                         syscheck.file_entry_limit,
                                          syscheck.min_sync_interval,
                                          0,
                                          false);
@@ -91,7 +91,7 @@ void fim_initialize() {
                                          syscheck.sync_interval,
                                          fim_send_sync_state,
                                          loggingFunction,
-                                         syscheck.db_entry_file_limit,
+                                         syscheck.file_entry_limit,
                                          syscheck.min_sync_interval,
                                          syscheck.db_entry_registry_limit,
                                          syscheck.enable_registry_synchronization);

--- a/src/unit_tests/config_files/test_syscheck.conf
+++ b/src/unit_tests/config_files/test_syscheck.conf
@@ -14,11 +14,10 @@
     <auto_ignore frequency="10" timeframe="3600">no</auto_ignore>
 
     <!-- Maximum number of files to monitor -->
-    <db_entry_limit>
+    <file_limit>
       <enabled>yes</enabled>
-      <files>50000</files>
-      <registries>50000</registries>
-    </db_entry_limit>
+      <entries>50000</entries>
+    </file_limit>
 
     <!-- Directories to check  (perform all possible verifications) -->
     <directories whodata="yes" tags="tag1,tag2">/etc,/usr/bin,/usr/sbin</directories>

--- a/src/unit_tests/config_files/test_syscheck2.conf
+++ b/src/unit_tests/config_files/test_syscheck2.conf
@@ -12,11 +12,10 @@
     <auto_ignore frequency="10" timeframe="3600">no</auto_ignore>
 
     <!-- Maximum number of files to monitor -->
-    <db_entry_limit>
+    <file_limit>
       <enabled>yes</enabled>
-      <files>50000</files>
-      <registries>50000</registries>
-    </db_entry_limit>
+      <entries>50000</entries>
+    </file_limit>
 
     <!-- Directories to check  (perform all possible verifications) -->
     <directories whodata="yes" tags="tag1,tag2">/etc,/usr/bin,/usr/sbin</directories>

--- a/src/unit_tests/config_files/test_syscheck_config_win.conf
+++ b/src/unit_tests/config_files/test_syscheck_config_win.conf
@@ -14,11 +14,15 @@
     <auto_ignore frequency="10" timeframe="3600">no</auto_ignore>
 
     <!-- Maximum number of files to monitor -->
-    <db_entry_limit>
+    <file_limit>
       <enabled>yes</enabled>
-      <files>50000</files>
-      <registries>50000</registries>
-    </db_entry_limit>
+      <entries>50000</entries>
+    </file_limit>
+
+    <registry_limit>
+      <enabled>yes</enabled>
+      <entries>50000</entries>
+    </registry_limit>
 
     <!-- Default files to be monitored. -->
     <directories recursion_level="0" restrict="regedit.exe$|system.ini$|win.ini$">%WINDIR%</directories>

--- a/src/unit_tests/config_files/test_syscheck_max_dir.conf
+++ b/src/unit_tests/config_files/test_syscheck_max_dir.conf
@@ -14,11 +14,15 @@
     <auto_ignore frequency="10" timeframe="3600">no</auto_ignore>
 
     <!-- Maximum number of files to monitor -->
-    <db_entry_limit>
+    <file_limit>
       <enabled>yes</enabled>
-      <files>50000</files>
-      <registries>50000</registries>
-    </db_entry_limit>
+      <entries>50000</entries>
+    </file_limit>
+
+    <registry_limit>
+      <enabled>yes</enabled>
+      <entries>50000</entries>
+    </registry_limit>
 
     <!-- Directories to check  (perform all possible verifications) -->
     <directories whodata="yes" tags="tag1,tag2">/etc,/usr/bin,/usr/sbin</directories>

--- a/src/unit_tests/config_files/test_syscheck_top_level.conf
+++ b/src/unit_tests/config_files/test_syscheck_top_level.conf
@@ -14,11 +14,10 @@
     <auto_ignore frequency="10" timeframe="3600">no</auto_ignore>
 
     <!-- Maximum number of files to monitor -->
-    <db_entry_limit>
+    <file_limit>
       <enabled>yes</enabled>
-      <files>50000</files>
-      <registries>50000</registries>
-    </db_entry_limit>
+      <entries>50000</entries>
+    </file_limit>
 
     <!-- Directories to check  (perform all possible verifications) -->
     <directories realtime="yes" restrict="file$" recursion_level="0">/</directories>

--- a/src/unit_tests/config_files/test_syscheck_top_level_win.conf
+++ b/src/unit_tests/config_files/test_syscheck_top_level_win.conf
@@ -14,11 +14,15 @@
     <auto_ignore frequency="10" timeframe="3600">no</auto_ignore>
 
     <!-- Maximum number of files to monitor -->
-    <db_entry_limit>
+    <file_limit>
       <enabled>yes</enabled>
-      <files>50000</files>
-      <registries>50000</registries>
-    </db_entry_limit>
+      <entries>50000</entries>
+    </file_limit>
+
+    <registry_limit>
+      <enabled>yes</enabled>
+      <entries>50000</entries>
+    </registry_limit>
 
     <!-- Default files to be monitored. -->
     <directories recursion_level="0" realtime="yes">C:\.</directories>

--- a/src/unit_tests/config_files/test_syscheck_win.conf
+++ b/src/unit_tests/config_files/test_syscheck_win.conf
@@ -14,11 +14,15 @@
     <auto_ignore frequency="10" timeframe="3600">no</auto_ignore>
 
     <!-- Maximum number of files to monitor -->
-    <db_entry_limit>
+    <file_limit>
       <enabled>yes</enabled>
-      <files>50000</files>
-      <registries>50000</registries>
-    </db_entry_limit>
+      <entries>50000</entries>
+    </file_limit>
+
+    <registry_limit>
+      <enabled>yes</enabled>
+      <entries>50000</entries>
+    </registry_limit>
 
     <!-- Default files to be monitored. -->
     <directories recursion_level="0" restrict="regedit.exe$|system.ini$|win.ini$">%WINDIR%</directories>

--- a/src/unit_tests/config_files/test_syscheck_win2.conf
+++ b/src/unit_tests/config_files/test_syscheck_win2.conf
@@ -14,11 +14,15 @@
     <auto_ignore frequency="10" timeframe="3600">no</auto_ignore>
 
     <!-- Maximum number of files to monitor -->
-    <db_entry_limit>
+    <file_limit>
       <enabled>yes</enabled>
-      <files>50000</files>
-      <registries>50000</registries>
-    </db_entry_limit>
+      <entries>50000</entries>
+    </file_limit>
+
+    <registry_limit>
+      <enabled>yes</enabled>
+      <entries>50000</entries>
+    </registry_limit>
 
     <!-- Default files to be monitored. -->
     <directories recursion_level="0" restrict="regedit.exe$|system.ini$|win.ini$">%WINDIR%</directories>

--- a/src/unit_tests/config_files/test_syscheck_win_max_dir.conf
+++ b/src/unit_tests/config_files/test_syscheck_win_max_dir.conf
@@ -14,11 +14,15 @@
     <auto_ignore frequency="10" timeframe="3600">no</auto_ignore>
 
     <!-- Maximum number of files to monitor -->
-    <db_entry_limit>
+    <file_limit>
       <enabled>yes</enabled>
-      <files>50000</files>
-      <registries>50000</registries>
-    </db_entry_limit>
+      <entries>50000</entries>
+    </file_limit>
+
+    <registry_limit>
+      <enabled>yes</enabled>
+      <entries>50000</entries>
+    </registry_limit>
 
     <!-- Default files to be monitored. -->
     <directories recursion_level="0" restrict="regedit.exe$|system.ini$|win.ini$">%WINDIR%</directories>

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -464,14 +464,20 @@ static int teardown_struct_dirent(void **state) {
 static int setup_file_limit(void **state) {
     syscheck.file_limit_enabled = false;
     syscheck.file_entry_limit = 0;
-
+#ifdef TEST_WINAGENT
+    syscheck.registry_limit_enabled = false;
+    syscheck.db_entry_registry_limit = 0;
+#endif
     return 0;
 }
 
 static int teardown_file_limit(void **state) {
     syscheck.file_limit_enabled = true;
     syscheck.file_entry_limit = 50000;
-
+#ifdef TEST_WINAGENT
+    syscheck.registry_limit_enabled = true;
+    syscheck.db_entry_registry_limit = 100000;
+#endif
     return 0;
 }
 

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -462,15 +462,15 @@ static int teardown_struct_dirent(void **state) {
 }
 
 static int setup_file_limit(void **state) {
-    syscheck.db_entry_limit_enabled = false;
-    syscheck.db_entry_file_limit = 0;
+    syscheck.file_limit_enabled = false;
+    syscheck.file_entry_limit = 0;
 
     return 0;
 }
 
 static int teardown_file_limit(void **state) {
-    syscheck.db_entry_limit_enabled = true;
-    syscheck.db_entry_file_limit = 50000;
+    syscheck.file_limit_enabled = true;
+    syscheck.file_entry_limit = 50000;
 
     return 0;
 }
@@ -2744,7 +2744,7 @@ static void test_fim_check_db_state_normal_to_empty(void **state) {
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_NORMAL);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 0, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 0, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_EMPTY);
 }
@@ -2752,7 +2752,7 @@ static void test_fim_check_db_state_normal_to_empty(void **state) {
 static void test_fim_check_db_state_empty_to_empty(void **state) {
     assert_int_equal(_files_db_state, FIM_STATE_DB_EMPTY);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 0, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 0, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_EMPTY);
 }
@@ -2764,7 +2764,7 @@ static void test_fim_check_db_state_empty_to_full(void **state) {
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_EMPTY);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 50000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 50000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_FULL);
 }
@@ -2776,7 +2776,7 @@ static void test_fim_check_db_state_full_to_empty(void **state) {
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_FULL);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 0, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 0, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_EMPTY);
 }
@@ -2788,7 +2788,7 @@ static void test_fim_check_db_state_empty_to_90_percentage(void **state) {
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_EMPTY);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 46000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 46000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_90_PERCENTAGE);
 }
@@ -2800,7 +2800,7 @@ static void test_fim_check_db_state_90_percentage_to_empty(void **state) {
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_90_PERCENTAGE);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 0, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 0, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_EMPTY);
 }
@@ -2812,7 +2812,7 @@ static void test_fim_check_db_state_empty_to_80_percentage(void **state) {
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_EMPTY);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 41000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 41000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_80_PERCENTAGE);
 }
@@ -2824,7 +2824,7 @@ static void test_fim_check_db_state_80_percentage_to_empty(void **state) {
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_80_PERCENTAGE);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 0, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 0, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_EMPTY);
 }
@@ -2832,7 +2832,7 @@ static void test_fim_check_db_state_80_percentage_to_empty(void **state) {
 static void test_fim_check_db_state_empty_to_normal(void **state) {
     assert_int_equal(_files_db_state, FIM_STATE_DB_EMPTY);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 10000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 10000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_NORMAL);
 }
@@ -2840,7 +2840,7 @@ static void test_fim_check_db_state_empty_to_normal(void **state) {
 static void test_fim_check_db_state_normal_to_normal(void **state) {
     assert_int_equal(_files_db_state, FIM_STATE_DB_NORMAL);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 20000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 20000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_NORMAL);
 }
@@ -2852,7 +2852,7 @@ static void test_fim_check_db_state_normal_to_full(void **state) {
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_NORMAL);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 50000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 50000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_FULL);
 }
@@ -2864,7 +2864,7 @@ static void test_fim_check_db_state_full_to_normal(void **state) {
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_FULL);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 10000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 10000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_NORMAL);
 }
@@ -2877,7 +2877,7 @@ static void test_fim_check_db_state_normal_to_90_percentage(void **state) {
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_NORMAL);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 46000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 46000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_90_PERCENTAGE);
 }
@@ -2890,7 +2890,7 @@ static void test_fim_check_db_state_90_percentage_to_normal(void **state) {
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_90_PERCENTAGE);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 10000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 10000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_NORMAL);
 }
@@ -2902,7 +2902,7 @@ static void test_fim_check_db_state_normal_to_80_percentage(void **state) {
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_NORMAL);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 41000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 41000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_80_PERCENTAGE);
 }
@@ -2910,7 +2910,7 @@ static void test_fim_check_db_state_normal_to_80_percentage(void **state) {
 static void test_fim_check_db_state_80_percentage_to_80_percentage(void **state) {
     assert_int_equal(_files_db_state, FIM_STATE_DB_80_PERCENTAGE);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 42000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 42000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_80_PERCENTAGE);
 }
@@ -2922,7 +2922,7 @@ static void test_fim_check_db_state_80_percentage_to_full(void **state) {
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_80_PERCENTAGE);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 50000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 50000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_FULL);
 }
@@ -2935,7 +2935,7 @@ static void test_fim_check_db_state_full_to_80_percentage(void **state) {
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_FULL);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 41000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 41000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_80_PERCENTAGE);
 }
@@ -2947,7 +2947,7 @@ static void test_fim_check_db_state_80_percentage_to_90_percentage(void **state)
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_80_PERCENTAGE);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 46000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 46000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_90_PERCENTAGE);
 }
@@ -2955,7 +2955,7 @@ static void test_fim_check_db_state_80_percentage_to_90_percentage(void **state)
 static void test_fim_check_db_state_90_percentage_to_90_percentage(void **state) {
     assert_int_equal(_files_db_state, FIM_STATE_DB_90_PERCENTAGE);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 48000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 48000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_90_PERCENTAGE);
 }
@@ -2967,7 +2967,7 @@ static void test_fim_check_db_state_90_percentage_to_full(void **state) {
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_90_PERCENTAGE);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 50000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 50000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_FULL);
 }
@@ -2975,7 +2975,7 @@ static void test_fim_check_db_state_90_percentage_to_full(void **state) {
 static void test_fim_check_db_state_full_to_full(void **state) {
     assert_int_equal(_files_db_state, FIM_STATE_DB_FULL);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 60000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 60000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_FULL);
 }
@@ -2987,7 +2987,7 @@ static void test_fim_check_db_state_full_to_90_percentage(void **state) {
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_FULL);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 46000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 46000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_90_PERCENTAGE);
 }
@@ -2999,7 +2999,7 @@ static void test_fim_check_db_state_90_percentage_to_80_percentage(void **state)
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_90_PERCENTAGE);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 41000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 41000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_80_PERCENTAGE);
 }
@@ -3011,7 +3011,7 @@ static void test_fim_check_db_state_80_percentage_to_normal(void **state) {
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_80_PERCENTAGE);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, 10000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, 10000, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_NORMAL);
 }
@@ -3021,7 +3021,7 @@ static void test_fim_check_db_state_nodes_count_database_error(void **state) {
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_NORMAL);
 
-    fim_check_db_state(syscheck.db_entry_file_limit, -1, &_files_db_state, FIMDB_FILE_TABLE_NAME);
+    fim_check_db_state(syscheck.file_entry_limit, -1, &_files_db_state, FIMDB_FILE_TABLE_NAME);
 
     assert_int_equal(_files_db_state, FIM_STATE_DB_NORMAL);
 }

--- a/src/unit_tests/syscheckd/test_syscheck.c
+++ b/src/unit_tests/syscheckd/test_syscheck.c
@@ -52,7 +52,7 @@ static int setup_syscheck_config(void **state) {
     syscheck_conf->database_store            = FIM_DB_DISK;
     syscheck_conf->sync_interval             = 300;
     syscheck_conf->min_sync_interval         = 60;
-    syscheck_conf->db_entry_file_limit       = 100000;
+    syscheck_conf->file_entry_limit       = 100000;
 #ifdef WIN32
     syscheck_conf->db_entry_registry_limit   = 100000;
 #endif
@@ -102,14 +102,14 @@ void test_fim_initialize(void **state)
 #ifdef TEST_WINAGENT
     expect_wrapper_fim_db_init(syscheck_conf->database_store,
                                syscheck_conf->sync_interval,
-                               syscheck_conf->db_entry_file_limit,
+                               syscheck_conf->file_entry_limit,
                                syscheck_conf->min_sync_interval,
                                syscheck_conf->db_entry_registry_limit,
                                1);
 #else
     expect_wrapper_fim_db_init(syscheck_conf->database_store,
                                syscheck_conf->sync_interval,
-                               syscheck_conf->db_entry_file_limit,
+                               syscheck_conf->file_entry_limit,
                                syscheck_conf->min_sync_interval,
                                0,
                                0);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #13988|

## Description
This PR aims to split the configuration registry and file limits into two separate configuration blocks. 

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
```xml
    <file_limit>
      <enabled>yes</enabled>
      <entries>50000</entries>
    </file_limit>

    <registry_limit>
      <enabled>yes</enabled>
      <entries>50000</entries>
    </registry_limit>
```
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
- Memory tests for Windows
  - [ ] Scan-build report