### PR TITLE
DEV: Fix unit tests in 9103 branch

### DIFF
--- a/src/unit_tests/os_regex/CMakeLists.txt
+++ b/src/unit_tests/os_regex/CMakeLists.txt
@@ -28,11 +28,20 @@ list(APPEND os_regex_flags "-Wl,--wrap,getSyscheckConfig -Wl,--wrap,getRootcheck
                             -Wl,--wrap=_imp__rsync_initialize -Wl,--wrap=fim_db_teardown")
 else()
 list(APPEND os_regex_flags " ")
+endif()
+
 list(APPEND os_regex_def " ")
 
 # OS_Regex execute, regex_matching
 list(APPEND os_regex_names "test_os_regex_execute")
+if(${TARGET} STREQUAL "winagent")
+list(APPEND os_regex_flags "-Wl,--wrap,getSyscheckConfig -Wl,--wrap,getRootcheckConfig \
+                            -Wl,--wrap,getSyscheckInternalOptions -Wl,--wrap=Start_win32_Syscheck \
+                            -Wl,--wrap,syscom_dispatch -Wl,--wrap=is_fim_shutdown -Wl,--wrap=_imp__dbsync_initialize \
+                            -Wl,--wrap=_imp__rsync_initialize -Wl,--wrap=fim_db_teardown")
+else()
 list(APPEND os_regex_flags " ")
+endif()
 set(JSON_PATH_TEST "${CMAKE_CURRENT_SOURCE_DIR}/test_os_regex_execute.json")
 list(APPEND os_regex_def "JSON_PATH_TEST=\"${JSON_PATH_TEST}\"")
 


### PR DESCRIPTION
## Description
We have detected that the UTs are failing after updating the development branch. 
This PR aims to fix those UTs.
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example
### Previous error
```
root@c0bcb3f2c7c0:/share/wazuh/src/unit_tests/build# cmake -DTARGET=agent ..
-- The C compiler identification is GNU 9.4.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
Sourcefolder:/tmp/build/wazuh/src
CMake Error in os_regex/CMakeLists.txt:
  A logical block opening on the line

    /tmp/build/wazuh/src/unit_tests/os_regex/CMakeLists.txt:24 (if)

  is not closed.


-- Configuring incomplete, errors occurred!
See also "/tmp/build/wazuh/src/unit_tests/build/CMakeFiles/CMakeOutput.log".

```
### Fixed
```
root@c0bcb3f2c7c0:/share/wazuh/src/unit_tests/build# cmake -DTARGET=agent ..
-- The C compiler identification is GNU 11.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
Sourcefolder:/share/wazuh/src
-- Configuring done
-- Generating done
-- Build files have been written to: /share/wazuh/src/unit_tests/build
root@c0bcb3f2c7c0:/share/wazuh/src/unit_tests/build# make -j8 
[  1%] Linking C static library libGITHUB_O.a
[  1%] Linking C static library libEXECD_O.a
[  4%] Linking C static library libOFFICE365_O.a
[  4%] .....................................
...............................................
[100%] Built target test_create_db
root@c0bcb3f2c7c0:/share/wazuh/src/unit_tests/build# ctes j8 
bash: ctes: command not found
root@c0bcb3f2c7c0:/share/wazuh/src/unit_tests/build# ctest -j8 
Test project /share/wazuh/src/unit_tests/build
      Start  1: test_start_agent
      Start  2: test_notify
      Start  3: test_agentd_state
      Start  4: test_buffer
      Start  5: test_logcollector
      Start  6: test_read_multiline_regex
      Start  7: test_localfile-config
      Start  8: test_state
 1/57 Test  #1: test_start_agent ....................   Passed    0.04 sec
      Start  9: test_lccom
 2/57 Test  #4: test_buffer .........................   Passed    0.04 sec
      Start 10: test_macos_log
 3/57 Test  #7: test_localfile-config ...............   Passed    0.04 sec
      Start 11: test_read_macos
 4/57 Test  #3: test_agentd_state ...................   Passed    0.05 sec
      Start 12: test_execd
 5/57 Test  #2: test_notify .........................   Passed    0.05 sec
      Start 13: test_wm_github
 6/57 Test  #6: test_read_multiline_regex ...........   Passed    0.05 sec
      Start 14: test_wm_office365
 7/57 Test  #5: test_logcollector ...................   Passed    0.05 sec
      Start 15: test_syscom
 8/57 Test #10: test_macos_log ......................   Passed    0.03 sec
      Start 16: test_fim_diff_changes
 9/57 Test #12: test_execd ..........................   Passed    0.02 sec
      Start 17: test_run_realtime
10/57 Test  #9: test_lccom ..........................   Passed    0.04 sec
      Start 18: test_config
11/57 Test #15: test_syscom .........................   Passed    0.02 sec
      Start 19: test_syscheck
12/57 Test #11: test_read_macos .....................   Passed    0.04 sec
      Start 20: test_run_check
13/57 Test #13: test_wm_github ......................   Passed    0.05 sec
      Start 21: test_create_db
14/57 Test #16: test_fim_diff_changes ...............   Passed    0.05 sec
      Start 22: test_audit_healthcheck
15/57 Test #17: test_run_realtime ...................   Passed    0.05 sec
      Start 23: test_audit_rule_handling
16/57 Test #19: test_syscheck .......................   Passed    0.04 sec
      Start 24: test_syscheck_audit
17/57 Test #14: test_wm_office365 ...................   Passed    0.07 sec
      Start 25: test_audit_parse
18/57 Test #20: test_run_check ......................   Passed    0.04 sec
      Start 26: test_list_op
19/57 Test #18: test_config .........................   Passed    0.06 sec
      Start 27: test_file_op
20/57 Test #23: test_audit_rule_handling ............   Passed    0.03 sec
      Start 28: test_integrity_op
21/57 Test #21: test_create_db ......................   Passed    0.05 sec
      Start 29: test_rbtree_op
22/57 Test #27: test_file_op ........................   Passed    0.02 sec
      Start 30: test_validate_op
23/57 Test #22: test_audit_healthcheck ..............   Passed    0.04 sec
      Start 31: test_string_op
24/57 Test  #8: test_state ..........................***Failed    0.15 sec
      Start 32: test_expression
25/57 Test #26: test_list_op ........................   Passed    0.04 sec
      Start 33: test_version_op
26/57 Test #28: test_integrity_op ...................   Passed    0.01 sec
      Start 34: test_queue_op
27/57 Test #24: test_syscheck_audit .................   Passed    0.05 sec
      Start 35: test_queue_linked_op
28/57 Test #25: test_audit_parse ....................   Passed    0.05 sec
      Start 36: test_agent_op
29/57 Test #29: test_rbtree_op ......................   Passed    0.02 sec
      Start 37: test_enrollment_op
30/57 Test #30: test_validate_op ....................   Passed    0.02 sec
      Start 38: test_time_op
31/57 Test #31: test_string_op ......................   Passed    0.02 sec
      Start 39: test_buffer_op
32/57 Test #32: test_expression .....................   Passed    0.02 sec
      Start 40: test_utf8_op
33/57 Test #34: test_queue_op .......................   Passed    0.02 sec
      Start 41: test_log_builder
34/57 Test #35: test_queue_linked_op ................   Passed    0.02 sec
      Start 42: test_custom_output_search_replace
35/57 Test #36: test_agent_op .......................   Passed    0.02 sec
      Start 43: test_syscheck_op
36/57 Test #38: test_time_op ........................   Passed    0.01 sec
      Start 44: test_audit_op
37/57 Test #33: test_version_op .....................   Passed    0.03 sec
      Start 45: test_privsep_op
38/57 Test #39: test_buffer_op ......................   Passed    0.01 sec
      Start 46: test_mq_op
39/57 Test #40: test_utf8_op ........................   Passed    0.01 sec
      Start 47: test_remoted_op
40/57 Test #37: test_enrollment_op ..................   Passed    0.03 sec
      Start 48: test_atomic
41/57 Test #42: test_custom_output_search_replace ...   Passed    0.01 sec
      Start 49: test_url
42/57 Test #41: test_log_builder ....................   Passed    0.02 sec
      Start 50: test_sysinfo_utils
43/57 Test #44: test_audit_op .......................   Passed    0.01 sec
      Start 51: test_os_xml
44/57 Test #45: test_privsep_op .....................   Passed    0.01 sec
      Start 52: test_os_regex
45/57 Test #43: test_syscheck_op ....................   Passed    0.02 sec
      Start 53: test_os_regex_execute
46/57 Test #46: test_mq_op ..........................   Passed    0.02 sec
      Start 54: test_os_zlib
47/57 Test #48: test_atomic .........................   Passed    0.01 sec
      Start 55: test_os_net
48/57 Test #50: test_sysinfo_utils ..................   Passed    0.02 sec
      Start 56: test_fluentd_forwarder
49/57 Test #49: test_url ............................   Passed    0.02 sec
      Start 57: test_active-response
50/57 Test #47: test_remoted_op .....................   Passed    0.02 sec
51/57 Test #52: test_os_regex .......................   Passed    0.02 sec
52/57 Test #54: test_os_zlib ........................   Passed    0.01 sec
53/57 Test #55: test_os_net .........................   Passed    0.01 sec
54/57 Test #57: test_active-response ................   Passed    0.01 sec
55/57 Test #53: test_os_regex_execute ...............   Passed    0.03 sec
56/57 Test #56: test_fluentd_forwarder ..............   Passed    0.02 sec
57/57 Test #51: test_os_xml .........................   Passed    0.05 sec

98% tests passed, 1 tests failed out of 57

Total Test time (real) =   0.27 sec

The following tests FAILED:
          8 - test_state (Failed)
Errors while running CTest
Output from these tests are in: /share/wazuh/src/unit_tests/build/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
root@c0bcb3f2c7c0:/share/wazuh/src/unit_tests/build# 
```
### Windows:
```
oot@ubuntumanager:/home/vagrant/wazuh/src/unit_tests/build# ctest -j8 ; git status
Test project /home/vagrant/wazuh/src/unit_tests/build
      Start  1: test_start_agent
      Start  2: test_notify
      Start  7: test_win_execd
      Start  6: test_wm_office365
      Start  5: test_wm_github
      Start  3: test_agentd_state
      Start  4: test_buffer
      Start  8: test_win_utils
 1/45 Test  #8: test_win_utils ......................   Passed    0.79 sec
      Start 12: test_config
 2/45 Test  #2: test_notify .........................   Passed    0.84 sec
      Start 42: test_os_xml
 3/45 Test  #4: test_buffer .........................   Passed    0.84 sec
      Start 10: test_fim_diff_changes
 4/45 Test  #7: test_win_execd ......................   Passed    0.85 sec
      Start 20: test_win_whodata
 5/45 Test  #6: test_wm_office365 ...................   Passed    0.86 sec
      Start 11: test_run_realtime
 6/45 Test  #5: test_wm_github ......................   Passed    0.86 sec
      Start 17: test_create_db
 7/45 Test #12: test_config .........................   Passed    0.24 sec
      Start 15: test_run_realtime_event
 8/45 Test #11: test_run_realtime ...................   Passed    0.19 sec
      Start 32: test_enrollment_op
 9/45 Test #10: test_fim_diff_changes ...............   Passed    0.21 sec
      Start 13: test_syscheck
10/45 Test #17: test_create_db ......................   Passed    0.19 sec
      Start 18: test_registry
11/45 Test #20: test_win_whodata ....................   Passed    0.21 sec
      Start 16: test_run_check_event
12/45 Test #42: test_os_xml .........................   Passed    0.26 sec
      Start  9: test_syscom
13/45 Test #32: test_enrollment_op ..................   Passed    0.17 sec
      Start 14: test_run_check
14/45 Test #13: test_syscheck .......................   Passed    0.16 sec
      Start 39: test_atomic
15/45 Test #15: test_run_realtime_event .............   Passed    0.18 sec
      Start 25: test_validate_op
16/45 Test #18: test_registry .......................   Passed    0.17 sec
      Start 27: test_expression
17/45 Test #16: test_run_check_event ................   Passed    0.19 sec
      Start 41: test_sysinfo_utils
18/45 Test  #9: test_syscom .........................   Passed    0.18 sec
      Start 35: test_utf8_op
19/45 Test #39: test_atomic .........................   Passed    0.19 sec
      Start 30: test_queue_linked_op
20/45 Test #27: test_expression .....................   Passed    0.18 sec
      Start 43: test_os_regex
21/45 Test #25: test_validate_op ....................   Passed    0.20 sec
      Start 22: test_file_op
22/45 Test #14: test_run_check ......................   Passed    0.21 sec
      Start 29: test_queue_op
23/45 Test #41: test_sysinfo_utils ..................   Passed    0.17 sec
      Start 44: test_os_regex_execute
24/45 Test #35: test_utf8_op ........................   Passed    0.17 sec
      Start 36: test_log_builder
25/45 Test #30: test_queue_linked_op ................   Passed    0.16 sec
      Start 31: test_agent_op
26/45 Test #22: test_file_op ........................   Passed    0.16 sec
      Start 19: test_events
27/45 Test #43: test_os_regex .......................   Passed    0.18 sec
      Start 38: test_syscheck_op
28/45 Test #29: test_queue_op .......................   Passed    0.17 sec
      Start 21: test_list_op
29/45 Test #36: test_log_builder ....................   Passed    0.15 sec
      Start 40: test_url
30/45 Test #44: test_os_regex_execute ...............   Passed    0.18 sec
      Start 26: test_string_op
31/45 Test #19: test_events .........................   Passed    0.14 sec
      Start 45: test_os_zlib
32/45 Test #26: test_string_op ......................   Passed    0.13 sec
      Start 23: test_integrity_op
33/45 Test #38: test_syscheck_op ....................   Passed    0.14 sec
      Start 34: test_buffer_op
34/45 Test #31: test_agent_op .......................   Passed    0.17 sec
      Start 37: test_custom_output_search_replace
35/45 Test #40: test_url ............................   Passed    0.14 sec
      Start 28: test_version_op
36/45 Test #21: test_list_op ........................   Passed    0.18 sec
      Start 24: test_rbtree_op
37/45 Test #37: test_custom_output_search_replace ...   Passed    0.09 sec
      Start 33: test_time_op
38/45 Test #28: test_version_op .....................   Passed    0.09 sec
39/45 Test #34: test_buffer_op ......................   Passed    0.11 sec
40/45 Test #45: test_os_zlib ........................   Passed    0.14 sec
41/45 Test #23: test_integrity_op ...................   Passed    0.14 sec
42/45 Test #24: test_rbtree_op ......................   Passed    0.11 sec
43/45 Test #33: test_time_op ........................   Passed    0.09 sec
44/45 Test  #3: test_agentd_state ...................   Passed    3.04 sec
45/45 Test  #1: test_start_agent ....................   Passed    3.09 sec

100% tests passed, 0 tests failed out of 45

Total Test time (real) =   3.10 sec
On branch 9103-fix-unit-tests
Your branch is up to date with 'origin/9103-fix-unit-tests'.

nothing to commit, working tree clean
root@ubuntumanager:/home/vagrant/wazuh/src/unit_tests/build# 
```
The failing UT is not related to this change and it's being tracked on https://github.com/wazuh/wazuh/issues/14502
<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

<!-- Depending on the affected OS -->
- Memory tests for Linux

  - [x] AddressSanitizer
