### PR TITLE
14097 backport avoid memleak vdt

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -84,6 +84,7 @@ void wm_vuldet_oval_copy_rhsa(vulnerability *old, vulnerability *new);
 void wm_vuldet_oval_traverse_rhsa(vulnerability *vul_it);
 void wm_vuldet_add_oval_vulnerability(wm_vuldet_db *ctrl_block);
 void wm_vuldet_clean_vulnerability_info(wm_vuldet_db *ctrl_block);
+void wm_vuldet_clean_oval_vulnerability_node(vulnerability *vuln_node);
 int wm_vuldet_insert_cve_info(wm_vuldet_db *parsed_oval, sqlite3 *db, sqlite3_stmt *stmt);
 void wm_vuldet_set_subversion(char *version, char **os_minor);
 void wm_vuldet_get_package_os(const char *version, const char **os_major, char **os_minor);
@@ -848,6 +849,31 @@ static int teardown_info_cves(void **state) {
         free(info_cves->cwe);
         free(info_cves);
     }
+
+    return OS_SUCCESS;
+}
+
+static int setup_vuln_node(void **state) {
+    vulnerability *vuln_node = NULL;
+    os_calloc(1, sizeof(vulnerability), vuln_node);
+
+    if(!vuln_node) {
+        return OS_INVALID;
+    }
+
+    os_strdup("CVE-1234-1234", vuln_node->cve_id);
+    os_strdup("test_ref", vuln_node->package_name);
+    os_strdup("value_ref", vuln_node->package_version);
+    os_strdup("criterion", vuln_node->state_id);
+    vuln_node->ignore = 1;
+
+    os_calloc(2, sizeof(char *), vuln_node->rhsa_list);
+    os_strdup("reference_value", vuln_node->rhsa_list[0]);
+    vuln_node->rhsa_list[1] = NULL;
+
+    vuln_node->prev = NULL;
+
+    *state = vuln_node;
 
     return OS_SUCCESS;
 }
@@ -14709,6 +14735,47 @@ void test_wm_vuldet_oval_xml_parser_redhat_rhel5_invalid_target()
     os_free(update);
 }
 
+void test_wm_vuldet_oval_xml_parser_redhat_definition_without_criteria()
+{
+    XML_NODE node = NULL;
+    XML_NODE child_node = NULL;
+    update_node *update = NULL;
+    wm_vuldet_db *parsed_oval = NULL;
+
+    os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
+    os_calloc(1, sizeof(vulnerability), parsed_oval->vulnerabilities);
+    os_strdup("CVE-1234-1234", parsed_oval->vulnerabilities->cve_id);
+
+    // Create xml node
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), *node);
+    os_calloc(2, sizeof(char *), node[0]->attributes);
+    os_calloc(2, sizeof(char *), node[0]->values);
+
+    // Attribute of the node different from 'class' to avoid running recursive function
+    os_strdup("NOclass", node[0]->attributes[0]);
+    os_strdup("vulnerability", node[0]->values[0]);
+    os_strdup("definition", node[0]->element);
+
+    // Simulation that the <criteria> field does not exist.
+    parsed_oval->vulnerabilities->state_id = NULL;
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_REDHAT;
+
+    // Fake child so that the function can end
+    os_calloc(2, sizeof(xml_node *), child_node);
+    os_calloc(1, sizeof(xml_node), *child_node);
+    will_return(__wrap_OS_GetElementsbyNode, child_node);
+
+    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    assert_int_equal(ret, 0);
+
+    os_free(parsed_oval);
+    OS_ClearNode(node);
+    os_free(update);
+}
+
 void test_wm_vuldet_oval_xml_parser_rhel_architecture_equals()
 {
     XML_NODE node = NULL;
@@ -17442,6 +17509,22 @@ void test_wm_vuldet_clean_vulnerability_info_one_info_cves(void **state)
     wm_vuldet_clean_vulnerability_info(ctrl_block);
 
     os_free(ctrl_block);
+}
+
+// Tests wm_vuldet_clean_oval_vulnerability_node
+
+void test_wm_vuldet_clean_oval_vulnerability_node_empty(void **state)
+{
+    vulnerability *vuln_node = NULL;
+    os_calloc(1, sizeof(vulnerability), vuln_node);
+
+    wm_vuldet_clean_oval_vulnerability_node(vuln_node);
+}
+
+void test_wm_vuldet_clean_oval_vulnerability_node_with_vulns(void **state)
+{
+    vulnerability *vuln_node = *state;
+    wm_vuldet_clean_oval_vulnerability_node(vuln_node);
 }
 
 void test_wm_vuldet_insert_cve_info(void **state)
@@ -21016,6 +21099,7 @@ int main(void)
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_redhat_object),
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_redhat_object_valid_content),
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_redhat_rhel5_invalid_target),
+        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_redhat_definition_without_criteria),
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_rhel_architecture_equals),
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_rhel_architecture_pattern),
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_rhel_architecture_noarch),
@@ -21080,6 +21164,9 @@ int main(void)
         // Tests wm_vuldet_clean_vulnerability_info
         cmocka_unit_test(test_wm_vuldet_clean_vulnerability_info_no_info_cves),
         cmocka_unit_test_setup(test_wm_vuldet_clean_vulnerability_info_one_info_cves, setup_info_cves),
+        // Tests wm_vuldet_clean_oval_vulnerability_node
+        cmocka_unit_test(test_wm_vuldet_clean_oval_vulnerability_node_empty),
+        cmocka_unit_test_setup(test_wm_vuldet_clean_oval_vulnerability_node_with_vulns, setup_vuln_node),
         // Tests wm_vuldet_insert_cve_info
         cmocka_unit_test_setup_teardown(test_wm_vuldet_insert_cve_info, setup_info_cves, teardown_info_cves),
         // Tests wm_vuldet_set_subversion

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -84,7 +84,7 @@ void wm_vuldet_oval_copy_rhsa(vulnerability *old, vulnerability *new);
 void wm_vuldet_oval_traverse_rhsa(vulnerability *vul_it);
 void wm_vuldet_add_oval_vulnerability(wm_vuldet_db *ctrl_block);
 void wm_vuldet_clean_vulnerability_info(wm_vuldet_db *ctrl_block);
-void wm_vuldet_clean_oval_vulnerability_node(vulnerability *vuln_node);
+vulnerability *wm_vuldet_clean_oval_vulnerability_node(vulnerability *vuln_node);
 int wm_vuldet_insert_cve_info(wm_vuldet_db *parsed_oval, sqlite3 *db, sqlite3_stmt *stmt);
 void wm_vuldet_set_subversion(char *version, char **os_minor);
 void wm_vuldet_get_package_os(const char *version, const char **os_major, char **os_minor);
@@ -17518,13 +17518,15 @@ void test_wm_vuldet_clean_oval_vulnerability_node_empty(void **state)
     vulnerability *vuln_node = NULL;
     os_calloc(1, sizeof(vulnerability), vuln_node);
 
-    wm_vuldet_clean_oval_vulnerability_node(vuln_node);
+    vuln_node = wm_vuldet_clean_oval_vulnerability_node(vuln_node);
+    assert_null(vuln_node);
 }
 
 void test_wm_vuldet_clean_oval_vulnerability_node_with_vulns(void **state)
 {
     vulnerability *vuln_node = *state;
-    wm_vuldet_clean_oval_vulnerability_node(vuln_node);
+    vuln_node = wm_vuldet_clean_oval_vulnerability_node(vuln_node);
+    assert_null(vuln_node);
 }
 
 void test_wm_vuldet_insert_cve_info(void **state)

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -73,15 +73,22 @@ STATIC int wm_vuldet_json_parser(char *json_path, wm_vuldet_db *uparsed_vulnerab
 
 /**
  * @brief Add a new vulnerability to the linked list.
- * @param ctrl_block Parsed oval data strucure.
+ * @param ctrl_block Parsed oval data structure.
  *
  */
 STATIC void wm_vuldet_add_oval_vulnerability(wm_vuldet_db *ctrl_block);
 STATIC void wm_vuldet_add_vulnerability_info(wm_vuldet_db *ctrl_block);
 
 /**
+ * @brief Cleans up the vulnerability data structure of the node.
+ * @param vuln_node Vulnerability node data structure.
+ *
+ */
+STATIC void wm_vuldet_clean_oval_vulnerability_node(vulnerability *vuln_node);
+
+/**
  * @brief Clean the CVEs linked list data structure.
- * @param ctrl_block Parsed oval data strucure.
+ * @param ctrl_block Parsed oval data structure.
  *
  */
 STATIC void wm_vuldet_clean_vulnerability_info(wm_vuldet_db *ctrl_block);
@@ -3352,6 +3359,20 @@ void wm_vuldet_clean_vulnerability_info(wm_vuldet_db *ctrl_block) {
     }
 }
 
+void wm_vuldet_clean_oval_vulnerability_node(vulnerability *vuln_node) {
+    vulnerability *vuln_prev_ptr = vuln_node->prev;
+
+    w_FreeArray(vuln_node->rhsa_list);
+    os_free(vuln_node->rhsa_list);
+    os_free(vuln_node->cve_id);
+    os_free(vuln_node->package_name);
+    os_free(vuln_node->package_version);
+    os_free(vuln_node->state_id);
+    os_free(vuln_node);
+
+    vuln_node = vuln_prev_ptr;
+}
+
 void wm_vuldet_add_oval_vulnerability(wm_vuldet_db *ctrl_block) {
     vulnerability *new;
     os_calloc(1, sizeof(vulnerability), new);
@@ -3881,6 +3902,10 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                         goto end;
                     }
                 }
+            }
+            // If no <criteria> exist, the vulnerability node is cleaned to avoid memory leaks.
+            if (!parsed_oval->vulnerabilities->state_id) {
+                wm_vuldet_clean_oval_vulnerability_node(parsed_oval->vulnerabilities);
             }
         }
         else if (!strcmp(node[i]->element, XML_REFERENCE)) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -3905,7 +3905,8 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                 }
             }
             // If no <criteria> exist, the vulnerability node is cleaned to avoid memory leaks.
-            if (!parsed_oval->vulnerabilities->state_id) {
+            // Debian's OVAL is avoided, as it is only used to collect metadata from the CVEs.
+            if (parsed_oval->vulnerabilities && !parsed_oval->vulnerabilities->state_id && dist != FEED_DEBIAN) {
                 parsed_oval->vulnerabilities = wm_vuldet_clean_oval_vulnerability_node(parsed_oval->vulnerabilities);
             }
         }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -82,9 +82,10 @@ STATIC void wm_vuldet_add_vulnerability_info(wm_vuldet_db *ctrl_block);
 /**
  * @brief Cleans up the vulnerability data structure of the node.
  * @param vuln_node Vulnerability node data structure.
+ * @return Previous vulnerability.
  *
  */
-STATIC void wm_vuldet_clean_oval_vulnerability_node(vulnerability *vuln_node);
+STATIC vulnerability *wm_vuldet_clean_oval_vulnerability_node(vulnerability *vuln_node);
 
 /**
  * @brief Clean the CVEs linked list data structure.
@@ -3359,7 +3360,7 @@ void wm_vuldet_clean_vulnerability_info(wm_vuldet_db *ctrl_block) {
     }
 }
 
-void wm_vuldet_clean_oval_vulnerability_node(vulnerability *vuln_node) {
+vulnerability *wm_vuldet_clean_oval_vulnerability_node(vulnerability *vuln_node) {
     vulnerability *vuln_prev_ptr = vuln_node->prev;
 
     w_FreeArray(vuln_node->rhsa_list);
@@ -3370,7 +3371,7 @@ void wm_vuldet_clean_oval_vulnerability_node(vulnerability *vuln_node) {
     os_free(vuln_node->state_id);
     os_free(vuln_node);
 
-    vuln_node = vuln_prev_ptr;
+    return vuln_prev_ptr;
 }
 
 void wm_vuldet_add_oval_vulnerability(wm_vuldet_db *ctrl_block) {
@@ -3905,7 +3906,7 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
             }
             // If no <criteria> exist, the vulnerability node is cleaned to avoid memory leaks.
             if (!parsed_oval->vulnerabilities->state_id) {
-                wm_vuldet_clean_oval_vulnerability_node(parsed_oval->vulnerabilities);
+                parsed_oval->vulnerabilities = wm_vuldet_clean_oval_vulnerability_node(parsed_oval->vulnerabilities);
             }
         }
         else if (!strcmp(node[i]->element, XML_REFERENCE)) {


### PR DESCRIPTION
|Related issue|
|---|
| Closes #14097|

**This is a backport from**
- https://github.com/wazuh/wazuh/pull/13186

## Description

In issue #12405, a memory leak was found using a custom feed. Upon researching, the problem was caused when the feed was missing the `<criteria>` section, so the information collected from that vulnerability was not removed, causing the memory leak.

This PR aims to fix the memory leak to avoid future problems.

To do this, after parsing the entire `<definition>` block, if it does not have any information regarding the `state_id` (which is obtained by parsing the `<criteria>` block), then it clears the vulnerability information, so that it is not saved and continues parsing the next vulnerability.

In the code, the condition has been added once the recursion of the `<definition>` block is finished, since the `<criteria>` block, being a child node of `<definition>`, is parsed inside the recursion function.

## How to replicate it

Here are the steps to replicate the problem that has been fixed with this PR:

1. Remove the `<criteria>` section and its child nodes from an _XML_ feed, such as **_RHEL8's OVAL_**.
2. Specify the custom feed without the criteria in the configuration: 
```xml
    <provider name="redhat">
      <enabled>yes</enabled>
      <update_interval>1h</update_interval>
      <path>/var/ossec/custom-feeds/redhat/custom_redhat_json_feed.json</path>
      <os path="/var/ossec/custom-feeds/redhat/custom_rhel5_oval_feed_without_criteria.xml">5</os>
      <os path="/var/ossec/custom-feeds/redhat/custom_rhel6_oval_feed_without_criteria.xml">6</os>
      <os path="/var/ossec/custom-feeds/redhat/custom_rhel7_oval_feed_without_criteria.xml">7</os>
      <os path="/var/ossec/custom-feeds/redhat/custom_rhel8_oval_feed_without_criteria.xml">8</os>
    </provider>
```
3. Run the `valgrind` tool.

## Logs/Alerts example

```
==8705== LEAK SUMMARY:
==8705==    definitely lost: 0 bytes in 0 blocks
==8705==    indirectly lost: 0 bytes in 0 blocks
==8705==      possibly lost: 4,608 bytes in 14 blocks
==8705==    still reachable: 297,395 bytes in 100 blocks
==8705==         suppressed: 0 bytes in 0 blocks
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities
- [x] Added unit tests (100% tests passed, 0 tests failed out of 140)

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
