### PR TITLE
Retrieve vendor from macOS packages

### DIFF
--- a/src/data_provider/cppcheckSuppress.txt
+++ b/src/data_provider/cppcheckSuppress.txt
@@ -1,5 +1,5 @@
 *:*src/sysInfoLinux.cpp:259
-*:*src/packages/pkgWrapper.h:105
+*:*src/packages/pkgWrapper.h:114
 *:*src/packages/packagesWindowsParserHelper.h:54
 *:*src/packages/packagesWindowsParserHelper.h:182
 *:*src/packages/packagesWindowsParserHelper.h:197

--- a/src/data_provider/src/osinfo/sysOsParsers.cpp
+++ b/src/data_provider/src/osinfo/sysOsParsers.cpp
@@ -12,7 +12,6 @@
 #include "osinfo/sysOsParsers.h"
 #include "stringHelper.h"
 #include "sharedDefs.h"
-#include <regex>
 
 static bool parseUnixFile(const std::map<std::string, std::string>& keyMap,
                           const char separator,
@@ -56,29 +55,6 @@ static bool parseUnixFile(const std::map<std::string, std::string>& keyMap,
 }
 
 
-
-static bool findRegexInString(const std::string& in,
-                              std::string& match,
-                              const std::regex& pattern,
-                              const size_t matchIndex = 0,
-                              const std::string& start = "")
-{
-    bool ret{false};
-
-    if (start.empty() || Utils::startsWith(in, start))
-    {
-        std::smatch sm;
-        ret = std::regex_search(in, sm, pattern);
-
-        if (ret && sm.size() >= matchIndex)
-        {
-            match = sm[matchIndex];
-        }
-    }
-
-    return ret;
-}
-
 static bool findCodeNameInString(const std::string& in,
                                  std::string& output)
 {
@@ -106,21 +82,21 @@ static void findMajorMinorVersionInString(const std::string& in,
     std::string version;
     std::regex pattern{MAJOR_VERSION_PATTERN};
 
-    if (findRegexInString(in, version, pattern, 1))
+    if (Utils::findRegexInString(in, version, pattern, 1))
     {
         output["os_major"] = version;
     }
 
     pattern = MINOR_VERSION_PATTERN;
 
-    if (findRegexInString(in, version, pattern, 1))
+    if (Utils::findRegexInString(in, version, pattern, 1))
     {
         output["os_minor"] = version;
     }
 
     pattern = PATCH_VERSION_PATTERN;
 
-    if (findRegexInString(in, version, pattern, 1))
+    if (Utils::findRegexInString(in, version, pattern, 1))
     {
         output["os_patch"] = version;
     }
@@ -141,7 +117,7 @@ static bool findVersionInStream(std::istream& in,
     while (std::getline(in, line))
     {
         line = Utils::trim(line);
-        ret |= findRegexInString(line, data, pattern, matchIndex, start);
+        ret |= Utils::findRegexInString(line, data, pattern, matchIndex, start);
 
         if (ret)
         {
@@ -193,7 +169,7 @@ bool UbuntuOsParser::parseFile(std::istream& in, nlohmann::json& output)
         line = Utils::trim(line);
         std::string match;
 
-        if (findRegexInString(line, match, pattern, 0, DISTRIB_FIELD))
+        if (Utils::findRegexInString(line, match, pattern, 0, DISTRIB_FIELD))
         {
             output["os_version"] = match;
             findMajorMinorVersionInString(match, output);
@@ -224,7 +200,7 @@ bool BSDOsParser::parseUname(const std::string& in, nlohmann::json& output)
     constexpr auto PATTERN_MATCH{R"([0-9].*\.[0-9]*)"};
     std::string match;
     std::regex pattern{PATTERN_MATCH};
-    const auto ret {findRegexInString(in, match, pattern)};
+    const auto ret {Utils::findRegexInString(in, match, pattern)};
 
     if (ret)
     {
@@ -382,7 +358,7 @@ bool HpUxOsParser::parseUname(const std::string& in, nlohmann::json& output)
     constexpr auto PATTERN_MATCH{R"(B\.([0-9].*\.[0-9]*))"};
     std::string match;
     std::regex pattern{PATTERN_MATCH};
-    const auto ret {findRegexInString(in, match, pattern, 1)};
+    const auto ret {Utils::findRegexInString(in, match, pattern, 1)};
 
     if (ret)
     {
@@ -437,7 +413,7 @@ bool MacOsParser::parseUname(const std::string& in, nlohmann::json& output)
     constexpr auto PATTERN_MATCH{"[0-9]+"};
     std::string match;
     std::regex pattern{PATTERN_MATCH};
-    const auto ret {findRegexInString(in, match, pattern, 0)};
+    const auto ret {Utils::findRegexInString(in, match, pattern, 0)};
 
     if (ret)
     {

--- a/src/data_provider/src/packages/brewWrapper.h
+++ b/src/data_provider/src/packages/brewWrapper.h
@@ -27,6 +27,7 @@ class BrewWrapper final : public IPackageWrapper
             , m_format{"pkg"}
             , m_source{"homebrew"}
             , m_location{ctx.filePath}
+            , m_vendor{UNKNOWN_VALUE}
         {
             const auto rows { Utils::split(Utils::getFileContent(ctx.filePath + "/" + ctx.package + "/" + ctx.version + "/.brew/" + ctx.package + ".rb"), '\n')};
 
@@ -82,6 +83,10 @@ class BrewWrapper final : public IPackageWrapper
         {
             return m_location;
         }
+        std::string vendor() const override
+        {
+            return m_vendor;
+        }
 
     private:
         std::string m_name;
@@ -93,6 +98,7 @@ class BrewWrapper final : public IPackageWrapper
         std::string m_osPatch;
         const std::string m_source;
         const std::string m_location;
+        const std::string m_vendor;
 };
 
 

--- a/src/data_provider/src/packages/ipackageWrapper.h
+++ b/src/data_provider/src/packages/ipackageWrapper.h
@@ -28,5 +28,6 @@ class IPackageWrapper
         virtual std::string osPatch() const = 0;
         virtual std::string source() const = 0;
         virtual std::string location() const = 0;
+        virtual std::string vendor() const = 0;
 };
 #endif // _PACKAGE_INTERFACE_WRAPPER_H

--- a/src/data_provider/src/packages/packageMac.cpp
+++ b/src/data_provider/src/packages/packageMac.cpp
@@ -48,4 +48,5 @@ void BSDPackageImpl::buildPackageData(nlohmann::json& package)
     package["format"] = m_packageWrapper->format();
     package["source"] = m_packageWrapper->source();
     package["location"] = m_packageWrapper->location();
+    package["vendor"] = m_packageWrapper->vendor();
 }

--- a/src/data_provider/src/packages/pkgWrapper.h
+++ b/src/data_provider/src/packages/pkgWrapper.h
@@ -14,6 +14,7 @@
 
 #include <fstream>
 #include <istream>
+#include <regex>
 #include "stringHelper.h"
 #include "ipackageWrapper.h"
 #include "sharedDefs.h"
@@ -28,6 +29,8 @@ class PKGWrapper final : public IPackageWrapper
     public:
         explicit PKGWrapper(const PackageContext& ctx)
             : m_format{"pkg"}
+            , m_architecture{UNKNOWN_VALUE}
+            , m_vendor{UNKNOWN_VALUE}
         {
             getPkgData(ctx.filePath + "/" + ctx.package + "/" + APP_INFO_PATH);
         }
@@ -70,6 +73,10 @@ class PKGWrapper final : public IPackageWrapper
         {
             return m_location;
         }
+        std::string vendor() const override
+        {
+            return m_vendor;
+        }
 
     private:
         void getPkgData(const std::string& filePath)
@@ -85,6 +92,8 @@ class PKGWrapper final : public IPackageWrapper
                 }
             };
             const auto isBinary { isBinaryFnc() };
+            constexpr auto BUNDLEID_PATTERN{R"(^[^.]+\.([^.]+).*$)"};
+            static std::regex bundleIdRegex{BUNDLEID_PATTERN};
 
             static const auto getValueFnc
             {
@@ -125,10 +134,17 @@ class PKGWrapper final : public IPackageWrapper
                                  std::getline(data, line))
                         {
                             m_description = getValueFnc(line);
+
+                            std::string vendor;
+                            const auto ret {Utils::findRegexInString(m_description, vendor, bundleIdRegex, 1)};
+
+                            if (ret)
+                            {
+                                m_vendor = vendor;
+                            }
                         }
                     }
 
-                    m_architecture = UNKNOWN_VALUE;
                     m_source = filePath.find(UTILITIES_FOLDER) ? "utilities" : "applications";
                     m_location = filePath;
                 }
@@ -190,6 +206,7 @@ class PKGWrapper final : public IPackageWrapper
         std::string m_osPatch;
         std::string m_source;
         std::string m_location;
+        std::string m_vendor;
 };
 
 #endif //_PKG_WRAPPER_H

--- a/src/data_provider/tests/sysInfoPackagesMAC/sysInfoMacPackages_test.cpp
+++ b/src/data_provider/tests/sysInfoPackagesMAC/sysInfoMacPackages_test.cpp
@@ -33,6 +33,7 @@ class SysInfoMacPackagesWrapperMock: public IPackageWrapper
         MOCK_METHOD(std::string, osPatch, (), (const override));
         MOCK_METHOD(std::string, source, (), (const override));
         MOCK_METHOD(std::string, location, (), (const override));
+        MOCK_METHOD(std::string, vendor, (), (const override));
 };
 
 TEST_F(SysInfoMacPackagesTest, Test_SPEC_Data)
@@ -47,6 +48,7 @@ TEST_F(SysInfoMacPackagesTest, Test_SPEC_Data)
     EXPECT_CALL(*mock, format()).Times(1).WillOnce(Return("6"));
     EXPECT_CALL(*mock, source()).Times(1).WillOnce(Return("7"));
     EXPECT_CALL(*mock, location()).Times(1).WillOnce(Return("8"));
+    EXPECT_CALL(*mock, vendor()).Times(1).WillOnce(Return("9"));
 
     EXPECT_NO_THROW(std::make_unique<BSDPackageImpl>(mock)->buildPackageData(packages));
     EXPECT_EQ("1", packages.at("name").get_ref<const std::string&>());
@@ -57,4 +59,5 @@ TEST_F(SysInfoMacPackagesTest, Test_SPEC_Data)
     EXPECT_EQ("6", packages.at("format").get_ref<const std::string&>());
     EXPECT_EQ("7", packages.at("source").get_ref<const std::string&>());
     EXPECT_EQ("8", packages.at("location").get_ref<const std::string&>());
+    EXPECT_EQ("9", packages.at("vendor").get_ref<const std::string&>());
 }

--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -18,7 +18,7 @@
 #include <iomanip>
 #include <algorithm>
 #include <memory>
-
+#include <regex>
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
 
@@ -218,6 +218,27 @@ namespace Utils
         }
 
         return str;
+    }
+    static bool findRegexInString(const std::string& in,
+                              std::string& match,
+                              const std::regex& pattern,
+                              const size_t matchIndex = 0,
+                              const std::string& start = "")
+    {
+        bool ret{false};
+
+        if (start.empty() ||startsWith(in, start))
+        {
+            std::smatch sm;
+            ret = std::regex_search(in, sm, pattern);
+
+            if (ret && sm.size() >= matchIndex)
+            {
+                match = sm[matchIndex];
+            }
+        }
+
+        return ret;
     }
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#14074|

## Description

This PR aims to retrieve macOS packages vendors from .plist from CFBundleIdentifier, extracting it from Reverse Domain Name notation


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors