### PR TITLE
Add uptime timestamp to global and agents statistics

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -87,6 +87,8 @@ OSDecoderInfo *NULL_Decoder;
 int num_rule_matching_threads;
 OSHash *analysisd_agents_state;
 
+extern analysisd_state_t analysisd_state;
+
 /* execd queue */
 static int execdq = 0;
 
@@ -965,6 +967,9 @@ void OS_ReadMSG_analysisd(int m_queue)
     }
 
     mdebug1("FTS_Init completed.");
+
+    /* Global stats uptime */
+    analysisd_state.uptime = time(NULL);
 
     /* Create OSHash for agents statistics */
     analysisd_agents_state = OSHash_Create();

--- a/src/analysisd/state.c
+++ b/src/analysisd/state.c
@@ -24,7 +24,6 @@
 #endif
 
 analysisd_state_t analysisd_state = {0};
-
 queue_status_t queue_status;
 static pthread_mutex_t state_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t queue_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -233,8 +232,6 @@ static void w_inc_agents_archives_written(const char *agent_id);
 static void w_inc_agents_firewall_written(const char *agent_id);
 
 void * w_analysisd_state_main() {
-    analysisd_state.uptime = time(NULL);
-
     interval = getDefine_Int("analysisd", "state_interval", 0, 86400);
 
     if (!interval) {

--- a/src/analysisd/state.h
+++ b/src/analysisd/state.h
@@ -103,6 +103,7 @@ typedef struct _written_t {
 } written_t;
 
 typedef struct _analysisd_state_t {
+    uint64_t uptime;
     uint64_t received_bytes;
     uint64_t events_received;
     uint64_t events_processed;
@@ -112,6 +113,7 @@ typedef struct _analysisd_state_t {
 } analysisd_state_t;
 
 typedef struct _analysisd_agent_state_t {
+    uint64_t uptime;
     uint64_t events_processed;
     uint64_t alerts_written;
     uint64_t archives_written;

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -46,7 +46,6 @@ static OSHash *invalid_files;
 
 /* Internal functions prototypes */
 
-static void read_controlmsg(const char *agent_id, char *msg, char *group);
 static int send_file_toagent(const char *agent_id, const char *group, const char *name, const char *sum, char *sharedcfg_dir);
 
 /**

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -33,6 +33,8 @@ size_t global_counter;
 
 OSHash *remoted_agents_state;
 
+extern remoted_state_t remoted_state;
+
 STATIC void handle_outgoing_data_to_tcp_socket(int sock_client);
 STATIC void handle_incoming_data_from_tcp_socket(int sock_client);
 STATIC void handle_incoming_data_from_udp_socket(struct sockaddr_storage * peer_info);
@@ -86,6 +88,9 @@ void HandleSecure()
 
     struct sockaddr_storage peer_info;
     memset(&peer_info, 0, sizeof(struct sockaddr_storage));
+
+    /* Global stats uptime */
+    remoted_state.uptime = time(NULL);
 
     /* Create OSHash for agents statistics */
     remoted_agents_state = OSHash_Create();

--- a/src/remoted/state.c
+++ b/src/remoted/state.c
@@ -114,8 +114,6 @@ static void rem_inc_agents_send_request(const char *agent_id);
 static void rem_inc_agents_send_discarded(const char *agent_id);
 
 void * rem_state_main() {
-    remoted_state.uptime = time(NULL);
-
     int interval = getDefine_Int("remoted", "state_interval", 0, 86400);
 
     if (!interval) {
@@ -337,7 +335,7 @@ static void rem_inc_agents_send_ar(const char *agent_id) {
 static void rem_inc_agents_send_cfga(const char *agent_id) {
     w_mutex_lock(&agents_state_mutex);
     remoted_agent_state_t *agent_node = get_node(agent_id);
-    agent_node->sent_breakdown.cfga_count++;
+    agent_node->sent_breakdown.sca_count++;
     w_mutex_unlock(&agents_state_mutex);
 }
 
@@ -495,7 +493,7 @@ void rem_inc_send_ar(const char *agent_id) {
 
 void rem_inc_send_cfga(const char *agent_id) {
     w_mutex_lock(&state_mutex);
-    remoted_state.sent_breakdown.cfga_count++;
+    remoted_state.sent_breakdown.sca_count++;
     w_mutex_unlock(&state_mutex);
 
     if (agent_id != NULL) {
@@ -582,7 +580,7 @@ cJSON* rem_create_state_json() {
 
     cJSON_AddNumberToObject(_sent_breakdown, "ack", state_cpy.sent_breakdown.ack_count);
     cJSON_AddNumberToObject(_sent_breakdown, "ar", state_cpy.sent_breakdown.ar_count);
-    cJSON_AddNumberToObject(_sent_breakdown, "sca", state_cpy.sent_breakdown.cfga_count);
+    cJSON_AddNumberToObject(_sent_breakdown, "sca", state_cpy.sent_breakdown.sca_count);
     cJSON_AddNumberToObject(_sent_breakdown, "discarded", state_cpy.sent_breakdown.discarded_count);
     cJSON_AddNumberToObject(_sent_breakdown, "request", state_cpy.sent_breakdown.request_count);
     cJSON_AddNumberToObject(_sent_breakdown, "shared", state_cpy.sent_breakdown.shared_count);
@@ -650,7 +648,7 @@ cJSON* rem_create_agents_state_json(int* agents_ids) {
 
                 cJSON_AddNumberToObject(_sent_breakdown, "ack", agent_state->sent_breakdown.ack_count);
                 cJSON_AddNumberToObject(_sent_breakdown, "ar", agent_state->sent_breakdown.ar_count);
-                cJSON_AddNumberToObject(_sent_breakdown, "sca", agent_state->sent_breakdown.cfga_count);
+                cJSON_AddNumberToObject(_sent_breakdown, "sca", agent_state->sent_breakdown.sca_count);
                 cJSON_AddNumberToObject(_sent_breakdown, "discarded", agent_state->sent_breakdown.discarded_count);
                 cJSON_AddNumberToObject(_sent_breakdown, "request", agent_state->sent_breakdown.request_count);
                 cJSON_AddNumberToObject(_sent_breakdown, "shared", agent_state->sent_breakdown.shared_count);

--- a/src/remoted/state.c
+++ b/src/remoted/state.c
@@ -582,7 +582,7 @@ cJSON* rem_create_state_json() {
 
     cJSON_AddNumberToObject(_sent_breakdown, "ack", state_cpy.sent_breakdown.ack_count);
     cJSON_AddNumberToObject(_sent_breakdown, "ar", state_cpy.sent_breakdown.ar_count);
-    cJSON_AddNumberToObject(_sent_breakdown, "cfga", state_cpy.sent_breakdown.cfga_count);
+    cJSON_AddNumberToObject(_sent_breakdown, "sca", state_cpy.sent_breakdown.cfga_count);
     cJSON_AddNumberToObject(_sent_breakdown, "discarded", state_cpy.sent_breakdown.discarded_count);
     cJSON_AddNumberToObject(_sent_breakdown, "request", state_cpy.sent_breakdown.request_count);
     cJSON_AddNumberToObject(_sent_breakdown, "shared", state_cpy.sent_breakdown.shared_count);
@@ -650,7 +650,7 @@ cJSON* rem_create_agents_state_json(int* agents_ids) {
 
                 cJSON_AddNumberToObject(_sent_breakdown, "ack", agent_state->sent_breakdown.ack_count);
                 cJSON_AddNumberToObject(_sent_breakdown, "ar", agent_state->sent_breakdown.ar_count);
-                cJSON_AddNumberToObject(_sent_breakdown, "cfga", agent_state->sent_breakdown.cfga_count);
+                cJSON_AddNumberToObject(_sent_breakdown, "sca", agent_state->sent_breakdown.cfga_count);
                 cJSON_AddNumberToObject(_sent_breakdown, "discarded", agent_state->sent_breakdown.discarded_count);
                 cJSON_AddNumberToObject(_sent_breakdown, "request", agent_state->sent_breakdown.request_count);
                 cJSON_AddNumberToObject(_sent_breakdown, "shared", agent_state->sent_breakdown.shared_count);

--- a/src/remoted/state.h
+++ b/src/remoted/state.h
@@ -45,6 +45,7 @@ typedef struct _sent_msgs_t {
 } sent_msgs_t;
 
 typedef struct _remoted_state_t {
+    uint64_t uptime;
     uint64_t recv_bytes;
     uint64_t sent_bytes;
     uint32_t tcp_sessions;
@@ -54,6 +55,7 @@ typedef struct _remoted_state_t {
 } remoted_state_t;
 
 typedef struct _remoted_agent_state_t {
+    uint64_t uptime;
     uint64_t recv_evt_count;
     uint64_t recv_ctrl_count;
     ctrl_msgs_t ctrl_breakdown;

--- a/src/remoted/state.h
+++ b/src/remoted/state.h
@@ -39,7 +39,7 @@ typedef struct _sent_msgs_t {
     uint64_t ack_count;
     uint64_t shared_count;
     uint32_t ar_count;
-    uint32_t cfga_count;
+    uint32_t sca_count;
     uint32_t request_count;
     uint32_t discarded_count;
 } sent_msgs_t;

--- a/src/unit_tests/analysisd/test_analysis-state.c
+++ b/src/unit_tests/analysisd/test_analysis-state.c
@@ -38,6 +38,7 @@ void w_analysisd_clean_agents_state();
 /* setup/teardown */
 
 static int test_setup(void ** state) {
+    analysisd_state.uptime = 123456789;
     analysisd_state.received_bytes = 123654789;
     analysisd_state.events_received = 4589;
     analysisd_state.events_decoded_breakdown.agent = 1;
@@ -162,6 +163,7 @@ static int test_setup_agent(void ** state) {
     will_return(__wrap_time, 123456789);
     analysisd_agents_state = __wrap_OSHash_Create();
 
+    test_data->agent_state->uptime = 123456789;
     test_data->agent_state->events_processed = 1286;
     test_data->agent_state->alerts_written = 269;
     test_data->agent_state->archives_written = 1286;
@@ -259,6 +261,8 @@ static int test_setup_empty_hash_table(void ** state) {
     os_calloc(1, sizeof(test_struct_t),test_data);
     os_calloc(1, sizeof(analysisd_agent_state_t), test_data->agent_state);
 
+    test_data->agent_state->uptime = 123456789;
+
     test_mode = 0;
     will_return(__wrap_time, 123456789);
     analysisd_agents_state = __wrap_OSHash_Create();
@@ -291,6 +295,8 @@ void test_asys_create_state_json(void ** state) {
     cJSON* state_json = asys_create_state_json();
 
     assert_non_null(state_json);
+
+    assert_int_equal(cJSON_GetObjectItem(state_json, "uptime")->valueint, 123456789);
 
     assert_non_null(cJSON_GetObjectItem(state_json, "metrics"));
     cJSON* metrics = cJSON_GetObjectItem(state_json, "metrics");
@@ -577,6 +583,7 @@ void test_asys_create_agents_state_json(void ** state) {
     assert_non_null(cJSON_GetArrayItem(agents, 0));
     cJSON* agent = cJSON_GetArrayItem(agents, 0);
     assert_int_equal(cJSON_GetObjectItem(agent, "id")->valueint, 1);
+    assert_int_equal(cJSON_GetObjectItem(agent, "uptime")->valueint, 123456789);
 
     assert_non_null(cJSON_GetObjectItem(agent, "metrics"));
     cJSON* agent_metrics = cJSON_GetObjectItem(agent, "metrics");
@@ -648,6 +655,8 @@ void test_asys_get_node_new_node(void ** state) {
     expect_value(__wrap_OSHash_Get_ex, self, analysisd_agents_state);
     expect_string(__wrap_OSHash_Get_ex, key, agent_id);
     will_return(__wrap_OSHash_Get_ex, NULL);
+
+    will_return(__wrap_time, 123456789);
 
     expect_value(__wrap_OSHash_Add_ex, self, analysisd_agents_state);
     expect_string(__wrap_OSHash_Add_ex, key, agent_id);

--- a/src/unit_tests/remoted/test_remote-state.c
+++ b/src/unit_tests/remoted/test_remote-state.c
@@ -40,6 +40,7 @@ void w_remoted_clean_agents_state();
 /* setup/teardown */
 
 static int test_setup(void ** state) {
+    remoted_state.uptime = 123456789;
     remoted_state.tcp_sessions = 5;
     remoted_state.recv_bytes = 123456;
     remoted_state.sent_bytes = 234567;
@@ -74,6 +75,7 @@ static int test_setup_agent(void ** state) {
     will_return(__wrap_time, 123456789);
     remoted_agents_state = __wrap_OSHash_Create();
 
+    test_data->agent_state->uptime = 123456789;
     test_data->agent_state->recv_evt_count = 12568;
     test_data->agent_state->recv_ctrl_count = 2568;
     test_data->agent_state->ctrl_breakdown.keepalive_count = 1234;
@@ -119,6 +121,8 @@ static int test_setup_empty_hash_table(void ** state) {
     os_calloc(1, sizeof(test_struct_t),test_data);
     os_calloc(1, sizeof(remoted_agent_state_t), test_data->agent_state);
 
+    test_data->agent_state->uptime = 123456789;
+
     test_mode = 0;
     will_return(__wrap_time, 123456789);
     remoted_agents_state = __wrap_OSHash_Create();
@@ -153,6 +157,8 @@ void test_rem_create_state_json(void ** state) {
     cJSON* state_json = rem_create_state_json();
 
     assert_non_null(state_json);
+
+    assert_int_equal(cJSON_GetObjectItem(state_json, "uptime")->valueint, 123456789);
 
     assert_non_null(cJSON_GetObjectItem(state_json, "metrics"));
     cJSON* metrics = cJSON_GetObjectItem(state_json, "metrics");
@@ -253,6 +259,7 @@ void test_rem_create_agents_state_json(void ** state) {
     assert_non_null(cJSON_GetArrayItem(agents, 0));
     cJSON* agent = cJSON_GetArrayItem(agents, 0);
     assert_int_equal(cJSON_GetObjectItem(agent, "id")->valueint, 1);
+    assert_int_equal(cJSON_GetObjectItem(agent, "uptime")->valueint, 123456789);
 
     assert_non_null(cJSON_GetObjectItem(agent, "metrics"));
     cJSON* agent_metrics = cJSON_GetObjectItem(agent, "metrics");
@@ -295,6 +302,8 @@ void test_rem_get_node_new_node(void ** state) {
     expect_value(__wrap_OSHash_Get_ex, self, remoted_agents_state);
     expect_string(__wrap_OSHash_Get_ex, key, agent_id);
     will_return(__wrap_OSHash_Get_ex, NULL);
+
+    will_return(__wrap_time, 123456789);
 
     expect_value(__wrap_OSHash_Add_ex, self, remoted_agents_state);
     expect_string(__wrap_OSHash_Add_ex, key, agent_id);

--- a/src/unit_tests/remoted/test_remote-state.c
+++ b/src/unit_tests/remoted/test_remote-state.c
@@ -58,7 +58,7 @@ static int test_setup(void ** state) {
     remoted_state.sent_breakdown.ack_count = 1114;
     remoted_state.sent_breakdown.shared_count = 2540;
     remoted_state.sent_breakdown.ar_count = 18;
-    remoted_state.sent_breakdown.cfga_count = 8;
+    remoted_state.sent_breakdown.sca_count = 8;
     remoted_state.sent_breakdown.request_count = 9;
     remoted_state.sent_breakdown.discarded_count = 85;
 
@@ -85,7 +85,7 @@ static int test_setup_agent(void ** state) {
     test_data->agent_state->sent_breakdown.ack_count = 2346;
     test_data->agent_state->sent_breakdown.shared_count = 235;
     test_data->agent_state->sent_breakdown.ar_count = 514;
-    test_data->agent_state->sent_breakdown.cfga_count = 134;
+    test_data->agent_state->sent_breakdown.sca_count = 134;
     test_data->agent_state->sent_breakdown.request_count = 153;
     test_data->agent_state->sent_breakdown.discarded_count = 235;
 

--- a/src/unit_tests/remoted/test_remote-state.c
+++ b/src/unit_tests/remoted/test_remote-state.c
@@ -211,8 +211,8 @@ void test_rem_create_state_json(void ** state) {
     assert_int_equal(cJSON_GetObjectItem(sent, "shared")->valueint, 2540);
     assert_non_null(cJSON_GetObjectItem(sent, "ar"));
     assert_int_equal(cJSON_GetObjectItem(sent, "ar")->valueint, 18);
-    assert_non_null(cJSON_GetObjectItem(sent, "cfga"));
-    assert_int_equal(cJSON_GetObjectItem(sent, "cfga")->valueint, 8);
+    assert_non_null(cJSON_GetObjectItem(sent, "sca"));
+    assert_int_equal(cJSON_GetObjectItem(sent, "sca")->valueint, 8);
     assert_non_null(cJSON_GetObjectItem(sent, "request"));
     assert_int_equal(cJSON_GetObjectItem(sent, "request")->valueint, 9);
     assert_non_null(cJSON_GetObjectItem(sent, "discarded"));
@@ -287,7 +287,7 @@ void test_rem_create_agents_state_json(void ** state) {
     assert_int_equal(cJSON_GetObjectItem(messages_sent_breakdown, "ack")->valueint, 2346);
     assert_int_equal(cJSON_GetObjectItem(messages_sent_breakdown, "shared")->valueint, 235);
     assert_int_equal(cJSON_GetObjectItem(messages_sent_breakdown, "ar")->valueint, 514);
-    assert_int_equal(cJSON_GetObjectItem(messages_sent_breakdown, "cfga")->valueint, 134);
+    assert_int_equal(cJSON_GetObjectItem(messages_sent_breakdown, "sca")->valueint, 134);
     assert_int_equal(cJSON_GetObjectItem(messages_sent_breakdown, "request")->valueint, 153);
     assert_int_equal(cJSON_GetObjectItem(messages_sent_breakdown, "discarded")->valueint, 235);
 

--- a/src/unit_tests/wazuh_db/test_wazuh_db_state.c
+++ b/src/unit_tests/wazuh_db/test_wazuh_db_state.c
@@ -19,6 +19,7 @@ extern wdb_state_t wdb_state;
 /* setup/teardown */
 
 static int test_setup(void ** state) {
+    wdb_state.uptime = 123456789;
     wdb_state.queries_total = 856;
     wdb_state.queries_breakdown.wazuhdb_queries = 212;
     wdb_state.queries_breakdown.wazuhdb_breakdown.remove_queries = 212;
@@ -254,6 +255,8 @@ void test_wazuhdb_create_state_json(void ** state) {
     *state = (void *)state_json;
 
     assert_non_null(state_json);
+
+    assert_int_equal(cJSON_GetObjectItem(state_json, "uptime")->valueint, 123456789);
 
     assert_non_null(cJSON_GetObjectItem(state_json, "metrics"));
     cJSON* metrics = cJSON_GetObjectItem(state_json, "metrics");

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -10,6 +10,7 @@
  */
 
 #include "wdb.h"
+#include "wdb_state.h"
 #include <os_net/os_net.h>
 
 static void wdb_help() __attribute__ ((noreturn));
@@ -21,6 +22,7 @@ static void * run_gc(void * args);
 static void * run_up(void * args);
 static void * run_backup(void * args);
 
+extern wdb_state_t wdb_state;
 
 //int wazuhdb_fdsock;
 wnotify_t * notify_queue;
@@ -191,6 +193,10 @@ int main(int argc, char ** argv)
         merror_exit("at run_dealer(): wnotify_init(): %s (%d)",
                 strerror(errno), errno);
     }
+
+    // Stats uptime
+
+    wdb_state.uptime = time(NULL);
 
     // Start threads
 

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -194,7 +194,7 @@ int main(int argc, char ** argv)
                 strerror(errno), errno);
     }
 
-    // Stats uptime
+    // Global stats uptime
 
     wdb_state.uptime = time(NULL);
 

--- a/src/wazuh_db/wdb_state.c
+++ b/src/wazuh_db/wdb_state.c
@@ -907,6 +907,7 @@ cJSON* wdb_create_state_json() {
 
     cJSON *wdb_state_json = cJSON_CreateObject();
 
+    cJSON_AddNumberToObject(wdb_state_json, "uptime", wdb_state_cpy.uptime);
     cJSON_AddNumberToObject(wdb_state_json, "timestamp", time(NULL));
     cJSON_AddStringToObject(wdb_state_json, "name", ARGV0);
 

--- a/src/wazuh_db/wdb_state.c
+++ b/src/wazuh_db/wdb_state.c
@@ -34,8 +34,8 @@ STATIC uint64_t get_task_time(wdb_state_t state);
 
 STATIC uint64_t get_time_total(wdb_state_t state);
 
-pthread_mutex_t db_state_t_mutex = PTHREAD_MUTEX_INITIALIZER;
 wdb_state_t wdb_state = {0};
+pthread_mutex_t db_state_t_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 void w_inc_queries_total() {
     w_mutex_lock(&db_state_t_mutex);

--- a/src/wazuh_db/wdb_state.h
+++ b/src/wazuh_db/wdb_state.h
@@ -238,6 +238,7 @@ typedef struct _queries_breakdown_t {
 } queries_breakdown_t;
 
 typedef struct _db_stats_t {
+    uint64_t uptime;
     uint64_t queries_total;
     queries_breakdown_t queries_breakdown;
 } wdb_state_t;


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/14457|

## Description

A new timestamp called uptime is added to global and agents statistics in order to know when the count of the metrics started.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)
