### PR TITLE
Fix UBS errors in vuln detector UTs.

### DIFF
--- a/src/unit_tests/os_auth/test_auth_key_request.c
+++ b/src/unit_tests/os_auth/test_auth_key_request.c
@@ -291,7 +291,7 @@ void test_get_agent_info_from_json_agent_success(void **state) {
     will_return(__wrap_cJSON_GetObjectItem, key);
 
     key_request_agent_info *ret = get_agent_info_from_json(input_raw_json, &error_msg);
-    
+
     assert_string_equal(ret->id, id->valuestring);
     assert_string_equal(ret->name, name->valuestring);
     assert_string_equal(ret->ip, ip->valuestring);
@@ -304,7 +304,7 @@ void test_get_agent_info_from_json_agent_success(void **state) {
     __real_cJSON_Delete(ip);
     __real_cJSON_Delete(key);
     __real_cJSON_Delete(input_raw_json);
-    
+
     key_request_agent_info_destroy(ret);
 }
 
@@ -339,7 +339,7 @@ void test_key_request_socket_output_long_request(void **state) {
 
     memset(buffer_request, 'a', 126);
     buffer_request[126] = '\0';
- 
+
     will_return(__wrap_external_socket_connect, 4);
     expect_string(__wrap__mdebug1, formatted_msg, "Request is too long for socket.");
 
@@ -347,7 +347,7 @@ void test_key_request_socket_output_long_request(void **state) {
     assert_null(ret);
 }
 
-void test_key_request_socket_output_send_fail(void **state) { 
+void test_key_request_socket_output_send_fail(void **state) {
     will_return(__wrap_external_socket_connect, 4);
     will_return(__wrap_send, -1);
 
@@ -355,7 +355,7 @@ void test_key_request_socket_output_send_fail(void **state) {
     assert_null(ret);
 }
 
-void test_key_request_socket_output_no_data_received(void **state) { 
+void test_key_request_socket_output_no_data_received(void **state) {
     will_return(__wrap_external_socket_connect, 4);
 
     will_return(__wrap_send, 0);
@@ -366,7 +366,7 @@ void test_key_request_socket_output_no_data_received(void **state) {
     assert_null(ret);
 }
 
-void test_key_request_socket_output_empty_string_received(void **state) { 
+void test_key_request_socket_output_empty_string_received(void **state) {
     will_return(__wrap_external_socket_connect, 4);
 
     will_return(__wrap_send, 0);
@@ -376,7 +376,7 @@ void test_key_request_socket_output_empty_string_received(void **state) {
     assert_null(ret);
 }
 
-void test_key_request_socket_output_success(void **state) { 
+void test_key_request_socket_output_success(void **state) {
     will_return(__wrap_external_socket_connect, 4);
 
     will_return(__wrap_send, 0);
@@ -455,6 +455,8 @@ void test_key_request_dispatch_error_parsing_json(void **state) {
     expect_string(__wrap__mdebug2, formatted_msg, "Socket output: Hello World!");
 
     will_return(__wrap_cJSON_ParseWithOpts, NULL);
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
+
     expect_string(__wrap__mdebug1, formatted_msg, "Error parsing JSON event ()");
 
     expect_value(__wrap_OSHash_Delete_ex, self, NULL);
@@ -479,6 +481,7 @@ void test_key_request_dispatch_error_parsing_agent_json(void **state) {
     will_return(__wrap_recv, 12);
     expect_string(__wrap__mdebug2, formatted_msg, "Socket output: Hello World!");
 
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
     will_return(__wrap_cJSON_ParseWithOpts, (cJSON *)1);
     will_return(__wrap_cJSON_GetObjectItem, field);
     will_return(__wrap_cJSON_GetObjectItem, msg);
@@ -549,6 +552,8 @@ void test_key_request_dispatch_success(void **state) {
     will_return(__wrap_cJSON_GetObjectItem, name);
     will_return(__wrap_cJSON_GetObjectItem, ip);
     will_return(__wrap_cJSON_GetObjectItem, key);
+
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
     will_return(__wrap_cJSON_ParseWithOpts, (cJSON *)1);
 
     expect_string(__wrap__mdebug1, formatted_msg, "Forwarding agent key request response to the master node for agent '001'");
@@ -592,6 +597,8 @@ void test_key_request_dispatch_success_add_agent(void **state) {
     will_return(__wrap_send, 0);
     will_return(__wrap_recv, 12);
     expect_string(__wrap__mdebug2, formatted_msg, "Socket output: Hello World!");
+
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
     will_return(__wrap_cJSON_ParseWithOpts, (cJSON *)1);
 
     will_return(__wrap_cJSON_GetObjectItem, field);
@@ -626,7 +633,7 @@ void test_key_request_dispatch_success_add_agent(void **state) {
     expect_string(__wrap_OSHash_Delete_ex, key, buffer);
     will_return(__wrap_OSHash_Delete_ex, 0);
 
-    int ret = key_request_dispatch(buffer); 
+    int ret = key_request_dispatch(buffer);
     assert_int_equal(ret, 0);
 
     __real_cJSON_Delete(response);
@@ -667,6 +674,7 @@ void test_key_request_dispatch_success_exec_output(void **state) {
     will_return(__wrap_wm_exec, 0);
     expect_string(__wrap__mdebug2, formatted_msg, "Exec output: Output command");
 
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
     will_return(__wrap_cJSON_ParseWithOpts, (cJSON *)1);
     will_return(__wrap_cJSON_GetObjectItem, field);
     will_return(__wrap_cJSON_GetObjectItem, data);
@@ -700,7 +708,7 @@ void test_key_request_dispatch_success_exec_output(void **state) {
     expect_string(__wrap_OSHash_Delete_ex, key, buffer);
     will_return(__wrap_OSHash_Delete_ex, 0);
 
-    int ret = key_request_dispatch(buffer); 
+    int ret = key_request_dispatch(buffer);
     assert_int_equal(ret, 0);
 
     __real_cJSON_Delete(response);
@@ -745,6 +753,7 @@ void test_key_request_dispatch_error_socket_success_exec_output(void **state) {
     will_return(__wrap_wm_exec, 0);
     expect_string(__wrap__mdebug2, formatted_msg, "Exec output: Output command");
 
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
     will_return(__wrap_cJSON_ParseWithOpts, (cJSON *)1);
     will_return(__wrap_cJSON_GetObjectItem, field);
     will_return(__wrap_cJSON_GetObjectItem, data);
@@ -778,7 +787,7 @@ void test_key_request_dispatch_error_socket_success_exec_output(void **state) {
     expect_string(__wrap_OSHash_Delete_ex, key, buffer);
     will_return(__wrap_OSHash_Delete_ex, 0);
 
-    int ret = key_request_dispatch(buffer); 
+    int ret = key_request_dispatch(buffer);
     assert_int_equal(ret, 0);
 
     __real_cJSON_Delete(response);

--- a/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
@@ -871,10 +871,11 @@ void test_wdb_remove_vuln_cves_by_status_error_json_result(void **state)
     will_return(__wrap_wdbc_parse_result, WDBC_OK);
 
     // Parsing JSON result
+    will_return(__wrap_cJSON_ParseWithOpts, "a JSON error");
     will_return(__wrap_cJSON_ParseWithOpts, NULL);
 
     expect_string(__wrap__mdebug1, formatted_msg, "Invalid vuln_cves JSON results syntax after removing vulnerabilities.");
-    expect_string(__wrap__mdebug2, formatted_msg, "JSON error near: (null)");
+    expect_string(__wrap__mdebug2, formatted_msg, "JSON error near: a JSON error");
 
     //Cleaning  memory
     expect_function_call(__wrap_cJSON_Delete);
@@ -918,6 +919,7 @@ void test_wdb_remove_vuln_cves_by_status_success_ok(void **state)
     will_return(__wrap_wdbc_parse_result, WDBC_OK);
 
     // Parsing JSON result
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
     will_return(__wrap_cJSON_ParseWithOpts, 1);
 
     //Cleaning  memory
@@ -977,6 +979,7 @@ void test_wdb_remove_vuln_cves_by_status_success_due(void **state)
     will_return(__wrap_wdbc_parse_result, WDBC_DUE);
 
     // Parsing JSON result
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
     will_return(__wrap_cJSON_ParseWithOpts, root1);
 
     //// Second call to Wazuh DB
@@ -992,7 +995,9 @@ void test_wdb_remove_vuln_cves_by_status_success_due(void **state)
     will_return(__wrap_wdbc_parse_result, WDBC_OK);
 
     // Parsing JSON result
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
     will_return(__wrap_cJSON_ParseWithOpts, root2);
+
     will_return(__wrap_cJSON_Duplicate, row);
     expect_function_call(__wrap_cJSON_AddItemToArray);
     will_return(__wrap_cJSON_AddItemToArray, true);

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -13724,6 +13724,7 @@ void test_wm_vuldet_oval_xml_parser_null_element()
 {
     XML_NODE node = NULL;
     update_node *update = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(xml_node *), node);
     os_calloc(1, sizeof(xml_node), *node);
@@ -13732,7 +13733,7 @@ void test_wm_vuldet_oval_xml_parser_null_element()
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(1231): Invalid NULL element in the configuration.");
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, NULL, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, NULL, update, 0);
 
     assert_int_equal(ret, OS_INVALID);
 
@@ -13746,6 +13747,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_invalid_element()
     XML_NODE node = NULL;
     XML_NODE child_node = NULL;
     update_node *update = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(xml_node *), node);
     os_calloc(1, sizeof(xml_node), *node);
@@ -13758,8 +13760,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_invalid_element()
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(1230): Invalid element in the configuration: 'linux-def:dpkginfo_state'.");
-
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, NULL, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, NULL, update, 0);
 
     assert_int_equal(ret, OS_INVALID);
 
@@ -13772,6 +13773,8 @@ void test_wm_vuldet_oval_xml_parser_constant_invalid_element()
 {
     XML_NODE node = NULL;
     update_node *update = NULL;
+    OS_XML mock = {0};
+
 
     os_calloc(1, sizeof(xml_node *), node);
     os_calloc(1, sizeof(xml_node), *node);
@@ -13785,7 +13788,7 @@ void test_wm_vuldet_oval_xml_parser_constant_invalid_element()
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(1230): Invalid element in the configuration: 'constant_variable'.");
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, NULL, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, NULL, update, 0);
 
     assert_int_equal(ret, OS_INVALID);
 
@@ -13798,6 +13801,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_test_invalid_element()
 {
     XML_NODE node = NULL;
     update_node *update = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(xml_node *), node);
     os_calloc(1, sizeof(xml_node), *node);
@@ -13811,7 +13815,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_test_invalid_element()
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(1230): Invalid element in the configuration: 'linux-def:dpkginfo_test'.");
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, NULL, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, NULL, update, 0);
 
     assert_int_equal(ret, OS_INVALID);
 
@@ -13824,6 +13828,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_invalid_element()
 {
     XML_NODE node = NULL;
     update_node *update = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(xml_node *), node);
     os_calloc(1, sizeof(xml_node), *node);
@@ -13837,7 +13842,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_invalid_element()
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(1230): Invalid element in the configuration: 'linux-def:dpkginfo_object'.");
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, NULL, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, NULL, update, 0);
 
     assert_int_equal(ret, OS_INVALID);
 
@@ -13850,6 +13855,7 @@ void test_wm_vuldet_oval_xml_parser_definition_invalid_element()
 {
     XML_NODE node = NULL;
     update_node *update = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(xml_node *), node);
     os_calloc(1, sizeof(xml_node), *node);
@@ -13863,7 +13869,7 @@ void test_wm_vuldet_oval_xml_parser_definition_invalid_element()
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(1230): Invalid element in the configuration: 'definition'.");
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, NULL, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, NULL, update, 0);
 
     assert_int_equal(ret, OS_INVALID);
 
@@ -13876,6 +13882,7 @@ void test_wm_vuldet_oval_xml_parser_criteria_invalid_element()
 {
     XML_NODE node = NULL;
     update_node *update = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(xml_node *), node);
     os_calloc(1, sizeof(xml_node), *node);
@@ -13889,7 +13896,7 @@ void test_wm_vuldet_oval_xml_parser_criteria_invalid_element()
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(1230): Invalid element in the configuration: 'criteria'.");
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, NULL, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, NULL, update, 0);
 
     assert_int_equal(ret, OS_INVALID);
 
@@ -13902,6 +13909,7 @@ void test_wm_vuldet_oval_xml_parser_other_invalid_element()
 {
     XML_NODE node = NULL;
     update_node *update = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(xml_node *), node);
     os_calloc(1, sizeof(xml_node), *node);
@@ -13915,7 +13923,7 @@ void test_wm_vuldet_oval_xml_parser_other_invalid_element()
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(1230): Invalid element in the configuration: 'generator'.");
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, NULL, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, NULL, update, 0);
 
     assert_int_equal(ret, OS_INVALID);
 
@@ -13932,6 +13940,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_read_attribute()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
 
@@ -13955,7 +13964,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_read_attribute()
     expect_string(__wrap__mterror, formatted_msg, "(1231): Invalid NULL element in the configuration.");
 
     // call for node
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_ptr_not_equal(parsed_oval->info_states, NULL);
 
@@ -13971,6 +13980,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_constant_read_attribute()
     XML_NODE node = NULL;
     XML_NODE child_node = NULL;
     update_node *update = NULL;
+    OS_XML mock = {0};
     wm_vuldet_db *parsed_oval = NULL;
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
@@ -13996,7 +14006,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_constant_read_attribute()
     os_strdup("id_value", child_node[0]->content);
     will_return(__wrap_OS_GetElementsbyNode, child_node);
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_int_equal(parsed_oval->vars->elements, 1);
 
@@ -14015,6 +14025,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_test_read_attribute()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
 
@@ -14038,7 +14049,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_test_read_attribute()
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(1231): Invalid NULL element in the configuration.");
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_tests->id, node[0]->values[0]);
 
@@ -14055,6 +14066,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_read_attribute()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
 
@@ -14078,7 +14090,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_read_attribute()
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(1231): Invalid NULL element in the configuration.");
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_objs->id, node[0]->values[0]);
 
@@ -14095,6 +14107,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_no_attribute()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
 
@@ -14116,7 +14129,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_no_attribute()
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(1231): Invalid NULL element in the configuration.");
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, VU_PACKG);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, VU_PACKG);
     assert_int_equal(ret, 0);
     assert_null(parsed_oval->info_objs);
 
@@ -14131,6 +14144,8 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_no_vars()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
+
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_obj), parsed_oval->info_objs);
@@ -14150,7 +14165,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_no_vars()
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5413): Invalid OVAL object type: 'Parameters 'var_check' and 'var_ref' were expected'");
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, VU_OBJ);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, VU_OBJ);
     assert_int_equal(ret, 0);
     assert_null(parsed_oval->info_objs->obj);
 
@@ -14166,6 +14181,8 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_valid_content()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
+
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_obj), parsed_oval->info_objs);
@@ -14179,7 +14196,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_valid_content()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, VU_OBJ);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, VU_OBJ);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_objs->obj, node[0]->content);
 
@@ -14196,6 +14213,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_empty()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
 
@@ -14210,7 +14228,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_empty()
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5413): Invalid OVAL object type: 'Empty object'");
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, VU_OBJ);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, VU_OBJ);
     assert_int_equal(ret, 0);
 
     os_free(parsed_oval);
@@ -14224,6 +14242,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_valid_vars()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_obj), parsed_oval->info_objs);
@@ -14242,7 +14261,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_valid_vars()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, VU_OBJ);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, VU_OBJ);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_objs->obj, node[0]->values[1]);
 
@@ -14259,6 +14278,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_invalid_vars()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
 
@@ -14279,7 +14299,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_invalid_vars()
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5413): Invalid OVAL object type: 'Unexpected var_check: 'at least three''");
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, VU_OBJ);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, VU_OBJ);
     assert_int_equal(ret, 0);
 
     os_free(parsed_oval);
@@ -14293,6 +14313,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_xml_operation()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_state), parsed_oval->info_states);
@@ -14310,7 +14331,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_xml_operation()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, VU_OBJ);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, VU_OBJ);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_states->operation, node[0]->values[0]);
     assert_string_equal(parsed_oval->info_states->operation_value, node[0]->content);
@@ -14329,6 +14350,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_xml_datatype()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_state), parsed_oval->info_states);
@@ -14346,7 +14368,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_xml_datatype()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, VU_OBJ);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, VU_OBJ);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_states->operation, vu_package_comp[VU_COMP_EQ]);
     assert_string_equal(parsed_oval->info_states->operation_value, node[0]->content);
@@ -14365,6 +14387,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_state()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_test), parsed_oval->info_tests);
@@ -14381,7 +14404,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_state()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, VU_PACKG);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, VU_PACKG);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_tests->state, node[0]->values[0]);
 
@@ -14398,6 +14421,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_ref()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_test), parsed_oval->info_tests);
@@ -14414,7 +14438,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_ref()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, VU_PACKG);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, VU_PACKG);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_tests->obj, node[0]->values[0]);
 
@@ -14431,6 +14455,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_valid_definition()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
 
@@ -14454,7 +14479,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_valid_definition()
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(1231): Invalid NULL element in the configuration.");
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, OS_INVALID);
     assert_ptr_not_equal(parsed_oval->vulnerabilities, NULL);
     assert_ptr_not_equal(parsed_oval->info_cves, NULL);
@@ -14472,6 +14497,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_valid_definition_patch()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
 
@@ -14495,7 +14521,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_valid_definition_patch()
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(1231): Invalid NULL element in the configuration.");
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, OS_INVALID);
     assert_ptr_not_equal(parsed_oval->vulnerabilities, NULL);
     assert_ptr_not_equal(parsed_oval->info_cves, NULL);
@@ -14513,6 +14539,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_reference_url()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_cve), parsed_oval->info_cves);
@@ -14529,7 +14556,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_reference_url()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_cves->refs->values[0], node[0]->values[0]);
 
@@ -14548,6 +14575,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_reference_id()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_cve), parsed_oval->info_cves);
@@ -14565,7 +14593,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_reference_id()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_cves->cveid, node[0]->values[0]);
     assert_string_equal(parsed_oval->vulnerabilities->cve_id, node[0]->values[0]);
@@ -14585,6 +14613,8 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_reference_id_cve_exists()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
+
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_cve), parsed_oval->info_cves);
@@ -14603,7 +14633,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_reference_id_cve_exists()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_cves->prev->cveid, node[0]->values[0]);
 
@@ -14625,6 +14655,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_title()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_cve), parsed_oval->info_cves);
@@ -14644,7 +14675,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_title()
     update->dist_ref = FEED_DEBIAN;
     parsed_oval->OS = "BUSTER";
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_cves->title, node[0]->content);
 
@@ -14662,6 +14693,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_invalid_criteria()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
 
@@ -14681,7 +14713,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_invalid_criteria()
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(1231): Invalid NULL element in the configuration.");
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, OS_INVALID);
 
     os_free(parsed_oval);
@@ -14695,6 +14727,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_invalid_child()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
 
@@ -14718,7 +14751,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_invalid_child()
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(1231): Invalid NULL element in the configuration.");
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, OS_INVALID);
 
     os_free(parsed_oval);
@@ -14732,6 +14765,8 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criterion_test_ref()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
+
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(vulnerability), parsed_oval->vulnerabilities);
@@ -14751,7 +14786,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criterion_test_ref()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(node[0]->values[1], parsed_oval->vulnerabilities->state_id);
 
@@ -14771,6 +14806,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criterion_ignore()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(vulnerability), parsed_oval->vulnerabilities);
@@ -14790,7 +14826,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criterion_ignore()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_int_equal(parsed_oval->vulnerabilities->ignore, 1);
 
@@ -14807,6 +14843,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_description()
     XML_NODE node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_cve), parsed_oval->info_cves);
@@ -14820,7 +14857,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_description()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_cves->description, node[0]->content);
 
@@ -14836,6 +14873,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_product_version()
     XML_NODE node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
 
@@ -14848,7 +14886,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_product_version()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->metadata.product_version, node[0]->content);
 
@@ -14863,6 +14901,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_product_name()
     XML_NODE node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
 
@@ -14875,7 +14914,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_product_name()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->metadata.product_name, node[0]->content);
 
@@ -14890,6 +14929,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_product_timestamp()
     XML_NODE node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
 
@@ -14902,7 +14942,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_product_timestamp()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->metadata.timestamp, node[0]->content);
 
@@ -14917,6 +14957,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_product_schemav()
     XML_NODE node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
 
@@ -14929,7 +14970,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_product_schemav()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->metadata.schema_version, node[0]->content);
 
@@ -14944,6 +14985,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_product_date()
     XML_NODE node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_cve), parsed_oval->info_cves);
@@ -14957,7 +14999,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_product_date()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_cves->published, node[0]->content);
 
@@ -14973,6 +15015,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_product_public_date()
     XML_NODE node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_cve), parsed_oval->info_cves);
@@ -14986,7 +15029,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_product_public_date()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_cves->published, node[0]->content);
 
@@ -15002,6 +15045,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_product_bug()
     XML_NODE node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_cve), parsed_oval->info_cves);
@@ -15015,7 +15059,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_product_bug()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_cves->bugzilla_references->values[0], node[0]->content);
 
@@ -15033,6 +15077,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_product_ref()
     XML_NODE node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_cve), parsed_oval->info_cves);
@@ -15046,7 +15091,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_product_ref()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_cves->refs->values[0], node[0]->content);
 
@@ -15064,6 +15109,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_updated()
     XML_NODE node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_cve), parsed_oval->info_cves);
@@ -15080,7 +15126,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_updated()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_cves->updated, node[0]->values[0]);
 
@@ -15096,6 +15142,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_severity()
     XML_NODE node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_cve), parsed_oval->info_cves);
@@ -15109,7 +15156,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_severity()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_cves->severity, node[0]->content);
 
@@ -15125,6 +15172,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_null_severity()
     XML_NODE node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_cve), parsed_oval->info_cves);
@@ -15138,7 +15186,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_null_severity()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_null(parsed_oval->info_cves->severity);
 
@@ -15155,6 +15203,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_other_invalid()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
 
@@ -15178,7 +15227,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_other_invalid()
     expect_string(__wrap__mterror, formatted_msg, "(1231): Invalid NULL element in the configuration.");
 
     // call for node
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, OS_INVALID);
 
     os_free(parsed_oval);
@@ -15192,6 +15241,7 @@ void test_wm_vuldet_oval_xml_parser_redhat_state()
 {
     XML_NODE node = NULL;
     update_node *update = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(xml_node *), node);
     os_calloc(1, sizeof(xml_node), *node);
@@ -15205,7 +15255,7 @@ void test_wm_vuldet_oval_xml_parser_redhat_state()
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(1230): Invalid element in the configuration: 'red-def:rpminfo_state'.");
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, NULL, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, NULL, update, 0);
 
     assert_int_equal(ret, OS_INVALID);
 
@@ -15218,6 +15268,7 @@ void test_wm_vuldet_oval_xml_parser_redhat_test()
 {
     XML_NODE node = NULL;
     update_node *update = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(xml_node *), node);
     os_calloc(1, sizeof(xml_node), *node);
@@ -15231,7 +15282,7 @@ void test_wm_vuldet_oval_xml_parser_redhat_test()
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(1230): Invalid element in the configuration: 'red-def:rpminfo_test'.");
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, NULL, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, NULL, update, 0);
 
     assert_int_equal(ret, OS_INVALID);
 
@@ -15244,6 +15295,7 @@ void test_wm_vuldet_oval_xml_parser_redhat_object()
 {
     XML_NODE node = NULL;
     update_node *update = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(xml_node *), node);
     os_calloc(1, sizeof(xml_node), *node);
@@ -15257,7 +15309,7 @@ void test_wm_vuldet_oval_xml_parser_redhat_object()
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(1230): Invalid element in the configuration: 'red-def:rpminfo_object'.");
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, NULL, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, NULL, update, 0);
 
     assert_int_equal(ret, OS_INVALID);
 
@@ -15272,6 +15324,7 @@ void test_wm_vuldet_oval_xml_parser_redhat_object_valid_content()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_obj), parsed_oval->info_objs);
@@ -15285,7 +15338,7 @@ void test_wm_vuldet_oval_xml_parser_redhat_object_valid_content()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_REDHAT;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, VU_OBJ);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, VU_OBJ);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_objs->obj, node[0]->content);
 
@@ -15302,6 +15355,7 @@ void test_wm_vuldet_oval_xml_parser_redhat_rhel5_invalid_target()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_state), parsed_oval->info_states);
@@ -15322,7 +15376,7 @@ void test_wm_vuldet_oval_xml_parser_redhat_rhel5_invalid_target()
     update->dist_ref = FEED_REDHAT;
     update->dist_tag_ref = FEED_RHEL5;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
 
     os_free(parsed_oval->info_states);
@@ -15337,6 +15391,7 @@ void test_wm_vuldet_oval_xml_parser_redhat_definition_without_criteria()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(vulnerability), parsed_oval->vulnerabilities);
@@ -15364,7 +15419,7 @@ void test_wm_vuldet_oval_xml_parser_redhat_definition_without_criteria()
     os_calloc(1, sizeof(xml_node), *child_node);
     will_return(__wrap_OS_GetElementsbyNode, child_node);
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
 
     os_free(parsed_oval);
@@ -15378,6 +15433,7 @@ void test_wm_vuldet_oval_xml_parser_rhel_architecture_equals()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_state), parsed_oval->info_states);
@@ -15397,7 +15453,7 @@ void test_wm_vuldet_oval_xml_parser_rhel_architecture_equals()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_REDHAT;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_states->arch[0], node[0]->content);
 
@@ -15415,6 +15471,7 @@ void test_wm_vuldet_oval_xml_parser_rhel_architecture_pattern()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_state), parsed_oval->info_states);
@@ -15434,7 +15491,7 @@ void test_wm_vuldet_oval_xml_parser_rhel_architecture_pattern()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_REDHAT;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_states->arch[0], "x86_64");
     assert_string_equal(parsed_oval->info_states->arch[1], "i386");
@@ -15456,6 +15513,7 @@ void test_wm_vuldet_oval_xml_parser_rhel_architecture_noarch()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_state), parsed_oval->info_states);
@@ -15475,7 +15533,7 @@ void test_wm_vuldet_oval_xml_parser_rhel_architecture_noarch()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_REDHAT;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_states->arch[0], "noarch");
 
@@ -15496,6 +15554,7 @@ void test_wm_vuldet_oval_xml_parser_suse_criterion_assign_dependencies()
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
     dependencies deps;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(vulnerability), parsed_oval->vulnerabilities);
@@ -15520,7 +15579,7 @@ void test_wm_vuldet_oval_xml_parser_suse_criterion_assign_dependencies()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_SUSE;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal("test", parsed_oval->vulnerabilities->deps->test_ref[0]);
     assert_int_equal(1, parsed_oval->vulnerabilities->deps->elements);
@@ -15548,6 +15607,7 @@ void test_wm_vuldet_oval_xml_parser_suse_criterion_test_ref_null_dependencies()
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(vulnerability), parsed_oval->vulnerabilities);
@@ -15567,7 +15627,7 @@ void test_wm_vuldet_oval_xml_parser_suse_criterion_test_ref_null_dependencies()
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_SUSE;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(node[0]->values[1], parsed_oval->vulnerabilities->state_id);
     assert_null(parsed_oval->vulnerabilities->deps);
@@ -15586,6 +15646,7 @@ void test_wm_vuldet_oval_xml_parser_suse_criterion_test_ref_null_dependencies()
 void test_wm_vuldet_oval_xml_parser_suse_state() {
     XML_NODE node = NULL;
     update_node *update = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(xml_node *), node);
     os_calloc(1, sizeof(xml_node), *node);
@@ -15599,7 +15660,7 @@ void test_wm_vuldet_oval_xml_parser_suse_state() {
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(1230): Invalid element in the configuration: 'rpminfo_state'.");
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, NULL, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, NULL, update, 0);
 
     assert_int_equal(ret, OS_INVALID);
 
@@ -15611,6 +15672,7 @@ void test_wm_vuldet_oval_xml_parser_suse_state() {
 void test_wm_vuldet_oval_xml_parser_suse_test() {
     XML_NODE node = NULL;
     update_node *update = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(xml_node *), node);
     os_calloc(1, sizeof(xml_node), *node);
@@ -15624,7 +15686,7 @@ void test_wm_vuldet_oval_xml_parser_suse_test() {
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(1230): Invalid element in the configuration: 'rpminfo_test'.");
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, NULL, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, NULL, update, 0);
 
     assert_int_equal(ret, OS_INVALID);
 
@@ -15636,6 +15698,7 @@ void test_wm_vuldet_oval_xml_parser_suse_test() {
 void test_wm_vuldet_oval_xml_parser_suse_object() {
     XML_NODE node = NULL;
     update_node *update = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(xml_node *), node);
     os_calloc(1, sizeof(xml_node), *node);
@@ -15649,7 +15712,7 @@ void test_wm_vuldet_oval_xml_parser_suse_object() {
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(1230): Invalid element in the configuration: 'rpminfo_object'.");
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, NULL, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, NULL, update, 0);
 
     assert_int_equal(ret, OS_INVALID);
 
@@ -15663,6 +15726,7 @@ void test_wm_vuldet_oval_xml_parser_suse_object_valid_content() {
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_obj), parsed_oval->info_objs);
@@ -15676,7 +15740,7 @@ void test_wm_vuldet_oval_xml_parser_suse_object_valid_content() {
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_SUSE;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, VU_OBJ);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, VU_OBJ);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_objs->obj, node[0]->content);
 
@@ -15692,6 +15756,7 @@ void test_wm_vuldet_oval_xml_parser_suse_evr() {
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_state), parsed_oval->info_states);
@@ -15711,7 +15776,7 @@ void test_wm_vuldet_oval_xml_parser_suse_evr() {
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_SUSE;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
 
     os_free(parsed_oval->info_states->operation_value);
@@ -15720,6 +15785,7 @@ void test_wm_vuldet_oval_xml_parser_suse_evr() {
     os_free(parsed_oval);
     OS_ClearNode(node);
     os_free(update);
+
 }
 
 void test_wm_vuldet_oval_xml_parser_suse_evr_version() {
@@ -15727,6 +15793,7 @@ void test_wm_vuldet_oval_xml_parser_suse_evr_version() {
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_state), parsed_oval->info_states);
@@ -15746,7 +15813,7 @@ void test_wm_vuldet_oval_xml_parser_suse_evr_version() {
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_SUSE;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
 
     os_free(parsed_oval->info_states->operation_value);
@@ -15762,6 +15829,7 @@ void test_wm_vuldet_oval_xml_parser_suse_arch() {
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_state), parsed_oval->info_states);
@@ -15781,7 +15849,7 @@ void test_wm_vuldet_oval_xml_parser_suse_arch() {
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_SUSE;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_states->arch[0], "x86_64");
     assert_string_equal(parsed_oval->info_states->arch[1], "i386");
@@ -15802,6 +15870,7 @@ void test_wm_vuldet_oval_xml_parser_suse_state_ref() {
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_test), parsed_oval->info_tests);
@@ -15818,7 +15887,7 @@ void test_wm_vuldet_oval_xml_parser_suse_state_ref() {
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_SUSE;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, VU_PACKG);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, VU_PACKG);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_tests->state, node[0]->values[0]);
 
@@ -15834,6 +15903,7 @@ void test_wm_vuldet_oval_xml_parser_suse_object_ref() {
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_test), parsed_oval->info_tests);
@@ -15850,7 +15920,7 @@ void test_wm_vuldet_oval_xml_parser_suse_object_ref() {
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_SUSE;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, VU_PACKG);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, VU_PACKG);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_tests->obj, node[0]->values[0]);
 
@@ -15866,6 +15936,7 @@ void test_wm_vuldet_oval_xml_parser_suse_criterion_not_affected() {
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(vulnerability), parsed_oval->vulnerabilities);
@@ -15885,7 +15956,7 @@ void test_wm_vuldet_oval_xml_parser_suse_criterion_not_affected() {
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_SUSE;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_int_equal(parsed_oval->vulnerabilities->ignore, 1);
 
@@ -15902,6 +15973,7 @@ void test_wm_vuldet_oval_xml_parser_suse_criterion_skip() {
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(vulnerability), parsed_oval->vulnerabilities);
@@ -15919,7 +15991,7 @@ void test_wm_vuldet_oval_xml_parser_suse_criterion_skip() {
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_SUSE;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
 
     os_free(parsed_oval->vulnerabilities->deps->test_ref[0]);
@@ -15939,6 +16011,7 @@ void test_wm_vuldet_oval_xml_parser_suse_cve() {
     XML_NODE child_node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_cve), parsed_oval->info_cves);
@@ -15953,7 +16026,7 @@ void test_wm_vuldet_oval_xml_parser_suse_cve() {
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_SUSE;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_cves->cveid, node[0]->content);
     assert_string_equal(parsed_oval->vulnerabilities->cve_id, node[0]->content);
@@ -15971,6 +16044,7 @@ void test_wm_vuldet_oval_xml_parser_suse_description() {
     XML_NODE node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_cve), parsed_oval->info_cves);
@@ -15984,7 +16058,7 @@ void test_wm_vuldet_oval_xml_parser_suse_description() {
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_SUSE;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_cves->description, "This is the description.");
 
@@ -15999,6 +16073,7 @@ void test_wm_vuldet_oval_xml_parser_suse_issued() {
     XML_NODE node = NULL;
     update_node *update = NULL;
     wm_vuldet_db *parsed_oval = NULL;
+    OS_XML mock = {0};
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(info_cve), parsed_oval->info_cves);
@@ -16015,7 +16090,7 @@ void test_wm_vuldet_oval_xml_parser_suse_issued() {
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_SUSE;
 
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    int ret = wm_vuldet_oval_xml_parser(&mock, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
     assert_string_equal(parsed_oval->info_cves->published, node[0]->values[0]);
 
@@ -21818,10 +21893,11 @@ void test_wm_vuldet_recv_wdb_by_row_json_syntax_error() {
     will_return(__wrap_OS_RecvSecureTCP, response);
     will_return(__wrap_OS_RecvSecureTCP, strlen(response));
 
+    will_return(__wrap_cJSON_ParseWithOpts, "a JSON error");
     will_return(__wrap_cJSON_ParseWithOpts, j_object);
 
     expect_string(__wrap__mdebug1, formatted_msg, "Invalid JSON syntax in vulnerability detector database request.");
-    expect_string(__wrap__mdebug2, formatted_msg, "JSON error near: (null)");
+    expect_string(__wrap__mdebug2, formatted_msg, "JSON error near: a JSON error");
 
     expect_function_calls(__wrap_cJSON_Delete, 2);
 
@@ -21851,6 +21927,7 @@ void test_wm_vuldet_recv_wdb_by_row_not_synced() {
     will_return(__wrap_OS_RecvSecureTCP, response);
     will_return(__wrap_OS_RecvSecureTCP, strlen(response));
 
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
     will_return(__wrap_cJSON_ParseWithOpts, j_object);
 
     will_return(__wrap_cJSON_GetObjectItem, j_status);
@@ -21884,6 +21961,7 @@ void test_wm_vuldet_recv_wdb_by_row_error_status() {
     will_return(__wrap_OS_RecvSecureTCP, response);
     will_return(__wrap_OS_RecvSecureTCP, strlen(response));
 
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
     will_return(__wrap_cJSON_ParseWithOpts, j_object);
 
     will_return(__wrap_cJSON_GetObjectItem, j_status);
@@ -21918,6 +21996,7 @@ void test_wm_vuldet_recv_wdb_by_row_success_empty() {
     will_return(__wrap_OS_RecvSecureTCP, response);
     will_return(__wrap_OS_RecvSecureTCP, strlen(response));
 
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
     will_return(__wrap_cJSON_ParseWithOpts, j_object);
 
     will_return(__wrap_cJSON_GetObjectItem, j_status);
@@ -21949,6 +22028,7 @@ void test_wm_vuldet_recv_wdb_by_row_no_status() {
     will_return(__wrap_OS_RecvSecureTCP, response);
     will_return(__wrap_OS_RecvSecureTCP, strlen(response));
 
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
     will_return(__wrap_cJSON_ParseWithOpts, j_object);
 
     will_return(__wrap_cJSON_GetObjectItem, NULL);
@@ -21983,6 +22063,8 @@ void test_wm_vuldet_recv_wdb_by_row_success() {
     expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
     will_return(__wrap_OS_RecvSecureTCP, response);
     will_return(__wrap_OS_RecvSecureTCP, strlen(response));
+
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
     will_return(__wrap_cJSON_ParseWithOpts, j_object);
 
     expect_function_call(__wrap_cJSON_AddItemToArray);
@@ -21993,6 +22075,8 @@ void test_wm_vuldet_recv_wdb_by_row_success() {
     expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
     will_return(__wrap_OS_RecvSecureTCP, response2);
     will_return(__wrap_OS_RecvSecureTCP, strlen(response2));
+
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
     will_return(__wrap_cJSON_ParseWithOpts, j_object2);
 
     will_return(__wrap_cJSON_GetObjectItem, j_status);
@@ -22058,6 +22142,8 @@ void test_wm_vuldet_get_hotfixes_success() {
     expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
     will_return(__wrap_OS_RecvSecureTCP, response);
     will_return(__wrap_OS_RecvSecureTCP, strlen(response));
+
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
     will_return(__wrap_cJSON_ParseWithOpts, j_object);
 
     expect_function_call(__wrap_cJSON_AddItemToArray);
@@ -22068,6 +22154,8 @@ void test_wm_vuldet_get_hotfixes_success() {
     expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
     will_return(__wrap_OS_RecvSecureTCP, response2);
     will_return(__wrap_OS_RecvSecureTCP, strlen(response2));
+
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
     will_return(__wrap_cJSON_ParseWithOpts, j_object2);
 
     will_return(__wrap_cJSON_GetObjectItem, j_status);
@@ -22149,6 +22237,8 @@ void test_wm_vuldet_get_software_success() {
     expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
     will_return(__wrap_OS_RecvSecureTCP, response);
     will_return(__wrap_OS_RecvSecureTCP, strlen(response));
+
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
     will_return(__wrap_cJSON_ParseWithOpts, j_object);
 
     expect_function_call(__wrap_cJSON_AddItemToArray);
@@ -22159,6 +22249,8 @@ void test_wm_vuldet_get_software_success() {
     expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
     will_return(__wrap_OS_RecvSecureTCP, response2);
     will_return(__wrap_OS_RecvSecureTCP, strlen(response2));
+
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
     will_return(__wrap_cJSON_ParseWithOpts, j_object2);
 
     will_return(__wrap_cJSON_GetObjectItem, j_status);

--- a/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.c
+++ b/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.c
@@ -115,7 +115,7 @@ cJSON * __wrap_cJSON_Parse(__attribute__ ((__unused__)) const char *value) {
 cJSON * __wrap_cJSON_ParseWithOpts(__attribute__ ((__unused__)) const char *value,
                                    const char **return_parse_end,
                                    __attribute__ ((__unused__)) cJSON_bool require_null_terminated) {
-    *return_parse_end = NULL;
+    *return_parse_end = mock_type(char *);
     return mock_type(cJSON *);
 }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -29,6 +29,9 @@
 #ifdef WAZUH_UNIT_TESTING
 // Remove STATIC qualifier from tests
 #define STATIC
+#undef assert
+#define assert(expression) \
+    mock_assert((int)(expression), #expression, __FILE__, __LINE__);
 #else
 #define STATIC static
 #endif
@@ -3897,6 +3900,9 @@ void wm_vuldet_update_dependency_list_suse(const xml_node *criterion_dep, wm_vul
 }
 
 int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_oval, update_node *update, vu_logic condition) {
+    assert(xml != NULL);
+    assert(node != NULL);
+
     int i, j;
     int retval = 0;
     XML_NODE chld_node = NULL;


### PR DESCRIPTION
|Related issue|
|---|
|Closes #14149|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR aims to fix the runtime errors detected by UBS (undefined behavior sanitizer) while running the Vulnerabilty Detector UTs

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
All the tests were run using Ubuntu 22.04.
<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example
```
root@ubuntumanager:/home/vagrant/wazuh/src/unit_tests/build/wazuh_modules/vulnerability_detector# ctest
Test project /home/vagrant/wazuh/src/unit_tests/build/wazuh_modules/vulnerability_detector
    Start 1: test_wm_vuln_detector
1/3 Test #1: test_wm_vuln_detector ............   Passed    0.08 sec
    Start 2: test_wm_vuln_detector_evr
2/3 Test #2: test_wm_vuln_detector_evr ........   Passed    0.02 sec
    Start 3: test_wm_vuln_detector_nvd
3/3 Test #3: test_wm_vuln_detector_nvd ........   Passed    0.05 sec

100% tests passed, 0 tests failed out of 3

Total Test time (real) =   0.14 sec
```
Results of the test:
[`/home/vagrant/wazuh/src/unit_tests/build/wazuh_modules/vulnerability_detector/Testing/Temporary/LastTest.log`](https://github.com/wazuh/wazuh/files/9064556/LastTest.log)

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
