### PR TITLE
Check mtime in cluster files before overwriting them

### DIFF
--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -312,7 +312,7 @@ def compress_files(name, list_path, cluster_control_json=None):
         Path where the zip file has been saved.
     """
     failed_files = list()
-    zip_file_path = path.join(common.wazuh_path, 'queue', 'cluster', name, f'{name}-{time()}-{str(random())[2:]}.zip')
+    zip_file_path = path.join(common.wazuh_path, 'queue', 'cluster', name, f'{name}-{str(random())[2:]}-{time()}.zip')
     if not path.exists(path.dirname(zip_file_path)):
         mkdir_with_mode(path.dirname(zip_file_path))
     with zipfile.ZipFile(zip_file_path, 'x') as zf:


### PR DESCRIPTION
|Related issue|
|---|
| Closes #14505 |

## Description

This PR changes the worker's Integrity sync task behavior so the use case described at #14505 is prevented. Now, while replacing worker files with those coming from the master, any file whose modification time is newer than the timestamp when the zip started to be created in the master, won't be replaced. 

This way, if the DAPI changed a custom rule in all nodes, the master won't replace the file with an old copy. However, if the file is still different in the next iteration, it will be changed (since the zip timestamp will be newer than the file's modification time).

## Logs/Alerts example
This message will be logged when a file isn't replaced:
```
2022/08/08 12:50:03 INFO: [Worker worker1] [Integrity sync] Starting.
2022/08/08 12:50:03 INFO: [Worker worker1] [Integrity sync] Files to create: 0 | Files to update: 1 | Files to delete: 0 | Files to send: 0
2022/08/08 12:50:14 WARNING: [Worker worker1] [Integrity sync] The compression date of this master's file is older than its modification date on the current node, so it will not be replaced: /var/ossec/etc/rules/local_rules.xml
2022/08/08 12:50:28 INFO: [Worker worker1] [Integrity sync] Finished in 25.375s.
```
