### PR TITLE
Improved framework functions used by MITRE API endpoints

### DIFF
--- a/api/api/controllers/mitre_controller.py
+++ b/api/api/controllers/mitre_controller.py
@@ -13,9 +13,6 @@ from wazuh.core.cluster.dapi.dapi import DistributedAPI
 
 logger = logging.getLogger('wazuh-api')
 
-MITRE_TECHNIQUES_TIMEOUT = 30
-MITRE_SOFTWARE_TIMEOUT = 15
-
 
 async def get_metadata(request, pretty=False, wait_for_complete=False):
     """Return the metadata of the MITRE's database
@@ -212,8 +209,7 @@ async def get_techniques(request, technique_ids=None, pretty=False, wait_for_com
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies'],
-                          api_timeout=MITRE_TECHNIQUES_TIMEOUT)
+                          rbac_permissions=request['token_info']['rbac_policies'])
 
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -382,8 +378,7 @@ async def get_software(request, software_ids=None, pretty=False, wait_for_comple
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies'],
-                          api_timeout=MITRE_SOFTWARE_TIMEOUT)
+                          rbac_permissions=request['token_info']['rbac_policies'])
 
     data = raise_if_exc(await dapi.distribute_function())
 

--- a/api/api/controllers/test/test_mitre_controller.py
+++ b/api/api/controllers/test/test_mitre_controller.py
@@ -170,8 +170,7 @@ async def test_get_software(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_r
                                       is_async=False,
                                       wait_for_complete=False,
                                       logger=ANY,
-                                      rbac_permissions=mock_request['token_info']['rbac_policies'],
-                                      api_timeout=15)
+                                      rbac_permissions=mock_request['token_info']['rbac_policies'])
 
     mock_exc.assert_called_once_with(mock_dfunc.return_value)
     mock_remove.assert_called_once_with(f_kwargs)
@@ -239,8 +238,7 @@ async def test_get_techniques(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock
                                       is_async=False,
                                       wait_for_complete=False,
                                       logger=ANY,
-                                      rbac_permissions=mock_request['token_info']['rbac_policies'],
-                                      api_timeout=30)
+                                      rbac_permissions=mock_request['token_info']['rbac_policies'])
 
     mock_exc.assert_called_once_with(mock_dfunc.return_value)
     mock_remove.assert_called_once_with(f_kwargs)

--- a/api/test/integration/test_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_mitre_endpoints.tavern.yaml
@@ -951,7 +951,6 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        wait_for_complete: true
         limit: 1
         offset: 0
     response:
@@ -1560,7 +1559,6 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: GET
       params:
-        wait_for_complete: true
         limit: 1
         offset: 0
     response:

--- a/api/test/integration/test_rbac_white_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_mitre_endpoints.tavern.yaml
@@ -71,8 +71,6 @@ stages:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/mitre/techniques"
       method: GET
-      params:
-        wait_for_complete: true
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -124,8 +122,6 @@ stages:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/mitre/software"
       method: GET
-      params:
-        wait_for_complete: true
       headers:
         Authorization: "Bearer {test_login_token}"
     response:

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -31,8 +31,8 @@ EXTRA_FIELDS = {'url', 'source', 'external_id'}
 
 # Table name and keys
 DEFAULT_PK = 'id'
-MAIN_TABLES_PKS = {table: 'id' for table in {'technique', 'mitigation', 'tactic', 'group', 'software', 'reference'}} \
-                  | {'metadata': 'key'}
+MAIN_TABLES_PKS = {table: DEFAULT_PK for table in
+                   {'technique', 'mitigation', 'tactic', 'group', 'software', 'reference'}} | {'metadata': 'key'}
 
 
 class WazuhDBQueryMitre(WazuhDBQuery):

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -516,7 +516,7 @@ def get_mitre_items(mitre_class: callable):
     dict
         Dictionary with information about the fields of the MITRE objects and the items obtained.
     """
-    info = {'min_select_fields': None, 'allowed_fields': None}
+    info = dict()
     db_query = mitre_class(limit=None)
     info['allowed_fields'] = \
         set(db_query.fields.keys()).union(set(db_query.relation_fields)).union(db_query.extra_fields)

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -11,6 +11,9 @@ from wazuh.core import common
 from wazuh.core.utils import WazuhDBQuery, WazuhDBBackend
 from wazuh.core.utils import process_array
 
+# Default request_slice value
+DEFAULT_REQUEST_SLICE = 500
+
 # Optimal request_slice values for each WazuhDBQuery
 # TACTICS_REQUEST_SLICE = 500  # Default WazuhDBQueryMitre request_slice value
 MITIGATIONS_REQUEST_SLICE = 64
@@ -26,13 +29,18 @@ SELECT_FIELDS_REFERENCES = ['url', 'description', 'source', 'external_id']
 # Extra fields from references
 EXTRA_FIELDS = {'url', 'source', 'external_id'}
 
+# Table name and keys
+DEFAULT_PK = 'id'
+MAIN_TABLES_PKS = {table: 'id' for table in {'technique', 'mitigation', 'tactic', 'group', 'software', 'reference'}} \
+                  | {'metadata': 'key'}
+
 
 class WazuhDBQueryMitre(WazuhDBQuery):
 
     def __init__(self, offset: int = 0, limit: Union[int, None] = common.database_limit, query: str = '',
-                 count: bool = True, table: str = '', sort: dict = None, default_sort_field: str = 'id',
+                 count: bool = True, table: str = '', sort: dict = None, default_sort_field: str = DEFAULT_PK,
                  default_sort_order='ASC', fields=None, search: dict = None, select: list = None,
-                 min_select_fields=None, filters=None, request_slice=500):
+                 min_select_fields=None, filters=None, request_slice=DEFAULT_REQUEST_SLICE):
         """Create an instance of WazuhDBQueryMitre query."""
 
         if filters is None:
@@ -79,6 +87,7 @@ class WazuhDBQueryMitre(WazuhDBQuery):
 
 
 class WazuhDBQueryMitreMetadata(WazuhDBQueryMitre):
+    TABLE_NAME = 'metadata'
 
     def __init__(self):
         """Create an instance of WazuhDBQueryMitreMetadata query."""
@@ -86,14 +95,28 @@ class WazuhDBQueryMitreMetadata(WazuhDBQueryMitre):
         min_select_fields = {'key', 'value'}
         fields = {'key': 'key', 'value': 'value'}
 
-        WazuhDBQueryMitre.__init__(self, table='metadata', min_select_fields=min_select_fields, fields=fields,
-                                   default_sort_field='key')
+        WazuhDBQueryMitre.__init__(self, table=self.TABLE_NAME, min_select_fields=min_select_fields, fields=fields,
+                                   default_sort_field=MAIN_TABLES_PKS[self.TABLE_NAME])
 
     def _filter_status(self, status_filter):
         pass
 
 
 class WazuhDBQueryMitreRelational(WazuhDBQueryMitre):
+    TABLE_FIELDS = {
+        'phase': {'min_select_fields': {'tactic_id', 'tech_id'},
+                  'default_sort_field': 'tactic_id',
+                  'fields': {'tactic_id': 'tactic_id', 'tech_id': 'tech_id'}},
+        # source_id refers to mitigation_id, group_id or software_id
+        # target_id always refers to technique_id
+        'mitigate': {'min_select_fields': {'source_id', 'target_id'},
+                     'default_sort_field': 'source_id',
+                     'fields': {'source_id': 'source_id', 'target_id': 'target_id'}},
+        'use': {'min_select_fields': {'source_id', 'target_id'},
+                'default_sort_field': 'source_id',
+                'fields': {'source_id': 'source_id', 'source_type': 'source_type',
+                           'target_id': 'target_id', 'target_type': 'target_type'}},
+    }
 
     def __init__(self, table: str = None, offset: int = 0, limit: Union[int, None] = common.database_limit,
                  query: str = '', count: bool = True, sort: dict = None, default_sort_order: str = 'ASC',
@@ -110,28 +133,11 @@ class WazuhDBQueryMitreRelational(WazuhDBQueryMitre):
             The value of the output dictionary will be the value of the remaining key.
         """
 
-        if filters is None:
-            filters = {}
-        if min_select_fields is None:
-            if table == 'phase':
-                self.min_select_fields = {'tactic_id', 'tech_id'}
-                default_sort_field = 'tactic_id'
-            elif table == 'mitigate' or table == 'use':
-                # source_id refers to mitigation_id, group_id or software_id
-                # target_id always refers to technique_id
-                self.min_select_fields = {'source_id', 'target_id'}
-                default_sort_field = 'source_id'
-        else:
-            self.min_select_fields = min_select_fields
-        if fields is None:
-            if table == 'phase':
-                fields = {'tactic_id': 'tactic_id', 'tech_id': 'tech_id'}
-            elif table == 'mitigate':
-                fields = {'source_id': 'source_id', 'target_id': 'target_id'}
-            elif table == 'use':
-                fields = {'source_id': 'source_id', 'source_type': 'source_type',
-                          'target_id': 'target_id', 'target_type': 'target_type'}
-        self.dict_key = dict_key if dict_key else next(iter(self.min_select_fields))
+        self.min_select_fields = min_select_fields or self.TABLE_FIELDS[table]['min_select_fields']
+        self.dict_key = dict_key or next(iter(self.min_select_fields))
+        default_sort_field = default_sort_field or self.TABLE_FIELDS[table]['default_sort_field']
+        fields = fields or self.TABLE_FIELDS[table]['fields']
+        filters = filters or {}
 
         WazuhDBQueryMitre.__init__(self, table=table, min_select_fields=self.min_select_fields, fields=fields,
                                    filters=filters, offset=offset, limit=limit, query=query, count=count,
@@ -163,26 +169,23 @@ class WazuhDBQueryMitreRelational(WazuhDBQueryMitre):
 
 
 class WazuhDBQueryMitreMitigations(WazuhDBQueryMitre):
+    TABLE_NAME = 'mitigation'
 
     def __init__(self, offset: int = 0, limit: Union[int, None] = common.database_limit, query: str = '',
-                 count: bool = True, sort: dict = None, default_sort_field: str = 'id', default_sort_order='ASC',
+                 count: bool = True, sort: dict = None, default_sort_field: str = '', default_sort_order='ASC',
                  fields=None, search: dict = None, select: list = None, min_select_fields=None, filters=None):
         """Create an instance of WazuhDBQueryMitreMitigations query."""
 
-        if select is None:
-            select = set()
-        if filters is None:
-            filters = dict()
-        self.min_select_fields = min_select_fields
-        if min_select_fields is None:
-            self.min_select_fields = {'id'}
-        self.fields = fields
-        if fields is None:
-            self.fields = {'id': 'id', 'name': 'name', 'description': 'description', 'created_time': 'created_time',
-                           'modified_time': 'modified_time', 'mitre_version': 'mitre_version',
-                           'revoked_by': 'revoked_by', 'deprecated': 'deprecated'}
+        default_sort_field = default_sort_field or MAIN_TABLES_PKS[self.TABLE_NAME]
+        select = select or set()
+        filters = filters or dict()
+        self.min_select_fields = min_select_fields or {MAIN_TABLES_PKS[self.TABLE_NAME]}
+        self.fields = fields or {'id': 'id', 'name': 'name', 'description': 'description',
+                                 'created_time': 'created_time',
+                                 'modified_time': 'modified_time', 'mitre_version': 'mitre_version',
+                                 'revoked_by': 'revoked_by', 'deprecated': 'deprecated'}
 
-        WazuhDBQueryMitre.__init__(self, table='mitigation', min_select_fields=self.min_select_fields,
+        WazuhDBQueryMitre.__init__(self, table=self.TABLE_NAME, min_select_fields=self.min_select_fields,
                                    fields=self.fields, filters=filters, offset=offset, limit=limit, query=query,
                                    count=count, sort=sort, default_sort_field=default_sort_field,
                                    default_sort_order=default_sort_order, search=search,
@@ -200,12 +203,7 @@ class WazuhDBQueryMitreMitigations(WazuhDBQueryMitre):
         """
         super()._execute_data_query()
 
-        mitigation_ids = set()
-        for mitigation in self._data:
-            mitigation_ids.add(mitigation['id'])
-
-        with WazuhDBQueryMitreRelational(table='mitigate', filters={'source_id': list(mitigation_ids)},
-                                         dict_key='source_id', limit=None) as mitre_relational_query:
+        with WazuhDBQueryMitreRelational(table='mitigate', dict_key='source_id', limit=None) as mitre_relational_query:
             techniques = mitre_relational_query.run()
 
         with WazuhDBQueryMitreReferences(limit=None, filters={'type': 'mitigation'},
@@ -225,25 +223,21 @@ class WazuhDBQueryMitreMitigations(WazuhDBQueryMitre):
 
 
 class WazuhDBQueryMitreReferences(WazuhDBQueryMitre):
+    TABLE_NAME = 'reference'
 
     def __init__(self, offset: int = 0, limit: Union[int, None] = common.database_limit, query: str = '',
-                 count: bool = True, sort: dict = None, default_sort_field: str = 'id', default_sort_order='ASC',
+                 count: bool = True, sort: dict = None, default_sort_field: str = '', default_sort_order='ASC',
                  fields=None, search: dict = None, select: list = None, min_select_fields=None, filters=None):
         """Create an instance of WazuhDBQueryMitreReferences query."""
 
-        if select is None:
-            select = set()
-        if filters is None:
-            filters = dict()
-        self.min_select_fields = min_select_fields
-        if min_select_fields is None:
-            self.min_select_fields = {'id'}
-        self.fields = fields
-        if fields is None:
-            self.fields = {'id': 'id', 'source': 'source', 'external_id': 'external_id', 'url': 'url',
-                           'description': 'description', 'type': 'type'}
+        default_sort_field = default_sort_field or MAIN_TABLES_PKS[self.TABLE_NAME]
+        select = select or set()
+        filters = filters or dict()
+        self.min_select_fields = min_select_fields or {MAIN_TABLES_PKS[self.TABLE_NAME]}
+        self.fields = fields or {'id': 'id', 'source': 'source', 'external_id': 'external_id', 'url': 'url',
+                                 'description': 'description', 'type': 'type'}
 
-        WazuhDBQueryMitre.__init__(self, table='reference', min_select_fields=self.min_select_fields,
+        WazuhDBQueryMitre.__init__(self, table=self.TABLE_NAME, min_select_fields=self.min_select_fields,
                                    fields=self.fields, filters=filters, offset=offset, limit=limit, query=query,
                                    count=count, sort=sort, default_sort_field=default_sort_field,
                                    default_sort_order=default_sort_order, search=search,
@@ -255,25 +249,21 @@ class WazuhDBQueryMitreReferences(WazuhDBQueryMitre):
 
 
 class WazuhDBQueryMitreTactics(WazuhDBQueryMitre):
+    TABLE_NAME = 'tactic'
 
     def __init__(self, offset: int = 0, limit: Union[int, None] = common.database_limit, query: str = '',
-                 count: bool = True, sort: dict = None, default_sort_field: str = 'id', default_sort_order='ASC',
+                 count: bool = True, sort: dict = None, default_sort_field: str = '', default_sort_order='ASC',
                  fields=None, search: dict = None, select: list = None, min_select_fields=None, filters=None):
         """Create an instance of WazuhDBQueryMitreTactics query."""
 
-        if select is None:
-            select = set()
-        if filters is None:
-            filters = dict()
-        self.min_select_fields = min_select_fields
-        if min_select_fields is None:
-            self.min_select_fields = {'id'}
-        self.fields = fields
-        if fields is None:
-            self.fields = {'id': 'id', 'name': 'name', 'description': 'description', 'short_name': 'short_name',
-                           'created_time': 'created_time', 'modified_time': 'modified_time'}
+        default_sort_field = default_sort_field or MAIN_TABLES_PKS[self.TABLE_NAME]
+        select = select or set()
+        filters = filters or dict()
+        self.min_select_fields = min_select_fields or {MAIN_TABLES_PKS[self.TABLE_NAME]}
+        self.fields = fields or {'id': 'id', 'name': 'name', 'description': 'description', 'short_name': 'short_name',
+                                 'created_time': 'created_time', 'modified_time': 'modified_time'}
 
-        WazuhDBQueryMitre.__init__(self, table='tactic', min_select_fields=self.min_select_fields,
+        WazuhDBQueryMitre.__init__(self, table=self.TABLE_NAME, min_select_fields=self.min_select_fields,
                                    fields=self.fields, filters=filters, offset=offset, limit=limit, query=query,
                                    count=count, sort=sort, default_sort_field=default_sort_field,
                                    default_sort_order=default_sort_order, search=search,
@@ -289,12 +279,7 @@ class WazuhDBQueryMitreTactics(WazuhDBQueryMitre):
         """This function will add to the result the techniques related to each tactic."""
         super()._execute_data_query()
 
-        tactic_ids = set()
-        for tactic in self._data:
-            tactic_ids.add(tactic['id'])
-
-        with WazuhDBQueryMitreRelational(table='phase', filters={'tactic_id': list(tactic_ids)},
-                                         dict_key='tactic_id', limit=None) as mitre_relational_query:
+        with WazuhDBQueryMitreRelational(table='phase', dict_key='tactic_id', limit=None) as mitre_relational_query:
             techniques = mitre_relational_query.run()
 
         with WazuhDBQueryMitreReferences(limit=None, filters={'type': 'tactic'},
@@ -314,28 +299,25 @@ class WazuhDBQueryMitreTactics(WazuhDBQueryMitre):
 
 
 class WazuhDBQueryMitreTechniques(WazuhDBQueryMitre):
+    TABLE_NAME = 'technique'
 
     def __init__(self, offset: int = 0, limit: Union[int, None] = common.database_limit, query: str = '',
-                 count: bool = True, sort: dict = None, default_sort_field: str = 'id', default_sort_order='ASC',
+                 count: bool = True, sort: dict = None, default_sort_field: str = '', default_sort_order='ASC',
                  fields=None, search: dict = None, select: list = None, min_select_fields=None, filters=None):
         """Create an instance of WazuhDBQueryMitreTechniques query."""
 
-        if select is None:
-            select = set()
-        if filters is None:
-            filters = dict()
-        self.min_select_fields = min_select_fields
-        if min_select_fields is None:
-            self.min_select_fields = {'id'}
-        self.fields = fields
-        if fields is None:
-            self.fields = {'id': 'id', 'name': 'name', 'description': 'description', 'created_time': 'created_time',
-                           'modified_time': 'modified_time', 'mitre_version': 'mitre_version',
-                           'mitre_detection': 'mitre_detection', 'network_requirements': 'network_requirements',
-                           'remote_support': 'remote_support', 'revoked_by': 'revoked_by', 'deprecated': 'deprecated',
-                           'subtechnique_of': 'subtechnique_of'}
+        default_sort_field = default_sort_field or MAIN_TABLES_PKS[self.TABLE_NAME]
+        select = select or set()
+        filters = filters or dict()
+        self.min_select_fields = min_select_fields or {MAIN_TABLES_PKS[self.TABLE_NAME]}
+        self.fields = fields or {'id': 'id', 'name': 'name', 'description': 'description',
+                                 'created_time': 'created_time', 'modified_time': 'modified_time',
+                                 'mitre_version': 'mitre_version', 'mitre_detection': 'mitre_detection',
+                                 'network_requirements': 'network_requirements', 'remote_support': 'remote_support',
+                                 'revoked_by': 'revoked_by', 'deprecated': 'deprecated',
+                                 'subtechnique_of': 'subtechnique_of'}
 
-        WazuhDBQueryMitre.__init__(self, table='technique', min_select_fields=self.min_select_fields,
+        WazuhDBQueryMitre.__init__(self, table=self.TABLE_NAME, min_select_fields=self.min_select_fields,
                                    fields=self.fields, filters=filters, offset=offset, limit=limit, query=query,
                                    count=count, sort=sort, default_sort_field=default_sort_field,
                                    default_sort_order=default_sort_order, search=search,
@@ -358,26 +340,18 @@ class WazuhDBQueryMitreTechniques(WazuhDBQueryMitre):
         for technique in self._data:
             technique_ids.add(technique['id'])
 
-        with WazuhDBQueryMitreRelational(table='phase', filters={'tech_id': list(technique_ids)},
-                                         dict_key='tech_id', limit=None) as mitre_relational_query:
+        with WazuhDBQueryMitreRelational(table='phase', dict_key='tech_id', limit=None) as mitre_relational_query:
             tactics = mitre_relational_query.run()
 
-        with WazuhDBQueryMitreRelational(table='mitigate', filters={'target_id': list(technique_ids)},
-                                         dict_key='target_id', limit=None) as mitre_relational_query:
+        with WazuhDBQueryMitreRelational(table='mitigate', dict_key='target_id', limit=None) as mitre_relational_query:
             mitigations = mitre_relational_query.run()
 
-        with WazuhDBQueryMitreRelational(table='use',
-                                         filters={'target_id': list(technique_ids),
-                                                  'target_type': 'technique', 'source_type': 'software'},
-                                         dict_key='target_id',
-                                         limit=None) as mitre_relational_query:
+        with WazuhDBQueryMitreRelational(table='use', filters={'target_type': 'technique', 'source_type': 'software'},
+                                         dict_key='target_id', limit=None) as mitre_relational_query:
             software = mitre_relational_query.run()
 
-        with WazuhDBQueryMitreRelational(table='use',
-                                         filters={'target_id': list(technique_ids),
-                                                  'target_type': 'technique', 'source_type': 'group'},
-                                         dict_key='target_id',
-                                         limit=None) as mitre_relational_query:
+        with WazuhDBQueryMitreRelational(table='use', filters={'target_type': 'technique', 'source_type': 'group'},
+                                         dict_key='target_id', limit=None) as mitre_relational_query:
             groups = mitre_relational_query.run()
 
         with WazuhDBQueryMitreReferences(limit=None, filters={'type': 'technique'},
@@ -400,26 +374,24 @@ class WazuhDBQueryMitreTechniques(WazuhDBQueryMitre):
 
 
 class WazuhDBQueryMitreGroups(WazuhDBQueryMitre):
+    TABLE_NAME = 'group'
 
     def __init__(self, offset: int = 0, limit: Union[int, None] = common.database_limit, query: str = '',
-                 count: bool = True, sort: dict = None, default_sort_field: str = 'id', default_sort_order='ASC',
+                 count: bool = True, sort: dict = None, default_sort_field: str = '', default_sort_order='ASC',
                  fields=None, search: dict = None, select: list = None, min_select_fields=None, filters=None):
         """Create an instance of WazuhDBQueryMitreGroups query."""
 
-        if select is None:
-            select = set()
-        if filters is None:
-            filters = dict()
-        self.min_select_fields = min_select_fields
-        if min_select_fields is None:
-            self.min_select_fields = {'id'}
-        self.fields = fields
-        if fields is None:
-            self.fields = {'id': 'id', 'name': 'name', 'description': 'description', 'created_time': 'created_time',
-                           'modified_time': 'modified_time', 'mitre_version': 'mitre_version',
-                           'revoked_by': 'revoked_by', 'deprecated': 'deprecated'}
+        default_sort_field = default_sort_field or MAIN_TABLES_PKS[self.TABLE_NAME]
+        select = select or set()
+        filters = filters or dict()
+        self.min_select_fields = min_select_fields or {MAIN_TABLES_PKS[self.TABLE_NAME]}
+        self.fields = fields or {'id': 'id', 'name': 'name', 'description': 'description',
+                                 'created_time': 'created_time', 'modified_time': 'modified_time',
+                                 'mitre_version': 'mitre_version', 'revoked_by': 'revoked_by',
+                                 'deprecated': 'deprecated'}
 
-        WazuhDBQueryMitre.__init__(self, table='`group`', min_select_fields=self.min_select_fields,
+        # The 'group' table needs to be quoted to avoid an SQL syntax error ('group' is a reserved word)
+        WazuhDBQueryMitre.__init__(self, table=f"`{self.TABLE_NAME}`", min_select_fields=self.min_select_fields,
                                    fields=self.fields, filters=filters, offset=offset, limit=limit, query=query,
                                    count=count, sort=sort, default_sort_field=default_sort_field,
                                    default_sort_order=default_sort_order, search=search,
@@ -440,18 +412,12 @@ class WazuhDBQueryMitreGroups(WazuhDBQueryMitre):
         for group in self._data:
             group_ids.add(group['id'])
 
-        with WazuhDBQueryMitreRelational(table='use',
-                                         filters={'source_id': list(group_ids),
-                                                  'target_type': 'software', 'source_type': 'group'},
-                                         dict_key='source_id',
-                                         limit=None) as mitre_relational_query:
+        with WazuhDBQueryMitreRelational(table='use', filters={'target_type': 'software', 'source_type': 'group'},
+                                         dict_key='source_id', limit=None) as mitre_relational_query:
             software = mitre_relational_query.run()
 
-        with WazuhDBQueryMitreRelational(table='use',
-                                         filters={'source_id': list(group_ids),
-                                                  'target_type': 'technique', 'source_type': 'group'},
-                                         dict_key='source_id',
-                                         limit=None) as mitre_relational_query:
+        with WazuhDBQueryMitreRelational(table='use', filters={'target_type': 'technique', 'source_type': 'group'},
+                                         dict_key='source_id', limit=None) as mitre_relational_query:
             techniques = mitre_relational_query.run()
 
         with WazuhDBQueryMitreReferences(limit=None, filters={'type': 'group'},
@@ -472,26 +438,23 @@ class WazuhDBQueryMitreGroups(WazuhDBQueryMitre):
 
 
 class WazuhDBQueryMitreSoftware(WazuhDBQueryMitre):
+    TABLE_NAME = 'software'
 
     def __init__(self, offset: int = 0, limit: Union[int, None] = common.database_limit, query: str = '',
-                 count: bool = True, sort: dict = None, default_sort_field: str = 'id', default_sort_order='ASC',
+                 count: bool = True, sort: dict = None, default_sort_field: str = '', default_sort_order='ASC',
                  fields=None, search: dict = None, select: list = None, min_select_fields=None, filters=None):
         """Create an instance of WazuhDBQueryMitreSoftware query."""
 
-        if select is None:
-            select = set()
-        if filters is None:
-            filters = dict()
-        self.min_select_fields = min_select_fields
-        if min_select_fields is None:
-            self.min_select_fields = {'id'}
-        self.fields = fields
-        if fields is None:
-            self.fields = {'id': 'id', 'name': 'name', 'description': 'description', 'created_time': 'created_time',
-                           'modified_time': 'modified_time', 'mitre_version': 'mitre_version',
-                           'revoked_by': 'revoked_by', 'deprecated': 'deprecated'}
+        default_sort_field = default_sort_field or MAIN_TABLES_PKS[self.TABLE_NAME]
+        select = select or set()
+        filters = filters or dict()
+        self.min_select_fields = min_select_fields or {MAIN_TABLES_PKS[self.TABLE_NAME]}
+        self.fields = fields or {'id': 'id', 'name': 'name', 'description': 'description',
+                                 'created_time': 'created_time', 'modified_time': 'modified_time',
+                                 'mitre_version': 'mitre_version', 'revoked_by': 'revoked_by',
+                                 'deprecated': 'deprecated'}
 
-        WazuhDBQueryMitre.__init__(self, table='software', min_select_fields=self.min_select_fields,
+        WazuhDBQueryMitre.__init__(self, table=self.TABLE_NAME, min_select_fields=self.min_select_fields,
                                    fields=self.fields, filters=filters, offset=offset, limit=limit, query=query,
                                    count=count, sort=sort, default_sort_field=default_sort_field,
                                    default_sort_order=default_sort_order, search=search,
@@ -512,20 +475,12 @@ class WazuhDBQueryMitreSoftware(WazuhDBQueryMitre):
         for group in self._data:
             software_ids.add(group['id'])
 
-        with WazuhDBQueryMitreRelational(table='use',
-                                         filters={'target_id': list(software_ids),
-                                                  'target_type': 'software',
-                                                  'source_type': 'group'},
-                                         dict_key='target_id',
-                                         limit=None) as mitre_relational_query:
+        with WazuhDBQueryMitreRelational(table='use', filters={'target_type': 'software', 'source_type': 'group'},
+                                         dict_key='target_id', limit=None) as mitre_relational_query:
             groups = mitre_relational_query.run()
 
-        with WazuhDBQueryMitreRelational(table='use',
-                                         filters={'source_id': list(software_ids),
-                                                  'target_type': 'technique',
-                                                  'source_type': 'software'},
-                                         dict_key='source_id',
-                                         limit=None) as mitre_relational_query:
+        with WazuhDBQueryMitreRelational(table='use', filters={'target_type': 'technique', 'source_type': 'software'},
+                                         dict_key='source_id', limit=None) as mitre_relational_query:
             techniques = mitre_relational_query.run()
 
         with WazuhDBQueryMitreReferences(limit=None, filters={'type': 'software'},

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -873,7 +873,7 @@ def get_mitre_items(mitre_class: callable) -> tuple:
     Returns
     -------
     tuple
-        Dictionary with information about the fields of the MITRE objects and the items obtained.
+        Tuple containing a dictionary with fields information, and a dictionary with the items obtained.
     """
     info = {}
     db_query = mitre_class(limit=None)

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -21,7 +21,8 @@ REFERENCES_REQUEST_SLICE = 128
 GROUPS_REQUEST_SLICE = 64
 SOFTWARE_REQUEST_SLICE = 64
 TECHNIQUES_REQUEST_SLICE = 32
-RELATIONAL_REQUEST_SLICE = 256
+# All the relational queries will have the default request slice BUT the technique-groups one as its optimal RS is 485
+RELATIONAL_REQUEST_SLICE_TECHNIQUE_GROUPS = 485
 
 # Select used for each item's references
 SELECT_FIELDS_REFERENCES = ['url', 'description', 'source', 'external_id']
@@ -121,7 +122,7 @@ class WazuhDBQueryMitreRelational(WazuhDBQueryMitre):
     def __init__(self, table: str = None, offset: int = 0, limit: Union[int, None] = common.database_limit,
                  query: str = '', count: bool = True, sort: dict = None, default_sort_order: str = 'ASC',
                  default_sort_field: str = None, fields=None, search: dict = None, select: list = None,
-                 min_select_fields=None, filters=None, dict_key: str = None, request_slice=RELATIONAL_REQUEST_SLICE):
+                 min_select_fields=None, filters=None, dict_key: str = None, request_slice=DEFAULT_REQUEST_SLICE):
         """WazuhDBQueryMitreRelational constructor
         This class will always generate dictionaries with two keys, this is because it handles relational tables,
         where the relationship of two objects is specified.
@@ -352,8 +353,9 @@ class WazuhDBQueryMitreTechniques(WazuhDBQueryMitre):
             software = mitre_relational_query.run()
 
         with WazuhDBQueryMitreRelational(table='use', filters={'target_type': 'technique', 'source_type': 'group'},
-                                         dict_key='target_id', select=['source_id', 'target_id'],
-                                         limit=None) as mitre_relational_query:
+                                         dict_key='target_id', select=['source_id', 'target_id'], limit=None,
+                                         request_slice=RELATIONAL_REQUEST_SLICE_TECHNIQUE_GROUPS) \
+                as mitre_relational_query:
             groups = mitre_relational_query.run()
 
         with WazuhDBQueryMitreReferences(limit=None, filters={'type': 'technique'},
@@ -420,8 +422,9 @@ class WazuhDBQueryMitreGroups(WazuhDBQueryMitre):
             software = mitre_relational_query.run()
 
         with WazuhDBQueryMitreRelational(table='use', filters={'target_type': 'technique', 'source_type': 'group'},
-                                         dict_key='source_id', select=['source_id', 'target_id'],
-                                         limit=None) as mitre_relational_query:
+                                         dict_key='source_id', select=['source_id', 'target_id'], limit=None,
+                                         request_slice=RELATIONAL_REQUEST_SLICE_TECHNIQUE_GROUPS) \
+                as mitre_relational_query:
             techniques = mitre_relational_query.run()
 
         with WazuhDBQueryMitreReferences(limit=None, filters={'type': 'group'},

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -347,11 +347,13 @@ class WazuhDBQueryMitreTechniques(WazuhDBQueryMitre):
             mitigations = mitre_relational_query.run()
 
         with WazuhDBQueryMitreRelational(table='use', filters={'target_type': 'technique', 'source_type': 'software'},
-                                         dict_key='target_id', limit=None) as mitre_relational_query:
+                                         dict_key='target_id', select=['source_id', 'target_id'],
+                                         limit=None) as mitre_relational_query:
             software = mitre_relational_query.run()
 
         with WazuhDBQueryMitreRelational(table='use', filters={'target_type': 'technique', 'source_type': 'group'},
-                                         dict_key='target_id', limit=None) as mitre_relational_query:
+                                         dict_key='target_id', select=['source_id', 'target_id'],
+                                         limit=None) as mitre_relational_query:
             groups = mitre_relational_query.run()
 
         with WazuhDBQueryMitreReferences(limit=None, filters={'type': 'technique'},
@@ -413,11 +415,13 @@ class WazuhDBQueryMitreGroups(WazuhDBQueryMitre):
             group_ids.add(group['id'])
 
         with WazuhDBQueryMitreRelational(table='use', filters={'target_type': 'software', 'source_type': 'group'},
-                                         dict_key='source_id', limit=None) as mitre_relational_query:
+                                         dict_key='source_id', select=['source_id', 'target_id'],
+                                         limit=None) as mitre_relational_query:
             software = mitre_relational_query.run()
 
         with WazuhDBQueryMitreRelational(table='use', filters={'target_type': 'technique', 'source_type': 'group'},
-                                         dict_key='source_id', limit=None) as mitre_relational_query:
+                                         dict_key='source_id', select=['source_id', 'target_id'],
+                                         limit=None) as mitre_relational_query:
             techniques = mitre_relational_query.run()
 
         with WazuhDBQueryMitreReferences(limit=None, filters={'type': 'group'},
@@ -476,11 +480,13 @@ class WazuhDBQueryMitreSoftware(WazuhDBQueryMitre):
             software_ids.add(group['id'])
 
         with WazuhDBQueryMitreRelational(table='use', filters={'target_type': 'software', 'source_type': 'group'},
-                                         dict_key='target_id', limit=None) as mitre_relational_query:
+                                         dict_key='target_id', select=['source_id', 'target_id'],
+                                         limit=None) as mitre_relational_query:
             groups = mitre_relational_query.run()
 
         with WazuhDBQueryMitreRelational(table='use', filters={'target_type': 'technique', 'source_type': 'software'},
-                                         dict_key='source_id', limit=None) as mitre_relational_query:
+                                         dict_key='source_id', select=['source_id', 'target_id'],
+                                         limit=None) as mitre_relational_query:
             techniques = mitre_relational_query.run()
 
         with WazuhDBQueryMitreReferences(limit=None, filters={'type': 'software'},


### PR DESCRIPTION
|Related issue|
|---|
| close https://github.com/wazuh/wazuh/issues/14167|



## Description

This PR closes https://github.com/wazuh/wazuh/issues/14167.

In this pull request, I have improved all the MITRE framework functions. There is more information about the new design in the related issue's comments.

Apart from the time improvements, I have also reviewed the request_slice values, reviewed the queries to improve the optimal request_slice for relational queries, made profiling, and removed timeouts.


#### New total times (API integration tests environment, CI hosts)

Specs: **4 GB RAM and 2 CPU cores** (Wazuh deployment in a Docker environment). Specs between the minimum and the recommended for a Wazuh manager.

| Endpoint               | Response time |
|------------------------|---------------|
| GET /mitre/metadata    | 1.04 s        |
| GET /mitre/mitigations | 3.21 s        |
| GET /mitre/references  | 2.82 s        |
| GET /mitre/tactics     | 2.20 s        |
| GET /mitre/techniques  | 5.74 s        |
| GET /mitre/groups      | 2.51 s        |
| GET /mitre/software    | 3.61 s        |





As we can see there is no need to use custom timeouts.