### PR TITLE
Deprecate Azure and AWS authentication method

### DIFF
--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -56,6 +56,7 @@ static const char *CLOUDWATCHLOGS_SERVICE_TYPE = "cloudwatchlogs";
 static const char *CISCO_UMBRELLA_BUCKET_TYPE = "cisco_umbrella";
 
 static const char *AUTHENTICATION_OPTIONS_URL = "https://documentation.wazuh.com/current/amazon/services/prerequisites/credentials.html";
+static const char *DEPRECATED_MESSAGE = "Deprecated tag <%s> found at module '%s'. This tag was deprecated in %s; please use a different authentication method. Check %s for more information.";
 
 // Parse XML
 
@@ -238,7 +239,7 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                         }
                     } else if (!strcmp(children[j]->element, XML_ACCESS_KEY)) {
                         if (strlen(children[j]->content) != 0) {
-                            mwarn("Deprecated tag <%s> found at module '%s'. This tag was deprecated in 4.4. Please, use a different authentication method. Check %s for more information.", children[j]->element, WM_AWS_CONTEXT.name, AUTHENTICATION_OPTIONS_URL);
+                            mwarn(DEPRECATED_MESSAGE, children[j]->element, WM_AWS_CONTEXT.name, "4.4", AUTHENTICATION_OPTIONS_URL);
                             free(cur_bucket->access_key);
                             os_strdup(children[j]->content, cur_bucket->access_key);
                         }
@@ -249,7 +250,7 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                         }
                     } else if (!strcmp(children[j]->element, XML_SECRET_KEY)) {
                         if (strlen(children[j]->content) != 0) {
-                            mwarn("Deprecated tag <%s> found at module '%s'. This tag was deprecated in 4.4. Please, use a different authentication method. Check %s for more information.", children[j]->element, WM_AWS_CONTEXT.name, AUTHENTICATION_OPTIONS_URL);
+                            mwarn(DEPRECATED_MESSAGE, children[j]->element, WM_AWS_CONTEXT.name, "4.4", AUTHENTICATION_OPTIONS_URL);
                             free(cur_bucket->secret_key);
                             os_strdup(children[j]->content, cur_bucket->secret_key);
                         }
@@ -386,7 +387,7 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                     os_strdup(children[j]->content, cur_service->aws_account_id);
                 } else if (!strcmp(children[j]->element, XML_ACCESS_KEY)) {
                     if (strlen(children[j]->content) != 0) {
-                        mwarn("Deprecated tag <%s> found at module '%s'. This tag was deprecated in 4.4. Please, use a different authentication method. Check %s for more information.", children[j]->element, WM_AWS_CONTEXT.name, AUTHENTICATION_OPTIONS_URL);
+                        mwarn(DEPRECATED_MESSAGE, children[j]->element, WM_AWS_CONTEXT.name, "4.4", AUTHENTICATION_OPTIONS_URL);
                         free(cur_service->access_key);
                         os_strdup(children[j]->content, cur_service->access_key);
                     }
@@ -397,7 +398,7 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                     }
                 } else if (!strcmp(children[j]->element, XML_SECRET_KEY)) {
                     if (strlen(children[j]->content) != 0) {
-                        mwarn("Deprecated tag <%s> found at module '%s'. This tag was deprecated in 4.4. Please, use a different authentication method. Check %s for more information.", children[j]->element, WM_AWS_CONTEXT.name, AUTHENTICATION_OPTIONS_URL);
+                        mwarn(DEPRECATED_MESSAGE, children[j]->element, WM_AWS_CONTEXT.name, "4.4", AUTHENTICATION_OPTIONS_URL);
                         free(cur_service->secret_key);
                         os_strdup(children[j]->content, cur_service->secret_key);
                     }

--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -55,6 +55,8 @@ static const char *INSPECTOR_SERVICE_TYPE = "inspector";
 static const char *CLOUDWATCHLOGS_SERVICE_TYPE = "cloudwatchlogs";
 static const char *CISCO_UMBRELLA_BUCKET_TYPE = "cisco_umbrella";
 
+static const char *AUTHENTICATION_OPTIONS_URL = "https://documentation.wazuh.com/current/amazon/services/prerequisites/credentials.html";
+
 // Parse XML
 
 int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
@@ -236,6 +238,7 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                         }
                     } else if (!strcmp(children[j]->element, XML_ACCESS_KEY)) {
                         if (strlen(children[j]->content) != 0) {
+                            mwarn("Deprecated tag <%s> found at module '%s'. This tag was deprecated in 4.4. Please, use a different authentication method. Check %s for more information.", children[j]->element, WM_AWS_CONTEXT.name, AUTHENTICATION_OPTIONS_URL);
                             free(cur_bucket->access_key);
                             os_strdup(children[j]->content, cur_bucket->access_key);
                         }
@@ -246,6 +249,7 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                         }
                     } else if (!strcmp(children[j]->element, XML_SECRET_KEY)) {
                         if (strlen(children[j]->content) != 0) {
+                            mwarn("Deprecated tag <%s> found at module '%s'. This tag was deprecated in 4.4. Please, use a different authentication method. Check %s for more information.", children[j]->element, WM_AWS_CONTEXT.name, AUTHENTICATION_OPTIONS_URL);
                             free(cur_bucket->secret_key);
                             os_strdup(children[j]->content, cur_bucket->secret_key);
                         }
@@ -382,6 +386,7 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                     os_strdup(children[j]->content, cur_service->aws_account_id);
                 } else if (!strcmp(children[j]->element, XML_ACCESS_KEY)) {
                     if (strlen(children[j]->content) != 0) {
+                        mwarn("Deprecated tag <%s> found at module '%s'. This tag was deprecated in 4.4. Please, use a different authentication method. Check %s for more information.", children[j]->element, WM_AWS_CONTEXT.name, AUTHENTICATION_OPTIONS_URL);
                         free(cur_service->access_key);
                         os_strdup(children[j]->content, cur_service->access_key);
                     }
@@ -392,6 +397,7 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                     }
                 } else if (!strcmp(children[j]->element, XML_SECRET_KEY)) {
                     if (strlen(children[j]->content) != 0) {
+                        mwarn("Deprecated tag <%s> found at module '%s'. This tag was deprecated in 4.4. Please, use a different authentication method. Check %s for more information.", children[j]->element, WM_AWS_CONTEXT.name, AUTHENTICATION_OPTIONS_URL);
                         free(cur_service->secret_key);
                         os_strdup(children[j]->content, cur_service->secret_key);
                     }

--- a/src/config/wmodules-azure.c
+++ b/src/config/wmodules-azure.c
@@ -48,6 +48,8 @@ static void wm_clean_request(wm_azure_request_t * request);
 static void wm_clean_storage(wm_azure_storage_t * storage);
 static void wm_clean_container(wm_azure_container_t * container);
 
+static const char *AUTHENTICATION_OPTIONS_URL = "https://documentation.wazuh.com/current/azure/activity-services/prerequisites/credentials.html";
+
 // Parse XML
 
 int wm_azure_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
@@ -237,9 +239,11 @@ int wm_azure_api_read(const OS_XML *xml, XML_NODE nodes, wm_azure_api_t * api_co
 
         } else if (!strcmp(nodes[i]->element, XML_APP_ID)) {
             if (*nodes[i]->content != '\0')
+                mwarn("Deprecated tag <%s> found at module '%s'. This tag was deprecated in 4.4. Please, use a different authentication method. Check %s for more information.", nodes[i]->element, WM_AZURE_CONTEXT.name, AUTHENTICATION_OPTIONS_URL);
                 os_strdup(nodes[i]->content, api_config->application_id);
         } else if (!strcmp(nodes[i]->element, XML_APP_KEY)) {
             if (*nodes[i]->content != '\0')
+                mwarn("Deprecated tag <%s> found at module '%s'. This tag was deprecated in 4.4. Please, use a different authentication method. Check %s for more information.", nodes[i]->element, WM_AZURE_CONTEXT.name, AUTHENTICATION_OPTIONS_URL);
                 os_strdup(nodes[i]->content, api_config->application_key);
         } else if (!strcmp(nodes[i]->element, XML_AUTH_PATH)) {
             if (*nodes[i]->content != '\0')
@@ -469,8 +473,10 @@ int wm_azure_storage_read(const OS_XML *xml, XML_NODE nodes, wm_azure_storage_t 
 
         } else if (nodes[i]->content != NULL && *nodes[i]->content != '\0') {
             if (!strcmp(nodes[i]->element, XML_ACCOUNT_NAME)) {
+                mwarn("Deprecated tag <%s> found at module '%s'. This tag was deprecated in 4.4. Please, use a different authentication method. Check %s for more information.", nodes[i]->element, WM_AZURE_CONTEXT.name, AUTHENTICATION_OPTIONS_URL);
                 os_strdup(nodes[i]->content, storage->account_name);
             } else if (!strcmp(nodes[i]->element, XML_ACCOUNT_KEY)) {
+                mwarn("Deprecated tag <%s> found at module '%s'. This tag was deprecated in 4.4. Please, use a different authentication method. Check %s for more information.", nodes[i]->element, WM_AZURE_CONTEXT.name, AUTHENTICATION_OPTIONS_URL);
                 os_strdup(nodes[i]->content, storage->account_key);
             } else if (!strcmp(nodes[i]->element, XML_AUTH_PATH)) {
                 os_strdup(nodes[i]->content, storage->auth_path);

--- a/src/config/wmodules-azure.c
+++ b/src/config/wmodules-azure.c
@@ -49,6 +49,7 @@ static void wm_clean_storage(wm_azure_storage_t * storage);
 static void wm_clean_container(wm_azure_container_t * container);
 
 static const char *AUTHENTICATION_OPTIONS_URL = "https://documentation.wazuh.com/current/azure/activity-services/prerequisites/credentials.html";
+static const char *DEPRECATED_MESSAGE = "Deprecated tag <%s> found at module '%s'. This tag was deprecated in %s; please use a different authentication method. Check %s for more information.";
 
 // Parse XML
 
@@ -239,11 +240,11 @@ int wm_azure_api_read(const OS_XML *xml, XML_NODE nodes, wm_azure_api_t * api_co
 
         } else if (!strcmp(nodes[i]->element, XML_APP_ID)) {
             if (*nodes[i]->content != '\0')
-                mwarn("Deprecated tag <%s> found at module '%s'. This tag was deprecated in 4.4. Please, use a different authentication method. Check %s for more information.", nodes[i]->element, WM_AZURE_CONTEXT.name, AUTHENTICATION_OPTIONS_URL);
+                mwarn(DEPRECATED_MESSAGE, nodes[i]->element, WM_AZURE_CONTEXT.name, "4.4", AUTHENTICATION_OPTIONS_URL);
                 os_strdup(nodes[i]->content, api_config->application_id);
         } else if (!strcmp(nodes[i]->element, XML_APP_KEY)) {
             if (*nodes[i]->content != '\0')
-                mwarn("Deprecated tag <%s> found at module '%s'. This tag was deprecated in 4.4. Please, use a different authentication method. Check %s for more information.", nodes[i]->element, WM_AZURE_CONTEXT.name, AUTHENTICATION_OPTIONS_URL);
+                mwarn(DEPRECATED_MESSAGE, nodes[i]->element, WM_AZURE_CONTEXT.name, "4.4", AUTHENTICATION_OPTIONS_URL);
                 os_strdup(nodes[i]->content, api_config->application_key);
         } else if (!strcmp(nodes[i]->element, XML_AUTH_PATH)) {
             if (*nodes[i]->content != '\0')
@@ -473,10 +474,10 @@ int wm_azure_storage_read(const OS_XML *xml, XML_NODE nodes, wm_azure_storage_t 
 
         } else if (nodes[i]->content != NULL && *nodes[i]->content != '\0') {
             if (!strcmp(nodes[i]->element, XML_ACCOUNT_NAME)) {
-                mwarn("Deprecated tag <%s> found at module '%s'. This tag was deprecated in 4.4. Please, use a different authentication method. Check %s for more information.", nodes[i]->element, WM_AZURE_CONTEXT.name, AUTHENTICATION_OPTIONS_URL);
+                mwarn(DEPRECATED_MESSAGE, nodes[i]->element, WM_AZURE_CONTEXT.name, "4.4", AUTHENTICATION_OPTIONS_URL);
                 os_strdup(nodes[i]->content, storage->account_name);
             } else if (!strcmp(nodes[i]->element, XML_ACCOUNT_KEY)) {
-                mwarn("Deprecated tag <%s> found at module '%s'. This tag was deprecated in 4.4. Please, use a different authentication method. Check %s for more information.", nodes[i]->element, WM_AZURE_CONTEXT.name, AUTHENTICATION_OPTIONS_URL);
+                mwarn(DEPRECATED_MESSAGE, nodes[i]->element, WM_AZURE_CONTEXT.name, "4.4", AUTHENTICATION_OPTIONS_URL);
                 os_strdup(nodes[i]->content, storage->account_key);
             } else if (!strcmp(nodes[i]->element, XML_AUTH_PATH)) {
                 os_strdup(nodes[i]->content, storage->auth_path);

--- a/src/unit_tests/wazuh_modules/azure/test_wm_azure.c
+++ b/src/unit_tests/wazuh_modules/azure/test_wm_azure.c
@@ -36,8 +36,7 @@ extern int test_mode;
 static void wmodule_cleanup(wmodule *module){
     wm_azure_t* module_data = (wm_azure_t *)module->data;
     if(module_data->api_config){
-        free(module_data->api_config->application_key);
-        free(module_data->api_config->application_id);
+        free(module_data->api_config->auth_path);
         free(module_data->api_config->tenantdomain);
         free(module_data->api_config->request->time_offset);
         free(module_data->api_config->request->workspace);
@@ -60,8 +59,7 @@ static int setup_module() {
         "<interval>5m</interval>\n"
         "<run_on_start>no</run_on_start>\n"
         "<log_analytics>\n"
-        "    <application_id>8b7...c14</application_id>\n"
-        "    <application_key>w22...91x</application_key>\n"
+        "    <auth_path>/var/ossec/wodles/azure/credentials.txt</auth_path>\n"
         "    <tenantdomain>wazuh.onmicrosoft.com</tenantdomain>\n"
         "    <request>\n"
         "        <tag>azure-activity</tag>\n"
@@ -154,8 +152,7 @@ void test_fake_tag(void **state) {
         "<time>00:01</time>\n"
         "<run_on_start>no</run_on_start>\n"
         "<log_analytics>\n"
-        "    <application_id>8b7...c14</application_id>\n"
-        "    <application_key>w22...91x</application_key>\n"
+        "    <auth_path>/var/ossec/wodles/azure/credentials.txt</auth_path>\n"
         "    <tenantdomain>wazuh.onmicrosoft.com</tenantdomain>\n"
         "    <request>\n"
         "        <tag>azure-activity</tag>\n"
@@ -178,8 +175,7 @@ void test_read_scheduling_monthday_configuration(void **state) {
         "<day>4</day>\n"
         "<run_on_start>no</run_on_start>\n"
         "<log_analytics>\n"
-        "    <application_id>8b7...c14</application_id>\n"
-        "    <application_key>w22...91x</application_key>\n"
+        "    <auth_path>/var/ossec/wodles/azure/credentials.txt</auth_path>\n"
         "    <tenantdomain>wazuh.onmicrosoft.com</tenantdomain>\n"
         "    <request>\n"
         "        <tag>azure-activity</tag>\n"
@@ -208,8 +204,7 @@ void test_read_scheduling_weekday_configuration(void **state) {
         "<wday>Friday</wday>\n"
         "<run_on_start>no</run_on_start>\n"
         "<log_analytics>\n"
-        "    <application_id>8b7...c14</application_id>\n"
-        "    <application_key>w22...91x</application_key>\n"
+        "    <auth_path>/var/ossec/wodles/azure/credentials.txt</auth_path>\n"
         "    <tenantdomain>wazuh.onmicrosoft.com</tenantdomain>\n"
         "    <request>\n"
         "        <tag>azure-activity</tag>\n"
@@ -237,8 +232,7 @@ void test_read_scheduling_daytime_configuration(void **state) {
         "<time>00:10</time>\n"
         "<run_on_start>no</run_on_start>\n"
         "<log_analytics>\n"
-        "    <application_id>8b7...c14</application_id>\n"
-        "    <application_key>w22...91x</application_key>\n"
+        "    <auth_path>/var/ossec/wodles/azure/credentials.txt</auth_path>\n"
         "    <tenantdomain>wazuh.onmicrosoft.com</tenantdomain>\n"
         "    <request>\n"
         "        <tag>azure-activity</tag>\n"
@@ -265,8 +259,7 @@ void test_read_scheduling_interval_configuration(void **state) {
         "<interval>3h</interval>\n"
         "<run_on_start>no</run_on_start>\n"
         "<log_analytics>\n"
-        "    <application_id>8b7...c14</application_id>\n"
-        "    <application_key>w22...91x</application_key>\n"
+        "    <auth_path>/var/ossec/wodles/azure/credentials.txt</auth_path>\n"
         "    <tenantdomain>wazuh.onmicrosoft.com</tenantdomain>\n"
         "    <request>\n"
         "        <tag>azure-activity</tag>\n"

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -62,6 +62,9 @@ if sys.version_info[0] == 3:
 # Constants
 ################################################################################
 
+AUTHENTICATION_OPTIONS_URL = "https://documentation.wazuh.com/current/amazon/services/prerequisites/credentials.html"
+
+
 # Enable/disable debug mode
 debug_level = 0
 
@@ -232,6 +235,9 @@ class WazuhIntegration:
         conn_args = {}
 
         if access_key is not None and secret_key is not None:
+            print("Deprecated authentication method found at module 'aws-s3'. This method was deprecated in 4.4. "
+                  f"Please, use a different authentication method. Check {AUTHENTICATION_OPTIONS_URL} "
+                  "for more information.")
             conn_args['aws_access_key_id'] = access_key
             conn_args['aws_secret_access_key'] = secret_key
 
@@ -3438,8 +3444,16 @@ def get_script_arguments():
                         help='AWS Account ID for logs', required=False,
                         type=arg_valid_accountid)
     parser.add_argument('-d', '--debug', action='store', dest='debug', default=0, help='Enable debug')
-    parser.add_argument('-a', '--access_key', dest='access_key', help='S3 Access key credential', default=None)
-    parser.add_argument('-k', '--secret_key', dest='secret_key', help='S3 Secret key credential', default=None)
+    parser.add_argument('-a', '--access_key', dest='access_key', default=None,
+                        help='S3 Access key credential. This option was deprecated in 4.4. Please use another '
+                             'authentication method instead. Check '
+                             'https://documentation.wazuh.com/current/amazon/services/prerequisites/credentials.html '
+                             'for more information.')
+    parser.add_argument('-k', '--secret_key', dest='secret_key', default=None,
+                        help='S3 Access key credential. This option was deprecated in 4.4. Please use another '
+                             'authentication method instead. Check '
+                             'https://documentation.wazuh.com/current/amazon/services/prerequisites/credentials.html '
+                             'for more information.')
     # Beware, once you delete history it's gone.
     parser.add_argument('-R', '--remove', action='store_true', dest='deleteFile',
                         help='Remove processed files from the AWS S3 bucket', default=False)

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -62,8 +62,9 @@ if sys.version_info[0] == 3:
 # Constants
 ################################################################################
 
-AUTHENTICATION_OPTIONS_URL = "https://documentation.wazuh.com/current/amazon/services/prerequisites/credentials.html"
-
+CREDENTIALS_URL = 'https://documentation.wazuh.com/current/amazon/services/prerequisites/credentials.html'
+DEPRECATED_MESSAGE = 'The {name} authentication parameter was deprecated in {release}. ' \
+                     'Please use another authentication method instead. Check {url} for more information.'
 
 # Enable/disable debug mode
 debug_level = 0
@@ -235,9 +236,7 @@ class WazuhIntegration:
         conn_args = {}
 
         if access_key is not None and secret_key is not None:
-            print("Deprecated authentication method found at module 'aws-s3'. This method was deprecated in 4.4. "
-                  f"Please, use a different authentication method. Check {AUTHENTICATION_OPTIONS_URL} "
-                  "for more information.")
+            print(DEPRECATED_MESSAGE.format(name="access_key and secret_key", release="4.4", url=CREDENTIALS_URL))
             conn_args['aws_access_key_id'] = access_key
             conn_args['aws_secret_access_key'] = secret_key
 
@@ -3427,7 +3426,6 @@ def arg_valid_iam_role_duration(arg_string):
         raise argparse.ArgumentTypeError("Invalid session duration specified. Value must be between 900 and 3600.")
     return int(arg_string)
 
-
 def get_script_arguments():
     parser = argparse.ArgumentParser(usage="usage: %(prog)s [options]",
                                      description="Wazuh wodle for monitoring AWS",
@@ -3445,15 +3443,11 @@ def get_script_arguments():
                         type=arg_valid_accountid)
     parser.add_argument('-d', '--debug', action='store', dest='debug', default=0, help='Enable debug')
     parser.add_argument('-a', '--access_key', dest='access_key', default=None,
-                        help='S3 Access key credential. This option was deprecated in 4.4. Please use another '
-                             'authentication method instead. Check '
-                             'https://documentation.wazuh.com/current/amazon/services/prerequisites/credentials.html '
-                             'for more information.')
+                        help='S3 Access key credential. '
+                             f'{DEPRECATED_MESSAGE.format(name="access_key", release="4.4", url=CREDENTIALS_URL)}')
     parser.add_argument('-k', '--secret_key', dest='secret_key', default=None,
-                        help='S3 Access key credential. This option was deprecated in 4.4. Please use another '
-                             'authentication method instead. Check '
-                             'https://documentation.wazuh.com/current/amazon/services/prerequisites/credentials.html '
-                             'for more information.')
+                        help='S3 Access key credential. '
+                             f'{DEPRECATED_MESSAGE.format(name="secret_key", release="4.4", url=CREDENTIALS_URL)}')
     # Beware, once you delete history it's gone.
     parser.add_argument('-R', '--remove', action='store_true', dest='deleteFile',
                         help='Remove processed files from the AWS S3 bucket', default=False)

--- a/wodles/azure/azure-logs.py
+++ b/wodles/azure/azure-logs.py
@@ -56,6 +56,7 @@ log_levels = {0: logging.WARNING,
               1: logging.INFO,
               2: logging.DEBUG}
 
+AUTHENTICATION_OPTIONS_URL = "https://documentation.wazuh.com/current/azure/activity-services/prerequisites/credentials.html"
 
 def set_logger():
     """Set the logger configuration."""
@@ -77,9 +78,11 @@ def get_script_arguments():
 
     # Log Analytics arguments #
     parser.add_argument("--la_id", metavar='ID', type=str, required=False,
-                        help="Application ID for Log Analytics authentication.")
+                        help="Application ID for Log Analytics authentication. This option was deprecated in 4.4. "
+                             "Please use another authentication method instead.")
     parser.add_argument("--la_key", metavar="KEY", type=str, required=False,
-                        help="Application Key for Log Analytics authentication.")
+                        help="Application Key for Log Analytics authentication. This option was deprecated in 4.4. "
+                             "Please use another authentication method instead.")
     parser.add_argument("--la_auth_path", metavar="filepath", type=str, required=False,
                         help="Path of the file containing the credentials for authentication.")
     parser.add_argument("--la_tenant_domain", metavar="domain", type=str, required=False,
@@ -95,9 +98,11 @@ def get_script_arguments():
 
     # Graph arguments #
     parser.add_argument("--graph_id", metavar='ID', type=str, required=False,
-                        help="Application ID for Graph authentication.")
+                        help="Application ID for Graph authentication. This option was deprecated in 4.4. "
+                             "Please use another authentication method instead.")
     parser.add_argument("--graph_key", metavar="KEY", type=str, required=False,
-                        help="Application KEY for Graph authentication.")
+                        help="Application KEY for Graph authentication. This option was deprecated in 4.4. "
+                             "Please use another authentication method instead.")
     parser.add_argument("--graph_auth_path", metavar="filepath", type=str, required=False,
                         help="Path of the file containing the credentials authentication.")
     parser.add_argument("--graph_tenant_domain", metavar="domain", type=str, required=False,
@@ -111,9 +116,11 @@ def get_script_arguments():
 
     # Storage arguments #
     parser.add_argument("--account_name", metavar='account', type=str, required=False,
-                        help="Storage account name for authentication.")
+                        help="Storage account name for authentication. This option was deprecated in 4.4. "
+                             "Please use another authentication method instead.")
     parser.add_argument("--account_key", metavar='KEY', type=str, required=False,
-                        help="Storage account key for authentication.")
+                        help="Storage account key for authentication. This option was deprecated in 4.4. "
+                             "Please use another authentication method instead.")
     parser.add_argument("--storage_auth_path", metavar="filepath", type=str, required=False,
                         help="Path of the file containing the credentials authentication.")
     parser.add_argument("--container", metavar="container", required=False, type=arg_valid_container_name,
@@ -280,6 +287,9 @@ def start_log_analytics():
     if args.la_auth_path and args.la_tenant_domain:
         client, secret = read_auth_file(auth_path=args.la_auth_path, fields=("application_id", "application_key"))
     elif args.la_id and args.la_key and args.la_tenant_domain:
+        logging.error("Deprecated authentication method found at module 'azure-logs'. "
+                        "This method was deprecated in 4.4. Please, use a different authentication method. "
+                        f"Check {AUTHENTICATION_OPTIONS_URL} for more information.")
         client = args.la_id
         secret = args.la_key
     else:
@@ -457,6 +467,9 @@ def start_graph():
     if args.graph_auth_path and args.graph_tenant_domain:
         client, secret = read_auth_file(auth_path=args.graph_auth_path, fields=("application_id", "application_key"))
     elif args.graph_id and args.graph_key and args.graph_tenant_domain:
+        logging.warning("Deprecated authentication method found at module 'azure-logs'. "
+                        "This method was deprecated in 4.4. Please, use a different authentication method. "
+                        f"Check {AUTHENTICATION_OPTIONS_URL} for more information.")
         client = args.graph_id
         secret = args.graph_key
     else:
@@ -589,6 +602,9 @@ def start_storage():
     if args.storage_auth_path:
         name, key = read_auth_file(auth_path=args.storage_auth_path, fields=("account_name", "account_key"))
     elif args.account_name and args.account_key:
+        logging.warning("Deprecated authentication method found at module 'azure-logs'. "
+                        "This method was deprecated in 4.4. Please, use a different authentication method. "
+                        f"Check {AUTHENTICATION_OPTIONS_URL} for more information.")
         name = args.account_name
         key = args.account_key
     else:

--- a/wodles/azure/azure-logs.py
+++ b/wodles/azure/azure-logs.py
@@ -56,7 +56,10 @@ log_levels = {0: logging.WARNING,
               1: logging.INFO,
               2: logging.DEBUG}
 
-AUTHENTICATION_OPTIONS_URL = "https://documentation.wazuh.com/current/azure/activity-services/prerequisites/credentials.html"
+CREDENTIALS_URL = 'https://documentation.wazuh.com/current/amazon/services/prerequisites/credentials.html'
+DEPRECATED_MESSAGE = 'The {name} authentication parameter was deprecated in {release}. ' \
+                     'Please use another authentication method instead. Check {url} for more information.'
+
 
 def set_logger():
     """Set the logger configuration."""
@@ -78,11 +81,11 @@ def get_script_arguments():
 
     # Log Analytics arguments #
     parser.add_argument("--la_id", metavar='ID', type=str, required=False,
-                        help="Application ID for Log Analytics authentication. This option was deprecated in 4.4. "
-                             "Please use another authentication method instead.")
+                        help="Application ID for Log Analytics authentication. "
+                             f"{DEPRECATED_MESSAGE.format(name='la_id', release='4.4', url=CREDENTIALS_URL)}")
     parser.add_argument("--la_key", metavar="KEY", type=str, required=False,
-                        help="Application Key for Log Analytics authentication. This option was deprecated in 4.4. "
-                             "Please use another authentication method instead.")
+                        help="Application Key for Log Analytics authentication. "
+                             f"{DEPRECATED_MESSAGE.format(name='la_key', release='4.4', url=CREDENTIALS_URL)}")
     parser.add_argument("--la_auth_path", metavar="filepath", type=str, required=False,
                         help="Path of the file containing the credentials for authentication.")
     parser.add_argument("--la_tenant_domain", metavar="domain", type=str, required=False,
@@ -98,11 +101,11 @@ def get_script_arguments():
 
     # Graph arguments #
     parser.add_argument("--graph_id", metavar='ID', type=str, required=False,
-                        help="Application ID for Graph authentication. This option was deprecated in 4.4. "
-                             "Please use another authentication method instead.")
+                        help="Application ID for Graph authentication. "
+                             f"{DEPRECATED_MESSAGE.format(name='graph_id', release='4.4', url=CREDENTIALS_URL)}")
     parser.add_argument("--graph_key", metavar="KEY", type=str, required=False,
-                        help="Application KEY for Graph authentication. This option was deprecated in 4.4. "
-                             "Please use another authentication method instead.")
+                        help="Application KEY for Graph authentication. "
+                             f"{DEPRECATED_MESSAGE.format(name='graph_key', release='4.4', url=CREDENTIALS_URL)}")
     parser.add_argument("--graph_auth_path", metavar="filepath", type=str, required=False,
                         help="Path of the file containing the credentials authentication.")
     parser.add_argument("--graph_tenant_domain", metavar="domain", type=str, required=False,
@@ -116,11 +119,11 @@ def get_script_arguments():
 
     # Storage arguments #
     parser.add_argument("--account_name", metavar='account', type=str, required=False,
-                        help="Storage account name for authentication. This option was deprecated in 4.4. "
-                             "Please use another authentication method instead.")
+                        help="Storage account name for authentication. "
+                             f"{DEPRECATED_MESSAGE.format(name='account_name', release='4.4', url=CREDENTIALS_URL)}")
     parser.add_argument("--account_key", metavar='KEY', type=str, required=False,
-                        help="Storage account key for authentication. This option was deprecated in 4.4. "
-                             "Please use another authentication method instead.")
+                        help="Storage account key for authentication. "
+                             f"{DEPRECATED_MESSAGE.format(name='account_key', release='4.4', url=CREDENTIALS_URL)}")
     parser.add_argument("--storage_auth_path", metavar="filepath", type=str, required=False,
                         help="Path of the file containing the credentials authentication.")
     parser.add_argument("--container", metavar="container", required=False, type=arg_valid_container_name,
@@ -287,9 +290,7 @@ def start_log_analytics():
     if args.la_auth_path and args.la_tenant_domain:
         client, secret = read_auth_file(auth_path=args.la_auth_path, fields=("application_id", "application_key"))
     elif args.la_id and args.la_key and args.la_tenant_domain:
-        logging.error("Deprecated authentication method found at module 'azure-logs'. "
-                        "This method was deprecated in 4.4. Please, use a different authentication method. "
-                        f"Check {AUTHENTICATION_OPTIONS_URL} for more information.")
+        logging.warning(DEPRECATED_MESSAGE.format(name="la_id and la_key", release="4.4", url=CREDENTIALS_URL))
         client = args.la_id
         secret = args.la_key
     else:
@@ -467,9 +468,7 @@ def start_graph():
     if args.graph_auth_path and args.graph_tenant_domain:
         client, secret = read_auth_file(auth_path=args.graph_auth_path, fields=("application_id", "application_key"))
     elif args.graph_id and args.graph_key and args.graph_tenant_domain:
-        logging.warning("Deprecated authentication method found at module 'azure-logs'. "
-                        "This method was deprecated in 4.4. Please, use a different authentication method. "
-                        f"Check {AUTHENTICATION_OPTIONS_URL} for more information.")
+        logging.warning(DEPRECATED_MESSAGE.format(name="graph_id and graph_key", release="4.4", url=CREDENTIALS_URL))
         client = args.graph_id
         secret = args.graph_key
     else:
@@ -602,9 +601,7 @@ def start_storage():
     if args.storage_auth_path:
         name, key = read_auth_file(auth_path=args.storage_auth_path, fields=("account_name", "account_key"))
     elif args.account_name and args.account_key:
-        logging.warning("Deprecated authentication method found at module 'azure-logs'. "
-                        "This method was deprecated in 4.4. Please, use a different authentication method. "
-                        f"Check {AUTHENTICATION_OPTIONS_URL} for more information.")
+        logging.warning(DEPRECATED_MESSAGE.format(name="account_name and account_key", release="4.4", url=CREDENTIALS_URL))
         name = args.account_name
         key = args.account_key
     else:


### PR DESCRIPTION
|Related issue|
|---|
| #14508 |


## Description

In #13660 we have reviewed the different authentication options and we have concluded that we should deprecate and remove the option that allows the user to store their credentials as plain text in the ossec.conf. 

This PR applies the necessary changes to deprecate this option. The idea is to deprecate this in `4.4` and completely remove the option in `5.0`.

Here is some of the major changes we have applied:
- Updated the `ossec.conf` parser to detect these parameters and show a warning message.
- Updated `-h` option of the python module to show that these parameters are now deprecated.
- Updated the python module to show a warning if the user try to manually run it using these parameters.

More details about the introduced changes and the testing performed can be found in #14508.