### PR TITLE
Standarize time install date

### DIFF
--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -345,7 +345,7 @@ static void getPackagesFromReg(const HKEY key, const std::string& subKey, std::f
 
                 if (packageReg.string("InstallDate", value))
                 {
-                    install_time = value;
+                    install_time = Utils::normalizeTimestamp(value, packageReg.keyModificationDate());
                 }
                 else
                 {

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -345,7 +345,14 @@ static void getPackagesFromReg(const HKEY key, const std::string& subKey, std::f
 
                 if (packageReg.string("InstallDate", value))
                 {
-                    install_time = Utils::normalizeTimestamp(value, packageReg.keyModificationDate());
+                    try
+                    {
+                        install_time = Utils::normalizeTimestamp(value, packageReg.keyModificationDate());
+                    }
+                    catch (const std::exception& e)
+                    {
+                        install_time = packageReg.keyModificationDate();
+                    }
                 }
                 else
                 {

--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -304,7 +304,11 @@ namespace Utils
 
     static bool isNumber(const std::string& str)
     {
-        return !str.empty() && std::string::npos == str.find_first_not_of("0123456789");
+        std::string::const_iterator it = str.begin();
+
+        while (it != str.end() && std::isdigit(*it)) ++it;
+
+        return !str.empty() && it == str.end();
     }
 }
 

--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -301,6 +301,11 @@ namespace Utils
 
         return ret;
     }
+
+    static bool isNumber(const std::string& str)
+    {
+        return std::string::npos == str.find_first_not_of("0123456789");
+    }
 }
 
 #pragma GCC diagnostic pop

--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -304,7 +304,7 @@ namespace Utils
 
     static bool isNumber(const std::string& str)
     {
-        return std::string::npos == str.find_first_not_of("0123456789");
+        return !str.empty() && std::string::npos == str.find_first_not_of("0123456789");
     }
 }
 

--- a/src/shared_modules/utils/tests/stringHelper_test.cpp
+++ b/src/shared_modules/utils/tests/stringHelper_test.cpp
@@ -400,3 +400,23 @@ TEST_F(StringUtilsTest, rawUnicodeToUTF8)
               "LC_CTYPE=",
               content);
 }
+
+TEST_F(StringUtilsTest, stringIsNumberFalse1)
+{
+    EXPECT_FALSE(Utils::isNumber("random_string"));
+}
+
+TEST_F(StringUtilsTest, stringIsNumberFalse2)
+{
+    EXPECT_FALSE(Utils::isNumber("r4nd0m_57r1n9"));
+}
+
+TEST_F(StringUtilsTest, stringIsNumberFalse3)
+{
+    EXPECT_FALSE(Utils::isNumber(""));
+}
+
+TEST_F(StringUtilsTest, stringIsNumberTrue)
+{
+    EXPECT_TRUE(Utils::isNumber("12345"));
+}

--- a/src/shared_modules/utils/tests/windowsHelper_test.cpp
+++ b/src/shared_modules/utils/tests/windowsHelper_test.cpp
@@ -184,7 +184,7 @@ TEST_F(WindowsHelperTest, getSerialNumberFromSMBIOSTables2NoEndDoubleNull_TEST)
     EXPECT_EQ(SERIAL_NUMBER_DATA, serialNumber);
 }
 
-TEST_F(WindowsHelperTest, normalizeTimestampSortValue)
+TEST_F(WindowsHelperTest, normalizeTimestampShortValue)
 {
     std::string value = "202202";
     std::string timestamp = "2022/02/15 14:04:50";
@@ -228,22 +228,33 @@ TEST_F(WindowsHelperTest, normalizeTimestampNotEqual)
     EXPECT_EQ(expected, result);
 }
 
-TEST_F(WindowsHelperTest, normalizeTimestampEqual1)
+TEST_F(WindowsHelperTest, normalizeTimestampEqual)
 {
     std::string value = "20220215";
     std::string timestamp = "2022/02/15 14:04:50";
-    std::string expected = "2022/02/15 17:04:50";
+    std::string expected = "2022/02/15 14:04:50";
 
     std::string result = Utils::normalizeTimestamp(value, timestamp);
 
     EXPECT_EQ(expected, result);
 }
 
-TEST_F(WindowsHelperTest, normalizeTimestampEqual2)
+TEST_F(WindowsHelperTest, normalizeTimestampWrongTimestamp1)
+{
+    std::string value = "a0220215";
+    std::string timestamp = "2022/02/15 23:59:59";
+    std::string expected = UNKNOWN_VALUE;
+
+    std::string result = Utils::normalizeTimestamp(value, timestamp);
+
+    EXPECT_EQ(expected, result);
+}
+
+TEST_F(WindowsHelperTest, normalizeTimestampWrongTimestamp2)
 {
     std::string value = "20220215";
-    std::string timestamp = "2022/02/15 23:59:59";
-    std::string expected = "2022/02/16 02:59:59";
+    std::string timestamp = "a022/02/15 23:59:59";
+    std::string expected = "2022/02/15 00:00:00";
 
     std::string result = Utils::normalizeTimestamp(value, timestamp);
 

--- a/src/shared_modules/utils/tests/windowsHelper_test.cpp
+++ b/src/shared_modules/utils/tests/windowsHelper_test.cpp
@@ -188,7 +188,7 @@ TEST_F(WindowsHelperTest, normalizeTimestampShortValue)
 {
     std::string value = "202202";
     std::string timestamp = "2022/02/15 14:04:50";
-    std::string expected = UNKNOWN_VALUE;
+    std::string expected;
 
     std::string result = Utils::normalizeTimestamp(value, timestamp);
 
@@ -199,7 +199,7 @@ TEST_F(WindowsHelperTest, normalizeTimestampLongValue)
 {
     std::string value = "2022021516";
     std::string timestamp = "2022/02/15 14:04:50";
-    std::string expected = UNKNOWN_VALUE;
+    std::string expected;
 
     std::string result = Utils::normalizeTimestamp(value, timestamp);
 
@@ -208,9 +208,9 @@ TEST_F(WindowsHelperTest, normalizeTimestampLongValue)
 
 TEST_F(WindowsHelperTest, normalizeTimestampUnknownValue)
 {
-    std::string value = UNKNOWN_VALUE;
+    std::string value;
     std::string timestamp = "2022/02/15 14:04:50";
-    std::string expected = UNKNOWN_VALUE;
+    std::string expected;
 
     std::string result = Utils::normalizeTimestamp(value, timestamp);
 
@@ -243,7 +243,7 @@ TEST_F(WindowsHelperTest, normalizeTimestampWrongTimestamp1)
 {
     std::string value = "a0220215";
     std::string timestamp = "2022/02/15 23:59:59";
-    std::string expected = UNKNOWN_VALUE;
+    std::string expected;
 
     std::string result = Utils::normalizeTimestamp(value, timestamp);
 

--- a/src/shared_modules/utils/tests/windowsHelper_test.cpp
+++ b/src/shared_modules/utils/tests/windowsHelper_test.cpp
@@ -184,4 +184,70 @@ TEST_F(WindowsHelperTest, getSerialNumberFromSMBIOSTables2NoEndDoubleNull_TEST)
     EXPECT_EQ(SERIAL_NUMBER_DATA, serialNumber);
 }
 
+TEST_F(WindowsHelperTest, normalizeTimestampSortValue)
+{
+    std::string value = "202202";
+    std::string timestamp = "2022/02/15 14:04:50";
+    std::string expected = UNKNOWN_VALUE;
+
+    std::string result = Utils::normalizeTimestamp(value, timestamp);
+
+    EXPECT_EQ(expected, result);
+}
+
+TEST_F(WindowsHelperTest, normalizeTimestampLongValue)
+{
+    std::string value = "2022021516";
+    std::string timestamp = "2022/02/15 14:04:50";
+    std::string expected = UNKNOWN_VALUE;
+
+    std::string result = Utils::normalizeTimestamp(value, timestamp);
+
+    EXPECT_EQ(expected, result);
+}
+
+TEST_F(WindowsHelperTest, normalizeTimestampUnknownValue)
+{
+    std::string value = UNKNOWN_VALUE;
+    std::string timestamp = "2022/02/15 14:04:50";
+    std::string expected = UNKNOWN_VALUE;
+
+    std::string result = Utils::normalizeTimestamp(value, timestamp);
+
+    EXPECT_EQ(expected, result);
+}
+
+TEST_F(WindowsHelperTest, normalizeTimestampNotEqual)
+{
+    std::string value = "20220214";
+    std::string timestamp = "2022/02/15 14:04:50";
+    std::string expected = "2022/02/14 00:00:00";
+
+    std::string result = Utils::normalizeTimestamp(value, timestamp);
+
+    EXPECT_EQ(expected, result);
+}
+
+TEST_F(WindowsHelperTest, normalizeTimestampEqual1)
+{
+    std::string value = "20220215";
+    std::string timestamp = "2022/02/15 14:04:50";
+    std::string expected = "2022/02/15 17:04:50";
+
+    std::string result = Utils::normalizeTimestamp(value, timestamp);
+
+    EXPECT_EQ(expected, result);
+}
+
+TEST_F(WindowsHelperTest, normalizeTimestampEqual2)
+{
+    std::string value = "20220215";
+    std::string timestamp = "2022/02/15 23:59:59";
+    std::string expected = "2022/02/16 02:59:59";
+
+    std::string result = Utils::normalizeTimestamp(value, timestamp);
+
+    EXPECT_EQ(expected, result);
+}
+
 #endif

--- a/src/shared_modules/utils/tests/windowsHelper_test.cpp
+++ b/src/shared_modules/utils/tests/windowsHelper_test.cpp
@@ -184,81 +184,58 @@ TEST_F(WindowsHelperTest, getSerialNumberFromSMBIOSTables2NoEndDoubleNull_TEST)
     EXPECT_EQ(SERIAL_NUMBER_DATA, serialNumber);
 }
 
-TEST_F(WindowsHelperTest, normalizeTimestampShortValue)
+TEST_F(WindowsHelperTest, normalizeTimestampShortRegistryInstallDateValue)
 {
-    std::string value = "202202";
-    std::string timestamp = "2022/02/15 14:04:50";
-    std::string expected;
+    std::string RegistryInstallDateValue = "202202";
+    std::string RegistryModificationDateValue = "2022/02/15 14:04:50";
 
-    std::string result = Utils::normalizeTimestamp(value, timestamp);
-
-    EXPECT_EQ(expected, result);
+    EXPECT_ANY_THROW(Utils::normalizeTimestamp(RegistryInstallDateValue, RegistryModificationDateValue));
 }
 
-TEST_F(WindowsHelperTest, normalizeTimestampLongValue)
+TEST_F(WindowsHelperTest, normalizeTimestampLongRegistryInstallDateValue)
 {
-    std::string value = "2022021516";
-    std::string timestamp = "2022/02/15 14:04:50";
-    std::string expected;
+    std::string RegistryInstallDateValue = "2022021516";
+    std::string RegistryModificationDateValue = "2022/02/15 14:04:50";
 
-    std::string result = Utils::normalizeTimestamp(value, timestamp);
-
-    EXPECT_EQ(expected, result);
+    EXPECT_ANY_THROW(Utils::normalizeTimestamp(RegistryInstallDateValue, RegistryModificationDateValue));
 }
 
-TEST_F(WindowsHelperTest, normalizeTimestampUnknownValue)
+TEST_F(WindowsHelperTest, normalizeTimestampUnknownRegistryInstallDateValue)
 {
-    std::string value;
-    std::string timestamp = "2022/02/15 14:04:50";
-    std::string expected;
+    std::string RegistryInstallDateValue;
+    std::string RegistryModificationDateValue = "2022/02/15 14:04:50";
 
-    std::string result = Utils::normalizeTimestamp(value, timestamp);
-
-    EXPECT_EQ(expected, result);
+    EXPECT_ANY_THROW(Utils::normalizeTimestamp(RegistryInstallDateValue, RegistryModificationDateValue));
 }
 
 TEST_F(WindowsHelperTest, normalizeTimestampNotEqual)
 {
-    std::string value = "20220214";
-    std::string timestamp = "2022/02/15 14:04:50";
+    std::string RegistryInstallDateValue = "20220214";
+    std::string RegistryModificationDateValue = "2022/02/15 14:04:50";
     std::string expected = "2022/02/14 00:00:00";
 
-    std::string result = Utils::normalizeTimestamp(value, timestamp);
+    std::string result = Utils::normalizeTimestamp(RegistryInstallDateValue, RegistryModificationDateValue);
 
     EXPECT_EQ(expected, result);
 }
 
 TEST_F(WindowsHelperTest, normalizeTimestampEqual)
 {
-    std::string value = "20220215";
-    std::string timestamp = "2022/02/15 14:04:50";
+    std::string RegistryInstallDateValue = "20220215";
+    std::string RegistryModificationDateValue = "2022/02/15 14:04:50";
     std::string expected = "2022/02/15 14:04:50";
 
-    std::string result = Utils::normalizeTimestamp(value, timestamp);
+    std::string result = Utils::normalizeTimestamp(RegistryInstallDateValue, RegistryModificationDateValue);
 
     EXPECT_EQ(expected, result);
 }
 
-TEST_F(WindowsHelperTest, normalizeTimestampWrongTimestamp1)
+TEST_F(WindowsHelperTest, normalizeTimestampWrongRegistryInstallDateValue)
 {
-    std::string value = "a0220215";
-    std::string timestamp = "2022/02/15 23:59:59";
-    std::string expected;
+    std::string RegistryInstallDateValue = "a0220215";
+    std::string RegistryModificationDateValue = "2022/02/15 23:59:59";
 
-    std::string result = Utils::normalizeTimestamp(value, timestamp);
-
-    EXPECT_EQ(expected, result);
-}
-
-TEST_F(WindowsHelperTest, normalizeTimestampWrongTimestamp2)
-{
-    std::string value = "20220215";
-    std::string timestamp = "a022/02/15 23:59:59";
-    std::string expected = "2022/02/15 00:00:00";
-
-    std::string result = Utils::normalizeTimestamp(value, timestamp);
-
-    EXPECT_EQ(expected, result);
+    EXPECT_ANY_THROW(Utils::normalizeTimestamp(RegistryInstallDateValue, RegistryModificationDateValue));
 }
 
 #endif

--- a/src/shared_modules/utils/timeHelper.h
+++ b/src/shared_modules/utils/timeHelper.h
@@ -22,7 +22,7 @@
 
 namespace Utils
 {
-    static std::string getTimestamp(std::time_t time, bool utc = true)
+    static std::string getTimestamp(const std::time_t& time, const bool utc = true)
     {
         std::stringstream ss;
         // gmtime: result expressed as a UTC time

--- a/src/shared_modules/utils/timeHelper.h
+++ b/src/shared_modules/utils/timeHelper.h
@@ -22,11 +22,11 @@
 
 namespace Utils
 {
-    static std::string getTimestamp(std::time_t time)
+    static std::string getTimestamp(std::time_t time, bool utc = true)
     {
         std::stringstream ss;
         // gmtime: result expressed as a UTC time
-        tm* localTime { gmtime(&time) };
+        tm* localTime { utc ? gmtime(&time) : localtime(&time)};
         // Final timestamp: "YYYY/MM/DD hh:mm:ss"
         // Date
         ss << std::setfill('0') << std::setw(4) << std::to_string(localTime->tm_year + 1900);

--- a/src/shared_modules/utils/windowsHelper.h
+++ b/src/shared_modules/utils/windowsHelper.h
@@ -81,6 +81,22 @@ typedef struct SMBIOSBaseboardInfoStructure
     BYTE Version;
     BYTE SerialNumber;
 } SMBIOSBaseboardInfoStructure;
+constexpr auto REFERENCE_YEAR
+{
+    1900
+};
+
+//140512 represents 14:05:12.
+constexpr auto HOURMINSEC_VALUE_SIZE
+{
+    6
+};
+
+constexpr auto INSTALLDATE_REGISTRY_VALUE_SIZE
+{
+    8
+};
+
 
 namespace Utils
 {
@@ -177,62 +193,52 @@ namespace Utils
         return ret;
     }
 
-    static std::string normalizeTimestamp(std::string timestamp1, std::string timestamp2)
+    static std::string normalizeTimestamp(const std::string& timestamp1, const std::string& timestamp2)
     {
-        if (timestamp1.size() == 8)
-        {
-            std::string::iterator it;
+        std::string ret = UNKNOWN_VALUE;
 
-            for (it = timestamp1.begin(); it != timestamp1.end(); ++it)
+        if (timestamp1.size() == INSTALLDATE_REGISTRY_VALUE_SIZE)
+        {
+            if (isNumber(timestamp1))
             {
-                if (!isdigit(*it))
+                size_t pos = timestamp2.find(" ");
+
+                if (pos != std::string::npos)
                 {
-                    return UNKNOWN_VALUE;
+                    std::string date2_trimmed = timestamp2.substr(0, pos);
+                    std::string time2_trimmed = timestamp2.substr(pos + 1);
+
+                    Utils::replaceAll(date2_trimmed, "/", "");
+                    Utils::replaceAll(time2_trimmed, ":", "");
+
+                    if (date2_trimmed.size() == INSTALLDATE_REGISTRY_VALUE_SIZE
+                            || time2_trimmed.size() == HOURMINSEC_VALUE_SIZE)
+                    {
+                        if (date2_trimmed.compare(timestamp1) == 0)
+                        {
+                            ret = timestamp2;
+                        }
+                        else
+                        {
+                            std::unique_ptr<tm> local_time_s { std::make_unique<tm>() };
+
+                            local_time_s->tm_year = std::stoi(timestamp1.substr(0, 4)) - REFERENCE_YEAR;
+                            local_time_s->tm_mon = std::stoi(timestamp1.substr(4, 2)) - 1;
+                            local_time_s->tm_mday = std::stoi(timestamp1.substr(6, 2));
+                            local_time_s->tm_hour = 0;
+                            local_time_s->tm_min = 0;
+                            local_time_s->tm_sec = 0;
+
+                            time_t local_time = mktime(local_time_s.get());
+
+                            ret = Utils::getTimestamp(local_time, false);
+                        }
+                    }
                 }
             }
-
-            size_t pos = timestamp2.find(" ");
-
-            if (pos == std::string::npos)
-            {
-                return UNKNOWN_VALUE;
-            }
-
-            std::string date2_trimmed = timestamp2.substr(0, pos);
-            std::string time2_trimmed = timestamp2.substr(pos + 1);
-            date2_trimmed.erase(remove(date2_trimmed.begin(), date2_trimmed.end(), '/'), date2_trimmed.end());
-            time2_trimmed.erase(remove(time2_trimmed.begin(), time2_trimmed.end(), ':'), time2_trimmed.end());
-
-            if (date2_trimmed.size() != 8 || time2_trimmed.size() != 6)
-            {
-                return UNKNOWN_VALUE;
-            }
-
-            tm* local_time_s = new tm();
-            size_t reference_year = 1900;
-
-            if (date2_trimmed.compare(timestamp1) == 0)
-            {
-                return timestamp2;
-            }
-            else
-            {
-                local_time_s->tm_year = stoi(timestamp1.substr(0, 4)) - reference_year;
-                local_time_s->tm_mon = stoi(timestamp1.substr(4, 2)) - 1;
-                local_time_s->tm_mday = stoi(timestamp1.substr(6, 2));
-                local_time_s->tm_hour = 0;
-                local_time_s->tm_min = 0;
-                local_time_s->tm_sec = 0;
-            }
-
-            time_t local_time = mktime(local_time_s);
-
-            return Utils::getTimestamp(local_time, false);
         }
-        else
-        {
-            return UNKNOWN_VALUE;
-        }
+
+        return ret;
     }
 
     /* Reference: https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_2.6.0.pdf */

--- a/src/shared_modules/utils/windowsHelper.h
+++ b/src/shared_modules/utils/windowsHelper.h
@@ -27,7 +27,7 @@
 #include "mem_op.h"
 #include "stringHelper.h"
 #include "encodingWindowsHelper.h"
-#include "sharedDefs.h"
+#include "../../data_provider/src/sharedDefs.h"
 #include "timeHelper.h"
 
 #pragma GCC diagnostic push
@@ -199,15 +199,16 @@ namespace Utils
             }
 
             std::string date2_trimmed = timestamp2.substr(0, pos);
-            std::string time2_trimmed = timestamp2.substr(pos+1);
+            std::string time2_trimmed = timestamp2.substr(pos + 1);
             date2_trimmed.erase(remove(date2_trimmed.begin(), date2_trimmed.end(), '/'), date2_trimmed.end());
             time2_trimmed.erase(remove(time2_trimmed.begin(), time2_trimmed.end(), ':'), time2_trimmed.end());
 
-            if (date2_trimmed.size() != 8 || time2_trimmed.size() != 6) {
+            if (date2_trimmed.size() != 8 || time2_trimmed.size() != 6)
+            {
                 return UNKNOWN_VALUE;
             }
 
-            tm *local_time_s = new tm();
+            tm* local_time_s = new tm();
             size_t reference_year = 1900;
 
             if (date2_trimmed.compare(timestamp1) == 0)
@@ -216,9 +217,9 @@ namespace Utils
             }
             else
             {
-                local_time_s->tm_year = stoi(timestamp1.substr(0,4)) - reference_year;
-                local_time_s->tm_mon = stoi(timestamp1.substr(4,2)) - 1;
-                local_time_s->tm_mday = stoi(timestamp1.substr(6,2));
+                local_time_s->tm_year = stoi(timestamp1.substr(0, 4)) - reference_year;
+                local_time_s->tm_mon = stoi(timestamp1.substr(4, 2)) - 1;
+                local_time_s->tm_mday = stoi(timestamp1.substr(6, 2));
                 local_time_s->tm_hour = 0;
                 local_time_s->tm_min = 0;
                 local_time_s->tm_sec = 0;

--- a/src/shared_modules/utils/windowsHelper.h
+++ b/src/shared_modules/utils/windowsHelper.h
@@ -27,6 +27,8 @@
 #include "mem_op.h"
 #include "stringHelper.h"
 #include "encodingWindowsHelper.h"
+#include "sharedDefs.h"
+#include "timeHelper.h"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
@@ -175,6 +177,63 @@ namespace Utils
         return ret;
     }
 
+    static std::string normalizeTimestamp(std::string timestamp1, std::string timestamp2)
+    {
+        if (timestamp1.size() == 8)
+        {
+            std::string::iterator it;
+
+            for (it = timestamp1.begin(); it != timestamp1.end(); ++it)
+            {
+                if (!isdigit(*it))
+                {
+                    return UNKNOWN_VALUE;
+                }
+            }
+
+            size_t pos = timestamp2.find(" ");
+
+            if (pos == std::string::npos)
+            {
+                return UNKNOWN_VALUE;
+            }
+
+            std::string date2_trimmed = timestamp2.substr(0, pos);
+            std::string time2_trimmed = timestamp2.substr(pos+1);
+            date2_trimmed.erase(remove(date2_trimmed.begin(), date2_trimmed.end(), '/'), date2_trimmed.end());
+            time2_trimmed.erase(remove(time2_trimmed.begin(), time2_trimmed.end(), ':'), time2_trimmed.end());
+
+            if (date2_trimmed.size() != 8 || time2_trimmed.size() != 6) {
+                return UNKNOWN_VALUE;
+            }
+
+            tm *local_time_s = new tm();
+            size_t reference_year = 1900;
+
+            if (date2_trimmed.compare(timestamp1) == 0)
+            {
+                return timestamp2;
+            }
+            else
+            {
+                local_time_s->tm_year = stoi(timestamp1.substr(0,4)) - reference_year;
+                local_time_s->tm_mon = stoi(timestamp1.substr(4,2)) - 1;
+                local_time_s->tm_mday = stoi(timestamp1.substr(6,2));
+                local_time_s->tm_hour = 0;
+                local_time_s->tm_min = 0;
+                local_time_s->tm_sec = 0;
+            }
+
+            time_t local_time = mktime(local_time_s);
+
+            return Utils::getTimestamp(local_time, false);
+        }
+        else
+        {
+            return UNKNOWN_VALUE;
+        }
+    }
+
     /* Reference: https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_2.6.0.pdf */
     static std::string getSerialNumberFromSmbios(const BYTE* rawData, const DWORD rawDataSize)
     {
@@ -253,7 +312,10 @@ namespace Utils
         const time_t epochTime { static_cast<long int> ((time / 10000000ULL) - WINDOWS_UNIX_EPOCH_DIFF_SECONDS) };
         char formatString[20] = {0};
 
-        std::strftime(formatString, sizeof(formatString), "%Y/%m/%d %H:%M:%S", std::localtime(&epochTime));
+        tm utc_time;
+        gmtime_s(&utc_time, &epochTime);
+
+        std::strftime(formatString, sizeof(formatString), "%Y/%m/%d %H:%M:%S", &utc_time);
         return formatString;
     }
 

--- a/src/shared_modules/utils/windowsHelper.h
+++ b/src/shared_modules/utils/windowsHelper.h
@@ -219,7 +219,7 @@ namespace Utils
                         }
                         else
                         {
-                            tm local_time_s { 0 };
+                            tm local_time_s {};
                             local_time_s.tm_year = std::stoi(timestamp1.substr(0, 4)) - REFERENCE_YEAR;
                             local_time_s.tm_mon = std::stoi(timestamp1.substr(4, 2)) - 1;
                             local_time_s.tm_mday = std::stoi(timestamp1.substr(6, 2));

--- a/src/shared_modules/utils/windowsHelper.h
+++ b/src/shared_modules/utils/windowsHelper.h
@@ -27,7 +27,6 @@
 #include "mem_op.h"
 #include "stringHelper.h"
 #include "encodingWindowsHelper.h"
-#include "../../data_provider/src/sharedDefs.h"
 #include "timeHelper.h"
 
 #pragma GCC diagnostic push
@@ -195,7 +194,7 @@ namespace Utils
 
     static std::string normalizeTimestamp(const std::string& timestamp1, const std::string& timestamp2)
     {
-        std::string ret = UNKNOWN_VALUE;
+        std::string normalizedTimestamp;
 
         if (timestamp1.size() == INSTALLDATE_REGISTRY_VALUE_SIZE)
         {
@@ -216,7 +215,7 @@ namespace Utils
                     {
                         if (date2_trimmed.compare(timestamp1) == 0)
                         {
-                            ret = timestamp2;
+                            normalizedTimestamp = timestamp2;
                         }
                         else
                         {
@@ -231,14 +230,14 @@ namespace Utils
 
                             time_t local_time = mktime(local_time_s.get());
 
-                            ret = Utils::getTimestamp(local_time, false);
+                            normalizedTimestamp = Utils::getTimestamp(local_time, false);
                         }
                     }
                 }
             }
         }
 
-        return ret;
+        return normalizedTimestamp;
     }
 
     /* Reference: https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_2.6.0.pdf */

--- a/src/shared_modules/utils/windowsHelper.h
+++ b/src/shared_modules/utils/windowsHelper.h
@@ -200,7 +200,7 @@ namespace Utils
         {
             if (isNumber(timestamp1))
             {
-                size_t pos = timestamp2.find(" ");
+                size_t pos = timestamp2.find(' ');
 
                 if (pos != std::string::npos)
                 {
@@ -219,16 +219,14 @@ namespace Utils
                         }
                         else
                         {
-                            std::unique_ptr<tm> local_time_s { std::make_unique<tm>() };
-
-                            local_time_s->tm_year = std::stoi(timestamp1.substr(0, 4)) - REFERENCE_YEAR;
-                            local_time_s->tm_mon = std::stoi(timestamp1.substr(4, 2)) - 1;
-                            local_time_s->tm_mday = std::stoi(timestamp1.substr(6, 2));
-                            local_time_s->tm_hour = 0;
-                            local_time_s->tm_min = 0;
-                            local_time_s->tm_sec = 0;
-
-                            time_t local_time = mktime(local_time_s.get());
+                            tm local_time_s { 0 };
+                            local_time_s.tm_year = std::stoi(timestamp1.substr(0, 4)) - REFERENCE_YEAR;
+                            local_time_s.tm_mon = std::stoi(timestamp1.substr(4, 2)) - 1;
+                            local_time_s.tm_mday = std::stoi(timestamp1.substr(6, 2));
+                            local_time_s.tm_hour = 0;
+                            local_time_s.tm_min = 0;
+                            local_time_s.tm_sec = 0;
+                            time_t local_time = mktime(&local_time_s);
 
                             normalizedTimestamp = Utils::getTimestamp(local_time, false);
                         }

--- a/src/shared_modules/utils/windowsHelper.h
+++ b/src/shared_modules/utils/windowsHelper.h
@@ -198,53 +198,61 @@ namespace Utils
     {
         std::string normalizedTimestamp;
 
-        if (dateISO8601CalendarDateFormat.size() == INSTALLDATE_REGISTRY_VALUE_SIZE)
+        if (dateISO8601CalendarDateFormat.size() != INSTALLDATE_REGISTRY_VALUE_SIZE)
         {
-            if (isNumber(dateISO8601CalendarDateFormat))
+            throw std::runtime_error("Invalid dateISO8601CalendarDateFormat size.");
+        }
+
+        if (!isNumber(dateISO8601CalendarDateFormat))
+        {
+            throw std::runtime_error("Invalid dateISO8601CalendarDateFormat format.");
+        }
+
+        const auto pos = dateISO8601CombinedFormat.find(' ');
+
+        if (pos != std::string::npos)
+        {
+            // Substracts "YYYY/MM/DD" from "YYYY/MM/DD hh:mm:ss" string.
+            auto dateTrimmed = dateISO8601CombinedFormat.substr(0, pos);
+            // Substracts "hh:mm:ss" from "YYYY/MM/DD hh:mm:ss" string.
+            auto timeTrimmed = dateISO8601CombinedFormat.substr(pos + 1);
+
+            // Converts "YYYY/MM/DD" string to "YYYYMMDD".
+            Utils::replaceAll(dateTrimmed, "/", "");
+            // Converts "hh:mm:ss" string to "hhmmss".
+            Utils::replaceAll(timeTrimmed, ":", "");
+
+            if (dateTrimmed.size() == INSTALLDATE_REGISTRY_VALUE_SIZE
+                    || timeTrimmed.size() == HOURMINSEC_VALUE_SIZE)
             {
-                const auto pos = dateISO8601CombinedFormat.find(' ');
-
-                if (pos != std::string::npos)
+                if (dateTrimmed.compare(dateISO8601CalendarDateFormat) == 0)
                 {
-                    // Substracts "YYYY/MM/DD" from "YYYY/MM/DD hh:mm:ss" string.
-                    auto dateTrimmed = dateISO8601CombinedFormat.substr(0, pos);
-                    // Substracts "hh:mm:ss" from "YYYY/MM/DD hh:mm:ss" string.
-                    auto timeTrimmed = dateISO8601CombinedFormat.substr(pos + 1);
+                    normalizedTimestamp = dateISO8601CombinedFormat;
+                }
+                else
+                {
+                    tm local_time_s {};
 
-                    // Converts "YYYY/MM/DD" string to "YYYYMMDD".
-                    Utils::replaceAll(dateTrimmed, "/", "");
-                    // Converts "hh:mm:ss" string to "hhmmss".
-                    Utils::replaceAll(timeTrimmed, ":", "");
+                    // Parsing YYYYMMDD date format string.
+                    local_time_s.tm_year = std::stoi(dateISO8601CalendarDateFormat.substr(0, 4)) - REFERENCE_YEAR;
+                    local_time_s.tm_mon = std::stoi(dateISO8601CalendarDateFormat.substr(4, 2)) - 1;
+                    local_time_s.tm_mday = std::stoi(dateISO8601CalendarDateFormat.substr(6, 2));
+                    local_time_s.tm_hour = 0;
+                    local_time_s.tm_min = 0;
+                    local_time_s.tm_sec = 0;
+                    time_t local_time = mktime(&local_time_s);
 
-                    if (dateTrimmed.size() == INSTALLDATE_REGISTRY_VALUE_SIZE
-                            || timeTrimmed.size() == HOURMINSEC_VALUE_SIZE)
-                    {
-                        if (dateTrimmed.compare(dateISO8601CalendarDateFormat) == 0)
-                        {
-                            normalizedTimestamp = dateISO8601CombinedFormat;
-                        }
-                        else
-                        {
-                            tm local_time_s {};
-
-                            try
-                            {
-                                // Parsing YYYYMMDD date format string.
-                                local_time_s.tm_year = std::stoi(dateISO8601CalendarDateFormat.substr(0, 4)) - REFERENCE_YEAR;
-                                local_time_s.tm_mon = std::stoi(dateISO8601CalendarDateFormat.substr(4, 2)) - 1;
-                                local_time_s.tm_mday = std::stoi(dateISO8601CalendarDateFormat.substr(6, 2));
-                                local_time_s.tm_hour = 0;
-                                local_time_s.tm_min = 0;
-                                local_time_s.tm_sec = 0;
-                                time_t local_time = mktime(&local_time_s);
-
-                                normalizedTimestamp = Utils::getTimestamp(local_time, false);
-                            }
-                            catch (...) {}
-                        }
-                    }
+                    normalizedTimestamp = Utils::getTimestamp(local_time, false);
                 }
             }
+            else
+            {
+                throw std::runtime_error("Invalid dateISO8601CombinedFormat format.");
+            }
+        }
+        else
+        {
+            throw std::runtime_error("Invalid dateISO8601CombinedFormat date/time separator.");
         }
 
         return normalizedTimestamp;


### PR DESCRIPTION
|Related issue|
|---|
|#13884|

## Description

This PR converts the timestamp where a package was installed (install_time in `sys_programs`) into a `"%Y/%m/%d %H:%M:%S"` format value. 

## Dod

<details>
<summary>Expand</summary>

- Scan-build 

![image](https://user-images.githubusercontent.com/13010397/188734640-4a5ae35c-f424-419b-801d-029748bf7cdb.png)

- UTs

![image](https://user-images.githubusercontent.com/13010397/178338386-6f1f8ece-e002-4de1-ac16-3e550cee7e2c.png)

</details>

## Update 03/03/23 

### Smoke test after rebase

<details>
<summary>Expand</summary>

- Scan-build 

![image](https://user-images.githubusercontent.com/13010397/222816841-d00e3cad-5f22-4356-b1ec-e1c285c941c0.png)

- UTs

![image](https://user-images.githubusercontent.com/13010397/222822745-737139c9-9d70-4eab-9c6d-bd62c1417b6c.png)

- Current state of 4.5 branch

![2023-03-03_16-26](https://user-images.githubusercontent.com/13010397/222810687-8bffa972-11df-4939-a92a-5945de1ec5f7.png)

- This implementation 

![image](https://user-images.githubusercontent.com/13010397/222816503-1749d0af-11eb-47f1-92fc-9208c9434f9e.png)

</details>

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Windows
  - [x] Scan-build report

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)