### PR TITLE
Add cluster command to get hash of custom ruleset files

### DIFF
--- a/framework/wazuh/cluster.py
+++ b/framework/wazuh/cluster.py
@@ -4,7 +4,7 @@
 from wazuh.core import common
 from wazuh.core.cluster import local_client
 from wazuh.core.cluster.cluster import get_node
-from wazuh.core.cluster.control import get_health, get_nodes, get_ruleset_integrity
+from wazuh.core.cluster.control import get_health, get_nodes
 from wazuh.core.cluster.utils import get_cluster_status, read_cluster_config, read_config
 from wazuh.core.exception import WazuhError, WazuhResourceNotFound
 from wazuh.core.results import AffectedItemsWazuhResult, WazuhResult
@@ -75,35 +75,6 @@ async def get_health_nodes(lc: local_client.LocalClient, filter_node=None):
     result.affected_items = sorted(result.affected_items, key=lambda i: i['info']['name'])
     result.total_affected_items = len(result.affected_items)
 
-    return result
-
-
-@expose_resources(actions=['cluster:read'], resources=['node:id:{filter_node}'], post_proc_func=async_list_handler)
-async def get_ruleset_sync(lc: local_client.LocalClient, filter_node=None, master_integrity={}):
-    """ Wrapper for get_health """
-    result = AffectedItemsWazuhResult(all_msg='All selected nodes ruleset are synced',
-                                      some_msg='Some nodes ruleset are not synced',
-                                      none_msg='No ruleset synced'
-                                      )
-
-    local_ruleset_integrity = await get_ruleset_integrity(lc)
-    synced = False
-
-    for file_path, file_info in master_integrity.items():
-        if file_path not in local_ruleset_integrity or file_info['md5'] != local_ruleset_integrity[file_path]['md5']:
-            break
-    else:
-        synced = True
-
-    # result.affected_items.append()
-
-
-    # for v in data['nodes'].values():
-    #     result.affected_items.append(v)
-    #
-    # result.affected_items = sorted(result.affected_items, key=lambda i: i['info']['name'])
-    # result.total_affected_items = len(result.affected_items)
-    #
     return result
 
 

--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -270,7 +270,7 @@ def get_files_status(previous_status=None, get_md5=True):
 
 
 def get_ruleset_status(previous_status):
-    """Get MD5 of custom ruleset files.
+    """Get hash of custom ruleset files.
 
     Parameters
     ----------
@@ -280,7 +280,7 @@ def get_ruleset_status(previous_status):
     Returns
     -------
     Dict
-        Relative path and MD5 of local ruleset files.
+        Relative path and hash of local ruleset files.
     """
     final_items = {}
     cluster_items = get_cluster_items()

--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -22,7 +22,7 @@ from wazuh.core import common
 from wazuh.core.InputValidator import InputValidator
 from wazuh.core.agent import WazuhDBQueryAgents
 from wazuh.core.cluster.utils import get_cluster_items, read_config
-from wazuh.core.utils import md5, mkdir_with_mode
+from wazuh.core.utils import md5, mkdir_with_mode, to_relative_path
 
 logger = logging.getLogger('wazuh')
 agent_groups_path = os.path.relpath(common.groups_path, common.wazuh_path)
@@ -267,6 +267,38 @@ def get_files_status(previous_status=None, get_md5=True):
             logger.warning(f"Error getting file status: {e}.")
 
     return final_items
+
+
+def get_ruleset_status(previous_status):
+    """Get MD5 of custom ruleset files.
+
+    Parameters
+    ----------
+    previous_status : dict
+        Integrity information of local files.
+
+    Returns
+    -------
+    Dict
+        Relative path and MD5 of local ruleset files.
+    """
+    final_items = {}
+    cluster_items = get_cluster_items()
+    user_ruleset = [os.path.join(to_relative_path(user_path), '') for user_path in [common.user_decoders_path,
+                                                                                    common.user_rules_path,
+                                                                                    common.user_lists_path]]
+
+    for file_path, item in cluster_items['files'].items():
+        if file_path == "excluded_files" or file_path == "excluded_extensions" or file_path not in user_ruleset:
+            continue
+        try:
+            final_items.update(
+                walk_dir(file_path, item['recursive'], item['files'], cluster_items['files']['excluded_files'],
+                         cluster_items['files']['excluded_extensions'], file_path, previous_status, True))
+        except Exception as e:
+            logger.warning(f"Error getting file status: {e}.")
+
+    return {file_path: file_data['md5'] for file_path, file_data in final_items.items()}
 
 
 def update_cluster_control_with_failed(failed_files, ko_files):

--- a/framework/wazuh/core/cluster/local_server.py
+++ b/framework/wazuh/core/cluster/local_server.py
@@ -63,6 +63,8 @@ class LocalServerHandler(server.AbstractServerHandler):
             return self.get_nodes(data)
         elif command == b'get_health':
             return self.get_health(data)
+        elif command == b'ruleset_md5':
+            return self.get_ruleset_status()
         elif command == b'send_file':
             path, node_name = data.decode().split(' ')
             return self.send_file_request(path, node_name)
@@ -120,6 +122,18 @@ class LocalServerHandler(server.AbstractServerHandler):
             If the method is not implemented.
         """
         raise NotImplementedError
+
+    def get_ruleset_status(self):
+        """Obtain local ruleset paths and MD5 hash.
+
+        Returns
+        -------
+        bytes
+            Result.
+        bytes
+            JSON containing local file paths and their MD5 hash.
+        """
+        return b'ok', json.dumps(self.server.node.get_ruleset_status()).encode()
 
     def send_file_request(self, path, node_name):
         """Send a file from the API to the cluster.

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -1058,3 +1058,13 @@ class Master(server.AbstractServer):
         """
         return {'type': self.configuration['node_type'], 'cluster': self.configuration['name'],
                 'node': self.configuration['node_name']}
+
+    def get_ruleset_status(self):
+        """Obtain local ruleset paths and MD5 hash.
+
+        Returns
+        -------
+        Dict
+            Local file paths and their MD5 hash.
+        """
+        return wazuh.core.cluster.cluster.get_ruleset_status(self.integrity_control)

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -11,7 +11,6 @@ from calendar import timegm
 from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime
-from functools import partial
 from time import time
 from typing import Tuple, Dict, Callable
 from uuid import uuid4
@@ -1058,13 +1057,3 @@ class Master(server.AbstractServer):
         """
         return {'type': self.configuration['node_type'], 'cluster': self.configuration['name'],
                 'node': self.configuration['node_name']}
-
-    def get_ruleset_status(self):
-        """Obtain local ruleset paths and MD5 hash.
-
-        Returns
-        -------
-        Dict
-            Local file paths and their MD5 hash.
-        """
-        return wazuh.core.cluster.cluster.get_ruleset_status(self.integrity_control)

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -951,13 +951,3 @@ class Worker(client.AbstractClientManager):
         """
         return {'type': self.configuration['node_type'], 'cluster': self.configuration['name'],
                 'node': self.configuration['node_name']}
-
-    def get_ruleset_status(self):
-        """Obtain local ruleset paths and MD5 hash.
-
-        Returns
-        -------
-        Dict
-            Local file paths and their MD5 hash.
-        """
-        return cluster.get_ruleset_status(self.integrity_control)


### PR DESCRIPTION
|Related issue|
|---|
| Closes #14520 |

## Description

This PR adds a new command that can be used through the cluster socket (or the Local Client instead) to obtain a list with the custom ruleset files and their hashes. These files include:
- `etc/rules/`
- `etc/decoders/`
- `etc/lists/`

The command is `get_hash`, it does not expect any data parameters:
```PYTHON
response = await lc.execute(command=b'get_hash', data=b'', wait_for_complete=False)
```

The output shows the local data of the node on which the command is sent, and looks like this:
```JSON
{
    "etc/rules/local_rules.xml": "11bdb298d71a9bc09f7ebed616e5afca",
    "etc/decoders/local_decoder.xml": "49815af675bbb6841e9caf576593bca6",
    "etc/lists/audit-keys": "81f33d8d059879e1ba70a40351a0df1c",
    "etc/lists/security-eventchannel": "b7e07c024b7a44ff5f84bca8d91c17ab",
    "etc/lists/audit-keys.cdb": "9c4c9341414f1829e2060bdd47573882",
    "etc/lists/security-eventchannel.cdb": "79372e803ac0dfbed282085589a7cceb",
    "etc/lists/amazon/aws-sources": "24b8f44e0d4561d50f2690e31ef2ab04",
    "etc/lists/amazon/aws-eventnames": "c9df40b53d2fb62ca99cd4d98ed207f5",
    "etc/lists/amazon/aws-eventnames.cdb": "984841425168443d25b29d81950810ae",
}
```
