### PR TITLE
fix IPv6 syslog messages handled

### DIFF
--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -48,8 +48,6 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
 
     id = msg[0];
 
-    minfo("-----> msg '%s'", msg);
-
     /* Ignore the id of the message in here */
     msg += 2;
 
@@ -76,8 +74,6 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
     pieces++;
 
     os_strdup(msg, lf->location);
-
-    minfo("-----> lf->location '%s'", lf->location);
 
     /* Get the log length */
     loglen = strlen(pieces) + 1;

--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -64,8 +64,7 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
         src_msg = msg + IPV6_LAST_DIGIT;
     }
 
-    pieces = strchr(src_msg ? src_msg : msg, ':');
-    if (!pieces) {
+    if (pieces = strchr(src_msg != NULL ? src_msg : msg, ':'), pieces == NULL) {
         merror(FORMAT_ERROR);
         return (-1);
     }

--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -16,7 +16,7 @@
 #include "fts.h"
 #include "config.h"
 
-#define IPV6_LAST_DIGIT INET6_ADDRSTRLEN - 8
+#define IPV6_LAST_DIGIT 38
 
 /* To translate between month (int) to month (char) */
 static const char *(month[]) = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",

--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -53,7 +53,7 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
 
     /* Avoid ipv6 ':', msg that include "[" have an "->" after the ip */
     if (*msg == '[') {
-        if (!(src_msg = strstr(msg, "->"))) {
+        if (src_msg = strstr(msg, "->"), src_msg == NULL) {
             merror(FORMAT_ERROR);
             return (-1);
         }

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -10,6 +10,7 @@
 #include "logtest.h"
 #include "os_xml/os_xml.h"
 
+#define LOGTESTQUEUE SYSLOG_MQ
 
 OSHash *w_logtest_sessions;
 
@@ -262,7 +263,7 @@ int w_logtest_preprocessing_phase(Eventinfo * lf, cJSON * request) {
     int logsize = strlen(location_str) + strlen(event_str) + 4;
 
     os_calloc(logsize, sizeof(char), log);
-    snprintf(log, logsize, "1:%s:%s", location_str, event_str);
+    snprintf(log, logsize, "%c:%s:%s", LOGTESTQUEUE, location_str, event_str);
 
     if (OS_CleanMSG(log, lf) < 0) {
         os_free(log);

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -38,6 +38,9 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 list(APPEND analysisd_names "test_analysisd_syscheck")
 list(APPEND analysisd_flags "-Wl,--wrap,wdbc_query_ex -Wl,--wrap,wdbc_parse_result ${DEBUG_OP_WRAPPERS}")
 
+list(APPEND analysisd_names "test_cleanevent")
+list(APPEND analysisd_flags "-Wl,--wrap,_merror")
+
 list(APPEND analysisd_names "test_dbsync")
 list(APPEND analysisd_flags "-Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP \
                          -Wl,--wrap,connect_to_remoted -Wl,--wrap,send_msg_to_agent -Wl,--wrap,wdbc_query_ex \

--- a/src/unit_tests/analysisd/test_cleanevent.c
+++ b/src/unit_tests/analysisd/test_cleanevent.c
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2022, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+
+#include "../../analysisd/cleanevent.h"
+
+
+static int test_setup(void **state) {
+    Eventinfo *lf = NULL;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    *state = lf;
+
+    return OS_SUCCESS;
+}
+
+static int test_teardown(void **state) {
+    Eventinfo *lf = (Eventinfo *)*state;
+    os_free(lf->full_log);
+    os_free(lf->location);
+    os_free(lf->location);
+    os_free(lf->agent_id);
+    os_free(lf->hostname);
+    os_free(lf);
+
+    return OS_SUCCESS;
+}
+
+
+static void test_OS_CleanMSG_fail(void **state) {
+
+    Eventinfo lf;
+
+    char *msg;
+    os_calloc(20, sizeof(char), msg);
+    snprintf(msg, 20, "%s", "fail message");
+    expect_string(__wrap__merror, formatted_msg, "(1106): String not correctly formatted.");
+
+    int value = OS_CleanMSG(msg, &lf);
+
+    assert_int_equal(value, -1);
+
+    os_free(msg);
+}
+
+static void test_OS_CleanMSG_ossec_test_msg(void **state) {
+
+    Eventinfo *lf = (Eventinfo *)*state;
+
+    char *msg;
+    os_calloc(30, sizeof(char), msg);
+    snprintf(msg, 30, "%c:%s:%s", '1', "location test", "payload test");
+
+    int value = OS_CleanMSG(msg, lf);
+
+    assert_int_equal(value, 0);
+    assert_string_equal(lf->full_log, "payload test");
+    assert_string_equal(lf->location, "location test");
+
+    os_free(msg);
+}
+
+static void test_OS_CleanMSG_ossec_syslog_msg(void **state) {
+
+    Eventinfo *lf = (Eventinfo *)*state;
+
+    char *msg;
+    os_calloc(60, sizeof(char), msg);
+    snprintf(msg, 60, "%c:%s:%s", '1', "/var/log/syslog", "payload test");
+
+    int value = OS_CleanMSG(msg, lf);
+
+    assert_int_equal(value, 0);
+    assert_string_equal(lf->full_log, "payload test");
+    assert_string_equal(lf->location, "/var/log/syslog");
+
+    os_free(msg);
+}
+
+static void test_OS_CleanMSG_syslog_ipv4_msg(void **state) {
+
+    Eventinfo *lf = (Eventinfo *)*state;
+
+    char *msg;
+    os_calloc(30, sizeof(char), msg);
+    snprintf(msg, 30, "%c:%s:%s", '2', "127.0.0.1", "payload test");
+
+    int value = OS_CleanMSG(msg, lf);
+
+    assert_int_equal(value, 0);
+    assert_string_equal(lf->full_log, "payload test");
+    assert_string_equal(lf->location, "127.0.0.1");
+
+    os_free(msg);
+}
+
+static void test_OS_CleanMSG_syslog_ipv6_msg(void **state) {
+
+    Eventinfo *lf = (Eventinfo *)*state;
+
+    char *msg;
+    os_calloc(60, sizeof(char), msg);
+    snprintf(msg, 60, "%c:%s:%s", '2', "0000:0000:0000:0000:0000:0000:0000:0001", "payload test");
+
+    int value = OS_CleanMSG(msg, lf);
+
+    assert_int_equal(value, 0);
+    assert_string_equal(lf->full_log, "payload test");
+    assert_string_equal(lf->location, "0000:0000:0000:0000:0000:0000:0000:0001");
+
+    os_free(msg);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+
+        cmocka_unit_test(test_OS_CleanMSG_fail),
+        cmocka_unit_test_setup_teardown(test_OS_CleanMSG_ossec_test_msg, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_OS_CleanMSG_ossec_syslog_msg, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_OS_CleanMSG_syslog_ipv4_msg, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_OS_CleanMSG_syslog_ipv6_msg, test_setup, test_teardown),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
|Related issue|Manual Testing|
|---|---|
|https://github.com/wazuh/wazuh/issues/13708|https://github.com/wazuh/wazuh-qa/issues/3094|

## Description

Syslog messages received by the Wazuh Syslog server (remoted) via IPv6 are correctly handled, the `location` and `full_log` fields are correctly parsed (splitted).

## Use case 

Remote Syslog messages are received on the Wazuh manager, from a device which address is of the IPv6 format.

### Configuracion

```xml
  <global>
       ...
       <logall_json>yes</logall_json>
       ...
  </global>
  
  <remote>
    <connection>syslog</connection>
    <port>5050</port>
    <protocol>tcp</protocol>
    <ipv6>yes</ipv6>
    <allowed-ips>any</allowed-ips>
  </remote>
```
## Logs/Alerts example


## Tests

Send a Syslog message from an IPv6 address (in this case, through the loopback interface).

```bash
echo "IPv6 test msg" | nc -v -w 0 -6 "::1"  5050
```
or running wazuh-logtest
```bash
/var/ossec/bin/wazuh-logtest -l "0000:0000:0000:0000:0000:0000:0000:0001" -d
```

Result

```json
{
    "timestamp": "2022-06-03T16:50:16.660+0000",
    "agent": {
        "id": "000",
        "name": "200-u20-dev-manager"
    },
    "manager": {
        "name": "200-u20-dev-manager"
    },
    "id": "1654275016.1163645",
    "full_log": "IPv6 test msg",
    "decoder": {},
    "location": "0000:0000:0000:0000:0000:0000:0000:0001"
}
```
Testing ipv4

```bash
echo "IPv4 test msg" | nc -v -w 0 localhost 505
```
```json
{
    "timestamp": "2022-06-03T16:50:16.660+0000",
    "agent": {
        "id": "000",
        "name": "200-u20-dev-manager"
    },
    "manager": {
        "name": "200-u20-dev-manager"
    },
    "id": "1654275016.1163645",
    "full_log": "IPv4 test msg",
    "decoder": {},
    "location": "127.0.0.1"
}
```

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)
