### PR TITLE
Improve stringHelper UT coverage

### DIFF
--- a/src/shared_modules/utils/tests/stringHelper_test.cpp
+++ b/src/shared_modules/utils/tests/stringHelper_test.cpp
@@ -57,6 +57,7 @@ TEST_F(StringUtilsTest, SplitIndex)
     const auto splitTextVector { Utils::splitIndex("hello.world", '.', 0) };
     EXPECT_EQ(5ull, splitTextVector.size());
     EXPECT_EQ(splitTextVector, "hello");
+    EXPECT_THROW(Utils::splitIndex("hello.world", '.', 2), std::runtime_error);
 }
 
 TEST_F(StringUtilsTest, AsciiToHexString)


### PR DESCRIPTION
With this minor change, the UT lines coverage of _stringHelper_ reachs 100%.
