### PR TITLE
Fix checks in RTR tests

### DIFF
--- a/src/ci/run_check.py
+++ b/src/ci/run_check.py
@@ -326,35 +326,34 @@ def runReadyToReview(moduleName, clean=False, target="agent"):
     configPath = os.path.join(utils.currentPath(),
                               "input/test_tool_config.json")
     smokeTestConfig = utils.readJSONFile(jsonFilePath=configPath)
-    ### Uncomment after close https://github.com/wazuh/wazuh/issues/11025
-    # if target == "winagent":
-    #     build_tools.cleanAll()
-    #     build_tools.cleanExternals()
-    #     build_tools.makeDeps(targetName="agent", srcOnly=False)
-    #     build_tools.makeTarget(targetName="agent", tests=False, debug=True)
-    #     build_tools.cleanFolder(moduleName=moduleName,
-    #                             additionalFolder="build")
+    if target == "winagent":
+        build_tools.cleanAll()
+        build_tools.cleanExternals()
+        build_tools.makeDeps(targetName="agent", srcOnly=False)
+        build_tools.makeTarget(targetName="agent", tests=False, debug=True)
+        build_tools.cleanFolder(moduleName=moduleName,
+                                additionalFolder="build")
     if moduleName != "shared_modules/utils":
         runASAN(moduleName=moduleName,
                 testToolConfig=smokeTestConfig)
-    ### Uncomment after close https://github.com/wazuh/wazuh/issues/11025
-    # if moduleName == "syscheckd":
-    #     runTestToolForWindows(moduleName=moduleName,
-    #                           testToolConfig=smokeTestConfig)
-    #     runTestToolCheck(moduleName=moduleName)
-    # if moduleName != "syscheckd":
-    #     build_tools.cleanAll()
-    #     build_tools.cleanExternals()
-    # if target != "winagent":
-    #     utils.printHeader(moduleName=moduleName,
-    #                       headerKey="winagentTests")
-    #     build_tools.makeDeps(targetName="winagent",
-    #                          srcOnly=False)
-    #     build_tools.makeTarget(targetName="winagent",
-    #                            tests=True,
-    #                            debug=True)
-    #     runTests(moduleName=moduleName)
+    if moduleName == "syscheckd":
+        runTestToolForWindows(moduleName=moduleName,
+                              testToolConfig=smokeTestConfig)
+        runTestToolCheck(moduleName=moduleName)
+    if moduleName != "syscheckd":
+        build_tools.cleanAll()
+        build_tools.cleanExternals()
+    if target != "winagent":
+        utils.printHeader(moduleName=moduleName,
+                          headerKey="winagentTests")
+        build_tools.makeDeps(targetName="winagent",
+                             srcOnly=False)
+        build_tools.makeTarget(targetName="winagent",
+                               tests=True,
+                               debug=True)
+        runTests(moduleName=moduleName)
     if clean:
+        os.chdir(os.path.join(utils.rootPath(), moduleName))
         utils.deleteLogs(moduleName=moduleName)
     utils.printGreen(msg="[RTR: PASSED]",
                      module=moduleName)
@@ -494,14 +493,14 @@ def runTestToolForWindows(moduleName, testToolConfig):
     rootPath = os.path.join(utils.moduleDirPathBuild(moduleName),
                             "bin")
     if moduleName == "syscheckd":
-        libgcc = utils.findFile(name="libgcc_s_sjlj-1.dll",
+        libgcc = utils.findFile(name="libgcc_s_dw2-1.dll",
                                 path=utils.rootPath())
         rsync = utils.findFile(name="rsync.dll",
                                path=utils.rootPath())
         dbsync = utils.findFile(name="dbsync.dll",
                                 path=utils.rootPath())
         shutil.copyfile(libgcc,
-                        os.path.join(rootPath, "libgcc_s_sjlj-1.dll"))
+                        os.path.join(rootPath, "libgcc_s_dw2-1.dll"))
         shutil.copyfile(rsync,
                         os.path.join(rootPath, "rsync.dll"))
         shutil.copyfile(dbsync,

--- a/src/ci/utils.py
+++ b/src/ci/utils.py
@@ -76,9 +76,10 @@ def deleteLogs(moduleName):
                 headerKey="deletelogs")
     deleteFolderDic = build_tools.deleteFolderDic()
     for folder in deleteFolderDic[moduleName]:
-        build_tools.cleanFolder(moduleName,
-                                folder,
-                                folder)
+        if (os.path.exists(folder)):
+            build_tools.cleanFolder(moduleName,
+                                    folder,
+                                    folder)
     pytestResultsPath = os.path.join(CURRENT_DIR,
                                      "tests/results")
     out = subprocess.run("rm -rf {}".format(pytestResultsPath),


### PR DESCRIPTION
|EPIC|Component|
|---|---|
| https://github.com/wazuh/wazuh/issues/9103 | FIM |

|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/14373|

## Description
Hi team, there is a bug in our RTR check after the changes in Jenkins docker to Ubuntu 22.04. After we closed [this issue](https://github.com/wazuh/wazuh/issues/11025) I changed some details in our RTR check in order to work correctly.
Regards

## Tests
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report