### PR TITLE
Print error code when LookupAccountSid function fails

### DIFF
--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -65,6 +65,7 @@
 #define FIM_WARN_FORMAT_PATH                    "(6947): Error formatting path: '%s'"
 #define FIM_DATABASE_NODES_COUNT_FAIL           "(6948): Unable to get the number of entries in database."
 #define FIM_CJSON_ERROR_CREATE_ITEM             "(6949): Cannot create a cJSON item"
+#define FIM_REGISTRY_ACC_SID                    "(6950): Error in LookupAccountSid getting %s. (%ld): %s"
 
 
 /* Monitord warning messages */

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -760,7 +760,17 @@ char *get_user(const char *path, char **sid, HANDLE hndl, SE_OBJECT_TYPE object_
             mdebug1("Account owner not found for '%s'", path);
         }
         else {
-            merror("Error in LookupAccountSid.");
+            LPSTR messageBuffer = NULL;
+            LPSTR end;
+
+            FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                          NULL, dwErrorCode, 0, (LPTSTR) &messageBuffer, 0, NULL);
+            if (end = strchr(messageBuffer, '\r'), end) {
+                *end = '\0';
+            }
+
+            mwarn(FIM_REGISTRY_ACC_SID, "user", dwErrorCode, messageBuffer);
+            LocalFree(messageBuffer);
         }
 
         *AcctName = '\0';
@@ -1089,12 +1099,21 @@ char *get_registry_group(char **sid, HANDLE hndl) {
         DWORD dwErrorCode = 0;
 
         dwErrorCode = GetLastError();
-
         if (dwErrorCode == ERROR_NONE_MAPPED) {
             mdebug1("Group not found for registry key");
         }
         else {
-            merror("Error in LookupAccountSid.");
+            LPSTR messageBuffer = NULL;
+            LPSTR end;
+
+            FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                          NULL, dwErrorCode, 0, (LPTSTR) &messageBuffer, 0, NULL);
+            if (end = strchr(messageBuffer, '\r'), end) {
+                *end = '\0';
+            }
+
+            mwarn(FIM_REGISTRY_ACC_SID, "group", dwErrorCode, messageBuffer);
+            LocalFree(messageBuffer);
         }
 
         *GrpName = '\0';

--- a/src/unit_tests/shared/test_syscheck_op.c
+++ b/src/unit_tests/shared/test_syscheck_op.c
@@ -3445,8 +3445,8 @@ static void test_get_file_user_LookupAccountSid_error(void **state) {
 
     expect_LookupAccountSid_call("", "domainname", FALSE);
     expect_GetLastError_call(ERROR_ACCESS_DENIED);
-
-    expect_string(__wrap__merror, formatted_msg, "Error in LookupAccountSid.");
+    expect_FormatMessage_call("Access is denied.");
+    expect_string(__wrap__mwarn, formatted_msg, "(6950): Error in LookupAccountSid getting user. (5): Access is denied.");
 
     array[0] = get_file_user("C:\\a\\path", &array[1]);
 
@@ -3986,8 +3986,8 @@ void test_get_registry_group_LookupAccountSid_fails(void **state) {
 
     expect_LookupAccountSid_call("", "domainname", FALSE);
     expect_GetLastError_call(ERROR_ACCESS_DENIED);
-
-    expect_string(__wrap__merror, formatted_msg, "Error in LookupAccountSid.");
+    expect_FormatMessage_call("Access is denied.");
+    expect_string(__wrap__mwarn, formatted_msg, "(6950): Error in LookupAccountSid getting group. (5): Access is denied.");
 
     group = get_registry_group(&group_id, hndl);
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/14713|


## Description
This PR includes a better description of the errors that the LookupAccountSid function may produce. Printing the error code and the associated message.
Also the related unit tests have been modified.

## Log example
```
2022/07/24 13:47:48 wazuh-agent: WARNING: (6950): Error in LookupAccountSid getting group. GetLastError returned (1332): No mapping between account names and security IDs was done.
```
Warn message improved:
```
2022/07/24 17:13:59 wazuh-agent[2768] syscheck_op.c:1116 at get_registry_group(): WARNING: (6950): Error in LookupAccountSid getting group. (5): Access is denied.
```
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Windows
  - [x] Scan-build report
