### PR TITLE
Add a fseek check to avoid malformed merged.mg

### DIFF
--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -200,17 +200,6 @@ void DeleteState();
 
 
 /**
- * @brief Merge the specified files into one single file.
- *
- * @param finalpath Path of the generated file.
- * @param files Files to be merged.
- * @param tag Tag to be added on the generated file.
- * @return 1 if the merged file was created, 0 on error.
- */
-int MergeFiles(const char *finalpath, char **files, const char *tag) __attribute__((nonnull(1, 2)));
-
-
-/**
  * @brief Merge files recursively into one single file.
  *
  * @param finalpath Path of the generated file.

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -1230,7 +1230,7 @@ STATIC group_t* find_group_from_file(const char * file, const char * md5, char g
     for (i = 0; groups[i]; i++) {
         f_sum = groups[i]->f_sum;
 
-        if (f_sum) {
+        if (f_sum && f_sum[0] && f_sum[0]->name) {
             for (j = 0; f_sum[j]; j++) {
                 if (!(strcmp(f_sum[j]->name, file) || strcmp(f_sum[j]->sum, md5))) {
                     snprintf(group, OS_SIZE_65536, "%s", groups[i]->name);
@@ -1249,7 +1249,7 @@ STATIC group_t* find_multi_group_from_file(const char * file, const char * md5, 
     for (i = 0; multi_groups[i]; i++) {
         f_sum = multi_groups[i]->f_sum;
 
-        if (f_sum) {
+        if (f_sum && f_sum[0] && f_sum[0]->name) {
             for (j = 0; f_sum[j]; j++) {
                 if (!(strcmp(f_sum[j]->name, file) || strcmp(f_sum[j]->sum, md5))) {
                     snprintf(multigroup, OS_SIZE_65536, "%s", multi_groups[i]->name);
@@ -1270,6 +1270,16 @@ STATIC bool fsum_changed(file_sum **old_sum, file_sum **new_sum) {
             return false;
         } else {
             return true;
+        }
+    }
+
+    if (old_sum[0] && new_sum[0]) {
+        if (!old_sum[0]->name || !new_sum[0]->name) {
+            if (!old_sum[0]->name && !new_sum[0]->name) {
+                return false;
+            } else {
+                return true;
+            }
         }
     }
 

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -454,23 +454,22 @@ int check_path_type(const char *dir)
 }
 
 
-int IsFile(const char *file)
-{
+int IsFile(const char *file) {
     struct stat buf;
-	return (!stat(file, &buf) && S_ISREG(buf.st_mode)) ? 0 : -1;
+    return (!stat(file, &buf) && S_ISREG(buf.st_mode)) ? 0 : -1;
 }
 
 #ifndef WIN32
 
 int IsSocket(const char * file) {
     struct stat buf;
-	return (!stat(file, &buf) && S_ISSOCK(buf.st_mode)) ? 0 : -1;
+    return (!stat(file, &buf) && S_ISSOCK(buf.st_mode)) ? 0 : -1;
 }
 
 
 int IsLink(const char * file) {
     struct stat buf;
-	return (!lstat(file, &buf) && S_ISLNK(buf.st_mode)) ? 0 : -1;
+    return (!lstat(file, &buf) && S_ISLNK(buf.st_mode)) ? 0 : -1;
 }
 
 #endif // WIN32
@@ -883,25 +882,27 @@ int MergeAppendFile(const char *finalpath, const char *files, const char *tag, i
         }
     }
 
-    finalfp = fopen(finalpath, "a");
-    if (finalfp == NULL) {
-        merror("Unable to append merged file: '%s' due to [(%d)-(%s)].", finalpath, errno, strerror(errno));
+    if (finalfp = fopen(finalpath, "a"), finalfp == NULL) {
+        merror("Unable to open file: '%s' due to [(%d)-(%s)].", finalpath, errno, strerror(errno));
         return (0);
     }
 
-    fp = fopen(files, "r");
-    if (fp == NULL || (fseek(fp, 0, SEEK_END) != 0)) {
-        merror("Unable to append merge file '%s' due to [(%d)-(%s)].", files, errno, strerror(errno));
+    if (fp = fopen(files, "r"), fp == NULL) {
+        merror("Unable to open file: '%s' due to [(%d)-(%s)].", files, errno, strerror(errno));
         fclose(finalfp);
-        if (fp != NULL) {
-            fclose(fp);
-        }
+        return (0);
+    }
+
+    if (fseek(fp, 0, SEEK_END) != 0) {
+        merror("Unable to set EOF offset in file: '%s', due to [(%d)-(%s)].", files, errno, strerror(errno));
+        fclose(finalfp);
+        fclose(fp);
         return (0);
     }
 
     files_size = ftell(fp);
     if (files_size == 0) {
-        mwarn("file '%s' size 0.", files);
+        mwarn("file '%s' is empty.", files);
     }
 
     if (tag != NULL) {
@@ -911,7 +912,7 @@ int MergeAppendFile(const char *finalpath, const char *files, const char *tag, i
     fprintf(finalfp, "!%ld %s\n", files_size, files + path_offset);
 
     if (fseek(fp, 0, SEEK_SET) != 0) {
-        merror("Unable to append merge file '%s' due to [(%d)-(%s)].", files, errno, strerror(errno));
+        merror("Unable to set the offset in file: '%s', due to [(%d)-(%s)].", files, errno, strerror(errno));
         fclose(finalfp);
         fclose(fp);
         return (0);

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -839,6 +839,7 @@ int MergeAppendFile(const char *finalpath, const char *files, const char *tag, i
 {
     size_t n = 0;
     long files_size = 0;
+    long files_final_size = 0;
     char buf[2048 + 1];
     FILE *fp = NULL;
     FILE *finalfp = NULL;
@@ -902,7 +903,7 @@ int MergeAppendFile(const char *finalpath, const char *files, const char *tag, i
 
     files_size = ftell(fp);
     if (files_size == 0) {
-        mwarn("file '%s' is empty.", files);
+        mwarn("File '%s' is empty.", files);
     }
 
     if (tag != NULL) {
@@ -923,8 +924,15 @@ int MergeAppendFile(const char *finalpath, const char *files, const char *tag, i
         fwrite(buf, n, 1, finalfp);
     }
 
+    files_final_size = ftell(fp);
+
     fclose(fp);
     fclose(finalfp);
+
+    if (files_size != files_final_size) {
+        merror("File '%s' was modified after getting its size.", files);
+        return (0);
+    }
 
     return (1);
 }

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -45,7 +45,8 @@ list(APPEND remoted_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,w_
                             -Wl,--wrap,get_ipv4_string -Wl,--wrap,get_ipv6_string \
                             -Wl,--wrap,wdb_get_agent_group \
                             -Wl,--wrap,wdb_set_agent_groups_csv -Wl,--wrap,w_is_single_node \
-                            -Wl,--wrap,wdb_remove_group_db -Wl,--wrap,wdb_get_all_agents -Wl,--wrap,wdb_get_agent_info")
+                            -Wl,--wrap,wdb_remove_group_db -Wl,--wrap,wdb_get_all_agents -Wl,--wrap,wdb_get_agent_info \
+                            -Wl,--wrap,unlink -Wl,--wrap,getpid")
 
 list(APPEND remoted_names "test_secure")
 list(APPEND remoted_flags "-Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose -Wl,--wrap,remove \

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -16,7 +16,8 @@ if(NOT ${TARGET} STREQUAL "winagent")
                             -Wl,--wrap,bzip2_uncompress,--wrap,lstat \
                             -Wl,--wrap,gzopen,--wrap,gzread,--wrap,gzclose,--wrap,fgetc \
                             -Wl,--wrap,gzeof,--wrap,gzerror,--wrap,gzwrite,--wrap,fgetpos \
-                            -Wl,--wrap,realpath,--wrap,getenv,--wrap,atexit ${DEBUG_OP_WRAPPERS}")
+                            -Wl,--wrap,realpath,--wrap,getenv,--wrap,atexit ${DEBUG_OP_WRAPPERS} \
+                            -Wl,--wrap,merror,--wrap,fseek")
     list(APPEND shared_tests_flags "${FILE_OP_BASE_FLAGS}")
 else()
     list(APPEND shared_tests_flags "-Wl,--wrap,get_windows_file_time_epoch,--wrap,mdebug2 ${DEBUG_OP_WRAPPERS}")

--- a/src/unit_tests/shared/test_file_op.c
+++ b/src/unit_tests/shared/test_file_op.c
@@ -360,7 +360,7 @@ void test_MergeAppendFile_finalpath_open_fail(void **state) {
     expect_string(__wrap_fopen, mode, "a");
     will_return(__wrap_fopen, NULL);
 
-    expect_string(__wrap__merror, formatted_msg, "Unable to append merged file: '/test/shared/default/merged.mg' due to [(0)-(Success)].");
+    expect_string(__wrap__merror, formatted_msg, "Unable to open file: '/test/shared/default/merged.mg' due to [(0)-(Success)].");
 
     ret = MergeAppendFile(finalpath, file, tag, path_offset);
     assert_int_equal(ret, 0);
@@ -383,7 +383,7 @@ void test_MergeAppendFile_open_fail(void **state) {
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, NULL);
 
-    expect_string(__wrap__merror, formatted_msg, "Unable to append merge file 'test.txt' due to [(0)-(Success)].");
+    expect_string(__wrap__merror, formatted_msg, "Unable to open file: 'test.txt' due to [(0)-(Success)].");
 
     expect_value(__wrap_fclose, _File, 5);
     will_return(__wrap_fclose, 1);
@@ -410,7 +410,7 @@ void test_MergeAppendFile_fseek_fail(void **state) {
 
     will_return(__wrap_fseek, 1);
 
-    expect_string(__wrap__merror, formatted_msg, "Unable to append merge file 'test.txt' due to [(0)-(Success)].");
+    expect_string(__wrap__merror, formatted_msg, "Unable to set EOF offset in file: 'test.txt', due to [(0)-(Success)].");
 
     expect_value(__wrap_fclose, _File, 5);
     will_return(__wrap_fclose, 1);
@@ -441,7 +441,7 @@ void test_MergeAppendFile_fseek2_fail(void **state) {
     will_return(__wrap_fseek, 0);
 
     will_return(__wrap_ftell, 0);
-    expect_string(__wrap__mwarn, formatted_msg, "file '/test/shared/default/test.txt' size 0.");
+    expect_string(__wrap__mwarn, formatted_msg, "file '/test/shared/default/test.txt' is empty.");
 
     expect_value(__wrap_fprintf, __stream, 5);
     expect_string(__wrap_fprintf, formatted_msg, "#TAG_test\n");
@@ -453,7 +453,7 @@ void test_MergeAppendFile_fseek2_fail(void **state) {
 
     will_return(__wrap_fseek, -2);
 
-    expect_string(__wrap__merror, formatted_msg, "Unable to append merge file '/test/shared/default/test.txt' due to [(0)-(Success)].");
+    expect_string(__wrap__merror, formatted_msg, "Unable to set the offset in file: '/test/shared/default/test.txt', due to [(0)-(Success)].");
 
     expect_value(__wrap_fclose, _File, 5);
     will_return(__wrap_fclose, 1);


### PR DESCRIPTION
|Related issue|Manual Testing|
|---|---|
|https://github.com/wazuh/wazuh/issues/14375 https://github.com/wazuh/wazuh/issues/14771| [3201](https://github.com/wazuh/wazuh-qa/issues/3201) | 

## Description
The goal of this PR is avoid malformed `merged.mg` file, increasing the robustness of the file addition process.

## Configuration options
Default configuration

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [x] Added unit tests (for new features)