### PR TITLE
Engine - Create Apache decoders

### DIFF
--- a/src/engine/source/hlp/src/specificParsers.cpp
+++ b/src/engine/source/hlp/src/specificParsers.cpp
@@ -40,6 +40,8 @@ static const std::unordered_map<std::string_view, std::tuple<const char*, const 
         {"ISO8601", {"%Y-%d-%mT%T%z", "2018-08-14T14:30:02.203151+02:00"}},
         {"HTTPDATE", {"%d/%b/%Y:%T %z", "26/Dec/2016:16:22:14 +0000"}},
         {"NGINX_ERROR", {"%Y/%m/%d %T", "2016/10/25 14:49:34"}},
+        {"APACHE_ERROR", {"%a %b %d %T %Y", "Mon Dec 26 16:15:55.103786 2016"}},
+        {"APACHE_ERROR2", {"%a %b %d %T %Y", "Mon Dec 26 16:15:55 2016"}},
 };
 
 bool configureTsParser(Parser& parser, std::vector<std::string_view> const& args)

--- a/src/engine/test/assets/decoders/apache_access.yml
+++ b/src/engine/test/assets/decoders/apache_access.yml
@@ -1,0 +1,39 @@
+---
+name: apache_access
+parents:
+  - default_decoder
+
+metadata:
+  description: Parses Apache HTTPD access logs in its Common Log Format
+
+check:
+  #- queue: 1
+  - event.original: +exists
+
+parse:
+  logql:
+      # ::1 - - [26/Dec/2016:16:16:29 +0200] \"GET /favicon.ico HTTP/1.1\" 404 209
+      - event.original: <source.ip> - - [<timestamp/HTTPDATE>] "<http.request.method> <url.original> HTTP/<http.version>" <http.response.status_code> <http.response.body.bytes>
+      # 192.168.33.1 - - [26/Dec/2016:16:22:00 +0000] \"GET / HTTP/1.1\" 200 484 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36\"
+      - event.original: <source.ip> - - [<timestamp/HTTPDATE>] "<http.request.method> <url.original> HTTP/<http.version>" <http.response.status_code> <http.response.body.bytes> "-" "<user_agent.original>"
+      # 127.0.0.1 - - [02/Feb/2019:05:38:45 +0100] \"-\" 408 152 \"-\" \"-\"
+      - event.original: <source.ip> - - [<timestamp/HTTPDATE>] "-" <http.response.status_code> <http.response.body.bytes> "-" "-"
+      # monitoring-server - - [29/May/2017:19:02:48 +0000] \"GET /status HTTP/1.1\" 200 612 \"-\" \"Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2\"
+      - event.original: <source.address> - - [<timestamp/HTTPDATE>] "<http.request.method> <url.original> HTTP/<http.version>" <http.response.status_code> <http.response.body.bytes> "-" "<user_agent.original>"
+      # ::1 - - [26/Dec/2016:16:16:48 +0200] \"-\" 408 -
+      - event.original: <source.ip> - - [<timestamp/HTTPDATE>] "-" <http.response.status_code> -
+      - event.original: '[<timestamp/HTTPDATE>] <source.ip> TLSv<tls.version> <tls.cipher> "<http.request.method> <url.original> HTTP/<http.version>" <http.response.body.bytes>'
+      - event.original: '[<timestamp/HTTPDATE>] <source.ip> TLSv<tls.version> <tls.cipher> "<http.request.method> <url.original> HTTP/<http.version>" -'
+
+normalize:
+  - map:
+     event.kind: event
+     event.dataset: apache.access
+     event.category: +s_append/web
+     event.module: apache
+     service.type: apache
+     event.outcome: success
+  - check:
+      - http.response.status_code: +i_gt/399
+    map:
+      event.outcome: failure

--- a/src/engine/test/assets/decoders/apache_error.yml
+++ b/src/engine/test/assets/decoders/apache_error.yml
@@ -1,0 +1,36 @@
+---
+name: apache_error
+parents:
+  - default_decoder
+
+metadata:
+  description: Parses Apache HTTPD errors logs in its Common Log Format
+
+check:
+  - event.original: +exists
+
+parse:
+  logql:
+      # [Mon Dec 26 16:15:55.103786 2016] [core:notice] [pid 11379] AH00094: Command line: '/usr/local/Cellar/httpd24/2.4.23_2/bin/httpd'
+      - event.original: '[<timestamp/APACHE_ERROR>] [<_module>:<log.level>] [pid <process.pid>] <message>'
+      # [Fri Sep 09 10:42:29.902022 2011] [core:error] [pid 35708:tid 4328636416] [client 72.15.99.187] File does not exist: /usr/local/apache2/htdocs/favicon.ico
+      - event.original: '[<timestamp/APACHE_ERROR>] [<_module>:<log.level>] [pid <process.pid>:tid <process.thread.id>] [client <source.address>] <message>'
+      # [Thu Jun 27 06:58:09.169510 2019] [include:warn] [pid 15934] [client 123.123.123.123:12345] AH01374: mod_include: Options +Includes (or IncludesNoExec) wasn't set, INCLUDES filter removed: /test.html
+      - event.original: '[<timestamp/APACHE_ERROR>] [<_module>:<log.level>] [pid <process.pid>] [client <source.address>] <message>'
+      # [Mon Dec 26 16:22:08 2016] [error] [client 192.168.33.1] File does not exist: /var/www/favicon.ico
+      - event.original: '[<timestamp/APACHE_ERROR2>] [<log.level>] [client <source.ip>] <message>'
+      # [Mon Dec 26 16:17:53 2016] [notice] Apache/2.2.22 (Ubuntu) configured -- resuming normal operations
+      - event.original: '[<timestamp/APACHE_ERROR2>] [<log.level>] <message>'
+
+normalize:
+  - map:
+     event.kind: event
+     event.dataset: apache.error
+     event.category: +s_append/web
+     event.module: apache
+     service.type: apache
+     event.type: +s_append/info
+  - check:
+      - log.level: +r_match/^[eacw]
+    map:
+      event.type: +s_append/error

--- a/src/engine/test/assets/environments/demo_environment.yml
+++ b/src/engine/test/assets/environments/demo_environment.yml
@@ -11,6 +11,8 @@ decoders:
   - suricata-stats
   - json
   - windows-security
+  - apache_error
+  - apache_access
 
 rules:
   - source_malicious_ip


### PR DESCRIPTION
|Related issue|
|---|
|#13871|

### Description 
We want to test all features we have developed so far to further polish its cohesion within the engine.
As part of the epic https://github.com/wazuh/wazuh/issues/13803 we will write the `apache` decoders.

We need to create a decoder that generates an ECS compliant event, and rules to alert about possible security threats.

We need to use:

* high level parser
* logical expressions
* function helpers
* mapping new fields
* kvdb

All decoders will become part of a single environment that will receive logs and generate the corresponding events.