### PR TITLE
Improved AWS find_account_ids error management

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -24,6 +24,7 @@
 #   15 - Invalid endpoint URL
 #   16 - Throttling error
 #   17 - Invalid key format
+#   18 - Invalid prefix
 
 import argparse
 import signal
@@ -708,6 +709,8 @@ class AWSBucket(WazuhIntegration):
 
     def find_account_ids(self):
         try:
+            import pydevd_pycharm
+            pydevd_pycharm.settrace('172.22.0.1', port=12345, stdoutToServer=True, stderrToServer=True)
             prefixes = self.client.list_objects_v2(Bucket=self.bucket, Prefix=self.get_base_prefix(),
                                                    Delimiter='/')['CommonPrefixes']
             accounts = []
@@ -717,11 +720,8 @@ class AWSBucket(WazuhIntegration):
                     accounts.append(account_id)
             return accounts
         except KeyError:
-            bucket_types = {'cloudtrail', 'config', 'vpcflow', 'guardduty', 'waf', 'custom'}
-            print(f"ERROR: Invalid type of bucket. The bucket was set up as '{get_script_arguments().type.lower()}' "
-                  f"type and this bucket does not contain log files from this type. Try with other type: "
-                  f"{bucket_types - {get_script_arguments().type.lower()}}")
-            sys.exit(12)
+            print(f"ERROR: No prefix named {self.get_base_prefix()} found . Check the provided prefix and the location of the logs "
+            sys.exit(18)
 
     def find_regions(self, account_id):
         regions = self.client.list_objects_v2(Bucket=self.bucket,

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -718,7 +718,7 @@ class AWSBucket(WazuhIntegration):
                     accounts.append(account_id)
             return accounts
         except KeyError:
-            print(f"ERROR: No prefix named {self.get_base_prefix()} found . Check the provided prefix and the location of the logs "
+            print(f"ERROR: No prefix named {self.get_base_prefix()} found. Check the provided prefix and the location of the logs "
             sys.exit(18)
 
     def find_regions(self, account_id):

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -718,7 +718,8 @@ class AWSBucket(WazuhIntegration):
                     accounts.append(account_id)
             return accounts
         except KeyError:
-            print(f"ERROR: No prefix named {self.get_base_prefix()} found. Check the provided prefix and the location of the logs "
+            print(f"ERROR: No prefix named {self.get_base_prefix()} found. Check the provided prefix and the location of the logs for the bucket "
+                  f" type '{get_script_arguments().type.lower()}'")
             sys.exit(18)
 
     def find_regions(self, account_id):

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -709,8 +709,6 @@ class AWSBucket(WazuhIntegration):
 
     def find_account_ids(self):
         try:
-            import pydevd_pycharm
-            pydevd_pycharm.settrace('172.22.0.1', port=12345, stdoutToServer=True, stderrToServer=True)
             prefixes = self.client.list_objects_v2(Bucket=self.bucket, Prefix=self.get_base_prefix(),
                                                    Delimiter='/')['CommonPrefixes']
             accounts = []

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -718,7 +718,7 @@ class AWSBucket(WazuhIntegration):
                     accounts.append(account_id)
             return accounts
         except KeyError:
-            print(f"ERROR: No prefix named {self.get_base_prefix()} found. Check the provided prefix and the location of the logs for the bucket "
+            print(f"ERROR: No logs found in '{self.get_base_prefix()}'. Check the provided prefix and the location of the logs for the bucket "
                   f" type '{get_script_arguments().type.lower()}'")
             sys.exit(18)
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -719,7 +719,7 @@ class AWSBucket(WazuhIntegration):
             return accounts
         except KeyError:
             print(f"ERROR: No logs found in '{self.get_base_prefix()}'. Check the provided prefix and the location of the logs for the bucket "
-                  f" type '{get_script_arguments().type.lower()}'")
+                  f"type '{get_script_arguments().type.lower()}'")
             sys.exit(18)
 
     def find_regions(self, account_id):


### PR DESCRIPTION
|Related issue|
|---|
|#14087|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR closes #14087. It improves the error message presented to the users when the prefix for a specific bucket is not given.

## AWS Wodle Unit Tests

```
============================= test session starts ==============================
platform linux -- Python 3.9.5, pytest-6.0.1, py-1.11.0, pluggy-0.13.1 -- /home/test_user/venv/unittest-env/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.14.0-1047-oem-x86_64-with-glibc2.31', 'Packages': {'pytest': '6.0.1', 'py': '1.11.0', 'pluggy': '0.13.1'}, 'Plugins': {'cov': '3.0.0', 'trio': '0.7.0', 'metadata': '2.0.2', 'asyncio': '0.15.1', 'aiohttp': '0.3.0', 'html': '2.1.1'}}
rootdir: /home/test_user/git/wazuh/wodles
plugins: cov-3.0.0, trio-0.7.0, metadata-2.0.2, asyncio-0.15.1, aiohttp-0.3.0, html-2.1.1
collecting ... collected 38 items

aws/tests/test_aws.py::test_metadata_version_buckets[AWSCloudTrailBucket] PASSED [  2%]
aws/tests/test_aws.py::test_metadata_version_buckets[AWSConfigBucket] PASSED [  5%]
aws/tests/test_aws.py::test_metadata_version_buckets[AWSVPCFlowBucket] PASSED [  7%]
aws/tests/test_aws.py::test_metadata_version_buckets[AWSCustomBucket] PASSED [ 10%]
aws/tests/test_aws.py::test_metadata_version_buckets[AWSGuardDutyBucket] PASSED [ 13%]
aws/tests/test_aws.py::test_metadata_version_services[AWSInspector] PASSED [ 15%]
aws/tests/test_aws.py::test_db_maintenance[AWSCloudTrailBucket-schema_cloudtrail_test.sql-cloudtrail] PASSED [ 18%]
aws/tests/test_aws.py::test_db_maintenance[AWSConfigBucket-schema_config_test.sql-config] PASSED [ 21%]
aws/tests/test_aws.py::test_db_maintenance[AWSVPCFlowBucket-schema_vpcflow_test.sql-vpcflow] PASSED [ 23%]
aws/tests/test_aws.py::test_db_maintenance[AWSCustomBucket-schema_custom_test.sql-custom] PASSED [ 26%]
aws/tests/test_aws.py::test_db_maintenance[AWSGuardDutyBucket-schema_guardduty_test.sql-guardduty] PASSED [ 28%]
aws/tests/test_aws.py::test_decompress_file_gz[aws_bucket0-test.gz-gzip.open] PASSED [ 31%]
aws/tests/test_aws.py::test_decompress_file_gz[aws_bucket0-test.zip-zipfile.ZipFile] PASSED [ 34%]
aws/tests/test_aws.py::test_decompress_file_snappy_skip[aws_bucket0-test.snappy] PASSED [ 36%]
aws/tests/test_aws.py::test_decompress_snappy_ko[aws_bucket0-test.snappy-False-SystemExit] PASSED [ 39%]
aws/tests/test_aws.py::test_decompress_file_ko[.gz-aws_bucket0] PASSED   [ 42%]
aws/tests/test_aws.py::test_decompress_file_ko[.zip-aws_bucket0] PASSED  [ 44%]
aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-False] PASSED [ 47%]
aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-True] PASSED [ 50%]
aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-invalid-json-True] PASSED [ 52%]
aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-wrong-structure-True] PASSED [ 55%]
aws/tests/test_aws.py::test_aws_waf_load_information_from_file_ko[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-invalid-json-False-SystemExit] PASSED [ 57%]
aws/tests/test_aws.py::test_aws_waf_load_information_from_file_ko[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-wrong-structure-False-SystemExit] PASSED [ 60%]
aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2021/1/19-20210119] PASSED [ 63%]
aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2021/1/1-20210101] PASSED [ 65%]
aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2021/01/01-20210101] PASSED [ 68%]
aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2000/2/12-20000212] PASSED [ 71%]
aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2022/02/1-20220201] PASSED [ 73%]
aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file0-20211221] PASSED [ 76%]
aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file1-20200103] PASSED [ 78%]
aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file2-20200920] PASSED [ 81%]
aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file3-20210118] PASSED [ 84%]
aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file4-20200930] PASSED [ 86%]
aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file5-20201015] PASSED [ 89%]
aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file6-20210318] PASSED [ 92%]
aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file7-20210906] PASSED [ 94%]
aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file8-20211112] PASSED [ 97%]
aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file9-20210123] PASSED [100%]

============================== 38 passed in 0.22s ==============================

```

## Manual no prefix test

```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-no-logs -t alb -s 2020-Oct-21 -p dev -d2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
ERROR: No logs found in 'AWSLogs/'. Check the provided prefix and the location of the logs for the bucket  type 'alb'
```