### PR TITLE
Stop agent balancing mechanism earlier than expected when it doesn't work

### DIFF
--- a/framework/wazuh/core/cluster/agents_reconnect.py
+++ b/framework/wazuh/core/cluster/agents_reconnect.py
@@ -72,6 +72,8 @@ class AgentsReconnect:
         # Check agents balance
         self.balance_threshold = 3
         self.tolerance = tolerance
+        self.previous_deviation = None
+        self.expected_deviation = 0
 
         # Reconnection phase
         self.expected_rounds = 0
@@ -82,7 +84,7 @@ class AgentsReconnect:
         # General
         self.current_phase = AgentsReconnectionPhases.NOT_STARTED
 
-        # Provisional
+        # Sleep times
         self.posbalance_sleep = 60
         self.agents_connection_delay = 30
 
@@ -114,6 +116,7 @@ class AgentsReconnect:
                 self.nodes_stability_counter = 0
             self.expected_rounds = 0
             self.round_counter = 0
+            self.previous_deviation = None
             self.logger.debug("Reset all counters.")
         else:
             self.logger.debug(f"Disconnected {node_name} node, it is blacklisted, skipping counters reset.")
@@ -347,6 +350,16 @@ class AgentsReconnect:
         NotImplementedError("Not implemented yet")
 
     @staticmethod
+    def absolute_deviation(data):
+        agents_per_worker = [worker_agents['total'] for worker_agents in data.values()]
+        mean = sum(agents_per_worker) / len(agents_per_worker)
+        return sum(abs(item - mean) for item in agents_per_worker)
+
+    @staticmethod
+    def close_to_predicted(predicted, current, old):
+        return predicted == min([predicted, old], key=lambda x: abs(x - current))
+
+    @staticmethod
     def predict_distribution(nodes_info, max_assignments_per_node, calculate_rounds=False) -> dict:
         """Predict how reconnected agents will be distributed.
 
@@ -406,7 +419,8 @@ class AgentsReconnect:
                 moved_agents[smallest_node] += 1
                 not calculate_rounds and agents_id.append(nodes_info_cpy[biggest_node]['agents'].pop())
 
-        return {'agents': agents_id, 'rounds': rounds, 'partial_balance': partial_balance}
+        return {'agents': agents_id, 'rounds': rounds, 'partial_balance': partial_balance,
+                'distribution': nodes_info_cpy}
 
     async def reconnect_agents(self, agents_to_reconnect) -> list:
         """Redistribute agents in cluster.
@@ -487,7 +501,18 @@ class AgentsReconnect:
 
         elif self.round_counter < self.expected_rounds:
             self.round_counter += 1
+            if self.previous_deviation is not None:
+                current_deviation = self.absolute_deviation(self.env_status)
+                more_balanced = self.close_to_predicted(self.expected_deviation, current_deviation,
+                                                        self.previous_deviation)
+                if not more_balanced:
+                    self.logger.warning('Agents are not getting balanced even after reconnection. Something could be '
+                                        'misconfigured. Stopping task.')
+                    self.current_phase = AgentsReconnectionPhases.HALT
+                    return
             predict_info = self.predict_distribution(self.env_status, max_assignments_per_node)
+            self.previous_deviation = self.absolute_deviation(self.env_status)
+            self.expected_deviation = self.absolute_deviation(predict_info['distribution'])
             self.logger.info(f'Reconnecting agents (round {self.round_counter}/{self.expected_rounds}).')
 
         else:
@@ -500,7 +525,7 @@ class AgentsReconnect:
                 return
 
             self.logger.warning(f'Expected number of agent reconnection rounds has been exceeded '
-                                f'({self.round_counter + 1}/{self.expected_rounds}). Stopping this task.')
+                                f'({self.round_counter + 1}/{self.expected_rounds}). Stopping task.')
             self.current_phase = AgentsReconnectionPhases.HALT
             return
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #14681 |

## Description

This PR adds a new mechanism that stops the TCP balancing mechanism before more reconnection rounds are run if agents are not being correctly distributed. 

To achieve this in an efficient way, the Absolute Deviation (AD) is calculated for both, the previous distribution status and the expected/predicted one. If in the next reconnection round the actual distribution is closer to `previous` one than to `expected` one, it means that the mechanism is not working as expected (there could be any reason, for example, agents not using a load balancer). 

This way, the same agents do not receive reconnection requests once and again until the final round is run, which is quite useful when the mechanism is not working.


## Logs/Alerts example

```
2022/08/23 10:46:50 INFO: [Master] [Cluster balance] Cluster is stable.
2022/08/23 10:46:50 INFO: [Master] [Cluster balance] It will take 2 rounds to reconnect 17 agents. Starting a test round for 4 agents.
2022/08/23 10:46:50 INFO: [Master] [Cluster balance] Iteration complete. Sleeping 50 seconds.
2022/08/23 10:47:40 INFO: [Master] [Cluster balance] Cluster is stable.
2022/08/23 10:47:40 INFO: [Master] [Cluster balance] Reconnecting agents (round 1/2).
2022/08/23 10:47:40 INFO: [Master] [Cluster balance] Iteration complete. Sleeping 50 seconds.
2022/08/23 10:48:30 INFO: [Master] [Cluster balance] Cluster is stable.
2022/08/23 10:48:30 WARNING: [Master] [Cluster balance] Agents are not getting balanced even after reconnection. Something could be misconfigured. Stopping task.
2022/08/23 10:48:30 INFO: [Master] [Cluster balance] Halted.
```