### PR TITLE
Fixing regex in check 5.1.1 of Ubuntu 20.04 SCA

### DIFF
--- a/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
@@ -2445,7 +2445,7 @@ checks:
     condition: all
     rules:
       - 'c:systemctl is-enabled cron -> enabled'
-      - 'c:systemctl status cron -> r:Active: active (running)'
+      - 'c:systemctl status cron -> r:Active: active \(running\)'
 
 # 5.1.2 Ensure permissions on /etc/crontab are configured (Scored)
   - id: 19138


### PR DESCRIPTION
|Related issue|
|---|
|#14235|

## Description

Fixes failing SCA check 5.1.1, error in regex caused false positives