### PR TITLE
Fix for building unit tests

### DIFF
--- a/src/syscheckd/src/db/src/fimDB.cpp
+++ b/src/syscheckd/src/db/src/fimDB.cpp
@@ -58,6 +58,7 @@ void FIMDB::syncAlgorithm()
             snprintf(debugmsg, 1024, "Previous sync was successful. Sync interval is reset to: '%ds'", m_currentSyncInterval);
             m_loggingFunction(LOG_DEBUG_VERBOSE, debugmsg);
         }
+
         m_syncSuccessful = true;
 
         sync();

--- a/src/syscheckd/src/db/tests/db/ComponentTest/fileInterface/CMakeLists.txt
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/fileInterface/CMakeLists.txt
@@ -19,9 +19,9 @@ file(GLOB FILE_SRC
     "${SRC_FOLDER}/syscheckd/src/db/src/dbFileItem.cpp")
 
 file(GLOB FIMDB_SRC
-     "${SRC_FOLDER}/syscheckd/src/db/src/fimDB.cpp")
+    "${SRC_FOLDER}/syscheckd/src/db/src/fimDB.cpp")
 
- file(GLOB RSYNC_IMP_SRC
+file(GLOB RSYNC_IMP_SRC
     "${SRC_FOLDER}/shared_modules/rsync/src/*.cpp")
 
 file(GLOB DBSYNC_IMP_SRC

--- a/src/syscheckd/src/db/tests/db/dbItem/FileItem/CMakeLists.txt
+++ b/src/syscheckd/src/db/tests/db/dbItem/FileItem/CMakeLists.txt
@@ -7,7 +7,18 @@ set(CMAKE_CXX_FLAGS_DEBUG "-g --coverage")
 file(GLOB fileitem_UNIT_TEST_SRC
     "*.cpp")
 
+include_directories(${SRC_FOLDER}/shared_modules/dbsync/include/)
+include_directories(${SRC_FOLDER}/shared_modules/rsync/include/)
+include_directories(${SRC_FOLDER}/shared_modules/dbsync/src/)
+
 file(GLOB FILEITEM_SRC "${SRC_FOLDER}/syscheckd/src/db/src/dbFileItem.cpp")
+
+file(GLOB RSYNC_IMP_SRC
+    "${SRC_FOLDER}/shared_modules/rsync/src/*.cpp")
+
+file(GLOB DBSYNC_IMP_SRC
+    "${SRC_FOLDER}/shared_modules/dbsync/src/*.cpp"
+    "${SRC_FOLDER}/shared_modules/dbsync/src/sqlite/*.cpp")
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     file(GLOB WINDOWS_FILEITEM_SRC "${SRC_FOLDER}/syscheckd/src/db/src/fimDBSpecializationWindows.cpp")
@@ -16,7 +27,9 @@ endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 add_executable(fileitem_unit_test
     ${fileitem_UNIT_TEST_SRC}
     ${FILEITEM_SRC}
-    ${WINDOWS_FILEITEM_SRC})
+    ${WINDOWS_FILEITEM_SRC}
+    ${RSYNC_IMP_SRC}
+    ${DBSYNC_IMP_SRC})
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     target_link_libraries(fileitem_unit_test
@@ -31,9 +44,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         pthread
         sqlite3
         cjson
+        crypto
+        ws2_32
+        crypt32
         -static-libgcc -static-libstdc++
-        rsync
-        dbsync
     )
 else()
     target_link_libraries(fileitem_unit_test
@@ -47,10 +61,9 @@ else()
         optimized gmock_main
         pthread
         sqlite3
+        crypto
         cjson
         dl
-        rsync
-        dbsync
     )
 endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 

--- a/src/syscheckd/src/db/tests/db/dbItem/RegistryKey/CMakeLists.txt
+++ b/src/syscheckd/src/db/tests/db/dbItem/RegistryKey/CMakeLists.txt
@@ -7,7 +7,18 @@ set(CMAKE_CXX_FLAGS_DEBUG "-g --coverage")
 file(GLOB registrykey_UNIT_TEST_SRC
     "*.cpp")
 
+include_directories(${SRC_FOLDER}/shared_modules/dbsync/include/)
+include_directories(${SRC_FOLDER}/shared_modules/rsync/include/)
+include_directories(${SRC_FOLDER}/shared_modules/dbsync/src/)
+
 file(GLOB REGISTRYKEY_SRC "${SRC_FOLDER}/syscheckd/src/db/src/dbRegistryKey.cpp")
+
+file(GLOB RSYNC_IMP_SRC
+    "${SRC_FOLDER}/shared_modules/rsync/src/*.cpp")
+
+file(GLOB DBSYNC_IMP_SRC
+    "${SRC_FOLDER}/shared_modules/dbsync/src/*.cpp"
+    "${SRC_FOLDER}/shared_modules/dbsync/src/sqlite/*.cpp")
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     file(GLOB WINDOWS_REGISTRYKEY_SRC "${SRC_FOLDER}/syscheckd/src/db/src/fimDBSpecializationWindows.cpp")
@@ -16,7 +27,9 @@ endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 add_executable(registrykey_unit_test
     ${registrykey_UNIT_TEST_SRC}
     ${REGISTRYKEY_SRC}
-    ${WINDOWS_REGISTRYKEY_SRC})
+    ${WINDOWS_REGISTRYKEY_SRC}
+    ${RSYNC_IMP_SRC}
+    ${DBSYNC_IMP_SRC})
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     target_link_libraries(registrykey_unit_test
@@ -34,8 +47,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         crypto
         ws2_32
         crypt32
-        rsync
-        dbsync
         -static-libgcc -static-libstdc++
     )
 else()
@@ -52,9 +63,6 @@ else()
         sqlite3
         cjson
         crypto
-        ssl
-        rsync
-        dbsync
         dl
     )
 endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")

--- a/src/syscheckd/src/db/tests/db/dbItem/RegistryValue/CMakeLists.txt
+++ b/src/syscheckd/src/db/tests/db/dbItem/RegistryValue/CMakeLists.txt
@@ -7,7 +7,18 @@ set(CMAKE_CXX_FLAGS_DEBUG "-g --coverage")
 file(GLOB registryvalue_UNIT_TEST_SRC
     "*.cpp")
 
+include_directories(${SRC_FOLDER}/shared_modules/dbsync/include/)
+include_directories(${SRC_FOLDER}/shared_modules/rsync/include/)
+include_directories(${SRC_FOLDER}/shared_modules/dbsync/src/)
+
 file(GLOB REGISTRYVALUE_SRC "${SRC_FOLDER}/syscheckd/src/db/src/dbRegistryValue.cpp")
+
+file(GLOB RSYNC_IMP_SRC
+    "${SRC_FOLDER}/shared_modules/rsync/src/*.cpp")
+
+file(GLOB DBSYNC_IMP_SRC
+    "${SRC_FOLDER}/shared_modules/dbsync/src/*.cpp"
+    "${SRC_FOLDER}/shared_modules/dbsync/src/sqlite/*.cpp")
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     file(GLOB WINDOWS_REGISTRYVALUE_SRC "${SRC_FOLDER}/syscheckd/src/db/src/fimDBSpecializationWindows.cpp")
@@ -16,7 +27,9 @@ endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 add_executable(registryvalue_unit_test
     ${registryvalue_UNIT_TEST_SRC}
     ${REGISTRYVALUE_SRC}
-    ${WINDOWS_REGISTRYVALUE_SRC})
+    ${WINDOWS_REGISTRYVALUE_SRC}
+    ${RSYNC_IMP_SRC}
+    ${DBSYNC_IMP_SRC})
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     target_link_libraries(registryvalue_unit_test
@@ -35,8 +48,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         ws2_32
         crypt32
         -static-libgcc -static-libstdc++
-        rsync
-        dbsync
     )
 else()
     target_link_libraries(registryvalue_unit_test
@@ -52,10 +63,7 @@ else()
         sqlite3
         cjson
         crypto
-        ssl
         dl
-        rsync
-        dbsync
     )
 endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 


### PR DESCRIPTION
|EPIC|Component|
|---|---|
| https://github.com/wazuh/wazuh/issues/9103 | FIM |

### Description
Hi team, this pull-request is to fix unit tests that change how these unit tests are building if we add dbsync and rsync inside some tests these libraries have libraries that are breaking unit tests

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Unit tests passed
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] cppcheck (static code analysis)
  - [x] Coverage (unit tests coverage code)
  - [x] Sformat (code style)
  - [x] Scan build