### PR TITLE
Disable filebeat metrics

### DIFF
--- a/extensions/filebeat/7.x/filebeat.yml
+++ b/extensions/filebeat/7.x/filebeat.yml
@@ -13,3 +13,5 @@ setup.template.overwrite: true
 setup.ilm.enabled: false
 
 output.elasticsearch.hosts: ['http://YOUR_ELASTIC_SERVER_IP:9200']
+
+logging.metrics.enabled: false


### PR DESCRIPTION
|Related issue|
|---|
| [#1667](https://github.com/wazuh/wazuh-packages/issues/1667) |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
It is required to disable the periodic filebeat metrics, by default they are activated and configured with an interval of 30 seconds, so that they are no longer reported, it is necessary to specify the parameter logging.metrics.enabled: false in the template.

## Logs example

<!--
Paste here related logs
-->

## Tests
Filebeat config:

```

[root@stack-centos7 filebeat]# cat filebeat.yml 
# Wazuh - Filebeat configuration file
output.elasticsearch:
  hosts: ["127.0.0.1:9200"]
  protocol: https
  username: "admin"
  password: "admin"
  ssl.certificate_authorities:
    - /etc/filebeat/certs/root-ca.pem
  ssl.certificate: "/etc/filebeat/certs/filebeat.pem"
  ssl.key: "/etc/filebeat/certs/filebeat-key.pem"

setup.template.json.enabled: true
setup.template.json.path: '/etc/filebeat/wazuh-template.json'
setup.template.json.name: 'wazuh'
setup.ilm.overwrite: true
setup.ilm.enabled: false

logging.level: info
logging.to_files: true
logging.files:
  path: /var/log/filebeat
  name: filebeat
  keepfiles: 7
  permissions: 0640

filebeat.modules:
  - module: wazuh
    alerts:
      enabled: true
    archives:
      enabled: false
[root@stack-centos7 filebeat]# 

```
Logs:

```

[root@stack-centos7 filebeat]# tail -n100 -f /var/log/filebeat/filebeat
2022-06-27T20:07:24.153Z	INFO	[monitoring]	log/log.go:145	Non-zero metrics in the last 30s	{"monitoring": {"metrics": {"beat":{"cpu":{"system":{"ticks":60,"time":{"ms":61}},"total":{"ticks":110,"time":{"ms":119},"value":110},"user":{"ticks":50,"time":{"ms":58}}},"handles":{"limit":{"hard":4096,"soft":1024},"open":12},"info":{"ephemeral_id":"dd117881-d1f1-4376-af74-7ac1127fcec9","uptime":{"ms":30023}},"memstats":{"gc_next":6989984,"memory_alloc":5051432,"memory_total":12514896,"rss":29454336},"runtime":{"goroutines":25}},"filebeat":{"events":{"added":4,"done":4},"harvester":{"open_files":1,"running":1,"started":1}},"libbeat":{"config":{"module":{"running":0}},"output":{"events":{"acked":2,"batches":2,"total":2},"read":{"bytes":5145},"type":"elasticsearch","write":{"bytes":5486}},"pipeline":{"clients":1,"events":{"active":0,"filtered":2,"published":2,"retry":1,"total":4},"queue":{"acked":2}}},"registrar":{"states":{"current":1,"update":4},"writes":{"success":4,"total":4}},"system":{"cpu":{"cores":4},"load":{"1":0.2,"15":0.13,"5":0.11,"norm":{"1":0.05,"15":0.0325,"5":0.0275}}}}}}
2022-06-27T20:07:54.157Z	INFO	[monitoring]	log/log.go:145	Non-zero metrics in the last 30s	{"monitoring": {"metrics": {"beat":{"cpu":{"system":{"ticks":70,"time":{"ms":15}},"total":{"ticks":120,"time":{"ms":15},"value":120},"user":{"ticks":50}},"handles":{"limit":{"hard":4096,"soft":1024},"open":12},"info":{"ephemeral_id":"dd117881-d1f1-4376-af74-7ac1127fcec9","uptime":{"ms":60021}},"memstats":{"gc_next":6989984,"memory_alloc":5309632,"memory_total":12773096},"runtime":{"goroutines":25}},"filebeat":{"harvester":{"open_files":1,"running":1}},"libbeat":{"config":{"module":{"running":0}},"pipeline":{"clients":1,"events":{"active":0}}},"registrar":{"states":{"current":1}},"system":{"load":{"1":0.24,"15":0.14,"5":0.13,"norm":{"1":0.06,"15":0.035,"5":0.0325}}}}}}

```

Then a test was performed disabling the metrics:

```
[root@stack-centos7 filebeat]# cat filebeat.yml 
# Wazuh - Filebeat configuration file
output.elasticsearch:
  hosts: ["127.0.0.1:9200"]
  protocol: https
  username: "admin"
  password: "admin"
  ssl.certificate_authorities:
    - /etc/filebeat/certs/root-ca.pem
  ssl.certificate: "/etc/filebeat/certs/filebeat.pem"
  ssl.key: "/etc/filebeat/certs/filebeat-key.pem"

setup.template.json.enabled: true
setup.template.json.path: '/etc/filebeat/wazuh-template.json'
setup.template.json.name: 'wazuh'
setup.ilm.overwrite: true
setup.ilm.enabled: false

logging.level: info
logging.to_files: true
logging.files:
  path: /var/log/filebeat
  name: filebeat
  keepfiles: 7
  permissions: 0640

logging.metrics.enabled: false

filebeat.modules:
  - module: wazuh
    alerts:
      enabled: true
    archives:
      enabled: false

```
Logs:

```
[root@stack-centos7 filebeat]# tail -n100 -f /var/log/filebeat/filebeat
2022-06-27T20:12:34.289Z	INFO	instance/beat.go:299	Setup Beat: filebeat; Version: 7.10.2
2022-06-27T20:12:34.291Z	INFO	eslegclient/connection.go:99	elasticsearch url: https://127.0.0.1:9200
2022-06-27T20:12:34.291Z	INFO	[publisher]	pipeline/module.go:113	Beat name: stack-centos7
2022-06-27T20:12:34.292Z	INFO	beater/filebeat.go:117	Enabled modules/filesets: wazuh (alerts),  ()
2022-06-27T20:12:34.292Z	INFO	instance/beat.go:455	filebeat start running.
2022-06-27T20:12:34.293Z	INFO	memlog/store.go:119	Loading data file of '/var/lib/filebeat/registry/filebeat' succeeded. Active transaction id=0
2022-06-27T20:12:34.294Z	INFO	memlog/store.go:124	Finished loading transaction log file for '/var/lib/filebeat/registry/filebeat'. Active transaction id=87
2022-06-27T20:12:34.294Z	INFO	[registrar]	registrar/registrar.go:109	States Loaded from registrar: 1
2022-06-27T20:12:34.294Z	INFO	[crawler]	beater/crawler.go:71	Loading Inputs: 1
2022-06-27T20:12:34.295Z	INFO	log/input.go:157	Configured paths: [/var/ossec/logs/alerts/alerts.json]
2022-06-27T20:12:34.295Z	INFO	[crawler]	beater/crawler.go:141	Starting input (ID: 9132358592892857476)
2022-06-27T20:12:34.295Z	INFO	[crawler]	beater/crawler.go:108	Loading and starting Inputs completed. Enabled inputs: 1
2022-06-27T20:12:54.298Z	INFO	log/harvester.go:302	Harvester started for file: /var/ossec/logs/alerts/alerts.json
2022-06-27T20:12:55.298Z	INFO	[publisher_pipeline_output]	pipeline/output.go:143	Connecting to backoff(elasticsearch(https://127.0.0.1:9200))
2022-06-27T20:12:55.298Z	INFO	[publisher]	pipeline/retry.go:219	retryer: send unwait signal to consumer
2022-06-27T20:12:55.298Z	INFO	[publisher]	pipeline/retry.go:223	  done
2022-06-27T20:12:55.314Z	INFO	[esclientleg]	eslegclient/connection.go:314	Attempting to connect to Elasticsearch version 7.10.2
2022-06-27T20:12:55.315Z	INFO	[esclientleg]	eslegclient/connection.go:314	Attempting to connect to Elasticsearch version 7.10.2
2022-06-27T20:12:55.316Z	INFO	template/load.go:97	Template wazuh already exists and will not be overwritten.
2022-06-27T20:12:55.316Z	INFO	[index-management]	idxmgmt/std.go:298	Loaded index template.
2022-06-27T20:12:55.319Z	INFO	[publisher_pipeline_output]	pipeline/output.go:151	Connection to backoff(elasticsearch(https://127.0.0.1:9200)) established
```
