### PR TITLE
Update RC template names

### DIFF
--- a/.github/ISSUE_TEMPLATE/api-integration-tests.md
+++ b/.github/ISSUE_TEMPLATE/api-integration-tests.md
@@ -1,5 +1,5 @@
 ---
-name: [Release Candidate] API integration tests 
+name: Release Candidate - API integration tests 
 about: Report the results after running API integration tests.
 title: 'Release [WAZUH VERSION] - Release Candidate [RC VERSION] - API integration tests'
 labels: 'API, qa'

--- a/.github/ISSUE_TEMPLATE/footprint_metrics.md
+++ b/.github/ISSUE_TEMPLATE/footprint_metrics.md
@@ -1,5 +1,5 @@
 ---
-name: [Release Candidate] Footprint metrics 
+name: Release Candidate - Footprint metrics 
 about: Report the results after obtaining footprint metrics.
 title: 'Release [WAZUH VERSION] - Release Candidate [RC VERSION] - Footprint metrics'
 labels: 'cicd'

--- a/.github/ISSUE_TEMPLATE/python-unit-tests.md
+++ b/.github/ISSUE_TEMPLATE/python-unit-tests.md
@@ -1,5 +1,5 @@
 ---
-name: [Release Candidate] Python unit tests 
+name: Release Candidate - Python unit tests 
 about: Report the results after running Python unit tests.
 title: 'Release [WAZUH VERSION] - Release Candidate [RC VERSION] - Python unit tests'
 labels: 'API, framework, qa'

--- a/.github/ISSUE_TEMPLATE/release-manual-tests.md
+++ b/.github/ISSUE_TEMPLATE/release-manual-tests.md
@@ -1,5 +1,5 @@
 ---
-name: [Release Candidate] Manual tests 
+name: Release Candidate - Manual tests 
 about: Report the results after running manual tests for the specified release.
 title: 'Release [WAZUH VERSION] - Manual tests - [TEST NAME]'
 labels: 'release/4.3.0, type/manual-testing'

--- a/.github/ISSUE_TEMPLATE/system-tests.md
+++ b/.github/ISSUE_TEMPLATE/system-tests.md
@@ -1,5 +1,5 @@
 ---
-name: [Release Candidate] System tests 
+name: Release Candidate - System tests 
 about: Report the results after running system tests.
 title: 'Release [WAZUH VERSION] - Release Candidate [RC VERSION] - System tests'
 labels: 'module/cluster, module/rbac'

--- a/.github/ISSUE_TEMPLATE/workload-benchmarks-metrics.md
+++ b/.github/ISSUE_TEMPLATE/workload-benchmarks-metrics.md
@@ -1,5 +1,5 @@
 ---
-name: [Release Candidate] Workload benchmarks metrics 
+name: Release Candidate - Workload benchmarks metrics 
 about: Report the workload benchmarks metrics.
 title: 'Release [WAZUH VERSION] - Release Candidate [RC VERSION] - Workload benchmarks metrics'
 labels: 'API, cluster, qa'

--- a/.github/ISSUE_TEMPLATE/wpk-upgrade-tests.md
+++ b/.github/ISSUE_TEMPLATE/wpk-upgrade-tests.md
@@ -1,5 +1,5 @@
 ---
-name: [Release Candidate] WPK upgrade tests 
+name: Release Candidate - WPK upgrade tests 
 about: Report the results after upgrade agent via WPK.
 title: 'Release [WAZUH VERSION] - Release Candidate [RC VERSION] - WPK upgrade tests'
 labels: 'WPK, core'


### PR DESCRIPTION
|Related issue|
|---|
| Closes #14458 |

## Description

This PR changes the name of the Github templates from `[Release Candidate]` to `Release Candidate - ` so the templates are displayed again.