### PR TITLE
Show correct client error messages for AWS module

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -71,11 +71,12 @@ DEPRECATED_MESSAGE = 'The {name} authentication parameter was deprecated in {rel
 # Enable/disable debug mode
 debug_level = 0
 INVALID_CREDENTIALS_ERROR_CODE = "SignatureDoesNotMatch"
-INVALID_REQUEST_TIME_ERROR = "RequestTimeTooSkewed"
-THROTTLING_EXCEPTION_ERROR = "ThrottlingException"
+INVALID_REQUEST_TIME_ERROR_CODE = "RequestTimeTooSkewed"
+THROTTLING_EXCEPTION_ERROR_CODE = "ThrottlingException"
 
 INVALID_CREDENTIALS_ERROR_MESSAGE = "Invalid credentials to access S3 Bucket"
 INVALID_REQUEST_TIME_ERROR_MESSAGE = "The server datetime and datetime of the AWS environment differ"
+THROTTLING_EXCEPTION_ERROR_MESSAGE = "The 'check_bucket' request was denied due to request throttling"
 
 ################################################################################
 # Classes
@@ -1096,13 +1097,13 @@ class AWSBucket(WazuhIntegration):
             exit_number = 1
             error_code = error.response.get("Error", {}).get("Code")
 
-            if error_code == THROTTLING_EXCEPTION_ERROR:
-                error_message = "The 'check_bucket' request was denied due to request throttling."
+            if error_code == THROTTLING_EXCEPTION_ERROR_CODE:
+                error_message = f"{THROTTLING_EXCEPTION_ERROR_MESSAGE}: {error}"
                 exit_number = 16
             elif error_code == INVALID_CREDENTIALS_ERROR_CODE:
                 error_message = INVALID_CREDENTIALS_ERROR_MESSAGE
                 exit_number = 3
-            elif error_code == INVALID_REQUEST_TIME_ERROR:
+            elif error_code == INVALID_REQUEST_TIME_ERROR_CODE:
                 error_message = INVALID_REQUEST_TIME_ERROR_MESSAGE
                 exit_number = 19
 
@@ -2584,13 +2585,13 @@ class AWSServerAccess(AWSCustomBucket):
             exit_number = 1
             error_code = error.response.get("Error", {}).get("Code")
 
-            if error_code == THROTTLING_EXCEPTION_ERROR:
-                error_message = f"The 'check_bucket' request failed: {error}"
+            if error_code == THROTTLING_EXCEPTION_ERROR_CODE:
+                error_message = f"{THROTTLING_EXCEPTION_ERROR_MESSAGE}: {error}"
                 exit_number = 16
             elif error_code == INVALID_CREDENTIALS_ERROR_CODE:
                 error_message = INVALID_CREDENTIALS_ERROR_MESSAGE
                 exit_number = 3
-            elif error_code == INVALID_REQUEST_TIME_ERROR:
+            elif error_code == INVALID_REQUEST_TIME_ERROR_CODE:
                 error_message = INVALID_REQUEST_TIME_ERROR_MESSAGE
                 exit_number = 19
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -76,7 +76,7 @@ THROTTLING_EXCEPTION_ERROR_CODE = "ThrottlingException"
 
 INVALID_CREDENTIALS_ERROR_MESSAGE = "Invalid credentials to access S3 Bucket"
 INVALID_REQUEST_TIME_ERROR_MESSAGE = "The server datetime and datetime of the AWS environment differ"
-THROTTLING_EXCEPTION_ERROR_MESSAGE = "The 'check_bucket' request was denied due to request throttling"
+THROTTLING_EXCEPTION_ERROR_MESSAGE = "The '{name}' request was denied due to request throttling"
 
 ################################################################################
 # Classes
@@ -743,8 +743,8 @@ class AWSBucket(WazuhIntegration):
             return accounts
 
         except botocore.exceptions.ClientError as err:
-            if err.response['Error']['Code'] == 'ThrottlingException':
-                debug(f'Error: The "find_account_ids" request was denied due to request throttling. ', 2)
+            if err.response['Error']['Code'] == THROTTLING_EXCEPTION_ERROR_CODE:
+                debug(f'ERROR: {THROTTLING_EXCEPTION_ERROR_MESSAGE.format(name="find_account_ids")}.', 2)
                 sys.exit(16)
             else:
                 debug(f'ERROR: The "find_account_ids" request failed: {err}', 1)
@@ -768,8 +768,8 @@ class AWSBucket(WazuhIntegration):
                 return []
 
         except botocore.exceptions.ClientError as err:
-            if err.response['Error']['Code'] == 'ThrottlingException':
-                debug(f'Error: The "find_regions" request was denied due to request throttling. ', 2)
+            if err.response['Error']['Code'] == THROTTLING_EXCEPTION_ERROR_CODE:
+                debug(f'ERROR: {THROTTLING_EXCEPTION_ERROR_MESSAGE.format(name="find_regions")}. ', 2)
                 sys.exit(16)
             else:
                 debug(f'ERROR: The "find_account_ids" request failed: {err}', 1)
@@ -1098,7 +1098,7 @@ class AWSBucket(WazuhIntegration):
             error_code = error.response.get("Error", {}).get("Code")
 
             if error_code == THROTTLING_EXCEPTION_ERROR_CODE:
-                error_message = f"{THROTTLING_EXCEPTION_ERROR_MESSAGE}: {error}"
+                error_message = f"{THROTTLING_EXCEPTION_ERROR_MESSAGE.format(name='check_bucket')}: {error}"
                 exit_number = 16
             elif error_code == INVALID_CREDENTIALS_ERROR_CODE:
                 error_message = INVALID_CREDENTIALS_ERROR_MESSAGE
@@ -2586,7 +2586,7 @@ class AWSServerAccess(AWSCustomBucket):
             error_code = error.response.get("Error", {}).get("Code")
 
             if error_code == THROTTLING_EXCEPTION_ERROR_CODE:
-                error_message = f"{THROTTLING_EXCEPTION_ERROR_MESSAGE}: {error}"
+                error_message = f"{THROTTLING_EXCEPTION_ERROR_MESSAGE.format(name='check_bucket')}: {error}"
                 exit_number = 16
             elif error_code == INVALID_CREDENTIALS_ERROR_CODE:
                 error_message = INVALID_CREDENTIALS_ERROR_MESSAGE

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -72,6 +72,7 @@ DEPRECATED_MESSAGE = 'The {name} authentication parameter was deprecated in {rel
 debug_level = 0
 INVALID_CREDENTIALS_ERROR_CODE = "SignatureDoesNotMatch"
 INVALID_REQUEST_TIME_ERROR = "RequestTimeTooSkewed"
+THROTTLING_EXCEPTION_ERROR = "ThrottlingException"
 
 INVALID_CREDENTIALS_ERROR_MESSAGE = "Invalid credentials to access S3 Bucket"
 INVALID_REQUEST_TIME_ERROR_MESSAGE = "The server datetime and datetime of the AWS environment differ"
@@ -1095,9 +1096,9 @@ class AWSBucket(WazuhIntegration):
             exit_number = 1
             error_code = error.response.get("Error", {}).get("Code")
 
-            if error_code == 'ThrottlingException':
-                debug(f'Error: The "check_bucket" request was denied due to request throttling. ', 2)
-                sys.exit(16)
+            if error_code == THROTTLING_EXCEPTION_ERROR:
+                error_message = "The 'check_bucket' request was denied due to request throttling."
+                exit_number = 16
             elif error_code == INVALID_CREDENTIALS_ERROR_CODE:
                 error_message = INVALID_CREDENTIALS_ERROR_MESSAGE
                 exit_number = 3
@@ -2583,9 +2584,9 @@ class AWSServerAccess(AWSCustomBucket):
             exit_number = 1
             error_code = error.response.get("Error", {}).get("Code")
 
-            if error_code == 'ThrottlingException':
-                debug(f'ERROR: The "check_bucket" request failed: {error}', 1)
-                sys.exit(16)
+            if error_code == THROTTLING_EXCEPTION_ERROR:
+                error_message = f"The 'check_bucket' request failed: {error}"
+                exit_number = 16
             elif error_code == INVALID_CREDENTIALS_ERROR_CODE:
                 error_message = INVALID_CREDENTIALS_ERROR_MESSAGE
                 exit_number = 3

--- a/wodles/aws/tests/test_aws.py
+++ b/wodles/aws/tests/test_aws.py
@@ -366,6 +366,16 @@ def test_custom_get_creation_date(log_file: dict, expected_date: int, aws_custom
     expected_date : int
         The date that the method should return.
     aws_custom_bucket : aws_s3.AWSCustomBucket
-        Instance of the AWSCustomBucket class.  
+        Instance of the AWSCustomBucket class.
     """
     assert aws_custom_bucket.get_creation_date(log_file) == expected_date
+
+
+@pytest.mark.parametrize("error,message_map,expected_message", [
+    ({"Error": {"Code": "Foo", "Message": "Bar"}}, {"Foo": "Baz"}, "Baz"),
+    ({"Error": {"Code": "Foo", "Message": "Bar"}}, {}, "Bar"),
+])
+def test_get_client_error_message_return_a_valid_message(error: {}, message_map: dict, expected_message: str):
+    client_error_mock = MagicMock()
+    client_error_mock.response = error
+    assert aws_s3.AWSBucket._get_client_error_message(client_error_mock, message_map) == expected_message

--- a/wodles/aws/tests/test_aws.py
+++ b/wodles/aws/tests/test_aws.py
@@ -369,13 +369,3 @@ def test_custom_get_creation_date(log_file: dict, expected_date: int, aws_custom
         Instance of the AWSCustomBucket class.
     """
     assert aws_custom_bucket.get_creation_date(log_file) == expected_date
-
-
-@pytest.mark.parametrize("error,message_map,expected_message", [
-    ({"Error": {"Code": "Foo", "Message": "Bar"}}, {"Foo": "Baz"}, "Baz"),
-    ({"Error": {"Code": "Foo", "Message": "Bar"}}, {}, "Bar"),
-])
-def test_get_client_error_message_return_a_valid_message(error: {}, message_map: dict, expected_message: str):
-    client_error_mock = MagicMock()
-    client_error_mock.response = error
-    assert aws_s3.AWSBucket._get_client_error_message(client_error_mock, message_map) == expected_message


### PR DESCRIPTION
|Related issue|
|---|
|#13436|

## Description

This PR closes #13436. It fixes a bug caused when  `botocore.exceptions.ClientError` is catch. Now displays different messages for  `SignatureDoesNotMatch` and `RequestTimeTooSkewed` errors.

## Manual Tests

### Displaying an error for invalid credentials
```bash
root@1ba6185a394b:/var/ossec# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -s 2022-Feb-01 -p dev -d2
DEBUG: +++ Debug mode on - Level: 2
ERROR: Invalid credentials to access S3 Bucket
```

### Displaying an error for time difference
```bash
root@1ba6185a394b:/var/ossec# FAKETIME="2022-07-01 16:00:00" /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -s 2022-Feb-01 -p dev -d2
DEBUG: +++ Debug mode on - Level: 2
ERROR: The server datetime and datetime of the AWS environment differ
```
