### PR TITLE
Fix busy-looping in wazuh-maild when monitoring alerts.json

### DIFF
--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -370,6 +370,7 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
 
     /* Get message if available */
     if (al_json = jqueue_next(fileq), !al_json) {
+        sleep(1);
         return NULL;
     }
 

--- a/src/shared/json-queue.c
+++ b/src/shared/json-queue.c
@@ -71,8 +71,10 @@ cJSON * jqueue_next(file_queue * queue) {
     } else {
         queue->flags = 0;
 
-        if (stat(queue->file_name, &buf) < 0) {
-            merror(FSTAT_ERROR, queue->file_name, errno, strerror(errno));
+        // Check file stats, or sleep and retry if the file is missing.
+
+        if (stat(queue->file_name, &buf) < 0 && (errno != ENOENT || (sleep(1), stat(queue->file_name, &buf) < 0))) {
+            mwarn(FSTAT_ERROR, queue->file_name, errno, strerror(errno));
             fclose(queue->fp);
             queue->fp = NULL;
             return NULL;

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -161,7 +161,7 @@ list(APPEND shared_tests_names "test_json-queue")
 list(APPEND shared_tests_flags "${DEBUG_OP_WRAPPERS} -Wl,--wrap,fopen -Wl,--wrap,fclose \
                                 -Wl,--wrap,fflush -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite \
                                 -Wl,--wrap,remove -Wl,--wrap,fprintf -Wl,--wrap,fgets -Wl,--wrap,w_ftell \
-                                -Wl,--wrap,fgetpos -Wl,--wrap,fgetc")
+                                -Wl,--wrap,fgetpos -Wl,--wrap,fgetc,--wrap,stat,--wrap,sleep,--wrap,getpid,--wrap,clearerr")
 
 list(APPEND shared_tests_names "test_bqueue")
 list(APPEND shared_tests_flags "-Wl,--wrap,_merror -Wl,--wrap,_mdebug2")


### PR DESCRIPTION
|Related issue|
|---|
|Fixes #14431|

As proposed at the issue above, this PR applies the following changes to wazuh-maild:

1. Let wazuh-maild perform a one-second delay when _alerts.json_ has no new alerts.
2. Let the file reader perform an extra call to `stat` if _alerts.json_ is missing.
3. Replace the error log 1118 with a warning.
4. Add a unit test to check the behavior at point 2.

## Tests

### Unit tests

- [x] Check that `jqueue_next()` runs `sleep(1)` and an extra call to `stat("alerts.json")` if the first call fails with `errno == ENOENT` (file missing).

### Manual tests

These checks were performed with `<email_log_source>` set to `alerts.json`:

- [x] wazuh-maild consumes 0% CPU when idle (no new alerts at _alerts.json_).

```
  PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
12560 wazuh     20   0   22512   5000   3964 S   0.0   0.0   0:00.00 wazuh-maild
```

- [x] No warnings or errors when moving _alerts.json_ during one second:

```sh
cd /var/ossec/logs/alerts
mv alerts.json alerts.json.2; sleep 1; mv alerts.json.2 alerts.json
```

- [x] 1118 warning log only, when moving _alerts.json_ during two seconds:

```sh
cd /var/ossec/logs/alerts
mv alerts.json alerts.json.2; sleep 2; mv alerts.json.2 alerts.json
```

```
2022/07/27 11:02:12 wazuh-maild: WARNING: (1118): Could not retrieve information of file 'logs/alerts/alerts.json' due to [(2)-(No such file or directory)].
```

- [x] Error 1103 comes when moving _alerts.json_ during three seconds:

```sh
cd /var/ossec/logs/alerts
mv alerts.json alerts.json.2; sleep 3; mv alerts.json.2 alerts.json
```

```
2022/07/27 11:02:21 wazuh-maild: WARNING: (1118): Could not retrieve information of file 'logs/alerts/alerts.json' due to [(2)-(No such file or directory)].
2022/07/27 11:02:21 wazuh-maild: ERROR: (1103): Could not open file 'logs/alerts/alerts.json' due to [(2)-(No such file or directory)].
```