### PR TITLE
Modify/add ReadNodes pipelines tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,7 @@ src/shared_modules/dbsync/smokeTests/output/
 src/shared_modules/dbsync/smokeTests/temp.db
 src/shared_modules/rsync/coverage_report/
 src/shared_modules/utils/coverage_report/
+src/shared_modules/utils/tests/coverage_report
 src/wazuh_modules/syscollector/coverage_report/
 src/ossec.test
 src/tap_*

--- a/src/shared_modules/utils/tests/CMakeLists.txt
+++ b/src/shared_modules/utils/tests/CMakeLists.txt
@@ -8,6 +8,9 @@ if(COVERITY)
   add_definitions(-D__GNUC__=8)
 endif(COVERITY)
 
+# Enable testing
+enable_testing()
+
 set(CMAKE_CXX_FLAGS "-Wall -Wextra -std=c++14")
 set(CMAKE_CXX_FLAGS_DEBUG "-g --coverage")
 

--- a/src/shared_modules/utils/tests/filesystemHelper_test.cpp
+++ b/src/shared_modules/utils/tests/filesystemHelper_test.cpp
@@ -33,6 +33,15 @@ TEST_F(FilesystemUtilsTest, FilesystemExistsDir)
     EXPECT_TRUE(Utils::existsDir(R"(/usr)"));
 }
 
+TEST_F(FilesystemUtilsTest, FilesystemExistsRegular)
+{
+    // Check correct input
+    EXPECT_TRUE(Utils::existsRegular(R"(/etc/bash.bashrc)"));
+
+    // Check wrong input
+    EXPECT_FALSE(Utils::existsRegular(R"(/etc)"));
+}
+
 TEST_F(FilesystemUtilsTest, FilesystemEnumerateDir)
 {
     const auto items {Utils::enumerateDir(R"(/usr)")};


### PR DESCRIPTION
|Related issue|
|---|
|Closes #14284 |

## Description

To increase the coverage of the test on the `src/shared_modules/utils` files, I added some unit tests to test some functionality of the `filesystemHelper.h` and `pipelineNodesImp.h` files.
For that I have modified two unit test files `filesystemHelper_test.cpp` and `pipelineNodes_test.cpp`.

Other minor changes I made:
- Added a new directive in the `CMakeLists.txt` file to allow test execution using the `ctest` command from the terminal.
- Added `coverage_report` folder in `.gitignore` file to avoid tracking.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [x] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors