### PR TITLE
Fix data field on SyncTxnRows json files

### DIFF
--- a/src/syscheckd/src/db/smokeTests/FimDBTransaction/SyncTxnRows_1.json
+++ b/src/syscheckd/src/db/smokeTests/FimDBTransaction/SyncTxnRows_1.json
@@ -1,29 +1,29 @@
 {
     "action": "SyncTxnRows",
-    "body":
-    {
+    "body": {
         "table": "file_entry",
-        "data":
-        {
-            "attributes": "10",
-            "checksum": "a2fbef8f81af27155dcee5e3927ff6243593b91a",
-            "dev": 2221,
-            "gid": 0,
-            "group_name": "root",
-            "hash_md5": "4b531524aa13c8a54614100b570b3dc7",
-            "hash_sha1": "7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
-            "hash_sha256": "e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a",
-            "inode": 18277083,
-            "last_event": 1596489275,
-            "mode": 0,
-            "mtime": 1578075431,
-            "options": 131583,
-            "path": "/tmp/test_1.txt",
-            "perm": "-rw-rw-r--",
-            "scanned": 1,
-            "size": 4925,
-            "uid": 0,
-            "user_name": "fakeUser"
-        }
+        "data": [
+            {
+                "attributes": "10",
+                "checksum": "a2fbef8f81af27155dcee5e3927ff6243593b91a",
+                "dev": 2221,
+                "gid": 0,
+                "group_name": "root",
+                "hash_md5": "4b531524aa13c8a54614100b570b3dc7",
+                "hash_sha1": "7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
+                "hash_sha256": "e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a",
+                "inode": 18277083,
+                "last_event": 1596489275,
+                "mode": 0,
+                "mtime": 1578075431,
+                "options": 131583,
+                "path": "/tmp/test_1.txt",
+                "perm": "-rw-rw-r--",
+                "scanned": 1,
+                "size": 4925,
+                "uid": 0,
+                "user_name": "fakeUser"
+            }
+        ]
     }
 }

--- a/src/syscheckd/src/db/smokeTests/FimDBTransaction/SyncTxnRows_2.json
+++ b/src/syscheckd/src/db/smokeTests/FimDBTransaction/SyncTxnRows_2.json
@@ -1,29 +1,29 @@
 {
     "action": "SyncTxnRows",
-    "body":
-    {
+    "body": {
         "table": "file_entry",
-        "data":
-        {
-            "attributes": "10",
-            "checksum": "a2fbef8f81af27155dcee5e3927ff6243593b91a",
-            "dev": 2221,
-            "gid": 0,
-            "group_name": "root",
-            "hash_md5": "4b531524aa13c8a54614100b570b3dc7",
-            "hash_sha1": "7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
-            "hash_sha256": "e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a",
-            "inode": 18277083,
-            "last_event": 1596489275,
-            "mode": 0,
-            "mtime": 1578075431,
-            "options": 131583,
-            "path": "/tmp/test_2.txt",
-            "perm": "-rw-rw-r--",
-            "scanned": 1,
-            "size": 4925,
-            "uid": 0,
-            "user_name": "fakeUser"
-        }
+        "data": [
+            {
+                "attributes": "10",
+                "checksum": "a2fbef8f81af27155dcee5e3927ff6243593b91a",
+                "dev": 2221,
+                "gid": 0,
+                "group_name": "root",
+                "hash_md5": "4b531524aa13c8a54614100b570b3dc7",
+                "hash_sha1": "7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
+                "hash_sha256": "e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a",
+                "inode": 18277083,
+                "last_event": 1596489275,
+                "mode": 0,
+                "mtime": 1578075431,
+                "options": 131583,
+                "path": "/tmp/test_2.txt",
+                "perm": "-rw-rw-r--",
+                "scanned": 1,
+                "size": 4925,
+                "uid": 0,
+                "user_name": "fakeUser"
+            }
+        ]
     }
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes  #14494 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
There was an error in the JSON files that feed the FIMDB testtool with the data, causing a handled exception.

## Logs/Alerts example
```
root@a2a92d4c93a8:/share/wazuh/src/syscheckd/src/db/smokeTests# ../../../build/bin/fimdb_test_tool -c config.json -a FimDBTransaction/StartTransaction.json,FimDBTransaction/SyncTxnRows_1.json,FimDBTransaction/GetDeletedRows.json,FimDBTransaction/CountFiles.json,FimDBTransaction/StartTransaction.json,FimDBTransaction/SyncTxnRows_2.json,FimDBTransaction/CountFiles.json -o ./output
Actions: 7
Processing file: FimDBTransaction/StartTransaction.json
Processing file: FimDBTransaction/SyncTxnRows_1.json
{"data":[{"attributes":"10","checksum":"a2fbef8f81af27155dcee5e3927ff6243593b91a","dev":2221,"gid":0,"group_name":"root","hash_md5":"4b531524aa13c8a54614100b570b3dc7","hash_sha1":"7902feb66d0bcbe4eb88e1bfacf28befc38bd58b","hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a","inode":18277083,"last_event":1596489275,"mode":0,"mtime":1578075431,"options":131583,"path":"/tmp/test_1.txt","perm":"-rw-rw-r--","scanned":1,"size":4925,"uid":0,"user_name":"fakeUser"}],"table":"file_entry"}
Processing file: FimDBTransaction/GetDeletedRows.json
Processing file: FimDBTransaction/CountFiles.json
Processing file: FimDBTransaction/StartTransaction.json
Processing file: FimDBTransaction/SyncTxnRows_2.json
{"data":[{"attributes":"10","checksum":"a2fbef8f81af27155dcee5e3927ff6243593b91a","dev":2221,"gid":0,"group_name":"root","hash_md5":"4b531524aa13c8a54614100b570b3dc7","hash_sha1":"7902feb66d0bcbe4eb88e1bfacf28befc38bd58b","hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a","inode":18277083,"last_event":1596489275,"mode":0,"mtime":1578075431,"options":131583,"path":"/tmp/test_2.txt","perm":"-rw-rw-r--","scanned":1,"size":4925,"uid":0,"user_name":"fakeUser"}],"table":"file_entry"}
Processing file: FimDBTransaction/CountFiles.json
Resulting files are located in the ./output folder
root@a2a92d4c93a8:/share/wazuh/src/syscheckd/src/db/smokeTests# ^C
root@a2a92d4c93a8:/share/wazuh/src/syscheckd/src/db/smokeTests# 
```
```json
{
    "data": [
        {
            "Operation type": "INSERTED",
            "action": "SyncTxnRows",
            "value": {
                "attributes": "10",
                "checksum": "a2fbef8f81af27155dcee5e3927ff6243593b91a",
                "dev": 2221,
                "gid": 0,
                "group_name": "root",
                "hash_md5": "4b531524aa13c8a54614100b570b3dc7",
                "hash_sha1": "7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
                "hash_sha256": "e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a",
                "inode": 18277083,
                "last_event": 1596489275,
                "mode": 0,
                "mtime": 1578075431,
                "options": 131583,
                "path": "/tmp/test_1.txt",
                "perm": "-rw-rw-r--",
                "scanned": 1,
                "size": 4925,
                "uid": 0,
                "user_name": "fakeUser"
            }
        },
        {
            "Operation type": "INSERTED",
            "action": "SyncTxnRows",
            "value": {
                "attributes": "10",
                "checksum": "a2fbef8f81af27155dcee5e3927ff6243593b91a",
                "dev": 2221,
                "gid": 0,
                "group_name": "root",
                "hash_md5": "4b531524aa13c8a54614100b570b3dc7",
                "hash_sha1": "7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
                "hash_sha256": "e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a",
                "inode": 18277083,
                "last_event": 1596489275,
                "mode": 0,
                "mtime": 1578075431,
                "options": 131583,
                "path": "/tmp/test_2.txt",
                "perm": "-rw-rw-r--",
                "scanned": 1,
                "size": 4925,
                "uid": 0,
                "user_name": "fakeUser"
            }
        }
    ]
}
```


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors