### PR TITLE
Kill current clusterd process when binary is run

### DIFF
--- a/framework/scripts/wazuh_clusterd.py
+++ b/framework/scripts/wazuh_clusterd.py
@@ -170,12 +170,7 @@ def main():
     if args.test_config:
         sys.exit(0)
 
-    cluster_status = wazuh.core.cluster.utils.get_cluster_status()
-    if cluster_status['running'] == 'yes':
-        main_logger.error("Cluster is already running.", exc_info=False)
-        sys.exit(1)
-
-    # clean
+    # Clean cluster files from previous executions
     wazuh.core.cluster.cluster.clean_up()
 
     # Check for unused PID files


### PR DESCRIPTION
|Related issue|
|---|
| Closes #13767 |

## Description

This PR changes the `wazuh_clusterd.py` binary so it behaves the same way as `wazuh-apid.py` when it is executed while the same process was already running. Until now, as reported at #13767, a message like this one was printed:
```
# /var/ossec/bin/wazuh-clusterd -fdd
2022/06/07 09:42:07 ERROR: [Cluster] [Main] Cluster is already running.
```

Now, it will kill all related running processes and start new ones:
```
root@wazuh-master:/# /var/ossec/bin/wazuh-clusterd
root@wazuh-master:/# /var/ossec/bin/wazuh-clusterd -f
wazuh-clusterd: Orphan child process 5110 was terminated.
wazuh-clusterd: Orphan child process 5103 was terminated.
wazuh-clusterd: Orphan child process 5107 was terminated.
Starting cluster in foreground (pid: 5128)
2022/08/03 12:37:17 INFO: [Local Server] [Main] Serving on /var/ossec/queue/cluster/c-internal.sock
2022/08/03 12:37:17 INFO: [Master] [Main] Serving on ('0.0.0.0', 1516)
2022/08/03 12:37:17 INFO: [Master] [Local integrity] Starting.
2022/08/03 12:37:17 INFO: [Master] [Local agent-groups] Sleeping 30s before starting the agent-groups task, waiting for the workers connection.
```

Workers can connect after that without a problem, and the socket is correctly recreated. It works fine too in the workers:
```
root@wazuh-worker1:/# /var/ossec/bin/wazuh-clusterd -f
wazuh-clusterd: Orphan child process 635 was terminated.
Starting cluster in foreground (pid: 1274)
2022/08/03 12:45:01 INFO: [Local Server] [Main] Serving on /var/ossec/queue/cluster/c-internal.sock
```