### PR TITLE
Avoid scan-build error on github module

### DIFF
--- a/src/wazuh_modules/wm_github.c
+++ b/src/wazuh_modules/wm_github.c
@@ -363,10 +363,8 @@ STATIC void wm_github_execute_scan(wm_github *github_config, int initial_scan) {
 
                     if (org_fail = wm_github_get_fail_by_org_and_type(github_config->fails,
                         current->org_name, event_types[event_types_it]), org_fail && org_fail->fails) {
-                        #ifndef __clang_analyzer__
                         mtinfo(WM_GITHUB_LOGTAG, "Github organization '%s' and event type '%s', connected successfully.",
                             current->org_name, event_types[event_types_it]);
-                        #endif
                         org_fail->fails = 0;
                     }
                 }
@@ -392,7 +390,7 @@ STATIC wm_github_fail* wm_github_get_fail_by_org_and_type(wm_github_fail *fails,
             continue;
         }
 
-        if (!strncmp(current->org_name, org_name, strlen(org_name)) && ((!event_type && !current->event_type) ||
+        if (!strncmp(current->org_name, org_name, strlen(org_name)) && (!current->event_type ||
             (event_type && current->event_type && !strncmp(current->event_type, event_type, strlen(event_type))))) {
             target_org = 1;
         } else {

--- a/src/wazuh_modules/wm_github.c
+++ b/src/wazuh_modules/wm_github.c
@@ -363,8 +363,10 @@ STATIC void wm_github_execute_scan(wm_github *github_config, int initial_scan) {
 
                     if (org_fail = wm_github_get_fail_by_org_and_type(github_config->fails,
                         current->org_name, event_types[event_types_it]), org_fail && org_fail->fails) {
+                        #ifndef __clang_analyzer__
                         mtinfo(WM_GITHUB_LOGTAG, "Github organization '%s' and event type '%s', connected successfully.",
                             current->org_name, event_types[event_types_it]);
+                        #endif
                         org_fail->fails = 0;
                     }
                 }


### PR DESCRIPTION
|Related issue|Manual testing|
|---|---|
|https://github.com/wazuh/wazuh/issues/14194| https://github.com/wazuh/wazuh-qa/issues/3123|

## Description
Scan build tool reports a fail with message `Argument with 'nonnull' attribute passed null`,  but it's a false positive. The goal of this PR is avoid wm_github bug reported by scan-build.

## Build process with scan-build
```shellsession
scan-build make TARGET=server -j4
```

## Logs example

### 🔴 Running scan-build before apply fix:
```shellsession
wazuh_modules/wm_github.c:367:25: warning: Null pointer passed to 7th parameter expecting 'nonnull'
                        mtinfo(WM_GITHUB_LOGTAG, "Github organization '%s' and event type '%s', connected successfully.",
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./headers/debug_op.h:50:31: note: expanded from macro 'mtinfo'
#define mtinfo(tag, msg, ...) _mtinfo(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```

```shellsession
Done building server

scan-build: 1 bug found.
scan-build: Run 'scan-view /tmp/scan-build-2022-07-20-092245-13925-1' to examine bug reports.
```

### 🟢 Running scan-build with the fix:
```shellsession
Done building server

scan-build: Removing directory '/tmp/scan-build-2022-07-20-111904-15906-1' because it contains no reports.
scan-build: No bugs found.
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
