### PR TITLE
API endpoint to get cluster ruleset sync status

### DIFF
--- a/api/api/controllers/cluster_controller.py
+++ b/api/api/controllers/cluster_controller.py
@@ -9,6 +9,7 @@ from aiohttp import web
 from connexion.lifecycle import ConnexionResponse
 
 import wazuh.cluster as cluster
+import wazuh.core.cluster.cluster as core_cluster
 import wazuh.core.common as common
 import wazuh.manager as manager
 import wazuh.stats as stats
@@ -109,6 +110,56 @@ async def get_healthcheck(request, pretty=False, wait_for_complete=False, nodes_
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           local_client_arg='lc',
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          nodes=nodes
+                          )
+    data = raise_if_exc(await dapi.distribute_function())
+
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
+
+
+async def get_nodes_ruleset_sync_status(request, pretty=False, wait_for_complete=False, nodes_list="*"):
+    """Get cluster ruleset synchronization status.
+
+    Returns cluster ruleset synchronization status for all nodes or a list of them.
+
+    :param pretty: Show results in human-readable format
+    :param wait_for_complete: Disable timeout response
+    :param nodes_list: List of node ids
+
+    Parameters
+    ----------
+    pretty : bool
+        Show results in human-readable format.
+    wait_for_complete : bool
+        Disable timeout response.
+    nodes_list : list
+        Node IDs.
+
+    Returns
+    -------
+    ApiResponse
+        Nodes ruleset synchronization statuses.
+    """
+    nodes = raise_if_exc(await get_system_nodes())
+
+    master_dapi = DistributedAPI(f=core_cluster.get_node_ruleset_integrity,
+                                 request_type='local_master',
+                                 is_async=True,
+                                 wait_for_complete=wait_for_complete,
+                                 logger=logger,
+                                 local_client_arg='lc',
+                                 )
+    master_md5 = raise_if_exc(await master_dapi.distribute_function()).dikt
+
+    f_kwargs = {'node_list': nodes_list, 'master_md5': master_md5}
+    dapi = DistributedAPI(f=cluster.get_ruleset_sync_status,
+                          f_kwargs=remove_nones_to_dict(f_kwargs),
+                          request_type="distributed_master",
+                          is_async=True,
+                          wait_for_complete=wait_for_complete,
+                          logger=logger,
+                          broadcasting=nodes_list == "*",
                           rbac_permissions=request['token_info']['rbac_policies'],
                           nodes=nodes
                           )

--- a/api/api/controllers/test/test_cluster_controller.py
+++ b/api/api/controllers/test/test_cluster_controller.py
@@ -16,9 +16,11 @@ with patch('wazuh.common.wazuh_uid'):
             get_healthcheck, get_info_node, get_log_node, get_log_summary_node,
             get_node_config, get_stats_analysisd_node, get_stats_hourly_node,
             get_stats_node, get_stats_remoted_node, get_stats_weekly_node,
-            get_status, get_status_node, put_restart, update_configuration)
+            get_status, get_status_node, put_restart, update_configuration, get_nodes_ruleset_sync_status)
         from wazuh import cluster, common, manager, stats
+        from wazuh.core.cluster import cluster as core_cluster
         from wazuh.tests.util import RBAC_bypasser
+
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser
         del sys.modules['wazuh.rbac.orm']
 
@@ -107,6 +109,40 @@ async def test_get_healthcheck(mock_exc, mock_dapi, mock_remove, mock_dfunc, moc
         mock_exc.assert_has_calls([call(mock_snodes.return_value),
                                    call(mock_dfunc.return_value)])
         assert mock_exc.call_count == 2
+        mock_remove.assert_called_once_with(f_kwargs)
+        assert isinstance(result, web_response.Response)
+
+
+@pytest.mark.asyncio
+@patch('api.controllers.cluster_controller.DistributedAPI.distribute_function', return_value=AsyncMock())
+@patch('api.controllers.cluster_controller.remove_nones_to_dict')
+@patch('api.controllers.cluster_controller.DistributedAPI.__init__', return_value=None)
+@patch('api.controllers.cluster_controller.raise_if_exc', return_value=CustomAffectedItems())
+async def test_get_nodes_ruleset_sync_status(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request=MagicMock()):
+    """Verify 'get_nodes_ruleset_sync_status' endpoint is working as expected."""
+    with patch('api.controllers.cluster_controller.get_system_nodes', return_value=AsyncMock()) as mock_snodes:
+        result = await get_nodes_ruleset_sync_status(request=mock_request)
+        f_kwargs = {'node_list': '*',
+                    'master_md5': {'dikt_key': 'dikt_value'}
+                    }
+        mock_dapi.assert_has_calls([call(f=core_cluster.get_node_ruleset_integrity,
+                                         request_type="local_master",
+                                         is_async=True,
+                                         wait_for_complete=False,
+                                         logger=ANY,
+                                         local_client_arg="lc"),
+                                    call(f=cluster.get_ruleset_sync_status,
+                                         f_kwargs=mock_remove.return_value,
+                                         request_type="distributed_master",
+                                         is_async=True,
+                                         wait_for_complete=False,
+                                         logger=ANY,
+                                         rbac_permissions=mock_request['token_info']['rbac_policies'],
+                                         nodes=mock_exc.return_value,
+                                         broadcasting=True)])
+        mock_exc.assert_has_calls([call(mock_snodes.return_value),
+                                   call(mock_dfunc.return_value)])
+        assert mock_exc.call_count == 3
         mock_remove.assert_called_once_with(f_kwargs)
         assert isinstance(result, web_response.Response)
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -7983,7 +7983,7 @@ paths:
                   total_affected_items: 3
                   total_failed_items: 0
                   failed_items: []
-                message: "All selected nodes healthcheck information was returned"
+                message: "Nodes ruleset synchronization status was successfully read"
                 error: 0
         '400':
           $ref: '#/components/responses/ResponseError'

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -843,6 +843,19 @@ components:
                 $ref: '#/components/schemas/NodeHealthcheck'
         - $ref: '#/components/schemas/AllItemsResponse'
 
+    AllItemsResponseNodeRulesetSynchronizationStatus:
+      allOf:
+        - type: object
+          required:
+            - affected_items
+          properties:
+            affected_items:
+              type: array
+              description: "Items that successfully applied the API call action"
+              items:
+                $ref: '#/components/schemas/NodeRulesetSyncStatus'
+        - $ref: '#/components/schemas/AllItemsResponse'
+
     AllItemsResponseGroupIDs:
       allOf:
         - type: object
@@ -1722,6 +1735,16 @@ components:
                   type: boolean
                 sync_integrity_free:
                   type: boolean
+
+    NodeRulesetSyncStatus:
+      type: object
+      properties:
+        name:
+          type: string
+          description: "Node name"
+        synced:
+          type: boolean
+          description: "Whether the ruleset is synchronized or not"
 
     DaemonStatus:
       type: string
@@ -7906,6 +7929,57 @@ paths:
                           date_end_master: 2021-05-27T10:50:48.833854Z
                           n_synced_chunks: 1
                         last_keep_alive: 2021-05-27T10:50:18.650204Z
+                  total_affected_items: 3
+                  total_failed_items: 0
+                  failed_items: []
+                message: "All selected nodes healthcheck information was returned"
+                error: 0
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+
+  /cluster/ruleset/synchronization:
+    get:
+      tags:
+      - Cluster
+      summary: "Get cluster nodes ruleset synchronization status"
+      description: "Return ruleset synchronization status for all nodes or a list of them. This synchronization only
+      covers the user custom ruleset"
+      operationId: api.controllers.cluster_controller.get_nodes_ruleset_sync_status
+      x-rbac-actions:
+        - $ref: '#/x-rbac-catalog/actions/cluster:read'
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/nodes_list'
+      responses:
+        '200':
+          description: "Ruleset synchronization status for cluster nodes"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/AllItemsResponseNodeRulesetSynchronizationStatus'
+              example:
+                data:
+                  affected_items:
+                    - name: "master-node"
+                      synced: true
+                    - name: "worker1"
+                      synced: true
+                    - name: "worker2"
+                      synced: true
                   total_affected_items: 3
                   total_failed_items: 0
                   failed_items: []

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -108,6 +108,78 @@ stages:
           total_failed_items: 0
 
 ---
+test_name: GET /cluster/ruleset/synchronization
+
+stages:
+
+  - name: Get cluster ruleset synchronization status
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/ruleset/synchronization"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - name: 'master-node'
+              synced: !anybool
+            - name: 'worker1'
+              synced: !anybool
+            - name: 'worker2'
+              synced: !anybool
+          failed_items: []
+          total_affected_items: 3
+          total_failed_items: 0
+
+  - name: Get cluster ruleset synchronization status (specific node)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/ruleset/synchronization"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        nodes_list: "master-node"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - name: 'master-node'
+              synced: !anybool
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+
+  - name: Get cluster ruleset synchronization status (node does not exist)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/ruleset/synchronization"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        nodes_list: "not-exists"
+    response:
+      status_code: 200
+      json:
+        error: 1
+        data:
+          affected_items: []
+          failed_items:
+            - error:
+                code: 1730
+              id:
+                - "not-exists"
+          total_affected_items: 0
+          total_failed_items: 1
+
+---
 test_name: GET /cluster/local/info
 
 stages:

--- a/api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
@@ -78,6 +78,67 @@ stages:
           total_failed_items: 0
 
 ---
+test_name: GET /cluster/ruleset/synchronization
+
+stages:
+
+  - name: Get cluster ruleset synchronization status (partial response, user agnostic)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/ruleset/synchronization"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - name: 'worker1'
+              synced: !anybool
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+
+  - name: Get cluster ruleset synchronization status (permission denied)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/ruleset/synchronization"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        nodes_list: "master-node"
+    response:
+      <<: *permission_denied
+
+  - name: Get cluster ruleset synchronization status (partial response, user aware)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/ruleset/synchronization"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        nodes_list: "master-node,worker1"
+    response:
+      status_code: 200
+      json:
+        error: 2
+        data:
+          affected_items:
+            - name: 'worker1'
+              synced: !anybool
+          failed_items:
+            - error:
+                code: 4000
+              id:
+                - "master-node"
+          total_affected_items: 1
+          total_failed_items: 1
+
+---
 test_name: GET /cluster/local/info
 
 stages:

--- a/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
@@ -637,6 +637,40 @@ stages:
       <<: *empty_response
 
 ---
+test_name: GET /cluster/ruleset/synchronization
+
+stages:
+
+  - name: Get cluster ruleset synchronization status (empty response, user agnostic)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/ruleset/synchronization"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: []
+          failed_items: []
+          total_affected_items: 0
+          total_failed_items: 0
+
+  - name: Get cluster ruleset synchronization status (specific node, permission denied)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/ruleset/synchronization"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        nodes_list: "master-node"
+    response:
+      <<: *permission_denied
+
+---
 test_name: GET /cluster/local/config
 
 stages:

--- a/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
@@ -96,6 +96,32 @@ stages:
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0
+
+---
+test_name: GET /cluster/ruleset/synchronization
+
+stages:
+
+  - name: Get cluster ruleset synchronization status (partial response, user agnostic)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/ruleset/synchronization"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - name: 'master-node'
+              synced: !anybool
+            - name: 'worker2'
+              synced: !anybool
+          failed_items: []
+          total_affected_items: 2
+          total_failed_items: 0
         
 ---
 test_name: GET /cluster/local/info

--- a/framework/wazuh/cluster.py
+++ b/framework/wazuh/cluster.py
@@ -3,7 +3,7 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 from wazuh.core import common
 from wazuh.core.cluster import local_client
-from wazuh.core.cluster.cluster import get_node
+from wazuh.core.cluster.cluster import get_node, get_node_ruleset_integrity
 from wazuh.core.cluster.control import get_health, get_nodes
 from wazuh.core.cluster.utils import get_cluster_status, read_cluster_config, read_config
 from wazuh.core.exception import WazuhError, WazuhResourceNotFound
@@ -95,5 +95,39 @@ async def get_nodes_info(lc: local_client.LocalClient, filter_node=None, **kwarg
     for node in non_existent_nodes:
         result.add_failed_item(id_=node, error=WazuhResourceNotFound(1730))
     result.total_affected_items = data['totalItems']
+
+    return result
+
+
+@expose_resources(actions=['cluster:read'], resources=[f"node:id:{node_id}"],
+                  post_proc_func=async_list_handler)
+async def get_ruleset_sync_status(master_md5: dict = None):
+    """Compare node's md5 with the master node's to check the custom ruleset synchronization status.
+
+    Parameters
+    ----------
+    master_md5 : dict
+        Master node's ruleset integrity.
+
+    Returns
+    -------
+    AffectedItemsWazuhResult
+        Result with current node's custom ruleset integrity.
+    """
+    result = AffectedItemsWazuhResult(all_msg="Nodes ruleset synchronization status was successfully read",
+                                      some_msg="Could not read ruleset synchronization status in some nodes",
+                                      none_msg="Could not read ruleset synchronization status",
+                                      sort_casting=["str"]
+                                      )
+
+    try:
+        lc = local_client.LocalClient()
+        node_ruleset_integrity = await get_node_ruleset_integrity(lc)
+    except WazuhError as e:
+        result.add_failed_item(id_=node_id, error=e)
+    else:
+        result.affected_items.append({'name': node_id,
+                                      'synced': master_md5 == node_ruleset_integrity})
+    result.total_affected_items = len(result.affected_items)
 
     return result

--- a/framework/wazuh/cluster.py
+++ b/framework/wazuh/cluster.py
@@ -4,7 +4,7 @@
 from wazuh.core import common
 from wazuh.core.cluster import local_client
 from wazuh.core.cluster.cluster import get_node
-from wazuh.core.cluster.control import get_health, get_nodes, get_ruleset_integrity
+from wazuh.core.cluster.control import get_health, get_nodes
 from wazuh.core.cluster.utils import get_cluster_status, read_cluster_config, read_config
 from wazuh.core.exception import WazuhError, WazuhResourceNotFound
 from wazuh.core.results import AffectedItemsWazuhResult, WazuhResult
@@ -75,35 +75,6 @@ async def get_health_nodes(lc: local_client.LocalClient, filter_node=None):
     result.affected_items = sorted(result.affected_items, key=lambda i: i['info']['name'])
     result.total_affected_items = len(result.affected_items)
 
-    return result
-
-
-@expose_resources(actions=['cluster:read'], resources=['node:id:{filter_node}'], post_proc_func=async_list_handler)
-async def get_ruleset_sync(lc: local_client.LocalClient, filter_node=None, master_integrity={}):
-    """ Wrapper for get_health """
-    result = AffectedItemsWazuhResult(all_msg='All selected nodes ruleset are synced',
-                                      some_msg='Some nodes ruleset are not synced',
-                                      none_msg='No ruleset synced'
-                                      )
-
-    local_ruleset_integrity = await get_ruleset_integrity(lc)
-    synced = False
-
-    for file_path, file_info in master_integrity.items():
-        if file_path not in local_ruleset_integrity or file_info['md5'] != local_ruleset_integrity[file_path]['md5']:
-            break
-    else:
-        synced = True
-
-    # result.affected_items.append()
-
-
-    # for v in data['nodes'].values():
-    #     result.affected_items.append(v)
-    #
-    # result.affected_items = sorted(result.affected_items, key=lambda i: i['info']['name'])
-    # result.total_affected_items = len(result.affected_items)
-    #
     return result
 
 

--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -270,7 +270,7 @@ def get_files_status(previous_status=None, get_md5=True):
 
 
 def get_ruleset_status(previous_status):
-    """Get MD5 of custom ruleset files.
+    """Get hash of custom ruleset files.
 
     Parameters
     ----------
@@ -280,7 +280,7 @@ def get_ruleset_status(previous_status):
     Returns
     -------
     Dict
-        Relative path and MD5 of local ruleset files.
+        Relative path and hash of local ruleset files.
     """
     final_items = {}
     cluster_items = get_cluster_items()

--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -22,7 +22,7 @@ from wazuh.core import common
 from wazuh.core.InputValidator import InputValidator
 from wazuh.core.agent import WazuhDBQueryAgents
 from wazuh.core.cluster.utils import get_cluster_items, read_config
-from wazuh.core.utils import md5, mkdir_with_mode
+from wazuh.core.utils import md5, mkdir_with_mode, to_relative_path
 
 logger = logging.getLogger('wazuh')
 agent_groups_path = os.path.relpath(common.groups_path, common.wazuh_path)
@@ -267,6 +267,38 @@ def get_files_status(previous_status=None, get_md5=True):
             logger.warning(f"Error getting file status: {e}.")
 
     return final_items
+
+
+def get_ruleset_status(previous_status):
+    """Get MD5 of custom ruleset files.
+
+    Parameters
+    ----------
+    previous_status : dict
+        Integrity information of local files.
+
+    Returns
+    -------
+    Dict
+        Relative path and MD5 of local ruleset files.
+    """
+    final_items = {}
+    cluster_items = get_cluster_items()
+    user_ruleset = [os.path.join(to_relative_path(user_path), '') for user_path in [common.user_decoders_path,
+                                                                                    common.user_rules_path,
+                                                                                    common.user_lists_path]]
+
+    for file_path, item in cluster_items['files'].items():
+        if file_path == "excluded_files" or file_path == "excluded_extensions" or file_path not in user_ruleset:
+            continue
+        try:
+            final_items.update(
+                walk_dir(file_path, item['recursive'], item['files'], cluster_items['files']['excluded_files'],
+                         cluster_items['files']['excluded_extensions'], file_path, previous_status, True))
+        except Exception as e:
+            logger.warning(f"Error getting file status: {e}.")
+
+    return {file_path: file_data['md5'] for file_path, file_data in final_items.items()}
 
 
 def update_cluster_control_with_failed(failed_files, ko_files):

--- a/framework/wazuh/core/cluster/local_server.py
+++ b/framework/wazuh/core/cluster/local_server.py
@@ -63,6 +63,8 @@ class LocalServerHandler(server.AbstractServerHandler):
             return self.get_nodes(data)
         elif command == b'get_health':
             return self.get_health(data)
+        elif command == b'ruleset_md5':
+            return self.get_ruleset_status()
         elif command == b'send_file':
             path, node_name = data.decode().split(' ')
             return self.send_file_request(path, node_name)
@@ -120,6 +122,18 @@ class LocalServerHandler(server.AbstractServerHandler):
             If the method is not implemented.
         """
         raise NotImplementedError
+
+    def get_ruleset_status(self):
+        """Obtain local ruleset paths and MD5 hash.
+
+        Returns
+        -------
+        bytes
+            Result.
+        bytes
+            JSON containing local file paths and their MD5 hash.
+        """
+        return b'ok', json.dumps(self.server.node.get_ruleset_status()).encode()
 
     def send_file_request(self, path, node_name):
         """Send a file from the API to the cluster.

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -1058,3 +1058,13 @@ class Master(server.AbstractServer):
         """
         return {'type': self.configuration['node_type'], 'cluster': self.configuration['name'],
                 'node': self.configuration['node_name']}
+
+    def get_ruleset_status(self):
+        """Obtain local ruleset paths and MD5 hash.
+
+        Returns
+        -------
+        Dict
+            Local file paths and their MD5 hash.
+        """
+        return wazuh.core.cluster.cluster.get_ruleset_status(self.integrity_control)

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -11,7 +11,6 @@ from calendar import timegm
 from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime
-from functools import partial
 from time import time
 from typing import Tuple, Dict, Callable
 from uuid import uuid4
@@ -1058,13 +1057,3 @@ class Master(server.AbstractServer):
         """
         return {'type': self.configuration['node_type'], 'cluster': self.configuration['name'],
                 'node': self.configuration['node_name']}
-
-    def get_ruleset_status(self):
-        """Obtain local ruleset paths and MD5 hash.
-
-        Returns
-        -------
-        Dict
-            Local file paths and their MD5 hash.
-        """
-        return wazuh.core.cluster.cluster.get_ruleset_status(self.integrity_control)

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -951,13 +951,3 @@ class Worker(client.AbstractClientManager):
         """
         return {'type': self.configuration['node_type'], 'cluster': self.configuration['name'],
                 'node': self.configuration['node_name']}
-
-    def get_ruleset_status(self):
-        """Obtain local ruleset paths and MD5 hash.
-
-        Returns
-        -------
-        Dict
-            Local file paths and their MD5 hash.
-        """
-        return cluster.get_ruleset_status(self.integrity_control)

--- a/framework/wazuh/tests/data/security/rbac_catalog.yml
+++ b/framework/wazuh/tests/data/security/rbac_catalog.yml
@@ -271,6 +271,7 @@ get_rbac_actions:
           - GET /cluster/local/info
           - GET /cluster/nodes
           - GET /cluster/healthcheck
+          - GET /cluster/ruleset/synchronization
           - GET /cluster/local/config
           - GET /cluster/{node_id}/status
           - GET /cluster/{node_id}/info

--- a/framework/wazuh/tests/test_cluster.py
+++ b/framework/wazuh/tests/test_cluster.py
@@ -93,3 +93,33 @@ async def test_get_nodes_info():
     assert result.total_affected_items == expected['totalItems']
     assert result.failed_items[WazuhResourceNotFound(1730)] == {'noexists'}
     assert result.total_failed_items == 1
+
+
+@pytest.mark.parametrize("ruleset_integrity", [
+    True,
+    False
+])
+@patch("wazuh.cluster.node_id", new="testing_node")
+@pytest.mark.asyncio
+async def test_get_ruleset_sync_status(ruleset_integrity):
+    """Verify that `get_ruleset_sync_status` function correctly returns node ruleset synchronization status."""
+    master_md5 = {'key1': 'value1'}
+    with patch("wazuh.cluster.get_node_ruleset_integrity",
+               return_value=master_md5 if ruleset_integrity else {}) as ruleset_integrity_mock:
+        result = await cluster.get_ruleset_sync_status(master_md5=master_md5)
+        assert result.total_affected_items == 1
+        assert result.total_failed_items == 0
+        assert result.affected_items[0]['name'] == "testing_node"
+        assert result.affected_items[0]['synced'] is ruleset_integrity
+
+
+@patch("wazuh.cluster.node_id", new="testing_node")
+@pytest.mark.asyncio
+async def test_get_ruleset_sync_status_ko():
+    """Verify proper exceptions behavior with `get_ruleset_sync_status`."""
+    exc = WazuhError(1000)
+    with patch("wazuh.cluster.get_node_ruleset_integrity", side_effect=exc):
+        result = await cluster.get_ruleset_sync_status(master_md5={})
+        assert result.total_affected_items == 0
+        assert result.total_failed_items == 1
+        assert result.failed_items[exc] == {"testing_node"}


### PR DESCRIPTION
|Related issue|
|---|
| Closes #14533 |

## Description

This PR adds a new mechanism to obtain whether the files inside these folders are synced in the worker nodes of a cluster:
- `etc/decoders/`
- `etc/rules/`
- `etc/lists/`

For this, there is a new API endpoint:
```
GET /cluster/ruleset/synchronization
```
```JSON
{
  "data": {
    "affected_items": [
      {
        "name": "master-node",
        "synced": true
      },
      {
        "name": "worker1",
        "synced": true
      }
    ],
    "total_affected_items": 2,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Nodes ruleset synchronization status was successfully read",
  "error": 0
}
```

To compute this efficiently, the API asks the cluster (via a new command called `get_hash`) for the list of files and their hashes found in the directories listed above. The cluster reuses the information that it already calculates periodically for its Integrity task, so that only the hashes of recently-modified files are recalculated.
