### PR TITLE
Add a reconnection INFO message to Github and Office365 integration 

### DIFF
--- a/src/wazuh_modules/wm_github.c
+++ b/src/wazuh_modules/wm_github.c
@@ -361,8 +361,10 @@ STATIC void wm_github_execute_scan(wm_github *github_config, int initial_scan) {
                             new_scan_time_str, current->org_name, event_types[event_types_it], github_config->interval);
                     }
 
-                    org_fail = wm_github_get_fail_by_org_and_type(github_config->fails, current->org_name, event_types[event_types_it]);
-                    if (org_fail != NULL) {
+                    if (org_fail = wm_github_get_fail_by_org_and_type(github_config->fails,
+                        current->org_name, event_types[event_types_it]), org_fail && org_fail->fails) {
+                        mtinfo(WM_GITHUB_LOGTAG, "Github organization '%s' and event type '%s', connected successfully.",
+                            current->org_name, event_types[event_types_it]);
                         org_fail->fails = 0;
                     }
                 }
@@ -428,7 +430,7 @@ STATIC void wm_github_scan_failure_action(wm_github_fail **current_fails, char *
 
         org_fail->fails = 1;
     } else {
-        org_fail->fails = org_fail->fails + 1;
+        org_fail->fails++;
 
         if (org_fail->fails == RETRIES_TO_SEND_ERROR) {
             // Send fail message

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -297,7 +297,8 @@ STATIC void wm_office365_execute_scan(wm_office365* office365_config, int initia
                 continue;
             } else {
                 if (tenant_fail = wm_office365_get_fail_by_tenant_and_subscription(office365_config->fails,
-                    current_auth->tenant_id, NULL), tenant_fail) {
+                    current_auth->tenant_id, NULL), tenant_fail && tenant_fail->fails) {
+                    mtinfo(WM_OFFICE365_LOGTAG, "Office365 tenant '%s', connected successfully.", current_auth->tenant_id);
                     tenant_fail->fails = 0;
                 }
             }
@@ -763,7 +764,7 @@ STATIC void wm_office365_scan_failure_action(wm_office365_fail** current_fails, 
 
         tenant_fail->fails = 1;
     } else {
-        tenant_fail->fails = tenant_fail->fails + 1;
+        tenant_fail->fails++;
 
         if (tenant_fail->fails == WM_OFFICE365_RETRIES_TO_SEND_ERROR) {
             // Send fail message


### PR DESCRIPTION
|Related issue|Documentation|Manual Testing|
|---|---|---|
|https://github.com/wazuh/wazuh/issues/13944|||


## Description
The goal of this change is encrease the information about how Office365 and Github integration works. 
A new message is added per integration, it's an INFO message, shown when GitHub or Office365 integration works again after been disconnected.


Github message includes the organization and event type
```Github organization '%s' and event type '%s', connected successfully.```

Office365 includes teant
```Office365 tenant '%s', connected successfully.```

## Configuration options

Github
```
 <github>
    <enabled>yes</enabled>
    <interval>10s</interval>
    <time_delay>30s</time_delay>
    <curl_max_size>1M</curl_max_size>
    <only_future_events>yes</only_future_events>
    <api_auth>
      <org_name>orcanization</org_name>
      <api_token>ghp_token</api_token>
    </api_auth>
    <api_parameters>
      <event_type>all</event_type>
    </api_parameters>
  </github>
```

Office365
```
  <office365>
    <enabled>yes</enabled>
    <interval>1m</interval>
    <curl_max_size>1M</curl_max_size>
    <only_future_events>no</only_future_events>
    <api_auth>
        <tenant_id>tenant_id</tenant_id>
        <client_id>client_id</client_id>
        <client_secret>client_secret</client_secret>
    </api_auth>
    <subscriptions>
        <subscription>Audit.SharePoint</subscription>
        <subscription>Audit.AzureActiveDirectory</subscription>
        <subscription>Audit.Exchange</subscription>
        <subscription>Audit.General</subscription>
    </subscriptions>
  </office365>
```

## Logs example

Github
```
Start with invalid organization binarybeast2022
2022/06/30 23:05:57 wazuh-modulesd:github: WARNING: Sending GitHub internal message: '{"integration":"github","github":{"actor":"wazuh","organization":"binarybeast2022","event_type":"git","response":"{\"message\":\"Bad credentials\",\"documentation_url\":\"https://docs.github.com/rest\"}"}}'
2022/06/30 23:05:57 wazuh-modulesd:github: WARNING: Sending GitHub internal message: '{"integration":"github","github":{"actor":"wazuh","organization":"binarybeast2022","event_type":"web","response":"{\"message\":\"Bad credentials\",\"documentation_url\":\"https://docs.github.com/rest\"}"}}'

Disconnection... 

2022/06/30 23:06:51 wazuh-modulesd:github: WARNING: Sending GitHub internal message: '{"integration":"github","github":{"actor":"wazuh","organization":"wuazuh2022","event_type":"git","response":"Unknown error"}}'
2022/06/30 23:06:51 wazuh-modulesd:github: WARNING: Sending GitHub internal message: '{"integration":"github","github":{"actor":"wazuh","organization":"wuazuh2022","event_type":"web","response":"Unknown error"}}'

Reconnection...

2022/06/30 23:07:22 wazuh-modulesd:github: INFO: Github organization 'wuazuh2022' and event type 'git', connected successfully.
2022/06/30 23:07:23 wazuh-modulesd:github: INFO: Github organization 'wuazuh2022' and event type 'web', connected successfully.
```

Office365

```
Disconnection...
2022/06/30 22:11:18 wazuh-modulesd:office365: WARNING: Sending Office365 internal message: '{"integration":"office365","office365":{"actor":"wazuh","tenant_id":"0fea4e03-8146-453b-b889-54b4bd11565b","response":"Unknown error"}}'

Reconnection...
2022/06/30 22:11:49 wazuh-modulesd:office365: INFO: Office365 tenant '0fea4e03-8146-453b-b889-54b4bd11565b', connected successfully.
```
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)