### PR TITLE
Update external integrations github template

### DIFF
--- a/.github/ISSUE_TEMPLATE/external-integrations.md
+++ b/.github/ISSUE_TEMPLATE/external-integrations.md
@@ -45,7 +45,7 @@ In case of a bug report:
 ## Tasks
 - [ ] Test in a manager.
 - [ ] Test in an agent.
-- [ ] Unit tests without failures. Updated if there are any relevant changes.
+- [ ] Unit tests without failures using Python 3.6. Updated if there are any relevant changes.
 - [ ] Integration tests without failures. Updated if there are any relevant changes.
 - [ ] Update the documentation if necessary.
 - [ ] Add entry to the changelog if necessary.


### PR DESCRIPTION
## Description
This PR updates the External modules integrations github template to indicate that unit tests should be run specifically with python 3.6 to ensure compatibility.