### PR TITLE
Improve location message colons parsing

### DIFF
--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -25,10 +25,10 @@ static const char *(month[]) = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
 /* Format a received message in the Eventinfo structure */
 int OS_CleanMSG(char *msg, Eventinfo *lf)
 {
-    char loc_buff[OS_BUFFER_SIZE + 1] = {0};
+    char loc_buff[OS_SIZE_8192 + OS_SIZE_256 + 3] = {0};
     size_t loglen;
     char *pieces;
-    char * msg_cpy;
+    char *msg_cpy;
     struct tm p = { .tm_sec = 0 };
     struct timespec local_c_timespec;
 
@@ -48,7 +48,7 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
     *pieces = '\0';
     pieces++;
 
-    if (NULL == wstr_unescape(loc_buff, msg, '\\')) {
+    if (0 == wstr_unescape(loc_buff, sizeof(loc_buff), msg, '\\')) {
         merror(FORMAT_ERROR);
         return (-1);
     }

--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -25,7 +25,7 @@ static const char *(month[]) = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
 /* Format a received message in the Eventinfo structure */
 int OS_CleanMSG(char *msg, Eventinfo *lf)
 {
-    char loc_buff[OS_BUFFER_SIZE + 1];
+    char loc_buff[OS_BUFFER_SIZE + 1] = {0};
     size_t loglen;
     char *pieces;
     char * msg_cpy;

--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -25,9 +25,10 @@ static const char *(month[]) = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
 /* Format a received message in the Eventinfo structure */
 int OS_CleanMSG(char *msg, Eventinfo *lf)
 {
+    char loc_buff[OS_BUFFER_SIZE + 1];
     size_t loglen;
     char *pieces;
-    char *arrow = NULL;
+    char * msg_cpy;
     struct tm p = { .tm_sec = 0 };
     struct timespec local_c_timespec;
 
@@ -38,24 +39,21 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
     /* Ignore the id of the message in here */
     msg += 2;
 
-    /* Avoid ipv6 ':', msg that include "[" have an "->" after the ip */
-    if (*msg == '[') {
-        if (!(arrow = strstr(msg, "->"))) {
-            merror(FORMAT_ERROR);
-            return (-1);
-        }
+    /* Look for the first non scape ":" */
+    msg_cpy = msg;
+    if (pieces = wstr_chr(msg_cpy, ':'), pieces == NULL) {
+        merror(FORMAT_ERROR);
+        return (-1);
     }
+    *pieces = '\0';
+    pieces++;
 
-    pieces = strchr(arrow ? arrow : msg, ':');
-    if (!pieces) {
+    if (NULL == wstr_unescape(loc_buff, msg, '\\')) {
         merror(FORMAT_ERROR);
         return (-1);
     }
 
-    *pieces = '\0';
-    pieces++;
-
-    os_strdup(msg, lf->location);
+    os_strdup(loc_buff, lf->location);
 
     /* Get the log length */
     loglen = strlen(pieces) + 1;

--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -41,14 +41,14 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
 
     /* Look for the first non scape ":" */
     msg_cpy = msg;
-    if (pieces = wstr_chr(msg_cpy, ':'), pieces == NULL) {
+    if (pieces = wstr_chr_escape(msg_cpy, ':', '|'), pieces == NULL) {
         merror(FORMAT_ERROR);
         return (-1);
     }
     *pieces = '\0';
     pieces++;
 
-    if (OS_INVALID == wstr_unescape(loc_buff, sizeof(loc_buff), msg, '\\')) {
+    if (OS_INVALID == wstr_unescape(loc_buff, sizeof(loc_buff), msg, '|')) {
         merror(FORMAT_ERROR);
         return (-1);
     }

--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -48,7 +48,7 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
     *pieces = '\0';
     pieces++;
 
-    if (0 == wstr_unescape(loc_buff, sizeof(loc_buff), msg, '\\')) {
+    if (-1 == wstr_unescape(loc_buff, sizeof(loc_buff), msg, '\\')) {
         merror(FORMAT_ERROR);
         return (-1);
     }

--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -48,7 +48,7 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
     *pieces = '\0';
     pieces++;
 
-    if (-1 == wstr_unescape(loc_buff, sizeof(loc_buff), msg, '\\')) {
+    if (OS_INVALID == wstr_unescape(loc_buff, sizeof(loc_buff), msg, '\\')) {
         merror(FORMAT_ERROR);
         return (-1);
     }

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -260,7 +260,7 @@ int w_logtest_preprocessing_phase(Eventinfo * lf, cJSON * request) {
     location = cJSON_GetObjectItemCaseSensitive(request, W_LOGTEST_JSON_LOCATION);
     location_str = cJSON_GetStringValue(location);
 
-    if (NULL == wstr_escape(loc_buff, location_str, '\\', ':')) {
+    if (0 == wstr_escape(loc_buff, sizeof(loc_buff), location_str, '\\', ':')) {
         if (event_json) os_free(event_str);
         return -1;
     }

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -239,7 +239,7 @@ cJSON * w_logtest_process_log(cJSON * request, w_logtest_session_t * session,
 
 int w_logtest_preprocessing_phase(Eventinfo * lf, cJSON * request) {
 
-    char loc_buff[OS_BUFFER_SIZE + 1];
+    char loc_buff[OS_BUFFER_SIZE + 1] = {0};
     char * event_str = NULL;
     char * location_str = NULL;
     char * log = NULL;

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -239,6 +239,7 @@ cJSON * w_logtest_process_log(cJSON * request, w_logtest_session_t * session,
 
 int w_logtest_preprocessing_phase(Eventinfo * lf, cJSON * request) {
 
+    char loc_buff[OS_BUFFER_SIZE + 1];
     char * event_str = NULL;
     char * location_str = NULL;
     char * log = NULL;
@@ -259,10 +260,15 @@ int w_logtest_preprocessing_phase(Eventinfo * lf, cJSON * request) {
     location = cJSON_GetObjectItemCaseSensitive(request, W_LOGTEST_JSON_LOCATION);
     location_str = cJSON_GetStringValue(location);
 
-    int logsize = strlen(location_str) + strlen(event_str) + 4;
+    if (NULL == wstr_escape(loc_buff, location_str, '\\', ':')) {
+        if (event_json) os_free(event_str);
+        return -1;
+    }
+
+    int logsize = strlen(loc_buff) + strlen(event_str) + 4;
 
     os_calloc(logsize, sizeof(char), log);
-    snprintf(log, logsize, "1:%s:%s", location_str, event_str);
+    snprintf(log, logsize, "1:%s:%s", loc_buff, event_str);
 
     if (OS_CleanMSG(log, lf) < 0) {
         os_free(log);

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -260,7 +260,7 @@ int w_logtest_preprocessing_phase(Eventinfo * lf, cJSON * request) {
     location = cJSON_GetObjectItemCaseSensitive(request, W_LOGTEST_JSON_LOCATION);
     location_str = cJSON_GetStringValue(location);
 
-    if (-1 == wstr_escape(loc_buff, sizeof(loc_buff), location_str, '\\', ':')) {
+    if (OS_INVALID == wstr_escape(loc_buff, sizeof(loc_buff), location_str, '\\', ':')) {
         if (event_json) os_free(event_str);
         return -1;
     }

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -260,7 +260,7 @@ int w_logtest_preprocessing_phase(Eventinfo * lf, cJSON * request) {
     location = cJSON_GetObjectItemCaseSensitive(request, W_LOGTEST_JSON_LOCATION);
     location_str = cJSON_GetStringValue(location);
 
-    if (OS_INVALID == wstr_escape(loc_buff, sizeof(loc_buff), location_str, '\\', ':')) {
+    if (OS_INVALID == wstr_escape(loc_buff, sizeof(loc_buff), location_str, '|', ':')) {
         if (event_json) os_free(event_str);
         return -1;
     }

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -260,7 +260,7 @@ int w_logtest_preprocessing_phase(Eventinfo * lf, cJSON * request) {
     location = cJSON_GetObjectItemCaseSensitive(request, W_LOGTEST_JSON_LOCATION);
     location_str = cJSON_GetStringValue(location);
 
-    if (0 == wstr_escape(loc_buff, sizeof(loc_buff), location_str, '\\', ':')) {
+    if (-1 == wstr_escape(loc_buff, sizeof(loc_buff), location_str, '\\', ':')) {
         if (event_json) os_free(event_str);
         return -1;
     }

--- a/src/headers/string_op.h
+++ b/src/headers/string_op.h
@@ -102,6 +102,25 @@ char * wstr_replace(const char * string, const char * search, const char * repla
 // Locate first occurrence of non escaped character in string
 char * wstr_chr(char * str, int character);
 
+/* Escape a specific character from a character string
+ *
+ * dststr must be a valid pointer to a char buffer where escaped string will be stored.
+ * str must be a valid pointer to a string to escape.
+ * scape int is the value of the operator used to escape.
+ * toscape int is the value to scape.
+ * Returns pointer to dststr if success, or NULL if fail.
+ */
+char * wstr_escape(char *dststr, char *str, int scape, int toscape);
+
+/* Unescape a specific character from a character string
+ *
+ * dststr must be a valid pointer to a char buffer where unescaped string will be stored.
+ * str must be a valid pointer to a string to unescape.
+ * scape int is the value of the operator used to unescape.
+ * Returns pointer to dststr if success, or NULL if fail.
+ */
+char * wstr_unescape(char *dststr, char *str, int scape);
+
 // Free string array
 void free_strarray(char ** array);
 

--- a/src/headers/string_op.h
+++ b/src/headers/string_op.h
@@ -105,21 +105,23 @@ char * wstr_chr(char * str, int character);
 /* Escape a specific character from a character string
  *
  * dststr must be a valid pointer to a char buffer where escaped string will be stored.
+ * dst_size must be an unsigned int value, to control the size of the buffer.
  * str must be a valid pointer to a string to escape.
  * scape int is the value of the operator used to escape.
  * toscape int is the value to scape.
  * Returns pointer to dststr if success, or NULL if fail.
  */
-char * wstr_escape(char *dststr, char *str, int scape, int toscape);
+unsigned int wstr_escape(char *dststr, unsigned int dst_size, const char *str, int scape, int toscape);
 
 /* Unescape a specific character from a character string
  *
  * dststr must be a valid pointer to a char buffer where unescaped string will be stored.
+ * dst_size must be an unsigned int value, to control the size of the buffer.
  * str must be a valid pointer to a string to unescape.
  * scape int is the value of the operator used to unescape.
- * Returns pointer to dststr if success, or NULL if fail.
+ * Returns the size of the dststr if success, or 0 if fail.
  */
-char * wstr_unescape(char *dststr, char *str, int scape);
+unsigned int wstr_unescape(char *dststr, unsigned int dst_size, const char *str, int scape);
 
 // Free string array
 void free_strarray(char ** array);

--- a/src/headers/string_op.h
+++ b/src/headers/string_op.h
@@ -105,23 +105,23 @@ char * wstr_chr(char * str, int character);
 /* Escape a specific character from a character string
  *
  * dststr must be a valid pointer to a char buffer where escaped string will be stored.
- * dst_size must be an unsigned int value, to control the size of the buffer.
+ * dst_size must be an unsigned int value, to avoid overflow the buffer.
  * str must be a valid pointer to a string to escape.
  * scape int is the value of the operator used to escape.
  * toscape int is the value to scape.
- * Returns pointer to dststr if success, or NULL if fail.
+ * Returns a ssize_t, represents the size of the dststr if success, or -1 if fail.
  */
-unsigned int wstr_escape(char *dststr, unsigned int dst_size, const char *str, int scape, int toscape);
+ssize_t wstr_escape(char *dststr, unsigned int dst_size, const char *str, int scape, int toscape);
 
 /* Unescape a specific character from a character string
  *
  * dststr must be a valid pointer to a char buffer where unescaped string will be stored.
- * dst_size must be an unsigned int value, to control the size of the buffer.
+ * dst_size must be an unsigned int value, to avoid overflow the buffer.
  * str must be a valid pointer to a string to unescape.
  * scape int is the value of the operator used to unescape.
- * Returns the size of the dststr if success, or 0 if fail.
+ * Returns a ssize_t, represents the size of the dststr if success, or -1 if fail.
  */
-unsigned int wstr_unescape(char *dststr, unsigned int dst_size, const char *str, int scape);
+ssize_t wstr_unescape(char *dststr, unsigned int dst_size, const char *str, int scape);
 
 // Free string array
 void free_strarray(char ** array);

--- a/src/headers/string_op.h
+++ b/src/headers/string_op.h
@@ -109,7 +109,7 @@ char * wstr_chr(char * str, int character);
  * str must be a valid pointer to a string to escape.
  * scape int is the value of the operator used to escape.
  * toscape int is the value to scape.
- * Returns a ssize_t, represents the size of the dststr if success, or -1 if fail.
+ * Returns a ssize_t, represents the size of the dststr if success, or OS_INVALID if fail.
  */
 ssize_t wstr_escape(char *dststr, unsigned int dst_size, const char *str, int scape, int toscape);
 
@@ -119,7 +119,7 @@ ssize_t wstr_escape(char *dststr, unsigned int dst_size, const char *str, int sc
  * dst_size must be an unsigned int value, to avoid overflow the buffer.
  * str must be a valid pointer to a string to unescape.
  * scape int is the value of the operator used to unescape.
- * Returns a ssize_t, represents the size of the dststr if success, or -1 if fail.
+ * Returns a ssize_t, represents the size of the dststr if success, or OS_INVALID if fail.
  */
 ssize_t wstr_unescape(char *dststr, unsigned int dst_size, const char *str, int scape);
 

--- a/src/headers/string_op.h
+++ b/src/headers/string_op.h
@@ -102,26 +102,34 @@ char * wstr_replace(const char * string, const char * search, const char * repla
 // Locate first occurrence of non escaped character in string
 char * wstr_chr(char * str, int character);
 
+/* Locate first occurrence of non escaped character in string
+ *
+ * str must be a valid pointer to a string where look for a non escaped character.
+ * character int is the value of the non escaped character.
+ * escape int is the value of the operator used to escape.
+ * Returns a char *, represents the position of the non escaped character, or NULL if fail.
+ */char * wstr_chr_escape(char * str, int character, int escape);
+
 /* Escape a specific character from a character string
  *
  * dststr must be a valid pointer to a char buffer where escaped string will be stored.
  * dst_size must be an unsigned int value, to avoid overflow the buffer.
  * str must be a valid pointer to a string to escape.
- * scape int is the value of the operator used to escape.
- * toscape int is the value to scape.
+ * escape int is the value of the operator used to escape.
+ * toescape int is the value to escape.
  * Returns a ssize_t, represents the size of the dststr if success, or OS_INVALID if fail.
  */
-ssize_t wstr_escape(char *dststr, unsigned int dst_size, const char *str, int scape, int toscape);
+ssize_t wstr_escape(char *dststr, unsigned int dst_size, const char *str, int escape, int toescape);
 
 /* Unescape a specific character from a character string
  *
  * dststr must be a valid pointer to a char buffer where unescaped string will be stored.
  * dst_size must be an unsigned int value, to avoid overflow the buffer.
  * str must be a valid pointer to a string to unescape.
- * scape int is the value of the operator used to unescape.
+ * escape int is the value of the operator used to unescape.
  * Returns a ssize_t, represents the size of the dststr if success, or OS_INVALID if fail.
  */
-ssize_t wstr_unescape(char *dststr, unsigned int dst_size, const char *str, int scape);
+ssize_t wstr_unescape(char *dststr, unsigned int dst_size, const char *str, int escape);
 
 // Free string array
 void free_strarray(char ** array);

--- a/src/headers/string_op.h
+++ b/src/headers/string_op.h
@@ -100,36 +100,40 @@ char* filter_special_chars(const char *string);
 char * wstr_replace(const char * string, const char * search, const char * replace);
 
 // Locate first occurrence of non escaped character in string
-char * wstr_chr(char * str, int character);
+char * wstr_chr(const char * str, char character);
 
-/* Locate first occurrence of non escaped character in string
+/**
+ * @brief Locate first occurrence of non escaped character in string.
  *
- * str must be a valid pointer to a string where look for a non escaped character.
- * character int is the value of the non escaped character.
- * escape int is the value of the operator used to escape.
- * Returns a char *, represents the position of the non escaped character, or NULL if fail.
- */char * wstr_chr_escape(char * str, int character, int escape);
-
-/* Escape a specific character from a character string
- *
- * dststr must be a valid pointer to a char buffer where escaped string will be stored.
- * dst_size must be an unsigned int value, to avoid overflow the buffer.
- * str must be a valid pointer to a string to escape.
- * escape int is the value of the operator used to escape.
- * toescape int is the value to escape.
- * Returns a ssize_t, represents the size of the dststr if success, or OS_INVALID if fail.
+ * @param str A valid pointer to a string where look for a non escaped character.
+ * @param character The non escaped character.
+ * @param escape The character used to escape.
+ * @return The position of the non escaped character, or NULL if fail.
  */
-ssize_t wstr_escape(char *dststr, unsigned int dst_size, const char *str, int escape, int toescape);
+char * wstr_chr_escape(const char * str, char character, char escape);
 
-/* Unescape a specific character from a character string
+/**
+ * @brief Escape a specific character from a character string.
  *
- * dststr must be a valid pointer to a char buffer where unescaped string will be stored.
- * dst_size must be an unsigned int value, to avoid overflow the buffer.
- * str must be a valid pointer to a string to unescape.
- * escape int is the value of the operator used to unescape.
- * Returns a ssize_t, represents the size of the dststr if success, or OS_INVALID if fail.
+ * @param dststr A valid pointer to a char buffer where escaped string will be stored.
+ * @param dst_size The dststr size to control buffer overflow.
+ * @param str A valid pointer to a string to escape.
+ * @param escape The character used to escape.
+ * @param match The value to escape.
+ * @return The size of the dststr if success, or OS_INVALID if fail.
  */
-ssize_t wstr_unescape(char *dststr, unsigned int dst_size, const char *str, int escape);
+ssize_t wstr_escape(char *dststr, size_t dst_size, const char *str, char escape, char match);
+
+/**
+ * @brief Unescape a specific character from a character string.
+ *
+ * @param dststr A valid pointer to a char buffer where unescaped string will be stored.
+ * @param dst_size The dststr size to control buffer overflow.
+ * @param str A valid pointer to a string to unescape.
+ * @param escape The character used to unescape.
+ * @return The size of the dststr if success, or OS_INVALID if fail.
+ */
+ssize_t wstr_unescape(char *dststr, size_t dst_size, const char *str, char escape);
 
 // Free string array
 void free_strarray(char ** array);

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -412,16 +412,6 @@ void LogCollectorStart()
             }
 #endif
         }
-
-        if (current->alias) {
-            int ii = 0;
-            while (current->alias[ii] != '\0') {
-                if (current->alias[ii] == ':') {
-                    current->alias[ii] = '\\';
-                }
-                ii++;
-            }
-        }
     }
 
     //Save status localfiles to disk

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -75,9 +75,15 @@ int MQReconnectPredicated(const char *path, bool (*fn_ptr)()) {
 static int SendMSGAction(int queue, const char *message, const char *locmsg, char loc) {
     int __mq_rcode;
     char tmpstr[OS_MAXSTR + 1];
+    char loc_buff[OS_BUFFER_SIZE + 1];
     static int reported = 0;
 
     tmpstr[OS_MAXSTR] = '\0';
+
+    if (NULL == wstr_escape(loc_buff, (char *) locmsg, '\\', ':')) {
+        merror(FORMAT_ERROR);
+        return (0);
+    }
 
     if (loc == SECURE_MQ) {
         loc = message[0];
@@ -93,9 +99,9 @@ static int SendMSGAction(int queue, const char *message, const char *locmsg, cha
             return (0);
         }
 
-        snprintf(tmpstr, OS_MAXSTR, "%c:%s->%s", loc, locmsg, message);
+        snprintf(tmpstr, OS_MAXSTR, "%c:%s->%s", loc, loc_buff, message);
     } else {
-        snprintf(tmpstr, OS_MAXSTR, "%c:%s:%s", loc, locmsg, message);
+        snprintf(tmpstr, OS_MAXSTR, "%c:%s:%s", loc, loc_buff, message);
     }
 
     /* Queue not available */

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -80,8 +80,8 @@ int MQReconnectPredicated(const char *path, bool (*fn_ptr)()) {
 /* Send message primitive. */
 STATIC int SendMSGAction(int queue, const char *message, const char *locmsg, char loc) {
     int __mq_rcode;
-    char tmpstr[OS_MAXSTR + 1];
-    char loc_buff[OS_BUFFER_SIZE + 1];
+    char tmpstr[OS_MAXSTR + 1] = {0};
+    char loc_buff[OS_BUFFER_SIZE + 1] = {0};
     static int reported = 0;
 
     tmpstr[OS_MAXSTR] = '\0';

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -12,6 +12,12 @@
 #include "config/config.h"
 #include "os_net/os_net.h"
 
+#ifdef WAZUH_UNIT_TESTING
+#define STATIC
+#else
+#define STATIC static
+#endif
+
 static log_builder_t * mq_log_builder;
 int sock_fail_time;
 
@@ -72,7 +78,7 @@ int MQReconnectPredicated(const char *path, bool (*fn_ptr)()) {
 }
 
 /* Send message primitive. */
-static int SendMSGAction(int queue, const char *message, const char *locmsg, char loc) {
+STATIC int SendMSGAction(int queue, const char *message, const char *locmsg, char loc) {
     int __mq_rcode;
     char tmpstr[OS_MAXSTR + 1];
     char loc_buff[OS_BUFFER_SIZE + 1];

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -81,12 +81,12 @@ int MQReconnectPredicated(const char *path, bool (*fn_ptr)()) {
 STATIC int SendMSGAction(int queue, const char *message, const char *locmsg, char loc) {
     int __mq_rcode;
     char tmpstr[OS_MAXSTR + 1] = {0};
-    char loc_buff[OS_BUFFER_SIZE + 1] = {0};
+    char loc_buff[OS_SIZE_8192 + 1] = {0};
     static int reported = 0;
 
     tmpstr[OS_MAXSTR] = '\0';
 
-    if (NULL == wstr_escape(loc_buff, (char *) locmsg, '\\', ':')) {
+    if (0 == wstr_escape(loc_buff, sizeof(loc_buff), (char *) locmsg, '\\', ':')) {
         merror(FORMAT_ERROR);
         return (0);
     }

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -86,7 +86,7 @@ STATIC int SendMSGAction(int queue, const char *message, const char *locmsg, cha
 
     tmpstr[OS_MAXSTR] = '\0';
 
-    if (0 == wstr_escape(loc_buff, sizeof(loc_buff), (char *) locmsg, '\\', ':')) {
+    if (-1 == wstr_escape(loc_buff, sizeof(loc_buff), (char *) locmsg, '\\', ':')) {
         merror(FORMAT_ERROR);
         return (0);
     }

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -86,7 +86,7 @@ STATIC int SendMSGAction(int queue, const char *message, const char *locmsg, cha
 
     tmpstr[OS_MAXSTR] = '\0';
 
-    if (OS_INVALID == wstr_escape(loc_buff, sizeof(loc_buff), (char *) locmsg, '\\', ':')) {
+    if (OS_INVALID == wstr_escape(loc_buff, sizeof(loc_buff), (char *) locmsg, '|', ':')) {
         merror(FORMAT_ERROR);
         return (0);
     }

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -86,7 +86,7 @@ STATIC int SendMSGAction(int queue, const char *message, const char *locmsg, cha
 
     tmpstr[OS_MAXSTR] = '\0';
 
-    if (-1 == wstr_escape(loc_buff, sizeof(loc_buff), (char *) locmsg, '\\', ':')) {
+    if (OS_INVALID == wstr_escape(loc_buff, sizeof(loc_buff), (char *) locmsg, '\\', ':')) {
         merror(FORMAT_ERROR);
         return (0);
     }

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -328,42 +328,46 @@ char * wstr_chr(char * str, int character) {
 
 // Escape a specific character from a character string
 
-char * wstr_escape(char *dststr, char *str, int scape, int toscape) {
+unsigned int wstr_escape(char *dststr, unsigned int dst_size, const char *str, int scape, int toscape) {
 
-    char * str_cpy = str;
+    char * str_cpy = (char *) str;
     if (str_cpy == NULL || dststr == NULL) {
-        return NULL;
+        return 0;
     }
 
     unsigned int a = 0;
-    while(*str_cpy != '\0') {
+    while (*str_cpy != '\0' && a < dst_size -1) {
         if (*str_cpy == toscape || *str_cpy == scape) {
             dststr[a++] = scape;
         }
         dststr[a++] = *str_cpy++;
     }
     dststr[a] = '\0';
-    return dststr;
+    return a;
 }
 
 // Unescape a specific character from a character string
 
-char * wstr_unescape(char *dststr, char *str, int scape) {
+unsigned int wstr_unescape(char *dststr, unsigned int dst_size, const char *str, int scape) {
 
-    char * str_cpy = str;
+    char * str_cpy = (char *) str;
     if (str_cpy == NULL || dststr == NULL) {
-        return NULL;
+        return 0;
     }
 
     unsigned int a = 0;
-    while(*str_cpy != '\0') {
+    while (*str_cpy != '\0' && a < dst_size -1) {
         if (*str_cpy == scape) {
             str_cpy++;
         }
-        dststr[a++] = *str_cpy++;
+        if (*str_cpy != '\0') {
+            dststr[a++] = *str_cpy++;
+        } else {
+            break;
+        }
     }
     dststr[a] = '\0';
-    return dststr;
+    return a;
 }
 
 #ifdef WIN32

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -326,6 +326,46 @@ char * wstr_chr(char * str, int character) {
     return NULL;
 }
 
+// Escape a specific character from a character string
+
+char * wstr_escape(char *dststr, char *str, int scape, int toscape) {
+
+    char * str_cpy = str;
+    if (str_cpy == NULL || dststr == NULL) {
+        return NULL;
+    }
+
+    unsigned int a = 0;
+    while(*str_cpy != '\0') {
+        if (*str_cpy == toscape || *str_cpy == scape) {
+            dststr[a++] = scape;
+        }
+        dststr[a++] = *str_cpy++;
+    }
+    dststr[a] = '\0';
+    return dststr;
+}
+
+// Unescape a specific character from a character string
+
+char * wstr_unescape(char *dststr, char *str, int scape) {
+
+    char * str_cpy = str;
+    if (str_cpy == NULL || dststr == NULL) {
+        return NULL;
+    }
+
+    unsigned int a = 0;
+    while(*str_cpy != '\0') {
+        if (*str_cpy == scape) {
+            str_cpy++;
+        }
+        dststr[a++] = *str_cpy++;
+    }
+    dststr[a] = '\0';
+    return dststr;
+}
+
 #ifdef WIN32
 
 char *convert_windows_string(LPCWSTR string)

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -305,9 +305,16 @@ char * wstr_replace(const char * string, const char * search, const char * repla
     return result;
 }
 
-// Locate first occurrence of non escaped character in string
+// Locate first occurrence of non '\\' escaped character in string
 
 char * wstr_chr(char * str, int character) {
+
+    return wstr_chr_escape(str, character, '\\');
+}
+
+// Locate first occurrence of non escaped character in string
+
+char * wstr_chr_escape(char * str, int character, int escape) {
     char escaped = 0;
 
     for (;*str != '\0'; str++) {
@@ -315,7 +322,7 @@ char * wstr_chr(char * str, int character) {
             if (*str == character) {
                 return str;
             }
-            if (*str == '\\') {
+            if (*str == escape) {
                 escaped = 1;
             }
         } else {
@@ -328,7 +335,7 @@ char * wstr_chr(char * str, int character) {
 
 // Escape a specific character from a character string
 
-ssize_t wstr_escape(char *dststr, unsigned int dst_size, const char *str, int scape, int toscape) {
+ssize_t wstr_escape(char *dststr, unsigned int dst_size, const char *str, int escape, int toescape) {
 
     char * str_cpy = (char *) str;
     if (str_cpy == NULL || dststr == NULL) {
@@ -337,8 +344,8 @@ ssize_t wstr_escape(char *dststr, unsigned int dst_size, const char *str, int sc
 
     unsigned int a = 0;
     while (*str_cpy != '\0' && a < dst_size -1) {
-        if (*str_cpy == toscape || *str_cpy == scape) {
-            dststr[a++] = scape;
+        if (*str_cpy == toescape || *str_cpy == escape) {
+            dststr[a++] = escape;
         }
         dststr[a++] = *str_cpy++;
     }
@@ -348,7 +355,7 @@ ssize_t wstr_escape(char *dststr, unsigned int dst_size, const char *str, int sc
 
 // Unescape a specific character from a character string
 
-ssize_t wstr_unescape(char *dststr, unsigned int dst_size, const char *str, int scape) {
+ssize_t wstr_unescape(char *dststr, unsigned int dst_size, const char *str, int escape) {
 
     char * str_cpy = (char *) str;
     if (str_cpy == NULL || dststr == NULL) {
@@ -357,7 +364,7 @@ ssize_t wstr_unescape(char *dststr, unsigned int dst_size, const char *str, int 
 
     unsigned int a = 0;
     while (*str_cpy != '\0' && a < dst_size -1) {
-        if (*str_cpy == scape && *(str_cpy + 1) != '\0') {
+        if (*str_cpy == escape && *(str_cpy + 1) != '\0') {
             str_cpy++;
         }
         dststr[a++] = *str_cpy++;

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -349,8 +349,8 @@ ssize_t wstr_escape(char *dststr, size_t dst_size, const char *str, char escape,
     do {
         z = strcspn(str + i, charset);
 
-        if (str[i + z] == '\0' || (j + z) >= dst_size) {
-            z = (z + j <= dst_size) ? z : (dst_size - j - 1);
+        if (str[i + z] == '\0' || (j + z) >= (dst_size - 2)) {
+            z = (z + j <= dst_size - 1) ? z : (dst_size - j - 1);
             // End of str
             strncpy(dststr + j, str + i, z);
         } else {
@@ -368,7 +368,7 @@ ssize_t wstr_escape(char *dststr, size_t dst_size, const char *str, char escape,
 
         j += z;
         i += z;
-    } while (str[i] != '\0' && j < dst_size -1);
+    } while (str[i] != '\0' && j < (dst_size - 2));
 
     dststr[j] = '\0';
     return j;
@@ -390,13 +390,13 @@ ssize_t wstr_unescape(char *dststr, size_t dst_size, const char *str, char escap
 
     do {
         z = strcspn(str + i, charset);
-        z = (z + j <= dst_size) ? z : (dst_size - j - 1);
+        z = (z + j <= dst_size - 1) ? z : (dst_size - j - 1);
 
         strncpy(dststr + j, str + i, z);
         j += z;
         i += z;
 
-        if (str[i] != '\0' && j < dst_size -1) {
+        if (str[i] != '\0' && j < (dst_size - 1)) {
 
             if (str[i + 1] == escape) {
                 dststr[j++] = str[i++];
@@ -407,7 +407,7 @@ ssize_t wstr_unescape(char *dststr, size_t dst_size, const char *str, char escap
             i++;
         }
 
-    } while (str[i] != '\0' && j < dst_size -1);
+    } while (str[i] != '\0' && j < (dst_size - 1));
 
     dststr[j] = '\0';
     return j;

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -328,11 +328,11 @@ char * wstr_chr(char * str, int character) {
 
 // Escape a specific character from a character string
 
-unsigned int wstr_escape(char *dststr, unsigned int dst_size, const char *str, int scape, int toscape) {
+ssize_t wstr_escape(char *dststr, unsigned int dst_size, const char *str, int scape, int toscape) {
 
     char * str_cpy = (char *) str;
     if (str_cpy == NULL || dststr == NULL) {
-        return 0;
+        return -1;
     }
 
     unsigned int a = 0;
@@ -348,24 +348,21 @@ unsigned int wstr_escape(char *dststr, unsigned int dst_size, const char *str, i
 
 // Unescape a specific character from a character string
 
-unsigned int wstr_unescape(char *dststr, unsigned int dst_size, const char *str, int scape) {
+ssize_t wstr_unescape(char *dststr, unsigned int dst_size, const char *str, int scape) {
 
     char * str_cpy = (char *) str;
     if (str_cpy == NULL || dststr == NULL) {
-        return 0;
+        return -1;
     }
 
     unsigned int a = 0;
     while (*str_cpy != '\0' && a < dst_size -1) {
-        if (*str_cpy == scape) {
+        if (*str_cpy == scape && *(str_cpy + 1) != '\0') {
             str_cpy++;
         }
-        if (*str_cpy != '\0') {
-            dststr[a++] = *str_cpy++;
-        } else {
-            break;
-        }
+        dststr[a++] = *str_cpy++;
     }
+
     dststr[a] = '\0';
     return a;
 }

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -332,7 +332,7 @@ ssize_t wstr_escape(char *dststr, unsigned int dst_size, const char *str, int sc
 
     char * str_cpy = (char *) str;
     if (str_cpy == NULL || dststr == NULL) {
-        return -1;
+        return OS_INVALID;
     }
 
     unsigned int a = 0;
@@ -352,7 +352,7 @@ ssize_t wstr_unescape(char *dststr, unsigned int dst_size, const char *str, int 
 
     char * str_cpy = (char *) str;
     if (str_cpy == NULL || dststr == NULL) {
-        return -1;
+        return OS_INVALID;
     }
 
     unsigned int a = 0;

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -307,71 +307,110 @@ char * wstr_replace(const char * string, const char * search, const char * repla
 
 // Locate first occurrence of non '\\' escaped character in string
 
-char * wstr_chr(char * str, int character) {
+char * wstr_chr(const char * str, char character) {
 
     return wstr_chr_escape(str, character, '\\');
 }
 
 // Locate first occurrence of non escaped character in string
 
-char * wstr_chr_escape(char * str, int character, int escape) {
-    char escaped = 0;
+char * wstr_chr_escape(const char * str, char character, char escape) {
+    bool escaped = false;
 
     for (;*str != '\0'; str++) {
         if (!escaped) {
             if (*str == character) {
-                return str;
+                return (char *)str;
             }
             if (*str == escape) {
-                escaped = 1;
+                escaped = true;
             }
         } else {
-            escaped = 0;
+            escaped = false;
         }
     }
-
     return NULL;
 }
 
 // Escape a specific character from a character string
 
-ssize_t wstr_escape(char *dststr, unsigned int dst_size, const char *str, int escape, int toescape) {
+ssize_t wstr_escape(char *dststr, size_t dst_size, const char *str, char escape, char match) {
 
-    char * str_cpy = (char *) str;
-    if (str_cpy == NULL || dststr == NULL) {
+    if (str == NULL || dststr == NULL) {
         return OS_INVALID;
     }
 
-    unsigned int a = 0;
-    while (*str_cpy != '\0' && a < dst_size -1) {
-        if (*str_cpy == toescape || *str_cpy == escape) {
-            dststr[a++] = escape;
+    size_t i = 0;   // Read position
+    size_t j = 0;   // Write position
+    size_t z;       // Span length
+
+    char charset[3] = {escape, match, '\0'};
+
+    do {
+        z = strcspn(str + i, charset);
+
+        if (str[i + z] == '\0' || (j + z) >= dst_size) {
+            z = (z + j <= dst_size) ? z : (dst_size - j - 1);
+            // End of str
+            strncpy(dststr + j, str + i, z);
+        } else {
+            // Reserved character
+            strncpy(dststr + j, str + i, z);
+            dststr[j + z] = escape;
+            if (str[i + z] == escape) {
+                dststr[j + z + 1] = escape;
+            } else {
+                dststr[j + z + 1] = match;
+            }
+            z++;
+            j++;
         }
-        dststr[a++] = *str_cpy++;
-    }
-    dststr[a] = '\0';
-    return a;
+
+        j += z;
+        i += z;
+    } while (str[i] != '\0' && j < dst_size -1);
+
+    dststr[j] = '\0';
+    return j;
 }
 
 // Unescape a specific character from a character string
 
-ssize_t wstr_unescape(char *dststr, unsigned int dst_size, const char *str, int escape) {
+ssize_t wstr_unescape(char *dststr, size_t dst_size, const char *str, char escape) {
 
-    char * str_cpy = (char *) str;
-    if (str_cpy == NULL || dststr == NULL) {
+    if (str == NULL || dststr == NULL) {
         return OS_INVALID;
     }
 
-    unsigned int a = 0;
-    while (*str_cpy != '\0' && a < dst_size -1) {
-        if (*str_cpy == escape && *(str_cpy + 1) != '\0') {
-            str_cpy++;
-        }
-        dststr[a++] = *str_cpy++;
-    }
+    size_t i = 0;   // Read position
+    size_t j = 0;   // Write position
+    size_t z;       // Span length
 
-    dststr[a] = '\0';
-    return a;
+    char charset[2] = {escape, '\0'};
+
+    do {
+        z = strcspn(str + i, charset);
+        z = (z + j <= dst_size) ? z : (dst_size - j - 1);
+
+        strncpy(dststr + j, str + i, z);
+        j += z;
+        i += z;
+
+        if (str[i] != '\0' && j < dst_size -1) {
+
+            if (str[i + 1] == escape) {
+                dststr[j++] = str[i++];
+            }
+            else if (str[i + 1] == '\0') {
+                dststr[j++] = str[i];
+            }
+            i++;
+        }
+
+    } while (str[i] != '\0' && j < dst_size -1);
+
+    dststr[j] = '\0';
+    return j;
 }
 
 #ifdef WIN32

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -38,6 +38,9 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 list(APPEND analysisd_names "test_analysisd_syscheck")
 list(APPEND analysisd_flags "-Wl,--wrap,wdbc_query_ex -Wl,--wrap,wdbc_parse_result ${DEBUG_OP_WRAPPERS}")
 
+list(APPEND analysisd_names "test_cleanevent")
+list(APPEND analysisd_flags "-Wl,--wrap,_merror")
+
 list(APPEND analysisd_names "test_dbsync")
 list(APPEND analysisd_flags "-Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP \
                          -Wl,--wrap,connect_to_remoted -Wl,--wrap,send_msg_to_agent -Wl,--wrap,wdbc_query_ex \

--- a/src/unit_tests/analysisd/test_cleanevent.c
+++ b/src/unit_tests/analysisd/test_cleanevent.c
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2022, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+
+#include "../../analysisd/cleanevent.h"
+
+
+static int test_setup(void **state) {
+    Eventinfo *lf = NULL;
+    os_calloc(1, sizeof(Eventinfo), lf);
+    *state = lf;
+
+    return OS_SUCCESS;
+}
+
+static int test_teardown(void **state) {
+    Eventinfo *lf = (Eventinfo *)*state;
+    os_free(lf->full_log);
+    os_free(lf->location);
+    os_free(lf->location);
+    os_free(lf->agent_id);
+    os_free(lf->hostname);
+    os_free(lf);
+
+    return OS_SUCCESS;
+}
+
+
+static void test_OS_CleanMSG_fail(void **state) {
+
+    Eventinfo lf;
+
+    char *msg;
+    os_calloc(OS_BUFFER_SIZE, sizeof(char), msg);
+    snprintf(msg, OS_BUFFER_SIZE, "%s", "fail message");
+    expect_string(__wrap__merror, formatted_msg, "(1106): String not correctly formatted.");
+
+    int value = OS_CleanMSG(msg, &lf);
+
+    assert_int_equal(value, -1);
+
+    os_free(msg);
+}
+
+static void test_OS_CleanMSG_fail_short_msg(void **state) {
+
+    Eventinfo lf;
+
+    char *msg = NULL;
+    os_calloc(OS_BUFFER_SIZE, sizeof(char), msg);
+    snprintf(msg, OS_BUFFER_SIZE, "%s", "1:a");
+    expect_string(__wrap__merror, formatted_msg, "(1106): String not correctly formatted.");
+
+    int value = OS_CleanMSG(msg, &lf);
+
+    assert_int_equal(value, -1);
+
+    os_free(msg);
+}
+
+static void test_OS_CleanMSG_ossec_min_msg(void **state) {
+
+    Eventinfo *lf = (Eventinfo *)*state;
+
+    char *msg;
+    os_calloc(OS_BUFFER_SIZE, sizeof(char), msg);
+    snprintf(msg, OS_BUFFER_SIZE, "%c:%s:%s", '1', "a", "b");
+
+    int value = OS_CleanMSG(msg, lf);
+
+    assert_int_equal(value, 0);
+    assert_string_equal(lf->full_log, "b");
+    assert_string_equal(lf->location, "a");
+
+    os_free(msg);
+}
+
+static void test_OS_CleanMSG_ossec_arrow_msg(void **state) {
+
+    Eventinfo *lf = (Eventinfo *)*state;
+
+    char *msg;
+    os_calloc(OS_BUFFER_SIZE, sizeof(char), msg);
+    snprintf(msg, OS_BUFFER_SIZE, "%c:%s->%s", '5', "[015] (DESKTOP) any", "fim_registry:payload");
+
+    int value = OS_CleanMSG(msg, lf);
+
+    assert_int_equal(value, 0);
+    assert_string_equal(lf->full_log, "payload");
+    assert_string_equal(lf->location, "(DESKTOP) any->fim_registry");
+
+    os_free(msg);
+}
+
+static void test_OS_CleanMSG_ossec_test_msg(void **state) {
+
+    Eventinfo *lf = (Eventinfo *)*state;
+
+    char *msg;
+    os_calloc(OS_BUFFER_SIZE, sizeof(char), msg);
+    snprintf(msg, OS_BUFFER_SIZE, "%c:%s:%s", '1', "location test", "payload test");
+
+    int value = OS_CleanMSG(msg, lf);
+
+    assert_int_equal(value, 0);
+    assert_string_equal(lf->full_log, "payload test");
+    assert_string_equal(lf->location, "location test");
+
+    os_free(msg);
+}
+
+static void test_OS_CleanMSG_ossec_syslog_msg(void **state) {
+
+    Eventinfo *lf = (Eventinfo *)*state;
+
+    char *msg;
+    os_calloc(OS_BUFFER_SIZE, sizeof(char), msg);
+    snprintf(msg, OS_BUFFER_SIZE, "%c:%s:%s", '1', "/var/log/syslog", "payload test");
+
+    int value = OS_CleanMSG(msg, lf);
+
+    assert_int_equal(value, 0);
+    assert_string_equal(lf->full_log, "payload test");
+    assert_string_equal(lf->location, "/var/log/syslog");
+
+    os_free(msg);
+}
+
+static void test_OS_CleanMSG_syslog_ipv4_msg(void **state) {
+
+    Eventinfo *lf = (Eventinfo *)*state;
+
+    char *msg;
+    os_calloc(OS_BUFFER_SIZE, sizeof(char), msg);
+    snprintf(msg, OS_BUFFER_SIZE, "%c:%s:%s", '2', "127.0.0.1", "payload test");
+
+    int value = OS_CleanMSG(msg, lf);
+
+    assert_int_equal(value, 0);
+    assert_string_equal(lf->full_log, "payload test");
+    assert_string_equal(lf->location, "127.0.0.1");
+
+    os_free(msg);
+}
+
+static void test_OS_CleanMSG_syslog_ipv6_msg(void **state) {
+
+    Eventinfo *lf = (Eventinfo *)*state;
+
+    char *msg;
+    os_calloc(OS_BUFFER_SIZE, sizeof(char), msg);
+    snprintf(msg, OS_BUFFER_SIZE, "%c:%s:%s", '2', "0000\\:0000\\:0000\\:0000\\:0000\\:0000\\:0000\\:0001", "payload test");
+
+    int value = OS_CleanMSG(msg, lf);
+
+    assert_int_equal(value, 0);
+    assert_string_equal(lf->full_log, "payload test");
+    assert_string_equal(lf->location, "0000:0000:0000:0000:0000:0000:0000:0001");
+
+    os_free(msg);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+
+        cmocka_unit_test(test_OS_CleanMSG_fail),
+        cmocka_unit_test(test_OS_CleanMSG_fail_short_msg),
+        cmocka_unit_test_setup_teardown(test_OS_CleanMSG_ossec_min_msg, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_OS_CleanMSG_ossec_arrow_msg, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_OS_CleanMSG_ossec_test_msg, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_OS_CleanMSG_ossec_syslog_msg, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_OS_CleanMSG_syslog_ipv4_msg, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_OS_CleanMSG_syslog_ipv6_msg, test_setup, test_teardown),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/analysisd/test_cleanevent.c
+++ b/src/unit_tests/analysisd/test_cleanevent.c
@@ -160,7 +160,7 @@ static void test_OS_CleanMSG_syslog_ipv6_msg(void **state) {
 
     char *msg;
     os_calloc(OS_BUFFER_SIZE, sizeof(char), msg);
-    snprintf(msg, OS_BUFFER_SIZE, "%c:%s:%s", '2', "0000\\:0000\\:0000\\:0000\\:0000\\:0000\\:0000\\:0001", "payload test");
+    snprintf(msg, OS_BUFFER_SIZE, "%c:%s:%s", '2', "0000|:0000|:0000|:0000|:0000|:0000|:0000|:0001", "payload test");
 
     int value = OS_CleanMSG(msg, lf);
 

--- a/src/unit_tests/analysisd/test_logtest.c
+++ b/src/unit_tests/analysisd/test_logtest.c
@@ -3260,6 +3260,44 @@ void test_w_logtest_decoding_phase_no_program_name(void ** state)
 }
 
 // w_logtest_preprocessing_phase
+void test_w_logtest_preprocessing_phase_json_location_to_scape_ok(void ** state)
+{
+    Eventinfo lf = {0};
+    cJSON request = {0};
+
+    cJSON json_event = {0};
+    cJSON json_event_child = {0};
+    char * raw_event = strdup("{event}");
+    char * str_location = strdup("loc:at\\ion");
+
+    lf.log = strdup("{event}");
+
+    json_event.child = &json_event_child;
+
+
+    const int expect_retval = 0;
+    int retval;
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &json_event);
+    will_return(__wrap_cJSON_PrintUnformatted, raw_event);
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 8);
+    will_return(__wrap_cJSON_GetStringValue, str_location);
+
+    will_return(__wrap_OS_CleanMSG, 0);
+
+
+    retval = w_logtest_preprocessing_phase(&lf, &request);
+
+    assert_int_equal(retval, expect_retval);
+
+
+    os_free(str_location);
+    os_free(lf.log);
+
+
+}
+
 void test_w_logtest_preprocessing_phase_json_event_ok(void ** state)
 {
     Eventinfo lf = {0};
@@ -6587,6 +6625,7 @@ int main(void)
         // Tests w_logtest_generate_error_response
         cmocka_unit_test(test_w_logtest_generate_error_response_ok),
         // Tests w_logtest_preprocessing_phase
+        cmocka_unit_test(test_w_logtest_preprocessing_phase_json_location_to_scape_ok),
         cmocka_unit_test(test_w_logtest_preprocessing_phase_json_event_ok),
         cmocka_unit_test(test_w_logtest_preprocessing_phase_json_event_fail),
         cmocka_unit_test(test_w_logtest_preprocessing_phase_str_event_ok),

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -144,7 +144,7 @@ list(APPEND shared_tests_flags "-Wl,--wrap=sysconf,--wrap=getpwnam_r,--wrap=getg
 
 list(APPEND shared_tests_names "test_mq_op")
 list(APPEND shared_tests_flags "-Wl,--wrap,OS_BindUnixDomainWithPerms -Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,sleep \
-                                -Wl,--wrap,OS_getsocketsize ${DEBUG_OP_WRAPPERS}")
+                                -Wl,--wrap,OS_SendUnix -Wl,--wrap,OS_getsocketsize ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND shared_tests_names "test_remoted_op")
 list(APPEND shared_tests_flags "${DEBUG_OP_WRAPPERS}")

--- a/src/unit_tests/shared/test_mq_op.c
+++ b/src/unit_tests/shared/test_mq_op.c
@@ -19,6 +19,7 @@
 #include "../headers/shared.h"
 
 #include "../wrappers/common.h"
+#include "../wrappers/wazuh/os_net/os_net_wrappers.h"
 
 /* Define values may be changed */
 
@@ -32,19 +33,7 @@ int __wrap_OS_getsocketsize(int ossock) {
     return SOCKET_SIZE;
 }
 
-void __wrap_sleep(unsigned int seconds){};
-
-int __wrap_OS_BindUnixDomainWithPerms(const char * path, int type, int max_msg_size, uid_t uid, gid_t gid, mode_t perm) {
-    return (int) mock();
-}
-
-int __wrap_OS_BindUnixDomain(const char * path, int type, int max_msg_size){
-    return (int) mock();
-}
-
-int __wrap_OS_ConnectUnixDomain(const char * path, int type, int max_msg_size){
-    return (int) mock();
-}
+void __wrap_sleep(unsigned int seconds) { };
 
 bool ptr_function_value = false;
 
@@ -64,6 +53,12 @@ void test_start_mq_read_success(void ** state){
 
     int ret = 0;
 
+    expect_string(__wrap_OS_BindUnixDomainWithPerms, path, path);
+    expect_value(__wrap_OS_BindUnixDomainWithPerms, type, SOCK_DGRAM);
+    expect_value(__wrap_OS_BindUnixDomainWithPerms, max_msg_size, OS_MAXSTR + 512);
+    expect_value(__wrap_OS_BindUnixDomainWithPerms, uid, 0);
+    expect_value(__wrap_OS_BindUnixDomainWithPerms, gid, 0);
+    expect_value(__wrap_OS_BindUnixDomainWithPerms, perm, 0660);
     will_return(__wrap_OS_BindUnixDomainWithPerms, 0);
 
     ret = StartMQ(path, type, n_attempts);
@@ -80,6 +75,12 @@ void test_start_mq_read_fail(void ** state){
 
     int ret = 0;
 
+    expect_string(__wrap_OS_BindUnixDomainWithPerms, path, path);
+    expect_value(__wrap_OS_BindUnixDomainWithPerms, type, SOCK_DGRAM);
+    expect_value(__wrap_OS_BindUnixDomainWithPerms, max_msg_size, OS_MAXSTR + 512);
+    expect_value(__wrap_OS_BindUnixDomainWithPerms, uid, 0);
+    expect_value(__wrap_OS_BindUnixDomainWithPerms, gid, 0);
+    expect_value(__wrap_OS_BindUnixDomainWithPerms, perm, 0660);
     will_return(__wrap_OS_BindUnixDomainWithPerms, -1);
 
     ret = StartMQ(path, type, n_attempts);
@@ -98,6 +99,9 @@ void test_start_mq_write_simple_success(void ** state){
     int ret = 0;
     char messages[2][OS_SIZE_64];
 
+    expect_string(__wrap_OS_ConnectUnixDomain, path, path);
+    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_DGRAM);
+    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR + 256);
     will_return(__wrap_OS_ConnectUnixDomain, 0);
 
     snprintf(messages[0], OS_SIZE_64,"Connected succesfully to '%s' after %d attempts", path, 0);
@@ -121,6 +125,9 @@ void test_start_mq_write_simple_fail(void ** state){
     int ret = 0;
     errno = ERRNO;
 
+    expect_string(__wrap_OS_ConnectUnixDomain, path, path);
+    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_DGRAM);
+    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR + 256);
     will_return(__wrap_OS_ConnectUnixDomain, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Can't connect to '/test': Socket operation on non-socket (88). Attempt: 1");
 
@@ -142,10 +149,16 @@ void test_start_mq_write_multiple_success(void ** state){
     errno = ERRNO;
 
     for (int i = 0; i < n_attempts - 1; i++) {
+        expect_string(__wrap_OS_ConnectUnixDomain, path, path);
+        expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_DGRAM);
+        expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR + 256);
         will_return(__wrap_OS_ConnectUnixDomain, -1);
         snprintf(messages[i], OS_SIZE_1024, "Can't connect to '/test': Socket operation on non-socket (88). Attempt: %d", i + 1);
         expect_string(__wrap__mdebug1, formatted_msg, messages[i]);
     }
+    expect_string(__wrap_OS_ConnectUnixDomain, path, path);
+    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_DGRAM);
+    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR + 256);
     will_return(__wrap_OS_ConnectUnixDomain, 0);
 
     snprintf(messages[n_attempts - 1], OS_SIZE_1024,"Connected succesfully to '%s' after %d attempts", path, n_attempts - 1);
@@ -170,6 +183,9 @@ void test_start_mq_write_multiple_fail(void ** state){
     char messages[n_attempts][OS_SIZE_1024];
 
     for (int i = 0; i <= n_attempts - 1; i++) {
+        expect_string(__wrap_OS_ConnectUnixDomain, path, path);
+        expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_DGRAM);
+        expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR + 256);
         will_return(__wrap_OS_ConnectUnixDomain, -1);
         snprintf(messages[i], OS_SIZE_1024, "Can't connect to '/test': Socket operation on non-socket (88). Attempt: %d", i + 1);
         expect_string(__wrap__mdebug1, formatted_msg, messages[i]);
@@ -191,10 +207,16 @@ void test_start_mq_write_inf_success(void ** state){
     char messages[MAX_ATTEMPTS + 1][OS_SIZE_1024];
 
     for (int i = 0; i < MAX_ATTEMPTS - 1; i++) {
+        expect_string(__wrap_OS_ConnectUnixDomain, path, path);
+        expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_DGRAM);
+        expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR + 256);
         will_return(__wrap_OS_ConnectUnixDomain, -1);
         sprintf(messages[i], "Can't connect to '/test': Socket operation on non-socket (88). Attempt: %d", i + 1);
         expect_string(__wrap__mdebug1, formatted_msg, messages[i]);
     }
+    expect_string(__wrap_OS_ConnectUnixDomain, path, path);
+    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_DGRAM);
+    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR + 256);
     will_return(__wrap_OS_ConnectUnixDomain, 0);
 
     snprintf(messages[MAX_ATTEMPTS - 1], OS_SIZE_1024,"Connected succesfully to '%s' after %d attempts", path, MAX_ATTEMPTS - 1);
@@ -219,11 +241,17 @@ void test_start_mq_write_inf_fail(void ** state){
     char messages[MAX_ATTEMPTS][OS_SIZE_1024];
 
     for (int i = 0; i <= MAX_ATTEMPTS - 1; i++) {
+        expect_string(__wrap_OS_ConnectUnixDomain, path, path);
+        expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_DGRAM);
+        expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR + 256);
         will_return(__wrap_OS_ConnectUnixDomain, -1);
         snprintf(messages[i], OS_SIZE_1024, "Can't connect to '/test': Socket operation on non-socket (88). Attempt: %d", i + 1);
         expect_string(__wrap__mdebug1, formatted_msg, messages[i]);
     }
     /* Breaking the infinite loop */
+    expect_string(__wrap_OS_ConnectUnixDomain, path, path);
+    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_DGRAM);
+    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR + 256);
     will_return(__wrap_OS_ConnectUnixDomain, 0);
     /* Ignoring output */
     expect_any_count(__wrap__mdebug1, formatted_msg, -1);
@@ -240,6 +268,9 @@ void test_reconnect_mq_simple_success(void ** state){
     int ret = 0;
     char messages[2][OS_SIZE_64];
 
+    expect_string(__wrap_OS_ConnectUnixDomain, path, path);
+    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_DGRAM);
+    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR + 256);
     will_return(__wrap_OS_ConnectUnixDomain, 0);
 
     snprintf(messages[0], OS_SIZE_64, SUCCESSFULLY_RECONNECTED_SOCKET, path);
@@ -260,6 +291,9 @@ void test_reconnect_mq_simple_fail(void ** state){
 
     int ret = 0;
 
+    expect_string(__wrap_OS_ConnectUnixDomain, path, path);
+    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_DGRAM);
+    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR + 256);
     will_return(__wrap_OS_ConnectUnixDomain, -1);
 
     ret = MQReconnectPredicated(path, &ptr_function);
@@ -278,7 +312,14 @@ void test_reconnect_mq_complex_true(void ** state){
     char expected_str[OS_SIZE_128];
     char messages[2][OS_SIZE_128];
 
+    expect_string(__wrap_OS_ConnectUnixDomain, path, path);
+    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_DGRAM);
+    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR + 256);
     will_return(__wrap_OS_ConnectUnixDomain, -1);
+
+    expect_string(__wrap_OS_ConnectUnixDomain, path, path);
+    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_DGRAM);
+    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR + 256);
     will_return(__wrap_OS_ConnectUnixDomain, 0);
 
     snprintf(expected_str, OS_SIZE_128, UNABLE_TO_RECONNECT, path, error_message, error_message_id);
@@ -294,6 +335,93 @@ void test_reconnect_mq_complex_true(void ** state){
     assert_int_equal(ret, 0);
 }
 
+void test_SendMSGAction_format_error(void ** state){
+    (void)state;
+
+    expect_string(__wrap__merror, formatted_msg, "(1106): String not correctly formatted.");
+
+    int ret = SendMSG(0, "message", "location", SECURE_MQ);
+
+    assert_int_equal(ret, 0);
+}
+
+void test_SendMSGAction_queue_not_available(void ** state){
+    (void)state;
+
+    int ret = SendMSG(-1, "message", "location", SYSLOG_MQ);
+
+    assert_int_equal(ret, -1);
+}
+
+void test_SendMSGAction_socket_error(void ** state){
+    (void)state;
+    int queue = 0;
+
+    expect_value(__wrap_OS_SendUnix, socket, queue);
+    expect_string(__wrap_OS_SendUnix, msg, "2:location:message");
+    expect_value(__wrap_OS_SendUnix, size, 0);
+    will_return(__wrap_OS_SendUnix, OS_SOCKTERR);
+
+    expect_string(__wrap__merror, formatted_msg, "socketerr (not available).");
+
+    int ret = SendMSG(queue, "message", "location", SYSLOG_MQ);
+
+    assert_int_equal(ret, -1);
+}
+
+void test_SendMSGAction_socket_busy(void ** state){
+    (void)state;
+    int queue = 0;
+
+    expect_value(__wrap_OS_SendUnix, socket, queue);
+    expect_string(__wrap_OS_SendUnix, msg, "2:location:message");
+    expect_value(__wrap_OS_SendUnix, size, 0);
+    will_return(__wrap_OS_SendUnix, OS_INVALID);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Socket busy, discarding message.");
+    expect_string(__wrap__mwarn, formatted_msg, "Socket busy, discarding message.");
+
+    int ret = SendMSG(queue, "message", "location", SYSLOG_MQ);
+
+    assert_int_equal(ret, 0);
+}
+
+void test_SendMSGAction_non_secure_msg(void ** state){
+    (void)state;
+    int queue = 0;
+
+    expect_value(__wrap_OS_SendUnix, socket, queue);
+    expect_string(__wrap_OS_SendUnix, msg, "2:location:message");
+    expect_value(__wrap_OS_SendUnix, size, 0);
+    will_return(__wrap_OS_SendUnix, 1);
+
+    int ret = SendMSG(queue, "message", "location", SYSLOG_MQ);
+
+    assert_int_equal(ret, 0);
+}
+
+void test_SendMSGAction_secure_msg(void ** state){
+    (void)state;
+    int queue = 0;
+
+    expect_value(__wrap_OS_SendUnix, socket, queue);
+    expect_string(__wrap_OS_SendUnix, msg, "4:location->message:");
+    expect_value(__wrap_OS_SendUnix, size, 0);
+    will_return(__wrap_OS_SendUnix, 1);
+
+    int ret = SendMSG(queue, "4:message:", "location", SECURE_MQ);
+
+    assert_int_equal(ret, 0);
+}
+
+void test_SendMSGAction_secure_msg_keepalive(void ** state){
+    (void)state;
+    int ret = SendMSG(0, "4:keepalive", "location", SECURE_MQ);
+
+    assert_int_equal(ret, 0);
+}
+
+
 // Main test function
 
 int main(void){
@@ -308,7 +436,15 @@ int main(void){
        cmocka_unit_test(test_start_mq_write_inf_fail),
        cmocka_unit_test(test_reconnect_mq_simple_fail),
        cmocka_unit_test(test_reconnect_mq_complex_true),
-       cmocka_unit_test(test_reconnect_mq_simple_success)
+       cmocka_unit_test(test_reconnect_mq_simple_success),
+       // Test test_SendMSGAction
+       cmocka_unit_test(test_SendMSGAction_format_error),
+       cmocka_unit_test(test_SendMSGAction_queue_not_available),
+       cmocka_unit_test(test_SendMSGAction_socket_error),
+       cmocka_unit_test(test_SendMSGAction_socket_busy),
+       cmocka_unit_test(test_SendMSGAction_non_secure_msg),
+       cmocka_unit_test(test_SendMSGAction_secure_msg),
+       cmocka_unit_test(test_SendMSGAction_secure_msg_keepalive),
        };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/shared/test_string_op.c
+++ b/src/unit_tests/shared/test_string_op.c
@@ -753,121 +753,183 @@ void test_strarray_size(void ** state) {
 
 void test_wstr_escape_dststr_null(void ** state) {
 
-    char * ret = wstr_escape(NULL, "test string without colons", '\\', ':');
-    assert_null(ret);
+    unsigned int ret = wstr_escape(NULL, 0, "test string without colons", '\\', ':');
+    assert_int_equal(ret, 0);
 }
 
 void test_wstr_escape_str_null(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    char * ret = wstr_escape(dststr, NULL, '\\', ':');
-    assert_null(ret);
+    unsigned int ret = wstr_escape(dststr, sizeof(dststr), NULL, '\\', ':');
+    assert_int_equal(ret, 0);
 }
 
 void test_wstr_escape_not_escape(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    char * ret = wstr_escape(dststr, "test string without colons", '\\', ':');
+    unsigned int ret = wstr_escape(dststr, sizeof(dststr), "test string without colons", '\\', ':');
     assert_string_equal(dststr, "test string without colons");
-    assert_non_null(ret);
+    assert_int_equal(ret, 26);
 }
 
 void test_wstr_escape_colons_escape(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    char * ret = wstr_escape(dststr, "test string with one : colons", '\\', ':');
+    unsigned int ret = wstr_escape(dststr, sizeof(dststr), "test string with one : colons", '\\', ':');
     assert_string_equal(dststr, "test string with one \\: colons");
-    assert_non_null(ret);
+    assert_int_equal(ret, 30);
 }
 
 void test_wstr_escape_corner_colons_escape(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    char * ret = wstr_escape(dststr, ":::test string with multi : colons:::", '\\', ':');
+    unsigned int ret = wstr_escape(dststr, sizeof(dststr), ":::test string with multi : colons:::", '\\', ':');
     assert_string_equal(dststr, "\\:\\:\\:test string with multi \\: colons\\:\\:\\:");
-    assert_non_null(ret);
+    assert_int_equal(ret, 44);
 }
 
 void test_wstr_escape_backslash_and_colons_escape(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    char * ret = wstr_escape(dststr, "\\ \\ \\\\ \\: \\", '\\', ':');
+    unsigned int ret = wstr_escape(dststr, sizeof(dststr), "\\ \\ \\\\ \\: \\", '\\', ':');
     assert_string_equal(dststr, "\\\\ \\\\ \\\\\\\\ \\\\\\: \\\\");
-    assert_non_null(ret);
+    assert_int_equal(ret, 18);
 }
 
 void test_wstr_escape_at_sign_and_asterisk(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    char * ret = wstr_escape(dststr, "@ @@ * # * @@ @", '*', '@');
+    unsigned int ret = wstr_escape(dststr, sizeof(dststr), "@ @@ * # * @@ @", '*', '@');
     assert_string_equal(dststr, "*@ *@*@ ** # ** *@*@ *@");
-    assert_non_null(ret);
+    assert_int_equal(ret, 23);
+}
+
+void test_wstr_escape_buff_overflow(void ** state) {
+
+    char dststr[10];
+
+    unsigned int ret = wstr_escape(dststr, sizeof(dststr), "1 2 3 4 5 6 7", '*', '@');
+    assert_string_equal(dststr, "1 2 3 4 5");
+    assert_int_equal(ret, 9);
+}
+
+void test_wstr_escape_buff_overflow_escape(void ** state) {
+
+    char dststr[10];
+
+    unsigned int ret = wstr_escape(dststr, sizeof(dststr), "1 : 3 : 5 6 7", '\\', ':');
+    assert_string_equal(dststr, "1 \\: 3 \\:");
+    assert_int_equal(ret, 9);
+}
+
+void test_wstr_escape_one_scape(void ** state) {
+
+    char dststr[OS_BUFFER_SIZE];
+
+    unsigned int ret = wstr_escape(dststr, sizeof(dststr), "\\", '\\', ':');
+    assert_string_equal(dststr, "\\\\");
+    assert_int_equal(ret, 2);
 }
 
 void test_wstr_unescape_dststr_null(void ** state) {
 
-    char * ret = wstr_unescape(NULL, "test string without colons", '\\');
-    assert_null(ret);
+    unsigned int ret = wstr_unescape(NULL, 0, "test string without colons", '\\');
+    assert_int_equal(ret, 0);
 }
 
 void test_wstr_unescape_str_null(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    char * ret = wstr_unescape(dststr, NULL, '\\');
-    assert_null(ret);
+    unsigned int ret = wstr_unescape(dststr, sizeof(dststr), NULL, '\\');
+    assert_int_equal(ret, 0);
 }
 
 void test_wstr_unescape_not_escape(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    char * ret = wstr_unescape(dststr, "test string without colons", '\\');
+    unsigned int ret = wstr_unescape(dststr, sizeof(dststr), "test string without colons", '\\');
     assert_string_equal(dststr, "test string without colons");
-    assert_non_null(ret);
+    assert_int_equal(ret, 26);
 }
 
 void test_wstr_unescape_colons_escape(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    char * ret = wstr_unescape(dststr, "test string with one \\: colons", '\\');
+    unsigned int ret = wstr_unescape(dststr, sizeof(dststr), "test string with one \\: colons", '\\');
     assert_string_equal(dststr, "test string with one : colons");
-    assert_non_null(ret);
+    assert_int_equal(ret, 29);
 }
 
 void test_wstr_unescape_corner_colons_escape(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    char * ret = wstr_unescape(dststr, "\\:\\:\\:test string with multi \\: colons\\:\\:\\:", '\\');
+    unsigned int ret = wstr_unescape(dststr, sizeof(dststr), "\\:\\:\\:test string with multi \\: colons\\:\\:\\:", '\\');
     assert_string_equal(dststr, ":::test string with multi : colons:::");
-    assert_non_null(ret);
+    assert_int_equal(ret, 37);
 }
 
 void test_wstr_unescape_backslash_and_colons_escape(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    char * ret = wstr_unescape(dststr, "\\\\ \\\\ \\\\\\\\ \\\\\\: \\\\", '\\');
+    unsigned int ret = wstr_unescape(dststr, sizeof(dststr), "\\\\ \\\\ \\\\\\\\ \\\\\\: \\\\", '\\');
     assert_string_equal(dststr, "\\ \\ \\\\ \\: \\");
-    assert_non_null(ret);
+    assert_int_equal(ret, 11);
 }
 
 void test_wstr_unescape_at_sign_and_asterisk(void ** state) {
 
-    char * ret = NULL;
     char dststr[OS_BUFFER_SIZE];
 
-    ret = wstr_unescape(dststr, "*@ *@*@ ** # ** *@*@ *@", '*');
+    unsigned int ret = wstr_unescape(dststr, sizeof(dststr), "*@ *@*@ ** # ** *@*@ *@", '*');
     assert_string_equal(dststr, "@ @@ * # * @@ @");
-    assert_non_null(ret);
+    assert_int_equal(ret, 15);
+}
+
+void test_wstr_unescape_buff_overflow(void ** state) {
+
+    char dststr[10];
+
+    unsigned int ret = wstr_unescape(dststr, sizeof(dststr), "1 2 3 4 5 6 7", '*');
+    assert_string_equal(dststr, "1 2 3 4 5");
+    assert_int_equal(ret, 9);
+}
+
+void test_wstr_unescape_buff_overflow_escape(void ** state) {
+
+    char dststr[10];
+
+    unsigned int ret = wstr_unescape(dststr, sizeof(dststr), "1 \\: 3 \\: 5 6 7", '\\');
+    assert_string_equal(dststr, "1 : 3 : 5");
+    assert_int_equal(ret, 9);
+}
+
+void test_wstr_unescape_one_scape(void ** state) {
+
+    char dststr[OS_BUFFER_SIZE];
+
+    unsigned int ret = wstr_unescape(dststr, sizeof(dststr), "\\", '\\');
+    assert_string_equal(dststr, "");
+    assert_int_equal(ret, 0);
+}
+
+void test_wstr_unescape_end_scape(void ** state) {
+
+    char dststr[OS_BUFFER_SIZE];
+
+    unsigned int ret = wstr_unescape(dststr, sizeof(dststr), "test \\a b\\", '\\');
+    assert_string_equal(dststr, "test a b");
+    assert_int_equal(ret, 8);
 }
 
 void test_wstr_chr_str_eof(void ** state) {
@@ -984,6 +1046,9 @@ int main(void) {
         cmocka_unit_test(test_wstr_escape_corner_colons_escape),
         cmocka_unit_test(test_wstr_escape_backslash_and_colons_escape),
         cmocka_unit_test(test_wstr_escape_at_sign_and_asterisk),
+        cmocka_unit_test(test_wstr_escape_buff_overflow),
+        cmocka_unit_test(test_wstr_escape_buff_overflow_escape),
+        cmocka_unit_test(test_wstr_escape_one_scape),
         // Test wstr_unescape
         cmocka_unit_test(test_wstr_unescape_dststr_null),
         cmocka_unit_test(test_wstr_unescape_str_null),
@@ -992,6 +1057,10 @@ int main(void) {
         cmocka_unit_test(test_wstr_unescape_corner_colons_escape),
         cmocka_unit_test(test_wstr_unescape_backslash_and_colons_escape),
         cmocka_unit_test(test_wstr_unescape_at_sign_and_asterisk),
+        cmocka_unit_test(test_wstr_unescape_buff_overflow),
+        cmocka_unit_test(test_wstr_unescape_buff_overflow_escape),
+        cmocka_unit_test(test_wstr_unescape_one_scape),
+        cmocka_unit_test(test_wstr_unescape_end_scape),
         // Test wstr_chr
         cmocka_unit_test(test_wstr_chr_str_eof),
         cmocka_unit_test(test_wstr_chr_str_without_character),

--- a/src/unit_tests/shared/test_string_op.c
+++ b/src/unit_tests/shared/test_string_op.c
@@ -737,18 +737,168 @@ void test_os_shell_double_escape(void ** state) {
     os_free(ret2);
 }
 
-void test_strarray_size_null() {
+void test_strarray_size_null(void ** state) {
     assert_int_equal(strarray_size(0), 0);
 }
 
-void test_strarray_size_zero() {
+void test_strarray_size_zero(void ** state) {
     char *str_array[] = {0};
     assert_int_equal(strarray_size(str_array), 0);
 }
 
-void test_strarray_size() {
+void test_strarray_size(void ** state) {
     char *str_array[] = {"one", "two", "three", "four", "five", 0};
     assert_int_equal(strarray_size(str_array), 5);
+}
+
+void test_wstr_escape_dststr_null(void ** state) {
+
+    char * ret = wstr_escape(NULL, "test string without colons", '\\', ':');
+    assert_null(ret);
+}
+
+void test_wstr_escape_str_null(void ** state) {
+
+    char dststr[OS_BUFFER_SIZE];
+
+    char * ret = wstr_escape(dststr, NULL, '\\', ':');
+    assert_null(ret);
+}
+
+void test_wstr_escape_not_escape(void ** state) {
+
+    char dststr[OS_BUFFER_SIZE];
+
+    char * ret = wstr_escape(dststr, "test string without colons", '\\', ':');
+    assert_string_equal(dststr, "test string without colons");
+    assert_non_null(ret);
+}
+
+void test_wstr_escape_colons_escape(void ** state) {
+
+    char dststr[OS_BUFFER_SIZE];
+
+    char * ret = wstr_escape(dststr, "test string with one : colons", '\\', ':');
+    assert_string_equal(dststr, "test string with one \\: colons");
+    assert_non_null(ret);
+}
+
+void test_wstr_escape_corner_colons_escape(void ** state) {
+
+    char dststr[OS_BUFFER_SIZE];
+
+    char * ret = wstr_escape(dststr, ":::test string with multi : colons:::", '\\', ':');
+    assert_string_equal(dststr, "\\:\\:\\:test string with multi \\: colons\\:\\:\\:");
+    assert_non_null(ret);
+}
+
+void test_wstr_escape_backslash_and_colons_escape(void ** state) {
+
+    char dststr[OS_BUFFER_SIZE];
+
+    char * ret = wstr_escape(dststr, "\\ \\ \\\\ \\: \\", '\\', ':');
+    assert_string_equal(dststr, "\\\\ \\\\ \\\\\\\\ \\\\\\: \\\\");
+    assert_non_null(ret);
+}
+
+void test_wstr_escape_at_sign_and_asterisk(void ** state) {
+
+    char dststr[OS_BUFFER_SIZE];
+
+    char * ret = wstr_escape(dststr, "@ @@ * # * @@ @", '*', '@');
+    assert_string_equal(dststr, "*@ *@*@ ** # ** *@*@ *@");
+    assert_non_null(ret);
+}
+
+void test_wstr_unescape_dststr_null(void ** state) {
+
+    char * ret = wstr_unescape(NULL, "test string without colons", '\\');
+    assert_null(ret);
+}
+
+void test_wstr_unescape_str_null(void ** state) {
+
+    char dststr[OS_BUFFER_SIZE];
+
+    char * ret = wstr_unescape(dststr, NULL, '\\');
+    assert_null(ret);
+}
+
+void test_wstr_unescape_not_escape(void ** state) {
+
+    char dststr[OS_BUFFER_SIZE];
+
+    char * ret = wstr_unescape(dststr, "test string without colons", '\\');
+    assert_string_equal(dststr, "test string without colons");
+    assert_non_null(ret);
+}
+
+void test_wstr_unescape_colons_escape(void ** state) {
+
+    char dststr[OS_BUFFER_SIZE];
+
+    char * ret = wstr_unescape(dststr, "test string with one \\: colons", '\\');
+    assert_string_equal(dststr, "test string with one : colons");
+    assert_non_null(ret);
+}
+
+void test_wstr_unescape_corner_colons_escape(void ** state) {
+
+    char dststr[OS_BUFFER_SIZE];
+
+    char * ret = wstr_unescape(dststr, "\\:\\:\\:test string with multi \\: colons\\:\\:\\:", '\\');
+    assert_string_equal(dststr, ":::test string with multi : colons:::");
+    assert_non_null(ret);
+}
+
+void test_wstr_unescape_backslash_and_colons_escape(void ** state) {
+
+    char dststr[OS_BUFFER_SIZE];
+
+    char * ret = wstr_unescape(dststr, "\\\\ \\\\ \\\\\\\\ \\\\\\: \\\\", '\\');
+    assert_string_equal(dststr, "\\ \\ \\\\ \\: \\");
+    assert_non_null(ret);
+}
+
+void test_wstr_unescape_at_sign_and_asterisk(void ** state) {
+
+    char * ret = NULL;
+    char dststr[OS_BUFFER_SIZE];
+
+    ret = wstr_unescape(dststr, "*@ *@*@ ** # ** *@*@ *@", '*');
+    assert_string_equal(dststr, "@ @@ * # * @@ @");
+    assert_non_null(ret);
+}
+
+void test_wstr_chr_str_eof(void ** state) {
+
+    char * ret = wstr_chr("\0", ':');
+    assert_null(ret);
+}
+
+void test_wstr_chr_str_without_character(void ** state) {
+
+    char str[OS_BUFFER_SIZE] = "test string without colons";
+    char * ret = wstr_chr(str, ':');
+    assert_null(ret);
+}
+
+void test_wstr_chr_str_without_escaped_colons(void ** state) {
+
+    char str[OS_BUFFER_SIZE] = "test string with : escaped colons";
+    char * ret = wstr_chr(str, ':');
+    assert_non_null(ret);
+    assert_ptr_equal(ret, str+17);
+    assert_int_equal(*ret, str[17]);
+}
+
+void test_wstr_chr_str_with_escaped_colons(void ** state) {
+
+    char str[OS_BUFFER_SIZE] = "test string with \\: escaped : colons";
+    char * ret = wstr_chr(str, ':');
+    assert_non_null(ret);
+    assert_ptr_equal(ret, str+28);
+    assert_int_equal(*ret, str[28]);
 }
 
 /* Tests */
@@ -814,7 +964,6 @@ int main(void) {
         cmocka_unit_test(test_w_strcat_list_empty_list),
         cmocka_unit_test(test_w_strcat_list_one_element_list),
         cmocka_unit_test(test_w_strcat_list_large_list),
-
         // Test os_shell_escape
         cmocka_unit_test(test_os_shell_escape_already_escaped),
         cmocka_unit_test(test_os_shell_escape_not_escaped),
@@ -823,10 +972,32 @@ int main(void) {
         cmocka_unit_test(test_os_shell_avoid_escape_all),
         cmocka_unit_test(test_os_shell_escape_backslash),
         cmocka_unit_test(test_os_shell_double_escape),
-
+        // Test strarray_size
         cmocka_unit_test(test_strarray_size_null),
         cmocka_unit_test(test_strarray_size_zero),
-        cmocka_unit_test(test_strarray_size)
+        cmocka_unit_test(test_strarray_size),
+        // Test wstr_escape
+        cmocka_unit_test(test_wstr_escape_dststr_null),
+        cmocka_unit_test(test_wstr_escape_str_null),
+        cmocka_unit_test(test_wstr_escape_not_escape),
+        cmocka_unit_test(test_wstr_escape_colons_escape),
+        cmocka_unit_test(test_wstr_escape_corner_colons_escape),
+        cmocka_unit_test(test_wstr_escape_backslash_and_colons_escape),
+        cmocka_unit_test(test_wstr_escape_at_sign_and_asterisk),
+        // Test wstr_unescape
+        cmocka_unit_test(test_wstr_unescape_dststr_null),
+        cmocka_unit_test(test_wstr_unescape_str_null),
+        cmocka_unit_test(test_wstr_unescape_not_escape),
+        cmocka_unit_test(test_wstr_unescape_colons_escape),
+        cmocka_unit_test(test_wstr_unescape_corner_colons_escape),
+        cmocka_unit_test(test_wstr_unescape_backslash_and_colons_escape),
+        cmocka_unit_test(test_wstr_unescape_at_sign_and_asterisk),
+        // Test wstr_chr
+        cmocka_unit_test(test_wstr_chr_str_eof),
+        cmocka_unit_test(test_wstr_chr_str_without_character),
+        cmocka_unit_test(test_wstr_chr_str_without_escaped_colons),
+        cmocka_unit_test(test_wstr_chr_str_with_escaped_colons),
+
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/shared/test_string_op.c
+++ b/src/unit_tests/shared/test_string_op.c
@@ -819,6 +819,52 @@ void test_wstr_escape_buff_overflow(void ** state) {
     assert_int_equal(ret, 9);
 }
 
+void test_wstr_escape_buff_overflow_escape_same_size(void ** state) {
+
+    char dststr[9];
+
+    ssize_t ret = wstr_escape(dststr, sizeof(dststr), "123456789", '\\', ':');
+    assert_string_equal(dststr, "12345678");
+    assert_int_equal(ret, 8);
+}
+
+
+void test_wstr_escape_buff_overflow_escape_same_size_colons(void ** state) {
+
+    char dststr[9];
+
+    ssize_t ret = wstr_escape(dststr, sizeof(dststr), "12345678:", '\\', ':');
+    assert_string_equal(dststr, "12345678");
+    assert_int_equal(ret, 8);
+}
+
+void test_wstr_escape_buff_overflow_escape_same_size_before_last_colons(void ** state) {
+
+    char dststr[9];
+
+    ssize_t ret = wstr_escape(dststr, sizeof(dststr), "1234567:9", '\\', ':');
+    assert_string_equal(dststr, "1234567");
+    assert_int_equal(ret, 7);
+}
+
+void test_wstr_escape_buff_overflow_escape_same_size_last_before_last_colons(void ** state) {
+
+    char dststr[9];
+
+    ssize_t ret = wstr_escape(dststr, sizeof(dststr), "1234567::", '\\', ':');
+    assert_string_equal(dststr, "1234567");
+    assert_int_equal(ret, 7);
+}
+
+void test_wstr_escape_buff_overflow_escape_same_size_multi_colons(void ** state) {
+
+    char dststr[9];
+
+    ssize_t ret = wstr_escape(dststr, sizeof(dststr), "123456:::", '\\', ':');
+    assert_string_equal(dststr, "123456\\:");
+    assert_int_equal(ret, 8);
+}
+
 void test_wstr_escape_buff_overflow_escape(void ** state) {
 
     char dststr[10];
@@ -903,6 +949,33 @@ void test_wstr_unescape_buff_overflow(void ** state) {
     ssize_t ret = wstr_unescape(dststr, sizeof(dststr), "1 2 3 4 5 6 7", '*');
     assert_string_equal(dststr, "1 2 3 4 5");
     assert_int_equal(ret, 9);
+}
+
+void test_wstr_unescape_buff_overflow_same_size(void ** state) {
+
+    char dststr[9];
+
+    ssize_t ret = wstr_unescape(dststr, sizeof(dststr), "1234567*9", '*');
+    assert_string_equal(dststr, "12345679");
+    assert_int_equal(ret, 8);
+}
+
+void test_wstr_unescape_buff_overflow_same_size_last_escape(void ** state) {
+
+    char dststr[9];
+
+    ssize_t ret = wstr_unescape(dststr, sizeof(dststr), "12345678*", '*');
+    assert_string_equal(dststr, "12345678");
+    assert_int_equal(ret, 8);
+}
+
+void test_wstr_unescape_buff_overflow_same_size_last_escape_asterisk(void ** state) {
+
+    char dststr[9];
+
+    ssize_t ret = wstr_unescape(dststr, sizeof(dststr), "1234567**", '*');
+    assert_string_equal(dststr, "1234567*");
+    assert_int_equal(ret, 8);
 }
 
 void test_wstr_unescape_buff_overflow_escape(void ** state) {
@@ -1047,6 +1120,11 @@ int main(void) {
         cmocka_unit_test(test_wstr_escape_backslash_and_colons_escape),
         cmocka_unit_test(test_wstr_escape_at_sign_and_asterisk),
         cmocka_unit_test(test_wstr_escape_buff_overflow),
+        cmocka_unit_test(test_wstr_escape_buff_overflow_escape_same_size),
+        cmocka_unit_test(test_wstr_escape_buff_overflow_escape_same_size_colons),
+        cmocka_unit_test(test_wstr_escape_buff_overflow_escape_same_size_before_last_colons),
+        cmocka_unit_test(test_wstr_escape_buff_overflow_escape_same_size_last_before_last_colons),
+        cmocka_unit_test(test_wstr_escape_buff_overflow_escape_same_size_multi_colons),
         cmocka_unit_test(test_wstr_escape_buff_overflow_escape),
         cmocka_unit_test(test_wstr_escape_one_scape),
         // Test wstr_unescape
@@ -1058,6 +1136,9 @@ int main(void) {
         cmocka_unit_test(test_wstr_unescape_backslash_and_colons_escape),
         cmocka_unit_test(test_wstr_unescape_at_sign_and_asterisk),
         cmocka_unit_test(test_wstr_unescape_buff_overflow),
+        cmocka_unit_test(test_wstr_unescape_buff_overflow_same_size),
+        cmocka_unit_test(test_wstr_unescape_buff_overflow_same_size_last_escape),
+        cmocka_unit_test(test_wstr_unescape_buff_overflow_same_size_last_escape_asterisk),
         cmocka_unit_test(test_wstr_unescape_buff_overflow_escape),
         cmocka_unit_test(test_wstr_unescape_one_scape),
         cmocka_unit_test(test_wstr_unescape_end_scape),

--- a/src/unit_tests/shared/test_string_op.c
+++ b/src/unit_tests/shared/test_string_op.c
@@ -754,7 +754,7 @@ void test_strarray_size(void ** state) {
 void test_wstr_escape_dststr_null(void ** state) {
 
     ssize_t ret = wstr_escape(NULL, 0, "test string without colons", '\\', ':');
-    assert_int_equal(ret, -1);
+    assert_int_equal(ret, OS_INVALID);
 }
 
 void test_wstr_escape_str_null(void ** state) {
@@ -762,7 +762,7 @@ void test_wstr_escape_str_null(void ** state) {
     char dststr[OS_BUFFER_SIZE];
 
     ssize_t ret = wstr_escape(dststr, sizeof(dststr), NULL, '\\', ':');
-    assert_int_equal(ret, -1);
+    assert_int_equal(ret, OS_INVALID);
 }
 
 void test_wstr_escape_not_escape(void ** state) {
@@ -840,7 +840,7 @@ void test_wstr_escape_one_scape(void ** state) {
 void test_wstr_unescape_dststr_null(void ** state) {
 
     ssize_t ret = wstr_unescape(NULL, 0, "test string without colons", '\\');
-    assert_int_equal(ret, -1);
+    assert_int_equal(ret, OS_INVALID);
 }
 
 void test_wstr_unescape_str_null(void ** state) {
@@ -848,7 +848,7 @@ void test_wstr_unescape_str_null(void ** state) {
     char dststr[OS_BUFFER_SIZE];
 
     ssize_t ret = wstr_unescape(dststr, sizeof(dststr), NULL, '\\');
-    assert_int_equal(ret, -1);
+    assert_int_equal(ret, OS_INVALID);
 }
 
 void test_wstr_unescape_not_escape(void ** state) {

--- a/src/unit_tests/shared/test_string_op.c
+++ b/src/unit_tests/shared/test_string_op.c
@@ -787,8 +787,8 @@ void test_wstr_escape_corner_colons_escape(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    ssize_t ret = wstr_escape(dststr, sizeof(dststr), ":::test string with multi : colons:::", '\\', ':');
-    assert_string_equal(dststr, "\\:\\:\\:test string with multi \\: colons\\:\\:\\:");
+    ssize_t ret = wstr_escape(dststr, sizeof(dststr), ":::test string with multi : colons:::", '|', ':');
+    assert_string_equal(dststr, "|:|:|:test string with multi |: colons|:|:|:");
     assert_int_equal(ret, 44);
 }
 
@@ -873,7 +873,7 @@ void test_wstr_unescape_corner_colons_escape(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    ssize_t ret = wstr_unescape(dststr, sizeof(dststr), "\\:\\:\\:test string with multi \\: colons\\:\\:\\:", '\\');
+    ssize_t ret = wstr_unescape(dststr, sizeof(dststr), "|:|:|:test string with multi |: colons|:|:|:", '|');
     assert_string_equal(dststr, ":::test string with multi : colons:::");
     assert_int_equal(ret, 37);
 }
@@ -934,21 +934,21 @@ void test_wstr_unescape_end_scape(void ** state) {
 
 void test_wstr_chr_str_eof(void ** state) {
 
-    char * ret = wstr_chr("\0", ':');
+    char * ret = wstr_chr_escape("\0", ':', '\\');
     assert_null(ret);
 }
 
 void test_wstr_chr_str_without_character(void ** state) {
 
     char str[OS_BUFFER_SIZE] = "test string without colons";
-    char * ret = wstr_chr(str, ':');
+    char * ret = wstr_chr_escape(str, ':', '\\');
     assert_null(ret);
 }
 
 void test_wstr_chr_str_without_escaped_colons(void ** state) {
 
     char str[OS_BUFFER_SIZE] = "test string with : escaped colons";
-    char * ret = wstr_chr(str, ':');
+    char * ret = wstr_chr_escape(str, ':', '\\');
     assert_non_null(ret);
     assert_ptr_equal(ret, str+17);
     assert_int_equal(*ret, str[17]);
@@ -957,7 +957,7 @@ void test_wstr_chr_str_without_escaped_colons(void ** state) {
 void test_wstr_chr_str_with_escaped_colons(void ** state) {
 
     char str[OS_BUFFER_SIZE] = "test string with \\: escaped : colons";
-    char * ret = wstr_chr(str, ':');
+    char * ret = wstr_chr_escape(str, ':', '\\');
     assert_non_null(ret);
     assert_ptr_equal(ret, str+28);
     assert_int_equal(*ret, str[28]);

--- a/src/unit_tests/shared/test_string_op.c
+++ b/src/unit_tests/shared/test_string_op.c
@@ -753,23 +753,23 @@ void test_strarray_size(void ** state) {
 
 void test_wstr_escape_dststr_null(void ** state) {
 
-    unsigned int ret = wstr_escape(NULL, 0, "test string without colons", '\\', ':');
-    assert_int_equal(ret, 0);
+    ssize_t ret = wstr_escape(NULL, 0, "test string without colons", '\\', ':');
+    assert_int_equal(ret, -1);
 }
 
 void test_wstr_escape_str_null(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    unsigned int ret = wstr_escape(dststr, sizeof(dststr), NULL, '\\', ':');
-    assert_int_equal(ret, 0);
+    ssize_t ret = wstr_escape(dststr, sizeof(dststr), NULL, '\\', ':');
+    assert_int_equal(ret, -1);
 }
 
 void test_wstr_escape_not_escape(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    unsigned int ret = wstr_escape(dststr, sizeof(dststr), "test string without colons", '\\', ':');
+    ssize_t ret = wstr_escape(dststr, sizeof(dststr), "test string without colons", '\\', ':');
     assert_string_equal(dststr, "test string without colons");
     assert_int_equal(ret, 26);
 }
@@ -778,7 +778,7 @@ void test_wstr_escape_colons_escape(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    unsigned int ret = wstr_escape(dststr, sizeof(dststr), "test string with one : colons", '\\', ':');
+    ssize_t ret = wstr_escape(dststr, sizeof(dststr), "test string with one : colons", '\\', ':');
     assert_string_equal(dststr, "test string with one \\: colons");
     assert_int_equal(ret, 30);
 }
@@ -787,7 +787,7 @@ void test_wstr_escape_corner_colons_escape(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    unsigned int ret = wstr_escape(dststr, sizeof(dststr), ":::test string with multi : colons:::", '\\', ':');
+    ssize_t ret = wstr_escape(dststr, sizeof(dststr), ":::test string with multi : colons:::", '\\', ':');
     assert_string_equal(dststr, "\\:\\:\\:test string with multi \\: colons\\:\\:\\:");
     assert_int_equal(ret, 44);
 }
@@ -796,7 +796,7 @@ void test_wstr_escape_backslash_and_colons_escape(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    unsigned int ret = wstr_escape(dststr, sizeof(dststr), "\\ \\ \\\\ \\: \\", '\\', ':');
+    ssize_t ret = wstr_escape(dststr, sizeof(dststr), "\\ \\ \\\\ \\: \\", '\\', ':');
     assert_string_equal(dststr, "\\\\ \\\\ \\\\\\\\ \\\\\\: \\\\");
     assert_int_equal(ret, 18);
 }
@@ -805,7 +805,7 @@ void test_wstr_escape_at_sign_and_asterisk(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    unsigned int ret = wstr_escape(dststr, sizeof(dststr), "@ @@ * # * @@ @", '*', '@');
+    ssize_t ret = wstr_escape(dststr, sizeof(dststr), "@ @@ * # * @@ @", '*', '@');
     assert_string_equal(dststr, "*@ *@*@ ** # ** *@*@ *@");
     assert_int_equal(ret, 23);
 }
@@ -814,7 +814,7 @@ void test_wstr_escape_buff_overflow(void ** state) {
 
     char dststr[10];
 
-    unsigned int ret = wstr_escape(dststr, sizeof(dststr), "1 2 3 4 5 6 7", '*', '@');
+    ssize_t ret = wstr_escape(dststr, sizeof(dststr), "1 2 3 4 5 6 7", '*', '@');
     assert_string_equal(dststr, "1 2 3 4 5");
     assert_int_equal(ret, 9);
 }
@@ -823,7 +823,7 @@ void test_wstr_escape_buff_overflow_escape(void ** state) {
 
     char dststr[10];
 
-    unsigned int ret = wstr_escape(dststr, sizeof(dststr), "1 : 3 : 5 6 7", '\\', ':');
+    ssize_t ret = wstr_escape(dststr, sizeof(dststr), "1 : 3 : 5 6 7", '\\', ':');
     assert_string_equal(dststr, "1 \\: 3 \\:");
     assert_int_equal(ret, 9);
 }
@@ -832,30 +832,30 @@ void test_wstr_escape_one_scape(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    unsigned int ret = wstr_escape(dststr, sizeof(dststr), "\\", '\\', ':');
+    ssize_t ret = wstr_escape(dststr, sizeof(dststr), "\\", '\\', ':');
     assert_string_equal(dststr, "\\\\");
     assert_int_equal(ret, 2);
 }
 
 void test_wstr_unescape_dststr_null(void ** state) {
 
-    unsigned int ret = wstr_unescape(NULL, 0, "test string without colons", '\\');
-    assert_int_equal(ret, 0);
+    ssize_t ret = wstr_unescape(NULL, 0, "test string without colons", '\\');
+    assert_int_equal(ret, -1);
 }
 
 void test_wstr_unescape_str_null(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    unsigned int ret = wstr_unescape(dststr, sizeof(dststr), NULL, '\\');
-    assert_int_equal(ret, 0);
+    ssize_t ret = wstr_unescape(dststr, sizeof(dststr), NULL, '\\');
+    assert_int_equal(ret, -1);
 }
 
 void test_wstr_unescape_not_escape(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    unsigned int ret = wstr_unescape(dststr, sizeof(dststr), "test string without colons", '\\');
+    ssize_t ret = wstr_unescape(dststr, sizeof(dststr), "test string without colons", '\\');
     assert_string_equal(dststr, "test string without colons");
     assert_int_equal(ret, 26);
 }
@@ -864,7 +864,7 @@ void test_wstr_unescape_colons_escape(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    unsigned int ret = wstr_unescape(dststr, sizeof(dststr), "test string with one \\: colons", '\\');
+    ssize_t ret = wstr_unescape(dststr, sizeof(dststr), "test string with one \\: colons", '\\');
     assert_string_equal(dststr, "test string with one : colons");
     assert_int_equal(ret, 29);
 }
@@ -873,7 +873,7 @@ void test_wstr_unescape_corner_colons_escape(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    unsigned int ret = wstr_unescape(dststr, sizeof(dststr), "\\:\\:\\:test string with multi \\: colons\\:\\:\\:", '\\');
+    ssize_t ret = wstr_unescape(dststr, sizeof(dststr), "\\:\\:\\:test string with multi \\: colons\\:\\:\\:", '\\');
     assert_string_equal(dststr, ":::test string with multi : colons:::");
     assert_int_equal(ret, 37);
 }
@@ -882,7 +882,7 @@ void test_wstr_unescape_backslash_and_colons_escape(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    unsigned int ret = wstr_unescape(dststr, sizeof(dststr), "\\\\ \\\\ \\\\\\\\ \\\\\\: \\\\", '\\');
+    ssize_t ret = wstr_unescape(dststr, sizeof(dststr), "\\\\ \\\\ \\\\\\\\ \\\\\\: \\\\", '\\');
     assert_string_equal(dststr, "\\ \\ \\\\ \\: \\");
     assert_int_equal(ret, 11);
 }
@@ -891,7 +891,7 @@ void test_wstr_unescape_at_sign_and_asterisk(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    unsigned int ret = wstr_unescape(dststr, sizeof(dststr), "*@ *@*@ ** # ** *@*@ *@", '*');
+    ssize_t ret = wstr_unescape(dststr, sizeof(dststr), "*@ *@*@ ** # ** *@*@ *@", '*');
     assert_string_equal(dststr, "@ @@ * # * @@ @");
     assert_int_equal(ret, 15);
 }
@@ -900,7 +900,7 @@ void test_wstr_unescape_buff_overflow(void ** state) {
 
     char dststr[10];
 
-    unsigned int ret = wstr_unescape(dststr, sizeof(dststr), "1 2 3 4 5 6 7", '*');
+    ssize_t ret = wstr_unescape(dststr, sizeof(dststr), "1 2 3 4 5 6 7", '*');
     assert_string_equal(dststr, "1 2 3 4 5");
     assert_int_equal(ret, 9);
 }
@@ -909,7 +909,7 @@ void test_wstr_unescape_buff_overflow_escape(void ** state) {
 
     char dststr[10];
 
-    unsigned int ret = wstr_unescape(dststr, sizeof(dststr), "1 \\: 3 \\: 5 6 7", '\\');
+    ssize_t ret = wstr_unescape(dststr, sizeof(dststr), "1 \\: 3 \\: 5 6 7", '\\');
     assert_string_equal(dststr, "1 : 3 : 5");
     assert_int_equal(ret, 9);
 }
@@ -918,18 +918,18 @@ void test_wstr_unescape_one_scape(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    unsigned int ret = wstr_unescape(dststr, sizeof(dststr), "\\", '\\');
-    assert_string_equal(dststr, "");
-    assert_int_equal(ret, 0);
+    ssize_t ret = wstr_unescape(dststr, sizeof(dststr), "\\", '\\');
+    assert_string_equal(dststr, "\\");
+    assert_int_equal(ret, 1);
 }
 
 void test_wstr_unescape_end_scape(void ** state) {
 
     char dststr[OS_BUFFER_SIZE];
 
-    unsigned int ret = wstr_unescape(dststr, sizeof(dststr), "test \\a b\\", '\\');
-    assert_string_equal(dststr, "test a b");
-    assert_int_equal(ret, 8);
+    ssize_t ret = wstr_unescape(dststr, sizeof(dststr), "test \\a b\\", '\\');
+    assert_string_equal(dststr, "test a b\\");
+    assert_int_equal(ret, 9);
 }
 
 void test_wstr_chr_str_eof(void ** state) {

--- a/src/unit_tests/win32/CMakeLists.txt
+++ b/src/unit_tests/win32/CMakeLists.txt
@@ -28,7 +28,7 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 
 # Generate win32 tests
 list(APPEND win32_names "test_win_utils")
-list(APPEND win32_flags "-Wl,--wrap,cJSON_GetObjectItem -Wl,--wrap,cJSON_GetArraySize \
+list(APPEND win32_flags "-Wl,--wrap,cJSON_GetObjectItem -Wl,--wrap,cJSON_GetArraySize -Wl,--wrap,send_msg \
                         -Wl,--wrap,cJSON_GetArrayItem -Wl,--wrap,cJSON_GetStringValue -Wl,--wrap,time \
                         ${DEBUG_OP_WRAPPERS}")
 

--- a/src/unit_tests/wrappers/windows/libc/kernel32_wrappers.c
+++ b/src/unit_tests/wrappers/windows/libc/kernel32_wrappers.c
@@ -15,7 +15,6 @@
 #include <string.h>
 #include "kernel32_wrappers.h"
 
-
 DWORD wrap_WaitForSingleObject(HANDLE hMutex, long value) {
     check_expected(hMutex);
     check_expected(value);

--- a/src/unit_tests/wrappers/windows/libc/kernel32_wrappers.c
+++ b/src/unit_tests/wrappers/windows/libc/kernel32_wrappers.c
@@ -1,0 +1,28 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <string.h>
+#include "kernel32_wrappers.h"
+
+
+DWORD wrap_WaitForSingleObject(HANDLE hMutex, long value) {
+    check_expected(hMutex);
+    check_expected(value);
+    return mock();
+}
+
+bool wrap_ReleaseMutex(HANDLE hMutex) {
+    check_expected(hMutex);
+    return mock();
+}

--- a/src/unit_tests/wrappers/windows/libc/kernel32_wrappers.h
+++ b/src/unit_tests/wrappers/windows/libc/kernel32_wrappers.h
@@ -1,0 +1,26 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+
+#ifndef KERNEL32_WRAPPERS_WINDOWS_H
+#define KERNEL32_WRAPPERS_WINDOWS_H
+
+#include "shared.h"
+
+#undef WaitForSingleObject
+#define WaitForSingleObject wrap_WaitForSingleObject
+#undef ReleaseMutex
+#define ReleaseMutex wrap_ReleaseMutex
+
+
+DWORD wrap_WaitForSingleObject(HANDLE hMutex, long value);
+
+bool wrap_ReleaseMutex(HANDLE hMutex);
+
+#endif

--- a/src/unit_tests/wrappers/windows/libc/kernel32_wrappers.h
+++ b/src/unit_tests/wrappers/windows/libc/kernel32_wrappers.h
@@ -11,16 +11,16 @@
 #ifndef KERNEL32_WRAPPERS_WINDOWS_H
 #define KERNEL32_WRAPPERS_WINDOWS_H
 
-#include "shared.h"
+#include <stdbool.h>
+#include <windows.h>
+
+DWORD wrap_WaitForSingleObject(HANDLE hMutex, long value);
+
+bool wrap_ReleaseMutex(HANDLE hMutex);
 
 #undef WaitForSingleObject
 #define WaitForSingleObject wrap_WaitForSingleObject
 #undef ReleaseMutex
 #define ReleaseMutex wrap_ReleaseMutex
-
-
-DWORD wrap_WaitForSingleObject(HANDLE hMutex, long value);
-
-bool wrap_ReleaseMutex(HANDLE hMutex);
 
 #endif

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -20,9 +20,7 @@
 
 #ifdef WAZUH_UNIT_TESTING
 #include "unit_tests/wrappers/windows/libc/kernel32_wrappers.h"
-#include "unit_tests/win32/test_win_utils.c"
 #endif
-
 
 HANDLE hMutex;
 int win_debug_level;

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -18,6 +18,12 @@
 #include "sym_load.h"
 #include "../os_net/os_net.h"
 
+#ifdef WAZUH_UNIT_TESTING
+#include "unit_tests/wrappers/windows/libc/kernel32_wrappers.h"
+#include "unit_tests/win32/test_win_utils.c"
+#endif
+
+
 HANDLE hMutex;
 int win_debug_level;
 
@@ -322,7 +328,7 @@ int SendMSGAction(__attribute__((unused)) int queue, const char *message, const 
 
     if (OS_INVALID == wstr_escape(loc_buff, sizeof(loc_buff), (char *) locmsg, '|', ':')) {
         merror(FORMAT_ERROR);
-        return (retval);
+        return retval;
     }
 
     snprintf(tmpstr, OS_MAXSTR, "%c:%s:%s", loc, loc_buff, message);

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -291,7 +291,7 @@ int local_start()
 /* SendMSGAction for Windows */
 int SendMSGAction(__attribute__((unused)) int queue, const char *message, const char *locmsg, char loc)
 {
-    const char *pl;
+    char loc_buff[OS_SIZE_8192 + 1] = {0};
     char tmpstr[OS_MAXSTR + 2];
     DWORD dwWaitResult;
     int retval = -1;
@@ -320,16 +320,12 @@ int SendMSGAction(__attribute__((unused)) int queue, const char *message, const 
         }
     }   /* end - while for mutex... */
 
-    /* locmsg cannot have the C:, as we use it as delimiter */
-    pl = strchr(locmsg, ':');
-    if (pl) {
-        /* Set pl after the ":" if it exists */
-        pl++;
-    } else {
-        pl = locmsg;
+    if (OS_INVALID == wstr_escape(loc_buff, sizeof(loc_buff), (char *) locmsg, '|', ':')) {
+        merror(FORMAT_ERROR);
+        return (retval);
     }
 
-    snprintf(tmpstr, OS_MAXSTR, "%c:%s:%s", loc, pl, message);
+    snprintf(tmpstr, OS_MAXSTR, "%c:%s:%s", loc, loc_buff, message);
 
     /* Send events to the manager across the buffer */
     if (!agt->buffer){


### PR DESCRIPTION
|Related issues|Manual Testing|
|---|---|
|https://github.com/wazuh/wazuh/issues/13708 https://github.com/wazuh/wazuh/issues/10489 https://github.com/wazuh/wazuh/issues/14886|https://github.com/wazuh/wazuh-qa/issues/3244 https://github.com/wazuh/wazuh-qa/issues/3367|

## Description

Syslog messages received by the Wazuh Syslog server (remoted) via IPv6 are correctly handled, the `location` and `full_log` fields are correctly parsed (splitted).
Same behavior applies when logcolletor location message includes colons in the file name.

## Use case 

Remote Syslog messages are received on the Wazuh manager, from a device which address is of the IPv6 format.

### Configuracion

To test ipv syslog collection set on ossec.conf file:

```xml
  <global>
       ...
       <logall_json>yes</logall_json>
       ...
  </global>
  
  <remote>
    <connection>syslog</connection>
    <port>5050</port>
    <protocol>tcp</protocol>
    <ipv6>yes</ipv6>
    <allowed-ips>any</allowed-ips>
  </remote>
```

To test Logcollector events wrongly parsed for filenames with colons (:), 
set on ossec.conf:

```xml
<localfile>
  <location>PATH/*.log</location>
  <log_format>syslog</log_format>
</localfile>
```

## Steps to reproduce

-  Send a Syslog message from an IPv6 address (in this case, through the loopback interface).
    ```bash
    echo "IPv6 test msg" | nc -v -w 0 -6 "::1"  5050
    ```
    or running wazuh-logtest
    ```bash
    /var/ossec/bin/wazuh-logtest -l "0000:0000:0000:0000:0000:0000:0000:0001" -d
    ```
    type any message and press enter
    
    Result
    
    ```json
    {
        "timestamp": "2022-06-03T16:50:16.660+0000",
        "agent": {
            "id": "000",
            "name": "200-u20-dev-manager"
        },
        "manager": {
            "name": "200-u20-dev-manager"
        },
        "id": "1654275016.1163645",
        "full_log": "IPv6 test msg",
        "decoder": {},
        "location": "0000:0000:0000:0000:0000:0000:0000:0001"
    }
    ```
    Testing ipv4
    
    ```bash
    echo "IPv4 test msg" | nc -v -w 0 localhost 505
    ```
    ```json
    {
        "timestamp": "2022-06-03T16:50:16.660+0000",
        "agent": {
            "id": "000",
            "name": "200-u20-dev-manager"
        },
        "manager": {
            "name": "200-u20-dev-manager"
        },
        "id": "1654275016.1163645",
        "full_log": "IPv4 test msg",
        "decoder": {},
        "location": "127.0.0.1"
    }
    ```
-  To test Logcollector events wrongly parsed for filenames with colons (:)
    Creates a file with colons in the name to monitoring in a known path, for example PATH/2022-8-26.00:00:00.log
set on ossec.conf:

    ```xml
    <localfile>
       <location>PATH/*.log</location>
       <log_format>syslog</log_format>
    </localfile>
    ```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)
