### PR TITLE
Set `origin_module` variable correctly when sending API/framework messages to sockets

### DIFF
--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -226,7 +226,7 @@ class DistributedAPI:
             raise exception.WazuhError(1017, extra_message=extra_info)
 
     @staticmethod
-    def run_local(f, f_kwargs, logger, rbac_permissions, broadcasting, nodes, current_user):
+    def run_local(f, f_kwargs, logger, rbac_permissions, broadcasting, nodes, current_user, origin_module):
         """Run framework SDK function locally in another process."""
 
         def debug_log(logger, message):
@@ -240,6 +240,7 @@ class DistributedAPI:
         common.broadcast.set(broadcasting)
         common.cluster_nodes.set(nodes)
         common.current_user.set(current_user)
+        common.origin_module.set(origin_module)
         data = f(**f_kwargs)
         common.reset_context_cache()
         debug_log(logger, "Finished executing request locally")
@@ -269,7 +270,7 @@ class DistributedAPI:
             try:
                 if self.is_async:
                     task = self.run_local(self.f, self.f_kwargs, self.logger, self.rbac_permissions, self.broadcasting,
-                                          self.nodes, self.current_user)
+                                          self.nodes, self.current_user, self.origin_module)
 
                 else:
                     loop = asyncio.get_event_loop()
@@ -283,7 +284,7 @@ class DistributedAPI:
                     task = loop.run_in_executor(pool, partial(self.run_local, self.f, self.f_kwargs,
                                                               self.logger, self.rbac_permissions,
                                                               self.broadcasting, self.nodes,
-                                                              self.current_user))
+                                                              self.current_user, self.origin_module))
                 try:
                     data = await asyncio.wait_for(task, timeout=timeout)
                 except asyncio.TimeoutError:

--- a/framework/wazuh/core/tests/test_common.py
+++ b/framework/wazuh/core/tests/test_common.py
@@ -17,12 +17,12 @@ from wazuh.core.common import find_wazuh_path, wazuh_uid, wazuh_gid, context_cac
 ])
 def test_find_wazuh_path(fake_path, expected):
     with patch('wazuh.core.common.__file__', new=fake_path):
-        assert(find_wazuh_path.__wrapped__() == expected)
+        assert (find_wazuh_path.__wrapped__() == expected)
 
 
 def test_find_wazuh_path_relative_path():
     with patch('os.path.abspath', return_value='~/framework'):
-        assert(find_wazuh_path.__wrapped__() == '~')
+        assert (find_wazuh_path.__wrapped__() == '~')
 
 
 def test_wazuh_uid():
@@ -70,3 +70,32 @@ def test_context_cached():
                                                                                'calls to foo. '
     assert isinstance(get_context_cache()[json.dumps({"key": "foobar", "args": [], "kwargs": {"data": "bar"}})],
                       ContextVar)
+
+
+@patch('wazuh.core.logtest.create_wazuh_socket_message', side_effect=SystemExit)
+def test_origin_module_context_var_framework(mock_create_socket_msg):
+    """Test that the origin_module context variable is being set to framework."""
+    from wazuh import logtest
+
+    # side_effect used to avoid mocking the rest of functions
+    with pytest.raises(SystemExit):
+        logtest.run_logtest()
+
+    assert mock_create_socket_msg.call_args[1]['origin']['module'] == 'framework'
+
+
+@pytest.mark.asyncio
+@patch('wazuh.core.logtest.create_wazuh_socket_message', side_effect=SystemExit)
+@patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.check_wazuh_status', side_effect=None)
+async def test_origin_module_context_var_api(mock_check_wazuh_status, mock_create_socket_msg):
+    """Test that the origin_module context variable is being set to API."""
+    import logging
+    from wazuh.core.cluster.dapi import dapi
+    from wazuh import logtest
+
+    # side_effect used to avoid mocking the rest of functions
+    with pytest.raises(SystemExit):
+        d = dapi.DistributedAPI(f=logtest.run_logtest, logger=logging.getLogger('wazuh'), is_async=True)
+        await d.distribute_function()
+
+    assert mock_create_socket_msg.call_args[1]['origin']['module'] == 'API'


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/14125 |


## Description

This PR closes https://github.com/wazuh/wazuh/issues/14125.

In this pull request, I have updated the `run_local` function of `dapi.py` to include the `origin_module` context variable update so the messages created specify the correct module value.

#### Message examples

`PUT /logtest` endpoint, using the API, message sent to the socket:

`{'version': 1, 'origin': {'name': 'Logtest', 'module': 'API'}, 'command': 'log_processing', 'parameters': {'token': '111', 'event': 'string', 'log_format': 'string', 'location': 'string'}}`

Using the framework (`send_logtest_msg` function of `core/logtest.py`, message sent to the socket:

`{'version': 1, 'origin': {'name': 'Logtest', 'module': 'framework'},  'command': 'log_processing', 'parameters': {'token': '111', 'event': 'string', 'log_format': 'string', 'location': 'string'}}`


As we can see, with this fix the module variable is being set correctly.

I have also added new unit tests as this case was not being tested.

