### PR TITLE
Add analysis to list of sockets using JSON communication protocol in framework

### DIFF
--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -802,7 +802,7 @@ def get_active_configuration(agent_id: str, component: str, configuration: str) 
     dict
         The active configuration the agent is currently using.
     """
-    sockets_json_protocol = {'remote'}
+    sockets_json_protocol = {'remote', 'analysis'}
     component_socket_mapping = {'agent': 'agent', 'agentless': 'agentless', 'analysis': 'analysis', 'auth': 'auth',
                                 'com': 'com', 'csyslog': 'csyslog', 'integrator': 'integrator',
                                 'logcollector': 'logcollector', 'mail': 'mail', 'monitor': 'monitor',

--- a/framework/wazuh/core/tests/test_configuration.py
+++ b/framework/wazuh/core/tests/test_configuration.py
@@ -341,7 +341,7 @@ def test_upload_group_file(mock_safe_move, mock_open, mock_wazuh_uid, mock_wazuh
     ('000', 'auth', 'auth', 'ok {"auth": {}}'),
     ('000', 'agent', 'agent', 'ok {"agent": {"enabled": "yes"}}'),
     ('000', 'agentless', 'agentless', 'ok {"agentless": {"enabled": "yes"}}'),
-    ('000', 'analysis', 'analysis', 'ok {"analysis": {"enabled": "yes"}}'),
+    ('000', 'analysis', 'analysis', {"error": 0, "data": {"enabled": "yes"}}),
     ('000', 'com', 'com', 'ok {"com": {"enabled": "yes"}}'),
     ('000', 'csyslog', 'csyslog', 'ok {"csyslog": {"enabled": "yes"}}'),
     ('000', 'integrator', 'integrator', 'ok {"integrator": {"enabled": "yes"}}'),
@@ -374,7 +374,7 @@ def test_upload_group_file(mock_safe_move, mock_open, mock_wazuh_uid, mock_wazuh
 def test_get_active_configuration(mock_exists, mock_create_wazuh_socket_message, agent_id, component, socket,
                                   rec_msg):
     """This test checks the proper working of get_active_configuration function."""
-    sockets_json_protocol = {'remote'}
+    sockets_json_protocol = {'remote', 'analysis'}
     config = MagicMock()
 
     socket_class = "WazuhSocket" if socket not in sockets_json_protocol or agent_id != '000' else "WazuhSocketJSON"


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/13929 |



## Description

This PR closes https://github.com/wazuh/wazuh/issues/13929

In this pull request, I have added the analysis socket to the list used to indicate the sockets using the JSON protocol, in the `get_active_configuration` function of `core/configuration.py`. With this change, all the endpoints in charge of getting the agents or managers' active configurations work properly.


There is no need to add a changelog entry as the behavior/responses do not change. The only thing that changes is the way the framework communicates with the socket in the case of **analysisd**.

API responses before the changes:

`GET /agents/000/config/analysis/global
`

```
{
  "title": "Bad Request",
  "detail": "Requested component configuration does not exist: analysis:global",
  "remediation": "Please, visit the official documentation (https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.get_agent_config) to check available component configurations",
  "dapi_errors": {
    "master-node": {
      "error": "Requested component configuration does not exist: analysis:global"
    }
  },
  "error": 1116
}
```


API responses after the changes:

`GET /agents/000/config/analysis/global
`

```
{
  "data": {
    "global": {
      "email_notification": "no",
      "logall": "no",
      "logall_json": "no",
      "integrity_checking": 8,
      "rootkit_detection": 8,
      "host_information": 8,
      "prelude_output": "no",
      "zeromq_output": "no",
      "jsonout_output": "yes",
      "alerts_log": "yes",
      "stats": 4,
      "memory_size": 8192,
      "white_list": [
        "127.0.0.1",
        "8.8.8.8",
        "8.8.4.4",
        "localhost.localdomain"
      ],
      "rotate_interval": 0,
      "max_output_size": 0
    }
  },
  "error": 0
}
```


`GET /cluster/master-node/configuration/analysis/global
`
```
{
  "data": {
    "affected_items": [
      {
        "global": {
          "email_notification": "no",
          "logall": "no",
          "logall_json": "no",
          "integrity_checking": 8,
          "rootkit_detection": 8,
          "host_information": 8,
          "prelude_output": "no",
          "zeromq_output": "no",
          "jsonout_output": "yes",
          "alerts_log": "yes",
          "stats": 4,
          "memory_size": 8192,
          "white_list": [
            "127.0.0.1",
            "8.8.8.8",
            "8.8.4.4",
            "localhost.localdomain"
          ],
          "rotate_interval": 0,
          "max_output_size": 0
        }
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Active configuration was successfully read in specified node",
  "error": 0
}
```


`GET /cluster/master-node/configuration/analysis/active_response
`
```
{
  "data": {
    "affected_items": [
      {
        "active-response": []
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Active configuration was successfully read in specified node",
  "error": 0
}
```


`GET /cluster/worker1/configuration/analysis/alerts
`
```
{
  "data": {
    "affected_items": [
      {
        "alerts": {
          "email_alert_level": 12,
          "log_alert_level": 3
        }
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Active configuration was successfully read in specified node",
  "error": 0
}
```

`GET /manager/configuration/analysis/command
`
```
{
  "data": {
    "affected_items": [
      {
        "command": [
          {
            "name": "disable-account",
            "executable": "disable-account",
            "timeout_allowed": 1
          },
          {
            "name": "restart-wazuh",
            "executable": "restart-wazuh",
            "timeout_allowed": 0
          },
          {
            "name": "firewall-drop",
            "executable": "firewall-drop",
            "timeout_allowed": 1
          },
          {
            "name": "host-deny",
            "executable": "host-deny",
            "timeout_allowed": 1
          },
          {
            "name": "route-null",
            "executable": "route-null",
            "timeout_allowed": 1
          },
          {
            "name": "win_route-null",
            "executable": "route-null.exe",
            "timeout_allowed": 1
          },
          {
            "name": "netsh",
            "executable": "netsh.exe",
            "timeout_allowed": 1
          }
        ]
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Active configuration was successfully read in specified node",
  "error": 0
}
```

`GET /manager/configuration/analysis/internal
`
```
{
  "data": {
    "affected_items": [
      {
        "internal": {
          "analysisd": {
            "debug": 0,
            "default_timeframe": 360,
            "stats_maxdiff": 999000,
            "stats_mindiff": 1250,
            "stats_percent_diff": 150,
            "fts_list_size": 32,
            "fts_min_size_for_str": 14,
            "log_fw": 1,
            "decoder_order_size": 256,
            "label_cache_maxage": 10,
            "show_hidden_labels": 0,
            "rlimit_nofile": 458752,
            "min_rotate_interval": 600
          }
        }
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Active configuration was successfully read in specified node",
  "error": 0
}
```