### PR TITLE
Transform the `uptime` timestamp to datetime in API responses containing agents and manager statistics 

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -6214,8 +6214,8 @@ paths:
                     - timestamp: 2022-07-27T14:09:20+00:00
                       name: wazuh-remoted
                       agents:
-                        - id: 1
-                          uptime: 2022-07-27T14:09:20+00:00
+                        - uptime: 2022-07-27T14:09:20+00:00
+                          id: 1
                           metrics:
                             messages:
                               received_breakdown:
@@ -6236,8 +6236,8 @@ paths:
                     - timestamp: 2022-07-27T14:09:20+00:00
                       name: wazuh-analysisd
                       agents:
-                        - id: 1
-                          uptime: 2022-07-27T14:09:20+00:00
+                        - uptime: 2022-07-27T14:09:20+00:00
+                          id: 1
                           metrics:
                             events:
                               processed: 195

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1644,12 +1644,21 @@ components:
           format: date-time
         name:
           type: string
-          description: "Demon name"
+          description: "Daemon name"
           enum:
             - wazuh-analysisd
             - wazuh-remoted
-        statistics:
+        agents:
           type: object
+          properties:
+            uptime:
+              type: string
+              format: date-time
+            id:
+              type: integer
+              format: int32
+            metrics:
+              type: object
 
     ## CisCat models
     CiscatResults:
@@ -2065,17 +2074,20 @@ components:
     WazuhDaemonStatsItem:
       type: object
       properties:
+        uptime:
+          type: string
+          format: date-time
         timestamp:
           type: string
           format: date-time
         name:
           type: string
-          description: "Demon name"
+          description: "Daemon name"
           enum:
             - wazuh-analysisd
             - wazuh-remoted
             - wazuh-db
-        statistics:
+        metrics:
           type: object
 
     WazuhDaemonsStatus:
@@ -8946,7 +8958,7 @@ paths:
                     - uptime: 2022-07-27T14:09:20+00:00
                       timestamp: 2022-07-21T10:48:32+00:00
                       name: wazuh-remoted
-                      statistics:
+                      metrics:
                         tcp_sessions: 0
                         received_bytes: 0
                         messages_received_breakdown:
@@ -10442,7 +10454,7 @@ paths:
                     - uptime: 2022-07-27T14:09:20+00:00
                       timestamp: 2022-07-21T10:47:59+00:00
                       name: wazuh-db
-                      statistics:
+                      metrics:
                         queries_total: 1514
                         queries_breakdown:
                           wazuhdb_queries: 0

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -6215,6 +6215,7 @@ paths:
                       name: wazuh-remoted
                       agents:
                         - id: 1
+                          uptime: 2022-07-27T14:09:20+00:00
                           metrics:
                             messages:
                               received_breakdown:
@@ -6236,6 +6237,7 @@ paths:
                       name: wazuh-analysisd
                       agents:
                         - id: 1
+                          uptime: 2022-07-27T14:09:20+00:00
                           metrics:
                             events:
                               processed: 195
@@ -8941,7 +8943,8 @@ paths:
               example:
                 data:
                   affected_items:
-                    - timestamp: 2022-07-21T10:48:32+00:00
+                    - uptime: 2022-07-27T14:09:20+00:00
+                      timestamp: 2022-07-21T10:48:32+00:00
                       name: wazuh-remoted
                       statistics:
                         tcp_sessions: 0
@@ -10436,7 +10439,8 @@ paths:
               example:
                 data:
                   affected_items:
-                    - timestamp: 2022-07-21T10:47:59+00:00
+                    - uptime: 2022-07-27T14:09:20+00:00
+                      timestamp: 2022-07-21T10:47:59+00:00
                       name: wazuh-db
                       statistics:
                         queries_total: 1514

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1649,16 +1649,18 @@ components:
             - wazuh-analysisd
             - wazuh-remoted
         agents:
-          type: object
-          properties:
-            uptime:
-              type: string
-              format: date-time
-            id:
-              type: integer
-              format: int32
-            metrics:
-              type: object
+          type: array
+          items:
+            type: object
+            properties:
+              uptime:
+                type: string
+                format: date-time
+              id:
+                type: integer
+                format: int32
+              metrics:
+                type: object
 
     ## CisCat models
     CiscatResults:

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -2251,11 +2251,13 @@ stages:
               name: wazuh-remoted
               agents:
                 - id: 1
+                  uptime: !anystr
                   metrics: !anything
             - timestamp: !anystr
               name: wazuh-analysisd
               agents:
                 - id: 1
+                  uptime: !anystr
                   metrics: !anything
           failed_items: []
           total_affected_items: 2
@@ -2295,6 +2297,7 @@ stages:
               name: wazuh-remoted
               agents:
                 - id: 1
+                  uptime: !anystr
                   metrics: !anything
           failed_items: []
           total_affected_items: 1

--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -239,11 +239,13 @@ stages:
               name: wazuh-remoted
               agents:
                 - id: 1
+                  uptime: !anystr
                   metrics: !anything
             - timestamp: !anystr
               name: wazuh-analysisd
               agents:
                 - id: 1
+                  uptime: !anystr
                   metrics: !anything
           failed_items: [ ]
           total_affected_items: 2

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -253,11 +253,13 @@ stages:
               name: wazuh-remoted
               agents:
                 - id: 2
+                  uptime: !anystr
                   metrics: !anything
             - timestamp: !anystr
               name: wazuh-analysisd
               agents:
                 - id: 2
+                  uptime: !anystr
                   metrics: !anything
           failed_items: [ ]
           total_affected_items: 2

--- a/framework/wazuh/core/tests/test_stats.py
+++ b/framework/wazuh/core/tests/test_stats.py
@@ -95,29 +95,53 @@ def test_hourly_data():
     assert result[0]['interactions'] == 0
 
 
-@pytest.mark.parametrize('agents_list', [
-    None, [1, 2, 3]
+@pytest.mark.parametrize('agents_list, expected_socket_response, expected_result', [
+    (None,
+     {'timestamp': 1658400850,
+      'uptime': 1658400850,
+      'stats': 'value'},
+     {'timestamp': datetime(2022, 7, 21, 10, 54, 10, tzinfo=timezone.utc),
+      'uptime': datetime(2022, 7, 21, 10, 54, 10, tzinfo=timezone.utc),
+      'stats': 'value'}),
+
+    ([1, 2, 3],
+     {'timestamp': 1658400850,
+      'agents': [{'id': agent_id, 'uptime': 1658400850} for agent_id in [1, 2, 3]]},
+     {'timestamp': datetime(2022, 7, 21, 10, 54, 10, tzinfo=timezone.utc),
+      'agents': [{'id': agent_id, 'uptime': datetime(2022, 7, 21, 10, 54, 10, tzinfo=timezone.utc)} for agent_id in
+                 [1, 2, 3]]}),
+
+    ('all',
+     {'data': {'timestamp': 1658400850,
+               'agents': [{'id': agent_id, 'uptime': 1658400850} for agent_id in [1, 2, 3]]}},
+     {'data': {'timestamp': datetime(2022, 7, 21, 10, 54, 10, tzinfo=timezone.utc),
+               'agents': [{'id': agent_id, 'uptime': datetime(2022, 7, 21, 10, 54, 10, tzinfo=timezone.utc)} for
+                          agent_id in [1, 2, 3]]}})
 ])
 @patch('wazuh.core.wazuh_socket.WazuhSocketJSON.close')
 @patch('wazuh.core.wazuh_socket.WazuhSocketJSON.send')
 @patch('wazuh.core.wazuh_socket.WazuhSocketJSON.__init__', return_value=None)
-def test_get_daemons_stats_socket(mock__init__, mock_send, mock_close, agents_list):
+def test_get_daemons_stats_socket(mock__init__, mock_send, mock_close, agents_list, expected_socket_response,
+                                  expected_result):
     """Verify get_daemons_stats_socket(socket : str) function works as expected"""
     socket = '/test_path/socket'
     expected_msg = {'version': 1, 'origin': {'module': 'framework'},
                     'command': 'getagentsstats' if agents_list else 'getstats'}
     if agents_list:
         expected_msg |= {'parameters': {'agents': agents_list}}
+        if agents_list == 'all':
+            expected_msg['parameters'] |= {'last_id': 0}
 
     with patch('wazuh.core.wazuh_socket.WazuhSocketJSON.receive',
-               return_value={'timestamp': 1658400850, 'stats': 'value'}) as mock_receive:
-        result = stats.get_daemons_stats_socket(socket, agents_list=agents_list)
+               return_value=expected_socket_response) as mock_receive:
+        result = stats.get_daemons_stats_socket(socket, agents_list=agents_list,
+                                                last_id=0 if agents_list == 'all' else None)
 
         mock__init__.assert_called_once_with(socket)
         mock_send.assert_called_once_with(expected_msg)
         mock_receive.assert_called_once()
         mock_close.assert_called_once()
-        assert result == {'timestamp': datetime(2022, 7, 21, 10, 54, 10, tzinfo=timezone.utc), 'stats': 'value'}
+        assert result == expected_result
 
 
 @pytest.mark.parametrize('agents_list', [


### PR DESCRIPTION
|Related issue|
|---|
| #14472 |


## Description

This PR closes #14472.

In this PR, I have updated the framework functions in charge of communicating with the core socket and getting the manager and agents statistics. With these changes, the `uptime` field is transformed from timestamp to datetime.

I have also updated the unit tests, API integration tests, and API spec examples.

There is no need to include a changelog entry for this change because the PR is modifying new features.

#### Examples

Request

`GET /manager/daemons/stats?daemons_list=wazuh-remoted`

Response

```json
{
  "data": {
    "affected_items": [
      {
        "uptime": "2022-08-24T12:25:41+00:00",
        "timestamp": "2022-08-24T12:26:46+00:00",
        "name": "wazuh-remoted",
        "metrics": {
          "bytes": {
            "received": 4940,
            "sent": 397703
          },
          "keys_reload_count": 1,
          "messages": {
            "received_breakdown": {
              "control": 3,
              "control_breakdown": {
                "keepalive": 1,
                "request": 0,
                "shutdown": 1,
                "startup": 1
              },
              "dequeued_after": 0,
              "discarded": 0,
              "event": 15,
              "ping": 0,
              "unknown": 0
            },
            "sent_breakdown": {
              "ack": 3,
              "ar": 2,
              "discarded": 0,
              "request": 0,
              "sca": 0,
              "shared": 1002
            }
          },
          "queues": {
            "received": {
              "size": 131072,
              "usage": 0
            }
          },
          "tcp_sessions": 0
        }
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Statistical information for each daemon was successfully read",
  "error": 0
}
```

Request

`GET /cluster/worker1/daemons/stats?daemons_list=wazuh-remoted`

Response

```json
{
  "data": {
    "affected_items": [
      {
        "uptime": "2022-08-24T12:25:42+00:00",
        "timestamp": "2022-08-24T12:30:57+00:00",
        "name": "wazuh-remoted",
        "metrics": {
          "bytes": {
            "received": 961446,
            "sent": 4264
          },
          "keys_reload_count": 1,
          "messages": {
            "received_breakdown": {
              "control": 29,
              "control_breakdown": {
                "keepalive": 28,
                "request": 0,
                "shutdown": 0,
                "startup": 1
              },
              "dequeued_after": 0,
              "discarded": 0,
              "event": 2064,
              "ping": 0,
              "unknown": 0
            },
            "sent_breakdown": {
              "ack": 29,
              "ar": 9,
              "discarded": 0,
              "request": 0,
              "sca": 2,
              "shared": 0
            }
          },
          "queues": {
            "received": {
              "size": 131072,
              "usage": 0
            }
          },
          "tcp_sessions": 1
        }
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Statistical information for each daemon was successfully read",
  "error": 0
}
```

Request

`GET /agents/001/daemons/stats`

Response

```json
{
  "data": {
    "affected_items": [
      {
        "timestamp": "2022-08-24T12:31:11+00:00",
        "name": "wazuh-remoted",
        "agents": [
          {
            "uptime": "2022-08-24T12:26:19+00:00",
            "id": 1,
            "metrics": {
              "messages": {
                "received_breakdown": {
                  "control": 31,
                  "control_breakdown": {
                    "keepalive": 30,
                    "request": 0,
                    "shutdown": 0,
                    "startup": 1
                  },
                  "event": 2064
                },
                "sent_breakdown": {
                  "ack": 31,
                  "ar": 9,
                  "discarded": 0,
                  "request": 0,
                  "sca": 2,
                  "shared": 0
                }
              }
            }
          }
        ]
      },
      {
        "timestamp": "2022-08-24T12:31:11+00:00",
        "name": "wazuh-analysisd",
        "agents": [
          {
            "uptime": "2022-08-24T12:26:22+00:00",
            "id": 1,
            "metrics": {
              "events": {
                "processed": 401,
                "received_breakdown": {
                  "decoded_breakdown": {
                    "agent": 0,
                    "dbsync": 1660,
                    "integrations_breakdown": {
                      "virustotal": 0
                    },
                    "modules_breakdown": {
                      "aws": 0,
                      "azure": 0,
                      "ciscat": 0,
                      "command": 0,
                      "docker": 0,
                      "gcp": 0,
                      "github": 0,
                      "logcollector_breakdown": {
                        "eventchannel": 0,
                        "eventlog": 0,
                        "macos": 0,
                        "others": 11
                      },
                      "office365": 0,
                      "oscap": 0,
                      "osquery": 0,
                      "rootcheck": 2,
                      "sca": 388,
                      "syscheck": 2,
                      "syscollector": 0,
                      "upgrade": 0,
                      "vulnerability": 0
                    },
                    "monitor": 0,
                    "remote": 0
                  }
                },
                "written_breakdown": {
                  "alerts": 193,
                  "archives": 0,
                  "firewall": 0
                }
              }
            }
          }
        ]
      }
    ],
    "total_affected_items": 2,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Statistical information for each daemon was successfully read",
  "error": 0
}
```