### PR TITLE
Add queue_size setting to FIM setting in C code

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -118,6 +118,7 @@ int initialize_syscheck_configuration(syscheck_config *syscheck) {
     syscheck->min_sync_interval               = 60;
     syscheck->sync_thread_pool                = 1;
     syscheck->sync_max_eps                    = 10;
+    syscheck->sync_queue_size                 = 16384;
     syscheck->max_eps                         = 100;
     syscheck->max_files_per_second            = 0;
     syscheck->allow_remote_prefilter_cmd      = false;
@@ -1205,7 +1206,15 @@ static void parse_synchronization(syscheck_config * syscheck, XML_NODE node) {
         } else if (strcmp(node[i]->element, xml_response_timeout) == 0) {
             mdebug1("'%s' has been deprecated. This setting is skipped.", xml_response_timeout);
         } else if (strcmp(node[i]->element, xml_sync_queue_size) == 0) {
-            mdebug1("'%s' has been deprecated. This setting is skipped.", xml_sync_queue_size);
+            char * end;
+            long value = strtol(node[i]->content, &end, 10);
+
+            if (value < 2 || value > 1000000 || *end) {
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
+            }
+            else {
+                syscheck->sync_queue_size = value;
+            }
         } else if (strcmp(node[i]->element, xml_max_eps) == 0) {
             char * end;
             long value = strtol(node[i]->content, &end, 10);

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -408,7 +408,7 @@ typedef struct _config {
     int sync_thread_pool;                              /* Number of threads used by RSync */
     long sync_max_eps;                                 /* Maximum events per second for synchronization messages. */
     int max_eps;                                       /* Maximum events per second. */
-    long sync_queue_size;                              /* Data synchronization message queue size */
+    unsigned int sync_queue_size;                      /* Data synchronization message queue size */
 
     /* Windows only registry checking */
 #ifdef WIN32

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -408,6 +408,7 @@ typedef struct _config {
     int sync_thread_pool;                              /* Number of threads used by RSync */
     long sync_max_eps;                                 /* Maximum events per second for synchronization messages. */
     int max_eps;                                       /* Maximum events per second. */
+    long sync_queue_size;                              /* Data synchronization message queue size */
 
     /* Windows only registry checking */
 #ifdef WIN32

--- a/src/syscheckd/src/config.c
+++ b/src/syscheckd/src/config.c
@@ -480,6 +480,7 @@ cJSON *getSyscheckConfig(void) {
     cJSON_AddStringToObject(synchronization, "registry_enabled",
                             syscheck.enable_registry_synchronization ? "yes" : "no");
 #endif
+    cJSON_AddNumberToObject(synchronization, "queue_size", syscheck.sync_queue_size);
     cJSON_AddNumberToObject(synchronization, "interval", syscheck.sync_interval);
     cJSON_AddNumberToObject(synchronization, "max_eps", syscheck.sync_max_eps);
     cJSON_AddNumberToObject(synchronization, "min_interval", syscheck.min_sync_interval);

--- a/src/syscheckd/src/db/include/db.h
+++ b/src/syscheckd/src/db/include/db.h
@@ -51,11 +51,8 @@ FIMDBErrorCode fim_db_init(int storage,
                            uint32_t min_sync_interval_time,
                            int value_limit,
                            bool sync_registry_enabled,
-<<<<<<< HEAD
-                           int sync_thread_pool);
-=======
+                           int sync_thread_pool,
                            int sync_queue_size);
->>>>>>> 0dac890a52 (Add changes to support queue_size in FIMDB synchronization in c++ code)
 
 /**
  * @brief Get entry data using path.

--- a/src/syscheckd/src/db/include/db.h
+++ b/src/syscheckd/src/db/include/db.h
@@ -52,7 +52,7 @@ FIMDBErrorCode fim_db_init(int storage,
                            int value_limit,
                            bool sync_registry_enabled,
                            int sync_thread_pool,
-                           int sync_queue_size);
+                           unsigned int sync_queue_size);
 
 /**
  * @brief Get entry data using path.

--- a/src/syscheckd/src/db/include/db.h
+++ b/src/syscheckd/src/db/include/db.h
@@ -39,6 +39,7 @@ extern "C" {
  * @param min_sync_interval_time Minimum interval for synchronization process.
  * @param value_limit Maximum number of registry values to be monitored.
  * @param sync_registry_enable Flag to enable the registry synchronization.
+ * @param sync_queue_size Number to define the size of the queue to be synchronized.
  *
  * @return FIMDB_OK on success, FIMDB_ERROR on error.
  */
@@ -50,7 +51,11 @@ FIMDBErrorCode fim_db_init(int storage,
                            uint32_t min_sync_interval_time,
                            int value_limit,
                            bool sync_registry_enabled,
+<<<<<<< HEAD
                            int sync_thread_pool);
+=======
+                           int sync_queue_size);
+>>>>>>> 0dac890a52 (Add changes to support queue_size in FIMDB synchronization in c++ code)
 
 /**
  * @brief Get entry data using path.

--- a/src/syscheckd/src/db/include/db.hpp
+++ b/src/syscheckd/src/db/include/db.hpp
@@ -82,7 +82,11 @@ class EXPORTED DB final
         * @param minSyncIntervalTime Minimum interval for synchronization process.
         * @param valueLimit Registry value limit.
         * @param syncRegistryEnabled Flag to enable/disable the registry sync mechanism.
+<<<<<<< HEAD
         * @param syncThreadPool Number of threads used by RSync.
+=======
+        * @param syncQueueSize Number to define the size of the queue to be synchronized.
+>>>>>>> 0dac890a52 (Add changes to support queue_size in FIMDB synchronization in c++ code)
         */
         void init(const int storage,
                   const int syncInterval,
@@ -93,7 +97,11 @@ class EXPORTED DB final
                   const uint32_t minSyncIntervalTime,
                   int valueLimit,
                   bool syncRegistryEnabled,
+<<<<<<< HEAD
                   const int syncThreadPool);
+=======
+                  const int syncQueueSize);
+>>>>>>> 0dac890a52 (Add changes to support queue_size in FIMDB synchronization in c++ code)
 
         /**
         * @brief runIntegrity Execute the integrity mechanism.

--- a/src/syscheckd/src/db/include/db.hpp
+++ b/src/syscheckd/src/db/include/db.hpp
@@ -82,11 +82,8 @@ class EXPORTED DB final
         * @param minSyncIntervalTime Minimum interval for synchronization process.
         * @param valueLimit Registry value limit.
         * @param syncRegistryEnabled Flag to enable/disable the registry sync mechanism.
-<<<<<<< HEAD
         * @param syncThreadPool Number of threads used by RSync.
-=======
         * @param syncQueueSize Number to define the size of the queue to be synchronized.
->>>>>>> 0dac890a52 (Add changes to support queue_size in FIMDB synchronization in c++ code)
         */
         void init(const int storage,
                   const int syncInterval,
@@ -97,11 +94,8 @@ class EXPORTED DB final
                   const uint32_t minSyncIntervalTime,
                   int valueLimit,
                   bool syncRegistryEnabled,
-<<<<<<< HEAD
-                  const int syncThreadPool);
-=======
+                  const int syncThreadPool,
                   const int syncQueueSize);
->>>>>>> 0dac890a52 (Add changes to support queue_size in FIMDB synchronization in c++ code)
 
         /**
         * @brief runIntegrity Execute the integrity mechanism.

--- a/src/syscheckd/src/db/src/db.cpp
+++ b/src/syscheckd/src/db/src/db.cpp
@@ -42,7 +42,8 @@ void DB::init(const int storage,
                                  FIMDBCreator<OS_TYPE>::CreateStatement())
     };
 
-    auto rsyncHandler { std::make_shared<RemoteSync>(syncThreadPool, syncQueueSize) };
+    // auto rsyncHandler { std::make_shared<RemoteSync>(syncThreadPool, syncQueueSize) };
+    auto rsyncHandler { std::make_shared<RemoteSync>() };
 
     FIMDB::instance().init(syncInterval,
                            callbackSyncFileWrapper,

--- a/src/syscheckd/src/db/src/db.cpp
+++ b/src/syscheckd/src/db/src/db.cpp
@@ -32,11 +32,8 @@ void DB::init(const int storage,
               const uint32_t minSyncIntervalTime,
               const int valueLimit,
               bool syncRegistryEnabled,
-<<<<<<< HEAD
-              const int syncThreadPool)
-=======
-              const int syncQueueSize=0)
->>>>>>> 0dac890a52 (Add changes to support queue_size in FIMDB synchronization in c++ code)
+              const int syncThreadPool,
+              const int syncQueueSize)
 {
     auto path { storage == FIM_DB_MEMORY ? FIM_DB_MEMORY_PATH : FIM_DB_DISK_PATH };
     auto dbsyncHandler
@@ -126,11 +123,8 @@ FIMDBErrorCode fim_db_init(int storage,
                            uint32_t min_sync_interval_time,
                            int value_limit,
                            bool sync_registry_enabled,
-<<<<<<< HEAD
-                           int sync_thread_pool)
-=======
+                           int sync_thread_pool,
                            int sync_queue_size)
->>>>>>> 0dac890a52 (Add changes to support queue_size in FIMDB synchronization in c++ code)
 {
     auto retVal { FIMDBErrorCode::FIMDB_ERR };
 
@@ -231,7 +225,8 @@ FIMDBErrorCode fim_db_init(int storage,
                             min_sync_interval_time,
                             value_limit,
                             sync_registry_enabled,
-                            sync_thread_pool);
+                            sync_thread_pool,
+                            sync_queue_size);
         retVal = FIMDBErrorCode::FIMDB_OK;
 
     }

--- a/src/syscheckd/src/db/src/db.cpp
+++ b/src/syscheckd/src/db/src/db.cpp
@@ -124,7 +124,7 @@ FIMDBErrorCode fim_db_init(int storage,
                            int value_limit,
                            bool sync_registry_enabled,
                            int sync_thread_pool,
-                           int sync_queue_size)
+                           unsigned int sync_queue_size)
 {
     auto retVal { FIMDBErrorCode::FIMDB_ERR };
 

--- a/src/syscheckd/src/db/src/db.cpp
+++ b/src/syscheckd/src/db/src/db.cpp
@@ -32,7 +32,11 @@ void DB::init(const int storage,
               const uint32_t minSyncIntervalTime,
               const int valueLimit,
               bool syncRegistryEnabled,
+<<<<<<< HEAD
               const int syncThreadPool)
+=======
+              const int syncQueueSize=0)
+>>>>>>> 0dac890a52 (Add changes to support queue_size in FIMDB synchronization in c++ code)
 {
     auto path { storage == FIM_DB_MEMORY ? FIM_DB_MEMORY_PATH : FIM_DB_DISK_PATH };
     auto dbsyncHandler
@@ -122,7 +126,11 @@ FIMDBErrorCode fim_db_init(int storage,
                            uint32_t min_sync_interval_time,
                            int value_limit,
                            bool sync_registry_enabled,
+<<<<<<< HEAD
                            int sync_thread_pool)
+=======
+                           int sync_queue_size)
+>>>>>>> 0dac890a52 (Add changes to support queue_size in FIMDB synchronization in c++ code)
 {
     auto retVal { FIMDBErrorCode::FIMDB_ERR };
 

--- a/src/syscheckd/src/db/src/db.cpp
+++ b/src/syscheckd/src/db/src/db.cpp
@@ -42,7 +42,7 @@ void DB::init(const int storage,
                                  FIMDBCreator<OS_TYPE>::CreateStatement())
     };
 
-    auto rsyncHandler { std::make_shared<RemoteSync>() };
+    auto rsyncHandler { std::make_shared<RemoteSync>(syncThreadPool, syncQueueSize) };
 
     FIMDB::instance().init(syncInterval,
                            callbackSyncFileWrapper,

--- a/src/syscheckd/src/db/src/fimDB.cpp
+++ b/src/syscheckd/src/db/src/fimDB.cpp
@@ -55,7 +55,8 @@ void FIMDB::init(unsigned int syncInterval,
                  const int fileLimit,
                  const uint32_t minSyncIntervalTime,
                  const int registryLimit,
-                 const bool syncRegistryEnabled)
+                 const bool syncRegistryEnabled,
+                 int syncQueueSize)
 {
     m_syncInterval = syncInterval;
     m_dbsyncHandler = dbsyncHandler;

--- a/src/syscheckd/src/db/src/fimDB.hpp
+++ b/src/syscheckd/src/db/src/fimDB.hpp
@@ -124,6 +124,7 @@ class FIMDB
          * @param minSyncIntervalTime Minimum interval for synchronization process.
          * @param registryLimit Maximun number of registry values entries in database (only for Windows).
          * @param syncRegistryEnabled Flag to specify if the synchronization for registries is enabled (only for Windows).
+         * @param syncQueueSize Number to define the size of the queue to be synchronized.
          */
         void init(unsigned int syncInterval,
                   std::function<void(const std::string&)> callbackSyncFileWrapper,
@@ -134,7 +135,8 @@ class FIMDB
                   int fileLimit,
                   const uint32_t minSyncIntervalTime,
                   int registryLimit = 0,
-                  bool syncRegistryEnabled = true);
+                  bool syncRegistryEnabled = true,
+                  int syncQueueSize = 0);
 
         /**
          * @brief Remove a given item from the database

--- a/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
@@ -224,6 +224,7 @@ TEST(DBTest, TestInvalidFimLimit)
                     minSyncInterval,
                     -1,
                     true,
+                    0,
                     0)
     };
     ASSERT_EQ(result, FIMDB_ERR);
@@ -247,6 +248,7 @@ TEST(DBTest, TestValidFimLimit)
                     minSyncInterval,
                     100000,
                     true,
+                    0,
                     0)
     };
     ASSERT_EQ(result, FIMDB_OK);

--- a/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
@@ -223,7 +223,8 @@ TEST(DBTest, TestInvalidFimLimit)
                     -1,
                     minSyncInterval,
                     -1,
-                    true)
+                    true,
+                    0)
     };
     ASSERT_EQ(result, FIMDB_ERR);
 
@@ -245,7 +246,8 @@ TEST(DBTest, TestValidFimLimit)
                     100,
                     minSyncInterval,
                     100000,
-                    true)
+                    true,
+                    0)
     };
     ASSERT_EQ(result, FIMDB_OK);
 

--- a/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.h
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.h
@@ -88,11 +88,8 @@ class DBTestFixture : public testing::Test {
                         10,
                         100000,
                         true,
-<<<<<<< HEAD
-                        1);
-=======
+                        1,
                         0);
->>>>>>> 0dac890a52 (Add changes to support queue_size in FIMDB synchronization in c++ code)
 
             evt_data = {};
             evt_data.report_event = true;

--- a/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.h
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.h
@@ -88,7 +88,11 @@ class DBTestFixture : public testing::Test {
                         10,
                         100000,
                         true,
+<<<<<<< HEAD
                         1);
+=======
+                        0);
+>>>>>>> 0dac890a52 (Add changes to support queue_size in FIMDB synchronization in c++ code)
 
             evt_data = {};
             evt_data.report_event = true;

--- a/src/syscheckd/src/db/testtool/main.cpp
+++ b/src/syscheckd/src/db/testtool/main.cpp
@@ -52,6 +52,7 @@ int main(int argc, const char* argv[])
             const bool syncRegistryEnabled { jsonConfigFile.at("registry_sync") };
             const auto minSyncInterval{ jsonConfigFile.at("min_sync_interval").get<const uint32_t>() };
             const auto syncThreadPool{ jsonConfigFile.at("thread_pool").get<const uint32_t>() };
+            const auto syncQueueSize{ jsonConfigFile.at("queue_size").get<const uint32_t>() };
 
             std::function<void(const std::string&)> callbackSyncFileWrapper
             {
@@ -88,11 +89,8 @@ int main(int argc, const char* argv[])
                                     minSyncInterval,
                                     registryLimit,
                                     syncRegistryEnabled,
-<<<<<<< HEAD
-                                    syncThreadPool);
-=======
-                                    0);
->>>>>>> 0dac890a52 (Add changes to support queue_size in FIMDB synchronization in c++ code)
+                                    syncThreadPool,
+                                    syncQueueSize);
 
                 std::unique_ptr<TestContext> testContext { std::make_unique<TestContext>()};
                 testContext->outputPath = cmdLineArgs.outputFolder();

--- a/src/syscheckd/src/db/testtool/main.cpp
+++ b/src/syscheckd/src/db/testtool/main.cpp
@@ -88,7 +88,11 @@ int main(int argc, const char* argv[])
                                     minSyncInterval,
                                     registryLimit,
                                     syncRegistryEnabled,
+<<<<<<< HEAD
                                     syncThreadPool);
+=======
+                                    0);
+>>>>>>> 0dac890a52 (Add changes to support queue_size in FIMDB synchronization in c++ code)
 
                 std::unique_ptr<TestContext> testContext { std::make_unique<TestContext>()};
                 testContext->outputPath = cmdLineArgs.outputFolder();

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -86,11 +86,8 @@ void fim_initialize() {
                                          syscheck.min_sync_interval,
                                          0,
                                          false,
-<<<<<<< HEAD
-                                         syscheck.sync_thread_pool);
-=======
-                                         0);
->>>>>>> 0dac890a52 (Add changes to support queue_size in FIMDB synchronization in c++ code)
+                                         syscheck.sync_thread_pool,
+                                         syscheck.sync_queue_size);
 #else
     FIMDBErrorCode ret_val = fim_db_init(syscheck.database_store,
                                          syscheck.sync_interval,
@@ -100,11 +97,8 @@ void fim_initialize() {
                                          syscheck.min_sync_interval,
                                          syscheck.db_entry_registry_limit,
                                          syscheck.enable_registry_synchronization,
-<<<<<<< HEAD
-                                         syscheck.sync_thread_pool);
-=======
-                                         0);
->>>>>>> 0dac890a52 (Add changes to support queue_size in FIMDB synchronization in c++ code)
+                                         syscheck.sync_thread_pool,
+                                         syscheck.sync_queue_size);
 #endif
 
     if (ret_val != FIMDB_OK) {

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -86,7 +86,11 @@ void fim_initialize() {
                                          syscheck.min_sync_interval,
                                          0,
                                          false,
+<<<<<<< HEAD
                                          syscheck.sync_thread_pool);
+=======
+                                         0);
+>>>>>>> 0dac890a52 (Add changes to support queue_size in FIMDB synchronization in c++ code)
 #else
     FIMDBErrorCode ret_val = fim_db_init(syscheck.database_store,
                                          syscheck.sync_interval,
@@ -96,7 +100,11 @@ void fim_initialize() {
                                          syscheck.min_sync_interval,
                                          syscheck.db_entry_registry_limit,
                                          syscheck.enable_registry_synchronization,
+<<<<<<< HEAD
                                          syscheck.sync_thread_pool);
+=======
+                                         0);
+>>>>>>> 0dac890a52 (Add changes to support queue_size in FIMDB synchronization in c++ code)
 #endif
 
     if (ret_val != FIMDB_OK) {

--- a/src/unit_tests/config_files/test_syscheck2.conf
+++ b/src/unit_tests/config_files/test_syscheck2.conf
@@ -57,6 +57,7 @@
     <synchronization>
       <enabled>no</enabled>
       <interval>10m</interval>
+      <queue_size>1000</queue_size>
     </synchronization>
     <database>memory</database>
   </syscheck>

--- a/src/unit_tests/config_files/test_syscheck_max_dir.conf
+++ b/src/unit_tests/config_files/test_syscheck_max_dir.conf
@@ -76,6 +76,7 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>10m</interval>
+      <queue_size>1000</queue_size>
     </synchronization>
     <database>disk</database>
   </syscheck>

--- a/src/unit_tests/syscheckd/test_config.c
+++ b/src/unit_tests/syscheckd/test_config.c
@@ -138,6 +138,7 @@ void test_Read_Syscheck_Config_success(void **state)
     assert_int_equal(syscheck.allow_remote_prefilter_cmd, true);
     assert_non_null(syscheck.prefilter_cmd);    // It should be a valid binary absolute path
     assert_int_equal(syscheck.sync_interval, 600);
+    assert_int_equal(syscheck.sync_queue_size, 1000);
     assert_int_equal(syscheck.max_eps, 200);
     assert_int_equal(syscheck.disk_quota_enabled, true);
     assert_int_equal(syscheck.disk_quota_limit, 1024 * 1024);
@@ -206,6 +207,7 @@ void test_Read_Syscheck_Config_undefined(void **state)
     assert_int_equal(syscheck.allow_remote_prefilter_cmd, false);
     assert_null(syscheck.prefilter_cmd);
     assert_int_equal(syscheck.sync_interval, 600);
+    assert_int_equal(syscheck.sync_queue_size, 1000);
     assert_int_equal(syscheck.max_eps, 200);
     assert_int_equal(syscheck.disk_quota_enabled, true);
     assert_int_equal(syscheck.disk_quota_limit, 2 * 1024 * 1024);
@@ -259,6 +261,7 @@ void test_Read_Syscheck_Config_unparsed(void **state)
     assert_int_equal(syscheck.allow_remote_prefilter_cmd, false);
     assert_null(syscheck.prefilter_cmd);
     assert_int_equal(syscheck.sync_interval, 300);
+    assert_int_equal(syscheck.sync_queue_size, 16384);
     assert_int_equal(syscheck.max_eps, 100);
     assert_int_equal(syscheck.disk_quota_enabled, true);
     assert_int_equal(syscheck.disk_quota_limit, 1024 * 1024);

--- a/src/unit_tests/syscheckd/test_syscheck.c
+++ b/src/unit_tests/syscheckd/test_syscheck.c
@@ -53,7 +53,7 @@ static int setup_syscheck_config(void **state) {
     syscheck_conf->sync_interval             = 300;
     syscheck_conf->min_sync_interval         = 60;
     syscheck_conf->sync_thread_pool          = 1;
-    syscheck_conf->file_entry_limit          = 100000;
+    syscheck_conf->db_entry_file_limit       = 100000;
 #ifdef WIN32
     syscheck_conf->db_entry_registry_limit   = 100000;
 #endif

--- a/src/unit_tests/syscheckd/test_syscheck.c
+++ b/src/unit_tests/syscheckd/test_syscheck.c
@@ -53,6 +53,7 @@ static int setup_syscheck_config(void **state) {
     syscheck_conf->sync_interval             = 300;
     syscheck_conf->min_sync_interval         = 60;
     syscheck_conf->sync_thread_pool          = 1;
+    syscheck_conf->sync_queue_size           = 30;
     syscheck_conf->db_entry_file_limit       = 100000;
 #ifdef WIN32
     syscheck_conf->db_entry_registry_limit   = 100000;
@@ -107,7 +108,8 @@ void test_fim_initialize(void **state)
                                syscheck_conf->min_sync_interval,
                                syscheck_conf->db_entry_registry_limit,
                                1,
-                               syscheck_conf->sync_thread_pool);
+                               syscheck_conf->sync_thread_pool,
+                               syscheck_conf->sync_queue_size);
 #else
     expect_wrapper_fim_db_init(syscheck_conf->database_store,
                                syscheck_conf->sync_interval,
@@ -115,7 +117,8 @@ void test_fim_initialize(void **state)
                                syscheck_conf->min_sync_interval,
                                0,
                                0,
-                               syscheck_conf->sync_thread_pool);
+                               syscheck_conf->sync_thread_pool,
+                               syscheck_conf->sync_queue_size);
 #endif
     fim_initialize();
 }
@@ -200,7 +203,7 @@ void test_Start_win32_Syscheck_corrupted_config_file(void **state) {
 
     will_return(__wrap_rootcheck_init, 1);
 
-    expect_wrapper_fim_db_init(0, 300, 100000, 60, 100000, 1);
+    expect_wrapper_fim_db_init(0, 300, 100000, 60, 100000, 1, 1, 30);
     expect_function_call(__wrap_os_wait);
     expect_function_call(__wrap_start_daemon);
     assert_int_equal(Start_win32_Syscheck(), 0);
@@ -226,7 +229,7 @@ void test_Start_win32_Syscheck_syscheck_disabled_1(void **state) {
 
     will_return(__wrap_rootcheck_init, 0);
 
-    expect_wrapper_fim_db_init(0, 300, 100000, 60, 100000, 1);
+    expect_wrapper_fim_db_init(0, 300, 100000, 60, 100000, 1, 1, 30);
     expect_string(__wrap__minfo, formatted_msg, FIM_FILE_SIZE_LIMIT_DISABLED);
 
     expect_string(__wrap__minfo, formatted_msg, FIM_DISK_QUOTA_LIMIT_DISABLED);
@@ -256,7 +259,7 @@ void test_Start_win32_Syscheck_syscheck_disabled_2(void **state) {
 
     will_return(__wrap_rootcheck_init, 0);
 
-    expect_wrapper_fim_db_init(0, 300, 100000, 60, 100000, 1);
+    expect_wrapper_fim_db_init(0, 300, 100000, 60, 100000, 1, 1, 30);
     expect_string(__wrap__minfo, formatted_msg, FIM_FILE_SIZE_LIMIT_DISABLED);
 
     expect_string(__wrap__minfo, formatted_msg, FIM_DISK_QUOTA_LIMIT_DISABLED);
@@ -326,7 +329,7 @@ void test_Start_win32_Syscheck_dirs_and_registry(void **state) {
 
     expect_string(__wrap__minfo, formatted_msg, "(6004): No diff for file: 'Diff'");
 
-    expect_wrapper_fim_db_init(0, 300, 100000, 60, 100000, 1);
+    expect_wrapper_fim_db_init(0, 300, 100000, 60, 100000, 1, 1, 30);
     snprintf(info_msg, OS_MAXSTR, "Started (pid: %d).", getpid());
     expect_string(__wrap__minfo, formatted_msg, info_msg);
 
@@ -374,7 +377,7 @@ void test_Start_win32_Syscheck_whodata_active(void **state) {
 
     expect_string(__wrap__minfo, formatted_msg, "(6003): Monitoring path: 'c:\\dir1', with options 'whodata'.");
 
-    expect_wrapper_fim_db_init(0, 300, 100000, 60, 100000, 1);
+    expect_wrapper_fim_db_init(0, 300, 100000, 60, 100000, 1, 1, 30);
     expect_string(__wrap__minfo, formatted_msg, FIM_FILE_SIZE_LIMIT_DISABLED);
 
     expect_string(__wrap__minfo, formatted_msg, FIM_DISK_QUOTA_LIMIT_DISABLED);

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
@@ -45,7 +45,8 @@ FIMDBErrorCode __wrap_fim_db_init(int storage,
                                   uint32_t min_sync_interval,
                                   int value_limit,
                                   int sync_registry_enable,
-                                  int sync_thread_pool) {
+                                  int sync_thread_pool,
+                                  int sync_queue_size) {
     check_expected(storage);
     check_expected(sync_interval);
     check_expected(file_limit);
@@ -53,6 +54,7 @@ FIMDBErrorCode __wrap_fim_db_init(int storage,
     check_expected(value_limit);
     check_expected(sync_registry_enable);
     check_expected(sync_thread_pool);
+    check_expected(sync_queue_size);
 
     return mock_type(int);
 }
@@ -63,7 +65,8 @@ void expect_wrapper_fim_db_init(int storage,
                                 uint32_t min_sync_interval,
                                 int value_limit,
                                 int sync_registry_enable,
-                                int sync_thread_pool) {
+                                int sync_thread_pool,
+                                int sync_queue_size) {
     expect_value(__wrap_fim_db_init, storage, storage);
     expect_value(__wrap_fim_db_init, sync_interval, sync_interval);
     expect_value(__wrap_fim_db_init, file_limit, file_limit);
@@ -71,6 +74,7 @@ void expect_wrapper_fim_db_init(int storage,
     expect_value(__wrap_fim_db_init, value_limit, value_limit);
     expect_value(__wrap_fim_db_init, sync_registry_enable, sync_registry_enable);
     expect_value(__wrap_fim_db_init, sync_thread_pool, sync_thread_pool);
+    expect_value(__wrap_fim_db_init, sync_queue_size, sync_queue_size);
 
     will_return(__wrap_fim_db_init, FIMDB_OK);
 }

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
@@ -47,7 +47,8 @@ FIMDBErrorCode __wrap_fim_db_init(int storage,
                                   uint32_t min_sync_interval,
                                   int value_limit,
                                   int sync_registry_enable,
-                                  int sync_thread_pool);
+                                  int sync_thread_pool,
+                                  int sync_queue_size);
 
 void expect_wrapper_fim_db_init(int storage,
                                 int sync_interval,
@@ -55,7 +56,8 @@ void expect_wrapper_fim_db_init(int storage,
                                 uint32_t min_sync_interval,
                                 int value_limit,
                                 int sync_registry_enable,
-                                int sync_thread_pool);
+                                int sync_thread_pool,
+                                int sync_queue_size);
 
 FIMDBErrorCode __wrap_fim_db_remove_path(const char *path);
 


### PR DESCRIPTION
|Related issue|
|---|
|#14021|

Hello team, this PR implements the new setting related to RSync, it is called queue_size, it indicates the number of events that RSync can use to perform FIM sync. With this PR I add queue_size to thread pool setting.