### PR TITLE
Deprecate Debian Stretch in Vulnerability Detector

### DIFF
--- a/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
+++ b/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
@@ -18,7 +18,6 @@
     <!-- Debian OS vulnerabilities -->
     <provider name="debian">
       <enabled>no</enabled>
-      <os>stretch</os>
       <os>buster</os>
       <os>bullseye</os>
       <update_interval>1h</update_interval>

--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -184,11 +184,10 @@ int wm_vuldet_set_feed_version(char *feed, char *version, update_node **upd_list
             os_strdup(vu_feed_tag[FEED_BUSTER], upd->version);
             upd->dist_tag_ref = FEED_BUSTER;
             upd->dist_ext = vu_feed_ext[FEED_BUSTER];
-        } else if (!strcmp(version, "9") || strcasestr(version, vu_feed_tag[FEED_STRETCH])) {
-            os_index = CVE_STRETCH;
-            os_strdup(vu_feed_tag[FEED_STRETCH], upd->version);
-            upd->dist_tag_ref = FEED_STRETCH;
-            upd->dist_ext = vu_feed_ext[FEED_STRETCH];
+        } else if (!strcmp(version, "9") || strcasestr(version, "STRETCH")) {
+            mwarn("Debian Stretch is no longer supported.");
+            retval = OS_DEPRECATED;
+            goto end;
         } else if (!strcmp(version, "8") || strcasestr(version, "JESSIE")) {
             mwarn("Debian Jessie is no longer supported.");
             retval = OS_DEPRECATED;

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -1373,7 +1373,7 @@ void test_wm_vuldet_linux_rm_nvd_not_affected_packages_nvd_debian_discard(void *
     first->src_name = "test-wazuh-src";
     first->vendor = "Wazuh Inc.";
     agent->dist = FEED_DEBIAN;
-    agent->dist_ver = FEED_STRETCH;
+    agent->dist_ver = FEED_BUSTER;
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
 
@@ -1381,7 +1381,7 @@ void test_wm_vuldet_linux_rm_nvd_not_affected_packages_nvd_debian_discard(void *
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
     expect_string(__wrap_sqlite3_bind_text, buffer, cve);
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "STRETCH");
+    expect_string(__wrap_sqlite3_bind_text, buffer, "BUSTER");
 
     expect_sqlite3_step_call(SQLITE_ROW);
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -535,7 +535,6 @@ const char *vu_feed_tag[] = {
     "FOCAL",
     "JAMMY",
     // Debian versions
-    "STRETCH",
     "BUSTER",
     "BULLSEYE",
     // RedHat versions
@@ -599,7 +598,6 @@ const char *vu_feed_ext[] = {
     "Ubuntu Focal",
     "Ubuntu Jammy",
     // Debian versions
-    "Debian Stretch",
     "Debian Buster",
     "Debian Bullseye",
     // RedHat versions
@@ -5719,9 +5717,7 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
             }
             agent_dist = FEED_UBUNTU;
         } else if (strcasestr(agti_os_name, vu_feed_ext[FEED_DEBIAN])) {
-            if (strstr(agti_os_major, "9")) {
-                agent_dist_ver = FEED_STRETCH;
-            } else if (strstr(agti_os_major, "10")) {
+            if (strstr(agti_os_major, "10")) {
                 agent_dist_ver = FEED_BUSTER;
             } else if (strstr(agti_os_major, "11")) {
                 agent_dist_ver = FEED_BULLSEYE;
@@ -6467,7 +6463,6 @@ int wm_vuldet_generate_os_and_kernel_package(sqlite3 *db, scan_agent *agent) {
             product_name[0] = vu_os_product_name_list[PR_UBUNTU];
             vendor = vu_vendor_list[V_UBUNTU];
         break;
-        case FEED_STRETCH:
         case FEED_BUSTER:
         case FEED_BULLSEYE:
             product_name[0] = vu_os_product_name_list[PR_DEBIAN];

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -266,7 +266,6 @@ typedef enum vu_feed {
     FEED_FOCAL,
     FEED_JAMMY,
     // Debian versions
-    FEED_STRETCH,
     FEED_BUSTER,
     FEED_BULLSEYE,
     // RedHat versions
@@ -430,7 +429,6 @@ typedef enum cve_db {
     CVE_BIONIC,
     CVE_FOCAL,
     CVE_JAMMY,
-    CVE_STRETCH,
     CVE_BUSTER,
     CVE_BULLSEYE,
     CVE_REDHAT5,


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/14354|

## Description

Due to the removal of all references to vulnerabilities for the Debian Stretch target, it has been necessary to deprecate support for it. 

For this purpose, the following changes have been applied:
- Prevent OVAL download and indexing.
- Remove the configuration reference and add a Warning if added in the configuration.
- Prevent scanning for the Stretch agent.

## Configuration options

The Debian block in Vulnerability Detector after deprecation looks as follows:
```xml
    <!-- Debian OS vulnerabilities -->
    <provider name="debian">
      <enabled>no</enabled>
      <os>buster</os>
      <os>bullseye</os>
      <update_interval>1h</update_interval>
    </provider>
```

## Logs/Alerts example

Now, when trying to add the target stretch in the configuration, the following _Warning_ message will appear:
`wazuh-modulesd[5027] wmodules-vuln-detector.c:188 at wm_vuldet_set_feed_version(): WARNING: Debian Stretch is no longer supported.`

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
