### PR TITLE
Fix UTC timestamps calculation

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -173,7 +173,7 @@ class WazuhIntegration:
         self.discard_field = discard_field
         self.discard_regex = re.compile(fr'{discard_regex}')
         # to fetch logs using this date if no only_logs_after value was provided on the first execution
-        self.default_date = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+        self.default_date = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
 
     def migrate_from_38(self, **kwargs):
         self.db_maintenance(**kwargs)

--- a/wodles/azure/azure-logs.py
+++ b/wodles/azure/azure-logs.py
@@ -840,7 +840,7 @@ def offset_to_datetime(offset: str):
     if unit == 'h':
         return datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(hours=value)
     if unit == 'm':
-        return datetime.utcnow().replace(tzinfo=timezone.utcC) - timedelta(minutes=value)
+        return datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(minutes=value)
     if unit == 'd':
         return datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(days=value)
 

--- a/wodles/azure/azure-logs.py
+++ b/wodles/azure/azure-logs.py
@@ -19,7 +19,7 @@
 import logging
 import sys
 from argparse import ArgumentParser
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from hashlib import md5
 from json import dumps, loads, JSONDecodeError
 from os.path import abspath, dirname
@@ -30,7 +30,6 @@ from azure.storage.blob import BlockBlobService
 from azure.storage.common._error import AzureSigningError
 from azure.storage.common.retry import no_retry
 from dateutil.parser import parse
-from pytz import UTC
 from requests import get, post, HTTPError, RequestException
 
 import orm
@@ -839,11 +838,11 @@ def offset_to_datetime(offset: str):
     unit = offset[len(offset) - 1:]
 
     if unit == 'h':
-        return datetime.utcnow().replace(tzinfo=UTC) - timedelta(hours=value)
+        return datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(hours=value)
     if unit == 'm':
-        return datetime.utcnow().replace(tzinfo=UTC) - timedelta(minutes=value)
+        return datetime.utcnow().replace(tzinfo=timezone.utcC) - timedelta(minutes=value)
     if unit == 'd':
-        return datetime.utcnow().replace(tzinfo=UTC) - timedelta(days=value)
+        return datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(days=value)
 
     logging.error("Invalid offset format. Use 'h', 'm' or 'd' time unit.")
     exit(1)


### PR DESCRIPTION
|Related issue|
|---|
|#12833|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR closes https://github.com/wazuh/wazuh/issues/12833. It fixes the way that the AWS and Azure wodles generate timestamps. It requires #14465 to be finished due to its relation with `CloudWatch Logs` and their testing.

## AWS Wodle Unit tests
```
============================= test session starts ==============================
platform linux -- Python 3.9.5, pytest-6.0.1, py-1.11.0, pluggy-0.13.1 -- /home/test_user/venv/unittest-env/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.14.0-1047-oem-x86_64-with-glibc2.31', 'Packages': {'pytest': '6.0.1', 'py': '1.11.0', 'pluggy': '0.13.1'}, 'Plugins': {'cov': '3.0.0', 'trio': '0.7.0', 'metadata': '2.0.2', 'asyncio': '0.15.1', 'aiohttp': '0.3.0', 'html': '2.1.1'}}
rootdir: /home/test_user/git/wazuh/wodles
plugins: cov-3.0.0, trio-0.7.0, metadata-2.0.2, asyncio-0.15.1, aiohttp-0.3.0, html-2.1.1
collecting ... collected 38 items

aws/tests/test_aws.py::test_metadata_version_buckets[AWSCloudTrailBucket] PASSED [  2%]
aws/tests/test_aws.py::test_metadata_version_buckets[AWSConfigBucket] PASSED [  5%]
aws/tests/test_aws.py::test_metadata_version_buckets[AWSVPCFlowBucket] PASSED [  7%]
aws/tests/test_aws.py::test_metadata_version_buckets[AWSCustomBucket] PASSED [ 10%]
aws/tests/test_aws.py::test_metadata_version_buckets[AWSGuardDutyBucket] PASSED [ 13%]
aws/tests/test_aws.py::test_metadata_version_services[AWSInspector] PASSED [ 15%]
aws/tests/test_aws.py::test_db_maintenance[AWSCloudTrailBucket-schema_cloudtrail_test.sql-cloudtrail] PASSED [ 18%]
aws/tests/test_aws.py::test_db_maintenance[AWSConfigBucket-schema_config_test.sql-config] PASSED [ 21%]
aws/tests/test_aws.py::test_db_maintenance[AWSVPCFlowBucket-schema_vpcflow_test.sql-vpcflow] PASSED [ 23%]
aws/tests/test_aws.py::test_db_maintenance[AWSCustomBucket-schema_custom_test.sql-custom] PASSED [ 26%]
aws/tests/test_aws.py::test_db_maintenance[AWSGuardDutyBucket-schema_guardduty_test.sql-guardduty] PASSED [ 28%]
aws/tests/test_aws.py::test_decompress_file_gz[aws_bucket0-test.gz-gzip.open] PASSED [ 31%]
aws/tests/test_aws.py::test_decompress_file_gz[aws_bucket0-test.zip-zipfile.ZipFile] PASSED [ 34%]
aws/tests/test_aws.py::test_decompress_file_snappy_skip[aws_bucket0-test.snappy] PASSED [ 36%]
aws/tests/test_aws.py::test_decompress_snappy_ko[aws_bucket0-test.snappy-False-SystemExit] PASSED [ 39%]
aws/tests/test_aws.py::test_decompress_file_ko[.gz-aws_bucket0] PASSED   [ 42%]
aws/tests/test_aws.py::test_decompress_file_ko[.zip-aws_bucket0] PASSED  [ 44%]
aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-False] PASSED [ 47%]
aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-True] PASSED [ 50%]
aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-invalid-json-True] PASSED [ 52%]
aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-wrong-structure-True] PASSED [ 55%]
aws/tests/test_aws.py::test_aws_waf_load_information_from_file_ko[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-invalid-json-False-SystemExit] PASSED [ 57%]
aws/tests/test_aws.py::test_aws_waf_load_information_from_file_ko[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-wrong-structure-False-SystemExit] PASSED [ 60%]
aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2021/1/19-20210119] PASSED [ 63%]
aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2021/1/1-20210101] PASSED [ 65%]
aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2021/01/01-20210101] PASSED [ 68%]
aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2000/2/12-20000212] PASSED [ 71%]
aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2022/02/1-20220201] PASSED [ 73%]
aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file0-20211221] PASSED [ 76%]
aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file1-20200103] PASSED [ 78%]
aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file2-20200920] PASSED [ 81%]
aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file3-20210118] PASSED [ 84%]
aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file4-20200930] PASSED [ 86%]
aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file5-20201015] PASSED [ 89%]
aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file6-20210318] PASSED [ 92%]
aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file7-20210906] PASSED [ 94%]
aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file8-20211112] PASSED [ 97%]
aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file9-20210123] PASSED [100%]

============================== 38 passed in 0.23s ==============================
```

## Azure Wodle Unit tests
```
============================= test session starts ==============================
platform linux -- Python 3.9.5, pytest-6.0.1, py-1.11.0, pluggy-0.13.1 -- /home/test_user/venv/unittest-env/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.14.0-1047-oem-x86_64-with-glibc2.31', 'Packages': {'pytest': '6.0.1', 'py': '1.11.0', 'pluggy': '0.13.1'}, 'Plugins': {'cov': '3.0.0', 'trio': '0.7.0', 'metadata': '2.0.2', 'asyncio': '0.15.1', 'aiohttp': '0.3.0', 'html': '2.1.1'}}
rootdir: /home/test_user/git/wazuh/wodles
plugins: cov-3.0.0, trio-0.7.0, metadata-2.0.2, asyncio-0.15.1, aiohttp-0.3.0, html-2.1.1
collecting ... collected 138 items

azure/tests/test_azure.py::test_set_logger[0] PASSED                     [  0%]
azure/tests/test_azure.py::test_set_logger[1] PASSED                     [  1%]
azure/tests/test_azure.py::test_set_logger[2] PASSED                     [  2%]
azure/tests/test_azure.py::test_set_logger[3] PASSED                     [  2%]
azure/tests/test_azure.py::test_get_script_arguments PASSED              [  3%]
azure/tests/test_azure.py::test_get_script_arguments_exclusive[args0] PASSED [  4%]
azure/tests/test_azure.py::test_get_script_arguments_exclusive[args1] PASSED [  5%]
azure/tests/test_azure.py::test_get_script_arguments_exclusive[args2] PASSED [  5%]
azure/tests/test_azure.py::test_get_script_arguments_exclusive[args3] PASSED [  6%]
azure/tests/test_azure.py::test_arg_valid_container_name["string"] PASSED [  7%]
azure/tests/test_azure.py::test_arg_valid_container_name['string'] PASSED [  7%]
azure/tests/test_azure.py::test_arg_valid_container_name[None] PASSED    [  8%]
azure/tests/test_azure.py::test_arg_valid_graph_query["string"] PASSED   [  9%]
azure/tests/test_azure.py::test_arg_valid_graph_query['string'] PASSED   [ 10%]
azure/tests/test_azure.py::test_arg_valid_graph_query[string\\$] PASSED  [ 10%]
azure/tests/test_azure.py::test_arg_valid_graph_query[string 'test'] PASSED [ 11%]
azure/tests/test_azure.py::test_arg_valid_graph_query[None] PASSED       [ 12%]
azure/tests/test_azure.py::test_arg_valid_la_query[string!] PASSED       [ 13%]
azure/tests/test_azure.py::test_arg_valid_la_query[string\\!] PASSED     [ 13%]
azure/tests/test_azure.py::test_arg_valid_la_query[\\!string\\!] PASSED  [ 14%]
azure/tests/test_azure.py::test_arg_valid_la_query[None] PASSED          [ 15%]
azure/tests/test_azure.py::test_arg_valid_blob_extension["string"] PASSED [ 15%]
azure/tests/test_azure.py::test_arg_valid_blob_extension[*] PASSED       [ 16%]
azure/tests/test_azure.py::test_arg_valid_blob_extension["*"] PASSED     [ 17%]
azure/tests/test_azure.py::test_arg_valid_blob_extension[None] PASSED    [ 18%]
azure/tests/test_azure.py::test_read_auth_file[valid_authentication_file-fields0] PASSED [ 18%]
azure/tests/test_azure.py::test_read_auth_file[valid_authentication_file_alt-fields1] PASSED [ 19%]
azure/tests/test_azure.py::test_read_auth_file[valid_authentication_file_extra_line-fields2] PASSED [ 20%]
azure/tests/test_azure.py::test_read_auth_file[valid_authentication_file_storage-fields3] PASSED [ 21%]
azure/tests/test_azure.py::test_read_auth_file_ko[no_file] PASSED        [ 21%]
azure/tests/test_azure.py::test_read_auth_file_ko[empty_authentication_file] PASSED [ 22%]
azure/tests/test_azure.py::test_read_auth_file_ko[invalid_authentication_file] PASSED [ 23%]
azure/tests/test_azure.py::test_read_auth_file_ko[invalid_authentication_file_2] PASSED [ 23%]
azure/tests/test_azure.py::test_read_auth_file_ko[invalid_authentication_file_3] PASSED [ 24%]
azure/tests/test_azure.py::test_update_row_object[2022-01-01T12:00:00.000000Z-2022-06-15T12:00:00.000000Z] PASSED [ 25%]
azure/tests/test_azure.py::test_update_row_object[2022-01-01T12:00:00.000000Z-2022-12-31T12:00:00.000000Z] PASSED [ 26%]
azure/tests/test_azure.py::test_update_row_object[2022-06-15T12:00:00.000000Z-2022-06-15T12:00:00.000000Z] PASSED [ 26%]
azure/tests/test_azure.py::test_update_row_object[2022-06-15T12:00:00.000000Z-2022-12-31T12:00:00.000000Z] PASSED [ 27%]
azure/tests/test_azure.py::test_update_row_object[2022-12-31T12:00:00.000000Z-2022-12-31T12:00:00.000000Z] PASSED [ 28%]
azure/tests/test_azure.py::test_update_row_object_ko PASSED              [ 28%]
azure/tests/test_azure.py::test_update_row_object_ko_update PASSED       [ 29%]
azure/tests/test_azure.py::test_create_new_row PASSED                    [ 30%]
azure/tests/test_azure.py::test_create_new_row_ko PASSED                 [ 31%]
azure/tests/test_azure.py::test_start_log_analytics[None-client-secret-1d-query-workspace] PASSED [ 31%]
azure/tests/test_azure.py::test_start_log_analytics[/var/ossec/-None-None---] PASSED [ 32%]
azure/tests/test_azure.py::test_start_log_analytics_ko PASSED            [ 33%]
azure/tests/test_azure.py::test_start_log_analytics_ko_credentials PASSED [ 34%]
azure/tests/test_azure.py::test_build_log_analytics_query[2022-06-15T12:00:00.000000Z-2022-12-31T12:00:00.000000Z-2022-01-01T12:00:00.000000Z-False] PASSED [ 34%]
azure/tests/test_azure.py::test_build_log_analytics_query[2022-01-01T12:00:00.000000Z-2022-06-15T12:00:00.000000Z-2022-12-31T12:00:00.000000Z-False] PASSED [ 35%]
azure/tests/test_azure.py::test_build_log_analytics_query[2022-01-01T12:00:00.000000Z-2022-12-31T12:00:00.000000Z-2022-06-15T12:00:00.000000Z-False] PASSED [ 36%]
azure/tests/test_azure.py::test_build_log_analytics_query[2022-01-01T12:00:00.000000Z-2022-01-01T12:00:00.000000Z-2022-06-15T12:00:00.000000Z-True] PASSED [ 36%]
azure/tests/test_azure.py::test_build_log_analytics_query_ko PASSED      [ 37%]
azure/tests/test_azure.py::test_get_log_analytics_events[log_analytics_events-0] PASSED [ 38%]
azure/tests/test_azure.py::test_get_log_analytics_events[log_analytics_events-None] PASSED [ 39%]
azure/tests/test_azure.py::test_get_log_analytics_events[log_analytics_events_no_results-None] PASSED [ 39%]
azure/tests/test_azure.py::test_get_log_analytics_events[log_analytics_events_empty-None] PASSED [ 40%]
azure/tests/test_azure.py::test_get_log_analytics_events_error_responses PASSED [ 41%]
azure/tests/test_azure.py::test_get_time_position[columns0-0] PASSED     [ 42%]
azure/tests/test_azure.py::test_get_time_position[columns1-1] PASSED     [ 42%]
azure/tests/test_azure.py::test_get_time_position[columns2-None] PASSED  [ 43%]
azure/tests/test_azure.py::test_iter_log_analytics_events PASSED         [ 44%]
azure/tests/test_azure.py::test_start_graph[None-client-secret-1d-query] PASSED [ 44%]
azure/tests/test_azure.py::test_start_graph[/var/ossec/-None-None--] PASSED [ 45%]
azure/tests/test_azure.py::test_start_graph_ko PASSED                    [ 46%]
azure/tests/test_azure.py::test_start_graph_ko_credentials PASSED        [ 47%]
azure/tests/test_azure.py::test_build_graph_url[2022-06-15T12:00:00.000000Z-2022-12-31T12:00:00.000000Z-2022-01-01T12:00:00.000000Z-False] PASSED [ 47%]
azure/tests/test_azure.py::test_build_graph_url[2022-01-01T12:00:00.000000Z-2022-06-15T12:00:00.000000Z-2022-12-31T12:00:00.000000Z-False] PASSED [ 48%]
azure/tests/test_azure.py::test_build_graph_url[2022-01-01T12:00:00.000000Z-2022-12-31T12:00:00.000000Z-2022-06-15T12:00:00.000000Z-False] PASSED [ 49%]
azure/tests/test_azure.py::test_build_graph_url[2022-01-01T12:00:00.000000Z-2022-01-01T12:00:00.000000Z-2022-06-15T12:00:00.000000Z-True] PASSED [ 50%]
azure/tests/test_azure.py::test_build_graph_url_ko PASSED                [ 50%]
azure/tests/test_azure.py::test_get_graph_events PASSED                  [ 51%]
azure/tests/test_azure.py::test_get_graph_events_error_responses[400] PASSED [ 52%]
azure/tests/test_azure.py::test_get_graph_events_error_responses[500] PASSED [ 52%]
azure/tests/test_azure.py::test_start_storage[None-name-key-container] PASSED [ 53%]
azure/tests/test_azure.py::test_start_storage[/var/ossec/---*] PASSED    [ 54%]
azure/tests/test_azure.py::test_start_storage_ko[-None] PASSED           [ 55%]
azure/tests/test_azure.py::test_start_storage_ko[-AzureException] PASSED [ 55%]
azure/tests/test_azure.py::test_start_storage_ko[*-AzureSigningError] PASSED [ 56%]
azure/tests/test_azure.py::test_start_storage_ko[*-AzureException] PASSED [ 57%]
azure/tests/test_azure.py::test_start_storage_ko[*-None] PASSED          [ 57%]
azure/tests/test_azure.py::test_start_storage_ko_credentials PASSED      [ 58%]
azure/tests/test_azure.py::test_get_blobs[2022-06-15T12:00:00.000000Z-2022-01-01T12:00:00.000000Z-2022-01-01T12:00:00.000000Z-2022-12-31T12:00:00.000000Z-None-False-False-False-False] PASSED [ 59%]
azure/tests/test_azure.py::test_get_blobs[2022-06-15T12:00:00.000000Z-2022-06-15T12:00:00.000000Z-2022-12-31T12:00:00.000000Z-2022-01-01T12:00:00.000000Z-None-False-False-False-False] PASSED [ 60%]
azure/tests/test_azure.py::test_get_blobs[2022-12-31T12:00:00.000000Z-2022-06-15T12:00:00.000000Z-2022-12-31T12:00:00.000000Z-2022-01-01T12:00:00.000000Z-None-False-False-False-False] PASSED [ 60%]
azure/tests/test_azure.py::test_get_blobs[2022-01-01T12:00:00.000000Z-2022-06-15T12:00:00.000000Z-2022-12-31T12:00:00.000000Z-2022-01-01T12:00:00.000000Z-None-False-False-False-False] PASSED [ 61%]
azure/tests/test_azure.py::test_get_blobs[2022-01-01T12:00:00.000000Z-2022-06-15T12:00:00.000000Z-2022-12-31T12:00:00.000000Z-2022-01-01T12:00:00.000000Z-None-False-False-False-True] PASSED [ 62%]
azure/tests/test_azure.py::test_get_blobs[2022-12-31T12:00:00.000000Z-2022-01-01T12:00:00.000000Z-2022-06-15T12:00:00.000000Z-2022-12-31T12:00:00.000000Z-None-False-False-True-True] PASSED [ 63%]
azure/tests/test_azure.py::test_get_blobs[2022-12-31T12:00:00.000000Z-2022-12-31T12:00:00.000000Z-2022-12-31T12:00:00.000000Z-2022-12-31T12:00:00.000000Z-None-True-False-True-True] PASSED [ 63%]
azure/tests/test_azure.py::test_get_blobs[2022-12-31T12:00:00.000000Z-2022-01-01T12:00:00.000000Z-2022-06-15T12:00:00.000000Z-2022-12-31T12:00:00.000000Z-.json-False-False-False-True] PASSED [ 64%]
azure/tests/test_azure.py::test_get_blobs[2022-12-31T12:00:00.000000Z-2022-01-01T12:00:00.000000Z-2022-06-15T12:00:00.000000Z-2022-12-31T12:00:00.000000Z-.json-False-False-True-True] PASSED [ 65%]
azure/tests/test_azure.py::test_get_blobs[2022-12-31T12:00:00.000000Z-2022-01-01T12:00:00.000000Z-2022-06-15T12:00:00.000000Z-2022-12-31T12:00:00.000000Z-.json-False-True-False-True] PASSED [ 65%]
azure/tests/test_azure.py::test_get_blobs_list_blobs_ko PASSED           [ 66%]
azure/tests/test_azure.py::test_get_blobs_blob_data_ko[ValueError] PASSED [ 67%]
azure/tests/test_azure.py::test_get_blobs_blob_data_ko[AzureException] PASSED [ 68%]
azure/tests/test_azure.py::test_get_blobs_blob_data_ko[exception2] PASSED [ 68%]
azure/tests/test_azure.py::test_get_blobs_json_ko[JSONDecodeError] PASSED [ 69%]
azure/tests/test_azure.py::test_get_blobs_json_ko[TypeError] PASSED      [ 70%]
azure/tests/test_azure.py::test_get_blobs_json_ko[KeyError] PASSED       [ 71%]
azure/tests/test_azure.py::test_get_token PASSED                         [ 71%]
azure/tests/test_azure.py::test_get_token_ko[RequestException-None-None] PASSED [ 72%]
azure/tests/test_azure.py::test_get_token_ko[None-unauthorized_client-None] PASSED [ 73%]
azure/tests/test_azure.py::test_get_token_ko[None-invalid_client-None] PASSED [ 73%]
azure/tests/test_azure.py::test_get_token_ko[None-invalid_request-error_codes3] PASSED [ 74%]
azure/tests/test_azure.py::test_get_token_ko[None-invalid_request-error_codes4] PASSED [ 75%]
azure/tests/test_azure.py::test_get_token_ko[None-invalid-error_codes5] PASSED [ 76%]
azure/tests/test_azure.py::test_get_token_ko[None--error_codes6] PASSED  [ 76%]
azure/tests/test_azure.py::test_get_token_ko[None-None-error_codes7] PASSED [ 77%]
azure/tests/test_azure.py::test_send_message PASSED                      [ 78%]
azure/tests/test_azure.py::test_send_message_ko[111] PASSED              [ 78%]
azure/tests/test_azure.py::test_send_message_ko[90] PASSED               [ 79%]
azure/tests/test_azure.py::test_send_message_ko[1] PASSED                [ 80%]
azure/tests/test_azure.py::test_offset_to_datetime[1d-2022-12-30T12:00:00.000000Z] PASSED [ 81%]
azure/tests/test_azure.py::test_offset_to_datetime[1h-2022-12-31T11:00:00.000000Z] PASSED [ 81%]
azure/tests/test_azure.py::test_offset_to_datetime[1m-2022-12-31T11:59:00.000000Z] PASSED [ 82%]
azure/tests/test_azure.py::test_offset_to_datetime_ko PASSED             [ 83%]
azure/tests/test_orm.py::test_create_db[expected_table_names0-expected_columns0] PASSED [ 84%]
azure/tests/test_orm.py::test_add_get_row PASSED                         [ 84%]
azure/tests/test_orm.py::test_add_ko PASSED                              [ 85%]
azure/tests/test_orm.py::test_get_rows_ko PASSED                         [ 86%]
azure/tests/test_orm.py::test_update_row_ko PASSED                       [ 86%]
azure/tests/test_orm.py::test_load_dates_json[/home/test_user/git/wazuh/wodles/azure/tests/data/last_date_files/last_dates.json] PASSED [ 87%]
azure/tests/test_orm.py::test_load_dates_json[/home/test_user/git/wazuh/wodles/azure/tests/data/last_date_files/last_dates_graph.json] PASSED [ 88%]
azure/tests/test_orm.py::test_load_dates_json[/home/test_user/git/wazuh/wodles/azure/tests/data/last_date_files/last_dates_log_analytics.json] PASSED [ 89%]
azure/tests/test_orm.py::test_load_dates_json[/home/test_user/git/wazuh/wodles/azure/tests/data/last_date_files/last_dates_storage.json] PASSED [ 89%]
azure/tests/test_orm.py::test_load_dates_json[/home/test_user/git/wazuh/wodles/azure/tests/data/last_date_files/last_dates_old.json] PASSED [ 90%]
azure/tests/test_orm.py::test_load_dates_json[/home/test_user/git/wazuh/wodles/azure/tests/data/last_date_files/last_dates_clean.json] PASSED [ 91%]
azure/tests/test_orm.py::test_load_dates_json_no_file PASSED             [ 92%]
azure/tests/test_orm.py::test_load_dates_json_ko[/home/test_user/git/wazuh/wodles/azure/tests/data/last_date_files/last_dates_invalid.json] PASSED [ 92%]
azure/tests/test_orm.py::test_check_integrity[True-0] PASSED             [ 93%]
azure/tests/test_orm.py::test_check_integrity[True-100] PASSED           [ 94%]
azure/tests/test_orm.py::test_check_integrity[False-100] PASSED          [ 94%]
azure/tests/test_orm.py::test_check_integrity_ko PASSED                  [ 95%]
azure/tests/test_orm.py::test_migrate_from_last_dates_file[/home/test_user/git/wazuh/wodles/azure/tests/data/last_date_files/last_dates.json] PASSED [ 96%]
azure/tests/test_orm.py::test_migrate_from_last_dates_file[/home/test_user/git/wazuh/wodles/azure/tests/data/last_date_files/last_dates_graph.json] PASSED [ 97%]
azure/tests/test_orm.py::test_migrate_from_last_dates_file[/home/test_user/git/wazuh/wodles/azure/tests/data/last_date_files/last_dates_log_analytics.json] PASSED [ 97%]
azure/tests/test_orm.py::test_migrate_from_last_dates_file[/home/test_user/git/wazuh/wodles/azure/tests/data/last_date_files/last_dates_storage.json] PASSED [ 98%]
azure/tests/test_orm.py::test_migrate_from_last_dates_file[/home/test_user/git/wazuh/wodles/azure/tests/data/last_date_files/last_dates_old.json] PASSED [ 99%]
azure/tests/test_orm.py::test_migrate_from_last_dates_file[/home/test_user/git/wazuh/wodles/azure/tests/data/last_date_files/last_dates_clean.json] PASSED [100%]

============================= 138 passed in 0.67s ==============================

```