### PR TITLE
Add version control for agents reconnect procedure

### DIFF
--- a/framework/wazuh/core/cluster/agents_reconnect.py
+++ b/framework/wazuh/core/cluster/agents_reconnect.py
@@ -1,5 +1,4 @@
 import contextlib
-
 from datetime import timedelta
 from enum import Enum
 from math import ceil
@@ -270,7 +269,8 @@ class AgentsReconnect:
                 if info['agents'] > 0:
                     agent_query = WazuhDBQueryAgents(
                         count=False, filters={"status": "active", "node_name": node},
-                        limit=info['agents'], sort={"fields": ["id"], "order": "desc"}, select=["id"])
+                        limit=info['agents'], sort={"fields": ["id"], "order": "desc"}, select=["id"],
+                        query="(version>Wazuh v4.3.0,version=Wazuh v4.3.0);id!=000")
                     current_balance[node]['agents'] = [info["id"] for info in agent_query.run()["items"]]
                 else:
                     current_balance[node]['agents'] = []

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -1210,7 +1210,6 @@ class Master(server.AbstractServer):
             except agents_reconnect.SkippingException:
                 # Skip current iteration
                 logger.info("Skipping current iteration.")
-                pass
 
             # Check if the current phase is Halt
             if self.agents_reconnect.get_current_phase() == agents_reconnect.AgentsReconnectionPhases.HALT:


### PR DESCRIPTION
|Related issue|
|---|
|#14370|

## Description

This PR closes #14370. In this PR we have modified the system of obtaining agents in the cluster, now only the agents with version equal or superior to 4.3.0 will be candidates to be balanced.