### PR TITLE
Fix bug in RTR jenkins check

### DIFF
--- a/src/ci/build_tools.py
+++ b/src/ci/build_tools.py
@@ -38,11 +38,13 @@ def cleanAll():
     Raises:
         - ValueError: Raises an exception.
     """
+    os.chdir(utils.rootPath())
     out = subprocess.run("make clean",
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,
                          shell=True,
-                         check=True)
+                         check=True,
+                         text=True)
     if out.returncode == 0:
         utils.printGreen(msg="[CleanAll: PASSED]")
     else:
@@ -137,11 +139,13 @@ def cleanInternals():
     Raises:
         - ValueError: Raises an exception.
     """
+    os.chdir(utils.rootPath())
     out = subprocess.run("make clean-internals",
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,
                          shell=True,
-                         check=True)
+                         check=True,
+                         text=True)
     if out.returncode == 0:
         utils.printGreen(msg="[CleanInternals: PASSED]")
     else:
@@ -209,12 +213,12 @@ def configureCMake(moduleName, debugMode, testMode, withAsan):
     """
     utils.printSubHeader(moduleName=moduleName,
                          headerKey="configurecmake")
-    currentModuleNameDir = utils.moduleDirPath(moduleName=moduleName)
+    os.chdir(utils.moduleDirPath(moduleName=moduleName))
     currentPathDir = utils.moduleDirPathBuild(moduleName=moduleName)
     if not os.path.exists(currentPathDir):
         os.mkdir(currentPathDir)
     configureCMakeCommand = "cmake -S {} -B {}"\
-                            .format(currentModuleNameDir, currentPathDir)
+                            .format(".", currentPathDir)
     if debugMode:
         configureCMakeCommand += " -DCMAKE_BUILD_TYPE=Debug"
 
@@ -228,6 +232,7 @@ def configureCMake(moduleName, debugMode, testMode, withAsan):
                          stderr=subprocess.PIPE,
                          shell=True,
                          check=True)
+    os.chdir(utils.rootPath())
     if out.returncode == 0 and not out.stderr:
         utils.printGreen(msg="[ConfigureCMake: PASSED]")
     else:

--- a/src/ci/run_check.py
+++ b/src/ci/run_check.py
@@ -304,59 +304,55 @@ def runReadyToReview(moduleName, clean=False, target="agent"):
     """
     utils.printHeader(moduleName=moduleName,
                       headerKey="rtr")
-    try:
-        runCppCheck(moduleName=moduleName)
-        build_tools.makeDeps(targetName=target, srcOnly=False)
-        build_tools.makeTarget(targetName=target, tests=True, debug=True)
-        runTests(moduleName=moduleName)
+    runCppCheck(moduleName=moduleName)
+    build_tools.makeDeps(targetName=target, srcOnly=False)
+    build_tools.makeTarget(targetName=target, tests=True, debug=True)
+    runTests(moduleName=moduleName)
+    build_tools.cleanFolder(moduleName=moduleName,
+                            additionalFolder="build")
+    build_tools.configureCMake(moduleName=moduleName,
+                               debugMode=True,
+                               testMode=(False, True)
+                               [moduleName != "shared_modules/utils"],
+                               withAsan=False)
+    if target != "winagent":
+        build_tools.makeLib(moduleName=moduleName)
+        runValgrind(moduleName=moduleName)
+        runCoverage(moduleName=moduleName)
+    runAStyleCheck(moduleName=moduleName)
+    configPath = os.path.join(utils.currentPath(),
+                              "input/test_tool_config.json")
+    smokeTestConfig = utils.readJSONFile(jsonFilePath=configPath)
+    if target == "winagent":
+        build_tools.cleanAll()
+        build_tools.cleanExternals()
+        build_tools.makeDeps(targetName="agent", srcOnly=False)
+        build_tools.makeTarget(targetName="agent", tests=False, debug=True)
         build_tools.cleanFolder(moduleName=moduleName,
                                 additionalFolder="build")
-        build_tools.configureCMake(moduleName=moduleName,
-                                   debugMode=True,
-                                   testMode=(False, True)
-                                   [moduleName != "shared_modules/utils"],
-                                   withAsan=False)
-        if target != "winagent":
-            build_tools.makeLib(moduleName=moduleName)
-            runValgrind(moduleName=moduleName)
-            runCoverage(moduleName=moduleName)
-        runAStyleCheck(moduleName=moduleName)
-        configPath = os.path.join(utils.currentPath(),
-                                  "input/test_tool_config.json")
-        smokeTestConfig = utils.readJSONFile(jsonFilePath=configPath)
-        if target == "winagent":
-            build_tools.cleanAll()
-            build_tools.cleanExternals()
-            build_tools.makeDeps(targetName="agent", srcOnly=False)
-            build_tools.makeTarget(targetName="agent", tests=False, debug=True)
-            build_tools.cleanFolder(moduleName=moduleName,
-                                    additionalFolder="build")
-        if moduleName != "shared_modules/utils":
-            runASAN(moduleName=moduleName,
-                    testToolConfig=smokeTestConfig)
-        if moduleName == "syscheckd":
-            runTestToolForWindows(moduleName=moduleName,
-                                  testToolConfig=smokeTestConfig)
-            runTestToolCheck(moduleName=moduleName)
-        if moduleName != "syscheckd":
-            build_tools.cleanAll()
-            build_tools.cleanExternals()
-        if target != "winagent":
-            utils.printHeader(moduleName=moduleName,
-                              headerKey="winagentTests")
-            build_tools.makeDeps(targetName="winagent",
-                                 srcOnly=False)
-            build_tools.makeTarget(targetName="winagent",
-                                   tests=True,
-                                   debug=True)
-            runTests(moduleName=moduleName)
-        if clean:
-            utils.deleteLogs(moduleName=moduleName)
-        utils.printGreen(msg="[RTR: PASSED]",
-                         module=moduleName)
-    except Exception as e:
-        utils.printFail(msg="[RTR: FAILED]")
-        print(e)
+    if moduleName != "shared_modules/utils":
+        runASAN(moduleName=moduleName,
+                testToolConfig=smokeTestConfig)
+    if moduleName == "syscheckd":
+        runTestToolForWindows(moduleName=moduleName,
+                              testToolConfig=smokeTestConfig)
+        runTestToolCheck(moduleName=moduleName)
+    if moduleName != "syscheckd":
+        build_tools.cleanAll()
+        build_tools.cleanExternals()
+    if target != "winagent":
+        utils.printHeader(moduleName=moduleName,
+                          headerKey="winagentTests")
+        build_tools.makeDeps(targetName="winagent",
+                             srcOnly=False)
+        build_tools.makeTarget(targetName="winagent",
+                               tests=True,
+                               debug=True)
+        runTests(moduleName=moduleName)
+    if clean:
+        utils.deleteLogs(moduleName=moduleName)
+    utils.printGreen(msg="[RTR: PASSED]",
+                     module=moduleName)
 
 
 def runScanBuild(targetName):

--- a/src/ci/run_check.py
+++ b/src/ci/run_check.py
@@ -305,8 +305,12 @@ def runReadyToReview(moduleName, clean=False, target="agent"):
     utils.printHeader(moduleName=moduleName,
                       headerKey="rtr")
     runCppCheck(moduleName=moduleName)
-    build_tools.makeDeps(targetName=target, srcOnly=False)
-    build_tools.makeTarget(targetName=target, tests=True, debug=True)
+    runAStyleCheck(moduleName=moduleName)
+    build_tools.makeDeps(targetName=target,
+                         srcOnly=False)
+    build_tools.makeTarget(targetName=target,
+                           tests=True,
+                           debug=True)
     runTests(moduleName=moduleName)
     build_tools.cleanFolder(moduleName=moduleName,
                             additionalFolder="build")
@@ -319,7 +323,6 @@ def runReadyToReview(moduleName, clean=False, target="agent"):
         build_tools.makeLib(moduleName=moduleName)
         runValgrind(moduleName=moduleName)
         runCoverage(moduleName=moduleName)
-    runAStyleCheck(moduleName=moduleName)
     configPath = os.path.join(utils.currentPath(),
                               "input/test_tool_config.json")
     smokeTestConfig = utils.readJSONFile(jsonFilePath=configPath)
@@ -379,7 +382,7 @@ def runScanBuild(targetName):
                                tests=False,
                                debug=True)
         build_tools.cleanInternals()
-        scanBuildCommand = "scan-build-10 --status-bugs \
+        scanBuildCommand = "scan-build --status-bugs \
                             --use-cc=/usr/bin/i686-w64-mingw32-gcc \
                             --use-c++=/usr/bin/i686-w64-mingw32-g++-posix \
                             --analyzer-target=i686-w64-mingw32 \
@@ -388,7 +391,7 @@ def runScanBuild(targetName):
     else:
         build_tools.makeDeps(targetName=targetName,
                              srcOnly=False)
-        scanBuildCommand = "scan-build-10 --status-bugs \
+        scanBuildCommand = "scan-build --status-bugs \
                             --force-analyze-debug-code \
                             --exclude external/ make TARGET={} \
                             DEBUG=1 -j4".format(targetName)
@@ -546,13 +549,13 @@ def runTests(moduleName):
     if len(tests) > 0:
         os.chdir(currentDir)
         for test in tests:
-            #path = os.path.join(currentDir, test)
+            path = os.path.join(currentDir, test)
             if ".exe" in test:
                 command = f'WINEPATH="/usr/i686-w64-mingw32/lib;\
                             {utils.currentPath()}" \
-                            WINEARCH=win64 /usr/bin/wine ./{test}'
+                            WINEARCH=win64 /usr/bin/wine {path}'
             else:
-                command = "./{}".format(test)
+                command = path
             out = subprocess.run(command,
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE,

--- a/src/ci/run_check.py
+++ b/src/ci/run_check.py
@@ -544,14 +544,15 @@ def runTests(moduleName):
         if entry.is_file() and bool(re.match(reg, entry.name)):
             tests.append(entry.name)
     if len(tests) > 0:
+        os.chdir(currentDir)
         for test in tests:
-            path = os.path.join(currentDir, test)
+            #path = os.path.join(currentDir, test)
             if ".exe" in test:
                 command = f'WINEPATH="/usr/i686-w64-mingw32/lib;\
                             {utils.currentPath()}" \
-                            WINEARCH=win64 /usr/bin/wine {path}'
+                            WINEARCH=win64 /usr/bin/wine ./{test}'
             else:
-                command = path
+                command = "./{}".format(test)
             out = subprocess.run(command,
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE,

--- a/src/ci/run_check.py
+++ b/src/ci/run_check.py
@@ -326,32 +326,34 @@ def runReadyToReview(moduleName, clean=False, target="agent"):
     configPath = os.path.join(utils.currentPath(),
                               "input/test_tool_config.json")
     smokeTestConfig = utils.readJSONFile(jsonFilePath=configPath)
-    if target == "winagent":
-        build_tools.cleanAll()
-        build_tools.cleanExternals()
-        build_tools.makeDeps(targetName="agent", srcOnly=False)
-        build_tools.makeTarget(targetName="agent", tests=False, debug=True)
-        build_tools.cleanFolder(moduleName=moduleName,
-                                additionalFolder="build")
+    ### Uncomment after close https://github.com/wazuh/wazuh/issues/11025
+    # if target == "winagent":
+    #     build_tools.cleanAll()
+    #     build_tools.cleanExternals()
+    #     build_tools.makeDeps(targetName="agent", srcOnly=False)
+    #     build_tools.makeTarget(targetName="agent", tests=False, debug=True)
+    #     build_tools.cleanFolder(moduleName=moduleName,
+    #                             additionalFolder="build")
     if moduleName != "shared_modules/utils":
         runASAN(moduleName=moduleName,
                 testToolConfig=smokeTestConfig)
-    if moduleName == "syscheckd":
-        runTestToolForWindows(moduleName=moduleName,
-                              testToolConfig=smokeTestConfig)
-        runTestToolCheck(moduleName=moduleName)
-    if moduleName != "syscheckd":
-        build_tools.cleanAll()
-        build_tools.cleanExternals()
-    if target != "winagent":
-        utils.printHeader(moduleName=moduleName,
-                          headerKey="winagentTests")
-        build_tools.makeDeps(targetName="winagent",
-                             srcOnly=False)
-        build_tools.makeTarget(targetName="winagent",
-                               tests=True,
-                               debug=True)
-        runTests(moduleName=moduleName)
+    ### Uncomment after close https://github.com/wazuh/wazuh/issues/11025
+    # if moduleName == "syscheckd":
+    #     runTestToolForWindows(moduleName=moduleName,
+    #                           testToolConfig=smokeTestConfig)
+    #     runTestToolCheck(moduleName=moduleName)
+    # if moduleName != "syscheckd":
+    #     build_tools.cleanAll()
+    #     build_tools.cleanExternals()
+    # if target != "winagent":
+    #     utils.printHeader(moduleName=moduleName,
+    #                       headerKey="winagentTests")
+    #     build_tools.makeDeps(targetName="winagent",
+    #                          srcOnly=False)
+    #     build_tools.makeTarget(targetName="winagent",
+    #                            tests=True,
+    #                            debug=True)
+    #     runTests(moduleName=moduleName)
     if clean:
         utils.deleteLogs(moduleName=moduleName)
     utils.printGreen(msg="[RTR: PASSED]",

--- a/src/shared_modules/rsync/cppcheckSuppress.txt
+++ b/src/shared_modules/rsync/cppcheckSuppress.txt
@@ -1,3 +1,3 @@
 *:*src/rsyncImplementation.cpp:153
-*:*tests/implementation/rsyncImplementationTest.cpp:247
-*:*tests/interface/rsync_test.cpp:249
+*:*tests/implementation/rsyncImplementationTest.cpp:249
+*:*tests/interface/rsync_test.cpp:241

--- a/src/shared_modules/rsync/tests/interface/rsync_test.cpp
+++ b/src/shared_modules/rsync/tests/interface/rsync_test.cpp
@@ -1361,3 +1361,70 @@ TEST_F(RSyncTest, RegisterAndPushWithDoubleHandleDisconnect)
     remoteSync.reset();
 }
 
+TEST(RSyncBuilderRegisterConfigurationTest, TestExpectedHappyCase)
+{
+    auto registerConfig
+    {
+        RegisterConfiguration::builder().decoderType("JSON_RANGE")
+        .table("dbsync_osinfo")
+        .component("syscollector_osinfo")
+        .index("os_name")
+        .checksumField("checksum")
+        .noData(
+            QueryParameter::builder().rowFilter("WHERE os_name BETWEEN '?' and '?' ORDER BY os_name")
+        .columnList({"*"})
+        .distinctOpt(false)
+        .orderByOpt(""))
+        .countRange(
+            QueryParameter::builder().countFieldName("count")
+            .rowFilter("WHERE os_name BETWEEN '?' and '?' ORDER BY os_name")
+        .columnList({"count(*) AS count "})
+        .distinctOpt(false)
+        .orderByOpt(""))
+        .rowData(
+            QueryParameter::builder().rowFilter("WHERE os_name ='?'")
+        .columnList({"*"})
+        .distinctOpt(false)
+        .orderByOpt(""))
+        .rangeChecksum(
+            QueryParameter::builder().rowFilter("WHERE os_name BETWEEN '?' and '?' ORDER BY os_name")
+        .columnList({"*"})
+        .distinctOpt(false)
+        .orderByOpt(""))
+    };
+
+    EXPECT_EQ(registerConfig.config().dump(),
+              R"({"checksum_field":"checksum","component":"syscollector_osinfo","count_range_query_json":{"column_list":["count(*) AS count "],"count_field_name":"count","distinct_opt":false,"order_by_opt":"","row_filter":"WHERE os_name BETWEEN '?' and '?' ORDER BY os_name"},"decoder_type":"JSON_RANGE","index":"os_name","no_data_query_json":{"column_list":["*"],"distinct_opt":false,"order_by_opt":"","row_filter":"WHERE os_name BETWEEN '?' and '?' ORDER BY os_name"},"range_checksum_query_json":{"column_list":["*"],"distinct_opt":false,"order_by_opt":"","row_filter":"WHERE os_name BETWEEN '?' and '?' ORDER BY os_name"},"row_data_query_json":{"column_list":["*"],"distinct_opt":false,"order_by_opt":"","row_filter":"WHERE os_name ='?'"},"table":"dbsync_osinfo"})");
+}
+
+TEST(RSyncBuilderStartSyncConfigurationTest, TestExpectedHappyCase)
+{
+    auto startSyncConfig
+    {
+        StartSyncConfiguration::builder().component("syscollector_osinfo")
+        .table("dbsync_osinfo")
+        .index("os_name")
+        .checksumField("checksum")
+        .lastEvent("last_event")
+        .rangeChecksum(
+            QueryParameter::builder().rowFilter("WHERE os_name BETWEEN '?' and '?' ORDER BY os_name")
+        .columnList({"os_name", "checksum"})
+        .distinctOpt(false)
+        .orderByOpt("")
+        .countOpt(100))
+        .first(
+            QueryParameter::builder().rowFilter(" ")
+        .columnList({"os_name"})
+        .distinctOpt(false)
+        .orderByOpt("os_name DESC")
+        .countOpt(1))
+        .last(
+            QueryParameter::builder().rowFilter(" ")
+        .columnList({"os_name"})
+        .distinctOpt(false)
+        .orderByOpt("os_name ASC")
+        .countOpt(1))
+    };
+    EXPECT_EQ(startSyncConfig.config().dump(),
+              R"({"checksum_field":"checksum","component":"syscollector_osinfo","first_query":{"column_list":["os_name"],"count_opt":1,"distinct_opt":false,"order_by_opt":"os_name DESC","row_filter":" "},"index":"os_name","last_event":"last_event","last_query":{"column_list":["os_name"],"count_opt":1,"distinct_opt":false,"order_by_opt":"os_name ASC","row_filter":" "},"range_checksum_query_json":{"column_list":["os_name","checksum"],"count_opt":100,"distinct_opt":false,"order_by_opt":"","row_filter":"WHERE os_name BETWEEN '?' and '?' ORDER BY os_name"},"table":"dbsync_osinfo"})");
+}


### PR DESCRIPTION
|EPIC|Component|
|---|---|
| https://github.com/wazuh/wazuh/issues/9103 | FIM |

|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/14373|

## Description
Hi team, there is a bug in our RTR check that generates a problem inside jenkins as the RTR check does not generate any exception, this is because we are catching the exceptions this works in a local environment but this makes the Jenkins check never fails. 
Regards

## Tests
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report