### PR TITLE
CloudWatch Logs integration fix

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2841,7 +2841,7 @@ class AWSCloudWatchLogs(AWSService):
                 start_time,
                 end_time)
             VALUES
-                (':aws_region',
+                (:aws_region,
                 :aws_log_group,
                 :aws_log_stream,
                 :next_token,


### PR DESCRIPTION
|Related issue|
|---|
|#14465|

## Description

Hi team,

This PR closes #14465. It fixes a bug in the sql_cloudwatch_insert property of the AWSCloudWatchLogs class. 

## AWS Wodle Unit Tests

```
    ============================= test session starts ==============================
    platform linux -- Python 3.9.5, pytest-6.0.1, py-1.11.0, pluggy-0.13.1 -- /home/test_user/venv/unittest-env/bin/python3
    cachedir: .pytest_cache
    metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.14.0-1047-oem-x86_64-with-glibc2.31', 'Packages': {'pytest': '6.0.1', 'py': '1.11.0', 'pluggy': '0.13.1'}, 'Plugins': {'cov': '3.0.0', 'trio': '0.7.0', 'metadata': '2.0.2', 'asyncio': '0.15.1', 'aiohttp': '0.3.0', 'html': '2.1.1'}}
    rootdir: /home/test_user/git/wazuh/wodles
    plugins: cov-3.0.0, trio-0.7.0, metadata-2.0.2, asyncio-0.15.1, aiohttp-0.3.0, html-2.1.1
    collecting ... collected 38 items
    
    aws/tests/test_aws.py::test_metadata_version_buckets[AWSCloudTrailBucket] PASSED [  2%]
    aws/tests/test_aws.py::test_metadata_version_buckets[AWSConfigBucket] PASSED [  5%]
    aws/tests/test_aws.py::test_metadata_version_buckets[AWSVPCFlowBucket] PASSED [  7%]
    aws/tests/test_aws.py::test_metadata_version_buckets[AWSCustomBucket] PASSED [ 10%]
    aws/tests/test_aws.py::test_metadata_version_buckets[AWSGuardDutyBucket] PASSED [ 13%]
    aws/tests/test_aws.py::test_metadata_version_services[AWSInspector] PASSED [ 15%]
    aws/tests/test_aws.py::test_db_maintenance[AWSCloudTrailBucket-schema_cloudtrail_test.sql-cloudtrail] PASSED [ 18%]
    aws/tests/test_aws.py::test_db_maintenance[AWSConfigBucket-schema_config_test.sql-config] PASSED [ 21%]
    aws/tests/test_aws.py::test_db_maintenance[AWSVPCFlowBucket-schema_vpcflow_test.sql-vpcflow] PASSED [ 23%]
    aws/tests/test_aws.py::test_db_maintenance[AWSCustomBucket-schema_custom_test.sql-custom] PASSED [ 26%]
    aws/tests/test_aws.py::test_db_maintenance[AWSGuardDutyBucket-schema_guardduty_test.sql-guardduty] PASSED [ 28%]
    aws/tests/test_aws.py::test_decompress_file_gz[aws_bucket0-test.gz-gzip.open] PASSED [ 31%]
    aws/tests/test_aws.py::test_decompress_file_gz[aws_bucket0-test.zip-zipfile.ZipFile] PASSED [ 34%]
    aws/tests/test_aws.py::test_decompress_file_snappy_skip[aws_bucket0-test.snappy] PASSED [ 36%]
    aws/tests/test_aws.py::test_decompress_snappy_ko[aws_bucket0-test.snappy-False-SystemExit] PASSED [ 39%]
    aws/tests/test_aws.py::test_decompress_file_ko[.gz-aws_bucket0] PASSED   [ 42%]
    aws/tests/test_aws.py::test_decompress_file_ko[.zip-aws_bucket0] PASSED  [ 44%]
    aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-False] PASSED [ 47%]
    aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-True] PASSED [ 50%]
    aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-invalid-json-True] PASSED [ 52%]
    aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-wrong-structure-True] PASSED [ 55%]
    aws/tests/test_aws.py::test_aws_waf_load_information_from_file_ko[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-invalid-json-False-SystemExit] PASSED [ 57%]
    aws/tests/test_aws.py::test_aws_waf_load_information_from_file_ko[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-wrong-structure-False-SystemExit] PASSED [ 60%]
    aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2021/1/19-20210119] PASSED [ 63%]
    aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2021/1/1-20210101] PASSED [ 65%]
    aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2021/01/01-20210101] PASSED [ 68%]
    aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2000/2/12-20000212] PASSED [ 71%]
    aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2022/02/1-20220201] PASSED [ 73%]
    aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file0-20211221] PASSED [ 76%]
    aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file1-20200103] PASSED [ 78%]
    aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file2-20200920] PASSED [ 81%]
    aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file3-20210118] PASSED [ 84%]
    aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file4-20200930] PASSED [ 86%]
    aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file5-20201015] PASSED [ 89%]
    aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file6-20210318] PASSED [ 92%]
    aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file7-20210906] PASSED [ 94%]
    aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file8-20211112] PASSED [ 97%]
    aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file9-20210123] PASSED [100%]
    
    ============================== 38 passed in 0.27s ==============================

```

## Manual duplicates test 

```
/var/ossec/wodles/aws/aws-s3 -sr cloudwatchlogs -g 4_5_test -d 2 -s 2022-AUG-01 -p dev -r us-east-1
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Getting alerts from "us-east-1" region.
DEBUG: only logs: 1659312000000
DEBUG: +++ Table does not exist; create
DEBUG: Getting log streams for "4_5_test" log group
DEBUG: Found "test_stream" log stream in 4_5_test
DEBUG: Getting data from DB for log stream "test_stream" in log group "4_5_test"
DEBUG: Token: "None", start_time: "None", end_time: "None"
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "4_5_test" using token "None", start_time "1659312000000" and end_time "None"
DEBUG: +++ Sending events to Analysisd...
DEBUG: The message is "Test log 13 - 2022-8-1      1659355579"
DEBUG: +++ Sending events to Analysisd...
DEBUG: The message is "Test log 14 - 2022-8-5   1659625348516"
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "4_5_test" using token "f/37010882153963799441699564827112180521529041759098896384/s", start_time "1659312000000" and end_time "None"
DEBUG: Saving data for log group "4_5_test" and log stream "test_stream".
DEBUG: The saved values are "{'token': 'f/37010882153997250557490996819186541989166846442756603903/s', 'start_time': 1659312000000, 'end_time': 1659625354421}"
DEBUG: Purging the BD
DEBUG: Getting log streams for "4_5_test" log group
DEBUG: Found "test_stream" log stream in 4_5_test
DEBUG: committing changes and closing the DB


/var/ossec/wodles/aws/aws-s3 -sr cloudwatchlogs -g 4_5_test -d 2 -s 2022-AUG-01 -p dev -r us-east-1
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Getting alerts from "us-east-1" region.
DEBUG: only logs: 1659312000000
DEBUG: Getting log streams for "4_5_test" log group
DEBUG: Found "test_stream" log stream in 4_5_test
DEBUG: Getting data from DB for log stream "test_stream" in log group "4_5_test"
DEBUG: Token: "f/37010882153997250557490996819186541989166846442756603903/s", start_time: "1659312000000", end_time: "1659625354421"
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "4_5_test" using token "f/37010882153997250557490996819186541989166846442756603903/s", start_time "1659625354422" and end_time "None"
DEBUG: Saving data for log group "4_5_test" and log stream "test_stream".
DEBUG: The saved values are "{'token': 'f/37010882153997250557490996819186541989166846442756603903/s', 'start_time': 1659312000000, 'end_time': 1659625354422}"
DEBUG: Some data already exists on DB for that key. Updating their values...
DEBUG: Purging the BD
DEBUG: Getting log streams for "4_5_test" log group
DEBUG: Found "test_stream" log stream in 4_5_test
DEBUG: committing changes and closing the DB
```

