### PR TITLE
Adapt deprecated force settings in Authd to new force options

### DIFF
--- a/src/config/authd-config.c
+++ b/src/config/authd-config.c
@@ -74,7 +74,7 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
     config->force_options.disconnected_time = 3600;
     config->force_options.after_registration_time = 3600;
     short legacy_force_insert = -1;
-    short legacy_force_time = -1;
+    int legacy_force_time = -1;
     if (!node)
         return 0;
 
@@ -129,7 +129,8 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
             legacy_force_insert = b;
         } else if (!strcmp(node[i]->element, xml_force_time)) {
             mwarn("The <%s> tag is deprecated since version 4.3.0. Use <%s> instead.", xml_force_time, xml_force);
-            short b = eval_bool(node[i]->content);
+            char *end;
+            int b = strtol(node[i]->content, &end, 10);
             if (b < 0) {
                 merror(XML_VALUEERR, node[i]->element, node[i]->content);
                 return OS_INVALID;
@@ -231,10 +232,13 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
 
         config->force_options.enabled = legacy_force_insert;
     }
-    if (legacy_force_time > 0) {
-        mdebug1("Setting <force><enabled> tag to %s to comply with the legacy <%s> option found.",
-                legacy_force_time ? "'yes'" : "'no'", xml_force_time);
-        config->force_options.enabled = legacy_force_time;
+    if (legacy_force_time != -1) {
+        mdebug1("Setting <force>< disconnected_time> tag to %d to comply with the legacy <%s> option found.",
+                legacy_force_time, xml_force_time);
+        if(legacy_force_time != 0) {
+            config->force_options.enabled = false;
+        }
+        config->force_options.disconnected_time = legacy_force_time;
     }
     return 0;
 }

--- a/src/config/authd-config.c
+++ b/src/config/authd-config.c
@@ -75,6 +75,8 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
     config->force_options.after_registration_time = 3600;
     short legacy_force_insert = -1;
     int legacy_force_time = -1;
+    bool new_force_read = false;
+
     if (!node)
         return 0;
 
@@ -120,7 +122,7 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
 
             config->flags.use_source_ip = b;
         } else if (!strcmp(node[i]->element, xml_force_insert)) {
-            mwarn("The <%s> tag is deprecated since version 4.3.0. Use <%s> tag instead.", xml_force_insert, xml_force);
+            mwarn("The <%s> tag is deprecated. Use <%s> instead.", xml_force_insert, xml_force);
             short b = eval_bool(node[i]->content);
             if (b < 0) {
                 merror(XML_VALUEERR, node[i]->element, node[i]->content);
@@ -128,7 +130,7 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
             }
             legacy_force_insert = b;
         } else if (!strcmp(node[i]->element, xml_force_time)) {
-            mwarn("The <%s> tag is deprecated since version 4.3.0. Use <%s> instead.", xml_force_time, xml_force);
+            mwarn("The <%s> tag is deprecated. Use <%s> instead.", xml_force_time, xml_force);
             char *end;
             int b = strtol(node[i]->content, &end, 10);
             if (b < 0) {
@@ -137,6 +139,8 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
             }
             legacy_force_time = b;
         } else if (!strcmp(node[i]->element, xml_force)) {
+            new_force_read = true;
+
             xml_node **chld_node = NULL;
 
             if (chld_node = OS_GetElementsbyNode(xml, node[i]), !chld_node) {
@@ -226,20 +230,25 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
         }
     }
 
-    if (legacy_force_insert != -1) {
-        mdebug1("Setting <force><enabled> tag to %s to comply with the legacy <%s> option found.",
-                legacy_force_insert ? "'yes'" : "'no'", xml_force_insert);
+    if (!new_force_read) {
+        if (legacy_force_insert != -1) {
+            config->force_options.enabled = legacy_force_insert;
 
-        config->force_options.enabled = legacy_force_insert;
-    }
-    if (legacy_force_time != -1) {
-        mdebug1("Setting <force>< disconnected_time> tag to %d to comply with the legacy <%s> option found.",
-                legacy_force_time, xml_force_time);
-        if(legacy_force_time != 0) {
-            config->force_options.enabled = false;
+            mdebug1("Setting <force><enabled> tag to %s to comply with the legacy <%s> option found.",
+                    legacy_force_insert ? "'yes'" : "'no'", xml_force_insert);
         }
-        config->force_options.disconnected_time = legacy_force_time;
+        if (legacy_force_time != -1) {
+            if (legacy_force_time == 0) {
+                config->force_options.disconnected_time_enabled = false;
+            }
+            config->force_options.disconnected_time = legacy_force_time;
+
+            mdebug1("Setting <force><disconnected_time> tag to '%d' to comply with the legacy <%s> option found.",
+                legacy_force_time, xml_force_time);
+        }
     }
+    
+
     return 0;
 }
 

--- a/src/config/authd-config.c
+++ b/src/config/authd-config.c
@@ -246,6 +246,10 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
             mdebug1("Setting <force><disconnected_time> tag to '%d' to comply with the legacy <%s> option found.",
                 legacy_force_time, xml_force_time);
         }
+        mdebug1("The tag <force><after_registration_time> is not defined. Apply default value: '%d'.",
+                config->force_options.after_registration_time);
+        mdebug1("The tag <force><key_mismatch> is not defined. Apply default value: '%d'.",
+                config->force_options.key_mismatch ? "'true'" : "'false'");
     }
     
 

--- a/src/config/authd-config.c
+++ b/src/config/authd-config.c
@@ -246,10 +246,10 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
             mdebug1("Setting <force><disconnected_time> tag to '%d' to comply with the legacy <%s> option found.",
                 legacy_force_time, xml_force_time);
         }
-        mdebug1("The tag <force><after_registration_time> is not defined. Apply default value: '%d'.",
+        mdebug1("The tag <force><after_registration_time> is not defined. Applied default value: '%d'",
                 config->force_options.after_registration_time);
-        mdebug1("The tag <force><key_mismatch> is not defined. Apply default value: '%d'.",
-                config->force_options.key_mismatch ? "'true'" : "'false'");
+        mdebug1("The tag <force><key_mismatch> is not defined. Applied default value: '%s'",
+                config->force_options.key_mismatch ? "true" : "false");
     }
     
 

--- a/src/config/authd-config.c
+++ b/src/config/authd-config.c
@@ -119,7 +119,7 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
 
             config->flags.use_source_ip = b;
         } else if (!strcmp(node[i]->element, xml_force_insert)) {
-            mdebug1("The <%s> tag is deprecated since version 4.3.0.", xml_force_insert);
+            mwarn("The <%s> tag is deprecated since version 4.3.0.", xml_force_insert);
             short b = eval_bool(node[i]->content);
             if (b < 0) {
                 merror(XML_VALUEERR, node[i]->element, node[i]->content);
@@ -127,7 +127,7 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
             }
             legacy_force_insert = b;
         } else if (!strcmp(node[i]->element, xml_force_time)) {
-             mdebug1("The <%s> tag is deprecated since version 4.3.0.", xml_force_time);
+             mwarn("The <%s> tag is deprecated since version 4.3.0.", xml_force_time);
         } else if (!strcmp(node[i]->element, xml_force)) {
             xml_node **chld_node = NULL;
 
@@ -298,6 +298,10 @@ int w_read_force_config(XML_NODE node, authd_config_t *config) {
             config->force_options.key_mismatch = b;
         }
         // disconnected_time
+        else if (!strcmp(node[i]->element, "force_time")){
+            config->force_options.disconnected_time_enabled = false;
+            config->force_options.disconnected_time = 0;
+        }
         else if (!strcmp(node[i]->element, xml_disconnected_time)) {
             if (node[i]->attributes && node[i]->attributes[0]) {
                 if (!strcmp(node[i]->attributes[0], xml_enabled)) {

--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -319,8 +319,7 @@ char* local_dispatch(const char *input) {
             ierror = EINTERNAL;
             goto fail;
         }
-
-        if (response) {
+        else {
             output = cJSON_PrintUnformatted(response);
             cJSON_Delete(response);
         }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #14137|

## Description

Hi team, due to the new settings in `authd` there was a issue in which the agent didn't connect with the manager. 
When the manager was configured with a deprecated setting, the manager didn't show a message to advise about the wrong configuration, so this was changed by a `warning` message instead a `debug1` message and added a similar setting when appears a `force_time` tag.

## Configuration options
The settings to reproduce this bug would be:

```xml
<auth>
    <disabled>no</disabled>
    <port>1515</port>
    <use_source_ip>yes</use_source_ip>
    <force_insert>yes</force_insert>
    <force_time>0</force_time>
    <purge>yes</purge>
    <use_password>yes</use_password>
    <!-- <ssl_agent_ca></ssl_agent_ca> -->
    <ciphers>HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH</ciphers>
    <ssl_verify_host>no</ssl_verify_host>
    <ssl_manager_cert>etc/sslmanager.cert</ssl_manager_cert>
    <ssl_manager_key>etc/sslmanager.key</ssl_manager_key>
    <ssl_auto_negotiate>no</ssl_auto_negotiate>
  </auth>
```
  

## Logs/Alerts example
Now, when trying to add the old settings in the configuration, the following Warning message will appear:
```
2022/08/17 14:10:37 wazuh-authd: WARNING: The <force_insert> tag is deprecated since version 4.3.0.
2022/08/17 14:10:37 wazuh-authd: WARNING: The <force_time> tag is deprecated since version 4.3.0.
```


## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report
- Memory tests for macOS
  - [x] Scan-build report
  - [x] Leaks
  - [x] AddressSanitizer
