### PR TITLE
Add error checking to test tool checks

### DIFF
--- a/src/ci/tests/syscheckd/test_check_module.py
+++ b/src/ci/tests/syscheckd/test_check_module.py
@@ -364,12 +364,14 @@ def testFileTransactions(readResultFiles, configLogging, readFileTxnInputs):
                     testCase=testCase)
 
     for operation in resultTransactions:
+        assert "DB_ERROR" != operation['Operation type'],\
+               "Something has gone wrong with the test tool"
         if "INSERTED" in operation['Operation type']:
             checkTransactionOp(result=operation,
                                configLogging=configLogging,
                                testCase=testCase,
                                inputJSONs=inputJSONs)
-        if "DELETED" in operation['Operation type']:
+        elif "DELETED" in operation['Operation type']:
             assert operation['value']['path'] == "/tmp/test_1.txt"
             logger.info("{0:>20} {1:>20}\t\t\t\t{2}"
                         .format(testCase,
@@ -411,6 +413,8 @@ def testRegistryKeytransactions(readResultFiles,
                     testCase=testCase)
 
     for operation in resultTransactions:
+        assert "DB_ERROR" != operation['Operation type'],\
+               "Something has gone wrong with the test tool"
         if "INSERTED" in operation['Operation type']:
             checkTransactionOp(result=operation,
                                configLogging=configLogging,
@@ -459,6 +463,8 @@ def testRegistryDatatransactions(readResultFiles,
                     testCase=testCase)
 
     for operation in resultTransactions:
+        assert "DB_ERROR" != operation['Operation type'],\
+               "Something has gone wrong with the test tool"
         if "INSERTED" in operation['Operation type']:
             checkTransactionOp(result=operation,
                                configLogging=configLogging,

--- a/src/ci/tests/syscheckd/test_check_module.py
+++ b/src/ci/tests/syscheckd/test_check_module.py
@@ -297,7 +297,7 @@ def checkTransactionOp(result, configLogging, testCase, inputJSONs):
     """
     logger = configLogging
     for inputData in inputJSONs:
-        if result['value'] == inputData['body']['data']:
+        if result['value'] == inputData['body']['data'][0]:
             assert True
             break
     else:
@@ -365,7 +365,9 @@ def testFileTransactions(readResultFiles, configLogging, readFileTxnInputs):
 
     for operation in resultTransactions:
         assert "DB_ERROR" != operation['Operation type'],\
-               "Something has gone wrong with the test tool"
+               "Something has gone wrong with the test tool\
+               \n {}".format(operation['value']['exception'])
+
         if "INSERTED" in operation['Operation type']:
             checkTransactionOp(result=operation,
                                configLogging=configLogging,
@@ -414,7 +416,9 @@ def testRegistryKeytransactions(readResultFiles,
 
     for operation in resultTransactions:
         assert "DB_ERROR" != operation['Operation type'],\
-               "Something has gone wrong with the test tool"
+               "Something has gone wrong with the test tool\
+               \n {}".format(operation['value']['exception'])
+
         if "INSERTED" in operation['Operation type']:
             checkTransactionOp(result=operation,
                                configLogging=configLogging,
@@ -464,7 +468,8 @@ def testRegistryDatatransactions(readResultFiles,
 
     for operation in resultTransactions:
         assert "DB_ERROR" != operation['Operation type'],\
-               "Something has gone wrong with the test tool"
+               "Something has gone wrong with the test tool\
+               \n {}".format(operation['value']['exception'])
         if "INSERTED" in operation['Operation type']:
             checkTransactionOp(result=operation,
                                configLogging=configLogging,

--- a/src/syscheckd/src/db/smokeTests/FimDBTransaction/SyncTxnRowsRegistryData_1.json
+++ b/src/syscheckd/src/db/smokeTests/FimDBTransaction/SyncTxnRowsRegistryData_1.json
@@ -17,7 +17,8 @@
                 "hash_sha1": "7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
                 "hash_sha256": "e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a",
                 "arch": "[x64]",
-                "path": "/tmp/pathTestRegistry"
+                "path": "/tmp/pathTestRegistry",
+                "hash_full_path": "c26e28e20da25627fb939c9c67b04ef9d1c89f12"
             }
         ]
     }

--- a/src/syscheckd/src/db/smokeTests/FimDBTransaction/SyncTxnRowsRegistryData_2.json
+++ b/src/syscheckd/src/db/smokeTests/FimDBTransaction/SyncTxnRowsRegistryData_2.json
@@ -17,7 +17,8 @@
                 "hash_sha1": "7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
                 "hash_sha256": "e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a",
                 "arch": "[x32]",
-                "path": "/tmp/fakePath/someRegistry"
+                "path": "/tmp/fakePath/someRegistry",
+                "hash_full_path": "c26e28e20da25627fb939c9c67b04ef9d1c89f12"
             }
         ]
     }

--- a/src/syscheckd/src/db/smokeTests/FimDBTransaction/SyncTxnRowsRegistryKey_1.json
+++ b/src/syscheckd/src/db/smokeTests/FimDBTransaction/SyncTxnRowsRegistryKey_1.json
@@ -17,7 +17,8 @@
                 "perm": "-rw-rw-r--",
                 "scanned": 1,
                 "uid": 0,
-                "user_name": "fakeUser"
+                "user_name": "fakeUser",
+                "hash_full_path": "c26e28e20da25627fb939c9c67b04ef9d1c89f12"
             }
         ]
     }

--- a/src/syscheckd/src/db/smokeTests/FimDBTransaction/SyncTxnRowsRegistryKey_2.json
+++ b/src/syscheckd/src/db/smokeTests/FimDBTransaction/SyncTxnRowsRegistryKey_2.json
@@ -17,7 +17,8 @@
                 "perm": "-rw-rw-r--",
                 "scanned": 1,
                 "uid": 0,
-                "user_name": "fakeUser"
+                "user_name": "fakeUser",
+                "hash_full_path": "c26e28e20da25627fb939c9c67b04ef9d1c89f12"
             }
         ]
     }

--- a/src/syscheckd/src/db/smokeTests/integrityOps/SyncTxnRowsRegistryData_1.json
+++ b/src/syscheckd/src/db/smokeTests/integrityOps/SyncTxnRowsRegistryData_1.json
@@ -17,7 +17,8 @@
                 "hash_sha1": "7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
                 "hash_sha256": "e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a",
                 "arch": "[x64]",
-                "path": "/tmp/pathTestRegistry"
+                "path": "/tmp/pathTestRegistry",
+                "hash_full_path": "c26e28e20da25627fb939c9c67b04ef9d1c89f12"
             }
         ]
     }

--- a/src/syscheckd/src/db/smokeTests/integrityOps/SyncTxnRowsRegistryKey_1.json
+++ b/src/syscheckd/src/db/smokeTests/integrityOps/SyncTxnRowsRegistryKey_1.json
@@ -17,7 +17,8 @@
                 "perm": "-rw-rw-r--",
                 "scanned": 1,
                 "uid": 0,
-                "user_name": "fakeUser"
+                "user_name": "fakeUser",
+                "hash_full_path": "c26e28e20da25627fb939c9c67b04ef9d1c89f12"
             }
         ]
     }


### PR DESCRIPTION
|EPIC|Component|
|---|---|
| https://github.com/wazuh/wazuh/issues/9103 | FIM |

|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/14522|

## Description
Hi team, this pull-request is to add a new capability in our RTR check, this would be a check within the test tool checks because we found an error within our checks where the test tool was generating an exception however the test tool was passing it correctly.
Regards
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report
- Memory tests for macOS
  - [x] Scan-build report
  - [x] Leaks
  - [x] AddressSanitizer
