### PR TITLE
 Wazuh agent waits for the second syscollector scan to synchronize its inventory with the manager - Implementation

### DIFF
--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -58,7 +58,7 @@ static void wm_sys_send_diff_message(/*const void* data*/) {
  }
 
 static void wm_sys_send_dbsync_message(const void* data) {
-    if(!os_iswait() && !is_shutdown_process_started()) {
+    if(!is_shutdown_process_started()) {
         const int eps = 1000000/syscollector_sync_max_eps;
         if (wm_sendmsg_ex(eps, queue_fd, data, WM_SYS_LOCATION, DBSYNC_MQ, &is_shutdown_process_started) < 0) {
 #ifdef CLIENT


### PR DESCRIPTION
|Related issue|
|---|
|#13857|


## Description

This PR removes the check of connection with the manager in the agent during a **syscollector** synchronization.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
