### PR TITLE
Split address and port in AWS ALB Bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ All notable changes to this project will be documented in this file.
 - Refactored the functions in charge of synchronizing files in the cluster. ([#13065](https://github.com/wazuh/wazuh/pull/))
 - Changed MD5 hash function to BLAKE2 for cluster file comparison. ([#13079](https://github.com/wazuh/wazuh/pull/13079))
 - Renamed wazuh-logtest and wazuh-clusterd scripts to follow the same scheme as the other scripts (spaces symbolized with _ instead of -). ([#12926](https://github.com/wazuh/wazuh/pull/12926))
-- Improve the parse of ALB logs splitting `client_port`, `target_port`, `target_port_list` in separated `ip` and `port` for each key. ([14525](https://github.com/wazuh/wazuh/pull/14525))
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Refactored the functions in charge of synchronizing files in the cluster. ([#13065](https://github.com/wazuh/wazuh/pull/))
 - Changed MD5 hash function to BLAKE2 for cluster file comparison. ([#13079](https://github.com/wazuh/wazuh/pull/13079))
 - Renamed wazuh-logtest and wazuh-clusterd scripts to follow the same scheme as the other scripts (spaces symbolized with _ instead of -). ([#12926](https://github.com/wazuh/wazuh/pull/12926))
+- Improve the parse of ALB logs splitting `client_port`, `target_port`, `target_port_list` in separated `ip` and `port` for each key. ([14525](https://github.com/wazuh/wazuh/pull/14525))
 
 #### Fixed
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2489,7 +2489,15 @@ class AWSALBBucket(AWSLBBucket):
             for log_entry in tsv_file:
                 for field_to_process, ip_field in fields_to_process_map.items():
                     try:
-                        log_entry[ip_field], log_entry[field_to_process] = log_entry[field_to_process].split(":")
+                        if field_to_process == "target_port_list" and len(log_entry[field_to_process].split(" ")) > 1:
+                            # Handle case when `target_port_list` is space-delimited list
+                            ip_list = [i.split(":")[0] for i in log_entry[field_to_process].split(" ")]
+                            port_list = [i.split(":")[1] for i in log_entry[field_to_process].split(" ")]
+
+                            log_entry[ip_field] = " ".join(ip_list)
+                            log_entry[field_to_process] = " ".join(port_list)
+                        else:
+                            log_entry[ip_field], log_entry[field_to_process] = log_entry[field_to_process].split(":")
                     except ValueError:
                         debug(f"Unable to process correctly ABL log entry, for field {field_to_process}.", msg_level=1)
                         debug(f"Log Entry: {log_entry}", msg_level=2)

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -68,7 +68,6 @@ DEPRECATED_MESSAGE = 'The {name} authentication parameter was deprecated in {rel
 
 # Enable/disable debug mode
 debug_level = 0
-WARNING = "WARNING"
 
 ################################################################################
 # Classes
@@ -2481,13 +2480,19 @@ class AWSALBBucket(AWSLBBucket):
             tsv_file = csv.DictReader(f, fieldnames=fieldnames, delimiter=' ')
             tsv_file = [dict(x, source='alb') for x in tsv_file]
 
+            fields_to_process_map = {
+                "client_port": "client_ip",
+                "target_port": "target_ip",
+                "target_port_list": "target_ip_list"
+            }
+
             for log_entry in tsv_file:
-                try:
-                    log_entry["client_ip"], log_entry["client_port"] = log_entry["client_port"].split(":")
-                    log_entry["target_ip"], log_entry["target_port"] = log_entry["target_port"].split(":")
-                    log_entry["target_ip_list"], log_entry["target_port_list"] = log_entry["target_port_list"].split(":")
-                except ValueError:
-                    print(f"{WARNING}: Unable to process correctly malformed ABL log entry: {log_entry}.")
+                for field_to_process, ip_field in fields_to_process_map.items():
+                    try:
+                        log_entry[ip_field], log_entry[field_to_process] = log_entry[field_to_process].split(":")
+                    except ValueError:
+                        debug(f"Unable to process correctly ABL log entry, for field {field_to_process}.", msg_level=1)
+                        debug(f"Log Entry: {log_entry}", msg_level=2)
 
             return tsv_file
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2491,11 +2491,11 @@ class AWSALBBucket(AWSLBBucket):
                     try:
                         if field_to_process == "target_port_list" and len(log_entry[field_to_process].split(" ")) > 1:
                             # Handle case when `target_port_list` is space-delimited list
-                            ip_list = [i.split(":")[0] for i in log_entry[field_to_process].split(" ")]
-                            port_list = [i.split(":")[1] for i in log_entry[field_to_process].split(" ")]
-
-                            log_entry[ip_field] = " ".join(ip_list)
-                            log_entry[field_to_process] = " ".join(port_list)
+                            ips, ports = "", ""
+                            for item in [i.split(":") for i in log_entry[field_to_process].split(" ")]:
+                                ips += f"{item[0]} "
+                                ports += f"{item[1]} "
+                                log_entry[ip_field], log_entry[field_to_process] = ips.strip(), ports.strip()
                         else:
                             log_entry[ip_field], log_entry[field_to_process] = log_entry[field_to_process].split(":")
                     except ValueError:

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -68,7 +68,7 @@ DEPRECATED_MESSAGE = 'The {name} authentication parameter was deprecated in {rel
 
 # Enable/disable debug mode
 debug_level = 0
-
+WARNING = "WARNING"
 
 ################################################################################
 # Classes
@@ -2479,8 +2479,18 @@ class AWSALBBucket(AWSLBBucket):
                 "request_creation_time", "action_executed", "redirect_url", "error_reason", "target_port_list",
                 "target_status_code_list", "classification", "classification_reason")
             tsv_file = csv.DictReader(f, fieldnames=fieldnames, delimiter=' ')
+            tsv_file = [dict(x, source='alb') for x in tsv_file]
 
-            return [dict(x, source='alb') for x in tsv_file]
+            for log_entry in tsv_file:
+                try:
+                    log_entry["client_ip"], log_entry["client_port"] = log_entry["client_port"].split(":")
+                    log_entry["target_ip"], log_entry["target_port"] = log_entry["target_port"].split(":")
+                    log_entry["target_ip_list"], log_entry["target_port_list"] = log_entry["target_port_list"].split(":")
+                except ValueError:
+                    print(f"{WARNING}: Unable to process correctly malformed ABL log entry: {log_entry}.")
+
+            return tsv_file
+
 
 
 class AWSCLBBucket(AWSLBBucket):

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2489,16 +2489,12 @@ class AWSALBBucket(AWSLBBucket):
             for log_entry in tsv_file:
                 for field_to_process, ip_field in fields_to_process_map.items():
                     try:
-                        if field_to_process == "target_port_list" and len(log_entry[field_to_process].split(" ")) > 1:
-                            # Handle case when `target_port_list` is space-delimited list
-                            ips, ports = "", ""
-                            for item in [i.split(":") for i in log_entry[field_to_process].split(" ")]:
-                                ips += f"{item[0]} "
-                                ports += f"{item[1]} "
-                                log_entry[ip_field], log_entry[field_to_process] = ips.strip(), ports.strip()
-                        else:
-                            log_entry[ip_field], log_entry[field_to_process] = log_entry[field_to_process].split(":")
-                    except ValueError:
+                        port, ip = "", ""
+                        for item in [i.split(":") for i in log_entry[field_to_process].split()]:
+                            ip += f"{item[0]} "
+                            port += f"{item[1]} "
+                        log_entry[field_to_process], log_entry[ip_field] = port.strip(), ip.strip()
+                    except (ValueError, IndexError):
                         debug(f"Unable to process correctly ABL log entry, for field {field_to_process}.", msg_level=1)
                         debug(f"Log Entry: {log_entry}", msg_level=2)
 


### PR DESCRIPTION
|Related issue|
|---|
|#13095|

## Description
This PR closes #13095 . It improves the parse of ALB logs splitting `client_port`, `target_port`, `target_port_list` in separated `ip` and `port` for each key.

## Manual Test
```bash
root@1a356d9cc48c:/var/ossec# /var/ossec/framework/python/bin/python3 /var/ossec/wodles/aws/aws_s3.py -b wazuh-aws-wodle-alb -t alb -s 2021-Dec-21 -p dev -d2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/12/21
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/12/21/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20211221T0000Z_52.52.208.49_14pczeay.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/12/22/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20211222T0000Z_52.52.208.49_14pczeay.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/12/23/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20211223T0000Z_52.52.208.49_14pczeay.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/12/23/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20211230T0000Z_52.52.208.49_14pczeay.log
```

### The send alert with new fields.
```
** Alert 1660061728.6208: - amazon,aws,aws_alb,
2022 Aug 09 16:15:28 1a356d9cc48c->Wazuh-AWS
Rule: 80328 (level 5) -> 'AWS ALB: Status error:  - forward - Mozilla/5.0 (compatible; Nimbostratus-Bot/v1.3.2; http://cloudsystemnetworks.com) [ELB: app/ALB-framework-dev/959dfdbaed241613].'
{"integration": "aws", "aws": {"log_info": {"aws_account_alias": "", "log_file": "AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/12/23/XXXXXXXXXXXX-west-1_app.ALB-framework-dev.959dfdbaed241613_20211223T0000Z_52.52.208.49_14pczeay.log.gz", "s3bucket": "wazuh-aws-wodle-alb"}, "type": "http", "time": "2020-11-23T23:57:06.780380Z", "elb": "app/ALB-framework-dev/959dfdbaed241613", "client_port": "51444", "target_port": "80", "request_processing_time": "0.001", "target_processing_time": "0.001", "response_processing_time": "0.000", "elb_status_code": "403", "target_status_code": "403", "received_bytes": "136", "sent_bytes": "5173", "request": "GET http://52.52.208.49:80/ HTTP/1.1", "user_agent": "Mozilla/5.0 (compatible; Nimbostratus-Bot/v1.3.2; http://cloudsystemnetworks.com)", "ssl_cipher": "-", "ssl_protocol": "-", "target_group_arn": "arn:aws:elasticloadbalancing:us-west-1:XXXXXXXXXXXX:targetgroup/EC2/a7985a8385b86dc0", "trace_id": "Root=1-5fbc4c52-5a3a21203a0b9d20551c0535", "domain_name": "-", "chosen_cert_arn": "-", "matched_rule_priority": "0", "request_creation_time": "2020-11-23T23:57:06.778000Z", "action_executed": "forward", "redirect_url": "-", "error_reason": "-", "target_port_list": "80", "target_status_code_list": "403", "classification": "-", "classification_reason": "-", "source": "alb", "client_ip": "209.17.97.74", "target_ip": "10.0.0.125", "target_ip_list": "10.0.0.125"}}
integration: aws
aws.log_info.log_file: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/12/23/XXXXXXXXXXXX-west-1_app.ALB-framework-dev.959dfdbaed241613_20211223T0000Z_52.52.208.49_14pczeay.log.gz
aws.log_info.s3bucket: wazuh-aws-wodle-alb
aws.type: http
aws.time: 2020-11-23T23:57:06.780380Z
aws.elb: app/ALB-framework-dev/959dfdbaed241613
aws.client_port: 51444
aws.target_port: 80
aws.request_processing_time: 0.001
aws.target_processing_time: 0.001
aws.response_processing_time: 0.000
aws.elb_status_code: 403
aws.target_status_code: 403
aws.received_bytes: 136
aws.sent_bytes: 5173
aws.request: GET http://52.52.208.49:80/ HTTP/1.1
aws.user_agent: Mozilla/5.0 (compatible; Nimbostratus-Bot/v1.3.2; http://cloudsystemnetworks.com)
aws.ssl_cipher: -
aws.ssl_protocol: -
aws.target_group_arn: arn:aws:elasticloadbalancing:us-west-1:XXXXXXXXXXXX:targetgroup/EC2/a7985a8385b86dc0
aws.trace_id: Root=1-5fbc4c52-5a3a21203a0b9d20551c0535
aws.domain_name: -
aws.chosen_cert_arn: -
aws.matched_rule_priority: 0
aws.request_creation_time: 2020-11-23T23:57:06.778000Z
aws.action_executed: forward
aws.redirect_url: -
aws.error_reason: -
aws.target_port_list: 80
aws.target_status_code_list: 403
aws.classification: -
aws.classification_reason: -
aws.source: alb
aws.client_ip: 209.17.97.74
aws.target_ip: 10.0.0.125
aws.target_ip_list: 10.0.0.125
```

### Warning message for malformed log
```bash
WARNING: Unable to process correctly malformed ABL log entry: {'type': '2020-11-23T23:57:06.780380Z', 'time': 'app/ALB-framework-dev/959dfdbaed241613', 'elb': '209.17.97.74:51444', 'client_port': '80', 'target_port': '0.001', 'request_processing_time': '0.001', 'target_processing_time': '0.000', 'response_processing_time': '403', 'elb_status_code': '403', 'target_status_code': '136', 'received_bytes': '5173', 'sent_bytes': 'GET http://52.52.208.49:80/ HTTP/1.1', 'request': 'Mozilla/5.0 (compatible; Nimbostratus-Bot/v1.3.2; http://cloudsystemnetworks.com)', 'user_agent': '-', 'ssl_cipher': '-', 'ssl_protocol': 'arn:aws:elasticloadbalancing:us-west-1:XXXXXXXXXXXX:targetgroup/EC2/a7985a8385b86dc0', 'target_group_arn': 'Root=1-5fbc4c52-5a3a21203a0b9d20551c0535', 'trace_id': '-', 'domain_name': '-', 'chosen_cert_arn': '0', 'matched_rule_priority': '2020-11-23T23:57:06.778000Z', 'request_creation_time': 'forward', 'action_executed': '-', 'redirect_url': '-', 'error_reason': '10.0.0.125:80', 'target_port_list': '403', 'target_status_code_list': '-', 'classification': '-', 'classification_reason': None, 'source': 'alb', 'client_ip': '10.0.0.125'}.
DEBUG: +++ DB Maintenance
```