### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/api-framework.md
+++ b/.github/ISSUE_TEMPLATE/api-framework.md
@@ -2,7 +2,7 @@
 name: API/Framework issue 
 about: Report a bug or make a feature request.
 title: ''
-labels: ''
+labels: 'team/framework'
 assignees: ''
 
 ---
@@ -11,39 +11,18 @@ assignees: ''
 |---|---|
 | X.Y.Z-rev | Wazuh component |
 
+## Description
 <!--
 Whenever possible, issues should be created for bug reporting and feature requests.
 For questions related to the user experience, please refer:
 - Wazuh mailing list: https://groups.google.com/forum/#!forum/wazuh
 - Join Wazuh on Slack: https://wazuh.com/community/join-us-on-slack
-
-Please fill the table above. Feel free to extend it at your convenience.
 -->
 
 ## Checks
-
-### wazuh/wazuh
-- Unit tests without failures. Updated and/or expanded if there are new functions/methods/outputs:
-  - [ ] Cluster (`framework/wazuh/core/cluster/tests/` & `framework/wazuh/core/cluster/dapi/tests/`)
-  - [ ] Core (`framework/wazuh/core/tests/`)
-  - [ ] SDK (`framework/wazuh/tests/`)
-  - [ ] RBAC (`framework/wazuh/rbac/tests/`)
-  - [ ] API (`api/api/tests/`)
-- API tavern integration tests without failures. Updated and/or expanded if needed (`api/test/integration/`):
-  - [ ] Affected tests 
-  - [ ] Affected RBAC (black and white) tests
-- [ ] Review integration test mapping using the script (`api/test/integration/mapping/integration_test_api_endpoints.json`)
-- [ ] Review of spec.yaml examples and schemas (`api/api/spec/spec.yaml`)
-- [ ] Review exceptions remediation when any endpoint path changes or is removed (`framework/wazuh/core/exception.py`)
-- [ ] Changelog (`CHANGELOG.md`)
-<!-- If changes are made to any of the following components, uncomment the corresponding line 
-- [ ] **Integration tests** without failures for API configuration (`/wazuh-qa/tests/integration/test_api/test_config/`)
-- [ ] **System tests** for agent enrollment process (`/wazuh-qa/tests/system/test_cluster/test_agent_enrollment`)
-- [ ] **System tests** for agent info sync process in cluster (`/wazuh-qa/tests/system/test_cluster/test_agent_info_sync`)
-- [ ] **System tests** for agent key polling (`/wazuh-qa/tests/system/test_cluster/test_agent_key_polling`)
-- [ ] **System tests** for JWT invalidation (`/wazuh-qa/tests/system/test_jwt_invalidation`)
--->
-
-### wazuh/wazuh-documentation
-- [ ] Migration from 3.X for changed endpoints (`source/user-manual/api/equivalence.rst`)
-- [ ] Update RBAC reference with new/modified actions/resources/relationships (`source/user-manual/api/rbac/reference.rst`)
+<!-- Do not modify, this will be ticked during development -->
+The following elements have been updated or reviewed (should also be checked if no modification is required):
+- [ ] Tests (unit tests, API integration tests).
+- [ ] Changelog.
+- [ ] Documentation.
+- [ ] Integration test mapping (using `api/test/integration/mapping/_test_mapping.py`).

--- a/.github/ISSUE_TEMPLATE/api-integration-tests.md
+++ b/.github/ISSUE_TEMPLATE/api-integration-tests.md
@@ -1,5 +1,5 @@
 ---
-name: API integration tests 
+name: [Release Candidate] API integration tests 
 about: Report the results after running API integration tests.
 title: 'Release [WAZUH VERSION] - Release Candidate [RC VERSION] - API integration tests'
 labels: 'API, qa'

--- a/.github/ISSUE_TEMPLATE/footprint_metrics.md
+++ b/.github/ISSUE_TEMPLATE/footprint_metrics.md
@@ -1,5 +1,5 @@
 ---
-name: Footprint metrics 
+name: [Release Candidate] Footprint metrics 
 about: Report the results after obtaining footprint metrics.
 title: 'Release [WAZUH VERSION] - Release Candidate [RC VERSION] - Footprint metrics'
 labels: 'cicd'

--- a/.github/ISSUE_TEMPLATE/python-unit-tests.md
+++ b/.github/ISSUE_TEMPLATE/python-unit-tests.md
@@ -1,5 +1,5 @@
 ---
-name: Python unit tests 
+name: [Release Candidate] Python unit tests 
 about: Report the results after running Python unit tests.
 title: 'Release [WAZUH VERSION] - Release Candidate [RC VERSION] - Python unit tests'
 labels: 'API, framework, qa'

--- a/.github/ISSUE_TEMPLATE/release-manual-tests.md
+++ b/.github/ISSUE_TEMPLATE/release-manual-tests.md
@@ -1,5 +1,5 @@
 ---
-name: Release manual tests 
+name: [Release Candidate] Manual tests 
 about: Report the results after running manual tests for the specified release.
 title: 'Release [WAZUH VERSION] - Manual tests - [TEST NAME]'
 labels: 'release/4.3.0, type/manual-testing'

--- a/.github/ISSUE_TEMPLATE/system-tests.md
+++ b/.github/ISSUE_TEMPLATE/system-tests.md
@@ -1,8 +1,8 @@
 ---
-name: System tests 
+name: [Release Candidate] System tests 
 about: Report the results after running system tests.
 title: 'Release [WAZUH VERSION] - Release Candidate [RC VERSION] - System tests'
-labels: 'cluster, qa, RBAC'
+labels: 'module/cluster, module/rbac'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/workload-benchmarks-metrics.md
+++ b/.github/ISSUE_TEMPLATE/workload-benchmarks-metrics.md
@@ -1,5 +1,5 @@
 ---
-name: Workload benchmarks metrics 
+name: [Release Candidate] Workload benchmarks metrics 
 about: Report the workload benchmarks metrics.
 title: 'Release [WAZUH VERSION] - Release Candidate [RC VERSION] - Workload benchmarks metrics'
 labels: 'API, cluster, qa'

--- a/.github/ISSUE_TEMPLATE/wpk-upgrade-tests.md
+++ b/.github/ISSUE_TEMPLATE/wpk-upgrade-tests.md
@@ -1,5 +1,5 @@
 ---
-name: WPK upgrade tests 
+name: [Release Candidate] WPK upgrade tests 
 about: Report the results after upgrade agent via WPK.
 title: 'Release [WAZUH VERSION] - Release Candidate [RC VERSION] - WPK upgrade tests'
 labels: 'WPK, core'


### PR DESCRIPTION
|Related issue|
|---|
| Closes #13882 |

## Description

This PR updates the API/Framework issue template as requested in #13882. It now looks like this:
![image](https://user-images.githubusercontent.com/23361101/179531955-69c50504-866e-4ff4-a93f-c9d483b6685b.png)

It also adds `[Release Candidate]` in the name of every RC-related template.

