### PR TITLE
Deprecate `/manager/stats/analysisd`, `/manager/stats/remoted`, `/cluster/{node_id}/stats/analysisd`, and  `/cluster/{node_id}/stats/remoted`

### DIFF
--- a/api/api/controllers/cluster_controller.py
+++ b/api/api/controllers/cluster_controller.py
@@ -14,7 +14,7 @@ import wazuh.manager as manager
 import wazuh.stats as stats
 from api.encoder import dumps, prettify
 from api.models.base_model_ import Body
-from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc, deserialize_date
+from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc, deserialize_date, deprecate_endpoint
 from wazuh.core.cluster.control import get_system_nodes
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.core.results import AffectedItemsWazuhResult
@@ -347,12 +347,27 @@ async def get_stats_weekly_node(request, node_id, pretty=False, wait_for_complet
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-async def get_stats_analysisd_node(request, node_id, pretty=False, wait_for_complete=False):
-    """Get a specified node's analysisd stats.
+@deprecate_endpoint()
+async def get_stats_analysisd_node(request, node_id: str, pretty: bool = False,
+                                   wait_for_complete: bool = False) -> web.Response:
+    """Get a specified node's analysisd statistics.
 
-    :param node_id: Cluster node name.
-    :param pretty: Show results in human-readable format
-    :param wait_for_complete: Disable timeout response
+    Notes
+    -----
+    To be deprecated in v5.0.
+
+    Parameters
+    ----------
+    node_id : str
+        Cluster node name.
+    pretty : bool
+        Show results in human-readable format.
+    wait_for_complete : bool, optional
+        Whether to disable response timeout or not. Default `False`
+
+    Returns
+    -------
+    web.Response
     """
     f_kwargs = {'node_id': node_id,
                 'filename': common.ANALYSISD_STATS}
@@ -372,12 +387,27 @@ async def get_stats_analysisd_node(request, node_id, pretty=False, wait_for_comp
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-async def get_stats_remoted_node(request, node_id, pretty=False, wait_for_complete=False):
-    """Get a specified node's remoted stats.
+@deprecate_endpoint()
+async def get_stats_remoted_node(request, node_id: str, pretty: bool = False,
+                                 wait_for_complete: bool = False) -> web.Response:
+    """Get a specified node's remoted statistics.
 
-    :param node_id: Cluster node name.
-    :param pretty: Show results in human-readable format
-    :param wait_for_complete: Disable timeout response
+    Notes
+    -----
+    To be deprecated in v5.0.
+
+    Parameters
+    ----------
+    node_id : str
+        Cluster node name.
+    pretty : bool
+        Show results in human-readable format.
+    wait_for_complete : bool, optional
+        Whether to disable response timeout or not. Default `False`
+
+    Returns
+    -------
+    web.Response
     """
     f_kwargs = {'node_id': node_id,
                 'filename': common.REMOTED_STATS}
@@ -569,7 +599,7 @@ async def get_node_config(request, node_id, component, wait_for_complete=False, 
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-async def update_configuration(request, node_id, body,  pretty=False, wait_for_complete=False):
+async def update_configuration(request, node_id, body, pretty=False, wait_for_complete=False):
     """Update Wazuh configuration (ossec.conf) in node node_id.
 
     Parameters

--- a/api/api/controllers/manager_controller.py
+++ b/api/api/controllers/manager_controller.py
@@ -12,7 +12,7 @@ import wazuh.manager as manager
 import wazuh.stats as stats
 from api.encoder import dumps, prettify
 from api.models.base_model_ import Body
-from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc, deserialize_date
+from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc, deserialize_date, deprecate_endpoint
 from wazuh.core import common
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.core.results import AffectedItemsWazuhResult
@@ -185,11 +185,24 @@ async def get_stats_weekly(request, pretty=False, wait_for_complete=False):
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-async def get_stats_analysisd(request, pretty=False, wait_for_complete=False):
-    """Get manager's or local_node's analysisd stats.
+@deprecate_endpoint()
+async def get_stats_analysisd(request, pretty: bool = False, wait_for_complete: bool = False) -> web.Response:
+    """Get manager's or local_node's analysisd statistics.
 
-    :param pretty: Show results in human-readable format
-    :param wait_for_complete: Disable timeout response
+    Notes
+    -----
+    To be deprecated in v5.0.
+
+    Parameters
+    ----------
+    pretty : bool
+        Show results in human-readable format.
+    wait_for_complete : bool, optional
+        Whether to disable response timeout or not. Default `False`
+
+    Returns
+    -------
+    web.Response
     """
     f_kwargs = {'filename': common.ANALYSISD_STATS}
 
@@ -206,11 +219,24 @@ async def get_stats_analysisd(request, pretty=False, wait_for_complete=False):
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-async def get_stats_remoted(request, pretty=False, wait_for_complete=False):
-    """Get manager's or local_node's remoted stats.
+@deprecate_endpoint()
+async def get_stats_remoted(request, pretty: bool = False, wait_for_complete: bool = False) -> web.Response:
+    """Get manager's or local_node's remoted statistics.
 
-    :param pretty: Show results in human-readable format
-    :param wait_for_complete: Disable timeout response
+    Notes
+    -----
+    To be deprecated in v5.0.
+
+    Parameters
+    ----------
+    pretty : bool
+        Show results in human-readable format.
+    wait_for_complete : bool, optional
+        Whether to disable response timeout or not. Default `False`
+
+    Returns
+    -------
+    web.Response
     """
     f_kwargs = {'filename': common.REMOTED_STATS}
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -9032,6 +9032,7 @@ paths:
     get:
       tags:
       - Cluster
+      deprecated: true
       summary: "Get node stats analysisd"
       description: "Return Wazuh analysisd statistical information in node {node_id}"
       operationId: api.controllers.cluster_controller.get_stats_analysisd_node
@@ -9113,6 +9114,7 @@ paths:
     get:
       tags:
       - Cluster
+      deprecated: true
       summary: "Get node stats remoted"
       description: "Return Wazuh remoted statistical information in node {node_id}"
       operationId: api.controllers.cluster_controller.get_stats_remoted_node
@@ -10430,6 +10432,7 @@ paths:
     get:
       tags:
       - Manager
+      deprecated: true
       summary: "Get stats analysisd"
       description: "Return Wazuh analysisd statistical information"
       operationId: api.controllers.manager_controller.get_stats_analysisd
@@ -10508,6 +10511,7 @@ paths:
     get:
       tags:
       - Manager
+      deprecated: true
       summary: "Get stats remoted"
       description: "Return Wazuh remoted statistical information"
       operationId: api.controllers.manager_controller.get_stats_remoted

--- a/api/api/util.py
+++ b/api/api/util.py
@@ -332,7 +332,7 @@ def deprecate_endpoint(link: str = ''):
     Parameters
     ----------
     link : str
-        Documentation related with this deprecation.
+        Documentation related to this deprecation.
     """
     def add_deprecation_headers(func):
         @wraps(func)


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/13384 |

This PR closes https://github.com/wazuh/wazuh/issues/13384.

In this pull request, I have added the `deprecate_endpoint` decorator to the API functions related to the `/manager/stats/analysisd`, `/manager/stats/remoted`, `/cluster/{node_id}stats/analysisd`, and  `/cluster/{node_id}stats/remoted` endpoints.

I have also updated the API specification.

