### PR TITLE
Improve sshd disconnected decoder

### DIFF
--- a/ruleset/decoders/0310-ssh_decoders.xml
+++ b/ruleset/decoders/0310-ssh_decoders.xml
@@ -232,7 +232,7 @@
 <!-- 2020-03-24 08:38:47.230409-0700  localhost sshd[2531]: Disconnecting invalid user root 172.18.1.100 port 43042 -->
 <decoder name="sshd-disconnect">
   <parent>sshd</parent>
-  <prematch type="pcre2">Disconnect(ed|ing) (from )?(invalid )?user </prematch>
+  <prematch type="pcre2">Disconnect(?:ed|ing) (?:from )?(?:invalid )?user </prematch>
   <regex offset="after_prematch">^(\S+) (\S+) port (\d+)</regex>
   <order>srcuser,srcip,srcport</order>
 </decoder>

--- a/ruleset/decoders/0310-ssh_decoders.xml
+++ b/ruleset/decoders/0310-ssh_decoders.xml
@@ -226,12 +226,13 @@
   <order>user, srcip, srcport</order>
 </decoder>
 
-<!-- Dissconected from user -->
+<!-- Disconnected from user -->
 <!-- 2020-03-24 08:38:47.230409-0700  localhost sshd[2531]: Disconnected from user user 172.18.1.100 port 43042 -->
 <!-- 2020-03-24 08:38:47.230409-0700  localhost sshd[2531]: Disconnected from invalid user root 172.18.1.100 port 43042 -->
+<!-- 2020-03-24 08:38:47.230409-0700  localhost sshd[2531]: Disconnecting invalid user root 172.18.1.100 port 43042 -->
 <decoder name="sshd-disconnect">
   <parent>sshd</parent>
-  <prematch type="pcre2">Disconnected from (invalid )?user </prematch>
+  <prematch type="pcre2">Disconnect(ed|ing) (from )?(invalid )?user </prematch>
   <regex offset="after_prematch">^(\S+) (\S+) port (\d+)</regex>
   <order>srcuser,srcip,srcport</order>
 </decoder>

--- a/ruleset/testing/tests/sshd.ini
+++ b/ruleset/testing/tests/sshd.ini
@@ -164,6 +164,12 @@ rule = 5710
 alert = 5
 decoder = sshd
 
+[SSHD Disconnecting invalid]
+log 1 pass = 2020-03-24 08:38:47.230409-0700  localhost sshd[2531]: Disconnecting invalid user root 172.18.1.100 port 43042
+rule = 5710
+alert = 5
+decoder = sshd
+
 [SSHD insecure connection attempt]
 log 1 pass = 2020-03-24 10:32:31.672920-0700  localhost sshd[5374]: Did not receive identification string from 172.18.1.1 port 45824
 rule = 5706


### PR DESCRIPTION
|Related issue|
|---|
|#14126|


## Description

This PR aims to improve sshd disconnect decoder to support a new variety of message
## Tests

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [x] Added unit testing files ".ini"
  - [x] runtests.py executed without errors