### PR TITLE
Invalid calling convention for stop functions

### DIFF
--- a/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.c
+++ b/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.c
@@ -30,18 +30,17 @@
  * */
 #ifdef WIN32
 STATIC DWORD WINAPI wm_agent_upgrade_main(void *arg);
-STATIC DWORD WINAPI wm_agent_upgrade_destroy(void* upgrade_config);
 #else
 STATIC void* wm_agent_upgrade_main(wm_agent_upgrade* upgrade_config);
-STATIC void wm_agent_upgrade_destroy(wm_agent_upgrade* upgrade_config);
 #endif
+STATIC void wm_agent_upgrade_destroy(wm_agent_upgrade* upgrade_config);
 STATIC cJSON *wm_agent_upgrade_dump(const wm_agent_upgrade* upgrade_config);
 
 /* Context definition */
 const wm_context WM_AGENT_UPGRADE_CONTEXT = {
     AGENT_UPGRADE_WM_NAME,
     (wm_routine)wm_agent_upgrade_main,
-    (wm_routine)(void *)wm_agent_upgrade_destroy,
+    (void(*)(void *))wm_agent_upgrade_destroy,
     (cJSON * (*)(const void *))wm_agent_upgrade_dump,
     NULL,
     NULL
@@ -66,20 +65,12 @@ STATIC void *wm_agent_upgrade_main(wm_agent_upgrade* upgrade_config) {
 #endif
 }
 
-#ifdef WIN32
-STATIC DWORD WINAPI wm_agent_upgrade_destroy(void* upgrade_config_ptr) {
-    wm_agent_upgrade *upgrade_config = (wm_agent_upgrade *)upgrade_config_ptr;
-#else
 STATIC void wm_agent_upgrade_destroy(wm_agent_upgrade* upgrade_config) {
-#endif
     mtinfo(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_MODULE_FINISHED);
     #ifndef CLIENT
     os_free(upgrade_config->manager_config.wpk_repository);
     #endif
     os_free(upgrade_config);
-    #ifdef WIN32
-    return 0;
-    #endif
 }
 
 STATIC cJSON *wm_agent_upgrade_dump(const wm_agent_upgrade* upgrade_config){

--- a/src/wazuh_modules/task_manager/wm_task_manager.c
+++ b/src/wazuh_modules/task_manager/wm_task_manager.c
@@ -33,18 +33,17 @@ extern void mock_assert(const int result, const char* const expression,
 STATIC int wm_task_manager_init(wm_task_manager *task_config) __attribute__((nonnull));
 #ifdef WIN32
 STATIC DWORD WINAPI wm_task_manager_main(void *arg);
-STATIC DWORD WINAPI wm_task_manager_destroy(void* task_config);
 #else
 STATIC void* wm_task_manager_main(wm_task_manager* task_config);    // Module main function. It won't return
-STATIC void wm_task_manager_destroy(wm_task_manager* task_config);
 #endif
+STATIC void wm_task_manager_destroy(wm_task_manager* task_config);
 STATIC cJSON* wm_task_manager_dump(const wm_task_manager* task_config);
 
 /* Context definition */
 const wm_context WM_TASK_MANAGER_CONTEXT = {
     TASK_MANAGER_WM_NAME,
     (wm_routine)wm_task_manager_main,
-    (wm_routine)(void *)wm_task_manager_destroy,
+    (void (*)(void *))wm_task_manager_destroy,
     (cJSON * (*)(const void *))wm_task_manager_dump,
     NULL,
     NULL
@@ -219,16 +218,9 @@ STATIC void* wm_task_manager_main(wm_task_manager* task_config) {
 #endif
 }
 
-#ifdef WIN32
-STATIC DWORD WINAPI wm_task_manager_destroy(void* task_config) {
-#else
 STATIC void wm_task_manager_destroy(wm_task_manager* task_config) {
-#endif
     mtinfo(WM_TASK_MANAGER_LOGTAG, MOD_TASK_FINISH);
     os_free(task_config);
-    #ifdef WIN32
-    return 0;
-    #endif
 }
 
 STATIC cJSON* wm_task_manager_dump(const wm_task_manager* task_config){

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -446,7 +446,7 @@ int deps_id = 0;
 const wm_context WM_VULNDETECTOR_CONTEXT = {
     "vulnerability-detector",
     (wm_routine)wm_vuldet_main,
-    (wm_routine)(void *)wm_vuldet_destroy,
+    (void (*)(void *))wm_vuldet_destroy,
     (cJSON * (*)(const void *))wm_vuldet_dump,
     NULL,
     NULL

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -21,11 +21,10 @@
 static wm_aws *aws_config;                              // Pointer to aws_configuration
 #ifdef WIN32
 static DWORD WINAPI wm_aws_main(void *arg);             // Module main function. It won't return
-static DWORD WINAPI wm_aws_destroy(void *aws_config);   // Destroy data
 #else
 static void* wm_aws_main(wm_aws *aws_config);           // Module main function. It won't return
-static void wm_aws_destroy(wm_aws *aws_config);         // Destroy data
 #endif
+static void wm_aws_destroy(wm_aws *aws_config);         // Destroy data
 static void wm_aws_setup(wm_aws *_aws_config);          // Setup module
 static void wm_aws_check();                             // Check configuration, disable flag
 static void wm_aws_run_s3(wm_aws *aws_config, wm_aws_bucket *bucket);       // Run a s3 bucket
@@ -37,7 +36,7 @@ cJSON *wm_aws_dump(const wm_aws *aws_config);
 const wm_context WM_AWS_CONTEXT = {
     "aws-s3",
     (wm_routine)wm_aws_main,
-    (wm_routine)(void *)wm_aws_destroy,
+    (void(*)(void *))wm_aws_destroy,
     (cJSON * (*)(const void *))wm_aws_dump,
     NULL,
     NULL
@@ -262,15 +261,8 @@ cJSON *wm_aws_dump(const wm_aws *aws_config) {
 
 
 // Destroy data
-#ifdef WIN32
-DWORD WINAPI wm_aws_destroy(void *aws_config) {         // Destroy data
-#else
 void wm_aws_destroy(wm_aws *aws_config) {
-#endif
     free(aws_config);
-    #ifdef WIN32
-    return 0;
-    #endif
 }
 
 // Setup module

--- a/src/wazuh_modules/wm_azure.c
+++ b/src/wazuh_modules/wm_azure.c
@@ -34,7 +34,7 @@ cJSON *wm_azure_dump(const wm_azure_t *azure);                          // Dump 
 const wm_context WM_AZURE_CONTEXT = {
     AZ_WM_NAME,
     (wm_routine)wm_azure_main,
-    (wm_routine)(void *)wm_azure_destroy,
+    (void(*)(void *))wm_azure_destroy,
     (cJSON * (*)(const void *))wm_azure_dump,
     NULL,
     NULL

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -20,11 +20,10 @@ static int queue_fd;                                // Output queue file descrip
 
 #ifdef WIN32
 static DWORD WINAPI wm_ciscat_main(void *arg);                  // Module main function. It won't return
-static DWORD WINAPI wm_ciscat_destroy(void *ciscat);            // Destroy data
 #else
 static void* wm_ciscat_main(wm_ciscat *ciscat);        // Module main function. It won't return
-static void wm_ciscat_destroy(wm_ciscat *ciscat);      // Destroy data
 #endif
+static void wm_ciscat_destroy(wm_ciscat *ciscat);      // Destroy data
 static void wm_ciscat_setup(wm_ciscat *_ciscat);       // Setup module
 static void wm_ciscat_check();                       // Check configuration, disable flag
 static void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char *java_path, const char *ciscat_binary);      // Run a CIS-CAT policy
@@ -49,7 +48,7 @@ const char *WM_CISCAT_LOCATION = "wodle_cis-cat";  // Location field for event s
 const wm_context WM_CISCAT_CONTEXT = {
     "cis-cat",
     (wm_routine)wm_ciscat_main,
-    (wm_routine)(void *)wm_ciscat_destroy,
+    (void(*)(void *))wm_ciscat_destroy,
     (cJSON * (*)(const void *))wm_ciscat_dump,
     NULL,
     NULL
@@ -1575,12 +1574,7 @@ cJSON *wm_ciscat_dump(const wm_ciscat * ciscat) {
 }
 
 // Destroy data
-#ifdef WIN32
-DWORD WINAPI wm_ciscat_destroy(void *ptr_ciscat) {
-    wm_ciscat *ciscat = (wm_ciscat *)ptr_ciscat;
-#else
 void wm_ciscat_destroy(wm_ciscat *ciscat) {
-#endif
     wm_ciscat_eval *cur_eval;
     wm_ciscat_eval *next_eval;
     // Delete evals
@@ -1597,8 +1591,5 @@ void wm_ciscat_destroy(wm_ciscat *ciscat) {
     free(ciscat->ciscat_path);
     free(ciscat->ciscat_binary);
     free(ciscat);
-    #ifdef WIN32
-    return 0;
-    #endif
 }
 #endif

--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -13,11 +13,10 @@
 
 #ifdef WIN32
 static DWORD WINAPI wm_command_main(void *arg);             // Module main function. It won't return
-static DWORD WINAPI wm_command_destroy(void *command);      // Destroy data
 #else
 static void * wm_command_main(wm_command_t * command);    // Module main function. It won't return
-static void wm_command_destroy(wm_command_t * command);   // Destroy data
 #endif
+static void wm_command_destroy(wm_command_t * command);   // Destroy data
 cJSON *wm_command_dump(const wm_command_t * command);
 
 // Command module context definition
@@ -25,7 +24,7 @@ cJSON *wm_command_dump(const wm_command_t * command);
 const wm_context WM_COMMAND_CONTEXT = {
     "command",
     (wm_routine)wm_command_main,
-    (wm_routine)(void *)wm_command_destroy,
+    (void(*)(void *))wm_command_destroy,
     (cJSON * (*)(const void *))wm_command_dump,
     NULL,
     NULL
@@ -265,17 +264,9 @@ cJSON *wm_command_dump(const wm_command_t * command) {
 
 
 // Destroy data
-#ifdef WIN32
-DWORD WINAPI wm_command_destroy(void *ptr_command) {
-    wm_command_t * command = (wm_command_t *)ptr_command;
-#else
 void wm_command_destroy(wm_command_t * command) {
-#endif
     free(command->tag);
     free(command->command);
     free(command->full_command);
     free(command);
-    #ifdef WIN32
-    return 0;
-    #endif
 }

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -23,7 +23,7 @@ cJSON *wm_control_dump();
 const wm_context WM_CONTROL_CONTEXT = {
     "control",
     (wm_routine)wm_control_main,
-    (wm_routine)(void *)wm_control_destroy,
+    (void(*)(void *))wm_control_destroy,
     (cJSON * (*)(const void *))wm_control_dump,
     NULL,
     NULL

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -107,7 +107,7 @@ static int wm_sync_file(const char *dirname, const char *path);
 const wm_context WM_DATABASE_CONTEXT = {
     "database",
     (wm_routine)wm_database_main,
-    (wm_routine)wm_database_destroy,
+    (void(*)(void *))wm_database_destroy,
     (cJSON * (*)(const void *))wm_database_dump,
     NULL,
     NULL

--- a/src/wazuh_modules/wm_docker.c
+++ b/src/wazuh_modules/wm_docker.c
@@ -27,7 +27,7 @@ cJSON *wm_docker_dump(const wm_docker_t *docker_conf);         // Dump docker co
 const wm_context WM_DOCKER_CONTEXT = {
     "docker-listener",
     (wm_routine)wm_docker_main,
-    (wm_routine)(void *)wm_docker_destroy,
+    (void(*)(void *))wm_docker_destroy,
     (cJSON * (*)(const void *))wm_docker_dump,
     NULL,
     NULL

--- a/src/wazuh_modules/wm_download.c
+++ b/src/wazuh_modules/wm_download.c
@@ -36,7 +36,7 @@ static void wm_download_dispatch(char * buffer);
 const wm_context WM_DOWNLOAD_CONTEXT = {
     "download",
     (wm_routine)wm_download_main,
-    (wm_routine)(void *)wm_download_destroy,
+    (void (*)(void *))wm_download_destroy,
     (cJSON * (*)(const void *))wm_download_dump,
     NULL,
     NULL

--- a/src/wazuh_modules/wm_fluent.c
+++ b/src/wazuh_modules/wm_fluent.c
@@ -70,7 +70,7 @@ static void wm_fluent_poll_server(wm_fluent_t * fluent);
 const wm_context WM_FLUENT_CONTEXT = {
     FLUENT_WM_NAME,
     (wm_routine)wm_fluent_main,
-    (wm_routine)(void *)wm_fluent_destroy,
+    (void(*)(void *))wm_fluent_destroy,
     (cJSON * (*)(const void *))wm_fluent_dump,
     NULL,
     NULL

--- a/src/wazuh_modules/wm_gcp.c
+++ b/src/wazuh_modules/wm_gcp.c
@@ -44,18 +44,6 @@ static DWORD WINAPI wm_gcp_pubsub_main(void *arg);                     // Module
  * @param gcp_config Module configuration structure
  */
 static DWORD WINAPI wm_gcp_bucket_main(void *arg);                     // Module main function. It won't return
-
-/**
- * @brief Free configuration structure for Google Cloud Pub/Sub
- * @param gcp_config Module configuration structure
- */
-static DWORD WINAPI wm_gcp_pubsub_destroy(void *gcp_config);           // Destroy data
-
-/**
- * @brief Free configuration structure for Google Cloud bucket
- * @param gcp_config Module configuration structure
- */
-static DWORD WINAPI wm_gcp_bucket_destroy(void *gcp_config);           // Destroy data
 #else
 /**
  * @brief Main function for Google Cloud Pub/Sub
@@ -68,6 +56,7 @@ static void* wm_gcp_pubsub_main(wm_gcp_pubsub *gcp_config);          // Module m
  * @param gcp_config Module configuration structure
  */
 static void* wm_gcp_bucket_main(wm_gcp_bucket_base *gcp_config);          // Module main function. It won't return
+#endif
 
 /**
  * @brief Free configuration structure for Google Cloud Pub/Sub
@@ -80,7 +69,7 @@ static void wm_gcp_pubsub_destroy(wm_gcp_pubsub *gcp_config);        // Destroy 
  * @param gcp_config Module configuration structure
  */
 static void wm_gcp_bucket_destroy(wm_gcp_bucket_base *gcp_config);        // Destroy data
-#endif
+
 /**
  * @brief Run module function for Google Cloud bucket
  * @param exec_bucket Bucket configuration structure
@@ -108,7 +97,7 @@ static void wm_gcp_parse_output(char *output, char *tag);
 const wm_context WM_GCP_PUBSUB_CONTEXT = {
     GCP_PUBSUB_WM_NAME,
     (wm_routine)wm_gcp_pubsub_main,
-    (wm_routine)(void *)wm_gcp_pubsub_destroy,
+    (void(*)(void *))wm_gcp_pubsub_destroy,
     (cJSON * (*)(const void *))wm_gcp_pubsub_dump,
     NULL,
     NULL
@@ -117,7 +106,7 @@ const wm_context WM_GCP_PUBSUB_CONTEXT = {
 const wm_context WM_GCP_BUCKET_CONTEXT = {
     GCP_BUCKET_WM_NAME,
     (wm_routine)wm_gcp_bucket_main,
-    (wm_routine)(void *)wm_gcp_bucket_destroy,
+    (void(*)(void *))wm_gcp_bucket_destroy,
     (cJSON * (*)(const void *))wm_gcp_bucket_dump,
     NULL,
     NULL
@@ -450,27 +439,14 @@ void wm_gcp_bucket_run(wm_gcp_bucket *exec_bucket) {
     os_free(output);
 }
 
-#ifdef WIN32
-DWORD WINAPI wm_gcp_pubsub_destroy(void *gcp_config) {
-    wm_gcp_pubsub *data = (wm_gcp_pubsub *)gcp_config;
-#else
 void wm_gcp_pubsub_destroy(wm_gcp_pubsub * data) {
-#endif
     if (data->project_id) os_free(data->project_id);
     if (data->subscription_name) os_free(data->subscription_name);
     if (data->credentials_file) os_free(data->credentials_file);
     os_free(data);
-    #ifdef WIN32
-    return 0;
-    #endif
 }
 
-#ifdef WIN32
-DWORD WINAPI wm_gcp_bucket_destroy(void *gcp_config) {
-    wm_gcp_bucket_base * data = (wm_gcp_bucket_base *)gcp_config;
-#else
 void wm_gcp_bucket_destroy(wm_gcp_bucket_base * data) {
-#endif
     wm_gcp_bucket *cur_bucket;
     wm_gcp_bucket *next_bucket = data->buckets;
     while(next_bucket){
@@ -484,9 +460,6 @@ void wm_gcp_bucket_destroy(wm_gcp_bucket_base * data) {
         os_free(cur_bucket);
     }
     os_free(data);
-    #ifdef WIN32
-    return 0;
-    #endif
 }
 
 cJSON *wm_gcp_pubsub_dump(const wm_gcp_pubsub *data) {

--- a/src/wazuh_modules/wm_github.c
+++ b/src/wazuh_modules/wm_github.c
@@ -37,11 +37,10 @@ static char* event_types[] = {
 
 #ifdef WIN32
 STATIC DWORD WINAPI wm_github_main(void* arg);              // Module main function. It won't return
-STATIC DWORD WINAPI wm_github_destroy(void* github_config);
 #else
 STATIC void* wm_github_main(wm_github* github_config);    // Module main function. It won't return
-STATIC void wm_github_destroy(wm_github* github_config);
 #endif
+STATIC void wm_github_destroy(wm_github* github_config);
 STATIC void wm_github_auth_destroy(wm_github_auth* github_auth);
 STATIC void wm_github_fail_destroy(wm_github_fail* github_fails);
 cJSON *wm_github_dump(const wm_github* github_config);
@@ -76,7 +75,7 @@ STATIC void wm_github_scan_failure_action(wm_github_fail **current_fails, char *
 const wm_context WM_GITHUB_CONTEXT = {
     GITHUB_WM_NAME,
     (wm_routine)wm_github_main,
-    (wm_routine)(void *)wm_github_destroy,
+    (void(*)(void *))wm_github_destroy,
     (cJSON * (*)(const void *))wm_github_dump,
     NULL,
     NULL
@@ -125,20 +124,12 @@ void * wm_github_main(wm_github* github_config) {
 #endif
 }
 
-#ifdef WIN32
-STATIC DWORD WINAPI wm_github_destroy(void* ptr_github_config) {
-    wm_github *github_config = (wm_github *)ptr_github_config;
-#else
 void wm_github_destroy(wm_github* github_config) {
-#endif
     mtinfo(WM_GITHUB_LOGTAG, "Module GitHub finished.");
     wm_github_auth_destroy(github_config->auth);
     wm_github_fail_destroy(github_config->fails);
     os_free(github_config->event_type);
     os_free(github_config);
-    #ifdef WIN32
-    return 0;
-    #endif
 }
 
 void wm_github_auth_destroy(wm_github_auth* github_auth)

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -32,11 +32,10 @@
 
 #ifdef WIN32
 STATIC DWORD WINAPI wm_office365_main(void *arg);                   // Module main function. It won't return
-STATIC DWORD WINAPI wm_office365_destroy(void *office365_config);
 #else
 STATIC void* wm_office365_main(wm_office365* office365_config);    // Module main function. It won't return
-STATIC void wm_office365_destroy(wm_office365* office365_config);
 #endif
+STATIC void wm_office365_destroy(wm_office365* office365_config);
 STATIC void wm_office365_auth_destroy(wm_office365_auth* office365_auth);
 STATIC void wm_office365_subscription_destroy(wm_office365_subscription* office365_subscription);
 STATIC void wm_office365_fail_destroy(wm_office365_fail* office365_fails);
@@ -116,7 +115,7 @@ STATIC void wm_office365_scan_failure_action(wm_office365_fail** current_fails, 
 const wm_context WM_OFFICE365_CONTEXT = {
     OFFICE365_WM_NAME,
     (wm_routine)wm_office365_main,
-    (wm_routine)(void *)wm_office365_destroy,
+    (void(*)(void *))wm_office365_destroy,
     (cJSON * (*)(const void *))wm_office365_dump,
     NULL,
     NULL
@@ -161,20 +160,12 @@ void * wm_office365_main(wm_office365* office365_config) {
 #endif
 }
 
-#ifdef WIN32
-STATIC DWORD WINAPI wm_office365_destroy(void *office365_config_ptr) {
-    wm_office365 *office365_config = (wm_office365 *)office365_config_ptr;
-#else
 void wm_office365_destroy(wm_office365* office365_config) {
-#endif
     mtinfo(WM_OFFICE365_LOGTAG, "Module Office365 finished.");
     wm_office365_auth_destroy(office365_config->auth);
     wm_office365_subscription_destroy(office365_config->subscription);
     wm_office365_fail_destroy(office365_config->fails);
     os_free(office365_config);
-    #ifdef WIN32
-    return 0;
-    #endif
 }
 
 void wm_office365_auth_destroy(wm_office365_auth* office365_auth) {

--- a/src/wazuh_modules/wm_oscap.c
+++ b/src/wazuh_modules/wm_oscap.c
@@ -13,11 +13,10 @@
 
 #ifdef WIN32
 static DWORD WINAPI wm_oscap_main(wm_oscap *arg);       // Module main function. It won't return
-static DWORD WINAPI wm_oscap_destroy(void *oscap);      // Destroy data
 #else
 static void* wm_oscap_main(wm_oscap *oscap);        // Module main function. It won't return
-static void wm_oscap_destroy(wm_oscap *oscap);      // Destroy data
 #endif
+static void wm_oscap_destroy(wm_oscap *oscap);      // Destroy data
 cJSON *wm_oscap_dump(const wm_oscap *oscap);
 
 // OpenSCAP module context definition
@@ -25,7 +24,7 @@ cJSON *wm_oscap_dump(const wm_oscap *oscap);
 const wm_context WM_OSCAP_CONTEXT = {
     "open-scap",
     (wm_routine)wm_oscap_main,
-    (wm_routine)(void *)wm_oscap_destroy,
+    (void(*)(void *))wm_oscap_destroy,
     (cJSON * (*)(const void *))wm_oscap_dump,
     NULL,
     NULL
@@ -344,12 +343,7 @@ cJSON *wm_oscap_dump(const wm_oscap *oscap) {
 }
 
 // Destroy data
-#ifdef WIN32
-DWORD WINAPI wm_oscap_destroy(void *oscap_ptr) {
-    wm_oscap *oscap = (wm_oscap *)oscap_ptr;
-#else
 void wm_oscap_destroy(wm_oscap *oscap) {
-#endif
     wm_oscap_eval *cur_eval;
     wm_oscap_eval *next_eval;
     wm_oscap_profile *cur_profile;
@@ -377,8 +371,5 @@ void wm_oscap_destroy(wm_oscap *oscap) {
     }
 
     free(oscap);
-    #ifdef WIN32
-    return 0;
-    #endif
 }
 

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -39,11 +39,10 @@
 
 #ifdef WIN32
 static DWORD WINAPI wm_osquery_monitor_main(void *arg);
-static DWORD WINAPI wm_osquery_monitor_destroy(void *osquery_monitor);
 #else
 static void *wm_osquery_monitor_main(wm_osquery_monitor_t *osquery_monitor);
-static void wm_osquery_monitor_destroy(wm_osquery_monitor_t *osquery_monitor);
 #endif
+static void wm_osquery_monitor_destroy(wm_osquery_monitor_t *osquery_monitor);
 static int wm_osquery_check_logfile(const char * path, FILE * fp);
 static int wm_osquery_packs(wm_osquery_monitor_t *osquery);
 static char * wm_osquery_already_running(char * text);
@@ -54,7 +53,7 @@ static volatile int active = 1;
 const wm_context WM_OSQUERYMONITOR_CONTEXT = {
     "osquery",
     (wm_routine)wm_osquery_monitor_main,
-    (wm_routine)(void *)wm_osquery_monitor_destroy,
+    (void(*)(void *))wm_osquery_monitor_destroy,
     (cJSON * (*)(const void *))wm_osquery_dump,
     NULL,
     NULL
@@ -667,12 +666,7 @@ void *wm_osquery_monitor_main(wm_osquery_monitor_t *osquery) {
 #endif
 }
 
-#ifdef WIN32
-DWORD WINAPI wm_osquery_monitor_destroy(void *osquery_monitor_ptr) {
-    wm_osquery_monitor_t *osquery_monitor = (wm_osquery_monitor_t *)osquery_monitor_ptr;
-#else
 void wm_osquery_monitor_destroy(wm_osquery_monitor_t *osquery_monitor) {
-#endif
     int i;
 
     if (osquery_monitor)
@@ -690,9 +684,6 @@ void wm_osquery_monitor_destroy(wm_osquery_monitor_t *osquery_monitor) {
         free(osquery_monitor->packs);
         free(osquery_monitor);
     }
-    #ifdef WIN32
-    return 0;
-    #endif
 }
 
 // Get read data

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -47,11 +47,10 @@ static const int RETURN_INVALID = 2;
 
 #ifdef WIN32
 static DWORD WINAPI wm_sca_main(void *arg);         // Module main function. It won't return
-static DWORD WINAPI wm_sca_destroy(void *data);     // Destroy data
 #else
 static void * wm_sca_main(wm_sca_t * data);   // Module main function. It won't return
-static void wm_sca_destroy(wm_sca_t * data);  // Destroy data
 #endif
+static void wm_sca_destroy(wm_sca_t * data);  // Destroy data
 static int wm_sca_start(wm_sca_t * data);  // Start
 static cJSON *wm_sca_build_event(const cJSON * const check, const cJSON * const policy, char **p_alert_msg, int id, const char * const result, const char * const reason);
 static int wm_sca_send_event_check(wm_sca_t * data,cJSON *event);  // Send check event
@@ -117,7 +116,7 @@ cJSON *wm_sca_dump(const wm_sca_t * data);     // Read config
 const wm_context WM_SCA_CONTEXT = {
     SCA_WM_NAME,
     (wm_routine)wm_sca_main,
-    (wm_routine)(void *)wm_sca_destroy,
+    (void(*)(void *))wm_sca_destroy,
     (cJSON * (*)(const void *))wm_sca_dump,
     NULL,
     NULL
@@ -2066,15 +2065,8 @@ static int wm_sca_check_process_is_running(OSList *p_list, char *value, char **r
 }
 
 // Destroy data
-#ifdef WIN32
-DWORD WINAPI wm_sca_destroy(void *data) {
-#else
 void wm_sca_destroy(wm_sca_t * data) {
-#endif
     os_free(data);
-    #ifdef WIN32
-    return 0;
-    #endif
 }
 
 #ifdef WIN32

--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -19,11 +19,10 @@
 
 #ifdef WIN32
 static DWORD WINAPI wm_sys_main(void *arg);         // Module main function. It won't return
-static DWORD WINAPI wm_sys_destroy(void *data);      // Destroy data
 #else
 static void* wm_sys_main(wm_sys_t *sys);        // Module main function. It won't return
-static void wm_sys_destroy(wm_sys_t *data);      // Destroy data
 #endif
+static void wm_sys_destroy(wm_sys_t *data);      // Destroy data
 static void wm_sys_stop(wm_sys_t *sys);         // Module stopper
 const char *WM_SYS_LOCATION = "syscollector";   // Location field for event sending
 cJSON *wm_sys_dump(const wm_sys_t *sys);
@@ -37,7 +36,7 @@ bool shutdown_process_started = false;
 const wm_context WM_SYS_CONTEXT = {
     "syscollector",
     (wm_routine)wm_sys_main,
-    (wm_routine)(void *)wm_sys_destroy,
+    (void(*)(void *))wm_sys_destroy,
     (cJSON * (*)(const void *))wm_sys_dump,
     (int(*)(const char*))wm_sync_message,
     (void(*)(void *))wm_sys_stop
@@ -207,15 +206,8 @@ void* wm_sys_main(wm_sys_t *sys) {
     return 0;
 }
 
-#ifdef WIN32
-DWORD WINAPI wm_sys_destroy(void *data) {
-#else
 void wm_sys_destroy(wm_sys_t *data) {
-#endif
     free(data);
-#ifdef WIN32
-    return 0;
-#endif
 }
 
 void wm_sys_stop(__attribute__((unused))wm_sys_t *data) {

--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -40,7 +40,7 @@ const wm_context WM_SYS_CONTEXT = {
     (wm_routine)(void *)wm_sys_destroy,
     (cJSON * (*)(const void *))wm_sys_dump,
     (int(*)(const char*))wm_sync_message,
-    (wm_routine)(void *)wm_sys_stop
+    (void(*)(void *))wm_sys_stop
 };
 
 void *syscollector_module = NULL;

--- a/src/wazuh_modules/wmodules_def.h
+++ b/src/wazuh_modules/wmodules_def.h
@@ -38,7 +38,7 @@ typedef struct wm_context {
     wm_routine destroy;                 // Configuration destructor
     cJSON *(* dump)(const void *);
     int (* sync)(const char*);          // Sync
-    wm_routine stop;                    // Module destructor
+    void (*stop)(void *);               // Module destructor
 } wm_context;
 
 // Main module structure

--- a/src/wazuh_modules/wmodules_def.h
+++ b/src/wazuh_modules/wmodules_def.h
@@ -35,7 +35,7 @@ typedef void* (*wm_routine)(void*);         // Standard routine pointer
 typedef struct wm_context {
     const char *name;                   // Name for module
     wm_routine start;                   // Main function
-    wm_routine destroy;                 // Configuration destructor
+    void (*destroy)(void *);            // Configuration destructor
     cJSON *(* dump)(const void *);
     int (* sync)(const char*);          // Sync
     void (*stop)(void *);               // Module destructor


### PR DESCRIPTION
|Related issue|
|---|
|Closes #13077 |


## Description
This PR solves the problem described below.

RCA:
The root cause of this issue, is the misuse of __stdcall(AKA WINAPI) calling convention.

because of the function pointer it is treating a function as cdecl, calling a function that has stdcall convention

![image](https://user-images.githubusercontent.com/14300208/182987875-8d1ca73c-f862-4f6b-a464-69167020395e.png)


```
wazuh_agent!stop_wmodules:
00902030 53              push    ebx
00902031 83ec18          sub     esp,18h
00902034 8b1dd06ba300    mov     ebx,dword ptr [wazuh_agent!wmodules (00a36bd0)]
0090203a 85db            test    ebx,ebx
0090203c 741e            je      wazuh_agent!stop_wmodules+0x2c (0090205c)
0090203e 6690            nop
00902040 8b4304          mov     eax,dword ptr [ebx+4]
00902043 8b4014          mov     eax,dword ptr [eax+14h]
00902046 85c0            test    eax,eax
00902048 740b            je      wazuh_agent!stop_wmodules+0x25 (00902055)
0090204a 8b530c          mov     edx,dword ptr [ebx+0Ch]
0090204d 891424          mov     dword ptr [esp],edx
00902050 ffd0            call    eax
**00902052 83ec04          sub     esp,4**
00902055 8b5b10          mov     ebx,dword ptr [ebx+10h]
00902058 85db            test    ebx,ebx
0090205a 75e4            jne     wazuh_agent!stop_wmodules+0x10 (00902040)
0090205c 83c418          add     esp,18h
0090205f 5b              pop     ebx
00902060 c3              ret
00902061 8db42600000000  lea     esi,[esi]
00902068 8db42600000000  lea     esi,[esi]
0090206f 90
```

as you can see in this address (00902052), post to the call of a function you want to do the cleanup on the stack, moving the base pointer, this is typical of cdecl, when the above function is executed as stdcall, which already does this cleanup .


Callee function on this case -> wazuh_agent!wm_sys_stop
