### PR TITLE
Improve C++ UT coverage

### DIFF
--- a/src/shared_modules/dbsync/src/sqlite/sqlite_wrapper.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_wrapper.cpp
@@ -232,10 +232,10 @@ void Statement::bind(const int32_t index, const double_t value)
 
 std::string Statement::expand()
 {
-    auto c_str_exp = sqlite3_expanded_sql(m_stmt.get());
-    std::string str_exp (c_str_exp);
-    sqlite3_free(c_str_exp);
-    return str_exp;
+    auto pExpandedSQL{ sqlite3_expanded_sql(m_stmt.get()) };
+    std::string expandedSQLString{ pExpandedSQL };
+    sqlite3_free(pExpandedSQL);
+    return expandedSQLString;
 }
 
 std::unique_ptr<IColumn> Statement::column(const int32_t index)

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_wrapper.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_wrapper.cpp
@@ -232,7 +232,10 @@ void Statement::bind(const int32_t index, const double_t value)
 
 std::string Statement::expand()
 {
-    return sqlite3_sql(m_stmt.get());
+    auto c_str_exp = sqlite3_expanded_sql(m_stmt.get());
+    std::string str_exp (c_str_exp);
+    sqlite3_free(c_str_exp);
+    return str_exp;
 }
 
 std::unique_ptr<IColumn> Statement::column(const int32_t index)

--- a/src/shared_modules/dbsync/tests/sqlite/sqlite_test.cpp
+++ b/src/shared_modules/dbsync/tests/sqlite/sqlite_test.cpp
@@ -240,7 +240,7 @@ TEST_F(SQLiteTest, ColumnValue)
 
 TEST_F(SQLiteTest, StatementExpand)
 {
-    std::shared_ptr<IConnection> spConnection{ new Connection };
+    std::shared_ptr<IConnection> spConnection = std::make_shared<Connection>();
     Statement createStmt
     {
         spConnection,
@@ -253,12 +253,12 @@ TEST_F(SQLiteTest, StatementExpand)
         R"(INSERT INTO test_table (Colum1, Colum2, Colum3, Colum4, Colum5) VALUES (?,?,?,?,?);)"
     };
     const auto expectedStringStmt{ selectStmt.expand() };
-    EXPECT_TRUE(expectedStringStmt.compare("INSERT INTO test_table (Colum1, Colum2, Colum3, Colum4, Colum5) VALUES (NULL,NULL,NULL,NULL,NULL);") == 0);
+    EXPECT_EQ(expectedStringStmt, "INSERT INTO test_table (Colum1, Colum2, Colum3, Colum4, Colum5) VALUES (NULL,NULL,NULL,NULL,NULL);");
 }
 
 TEST_F(SQLiteTest, StatementExpandBind)
 {
-    std::shared_ptr<IConnection> spConnection{ new Connection };
+    std::shared_ptr<IConnection> spConnection = std::make_shared<Connection>();
     Statement createStmt
     {
         spConnection,
@@ -273,5 +273,5 @@ TEST_F(SQLiteTest, StatementExpandBind)
     insertStmt.bind(2, "bar");
     insertStmt.bind(3, 1000);
     const auto expectedStringStmt{ insertStmt.expand() };
-    EXPECT_TRUE(expectedStringStmt.compare("INSERT INTO test_table (Colum1, Colum2, Colum3, Colum4, Colum5) VALUES (NULL,'bar',1000,NULL,NULL);") == 0);
+    EXPECT_EQ(expectedStringStmt, "INSERT INTO test_table (Colum1, Colum2, Colum3, Colum4, Colum5) VALUES (NULL,'bar',1000,NULL,NULL);");
 }

--- a/src/shared_modules/dbsync/tests/sqlite/sqlite_test.cpp
+++ b/src/shared_modules/dbsync/tests/sqlite/sqlite_test.cpp
@@ -252,9 +252,8 @@ TEST_F(SQLiteTest, StatementExpand)
         spConnection,
         R"(INSERT INTO test_table (Colum1, Colum2, Colum3, Colum4, Colum5) VALUES (?,?,?,?,?);)"
     };
-    std::string stmt_exp = selectStmt.expand();
-    std::string expected_query("INSERT INTO test_table (Colum1, Colum2, Colum3, Colum4, Colum5) VALUES (NULL,NULL,NULL,NULL,NULL);");
-    EXPECT_EQ(true, expected_query.compare(stmt_exp) == 0);
+    const auto expectedStringStmt{ selectStmt.expand() };
+    EXPECT_TRUE(expectedStringStmt.compare("INSERT INTO test_table (Colum1, Colum2, Colum3, Colum4, Colum5) VALUES (NULL,NULL,NULL,NULL,NULL);") == 0);
 }
 
 TEST_F(SQLiteTest, StatementExpandBind)
@@ -266,14 +265,13 @@ TEST_F(SQLiteTest, StatementExpandBind)
         "CREATE TABLE test_table (Colum1 INTEGER, Colum2 TEXT, Colum3 BIGINT, Colum4 BIGINT, Colum5 FLOAT);"
     };
     createStmt.step();
-    Statement selectStmt
+    Statement insertStmt
     {
         spConnection,
         R"(INSERT INTO test_table (Colum1, Colum2, Colum3, Colum4, Colum5) VALUES (?,?,?,?,?);)"
     };
-    selectStmt.bind(2, "bar");
-    selectStmt.bind(3, 1000);
-    std::string stmt_exp = selectStmt.expand();
-    std::string expected_query("INSERT INTO test_table (Colum1, Colum2, Colum3, Colum4, Colum5) VALUES (NULL,'bar',1000,NULL,NULL);");
-    EXPECT_EQ(true, expected_query.compare(stmt_exp) == 0);
+    insertStmt.bind(2, "bar");
+    insertStmt.bind(3, 1000);
+    const auto expectedStringStmt{ insertStmt.expand() };
+    EXPECT_TRUE(expectedStringStmt.compare("INSERT INTO test_table (Colum1, Colum2, Colum3, Colum4, Colum5) VALUES (NULL,'bar',1000,NULL,NULL);") == 0);
 }

--- a/src/shared_modules/dbsync/tests/sqlite/sqlite_test.cpp
+++ b/src/shared_modules/dbsync/tests/sqlite/sqlite_test.cpp
@@ -241,12 +241,39 @@ TEST_F(SQLiteTest, ColumnValue)
 TEST_F(SQLiteTest, StatementExpand)
 {
     std::shared_ptr<IConnection> spConnection{ new Connection };
-    Statement stmt
+    Statement createStmt
     {
         spConnection,
-        R"(CREATE TABLE test_table (Colum1 INTEGER, Colum2 TEXT, Colum3 BIGINT, Colum4 BIGINT, Colum5 FLOAT);)"
+        "CREATE TABLE test_table (Colum1 INTEGER, Colum2 TEXT, Colum3 BIGINT, Colum4 BIGINT, Colum5 FLOAT);"
     };
-    std::string stmt_exp = stmt.expand();
-    std::string query("CREATE TABLE test_table (Colum1 INTEGER, Colum2 TEXT, Colum3 BIGINT, Colum4 BIGINT, Colum5 FLOAT);");
-    EXPECT_EQ(true,query.compare(stmt_exp)==0);
+    createStmt.step();
+    Statement selectStmt
+    {
+        spConnection,
+        R"(INSERT INTO test_table (Colum1, Colum2, Colum3, Colum4, Colum5) VALUES (?,?,?,?,?);)"
+    };
+    std::string stmt_exp = selectStmt.expand();
+    std::string expected_query("INSERT INTO test_table (Colum1, Colum2, Colum3, Colum4, Colum5) VALUES (NULL,NULL,NULL,NULL,NULL);");
+    EXPECT_EQ(true,expected_query.compare(stmt_exp)==0);
+}
+
+TEST_F(SQLiteTest, StatementExpandBind)
+{
+    std::shared_ptr<IConnection> spConnection{ new Connection };
+    Statement createStmt
+    {
+        spConnection,
+        "CREATE TABLE test_table (Colum1 INTEGER, Colum2 TEXT, Colum3 BIGINT, Colum4 BIGINT, Colum5 FLOAT);"
+    };
+    createStmt.step();
+    Statement selectStmt
+    {
+        spConnection,
+        R"(INSERT INTO test_table (Colum1, Colum2, Colum3, Colum4, Colum5) VALUES (?,?,?,?,?);)"
+    };
+    selectStmt.bind(2,"bar");
+    selectStmt.bind(3,1000);
+    std::string stmt_exp = selectStmt.expand();
+    std::string expected_query("INSERT INTO test_table (Colum1, Colum2, Colum3, Colum4, Colum5) VALUES (NULL,'bar',1000,NULL,NULL);");
+    EXPECT_EQ(true,expected_query.compare(stmt_exp)==0);
 }

--- a/src/shared_modules/dbsync/tests/sqlite/sqlite_test.cpp
+++ b/src/shared_modules/dbsync/tests/sqlite/sqlite_test.cpp
@@ -254,7 +254,7 @@ TEST_F(SQLiteTest, StatementExpand)
     };
     std::string stmt_exp = selectStmt.expand();
     std::string expected_query("INSERT INTO test_table (Colum1, Colum2, Colum3, Colum4, Colum5) VALUES (NULL,NULL,NULL,NULL,NULL);");
-    EXPECT_EQ(true,expected_query.compare(stmt_exp)==0);
+    EXPECT_EQ(true, expected_query.compare(stmt_exp) == 0);
 }
 
 TEST_F(SQLiteTest, StatementExpandBind)
@@ -271,9 +271,9 @@ TEST_F(SQLiteTest, StatementExpandBind)
         spConnection,
         R"(INSERT INTO test_table (Colum1, Colum2, Colum3, Colum4, Colum5) VALUES (?,?,?,?,?);)"
     };
-    selectStmt.bind(2,"bar");
-    selectStmt.bind(3,1000);
+    selectStmt.bind(2, "bar");
+    selectStmt.bind(3, 1000);
     std::string stmt_exp = selectStmt.expand();
     std::string expected_query("INSERT INTO test_table (Colum1, Colum2, Colum3, Colum4, Colum5) VALUES (NULL,'bar',1000,NULL,NULL);");
-    EXPECT_EQ(true,expected_query.compare(stmt_exp)==0);
+    EXPECT_EQ(true, expected_query.compare(stmt_exp) == 0);
 }

--- a/src/shared_modules/dbsync/tests/sqlite/sqlite_test.cpp
+++ b/src/shared_modules/dbsync/tests/sqlite/sqlite_test.cpp
@@ -237,3 +237,16 @@ TEST_F(SQLiteTest, ColumnValue)
     EXPECT_DOUBLE_EQ(4.0, spColumn5->value(double_t{}));
     EXPECT_EQ(SQLITE_FLOAT, spColumn5->type());
 }
+
+TEST_F(SQLiteTest, StatementExpand)
+{
+    std::shared_ptr<IConnection> spConnection{ new Connection };
+    Statement stmt
+    {
+        spConnection,
+        R"(CREATE TABLE test_table (Colum1 INTEGER, Colum2 TEXT, Colum3 BIGINT, Colum4 BIGINT, Colum5 FLOAT);)"
+    };
+    std::string stmt_exp = stmt.expand();
+    std::string query("CREATE TABLE test_table (Colum1 INTEGER, Colum2 TEXT, Colum3 BIGINT, Colum4 BIGINT, Colum5 FLOAT);");
+    EXPECT_EQ(true,query.compare(stmt_exp)==0);
+}

--- a/src/shared_modules/utils/tests/stringHelper_test.cpp
+++ b/src/shared_modules/utils/tests/stringHelper_test.cpp
@@ -59,6 +59,11 @@ TEST_F(StringUtilsTest, SplitIndex)
     EXPECT_EQ(splitTextVector, "hello");
 }
 
+TEST_F(StringUtilsTest, SplitIndexRuntimeError)
+{
+    EXPECT_THROW(Utils::splitIndex("hello.world", '.', 2), std::runtime_error);
+}
+
 TEST_F(StringUtilsTest, AsciiToHexString)
 {
     const std::vector<unsigned char> data{0x2d, 0x53, 0x3b, 0x9d, 0x9f, 0x0f, 0x06, 0xef, 0x4e, 0x3c, 0x23, 0xfd, 0x49, 0x6c, 0xfe, 0xb2, 0x78, 0x0e, 0xda, 0x7f};


### PR DESCRIPTION
|Related Issue|
|---|
| #14474 |

## Description
- To increase the UT coverage on `src/shared_modules/utils` files, I added a new UT for `stringHelper.h`. 
- To increase the UT coverage on `src/shared_modules/dbsync` files, I added a new UT for `sqlite_wrapper.cpp`.
- A method's functionality was fixed in `sqlite_wrapper.cpp`. Method `Statement::expand()` is not doing what it sould: as it's name says, it should call `sqlite3_expand_sql()` but it calls `sqlite3_sql()`.
