### PR TITLE
Add `GET /manager/daemons/stats` and `GET /cluster/{node_id}/daemons/stats`

### DIFF
--- a/api/api/controllers/cluster_controller.py
+++ b/api/api/controllers/cluster_controller.py
@@ -391,7 +391,7 @@ async def get_stats_analysisd_node(request, node_id, pretty=False, wait_for_comp
                 'filename': common.ANALYSISD_STATS}
 
     nodes = raise_if_exc(await get_system_nodes())
-    dapi = DistributedAPI(f=stats.get_daemons_stats,
+    dapi = DistributedAPI(f=stats.deprecated_get_daemons_stats,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
                           request_type='distributed_master',
                           is_async=False,
@@ -416,7 +416,7 @@ async def get_stats_remoted_node(request, node_id, pretty=False, wait_for_comple
                 'filename': common.REMOTED_STATS}
 
     nodes = raise_if_exc(await get_system_nodes())
-    dapi = DistributedAPI(f=stats.get_daemons_stats,
+    dapi = DistributedAPI(f=stats.deprecated_get_daemons_stats,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
                           request_type='distributed_master',
                           is_async=False,

--- a/api/api/controllers/manager_controller.py
+++ b/api/api/controllers/manager_controller.py
@@ -108,6 +108,33 @@ async def get_configuration(request, pretty=False, wait_for_complete=False, sect
     return response
 
 
+async def get_daemon_stats(request, pretty: bool = False, wait_for_complete: bool = False, daemons_list: list = None):
+    """Get Wazuh statistical information from the specified manager's daemons.
+
+    Parameters
+    ----------
+    pretty : bool
+        Show results in human-readable format.
+    wait_for_complete : bool
+        Disable timeout response.
+    daemons_list : list
+        List of the daemons to get statistical information from.
+    """
+    daemons_list = daemons_list or []
+    f_kwargs = {'daemons_list': daemons_list}
+
+    dapi = DistributedAPI(f=stats.get_daemons_stats,
+                          f_kwargs=remove_nones_to_dict(f_kwargs),
+                          request_type='local_any',
+                          is_async=False,
+                          wait_for_complete=wait_for_complete,
+                          logger=logger,
+                          rbac_permissions=request['token_info']['rbac_policies'])
+    data = raise_if_exc(await dapi.distribute_function())
+
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
+
+
 async def get_stats(request, pretty=False, wait_for_complete=False, date=None):
     """Get manager's or local_node's stats.
 
@@ -193,7 +220,7 @@ async def get_stats_analysisd(request, pretty=False, wait_for_complete=False):
     """
     f_kwargs = {'filename': common.ANALYSISD_STATS}
 
-    dapi = DistributedAPI(f=stats.get_daemons_stats,
+    dapi = DistributedAPI(f=stats.deprecated_get_daemons_stats,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
                           request_type='local_any',
                           is_async=False,
@@ -214,7 +241,7 @@ async def get_stats_remoted(request, pretty=False, wait_for_complete=False):
     """
     f_kwargs = {'filename': common.REMOTED_STATS}
 
-    dapi = DistributedAPI(f=stats.get_daemons_stats,
+    dapi = DistributedAPI(f=stats.deprecated_get_daemons_stats,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
                           request_type='local_any',
                           is_async=False,

--- a/api/api/controllers/test/test_cluster_controller.py
+++ b/api/api/controllers/test/test_cluster_controller.py
@@ -14,11 +14,12 @@ with patch('wazuh.common.wazuh_uid'):
             get_api_config, get_cluster_node, get_cluster_nodes,
             get_conf_validation, get_config, get_configuration_node,
             get_healthcheck, get_info_node, get_log_node, get_log_summary_node,
-            get_node_config, get_stats_analysisd_node, get_stats_hourly_node,
+            get_node_config, get_stats_analysisd_node, get_stats_hourly_node, get_daemon_stats_node,
             get_stats_node, get_stats_remoted_node, get_stats_weekly_node,
             get_status, get_status_node, put_restart, update_configuration)
         from wazuh import cluster, common, manager, stats
         from wazuh.tests.util import RBAC_bypasser
+
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser
         del sys.modules['wazuh.rbac.orm']
 
@@ -255,6 +256,36 @@ async def test_get_configuration_node(mock_exc, mock_dapi, mock_remove, mock_dfu
 @patch('api.controllers.cluster_controller.remove_nones_to_dict')
 @patch('api.controllers.cluster_controller.DistributedAPI.__init__', return_value=None)
 @patch('api.controllers.cluster_controller.raise_if_exc', return_value=CustomAffectedItems())
+async def test_get_daemon_stats_node(mock_exc, mock_dapi, mock_remove, mock_dfunc):
+    """Verify 'get_daemon_stats_node' function is working as expected."""
+    mock_request = MagicMock()
+    with patch('api.controllers.cluster_controller.get_system_nodes', return_value=AsyncMock()) as mock_snodes:
+        result = await get_daemon_stats_node(request=mock_request,
+                                             node_id='worker1',
+                                             daemons_list=['daemon_1', 'daemon_2'])
+
+        f_kwargs = {'node_id': 'worker1',
+                    'daemons_list': ['daemon_1', 'daemon_2']}
+        mock_dapi.assert_called_once_with(f=stats.get_daemons_stats,
+                                          f_kwargs=mock_remove.return_value,
+                                          request_type='distributed_master',
+                                          is_async=False,
+                                          wait_for_complete=False,
+                                          logger=ANY,
+                                          rbac_permissions=mock_request['token_info']['rbac_policies'],
+                                          nodes=mock_exc.return_value)
+        mock_remove.assert_called_once_with(f_kwargs)
+        mock_exc.assert_has_calls([call(mock_snodes.return_value), call(mock_dfunc.return_value)])
+        assert mock_exc.call_count == 2
+
+        assert isinstance(result, web_response.Response)
+
+
+@pytest.mark.asyncio
+@patch('api.controllers.cluster_controller.DistributedAPI.distribute_function', return_value=AsyncMock())
+@patch('api.controllers.cluster_controller.remove_nones_to_dict')
+@patch('api.controllers.cluster_controller.DistributedAPI.__init__', return_value=None)
+@patch('api.controllers.cluster_controller.raise_if_exc', return_value=CustomAffectedItems())
 @pytest.mark.parametrize('mock_date', [None, 'date_value'])
 async def test_get_stats_node(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_date, mock_request=MagicMock()):
     """Verify 'get_stats_node' endpoint is working as expected."""
@@ -356,7 +387,7 @@ async def test_get_stats_analysisd_node(mock_exc, mock_dapi, mock_remove, mock_d
         f_kwargs = {'node_id': '001',
                     'filename': common.ANALYSISD_STATS
                     }
-        mock_dapi.assert_called_once_with(f=stats.get_daemons_stats,
+        mock_dapi.assert_called_once_with(f=stats.deprecated_get_daemons_stats,
                                           f_kwargs=mock_remove.return_value,
                                           request_type='distributed_master',
                                           is_async=False,
@@ -385,7 +416,7 @@ async def test_get_stats_remoted_node(mock_exc, mock_dapi, mock_remove, mock_dfu
         f_kwargs = {'node_id': '001',
                     'filename': common.REMOTED_STATS
                     }
-        mock_dapi.assert_called_once_with(f=stats.get_daemons_stats,
+        mock_dapi.assert_called_once_with(f=stats.deprecated_get_daemons_stats,
                                           f_kwargs=mock_remove.return_value,
                                           request_type='distributed_master',
                                           is_async=False,

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1522,6 +1522,11 @@ components:
       description: "Agent ID|all"
       format: numbers_or_all
 
+    DaemonName:
+      type: string
+      description: "Daemon name"
+      format: daemon_names
+
     NodeID:
       type: string
       description: "Node ID"
@@ -3796,6 +3801,14 @@ components:
       schema:
         type: string
         format: alphanumeric
+    daemons_list:
+      in: query
+      name: daemons_list
+      description: "List of daemon names (separated by comma), all daemons selected by default if not specified"
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/DaemonName'
     decoder_name:
       in: query
       name: decoder_names
@@ -8639,6 +8652,76 @@ paths:
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
+  /cluster/{node_id}/daemon_stats:
+    get:
+      tags:
+        - Cluster
+      summary: "Get Wazuh daemon stats from a cluster node"
+      description: "Return Wazuh statistical information from specified daemons in a specified cluster node"
+      operationId: api.controllers.cluster_controller.get_daemon_stats_node
+      x-rbac-actions:
+        - $ref: '#/x-rbac-catalog/actions/cluster:read'
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/node_id'
+        - $ref: '#/components/parameters/daemons_list'
+      responses:
+        '200':
+          description: "Wazuh daemon stats"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/AllItemsResponseWazuhStats'
+              example:
+                data:
+                  affected_items:
+                    - hour: 15
+                      alerts:
+                        - sigid: 5303
+                          level: 3
+                          times: 1
+                        - sigid: 5501
+                          level: 3
+                          times: 4
+                        - sigid: 221
+                          level: 0
+                          times: 653
+                      totalAlerts: 658
+                      events: 4387
+                      firewall: 0
+                    - hour: 16
+                      alerts:
+                        - sigid: 5521
+                          level: 0
+                          times: 1
+                        - sigid: 530
+                          level: 0
+                          times: 120
+                      totalAlerts: 121
+                      events: 4379
+                      syscheck: 0
+                      firewall: 0
+                  total_affected_items: 2
+                  failed_items: [ ]
+                  total_failed_items: 0
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+
+
   /cluster/{node_id}/stats:
     get:
       tags:
@@ -10056,6 +10139,74 @@ paths:
           $ref: '#/components/responses/WrongContentTypeResponse'
         '413':
           $ref: '#/components/responses/RequestTooLargeResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+
+  /manager/daemon_stats:
+    get:
+      tags:
+      - Manager
+      summary: "Get Wazuh daemon stats"
+      description: "Return Wazuh statistical information from specified daemons"
+      operationId: api.controllers.manager_controller.get_daemon_stats
+      x-rbac-actions:
+        - $ref: '#/x-rbac-catalog/actions/manager:read'
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/daemons_list'
+      responses:
+        '200':
+          description: "Wazuh daemon stats"
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/ApiResponse'
+                - type: object
+                  properties:
+                    data:
+                      $ref: '#/components/schemas/AllItemsResponseWazuhStats'
+              example:
+                data:
+                  affected_items:
+                    - hour: 15
+                      alerts:
+                        - sigid: 5303
+                          level: 3
+                          times: 1
+                        - sigid: 5501
+                          level: 3
+                          times: 4
+                        - sigid: 221
+                          level: 0
+                          times: 653
+                      totalAlerts: 658
+                      events: 4387
+                      firewall: 0
+                    - hour: 16
+                      alerts:
+                        - sigid: 5521
+                          level: 0
+                          times: 1
+                        - sigid: 530
+                          level: 0
+                          times: 120
+                      totalAlerts: 121
+                      events: 4379
+                      syscheck: 0
+                      firewall: 0
+                  total_affected_items: 2
+                  failed_items: []
+                  total_failed_items: 0
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -791,6 +791,19 @@ components:
               items:
                 $ref: '#/components/schemas/AgentDistinct'
 
+    AllItemsResponseWazuhDaemonStats:
+      allOf:
+        - type: object
+          required:
+            - affected_items
+          properties:
+            affected_items:
+              type: array
+              description: "Items that successfully applied the API call action"
+              items:
+                $ref: '#/components/schemas/WazuhDaemonStatsItem'
+        - $ref: '#/components/schemas/AllItemsResponse'
+
     AllItemsResponseGroups:
       allOf:
         - type: object
@@ -2003,6 +2016,17 @@ components:
           description: "User's JWT token"
 
     # Cluster and manager models
+    WazuhDaemonStatsItem:
+      type: object
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+        name:
+          $ref: '#/components/schemas/DaemonName'
+        statistics:
+          type: object
+
     WazuhDaemonsStatus:
       type: object
       properties:
@@ -8677,38 +8701,42 @@ paths:
                   - type: object
                     properties:
                       data:
-                        $ref: '#/components/schemas/AllItemsResponseWazuhStats'
+                        $ref: '#/components/schemas/AllItemsResponseWazuhDaemonStats'
               example:
                 data:
                   affected_items:
-                    - hour: 15
-                      alerts:
-                        - sigid: 5303
-                          level: 3
-                          times: 1
-                        - sigid: 5501
-                          level: 3
-                          times: 4
-                        - sigid: 221
-                          level: 0
-                          times: 653
-                      totalAlerts: 658
-                      events: 4387
-                      firewall: 0
-                    - hour: 16
-                      alerts:
-                        - sigid: 5521
-                          level: 0
-                          times: 1
-                        - sigid: 530
-                          level: 0
-                          times: 120
-                      totalAlerts: 121
-                      events: 4379
-                      syscheck: 0
-                      firewall: 0
-                  total_affected_items: 2
-                  failed_items: [ ]
+                    - timestamp: 2022-07-21T10:48:32+00:00
+                      name: wazuh-remoted
+                      statistics:
+                        tcp_sessions: 0
+                        received_bytes: 0
+                        messages_received_breakdown:
+                          event_messages: 0
+                          control_messages: 0
+                          control_breakdown:
+                            request_messages: 0
+                            startup_messages: 0
+                            shutdown_messages: 0
+                            keepalive_messages: 0
+                          ping_messages: 0
+                          unknown_messages: 0
+                          dequeued_after_close_messages: 0
+                          discarded_messages: 0
+                        sent_bytes: 0
+                        messages_sent_breakdown:
+                          ack_messages: 0
+                          shared_file_messages: 0
+                          ar_messages: 0
+                          cfga_messages: 0
+                          request_messages: 0
+                          discarded_messages: 0
+                        queue_status:
+                          receive_queue_usage: 0
+                          receive_queue_size: 131072
+                        keys_reload_count: 0
+                        update_shared_files_count: 42
+                  total_affected_items: 1
+                  failed_items: []
                   total_failed_items: 0
         '400':
           $ref: '#/components/responses/ResponseError'
@@ -10166,37 +10194,212 @@ paths:
                 - type: object
                   properties:
                     data:
-                      $ref: '#/components/schemas/AllItemsResponseWazuhStats'
+                      $ref: '#/components/schemas/AllItemsResponseWazuhDaemonStats'
               example:
                 data:
                   affected_items:
-                    - hour: 15
-                      alerts:
-                        - sigid: 5303
-                          level: 3
-                          times: 1
-                        - sigid: 5501
-                          level: 3
-                          times: 4
-                        - sigid: 221
-                          level: 0
-                          times: 653
-                      totalAlerts: 658
-                      events: 4387
-                      firewall: 0
-                    - hour: 16
-                      alerts:
-                        - sigid: 5521
-                          level: 0
-                          times: 1
-                        - sigid: 530
-                          level: 0
-                          times: 120
-                      totalAlerts: 121
-                      events: 4379
-                      syscheck: 0
-                      firewall: 0
-                  total_affected_items: 2
+                    - timestamp: 2022-07-21T10:47:59+00:00
+                      name: wazuh-db
+                      statistics:
+                        queries_total: 1514
+                        queries_breakdown:
+                          wazuhdb_queries: 0
+                          wazuhdb_queries_breakdown:
+                            remove_queries: 0
+                            unknown_queries: 0
+                          agent_queries: 73
+                          agent_queries_breakdown:
+                            sql_queries: 0
+                            remove_queries: 0
+                            begin_queries: 0
+                            commit_queries: 0
+                            close_queries: 0
+                            syscheck_queries:
+                              syscheck_queries: 2
+                              fim_file_queries: 2
+                              fim_registry_queries: 0
+                            rootcheck_queries:
+                              rootcheck_queries: 2
+                            sca_queries:
+                              sca_queries: 6
+                            ciscat_queries:
+                              ciscat_queries: 0
+                            syscollector_queries:
+                              syscollector_processes_queries: 36
+                              syscollector_packages_queries: 1
+                              syscollector_hotfixes_queries: 0
+                              syscollector_ports_queries: 16
+                              syscollector_network_protocol_queries: 1
+                              syscollector_network_address_queries: 1
+                              syscollector_network_iface_queries: 2
+                              syscollector_hwinfo_queries: 2
+                              syscollector_osinfo_queries: 2
+                              process_queries: 0
+                              package_queries: 0
+                              hotfix_queries: 0
+                              port_queries: 0
+                              netproto_queries: 0
+                              netaddr_queries: 0
+                              netinfo_queries: 0
+                              hardware_queries: 0
+                              osinfo_queries: 0
+                            vulnerability_detector_queries:
+                              vuln_cves_queries: 0
+                            dbsync_queries: 0
+                            unknown_queries: 0
+                          global_queries: 161
+                          global_queries_breakdown:
+                            sql_queries: 0
+                            backup_queries: 0
+                            agent_queries: {
+                              insert-agent_queries: 1
+                              update-agent-data_queries: 1
+                              update-agent-name_queries: 1
+                              update-keepalive_queries: 0
+                              update-connection-status_queries: 0
+                              reset-agents-connection_queries: 1
+                              delete-agent_queries: 0
+                              select-agent-name_queries: 2
+                              select-agent-group_queries: 1
+                              select-keepalive_queries: 0
+                              find-agent_queries: 0
+                              get-agent-info_queries: 39
+                              get-all-agents_queries: 40
+                              get-agents-by-connection-status_queries: 0
+                              disconnect-agents_queries: 0
+                              sync-agent-info-get_queries: 0
+                              sync-agent-info-set_queries: 37
+                              sync-agent-groups-get_queries: 36
+                              set-agent-groups_queries: 0
+                              get-groups-integrity_queries: 0
+                            group_queries:
+                              insert-agent-group_queries: 0
+                              delete-group_queries: 0
+                              select-groups_queries: 1
+                              find-group_queries: 1
+                            belongs_queries:
+                              delete-agent-belong_queries: 0
+                              select-group-belong_queries: 0
+                              get-group-agents_queries: 0
+                            labels_queries:
+                              set-labels_queries: 0
+                              get-labels_queries: 0
+                            unknown_queries: 0
+                          task_queries: 3
+                          task_queries_breakdown:
+                            sql_queries: 0
+                            upgrade_queries:
+                              upgrade_queries: 0
+                              upgrade_custom_queries: 0
+                              upgrade_get_status_queries: 0
+                              upgrade_update_status_queries: 0
+                              upgrade_result_queries: 0
+                              upgrade_cancel_tasks_queries: 1
+                            set_timeout_queries: 1
+                            delete_old_queries: 1
+                            unknown_queries: 0
+                          mitre_queries: 1277
+                          mitre_queries_breakdown:
+                            sql_queries: 1277
+                            unknown_queries: 0
+                          unknown_queries: 0
+                        queries_time_total: 493
+                        queries_time_breakdown:
+                          wazuhdb_time: 0
+                          wazuhdb_time_breakdown:
+                            remove_time: 0
+                          agent_time: 351
+                          agent_time_breakdown:
+                            sql_time: 0
+                            remove_time: 0
+                            begin_time: 0
+                            commit_time: 0
+                            close_time: 0
+                            syscheck_time:
+                              syscheck_time: 49
+                              fim_file_time: 30
+                              fim_registry_time: 0
+                            rootcheck_time:
+                              rootcheck_time: 47
+                            sca_time:
+                              sca_time: 0
+                            ciscat_time:
+                              ciscat_time: 0
+                            syscollector_time:
+                              syscollector_processes_time: 17
+                              syscollector_packages_time: 33
+                              syscollector_hotfixes_time: 0
+                              syscollector_ports_time: 47
+                              syscollector_network_protocol_time: 27
+                              syscollector_network_address_time: 26
+                              syscollector_network_iface_time: 21
+                              syscollector_hwinfo_time: 20
+                              syscollector_osinfo_time: 27
+                              process_time: 0
+                              package_time: 0
+                              hotfix_time: 0
+                              port_time: 0
+                              netproto_time: 0
+                              netaddr_time: 0
+                              netinfo_time: 0
+                              hardware_time: 0
+                              osinfo_time: 0
+                            vulnerability_detector_time:
+                              vuln_cves_time: 0
+                            dbsync_time: 0
+                          global_time: 14
+                          global_time_breakdown:
+                            sql_time: 0
+                            backup_time: 0
+                            agent_time:
+                              insert-agent_time: 0
+                              update-agent-data_time: 0
+                              update-agent-name_time: 0
+                              update-keepalive_time: 0
+                              update-connection-status_time: 0
+                              reset-agents-connection_time: 0
+                              delete-agent_time: 0
+                              select-agent-name_time: 0
+                              select-agent-group_time: 0
+                              select-keepalive_time: 0
+                              find-agent_time: 0
+                              get-agent-info_time: 2
+                              get-all-agents_time: 1
+                              get-agents-by-connection-status_time: 0
+                              disconnect-agents_time: 0
+                              sync-agent-info-get_time: 0
+                              sync-agent-info-set_time: 6
+                              sync-agent-groups-get_time: 2
+                              set-agent-groups_time: 0
+                              get-groups-integrity_time: 0
+                            group_time:
+                              insert-agent-group_time: 0
+                              delete-group_time: 0
+                              select-groups_time: 0
+                              find-group_time: 0
+                            belongs_time:
+                              delete-agent-belong_time: 0
+                              select-group-belong_time: 0
+                              get-group-agents_time: 0
+                            labels_time:
+                              set-labels_time: 0
+                              get-labels_time: 0
+                          task_time: 0
+                          task_time_breakdown:
+                            sql_time: 0
+                            upgrade_time:
+                              upgrade_time: 0
+                              upgrade_custom_time: 0
+                              upgrade_get_status_time: 0
+                              upgrade_update_status_time: 0
+                              upgrade_result_time: 0
+                              upgrade_cancel_tasks_time: 0
+                            set_timeout_time: 0
+                            delete_old_time: 0
+                          mitre_time: 128
+                          mitre_time_breakdown:
+                            sql_time: 128
+                  total_affected_items: 1
                   failed_items: []
                   total_failed_items: 0
         '400':

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -10251,7 +10251,7 @@ paths:
                           global_queries_breakdown:
                             sql_queries: 0
                             backup_queries: 0
-                            agent_queries: {
+                            agent_queries:
                               insert-agent_queries: 1
                               update-agent-data_queries: 1
                               update-agent-name_queries: 1

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1535,11 +1535,6 @@ components:
       description: "Agent ID|all"
       format: numbers_or_all
 
-    DaemonName:
-      type: string
-      description: "Daemon name"
-      format: daemon_names
-
     NodeID:
       type: string
       description: "Node ID"
@@ -2023,7 +2018,14 @@ components:
           type: string
           format: date-time
         name:
-          $ref: '#/components/schemas/DaemonName'
+          type: array
+          description: "Demon name"
+          items:
+            type: string
+            enum:
+              - wazuh-analysisd
+              - wazuh-remoted
+              - wazuh-db
         statistics:
           type: object
 
@@ -3832,7 +3834,11 @@ components:
       schema:
         type: array
         items:
-          $ref: '#/components/schemas/DaemonName'
+          type: string
+          enum:
+            - wazuh-analysisd
+            - wazuh-remoted
+            - wazuh-db
     decoder_name:
       in: query
       name: decoder_names

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2018,14 +2018,12 @@ components:
           type: string
           format: date-time
         name:
-          type: array
+          type: string
           description: "Demon name"
-          items:
-            type: string
-            enum:
-              - wazuh-analysisd
-              - wazuh-remoted
-              - wazuh-db
+          enum:
+            - wazuh-analysisd
+            - wazuh-remoted
+            - wazuh-db
         statistics:
           type: object
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -8680,7 +8680,7 @@ paths:
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
-  /cluster/{node_id}/daemon_stats:
+  /cluster/{node_id}/daemons/stats:
     get:
       tags:
         - Cluster
@@ -10174,7 +10174,7 @@ paths:
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
-  /manager/daemon_stats:
+  /manager/daemons/stats:
     get:
       tags:
       - Manager

--- a/api/api/test/test_validator.py
+++ b/api/api/test/test_validator.py
@@ -9,7 +9,7 @@ import jsonschema as js
 import pytest
 
 from api.validator import (check_exp, check_xml, _alphanumeric_param,
-                           _array_numbers, _array_names, _boolean, _dates, _empty_boolean, _hashes,
+                           _array_numbers, _array_names, _boolean, _dates, _daemon_names, _empty_boolean, _hashes,
                            _ips, _names, _numbers, _wazuh_key, _paths, _query_param, _ranges, _search_param,
                            _sort_param, _timeframe_type, _type_format, _yes_no_boolean, _get_dirnames_path,
                            allowed_fields, is_safe_path, _wazuh_version,
@@ -30,6 +30,9 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
     # names
     ('alphanumeric1_param2', _alphanumeric_param),
     ('file_%1,file_2,file-3', _array_names),
+    ('wazuh-remoted', _daemon_names),
+    ('wazuh-analysisd', _daemon_names),
+    ('wazuh-db', _daemon_names),
     ('file%1-test_name1', _names),
     ('[(Random_symbols-string123)],<>!.+:"\'|=~#', _symbols_alphanumeric_param),
     ('Group_name-2', _group_names),
@@ -102,6 +105,7 @@ def test_validation_check_exp_ok(exp, regex_name):
     ('alphanumeric1_$param2', _alphanumeric_param),
     ('file-$', _array_names),
     ('file_1$,file_2#,file-3', _array_names),
+    ('wrong-daemon', _daemon_names),
     ('all', _group_names),
     ('.', _group_names),
     ('..', _group_names),

--- a/api/api/test/test_validator.py
+++ b/api/api/test/test_validator.py
@@ -8,11 +8,10 @@ import os
 import jsonschema as js
 import pytest
 
-from api.validator import (check_exp, check_xml, _alphanumeric_param,
-                           _array_numbers, _array_names, _boolean, _dates, _daemon_names, _empty_boolean, _hashes,
-                           _ips, _names, _numbers, _wazuh_key, _paths, _query_param, _ranges, _search_param,
-                           _sort_param, _timeframe_type, _type_format, _yes_no_boolean, _get_dirnames_path,
-                           allowed_fields, is_safe_path, _wazuh_version,
+from api.validator import (check_exp, check_xml, _alphanumeric_param, _array_numbers, _array_names, _boolean, _dates,
+                           _empty_boolean, _hashes, _ips, _names, _numbers, _wazuh_key, _paths, _query_param, _ranges,
+                           _search_param, _sort_param, _timeframe_type, _type_format, _yes_no_boolean,
+                           _get_dirnames_path, allowed_fields, is_safe_path, _wazuh_version,
                            _symbols_alphanumeric_param, _base64, _group_names, _group_names_or_all, _iso8601_date,
                            _iso8601_date_time, _numbers_or_all, _cdb_filename_path, _xml_filename_path, _xml_filename)
 
@@ -30,9 +29,6 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
     # names
     ('alphanumeric1_param2', _alphanumeric_param),
     ('file_%1,file_2,file-3', _array_names),
-    ('wazuh-remoted', _daemon_names),
-    ('wazuh-analysisd', _daemon_names),
-    ('wazuh-db', _daemon_names),
     ('file%1-test_name1', _names),
     ('[(Random_symbols-string123)],<>!.+:"\'|=~#', _symbols_alphanumeric_param),
     ('Group_name-2', _group_names),
@@ -105,7 +101,6 @@ def test_validation_check_exp_ok(exp, regex_name):
     ('alphanumeric1_$param2', _alphanumeric_param),
     ('file-$', _array_names),
     ('file_1$,file_2#,file-3', _array_names),
-    ('wrong-daemon', _daemon_names),
     ('all', _group_names),
     ('.', _group_names),
     ('..', _group_names),

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -18,6 +18,7 @@ _array_names = re.compile(r'^[\w\-.%]+(,[\w\-.%]+)*$')
 _base64 = re.compile(r'^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$')
 _boolean = re.compile(r'^true$|^false$')
 _dates = re.compile(r'^\d{8}$')
+_daemon_names = re.compile(r'^wazuh-analysisd$|^wazuh-remoted$|^wazuh-db$')
 _empty_boolean = re.compile(r'^$|(^true$|^false$)')
 _group_names = re.compile(r'^(?!^(\.{1,2}|all)$)[\w.\-]+$')
 _group_names_or_all = re.compile(r'^(?!^\.{1,2}$)[\w.\-]+$')
@@ -356,6 +357,11 @@ def format_wazuh_key(value):
 @draft4_format_checker.checks("wazuh_version")
 def format_wazuh_version(value):
     return check_exp(value, _wazuh_version)
+
+
+@draft4_format_checker.checks("daemon_names")
+def format_daemon_names(value):
+    return check_exp(value, _daemon_names)
 
 
 @draft4_format_checker.checks("date")

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -18,7 +18,6 @@ _array_names = re.compile(r'^[\w\-.%]+(,[\w\-.%]+)*$')
 _base64 = re.compile(r'^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$')
 _boolean = re.compile(r'^true$|^false$')
 _dates = re.compile(r'^\d{8}$')
-_daemon_names = re.compile(r'^wazuh-analysisd$|^wazuh-remoted$|^wazuh-db$')
 _empty_boolean = re.compile(r'^$|(^true$|^false$)')
 _group_names = re.compile(r'^(?!^(\.{1,2}|all)$)[\w.\-]+$')
 _group_names_or_all = re.compile(r'^(?!^\.{1,2}$)[\w.\-]+$')
@@ -357,11 +356,6 @@ def format_wazuh_key(value):
 @draft4_format_checker.checks("wazuh_version")
 def format_wazuh_version(value):
     return check_exp(value, _wazuh_version)
-
-
-@draft4_format_checker.checks("daemon_names")
-def format_daemon_names(value):
-    return check_exp(value, _daemon_names)
 
 
 @draft4_format_checker.checks("date")

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -1667,6 +1667,98 @@ stages:
         message: !anystr
 
 ---
+test_name: GET /cluster/{node_id}/daemon_stats
+
+marks:
+  - cluster
+  - parametrize:
+      key: node_id
+      vals:
+        - master-node
+        - worker1
+        - worker2
+
+stages:
+
+  # GET /cluster/{node_id}/daemon_stats
+  - name: Get all daemons' statistics from {node_id}
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/daemon_stats"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - name: wazuh-remoted
+            - name: wazuh-analysisd
+            - name: wazuh-db
+          total_affected_items: 3
+          failed_items: []
+          total_failed_items: 0
+
+  # GET /cluster/{node_id}/daemon_stats?daemons_list=wazuh-remoted
+  - name: Get statistics from a single daemon from {node_id}
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/daemon_stats"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        daemons_list: wazuh-remoted
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - name: wazuh-remoted
+          total_affected_items: 1
+          failed_items: []
+          total_failed_items: 0
+
+  # GET /cluster/{node_id}/daemon_stats?daemons_list=wazuh-remoted,wazuh-db,wazuh-analysisd
+  - name: Get statistics from a list of daemons from {node_id}
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/daemon_stats"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        daemons_list: wazuh-remoted,wazuh-db,wazuh-analysisd
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - name: wazuh-remoted
+            - name: wazuh-db
+            - name: wazuh-analysisd
+          total_affected_items: 3
+          failed_items: []
+          total_failed_items: 0
+
+  # GET /cluster/{node_id}/daemon_stats?daemons_list=wrong-daemon-name
+  - name: Try to get statistics from a wrong daemon from {node_id}
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/daemon_stats"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        daemons_list: wrong-daemon-name
+    response:
+      status_code: 400
+
+---
 test_name: GET /cluster/{node_id}/stats
 
 marks:

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -1667,7 +1667,7 @@ stages:
         message: !anystr
 
 ---
-test_name: GET /cluster/{node_id}/daemon_stats
+test_name: GET /cluster/{node_id}/daemons/stats
 
 marks:
   - cluster
@@ -1680,11 +1680,11 @@ marks:
 
 stages:
 
-  # GET /cluster/{node_id}/daemon_stats
+  # GET /cluster/{node_id}/daemons/stats
   - name: Get all daemons' statistics from {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/daemon_stats"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1701,11 +1701,11 @@ stages:
           failed_items: []
           total_failed_items: 0
 
-  # GET /cluster/{node_id}/daemon_stats?daemons_list=wazuh-remoted
+  # GET /cluster/{node_id}/daemons/stats?daemons_list=wazuh-remoted
   - name: Get statistics from a single daemon from {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/daemon_stats"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1722,11 +1722,11 @@ stages:
           failed_items: []
           total_failed_items: 0
 
-  # GET /cluster/{node_id}/daemon_stats?daemons_list=wazuh-remoted,wazuh-db,wazuh-analysisd
+  # GET /cluster/{node_id}/daemons/stats?daemons_list=wazuh-remoted,wazuh-db,wazuh-analysisd
   - name: Get statistics from a list of daemons from {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/daemon_stats"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1745,11 +1745,11 @@ stages:
           failed_items: []
           total_failed_items: 0
 
-  # GET /cluster/{node_id}/daemon_stats?daemons_list=wrong-daemon-name
+  # GET /cluster/{node_id}/daemons/stats?daemons_list=wrong-daemon-name
   - name: Try to get statistics from a wrong daemon from {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/daemon_stats"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -250,6 +250,88 @@ stages:
           total_affected_items: 0
           total_failed_items: 1
 
+---
+test_name: GET /manager/daemon_stats
+
+stages:
+
+  # GET /manager/daemon_stats
+  - name: Get all daemons' statistics
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/daemon_stats"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - name: wazuh-remoted
+            - name: wazuh-analysisd
+            - name: wazuh-db
+          total_affected_items: 3
+          failed_items: []
+          total_failed_items: 0
+
+  # GET /manager/daemon_stats?daemons_list=wazuh-remoted
+  - name: Get statistics from a single daemon
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/daemon_stats"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        daemons_list: wazuh-remoted
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - name: wazuh-remoted
+          total_affected_items: 1
+          failed_items: []
+          total_failed_items: 0
+
+  # GET /manager/daemon_stats?daemons_list=wazuh-remoted,wazuh-db,wazuh-analysisd
+  - name: Get statistics from a list of daemons
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/daemon_stats"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        daemons_list: wazuh-remoted,wazuh-db,wazuh-analysisd
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - name: wazuh-remoted
+            - name: wazuh-db
+            - name: wazuh-analysisd
+          total_affected_items: 3
+          failed_items: []
+          total_failed_items: 0
+
+  # GET /manager/daemon_stats?daemons_list=wrong-daemon-name
+  - name: Try to get statistics from a wrong daemon
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/daemon_stats"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        daemons_list: wrong-daemon-name
+    response:
+      status_code: 400
 
 ---
 test_name: GET /manager/stats

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -251,15 +251,15 @@ stages:
           total_failed_items: 1
 
 ---
-test_name: GET /manager/daemon_stats
+test_name: GET /manager/daemons/stats
 
 stages:
 
-  # GET /manager/daemon_stats
+  # GET /manager/daemons/stats
   - name: Get all daemons' statistics
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/daemon_stats"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -276,11 +276,11 @@ stages:
           failed_items: []
           total_failed_items: 0
 
-  # GET /manager/daemon_stats?daemons_list=wazuh-remoted
+  # GET /manager/daemons/stats?daemons_list=wazuh-remoted
   - name: Get statistics from a single daemon
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/daemon_stats"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -297,11 +297,11 @@ stages:
           failed_items: []
           total_failed_items: 0
 
-  # GET /manager/daemon_stats?daemons_list=wazuh-remoted,wazuh-db,wazuh-analysisd
+  # GET /manager/daemons/stats?daemons_list=wazuh-remoted,wazuh-db,wazuh-analysisd
   - name: Get statistics from a list of daemons
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/daemon_stats"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -320,11 +320,11 @@ stages:
           failed_items: []
           total_failed_items: 0
 
-  # GET /manager/daemon_stats?daemons_list=wrong-daemon-name
+  # GET /manager/daemons/stats?daemons_list=wrong-daemon-name
   - name: Try to get statistics from a wrong daemon
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/daemon_stats"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
@@ -449,6 +449,31 @@ stages:
       <<: *permission_denied
 
 ---
+test_name: GET /cluster/{node_id}/daemon_stats
+
+stages:
+
+  - name: Request daemons statistics from worker2 (Denied)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/daemon_stats"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      <<: *permission_denied
+
+  - name: Request daemons statistics from worker1 (Allow)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/daemon_stats"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+
+---
 test_name: GET /cluster/{node_id}/stats
 
 stages:

--- a/api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
@@ -449,14 +449,14 @@ stages:
       <<: *permission_denied
 
 ---
-test_name: GET /cluster/{node_id}/daemon_stats
+test_name: GET /cluster/{node_id}/daemons/stats
 
 stages:
 
   - name: Request daemons statistics from worker2 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/daemon_stats"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -466,7 +466,7 @@ stages:
   - name: Request daemons statistics from worker1 (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/daemon_stats"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_manager_endpoints.tavern.yaml
@@ -94,6 +94,21 @@ stages:
       <<: *permission_allowed
 
 ---
+test_name: GET /manager/daemon_stats
+
+stages:
+
+  - name: Request daemons statistics (Allow)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/daemon_stats"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+
+---
 test_name: GET /manager/stats
 
 stages:

--- a/api/test/integration/test_rbac_black_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_manager_endpoints.tavern.yaml
@@ -94,14 +94,14 @@ stages:
       <<: *permission_allowed
 
 ---
-test_name: GET /manager/daemon_stats
+test_name: GET /manager/daemons/stats
 
 stages:
 
   - name: Request daemons statistics (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/daemon_stats"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
@@ -752,6 +752,20 @@ stages:
       <<: *permission_denied
 
 ---
+test_name: GET /cluster/{node_id}/daemon_stats
+
+stages:
+  - name: Try to get all daemons' statistics from a specified node (worker1)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/daemon_stats"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      <<: *permission_denied
+
+---
 test_name: GET /cluster/{node_id}/stats
 
 stages:
@@ -1695,6 +1709,20 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
         content-type: application/octet-stream
+    response:
+      <<: *permission_denied
+
+---
+test_name: GET /manager/stats
+
+stages:
+  - name: Try to get all daemons' statistics
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/daemon_stats"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
     response:
       <<: *permission_denied
 

--- a/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
@@ -752,13 +752,13 @@ stages:
       <<: *permission_denied
 
 ---
-test_name: GET /cluster/{node_id}/daemon_stats
+test_name: GET /cluster/{node_id}/daemons/stats
 
 stages:
   - name: Try to get all daemons' statistics from a specified node (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/daemon_stats"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1719,7 +1719,7 @@ stages:
   - name: Try to get all daemons' statistics
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/daemon_stats"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
@@ -510,6 +510,31 @@ stages:
       <<: *permission_denied
 
 ---
+test_name: GET /cluster/{node_id}/daemon_stats
+
+stages:
+
+  - name: Request daemons statistics from worker1 (Denied)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/daemon_stats"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      <<: *permission_denied
+
+  - name: Request daemons statistics from worker2 (Allow)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/daemon_stats"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+
+---
 test_name: GET /cluster/{node_id}/stats
 
 stages:

--- a/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
@@ -510,14 +510,14 @@ stages:
       <<: *permission_denied
 
 ---
-test_name: GET /cluster/{node_id}/daemon_stats
+test_name: GET /cluster/{node_id}/daemons/stats
 
 stages:
 
   - name: Request daemons statistics from worker1 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/daemon_stats"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -527,7 +527,7 @@ stages:
   - name: Request daemons statistics from worker2 (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/daemon_stats"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_manager_endpoints.tavern.yaml
@@ -91,6 +91,21 @@ stages:
       <<: *permission_denied
 
 ---
+test_name: GET /manager/daemon_stats
+
+stages:
+
+  - name: Request daemons statistics (Denied)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/daemon_stats"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      <<: *permission_denied
+
+---
 test_name: GET /manager/stats
 
 stages:

--- a/api/test/integration/test_rbac_white_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_manager_endpoints.tavern.yaml
@@ -91,14 +91,14 @@ stages:
       <<: *permission_denied
 
 ---
-test_name: GET /manager/daemon_stats
+test_name: GET /manager/daemons/stats
 
 stages:
 
   - name: Request daemons statistics (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/daemon_stats"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -233,6 +233,7 @@ MULTI_GROUPS_PATH = os.path.join(WAZUH_PATH, 'var', 'multigroups')
 
 
 # ================================================ Wazuh path - Sockets ================================================
+ANALYSISD_SOCKET = os.path.join(WAZUH_PATH, 'queue', 'sockets', 'analysis')
 AR_SOCKET = os.path.join(WAZUH_PATH, 'queue', 'alerts', 'ar')
 EXECQ_SOCKET = os.path.join(WAZUH_PATH, 'queue', 'alerts', 'execq')
 AUTHD_SOCKET = os.path.join(WAZUH_PATH, 'queue', 'sockets', 'auth')

--- a/framework/wazuh/core/stats.py
+++ b/framework/wazuh/core/stats.py
@@ -137,7 +137,7 @@ def get_daemons_stats_socket(socket: str) -> dict:
     """
     # Create message
     full_message = wazuh_socket.create_wazuh_socket_message(origin={'module': common.origin_module.get()},
-                                                            command='getstats', parameters={})
+                                                            command='getstats')
 
     # Connect to socket
     try:

--- a/framework/wazuh/core/stats.py
+++ b/framework/wazuh/core/stats.py
@@ -146,9 +146,12 @@ def get_daemons_stats_socket(socket: str) -> dict:
         raise WazuhInternalError(1121, extra_message=socket)
 
     # Send message and receive socket response
-    s.send(full_message)
-    response = s.receive()
-    s.close()
+    try:
+        s.send(full_message)
+        response = s.receive()
+    finally:
+        s.close()
+
     try:
         response['timestamp'] = utils.get_date_from_timestamp(response['timestamp'])
     except KeyError:

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -1215,7 +1215,7 @@ def test_agent_get_config_ko(socket_mock, send_mock, mock_wazuh_socket):
         agent.get_config('com', 'active-response', 'Wazuh v3.6.0')
 
 
-@patch('wazuh.core.stats.WazuhSocket')
+@patch('wazuh.core.wazuh_socket.WazuhSocket')
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
 def test_agent_get_stats(socket_mock, send_mock, mock_wazuh_socket):
@@ -1226,7 +1226,7 @@ def test_agent_get_stats(socket_mock, send_mock, mock_wazuh_socket):
     assert result == {"test": 0}, 'Result message is not as expected.'
 
 
-@patch('wazuh.core.stats.WazuhSocket')
+@patch('wazuh.core.wazuh_socket.WazuhSocket')
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
 def test_agent_get_stats_ko(socket_mock, send_mock, mock_wazuh_socket):

--- a/framework/wazuh/stats.py
+++ b/framework/wazuh/stats.py
@@ -98,16 +98,14 @@ def get_daemons_stats(daemons_list: list = None):
     AffectedItemsWazuhResult
         Dictionary with the stats of the input file.
     """
-    available_daemons_stats = ['wazuh-remoted', 'wazuh-analysisd', 'wazuh-db']
     daemon_socket_mapping = {'wazuh-remoted': common.REMOTED_SOCKET,
                              'wazuh-analysisd': common.ANALYSISD_SOCKET,
                              'wazuh-db': common.WDB_SOCKET}
-    daemons_list = daemons_list or available_daemons_stats
     result = AffectedItemsWazuhResult(all_msg='Statistical information for each daemon was successfully read',
                                       some_msg='Could not read statistical information for some daemons',
                                       none_msg='Could not read statistical information for any daemon')
 
-    for daemon in daemons_list:
+    for daemon in daemons_list or daemon_socket_mapping.keys():
         try:
             result.affected_items.append(get_daemons_stats_socket(daemon_socket_mapping[daemon]))
         except WazuhException as e:

--- a/framework/wazuh/tests/data/security/rbac_catalog.yml
+++ b/framework/wazuh/tests/data/security/rbac_catalog.yml
@@ -275,6 +275,7 @@ get_rbac_actions:
           - GET /cluster/{node_id}/status
           - GET /cluster/{node_id}/info
           - GET /cluster/{node_id}/configuration
+          - GET /cluster/{node_id}/daemon_stats
           - GET /cluster/{node_id}/stats
           - GET /cluster/{node_id}/stats/hourly
           - GET /cluster/{node_id}/stats/weekly
@@ -416,6 +417,7 @@ get_rbac_actions:
           - GET /manager/status
           - GET /manager/info
           - GET /manager/configuration
+          - GET /manager/daemon_stats
           - GET /manager/stats
           - GET /manager/stats/hourly
           - GET /manager/stats/weekly

--- a/framework/wazuh/tests/data/security/rbac_catalog.yml
+++ b/framework/wazuh/tests/data/security/rbac_catalog.yml
@@ -275,7 +275,7 @@ get_rbac_actions:
           - GET /cluster/{node_id}/status
           - GET /cluster/{node_id}/info
           - GET /cluster/{node_id}/configuration
-          - GET /cluster/{node_id}/daemon_stats
+          - GET /cluster/{node_id}/daemons/stats
           - GET /cluster/{node_id}/stats
           - GET /cluster/{node_id}/stats/hourly
           - GET /cluster/{node_id}/stats/weekly
@@ -417,7 +417,7 @@ get_rbac_actions:
           - GET /manager/status
           - GET /manager/info
           - GET /manager/configuration
-          - GET /manager/daemon_stats
+          - GET /manager/daemons/stats
           - GET /manager/stats
           - GET /manager/stats/hourly
           - GET /manager/stats/weekly


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/13383 |



## Description

This PR closes https://github.com/wazuh/wazuh/issues/13383.

In this pull request, I have implemented the endpoints `GET /manager/daemons/stats` and `GET /cluster/{node_id}/daemons/stats` and their related framework functions.

More information and request and response examples can be seen in the related issue's comment: https://github.com/wazuh/wazuh/issues/13383#issuecomment-1191350859.

I have also updated the API integration tests, the unit tests, and the API spec.

Edit: Some API integration tests are failing due to https://github.com/wazuh/wazuh/issues/13929 and https://github.com/wazuh/wazuh/issues/14228.