### PR TITLE
Changes to distribute the libstdc++ and libgcc_s.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -14,6 +14,32 @@ uname_P := $(shell sh -c 'uname -p 2>/dev/null || echo not')
 uname_R := $(shell sh -c 'uname -r 2>/dev/null || echo not')
 uname_V := $(shell sh -c 'uname -v 2>/dev/null || echo not')
 uname_M := $(shell sh -c 'uname -m 2>/dev/null || echo not')
+
+ifeq (${TARGET}, winagent)
+WAZUH_LIB_OUTPUT_PATH := win32/
+STRIP_TOOL := i686-w64-mingw32-strip
+libstdc++_path := $(shell sh -c 'i686-w64-mingw32-g++-posix --print-file-name=libstdc++-6.dll 2>/dev/null || echo not')
+LIBSTDCPP_NAME := libstdc++-6.dll
+libgcc_s_path := $(shell sh -c 'i686-w64-mingw32-g++-posix --print-file-name=libgcc_s_dw2-1.dll 2>/dev/null || echo not')
+LIBGCC_S_NAME := libgcc_s_dw2-1.dll
+ifneq (,$(filter ${libgcc_s_path}, not ${LIBGCC_S_NAME}))
+libgcc_s_path := $(shell sh -c 'i686-w64-mingw32-g++-posix --print-file-name=libgcc_s_sjlj-1.dll 2>/dev/null || echo not')
+LIBGCC_S_NAME := libgcc_s_sjlj-1.dll
+endif
+else
+libstdc++_path := $(shell sh -c 'g++ --print-file-name=libstdc++.so.6 2>/dev/null || echo not')
+libgcc_s_path := $(shell sh -c 'g++ --print-file-name=libgcc_s.so.1 2>/dev/null || echo not')
+LIBSTDCPP_NAME := libstdc++.so.6
+LIBGCC_S_NAME := libgcc_s.so.1
+STRIP_TOOL := strip
+endif
+
+ifeq (, $(filter ${libstdc++_path}, not ${LIBSTDCPP_NAME}))
+ifeq (, $(filter ${libgcc_s_path}, not ${LIBGCC_S_NAME}))
+CPPLIBDEPS := ${LIBSTDCPP_NAME} ${LIBGCC_S_NAME}
+endif
+endif
+
 HAS_CHECKMODULE = $(shell command -v checkmodule > /dev/null && echo YES)
 HAS_SEMODULE_PACKAGE = $(shell command -v semodule_package > /dev/null && echo YES)
 CHECK_ARCHLINUX := $(shell sh -c 'grep "Arch Linux" /etc/os-release > /dev/null && echo YES || echo not')
@@ -683,52 +709,44 @@ BUILD_AGENT+=manage_agents
 BUILD_AGENT+=active-responses
 BUILD_AGENT+=wazuh-modulesd
 
-ifeq (${uname_S},SunOS)
-ifeq ($(uname_R),5.10)
-	BUILD_AGENT+=libgcc_s.so.1
-endif
-endif
-
 BUILD_CMAKE_PROJECTS+=build_sysinfo
 BUILD_CMAKE_PROJECTS+=build_shared_modules
 ifeq (,$(filter ${DISABLE_SYSC},YES yes y Y 1))
 BUILD_CMAKE_PROJECTS+=build_syscollector
 endif
 
+${WAZUH_LIB_OUTPUT_PATH}${LIBSTDCPP_NAME}: ${libstdc++_path}
+	cp $< $@ || :
+	${STRIP_TOOL} -x $@ || :
+
+${WAZUH_LIB_OUTPUT_PATH}${LIBGCC_S_NAME}: ${libgcc_s_path}
+	cp $< $@ || :
+	${STRIP_TOOL} -x $@ || :
 
 .PHONY: server local hybrid agent selinux
 
 ifeq (${MAKECMDGOALS},server)
 $(error Do not use 'server' directly, use 'TARGET=server')
 endif
-server: external
-ifneq (${uname_S},HP-UX)
-	${MAKE} ${BUILD_CMAKE_PROJECTS}
-endif
-	${MAKE} ${BUILD_SERVER}
+server: external ${CPPLIBDEPS}
+	${MAKE} ${BUILD_SERVER} ${BUILD_CMAKE_PROJECTS}
 
 ifeq (${MAKECMDGOALS},local)
 $(error Do not use 'local' directly, use 'TARGET=local')
 endif
-local: external
-ifneq (${uname_S},HP-UX)
-	${MAKE} ${BUILD_CMAKE_PROJECTS}
-endif
-	${MAKE} ${BUILD_SERVER}
+local: external ${CPPLIBDEPS}
+	${MAKE} ${BUILD_SERVER} ${BUILD_CMAKE_PROJECTS}
 
 ifeq (${MAKECMDGOALS},hybrid)
 $(error Do not use 'hybrid' directly, use 'TARGET=hybrid')
 endif
-hybrid: external
-ifneq (${uname_S},HP-UX)
-	${MAKE} ${BUILD_CMAKE_PROJECTS}
-endif
-	${MAKE} ${BUILD_SERVER}
+hybrid: external ${CPPLIBDEPS}
+	${MAKE} ${BUILD_SERVER} ${BUILD_CMAKE_PROJECTS}
 
 ifeq (${MAKECMDGOALS},agent)
 $(error Do not use 'agent' directly, use 'TARGET=agent')
 endif
-agent: external
+agent: external ${CPPLIBDEPS}
 ifneq (${uname_S},HP-UX)
 	${MAKE} ${BUILD_CMAKE_PROJECTS}
 endif
@@ -753,7 +771,7 @@ ifeq (${MAKECMDGOALS},winagent)
 $(error Do not use 'winagent' directly, use 'TARGET=winagent')
 endif
 .PHONY: winagent
-winagent: external win32/libwinpthread-1.dll win32/libgcc_s_dw2-1.dll
+winagent: external win32/libwinpthread-1.dll ${WAZUH_LIB_OUTPUT_PATH}${LIBGCC_S_NAME} ${WAZUH_LIB_OUTPUT_PATH}${LIBSTDCPP_NAME}
 	${MAKE} ${WINDOWS_BINS} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
 	${MAKE} ${WINDOWS_ACTIVE_RESPONSES} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
 	cd win32/ && ./unix2dos.pl ossec.conf > default-ossec.conf
@@ -784,9 +802,6 @@ win32/syscollector: win32/shared_modules win32/sysinfo
 	cd ${SYSCOLLECTOR} && mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SYSCOLLECTOR_TEST} ${SYSCOLLECTOR_RELEASE_TYPE} .. && ${MAKE}
 
 win32/libwinpthread-1.dll: ${WIN_PTHREAD_LIB}
-	cp $< $@
-
-win32/libgcc_s_dw2-1.dll: $(wildcard /usr/lib/gcc/i686-w64-mingw32/*-posix/libgcc_s_dw2-1.dll)
 	cp $< $@
 
 ####################
@@ -1698,13 +1713,6 @@ endif
 endif
 endif
 
-
-### libgcc_s #########
-
-LIBGCC := $(realpath $(dir $(shell which gcc))../lib/libgcc_s.so.1)
-libgcc_s.so.1: $(LIBGCC)
-	cp $< $@
-
 #### os_mail #########
 
 os_maild_c := $(wildcard os_maild/*.c)
@@ -2476,7 +2484,8 @@ clean-internals: clean-unit-tests
 	rm -rf $(SYSCOLLECTOR)build
 	rm -rf $(SYSINFO)build
 	rm -rf libwazuhext
-	rm -f libgcc_s.so.1
+	rm -rf libstdc++.so.6
+	rm -rf libgcc_s.so.1
 
 clean-unit-tests:
 	rm -f ${wrappers_syscheck_o}
@@ -2549,6 +2558,9 @@ clean-windows:
 	rm -f win32/libwinpthread-1.dll
 	rm -f win32/VERSION
 	rm -f win32/REVISION
+	rm -f win32/libstdc++-6.dll
+	rm -f win32/libgcc_s_dw2-1.dll
+	rm -f win32/libgcc_s_sjlj-1.dll
 
 clean-config:
 	rm -f ../etc/ossec.mc

--- a/src/Makefile
+++ b/src/Makefile
@@ -22,10 +22,6 @@ libstdc++_path := $(shell sh -c 'i686-w64-mingw32-g++-posix --print-file-name=li
 LIBSTDCPP_NAME := libstdc++-6.dll
 libgcc_s_path := $(shell sh -c 'i686-w64-mingw32-g++-posix --print-file-name=libgcc_s_dw2-1.dll 2>/dev/null || echo not')
 LIBGCC_S_NAME := libgcc_s_dw2-1.dll
-ifneq (,$(filter ${libgcc_s_path}, not ${LIBGCC_S_NAME}))
-libgcc_s_path := $(shell sh -c 'i686-w64-mingw32-g++-posix --print-file-name=libgcc_s_sjlj-1.dll 2>/dev/null || echo not')
-LIBGCC_S_NAME := libgcc_s_sjlj-1.dll
-endif
 else
 libstdc++_path := $(shell sh -c 'g++ --print-file-name=libstdc++.so.6 2>/dev/null || echo not')
 libgcc_s_path := $(shell sh -c 'g++ --print-file-name=libgcc_s.so.1 2>/dev/null || echo not')

--- a/src/Makefile
+++ b/src/Makefile
@@ -712,12 +712,12 @@ BUILD_CMAKE_PROJECTS+=build_syscollector
 endif
 
 ${WAZUH_LIB_OUTPUT_PATH}${LIBSTDCPP_NAME}: ${libstdc++_path}
-	cp $< $@ || :
-	${STRIP_TOOL} -x $@ || :
+	cp $< $@
+	${STRIP_TOOL} -x $@
 
 ${WAZUH_LIB_OUTPUT_PATH}${LIBGCC_S_NAME}: ${libgcc_s_path}
-	cp $< $@ || :
-	${STRIP_TOOL} -x $@ || :
+	cp $< $@
+	${STRIP_TOOL} -x $@
 
 .PHONY: server local hybrid agent selinux
 

--- a/src/data_provider/CMakeLists.txt
+++ b/src/data_provider/CMakeLists.txt
@@ -141,13 +141,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
       # MinGW generates position-independent-code for DLL by default
   )
 elseif(UNIX AND NOT APPLE)
-  if(CMAKE_SYSTEM STREQUAL "SunOS-5.10")
-    set_target_properties(sysinfo PROPERTIES
-      LINK_FLAGS "-static-libstdc++")
-  else()
-    set_target_properties(sysinfo PROPERTIES
-      LINK_FLAGS "-static-libgcc -static-libstdc++")
-  endif(CMAKE_SYSTEM STREQUAL "SunOS-5.10")
   if(NOT CMAKE_SYSTEM_NAME STREQUAL "AIX")
     string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,-rpath=$ORIGIN")
   else()

--- a/src/data_provider/CMakeLists.txt
+++ b/src/data_provider/CMakeLists.txt
@@ -136,7 +136,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   set_target_properties(sysinfo PROPERTIES
       PREFIX ""
       SUFFIX ".dll"
-      LINK_FLAGS "-Wl,--add-stdcall-alias -static-libstdc++"
+      LINK_FLAGS "-Wl,--add-stdcall-alias"
       POSITION_INDEPENDENT_CODE 0 # this is to avoid MinGW warning;
       # MinGW generates position-independent-code for DLL by default
   )

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -809,11 +809,22 @@ InstallCommon()
             chcon -t textrel_shlib_t ${INSTALLDIR}/lib/libsyscollector.so
         fi
     fi
-    if [ ${NUNAME} = 'SunOS' ]
+
+    if [ -f libstdc++.so.6 ]
     then
-        if [ ${VUNAME} = '5.10' ]
-        then
-            ${INSTALL} -m 0750 -o root -g 0 libgcc_s.so.1 ${INSTALLDIR}/lib
+        ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} libstdc++.so.6 ${INSTALLDIR}/lib
+
+        if ([ "X${DIST_NAME}" = "Xrhel" ] || [ "X${DIST_NAME}" = "Xcentos" ] || [ "X${DIST_NAME}" = "XCentOS" ]) && [ ${DIST_VER} -le 5 ]; then
+            chcon -t textrel_shlib_t ${INSTALLDIR}/lib/libstdc++.so.6
+        fi
+    fi
+
+    if [ -f libgcc_s.so.1 ]
+    then
+        ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} libgcc_s.so.1 ${INSTALLDIR}/lib
+
+        if ([ "X${DIST_NAME}" = "Xrhel" ] || [ "X${DIST_NAME}" = "Xcentos" ] || [ "X${DIST_NAME}" = "XCentOS" ]) && [ ${DIST_VER} -le 5 ]; then
+            chcon -t textrel_shlib_t ${INSTALLDIR}/lib/libgcc_s.so.1
         fi
     fi
 

--- a/src/shared_modules/dbsync/CMakeLists.txt
+++ b/src/shared_modules/dbsync/CMakeLists.txt
@@ -65,13 +65,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         # MinGW generates position-independent-code for DLL by default
   )
 elseif(UNIX AND NOT APPLE)
-  if(CMAKE_SYSTEM STREQUAL "SunOS-5.10")
-    set_target_properties(dbsync PROPERTIES
-      LINK_FLAGS "-static-libstdc++")
-  else()
-    set_target_properties(dbsync PROPERTIES
-      LINK_FLAGS "-static-libgcc -static-libstdc++")
-  endif(CMAKE_SYSTEM STREQUAL "SunOS-5.10")
   if(NOT CMAKE_SYSTEM_NAME STREQUAL "AIX")
     string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,-rpath=$ORIGIN")
   endif(NOT CMAKE_SYSTEM_NAME STREQUAL "AIX")

--- a/src/shared_modules/dbsync/CMakeLists.txt
+++ b/src/shared_modules/dbsync/CMakeLists.txt
@@ -60,7 +60,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   set_target_properties(dbsync PROPERTIES
         PREFIX ""
         SUFFIX ".dll"
-        LINK_FLAGS "-Wl,--add-stdcall-alias -static-libstdc++"
+        LINK_FLAGS "-Wl,--add-stdcall-alias"
         POSITION_INDEPENDENT_CODE 0 # this is to avoid MinGW warning;
         # MinGW generates position-independent-code for DLL by default
   )

--- a/src/shared_modules/rsync/CMakeLists.txt
+++ b/src/shared_modules/rsync/CMakeLists.txt
@@ -67,13 +67,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         # MinGW generates position-independent-code for DLL by default
   )
 elseif(UNIX AND NOT APPLE)
-  if(CMAKE_SYSTEM STREQUAL "SunOS-5.10")
-    set_target_properties(rsync PROPERTIES
-      LINK_FLAGS "-static-libstdc++")
-  else()
-    set_target_properties(rsync PROPERTIES
-      LINK_FLAGS "-static-libgcc -static-libstdc++")
-  endif(CMAKE_SYSTEM STREQUAL "SunOS-5.10")
   if(NOT CMAKE_SYSTEM_NAME STREQUAL "AIX")
     string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,-rpath=$ORIGIN")
   endif(NOT CMAKE_SYSTEM_NAME STREQUAL "AIX")

--- a/src/shared_modules/rsync/CMakeLists.txt
+++ b/src/shared_modules/rsync/CMakeLists.txt
@@ -62,7 +62,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   set_target_properties(rsync PROPERTIES
         PREFIX ""
         SUFFIX ".dll"
-        LINK_FLAGS "-Wl,--add-stdcall-alias -static-libstdc++"
+        LINK_FLAGS "-Wl,--add-stdcall-alias"
         POSITION_INDEPENDENT_CODE 0 # this is to avoid MinGW warning;
         # MinGW generates position-independent-code for DLL by default
   )

--- a/src/wazuh_modules/syscollector/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/CMakeLists.txt
@@ -85,13 +85,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         # MinGW generates position-independent-code for DLL by default
   )
 elseif(UNIX AND NOT APPLE)
-  if(CMAKE_SYSTEM STREQUAL "SunOS-5.10")
-    set_target_properties(syscollector PROPERTIES
-      LINK_FLAGS "-static-libstdc++")
-  else()
-    set_target_properties(syscollector PROPERTIES
-      LINK_FLAGS "-static-libgcc -static-libstdc++")
-  endif(CMAKE_SYSTEM STREQUAL "SunOS-5.10")
   if(NOT CMAKE_SYSTEM_NAME STREQUAL "AIX")
     string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,-rpath=$ORIGIN")
   endif(NOT CMAKE_SYSTEM_NAME STREQUAL "AIX")

--- a/src/wazuh_modules/syscollector/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/CMakeLists.txt
@@ -80,7 +80,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   set_target_properties(syscollector PROPERTIES
         PREFIX ""
         SUFFIX ".dll"
-        LINK_FLAGS "-Wl,--add-stdcall-alias -static-libstdc++"
+        LINK_FLAGS "-Wl,--add-stdcall-alias"
         POSITION_INDEPENDENT_CODE 0 # this is to avoid MinGW warning;
         # MinGW generates position-independent-code for DLL by default
   )

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -184,8 +184,8 @@
                     <Component Id="LIBGCC_S_DW2_1.DLL" DiskId="1" Guid="EB7C893F-E5C8-4038-8FBA-EF33F8B72CB6">
                         <File Id="LIBGCC_S_DW2_1.DLL" Name="libgcc_s_dw2-1.dll" Source="libgcc_s_dw2-1.dll" />
                     </Component>
-                    <Component Id="LIBSTDC++_6.DLL" DiskId="1" Guid="23EDBF99-6824-4128-8571-D77967B2980E">
-                        <File Id="LIBSTDC++_6.DLL" Name="libstdc++-6.dll" Source="libstdc++-6.dll" />
+                    <Component Id="LIBSTDCPP_6.DLL" DiskId="1" Guid="23EDBF99-6824-4128-8571-D77967B2980E">
+                        <File Id="LIBSTDCPP_6.DLL" Name="libstdc++-6.dll" Source="libstdc++-6.dll" />
                     </Component>
                     <Component Id="MANAGE_AGENTS.EXE" DiskId="1" Guid="C15C5883-00FB-41D7-B7E6-53C8BC30761F">
                         <File Id="MANAGE_AGENTS.EXE" Name="manage_agents.exe" Source="manage_agents.exe" />
@@ -238,7 +238,7 @@
                         <RemoveFile Id="NSIS_LIBWINPTHREAD_1_DLL" Name="libwinpthread-1.dll" On="install" />
                         <RemoveFile Id="NSIS_LIBGCC_S_SJLJ_1.DLL" Name="libgcc_s_sjlj-1.dll" On="install" />
                         <RemoveFile Id="NSIS_LIBGCC_S_DW2_1.DLL" Name="libgcc_s_dw2-1.dll" On="install" />
-                        <RemoveFile Id="NSIS_LIBSTDC++_6.DLL" Name="libstdc++-6.dll" On="install" />
+                        <RemoveFile Id="NSIS_LIBSTDCPP_6.DLL" Name="libstdc++-6.dll" On="install" />
                         <RemoveFile Id="NSIS_MANAGE_AGENTS_EXE" Name="manage_agents.exe" On="install" />
                         <RemoveFile Id="NSIS_OSSEC_AGENT_EXE" Name="ossec-agent.exe" On="install" />
                         <RemoveFile Id="NSIS_OSSEC_AGENT_STATE" Name="ossec-agent.state" On="install" />
@@ -580,7 +580,7 @@
             <ComponentRef Id="LICENSE.TXT" />
             <ComponentRef Id="LIBWINPTHREAD_1.DLL" />
             <ComponentRef Id="LIBGCC_S_DW2_1.DLL" />
-            <ComponentRef Id="LIBSTDC++_6.DLL" />
+            <ComponentRef Id="LIBSTDCPP_6.DLL" />
             <ComponentRef Id="MANAGE_AGENTS.EXE" />
             <ComponentRef Id="WAZUH_AGENT_EVENTCHANNEL.EXE" />
             <ComponentRef Id="WAZUH_AGENT.EXE" />

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -184,6 +184,9 @@
                     <Component Id="LIBGCC_S_DW2_1.DLL" DiskId="1" Guid="EB7C893F-E5C8-4038-8FBA-EF33F8B72CB6">
                         <File Id="LIBGCC_S_DW2_1.DLL" Name="libgcc_s_dw2-1.dll" Source="libgcc_s_dw2-1.dll" />
                     </Component>
+                    <Component Id="LIBSTDC++_6.DLL" DiskId="1" Guid="23EDBF99-6824-4128-8571-D77967B2980E">
+                        <File Id="LIBSTDC++_6.DLL" Name="libstdc++-6.dll" Source="libstdc++-6.dll" />
+                    </Component>
                     <Component Id="MANAGE_AGENTS.EXE" DiskId="1" Guid="C15C5883-00FB-41D7-B7E6-53C8BC30761F">
                         <File Id="MANAGE_AGENTS.EXE" Name="manage_agents.exe" Source="manage_agents.exe" />
                     </Component>
@@ -235,6 +238,7 @@
                         <RemoveFile Id="NSIS_LIBWINPTHREAD_1_DLL" Name="libwinpthread-1.dll" On="install" />
                         <RemoveFile Id="NSIS_LIBGCC_S_SJLJ_1.DLL" Name="libgcc_s_sjlj-1.dll" On="install" />
                         <RemoveFile Id="NSIS_LIBGCC_S_DW2_1.DLL" Name="libgcc_s_dw2-1.dll" On="install" />
+                        <RemoveFile Id="NSIS_LIBSTDC++_6.DLL" Name="libstdc++-6.dll" On="install" />
                         <RemoveFile Id="NSIS_MANAGE_AGENTS_EXE" Name="manage_agents.exe" On="install" />
                         <RemoveFile Id="NSIS_OSSEC_AGENT_EXE" Name="ossec-agent.exe" On="install" />
                         <RemoveFile Id="NSIS_OSSEC_AGENT_STATE" Name="ossec-agent.state" On="install" />
@@ -576,6 +580,7 @@
             <ComponentRef Id="LICENSE.TXT" />
             <ComponentRef Id="LIBWINPTHREAD_1.DLL" />
             <ComponentRef Id="LIBGCC_S_DW2_1.DLL" />
+            <ComponentRef Id="LIBSTDC++_6.DLL" />
             <ComponentRef Id="MANAGE_AGENTS.EXE" />
             <ComponentRef Id="WAZUH_AGENT_EVENTCHANNEL.EXE" />
             <ComponentRef Id="WAZUH_AGENT.EXE" />


### PR DESCRIPTION
|Related issue|
|---|
|Closes #14018 |

## Description
This pr is a proposal, to distribute the necessary libraries for compiled C++ projects, the reason for this is the associated issue, which is because of symbol interposition between two different versions of libstdc++.so when there are calls to NSS modules from procps.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors