### PR TITLE
Avoid errno value in unit tests

### DIFF
--- a/src/unit_tests/logcollector/test_state.c
+++ b/src/unit_tests/logcollector/test_state.c
@@ -883,9 +883,10 @@ void test_w_logcollector_state_dump_fail_open(void ** state) {
     expect_string(__wrap_fopen, mode, "w");
     will_return(__wrap_fopen, NULL);
 
-    expect_string(__wrap__merror, formatted_msg,
-                  "(1103): Could not open file "
-                  "'var/run/wazuh-logcollector.state' due to [(0)-(Success)].");
+    const char * error_msg = "(1103): Could not open file "
+                             "'" LOGCOLLECTOR_STATE "' due to";
+
+    expect_memory(__wrap__merror, formatted_msg, error_msg, strlen(error_msg));
 
     w_logcollector_state_dump();
 }
@@ -903,9 +904,10 @@ void test_w_logcollector_state_dump_fail_write(void ** state) {
     will_return(__wrap_fopen, (FILE *) 100);
     will_return(__wrap_fwrite, 0);
 
-    expect_string(__wrap__merror, formatted_msg,
-                  "(1110): Could not write file "
-                  "'var/run/wazuh-logcollector.state' due to [(0)-(Success)].");
+    const char * error_msg = "(1110): Could not write file "
+                             "'" LOGCOLLECTOR_STATE "' due to";
+
+    expect_memory(__wrap__merror, formatted_msg, error_msg, strlen(error_msg));
 
     expect_value(__wrap_fclose, _File, (FILE *) 100);
     will_return(__wrap_fclose, 0);

--- a/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
@@ -254,7 +254,9 @@ void test_wdb_create_agent_db_error_changing_owner(void **state)
     expect_value(__wrap_chown, __group, 0);
     will_return(__wrap_chown, OS_INVALID);
     will_return(__wrap_strerror, "error");
-    expect_string(__wrap__merror, formatted_msg, "(1135): Could not chown object 'var/db/agents/001-agent1.db' due to [(0)-(error)].");
+
+    const char * error_msg = "(1135): Could not chown object 'var/db/agents/001-agent1.db' due to";
+    expect_memory(__wrap__merror, formatted_msg, error_msg, strlen(error_msg));
 
     ret = wdb_create_agent_db(agent_id, agent_name);
 
@@ -299,7 +301,9 @@ void test_wdb_create_agent_db_error_changing_mode(void **state)
     expect_string(__wrap_chmod, path, "var/db/agents/001-agent1.db");
     will_return(__wrap_chmod, OS_INVALID);
     will_return(__wrap_strerror, "error");
-    expect_string(__wrap__merror, formatted_msg, "(1127): Could not chmod object 'var/db/agents/001-agent1.db' due to [(0)-(error)].");
+
+    const char * error_msg = "(1127): Could not chmod object 'var/db/agents/001-agent1.db' due to";
+    expect_memory(__wrap__merror, formatted_msg, error_msg, strlen(error_msg));
 
     ret = wdb_create_agent_db(agent_id, agent_name);
 
@@ -2177,12 +2181,16 @@ void test_wdb_remove_agent_db_error_removing_db_shm_wal(void **state) {
     expect_string(__wrap_remove, filename, "var/db/agents/001-agent1.db-shm");
     will_return(__wrap_remove, OS_INVALID);
     will_return(__wrap_strerror, "error");
-    expect_string(__wrap__mdebug2, formatted_msg, "(1129): Could not unlink file 'var/db/agents/001-agent1.db-shm' due to [(0)-(error)].");
+
+    const char * error_shm = "(1129): Could not unlink file 'var/db/agents/001-agent1.db-shm' due to";
+    expect_memory(__wrap__mdebug2, formatted_msg, error_shm, strlen(error_shm));
 
     expect_string(__wrap_remove, filename, "var/db/agents/001-agent1.db-wal");
     will_return(__wrap_remove, OS_INVALID);
     will_return(__wrap_strerror, "error");
-    expect_string(__wrap__mdebug2, formatted_msg, "(1129): Could not unlink file 'var/db/agents/001-agent1.db-wal' due to [(0)-(error)].");
+
+    const char * error_wal = "(1129): Could not unlink file 'var/db/agents/001-agent1.db-wal' due to";
+    expect_memory(__wrap__mdebug2, formatted_msg, error_wal, strlen(error_wal));
 
     ret = wdb_remove_agent_db(id, name);
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #14502|

## Description
This PR changes the approach taken by the previous unit tests, since from moment 0 the test is defined incorrectly.

If this error message were to happen, a 0(success) could never be returned as the expected value.

Since all filesystem calls are mocked, it is totally trivial to validate this value. Since the functions that could set the errno for this error are mocked.

![image](https://user-images.githubusercontent.com/14300208/183537478-24331601-5184-4a3f-b343-e28114a641b8.png)

![image](https://user-images.githubusercontent.com/14300208/183537358-02ec4b6a-3e4b-48ed-9530-dd12853deadd.png)

