### PR TITLE
Change delimiter of Windows WAZUH_MANAGER deploy variable

### DIFF
--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -63,8 +63,8 @@ If objFSO.fileExists(home_dir & "ossec.conf") Then
     objFile.Close
 
     If WAZUH_MANAGER <> "" or WAZUH_MANAGER_PORT <> "" or WAZUH_PROTOCOL <> "" or WAZUH_KEEP_ALIVE_INTERVAL <> "" or WAZUH_TIME_RECONNECT <> "" Then
-        If WAZUH_MANAGER <> "" and InStr(WAZUH_MANAGER,";") > 0 Then 'list of address
-            ip_list=Split(WAZUH_MANAGER,";")
+        If WAZUH_MANAGER <> "" and InStr(WAZUH_MANAGER,",") > 0 Then 'list of address
+            ip_list=Split(WAZUH_MANAGER,",")
             formatted_list ="    </server>" & vbCrLf
             not_replaced = True
             for each ip in ip_list


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh-packages/issues/1491 |

## Description
Hello team,

We have included a light change at WAZUH_MANAGER deployment variable parse.

## Configuration options
Example of use: `WAZUH_MANAGER="192.168.1.50,192.168.1.60,manager.example.com"`

## Logs/Alerts example
None

## Tests

Testing result
![image](https://user-images.githubusercontent.com/10661307/177150806-ea1204fa-8033-4f2c-bdcb-add94928a521.png)


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Package installation
