### PR TITLE
Solve OS detection rule bug on SCA Ubuntu 22.04

### DIFF
--- a/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
@@ -22,7 +22,7 @@ requirements:
   description: "Requirements for running the SCA scan against Ubuntu Linux 22.04 LTS"
   condition: all
   rules:
-    - "f:/etc/os-release -> r:Ubuntu 22.04 LTS"
+    - "f:/etc/os-release -> r:Ubuntu 22.04"
     - "f:/proc/sys/kernel/ostype -> Linux"
 
 checks:

--- a/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
@@ -12,8 +12,8 @@
 policy:
   id: "cis_ubuntu22-04"
   file: "cis_ubuntu22-04.yml"
-  name: "CIS benchmark for Ubuntu Linux 22.04 LTS based on CIS benchmark for Ubuntu Linux 22.04 LTS."
-  description: "This document provides prescriptive guidance for establishing a secure configuration posture for Ubuntu Linux 22.04 LTS based on CIS benchmark for Ubuntu Linux 22.04 LTS."
+  name: "CIS benchmark for Ubuntu Linux 22.04 LTS based on CIS benchmark for Ubuntu Linux 20.04 LTS."
+  description: "This document provides prescriptive guidance for establishing a secure configuration posture for Ubuntu Linux 22.04 LTS based on CIS benchmark for Ubuntu Linux 20.04 LTS."
   references:
     - https://www.cisecurity.org/cis-benchmarks/
 


### PR DESCRIPTION
|Related issue|
|---|
|#14663|


## Description
This PR solves a bug on Ubuntu Linux 22.04 SCA policy that prevents wazuh-agent from running the policy. 

## Actions
  - [x] Updated requirements rule to work on any 22.04.x version.
  - [x] Updated typo in policy name and description.

## Tests

- [x] Ubuntu Linux 22.04 SCA policy now works on Ubuntu 22.04.1 version.
