### PR TITLE
Corrects the grep filter for wazuh user detection

### DIFF
--- a/src/init/adduser.sh
+++ b/src/init/adduser.sh
@@ -72,7 +72,7 @@ else
         fi
     fi
 
-    if ! grep "^${USER}" /etc/passwd > /dev/null 2>&1; then
+    if ! grep "^${USER}:" /etc/passwd > /dev/null 2>&1; then
         if [ "$UNAME" = "OpenBSD" -o "$UNAME" = "SunOS" -o "$UNAME" = "HP-UX" -o "$UNAME" = "NetBSD" ]; then
             ${USERADD} -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}" "${USER}"
         elif [ "$UNAME" = "AIX" ]; then


### PR DESCRIPTION
|Related issue|
|---|
|Closes #14063|


## Description

This PR fixes the error in the installation script, when the grep filter detects the beginning of the user name and ignores the rest.

This script is used for the update by wpk and for the install/update from source:

https://github.com/wazuh/wazuh/blob/394f627b3915f64dfc1a5b7ba55f61076159d2d2/src/init/adduser.sh#L75

The passwd file:  `/etc/passwd` contains one line for each user account, with seven fields delimited by colons (“:”). The first its the login name.
The grep command filters for users that do not begin with `wazuh`, ignoring how they end, so if a `wazuh-indexer` user exists, the filtered grep will be positive, the if condition false, and then the user is never created at [line 83](https://github.com/wazuh/wazuh/blob/394f627b3915f64dfc1a5b7ba55f61076159d2d2/src/init/adduser.sh#L83).


## Installation logs

After creating a user (i.e. wazuh123) and installing the agent, you can see that there are no errors and creates the user wazuh correctly

```
    RESOURCES_URL:      https://packages.wazuh.com/deps/18
    EXTERNAL_SRC_ONLY:  
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_ZEROMQ:         no
    USE_GEOIP:          no
    USE_PRELUDE:        no
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        yes
    USE_AUDIT:          yes
    DISABLE_SYSC:       no
    DISABLE_CISCAT:     no
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DENABLE_SYSC -DENABLE_CISCAT -DENABLE_AUDIT -DCLIENT
Compiler:
    CFLAGS            -pthread -Iexternal/libdb/build_unix/ -Iexternal/pacman/lib/libalpm/ -Iexternal/libarchive/libarchive -Wl,--start-group -Iexternal/audit-userspace/lib -DNDEBUG -O2 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DENABLE_SYSC -DENABLE_CISCAT -DENABLE_AUDIT -DCLIENT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Ishared_modules/common -Ishared_modules/dbsync/include -Ishared_modules/rsync/include -Iwazuh_modules/syscollector/include  -Idata_provider/include  -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include 
    LDFLAGS           '-Wl,-rpath,/../lib' -pthread -lrt -ldl -O2 -Lshared_modules/dbsync/build/lib -Lshared_modules/rsync/build/lib  -Lwazuh_modules/syscollector/build/lib -Ldata_provider/build/lib
    LIBS              -lrt -ldl -lm 
    CC                cc
    MAKE              make
make[1]: Leaving directory `/root/repos/wazuh/src'

Done building agent

Wait for success...
success
Removing old SCA policies...
Installing SCA policies...


Created symlink from /etc/systemd/system/multi-user.target.wants/wazuh-agent.service to /usr/lib/systemd/system/wazuh-agent.service.

 - Configuration finished properly.

 - To start Wazuh:
      /var/ossec/bin/wazuh-control start

 - To stop Wazuh:
      /var/ossec/bin/wazuh-control stop

 - The configuration can be viewed or modified at /var/ossec/etc/ossec.conf


   Thanks for using Wazuh.
   Please don't hesitate to contact us if you need help or find
   any bugs.

   Use our public Mailing List at:
          https://groups.google.com/forum/#!forum/wazuh

   More information can be found at:
          - http://www.wazuh.com

    ---  Press ENTER to finish (maybe more information below). ---

 - More information at: 
   https://documentation.wazuh.com/


```

## Tests
- [x] Source installation
- [x] Source upgrade
- [ ] WPK Installation
