### PR TITLE
Allow using `wazuh-db` as `component` in API agents endpoints to get active configuration

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3620,6 +3620,7 @@ components:
         - monitor
         - request
         - syscheck
+        - wazuh-db
         - wmodules
     configuration:
       in: path
@@ -3807,6 +3808,16 @@ components:
         <td><code>&lt;syscheck&gt;</code>, <code>&lt;rootcheck&gt;</code></td>
         </tr>
         <tr>
+        <td>wazuh-db</td>
+        <td>internal</td>
+        <td><code>&lt;wazuh_db&gt;</code></td>
+        </tr>
+        <tr>
+        <td>wazuh-db</td>
+        <td>wdb</td>
+        <td><code>&lt;wdb&gt;</code></td>
+        </tr>
+        <tr>
         <td>wmodules</td>
         <td>wmodules</td>
         <td><code>&lt;wodle&gt;</code></td>
@@ -3840,6 +3851,7 @@ components:
         - remote
         - syscheck
         - rootcheck
+        - wdb
         - wmodules
     cve:
       in: query

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -13,7 +13,7 @@ stages:
     response:
       status_code: 200
       json: &basic_response
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '000'
@@ -93,7 +93,7 @@ stages:
           expected_name: data.affected_items[0].name
           expected_ip: data.affected_items[0].ip
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - status: active
@@ -189,7 +189,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '006'
@@ -207,7 +207,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           failed_items: []
@@ -223,7 +223,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data: &affected_empty_answer
           affected_items: []
           failed_items: []
@@ -318,7 +318,7 @@ stages:
     response: &old_wazuh_agents_response
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '009'
@@ -363,7 +363,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           <<: *affected_empty_answer
 
@@ -388,7 +388,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '000'
@@ -407,7 +407,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           <<: *affected_empty_answer
 
@@ -432,7 +432,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '000'
@@ -451,7 +451,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           <<: *affected_empty_answer
 
@@ -476,7 +476,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '000'
@@ -495,7 +495,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           <<: *affected_empty_answer
 
@@ -520,7 +520,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '000'
@@ -537,7 +537,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           <<: *affected_empty_answer
 
@@ -561,7 +561,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '000'
@@ -579,7 +579,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           <<: *affected_empty_answer
 
@@ -603,7 +603,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '000'
@@ -621,7 +621,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           <<: *affected_empty_answer
 
@@ -646,7 +646,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - manager: "{expected_manager_host:s}"
@@ -662,7 +662,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           <<: *affected_empty_answer
 
@@ -686,7 +686,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '009'
@@ -704,7 +704,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '009'
@@ -724,7 +724,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '009'
@@ -753,7 +753,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '001'
@@ -774,7 +774,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           <<: *affected_empty_answer
 
@@ -854,7 +854,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '002'
@@ -968,7 +968,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '009'
@@ -986,7 +986,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '009'
@@ -1003,7 +1003,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '010'
@@ -1020,7 +1020,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '000'
@@ -1062,7 +1062,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '009'
@@ -1093,7 +1093,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - status: active
@@ -1124,7 +1124,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - dateAdd: !anystr
@@ -1163,7 +1163,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           affected_items: []
           failed_items:
@@ -1289,7 +1289,7 @@ test_name: GET /agents/{agent_id}/config/{component}/{configuration}
 stages:
 
   # GET /agents/001/config/agent/client
-  - name: Request-Agent-Client
+  - name: Get client configuration from agent component
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/agent/client"
@@ -1299,7 +1299,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           client:
             auto_restart: !anystr
@@ -1310,7 +1310,7 @@ stages:
             server: !anything
             time-reconnect: !anyint
 
-  - name: Request-Agent-Buffer
+  - name: Get buffer configuration from agent component
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/agent/buffer"
@@ -1320,14 +1320,14 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           buffer:
             disabled: !anystr
             queue_size: !anyint
             events_per_second: !anyint
 
-  - name: Request-Agent-Labels
+  - name: Get labels configuration from agent component
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/agent/labels"
@@ -1337,11 +1337,11 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           labels: !anything
 
-  - name: Request-Agent-Internal
+  - name: Get internal configuration from agent component
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/agent/internal"
@@ -1351,7 +1351,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           internal:
             agent:
@@ -1379,7 +1379,7 @@ stages:
               request_rto_sec: !anyint
               verify_msg_id: !anyint
 
-  - name: Request-Analysis-Global
+  - name: Get global configuration from analysis component
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/analysis/global"
@@ -1389,7 +1389,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           global:
             alerts_log: !anystr
@@ -1408,7 +1408,7 @@ stages:
             white_list: !anything
             zeromq_output: !anystr
 
-  - name: Request-Analysis-Active-response
+  - name: Get active_response configuration from analysis component
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/analysis/active_response"
@@ -1418,11 +1418,11 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           active-response: !anything
 
-  - name: Request-Analysis-Alerts
+  - name: Get alerts configuration from analysis component
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/analysis/alerts"
@@ -1432,13 +1432,13 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           alerts:
             email_alert_level: !anyint
             log_alert_level: !anyint
 
-  - name: Request-Analysis-Command
+  - name: Get command configuration from analysis component
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/analysis/command"
@@ -1448,11 +1448,11 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           command: !anything
 
-  - name: Request-Analysis-Internal
+  - name: Get internal configuration from analysis component
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/analysis/internal"
@@ -1462,7 +1462,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           internal:
             analysisd:
@@ -1480,7 +1480,7 @@ stages:
               stats_mindiff: !anyint
               stats_percent_diff: !anyint
 
-  - name: Request-Auth-Auth
+  - name: Get auth configuration from auth component
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/auth/auth"
@@ -1490,7 +1490,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           auth:
             ciphers: !anystr
@@ -1505,7 +1505,7 @@ stages:
             use_password: !anystr
             use_source_ip: !anystr
 
-  - name: Request-Com-Active-response (Manager)
+  - name: Get active-response configuration from com component (Manager)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/com/active-response"
@@ -1515,12 +1515,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           active-response:
             disabled: !anystr
 
-  - name: Request-Com-Active-response (Agent)
+  - name: Get active-response configuration from com component (Agent)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/com/active-response"
@@ -1530,12 +1530,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           active-response:
             disabled: !anystr
 
-  - name: Request-Com-Internal (Manager)
+  - name: Get internal configuration from com component (Manager)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/com/internal"
@@ -1545,14 +1545,14 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           internal:
             execd:
               request_timeout: !anyint
               max_restart_lock: !anyint
 
-  - name: Request-Com-Internal (Agent)
+  - name: Get internal configuration from com component (Agent)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/com/internal"
@@ -1562,14 +1562,14 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           internal:
             execd:
               request_timeout: !anyint
               max_restart_lock: !anyint
 
-  - name: Request-Logcollector-Localfile (Manager)
+  - name: Get localfile configuration from logcollector component (Manager)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/logcollector/localfile"
@@ -1579,11 +1579,11 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           localfile: !anything
 
-  - name: Request-Logcollector-Localfile (Agent)
+  - name: Get localfile configuration from logcollector component (Agent)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/logcollector/localfile"
@@ -1593,11 +1593,11 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           localfile: !anything
 
-  - name: Request-Logcollector-Socker (Manager)
+  - name: Get socket configuration from logcollector component (Manager)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/logcollector/socket"
@@ -1607,7 +1607,7 @@ stages:
     response:
       status_code: 200
 
-  - name: Request-Logcollector-Socker (Agent)
+  - name: Get socket configuration from logcollector component (Agent)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/logcollector/socket"
@@ -1617,7 +1617,7 @@ stages:
     response:
       status_code: 200
 
-  - name: Request-Logcollector-Internal (Manager)
+  - name: Get internal configuration from logcollector component (Manager)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/logcollector/internal"
@@ -1627,7 +1627,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           internal:
             logcollector:
@@ -1647,7 +1647,7 @@ stages:
               sock_fail_time: !anyint
               vcheck_files: !anyint
 
-  - name: Request-Logcollector-Internal (Agent)
+  - name: Get internal configuration from logcollector component (Agent)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/logcollector/internal"
@@ -1657,7 +1657,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           internal:
             logcollector:
@@ -1677,7 +1677,7 @@ stages:
               sock_fail_time: !anyint
               vcheck_files: !anyint
 
-  - name: Request-Monitor-Internal
+  - name: Get internal configuration from monitor component
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/monitor/internal"
@@ -1687,7 +1687,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           monitord:
             compress: !anyint
@@ -1700,7 +1700,7 @@ stages:
             sign: !anyint
             size_rotate: !anyint
 
-  - name: Request-Request-Remote
+  - name: Get remote configuration from request component
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/request/remote"
@@ -1710,7 +1710,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           remote:
             - connection: !anystr
@@ -1719,7 +1719,7 @@ stages:
               protocol: !anylist
               queue_size: !anystr
 
-  - name: Request-Request-Internal
+  - name: Get internal configuration from request component
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/request/internal"
@@ -1729,7 +1729,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           internal:
             remoted:
@@ -1752,7 +1752,7 @@ stages:
               shared_reload: !anyint
               verify_msg_id: !anyint
 
-  - name: Request-Syscheck-Syscheck (Manager)
+  - name: Get syscheck configuration from syscheck component (Manager)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/syscheck/syscheck"
@@ -1762,7 +1762,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           syscheck:
             directories: !anything
@@ -1774,7 +1774,7 @@ stages:
             skip_nfs: !anystr
             whodata: !anything
 
-  - name: Request-Syscheck-Syscheck (Agent)
+  - name: Get syscheck configuration from syscheck component (Agent)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/syscheck/syscheck"
@@ -1784,7 +1784,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           syscheck:
             directories: !anything
@@ -1796,7 +1796,7 @@ stages:
             skip_nfs: !anystr
             whodata: !anything
 
-  - name: Request-Syscheck-Rootcheck (Manager)
+  - name: Get rootcheck configuration from syscheck component (Manager)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/syscheck/rootcheck"
@@ -1806,7 +1806,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           rootcheck:
             check_dev: !anystr
@@ -1824,7 +1824,7 @@ stages:
             scanall: !anystr
             skip_nfs: !anystr
 
-  - name: Request-Syscheck-Rootcheck (Agent)
+  - name: Get rootcheck configuration from syscheck component (Agent)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/syscheck/rootcheck"
@@ -1834,7 +1834,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           rootcheck:
             check_dev: !anystr
@@ -1852,7 +1852,7 @@ stages:
             scanall: !anystr
             skip_nfs: !anystr
 
-  - name: Request-Syscheck-Internal (Manager)
+  - name: Get internal configuration from syscheck component (Manager)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/syscheck/internal"
@@ -1862,7 +1862,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           internal:
             rootcheck:
@@ -1875,7 +1875,7 @@ stages:
               file_max_size: !anyint
               symlink_scan_interval: !anyint
 
-  - name: Request-Syscheck-Internal (Agent)
+  - name: Get internal configuration from syscheck component (Agent)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/syscheck/internal"
@@ -1885,7 +1885,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           internal:
             syscheck:
@@ -1898,7 +1898,7 @@ stages:
             rootcheck:
               sleep: !anyint
 
-  - name: Request-Wazuh-db-Internal
+  - name: Get internal configuration from wazuh-db component
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/wazuh-db/internal"
@@ -1908,7 +1908,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           wazuh_db:
             commit_time_max: !anyint
@@ -1916,7 +1916,7 @@ stages:
             open_db_limit: !anyint
             worker_pool_size: !anyint
 
-  - name: Request-Wazuh-db-Wdb
+  - name: Get wdb configuration from wazuh-db component
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/wazuh-db/wdb"
@@ -1926,7 +1926,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           wdb:
             backup:
@@ -1935,7 +1935,7 @@ stages:
                 interval: !anyint
                 max_files: !anyint
 
-  - name: Request-Wmodules-Wmodules (Manager)
+  - name: Get wmodules configuration from wmodules component (Manager)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/wmodules/wmodules"
@@ -1945,11 +1945,11 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           wmodules: !anything
 
-  - name: Request-Wmodules-Wmodules (Agent)
+  - name: Get wmodules configuration from wmodules component (Agent)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/wmodules/wmodules"
@@ -1959,7 +1959,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           wmodules: !anything
 
@@ -2031,7 +2031,7 @@ marks:
 
 stages:
 
-- name: Request-Com-Cluster (Manager)
+- name: Get cluster configuration from com component (Manager)
   request:
     verify: False
     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/com/cluster"
@@ -2041,7 +2041,7 @@ stages:
   response:
     status_code: 200
     json:
-      error: !anyint
+      error: 0
       data:
         bind_addr: !anystr
         disabled: !anybool
@@ -2068,7 +2068,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           affected_items: []
           failed_items:
@@ -2089,7 +2089,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           affected_items: []
           failed_items:
@@ -2122,7 +2122,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '001'
@@ -2146,7 +2146,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           affected_items: []
           failed_items:
@@ -2167,7 +2167,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           affected_items: []
           failed_items:
@@ -2200,7 +2200,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '001'
@@ -2269,7 +2269,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *stats_response
@@ -2374,7 +2374,7 @@ stages:
         json:
           expected_total_agents: data.affected_items[2].count
       json:
-        error: !anyint
+        error: 0
         data: &get_groups_answer
           affected_items:
             - name: 'default'
@@ -2399,7 +2399,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - name: 'group2'
@@ -2439,7 +2439,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           failed_items: []
@@ -2537,7 +2537,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - name: 'default'
@@ -2555,7 +2555,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           <<: *affected_empty_answer
 
@@ -2579,7 +2579,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - name: 'group1'
@@ -2619,7 +2619,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           <<: *get_groups_answer
 
@@ -2638,7 +2638,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '003'
@@ -2659,7 +2659,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '006'
@@ -2791,7 +2791,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '008'
@@ -2811,7 +2811,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           <<: *affected_empty_answer
 
@@ -2905,7 +2905,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '003'
@@ -2936,7 +2936,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '007'
@@ -2954,7 +2954,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '003'
@@ -3071,7 +3071,7 @@ stages:
     response:
       status_code: 200
       json: &groups_id_config_response
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - config: !anything
@@ -3147,7 +3147,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           total_affected_items: 1
@@ -3201,7 +3201,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - filename: !anystr
@@ -3226,7 +3226,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - filename: "{filename_saved}"
@@ -3266,7 +3266,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           total_affected_items: !anyint
@@ -3316,7 +3316,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           affected_items: []
           total_affected_items: 0
@@ -3375,7 +3375,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - filename: !anystr
@@ -3393,7 +3393,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           total_affected_items: 0
@@ -3442,7 +3442,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - filename: !anystr
@@ -3466,7 +3466,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data: !anything
 
   - name: Try get one file of a group, bad group
@@ -3548,7 +3548,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data: &get_agents_by_name_response
           affected_items:
             - id: '001'
@@ -3569,7 +3569,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: 0
 
@@ -3644,7 +3644,7 @@ stages:
     response:
       status_code: 200
       json: &no_group_response
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '011'
@@ -3663,7 +3663,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '011'
@@ -3769,7 +3769,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '011'
@@ -3786,7 +3786,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           <<: *affected_empty_answer
 
@@ -3908,7 +3908,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '009'
@@ -4016,7 +4016,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '006'
@@ -4076,7 +4076,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - count: !anyint
@@ -4100,7 +4100,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - count: !anyint
@@ -4145,7 +4145,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - count: !anyint
@@ -4165,7 +4165,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - count: !anyint
@@ -4272,7 +4272,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - count: 2
@@ -4290,7 +4290,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           <<: *affected_empty_answer
 
@@ -4326,7 +4326,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - count: 4
@@ -4376,7 +4376,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
@@ -4398,7 +4398,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           connection:
             active: 8
@@ -4426,7 +4426,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - ubuntu

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -1898,6 +1898,42 @@ stages:
             rootcheck:
               sleep: !anyint
 
+  - name: Request-Wazuh-db-Internal
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/wazuh-db/internal"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          wazuh_db:
+            commit_time_max: !anyint
+            commit_time_min: !anyint
+            open_db_limit: !anyint
+            worker_pool_size: !anyint
+
+  - name: Request-Wazuh-db-Wdb
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/wazuh-db/wdb"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          wdb:
+            backup:
+              - database: !anystr
+                enabled: !anybool
+                interval: !anyint
+                max_files: !anyint
 
   - name: Request-Wmodules-Wmodules (Manager)
     request:

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -1416,6 +1416,51 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
+  - name: Show the config of wazuh-db/internal on master
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/wazuh-db/internal"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - wazuh_db:
+                commit_time_max: !anyint
+                commit_time_min: !anyint
+                open_db_limit: !anyint
+                worker_pool_size: !anyint
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+
+  - name: Show the config of wazuh-db/wdb on master
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/wazuh-db/wdb"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - wdb:
+                backup:
+                  - database: !anystr
+                    enabled: !anybool
+                    interval: !anyint
+                    max_files: !anyint
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+
   - name: Show the config of wmodules/wmodules on master
     request:
       verify: False

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -943,7 +943,7 @@ test_name: GET /manager/configuration/{component}/{configuration}
 
 stages:
 
-  - name: Sow the config of analysis/global in the manager
+  - name: Show the config of analysis/global in the manager
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/analysis/global"

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -943,7 +943,7 @@ test_name: GET /manager/configuration/{component}/{configuration}
 
 stages:
 
-  - name: Try to show the config of analysis/global in the manager
+  - name: Sow the config of analysis/global in the manager
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/analysis/global"
@@ -961,7 +961,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of analysis/active_response in the manager
+  - name: Show the config of analysis/active_response in the manager
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/analysis/active_response"
@@ -980,7 +980,7 @@ stages:
           total_failed_items: 0
         message: !anystr
 
-  - name: Try to show the config of analysis/alerts in the manager
+  - name: Show the config of analysis/alerts in the manager
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/analysis/alerts"
@@ -998,7 +998,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of analysis/command in the manager
+  - name: Show the config of analysis/command in the manager
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/analysis/command"
@@ -1016,7 +1016,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of analysis/internal in the manager
+  - name: Show the config of analysis/internal in the manager
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/analysis/internal"
@@ -1034,7 +1034,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of auth in the manager
+  - name: Show the config of auth in the manager
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/auth/auth"
@@ -1052,7 +1052,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of com/internal in the manager
+  - name: Show the config of com/internal in the manager
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/com/internal"
@@ -1070,7 +1070,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of logcollector/localfile in the manager
+  - name: Show the config of logcollector/localfile in the manager
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/logcollector/localfile"
@@ -1088,7 +1088,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of logcollector/socket in the manager
+  - name: Show the config of logcollector/socket in the manager
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/logcollector/socket"
@@ -1105,7 +1105,7 @@ stages:
           total_affected_items: 0
           total_failed_items: 0
 
-  - name: Try to show the config of logcollector/internal in the manager
+  - name: Show the config of logcollector/internal in the manager
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/logcollector/internal"
@@ -1123,7 +1123,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of monitor/internal in the manager
+  - name: Show the config of monitor/internal in the manager
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/monitor/internal"
@@ -1141,7 +1141,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of request/remote in the manager
+  - name: Show the config of request/remote in the manager
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/request/remote"
@@ -1159,7 +1159,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of request/internal in the manager
+  - name: Show the config of request/internal in the manager
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/request/internal"
@@ -1177,7 +1177,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of syscheck/syscheck in the manager
+  - name: Show the config of syscheck/syscheck in the manager
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/syscheck/syscheck"
@@ -1195,7 +1195,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of syscheck/rootcheck in the manager
+  - name: Show the config of syscheck/rootcheck in the manager
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/syscheck/rootcheck"
@@ -1213,7 +1213,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of syscheck/internal in the manager
+  - name: Show the config of syscheck/internal in the manager
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/syscheck/internal"
@@ -1227,6 +1227,51 @@ stages:
         data:
           affected_items:
             - internal: !anything
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+
+  - name: Show the config of wazuh-db/internal in the manager
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/wazuh-db/internal"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - wazuh_db:
+                commit_time_max: !anyint
+                commit_time_min: !anyint
+                open_db_limit: !anyint
+                worker_pool_size: !anyint
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+
+  - name: Show the config of wazuh-db/wdb in the manager
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/wazuh-db/wdb"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - wdb:
+                backup:
+                  - database: !anystr
+                    enabled: !anybool
+                    interval: !anyint
+                    max_files: !anyint
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0

--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -130,7 +130,7 @@ test_name: GET /agents/{agent_id}/config/{component}/{configuration}
 
 stages:
 
-  - name: Try to get Request-Agent-Client for agent 004 (Denied)
+  - name: Try to get client configuration from agent component for agent 004 (Denied)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/004/config/agent/client"
@@ -140,7 +140,7 @@ stages:
     response:
       <<: *permission_denied
 
-  - name: Get Request-Agent-Client for agent 003 (Allowed)
+  - name: Get client configuration from agent component for agent 003 (Allowed)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/003/config/agent/client"

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -134,7 +134,7 @@ test_name: GET /agents/{agent_id}/config/{component}/{configuration}
 
 stages:
 
-  - name: Try to get Request-Agent-Client for agent 003 (Denied)
+  - name: Try to get client configuration from agent component for agent 003 (Denied)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/003/config/agent/client"
@@ -144,7 +144,7 @@ stages:
     response:
       <<: *permission_denied
 
-  - name: Get Request-Agent-Client for agent 002 (Allowed)
+  - name: Get client configuration from agent component for agent 002 (Allowed)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/002/config/agent/client"

--- a/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
@@ -128,7 +128,7 @@ stages:
 test_name: GET /agents/{agent_id}/config/{component}/{configuration}
 
 stages:
-  - name: Request-Agent-Client
+  - name: Try to get client configuration from agent component
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/agent/client"

--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -802,11 +802,16 @@ def get_active_configuration(agent_id: str, component: str, configuration: str) 
     dict
         The active configuration the agent is currently using.
     """
-    sockets_json_protocol = {'remote', 'analysis'}
+    sockets_json_protocol = {'remote', 'analysis', 'wdb'}
     component_socket_mapping = {'agent': 'agent', 'agentless': 'agentless', 'analysis': 'analysis', 'auth': 'auth',
                                 'com': 'com', 'csyslog': 'csyslog', 'integrator': 'integrator',
                                 'logcollector': 'logcollector', 'mail': 'mail', 'monitor': 'monitor',
-                                'request': 'remote', 'syscheck': 'syscheck', 'wmodules': 'wmodules'}
+                                'request': 'remote', 'syscheck': 'syscheck', 'wazuh-db': 'wdb', 'wmodules': 'wmodules'}
+    component_socket_dir_mapping = {'agent': 'sockets', 'agentless': 'sockets', 'analysis': 'sockets',
+                                    'auth': 'sockets', 'com': 'sockets', 'csyslog': 'sockets', 'integrator': 'sockets',
+                                    'logcollector': 'sockets', 'mail': 'sockets', 'monitor': 'sockets',
+                                    'request': 'sockets', 'syscheck': 'sockets', 'wazuh-db': 'db',
+                                    'wmodules': 'sockets'}
 
     if not component or not configuration:
         raise WazuhError(1307)
@@ -819,7 +824,8 @@ def get_active_configuration(agent_id: str, component: str, configuration: str) 
     def get_active_configuration_manager():
         """Get manager active configuration."""
         # Communicate with the socket that corresponds to the component requested
-        dest_socket = os_path.join(common.WAZUH_PATH, "queue", "sockets", component_socket_mapping[component])
+        dest_socket = os_path.join(common.WAZUH_PATH, "queue", component_socket_dir_mapping[component],
+                                   component_socket_mapping[component])
 
         # Verify component configuration
         if not os.path.exists(dest_socket):

--- a/framework/wazuh/core/tests/test_configuration.py
+++ b/framework/wazuh/core/tests/test_configuration.py
@@ -335,46 +335,47 @@ def test_upload_group_file(mock_safe_move, mock_open, mock_wazuh_uid, mock_wazuh
             configuration.upload_group_file('default', [], 'a.conf')
 
 
-@pytest.mark.parametrize("agent_id, component, socket, rec_msg", [
-    ('000', 'auth', 'auth', 'ok {"auth": {"use_password": "yes"}}'),
-    ('000', 'auth', 'auth', 'ok {"auth": {"use_password": "no"}}'),
-    ('000', 'auth', 'auth', 'ok {"auth": {}}'),
-    ('000', 'agent', 'agent', 'ok {"agent": {"enabled": "yes"}}'),
-    ('000', 'agentless', 'agentless', 'ok {"agentless": {"enabled": "yes"}}'),
-    ('000', 'analysis', 'analysis', {"error": 0, "data": {"enabled": "yes"}}),
-    ('000', 'com', 'com', 'ok {"com": {"enabled": "yes"}}'),
-    ('000', 'csyslog', 'csyslog', 'ok {"csyslog": {"enabled": "yes"}}'),
-    ('000', 'integrator', 'integrator', 'ok {"integrator": {"enabled": "yes"}}'),
-    ('000', 'logcollector', 'logcollector', 'ok {"logcollector": {"enabled": "yes"}}'),
-    ('000', 'mail', 'mail', 'ok {"mail": {"enabled": "yes"}}'),
-    ('000', 'monitor', 'monitor', 'ok {"monitor": {"enabled": "yes"}}'),
-    ('000', 'request', 'remote', {"error": 0, "data": {"enabled": "yes"}}),
-    ('000', 'syscheck', 'syscheck', 'ok {"syscheck": {"enabled": "yes"}}'),
-    ('000', 'wmodules', 'wmodules', 'ok {"wmodules": {"enabled": "yes"}}'),
-    ('001', 'auth', 'remote', 'ok {"auth": {"use_password": "yes"}}'),
-    ('001', 'auth', 'remote', 'ok {"auth": {"use_password": "no"}}'),
-    ('001', 'auth', 'remote', 'ok {"auth": {}}'),
-    ('001', 'agent', 'remote', 'ok {"agent": {"enabled": "yes"}}'),
-    ('001', 'agentless', 'remote', 'ok {"agentless": {"enabled": "yes"}}'),
-    ('001', 'analysis', 'remote', 'ok {"analysis": {"enabled": "yes"}}'),
-    ('001', 'com', 'remote', 'ok {"com": {"enabled": "yes"}}'),
-    ('001', 'csyslog', 'remote', 'ok {"csyslog": {"enabled": "yes"}}'),
-    ('001', 'integrator', 'remote', 'ok {"integrator": {"enabled": "yes"}}'),
-    ('001', 'logcollector', 'remote', 'ok {"logcollector": {"enabled": "yes"}}'),
-    ('001', 'mail', 'remote', 'ok {"mail": {"enabled": "yes"}}'),
-    ('001', 'monitor', 'remote', 'ok {"monitor": {"enabled": "yes"}}'),
-    ('001', 'request', 'remote', 'ok {"request": {"enabled": "yes"}}'),
-    ('001', 'syscheck', 'remote', 'ok {"syscheck": {"enabled": "yes"}}'),
-    ('001', 'wmodules', 'remote', 'ok {"wmodules": {"enabled": "yes"}}')
+@pytest.mark.parametrize("agent_id, component, socket, socket_dir, rec_msg", [
+    ('000', 'auth', 'auth', 'sockets', 'ok {"auth": {"use_password": "yes"}}'),
+    ('000', 'auth', 'auth', 'sockets', 'ok {"auth": {"use_password": "no"}}'),
+    ('000', 'auth', 'auth', 'sockets', 'ok {"auth": {}}'),
+    ('000', 'agent', 'agent', 'sockets', 'ok {"agent": {"enabled": "yes"}}'),
+    ('000', 'agentless', 'agentless', 'sockets', 'ok {"agentless": {"enabled": "yes"}}'),
+    ('000', 'analysis', 'analysis', 'sockets', {"error": 0, "data": {"enabled": "yes"}}),
+    ('000', 'com', 'com', 'sockets', 'ok {"com": {"enabled": "yes"}}'),
+    ('000', 'csyslog', 'csyslog', 'sockets', 'ok {"csyslog": {"enabled": "yes"}}'),
+    ('000', 'integrator', 'integrator', 'sockets', 'ok {"integrator": {"enabled": "yes"}}'),
+    ('000', 'logcollector', 'logcollector', 'sockets', 'ok {"logcollector": {"enabled": "yes"}}'),
+    ('000', 'mail', 'mail', 'sockets', 'ok {"mail": {"enabled": "yes"}}'),
+    ('000', 'monitor', 'monitor', 'sockets', 'ok {"monitor": {"enabled": "yes"}}'),
+    ('000', 'request', 'remote', 'sockets', {"error": 0, "data": {"enabled": "yes"}}),
+    ('000', 'syscheck', 'syscheck', 'sockets', 'ok {"syscheck": {"enabled": "yes"}}'),
+    ('000', 'wazuh-db', 'wdb', 'db', {"error": 0, "data": {"enabled": "yes"}}),
+    ('000', 'wmodules', 'wmodules', 'sockets', 'ok {"wmodules": {"enabled": "yes"}}'),
+    ('001', 'auth', 'remote', 'sockets', 'ok {"auth": {"use_password": "yes"}}'),
+    ('001', 'auth', 'remote', 'sockets', 'ok {"auth": {"use_password": "no"}}'),
+    ('001', 'auth', 'remote', 'sockets', 'ok {"auth": {}}'),
+    ('001', 'agent', 'remote', 'sockets', 'ok {"agent": {"enabled": "yes"}}'),
+    ('001', 'agentless', 'remote', 'sockets', 'ok {"agentless": {"enabled": "yes"}}'),
+    ('001', 'analysis', 'remote', 'sockets', 'ok {"analysis": {"enabled": "yes"}}'),
+    ('001', 'com', 'remote', 'sockets', 'ok {"com": {"enabled": "yes"}}'),
+    ('001', 'csyslog', 'remote', 'sockets', 'ok {"csyslog": {"enabled": "yes"}}'),
+    ('001', 'integrator', 'remote', 'sockets', 'ok {"integrator": {"enabled": "yes"}}'),
+    ('001', 'logcollector', 'remote', 'sockets', 'ok {"logcollector": {"enabled": "yes"}}'),
+    ('001', 'mail', 'remote', 'sockets', 'ok {"mail": {"enabled": "yes"}}'),
+    ('001', 'monitor', 'remote', 'sockets', 'ok {"monitor": {"enabled": "yes"}}'),
+    ('001', 'request', 'remote', 'sockets', 'ok {"request": {"enabled": "yes"}}'),
+    ('001', 'syscheck', 'remote', 'sockets', 'ok {"syscheck": {"enabled": "yes"}}'),
+    ('001', 'wmodules', 'remote', 'sockets', 'ok {"wmodules": {"enabled": "yes"}}')
 ])
 @patch('builtins.open', mock_open(read_data='test_password'))
 @patch('wazuh.core.wazuh_socket.create_wazuh_socket_message')
 @patch('os.path.exists')
 @patch('wazuh.core.common.WAZUH_PATH', new='/var/ossec')
 def test_get_active_configuration(mock_exists, mock_create_wazuh_socket_message, agent_id, component, socket,
-                                  rec_msg):
+                                  socket_dir, rec_msg):
     """This test checks the proper working of get_active_configuration function."""
-    sockets_json_protocol = {'remote', 'analysis'}
+    sockets_json_protocol = {'remote', 'analysis', 'wdb'}
     config = MagicMock()
 
     socket_class = "WazuhSocket" if socket not in sockets_json_protocol or agent_id != '000' else "WazuhSocketJSON"
@@ -386,7 +387,7 @@ def test_get_active_configuration(mock_exists, mock_create_wazuh_socket_message,
                     result = configuration.get_active_configuration(agent_id, component, config)
 
                     mock__init__.assert_called_with(
-                        f"/var/ossec/queue/sockets/{socket}" if agent_id == '000' else REMOTED_SOCKET)
+                        f"/var/ossec/queue/{socket_dir}/{socket}" if agent_id == '000' else REMOTED_SOCKET)
 
                     if socket_class == "WazuhSocket":
                         mock_send.assert_called_with(f"getconfig {config}".encode() if agent_id == '000' else \


### PR DESCRIPTION
|Related issue|
|---|
| #14229  |

This PR closes https://github.com/wazuh/wazuh/issues/14229

In this pull request, I have added the `wazuh-db` string to the enum used for the `component` variable. The `component` variable is the one used in the endpoints:

```
/agents/{agent_id}/config/{component}/{configuration}
/cluster/{node_id}/configuration/{component}/{configuration}
/manager/configuration/{component}/{configuration}
```

I have also updated the framework functions in charge of getting the components' active configuration.

Unit tests and API integration tests were also updated. The API integration tests are going to fail due to https://github.com/wazuh/wazuh/issues/13929, but I have performed them in my localhost with the conflictive tests commented:


```
test_agent_GET_endpoints.tavern.yaml - Cluster environment 
	 92 passed, 93 warnings
	 
test_manager_endpoints.tavern.yaml - Cluster environment 
	 31 passed, 32 warnings

test_cluster_endpoints.tavern.yaml - Cluster environment 
	 45 passed, 46 warnings
```
