### PR TITLE
Improve Amazon Linux 2 filter for control 1.5.2

### DIFF
--- a/ruleset/sca/amazon/cis_amazon_linux_2.yml
+++ b/ruleset/sca/amazon/cis_amazon_linux_2.yml
@@ -559,7 +559,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:sh -c "journalctl | grep \"protection: \" | tail -1" -> r:protection: active'
+      - 'c:sh -c "journalctl -k --boot | grep \"protection: \" | tail -1" -> r:protection: active'
       - 'not c:sh -c "[[ -n $(grep noexec[0-9]*=off /proc/cmdline) || -z $(grep -E -i \" (pae|nx) \" /proc/cpuinfo) || -n $(grep \"\\sNX\\s.*\\sprotection:\\s\" /var/log/dmesg | grep -v active) ]] && echo \"NX Protection is not active\"" -> r:^NX Protection is not active$'
 
   # 1.5.3 Ensure address space layout randomization (ASLR) is enabled.


### PR DESCRIPTION
| Component | Action type           | Main Issue 
| --- | --- | ---
| SCA       | Rework |  #14358 

## Main tasks

- [ ] Verify new command options works
- [ ] Verify SCA run with debug options for this control 

```
2022/08/04 18:26:25 sca[4407] wm_sca.c:1014 at wm_sca_do_scan(): DEBUG: Considering rule: 'c:sh -c "journalctl -k --boot | grep \"protection: \" | tail -1" -> r:protection: active'
2022/08/04 18:26:25 sca[4407] wm_sca.c:1128 at wm_sca_do_scan(): DEBUG: Running command: 'sh -c "journalctl -k --boot | grep \"protection: \" | tail -1"'
2022/08/04 18:26:25 sca[4407] wm_sca.c:1623 at wm_sca_read_command(): DEBUG: Executing command 'sh -c "journalctl -k --boot | grep \"protection: \" | tail -1"', and testing output with pattern 'r:protection: active'
2022/08/04 18:26:25 sca[4407] wm_sca.c:1629 at wm_sca_read_command(): DEBUG: Command 'sh -c "journalctl -k --boot | grep \"protection: \" | tail -1"' returned code 0
2022/08/04 18:26:25 sca[4407] wm_sca.c:1895 at wm_sca_pattern_matches(): DEBUG: Testing minterm (r:protection: active)(Aug 04 18:17:46 localhost kernel: NX (Execute Disable) protection: active) -> 1
2022/08/04 18:26:25 sca[4407] wm_sca.c:1898 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (r:protection: active)(Aug 04 18:17:46 localhost kernel: NX (Execute Disable) protection: active) -> 1
2022/08/04 18:26:25 sca[4407] wm_sca.c:1685 at wm_sca_read_command(): DEBUG: Result for (r:protection: active)(sh -c "journalctl -k --boot | grep \"protection: \" | tail -1") -> 1
2022/08/04 18:26:25 sca[4407] wm_sca.c:1131 at wm_sca_do_scan(): DEBUG: Command output matched.
2022/08/04 18:26:25 sca[4407] wm_sca.c:1218 at wm_sca_do_scan(): DEBUG: Result for rule 'c:sh -c "journalctl -k --boot | grep \"protection: \" | tail -1" -> r:protection: active': 1
2022/08/04 18:26:25 sca[4407] wm_sca.c:1014 at wm_sca_do_scan(): DEBUG: Considering rule: 'not c:sh -c "[[ -n $(grep noexec[0-9]*=off /proc/cmdline) || -z $(grep -E -i \" (pae|nx) \" /proc/cpuinfo) || -n $(grep \"\\sNX\\s.*\\sprotection:\\s\" /var/log/dmesg | grep -v active) ]] && echo \"NX Protection is not active\"" -> r:^NX Protection is not active$'
2022/08/04 18:26:25 sca[4407] wm_sca.c:1033 at wm_sca_do_scan(): DEBUG: Rule is negated.
2022/08/04 18:26:25 sca[4407] wm_sca.c:1128 at wm_sca_do_scan(): DEBUG: Running command: 'sh -c "[[ -n $(grep noexec[0-9]*=off /proc/cmdline) || -z $(grep -E -i \" (pae|nx) \" /proc/cpuinfo) || -n $(grep \"\\sNX\\s.*\\sprotection:\\s\" /var/log/dmesg | grep -v active) ]] && echo \"NX Protection is not active\""'
2022/08/04 18:26:25 sca[4407] wm_sca.c:1623 at wm_sca_read_command(): DEBUG: Executing command 'sh -c "[[ -n $(grep noexec[0-9]*=off /proc/cmdline) || -z $(grep -E -i \" (pae|nx) \" /proc/cpuinfo) || -n $(grep \"\\sNX\\s.*\\sprotection:\\s\" /var/log/dmesg | grep -v active) ]] && echo \"NX Protection is not active\""', and testing output with pattern 'r:^NX Protection is not active$'
2022/08/04 18:26:25 sca[4407] wm_sca.c:1629 at wm_sca_read_command(): DEBUG: Command 'sh -c "[[ -n $(grep noexec[0-9]*=off /proc/cmdline) || -z $(grep -E -i \" (pae|nx) \" /proc/cpuinfo) || -n $(grep \"\\sNX\\s.*\\sprotection:\\s\" /var/log/dmesg | grep -v active) ]] && echo \"NX Protection is not active\""' returned code 1
2022/08/04 18:26:25 sca[4407] wm_sca.c:1895 at wm_sca_pattern_matches(): DEBUG: Testing minterm (r:^NX Protection is not active$)(EMPTY_LINE) -> 0
2022/08/04 18:26:25 sca[4407] wm_sca.c:1898 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (r:^NX Protection is not active$)(EMPTY_LINE) -> 0
2022/08/04 18:26:25 sca[4407] wm_sca.c:1685 at wm_sca_read_command(): DEBUG: Result for (r:^NX Protection is not active$)(sh -c "[[ -n $(grep noexec[0-9]*=off /proc/cmdline) || -z $(grep -E -i \" (pae|nx) \" /proc/cpuinfo) || -n $(grep \"\\sNX\\s.*\\sprotection:\\s\" /var/log/dmesg | grep -v active) ]] && echo \"NX Protection is not active\"") -> 0
2022/08/04 18:26:25 sca[4407] wm_sca.c:1218 at wm_sca_do_scan(): DEBUG: Result for rule 'not c:sh -c "[[ -n $(grep noexec[0-9]*=off /proc/cmdline) || -z $(grep -E -i \" (pae|nx) \" /proc/cpuinfo) || -n $(grep \"\\sNX\\s.*\\sprotection:\\s\" /var/log/dmesg | grep -v active) ]] && echo \"NX Protection is not active\"" -> r:^NX Protection is not active$': 1
2022/08/04 18:26:25 sca[4407] wm_sca.c:1241 at wm_sca_do_scan(): DEBUG: Result for check id: 20529 'Ensure XD/NX support is enabled.' -> 1
```