### PR TITLE
Use command 'uname -m' to detect cpu architecture on makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1157,22 +1157,30 @@ CPYTHON := cpython
 PYTHON_SOURCE := no
 
 ifneq (${TARGET}, winagent)
-cpu_arch := ${uname_M}
-ifneq (,$(filter ${cpu_arch},x86_64 amd64))
-PRECOMPILED_ARCH := /amd64
+ifneq (,$(filter ${uname_S}, Linux Darwin))
+	cpu_arch := ${uname_M}
+	ifneq (,$(filter ${cpu_arch},x86_64 amd64))
+		PRECOMPILED_ARCH := /amd64
+	else
+	ifneq (,$(filter ${cpu_arch},i386 i686))
+		PRECOMPILED_ARCH := /i386
+	else
+	ifneq (,$(filter ${cpu_arch},aarch64 arm64))
+		PRECOMPILED_ARCH := /aarch64
+	else
+	ifneq (,$(filter ${cpu_arch},armv8l armv7l arm32 armhf))
+		PRECOMPILED_ARCH := /arm32
+	else
+		PRECOMPILED_ARCH := /${uname_P}
+	endif
+	endif
+	endif
+	endif
 else
-ifneq (,$(filter ${cpu_arch},i386 i686))
-PRECOMPILED_ARCH := /i386
+ifneq (,$(filter ${uname_S},HP-UX SunOS AIX))
+	PRECOMPILED_ARCH := /${uname_P}
 else
-ifneq (,$(filter ${cpu_arch},aarch64 arm64))
-PRECOMPILED_ARCH := /aarch64
-else
-ifneq (,$(filter ${cpu_arch},armv8l armv7l arm32 armhf))
-PRECOMPILED_ARCH := /arm32
-else
-PRECOMPILED_ARCH := /${uname_P}
-endif
-endif
+	PRECOMPILED_ARCH := /${uname_P}
 endif
 endif
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -1157,7 +1157,7 @@ CPYTHON := cpython
 PYTHON_SOURCE := no
 
 ifneq (${TARGET}, winagent)
-ifneq (,$(filter ${uname_S}, Linux Darwin))
+ifneq (,$(filter ${uname_S},Linux Darwin HP-UX))
 	cpu_arch := ${uname_M}
 	ifneq (,$(filter ${cpu_arch},x86_64 amd64))
 		PRECOMPILED_ARCH := /amd64
@@ -1170,17 +1170,39 @@ ifneq (,$(filter ${uname_S}, Linux Darwin))
 	else
 	ifneq (,$(filter ${cpu_arch},armv8l armv7l arm32 armhf))
 		PRECOMPILED_ARCH := /arm32
+    else
+    ifneq (,$(filter ${cpu_arch},ia64 9000/712))
+#   NOTE: this should be 'ia64', instead of 'not'. Keeping 'not' to match the remote folder.
+		PRECOMPILED_ARCH := /not
 	else
 		PRECOMPILED_ARCH := /${uname_P}
 	endif
 	endif
 	endif
 	endif
+	endif
 else
-ifneq (,$(filter ${uname_S},HP-UX SunOS AIX))
-	PRECOMPILED_ARCH := /${uname_P}
+ifneq (,$(filter ${uname_S},SunOS AIX))
+	cpu_arch := ${uname_P}
+    ifeq (${cpu_arch},powerpc)  
+		PRECOMPILED_ARCH := /powerpc
+	else
+	ifneq (,$(filter ${cpu_arch},sparc sun4u))
+		PRECOMPILED_ARCH := /sparc
+	else
+	ifneq (,$(filter ${cpu_arch},i386 i86pc))
+		PRECOMPILED_ARCH := /i386
+	else
+		PRECOMPILED_ARCH := /${uname_M}
+	endif
+	endif
+	endif
 else
-	PRECOMPILED_ARCH := /${uname_P}
+    cpu_arch := ${uname_M}
+    ifneq (,$(filter ${cpu_arch},unknown Unknown not))
+		cpu_arch := ${uname_P}
+    endif
+    PRECOMPILED_ARCH := /${cpu_arch}
 endif
 endif
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -1157,13 +1157,7 @@ CPYTHON := cpython
 PYTHON_SOURCE := no
 
 ifneq (${TARGET}, winagent)
-cpu_arch := ${uname_P}
-ifneq (,$(filter ${cpu_arch},unknown Unknown not))
-	cpu_arch := $(shell sh -c 'arch 2>/dev/null || echo not')
-endif
-ifneq (,$(filter ${cpu_arch},unknown Unknown not))
-	cpu_arch := ${uname_M}
-endif
+cpu_arch := ${uname_M}
 ifneq (,$(filter ${cpu_arch},x86_64 amd64))
 PRECOMPILED_ARCH := /amd64
 else

--- a/src/Makefile
+++ b/src/Makefile
@@ -1171,11 +1171,14 @@ ifneq (,$(filter ${uname_S},Linux Darwin HP-UX))
 	ifneq (,$(filter ${cpu_arch},armv8l armv7l arm32 armhf))
 		PRECOMPILED_ARCH := /arm32
     else
+	ifeq (${cpu_arch},ppc64le)
+		PRECOMPILED_ARCH := /ppc64le
+	else
     ifneq (,$(filter ${cpu_arch},ia64 9000/712))
-#   NOTE: this should be 'ia64', instead of 'not'. Keeping 'not' to match the remote folder.
-		PRECOMPILED_ARCH := /not
+		PRECOMPILED_ARCH := /ia64
 	else
 		PRECOMPILED_ARCH := /${uname_P}
+	endif
 	endif
 	endif
 	endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -1170,7 +1170,7 @@ else
 ifneq (,$(filter ${cpu_arch},armv8l armv7l arm32 armhf))
 PRECOMPILED_ARCH := /arm32
 else
-PRECOMPILED_ARCH := /${cpu_arch}
+PRECOMPILED_ARCH := /${uname_P}
 endif
 endif
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -1174,7 +1174,7 @@ ifneq (,$(filter ${uname_S},Linux Darwin HP-UX))
 	ifeq (${cpu_arch},ppc64le)
 		PRECOMPILED_ARCH := /ppc64le
 	else
-    ifneq (,$(filter ${cpu_arch},ia64 9000/712))
+    ifneq (,$(filter ${cpu_arch},ia64))
 		PRECOMPILED_ARCH := /ia64
 	else
 		PRECOMPILED_ARCH := /${uname_P}

--- a/src/Makefile
+++ b/src/Makefile
@@ -1159,53 +1159,53 @@ PYTHON_SOURCE := no
 ifneq (${TARGET}, winagent)
 ifneq (,$(filter ${uname_S},Linux Darwin HP-UX))
 	cpu_arch := ${uname_M}
-	ifneq (,$(filter ${cpu_arch},x86_64 amd64))
-		PRECOMPILED_ARCH := /amd64
-	else
-	ifneq (,$(filter ${cpu_arch},i386 i686))
-		PRECOMPILED_ARCH := /i386
-	else
-	ifneq (,$(filter ${cpu_arch},aarch64 arm64))
-		PRECOMPILED_ARCH := /aarch64
-	else
-	ifneq (,$(filter ${cpu_arch},armv8l armv7l arm32 armhf))
-		PRECOMPILED_ARCH := /arm32
-    else
-	ifeq (${cpu_arch},ppc64le)
-		PRECOMPILED_ARCH := /ppc64le
-	else
-    ifneq (,$(filter ${cpu_arch},ia64))
-		PRECOMPILED_ARCH := /ia64
-	else
-		PRECOMPILED_ARCH := /${uname_P}
-	endif
-	endif
-	endif
-	endif
-	endif
-	endif
+ifneq (,$(filter ${cpu_arch},x86_64 amd64))
+	PRECOMPILED_ARCH := /amd64
+else
+ifneq (,$(filter ${cpu_arch},i386 i686))
+	PRECOMPILED_ARCH := /i386
+else
+ifneq (,$(filter ${cpu_arch},aarch64 arm64))
+	PRECOMPILED_ARCH := /aarch64
+else
+ifneq (,$(filter ${cpu_arch},armv8l armv7l arm32 armhf))
+	PRECOMPILED_ARCH := /arm32
+else
+ifeq (${cpu_arch},ppc64le)
+	PRECOMPILED_ARCH := /ppc64le
+else
+ifneq (,$(filter ${cpu_arch},ia64))
+	PRECOMPILED_ARCH := /ia64
+else
+	PRECOMPILED_ARCH := /${uname_P}
+endif
+endif
+endif
+endif
+endif
+endif
 else
 ifneq (,$(filter ${uname_S},SunOS AIX))
 	cpu_arch := ${uname_P}
-    ifeq (${cpu_arch},powerpc)  
-		PRECOMPILED_ARCH := /powerpc
-	else
-	ifneq (,$(filter ${cpu_arch},sparc sun4u))
-		PRECOMPILED_ARCH := /sparc
-	else
-	ifneq (,$(filter ${cpu_arch},i386 i86pc))
-		PRECOMPILED_ARCH := /i386
-	else
-		PRECOMPILED_ARCH := /${uname_M}
-	endif
-	endif
-	endif
+ifeq (${cpu_arch},powerpc)  
+	PRECOMPILED_ARCH := /powerpc
+else
+ifneq (,$(filter ${cpu_arch},sparc sun4u))
+	PRECOMPILED_ARCH := /sparc
+else
+ifneq (,$(filter ${cpu_arch},i386 i86pc))
+	PRECOMPILED_ARCH := /i386
+else
+	PRECOMPILED_ARCH := /${uname_M}
+endif
+endif
+endif
 else
     cpu_arch := ${uname_M}
-    ifneq (,$(filter ${cpu_arch},unknown Unknown not))
-		cpu_arch := ${uname_P}
-    endif
-    PRECOMPILED_ARCH := /${cpu_arch}
+ifneq (,$(filter ${cpu_arch},unknown Unknown not))
+	cpu_arch := ${uname_P}
+endif
+	PRECOMPILED_ARCH := /${cpu_arch}
 endif
 endif
 endif


### PR DESCRIPTION
|Related issue|
|---|
|closes #14109|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR modifies the makefile to use 'uname -m' instead of 'uname -p' to detect the cpu architecture used to download the precompiled dependencies. 'uname -p' is not portable. See https://github.com/wazuh/wazuh/issues/14109#issuecomment-1175576954 for background information.

<!--
Add a clear description of how the problem has been solved.
-->

### Tests

| OS | Agent | Manager | uname -m | uname -p | Test |
|---|---|---|---|---|---|
|AmazonLinux 2| OK | OK |x86_64|x86_64 | :green_circle: [details](https://github.com/wazuh/wazuh/pull/14165#issuecomment-1176783846) |
| Ubuntu 22.04 | OK | OK | x86_64 | x86_64 | :green_circle: [details](https://github.com/wazuh/wazuh/pull/14165#issuecomment-1177732582)|
| Ubuntu 20.04 | OK | OK | x86_64 | x86_64 |:green_circle: [details](https://github.com/wazuh/wazuh/pull/14165#issuecomment-1177701013)|
| Arch Linux | OK | OK | x86_64 | unknown | :green_circle: [details](https://github.com/wazuh/wazuh/pull/14165#issuecomment-1177945094)
|CentOS 7 | OK| OK| x86_64|x86_64| :green_circle: [details](https://github.com/wazuh/wazuh/pull/14165#issuecomment-1178222835)|
|Fedora 36 | OK  | OK  | x86_64   | x86_64   | :green_circle: [details](https://github.com/wazuh/wazuh/pull/14165#issuecomment-1177983833) |
|OpenSUSE |OK |OK| x86_64  | x86_64  |:green_circle: [details](https://github.com/wazuh/wazuh/pull/14165#issuecomment-1177933905)|
|Solaris 10 | OK | N/A|sun4v|sparc|:green_circle: [details](https://github.com/wazuh/wazuh/pull/14165#issuecomment-1208168615)|
|Solaris 11 | OK | N/A| i86pc | i386 | :green_circle: [details](https://github.com/wazuh/wazuh/pull/14165#issuecomment-1177869296) / [Fix](https://github.com/wazuh/wazuh/pull/14165#issuecomment-1178952733) |
|macOS | OK | N/A | x86_64 | i386 | :yellow_circle: [details](https://github.com/wazuh/wazuh/pull/14165#issuecomment-1178519435) |
| Debian | OK | OK | x86_64 | unknown | :green_circle: [details](https://github.com/wazuh/wazuh/pull/14165#issuecomment-1178002140) |
| CentOS 7 (PowerPC) | OK | N/A | ppc64le | ppc64le | :green_circle:  [details](https://github.com/wazuh/wazuh/pull/14165#issuecomment-1180885960)  |
| Gentoo/Linux | OK | OK | x86_64 | Intel(R) Core(TM) i5-10210U CPU @ 1.60GHz | :green_circle: [details](https://github.com/wazuh/wazuh/pull/14165#issuecomment-1176790015) |
| AIX | OK | N/A|00CADA644C00|powerpc|:green_circle:[details](https://github.com/wazuh/wazuh/pull/14165#issuecomment-1208106466)|
| HP-UX | OK | N/A|ia64|illegal option|:green_circle:[details](https://github.com/wazuh/wazuh/pull/14165#issuecomment-1208124994)|

- [x] AmazonLinux 2 @jftuduri 
- [x] Ubuntu 22.04 @jftuduri 
- [x] Arch Linux @jftuduri 
- [x] CentOS 7 @sebasfalcone 
- [x] Fedora 36 @sebasfalcone
- [x] OpenSUSE @sebasfalcone
- [x] Ubuntu 20.04 @sebasfalcone
- [x] Solaris 11 @HanesSciarrone 
- [x] macOS  @HanesSciarrone 
- [x] Debian  @HanesSciarrone 
- [x] CentOS 7 (PowerPC)  @HanesSciarrone 
- [x] Gentoo/Linux @jftuduri 
- [x] AIX @jftuduri
- [x] HP-UX @jftuduri
- [x] Solaris 10 - sparc @jftuduri

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] MAC OS X
- [ ] Source installation

## DoD
- [x] Create folder amd64 for MacOS deps 17+ `deps/<version>/libraries/darwin/amd64`.
- [x] Change/Copy `deps/<version>/libraries/hpux/not/` to `deps/<version>/libraries/hpux/ia64/`
- [x] All tested OS and platforms pass.