### PR TITLE
GuardDuty AWS Wodle fix discard_regex 

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2155,18 +2155,6 @@ class AWSGuardDutyBucket(AWSCustomBucket):
         for msg in self.reformat_msg(event):
             self.send_msg(msg)
 
-    def iter_events(self, event_list, log_key, aws_account_id):
-        if event_list is not None:
-            for event in event_list:
-                if self._event_should_be_skipped(event):
-                    debug(
-                        f'+++ The "{self.discard_regex.pattern}" regex found a match in the "{self.discard_field}" field. '
-                        f'The event will be skipped.', 2)
-                    continue
-
-                event_msg = self.get_alert_msg(aws_account_id, log_key, event)
-
-
     def reformat_msg(self, event):
         debug('++ Reformat message', 3)
         if event['aws']['source'] == 'guardduty' and 'service' in event['aws'] and \

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -928,42 +928,48 @@ class AWSBucket(WazuhIntegration):
                 self.iter_files_in_bucket(aws_account_id, aws_region)
                 self.db_maintenance(aws_account_id=aws_account_id, aws_region=aws_region)
 
-    def _check_recursive(self, json_item=None, nested_field: str = '', regex: str = ''):
-        field_list = nested_field.split('.', 1)
-        try:
-            expression_to_evaluate = json_item[field_list[0]]
-        except TypeError:
-            if isinstance(json_item, list):
-                return any(self._check_recursive(i, field_list[0], regex=regex) for i in json_item)
-            return False
-        except KeyError:
-            return False
-        if len(field_list) == 1:
-            def check_regex(exp):
-                try:
-                    return re.match(regex, exp) is not None
-                except TypeError:
-                    return isinstance(exp, list) and any(check_regex(ex) for ex in exp)
-            return check_regex(expression_to_evaluate)
-        return self._check_recursive(expression_to_evaluate, field_list[1], regex=regex)
-
-    def _event_should_be_skipped(self, event_):
-        return self.discard_field and self.discard_regex \
-               and self._check_recursive(event_, nested_field=self.discard_field, regex=self.discard_regex)
-
+    def send_event(self, event):
+        # Change dynamic fields to strings; truncate values as needed
+        event_msg = self.reformat_msg(event)
+        # Send the message
+        self.send_msg(event_msg)
 
     def iter_events(self, event_list, log_key, aws_account_id):
+        def _check_recursive(json_item=None, nested_field: str = '', regex: str = ''):
+            field_list = nested_field.split('.', 1)
+            try:
+                expression_to_evaluate = json_item[field_list[0]]
+            except TypeError:
+                if isinstance(json_item, list):
+                    return any(_check_recursive(i, field_list[0], regex=regex) for i in json_item)
+                return False
+            except KeyError:
+                return False
+            if len(field_list) == 1:
+                def check_regex(exp):
+                    try:
+                        return re.match(regex, exp) is not None
+                    except TypeError:
+                        return isinstance(exp, list) and any(check_regex(ex) for ex in exp)
+
+                return check_regex(expression_to_evaluate)
+            return self._check_recursive(expression_to_evaluate, field_list[1], regex=regex)
+
+        def _event_should_be_skipped(event_):
+            return self.discard_field and self.discard_regex \
+                   and self._check_recursive(event_, nested_field=self.discard_field, regex=self.discard_regex)
+
         if event_list is not None:
             for event in event_list:
-                if self._event_should_be_skipped(event):
+                if _event_should_be_skipped(event):
                     debug(f'+++ The "{self.discard_regex.pattern}" regex found a match in the "{self.discard_field}" field. '
                           f'The event will be skipped.', 2)
                     continue
+                # Parse out all the values of 'None'
                 event_msg = self.get_alert_msg(aws_account_id, log_key, event)
-                # Change dynamic fields to strings; truncate values as needed
-                event_msg = self.reformat_msg(event_msg)
-                # Send the message
-                self.send_msg(event_msg)
+
+                self.send_event(event_msg)
+
 
     def iter_files_in_bucket(self, aws_account_id=None, aws_region=None):
         try:
@@ -2144,6 +2150,11 @@ class AWSGuardDutyBucket(AWSCustomBucket):
         db_table_name = 'guardduty'
         AWSCustomBucket.__init__(self, db_table_name, **kwargs)
 
+    def send_event(self, event):
+        # Send the message (splitted if it is necessary)
+        for msg in self.reformat_msg(event):
+            self.send_msg(msg)
+
     def iter_events(self, event_list, log_key, aws_account_id):
         if event_list is not None:
             for event in event_list:
@@ -2152,11 +2163,9 @@ class AWSGuardDutyBucket(AWSCustomBucket):
                         f'+++ The "{self.discard_regex.pattern}" regex found a match in the "{self.discard_field}" field. '
                         f'The event will be skipped.', 2)
                     continue
-                # Parse out all the values of 'None'
+
                 event_msg = self.get_alert_msg(aws_account_id, log_key, event)
-                # Send the message (splitted if it is necessary)
-                for msg in self.reformat_msg(event_msg):
-                    self.send_msg(msg)
+
 
     def reformat_msg(self, event):
         debug('++ Reformat message', 3)

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -953,11 +953,11 @@ class AWSBucket(WazuhIntegration):
                         return isinstance(exp, list) and any(check_regex(ex) for ex in exp)
 
                 return check_regex(expression_to_evaluate)
-            return self._check_recursive(expression_to_evaluate, field_list[1], regex=regex)
+            return _check_recursive(expression_to_evaluate, field_list[1], regex=regex)
 
         def _event_should_be_skipped(event_):
             return self.discard_field and self.discard_regex \
-                   and self._check_recursive(event_, nested_field=self.discard_field, regex=self.discard_regex)
+                   and _check_recursive(event_, nested_field=self.discard_field, regex=self.discard_regex)
 
         if event_list is not None:
             for event in event_list:


### PR DESCRIPTION
|Related issue|
|---|
|#11138|


## Description

This PR closes #11138. It refactors the `iter_events` method from the `AWSBucket` class, making it  more modular adding the `send_event` method. This last method is then overridden by the `AWSGuardDutyBucket` class and therefore not requiring to redefine `iter_events` in the latter.   

## AWS Wodle Unit tests
```
============================= test session starts ==============================
platform linux -- Python 3.9.5, pytest-6.0.1, py-1.11.0, pluggy-0.13.1 -- /home/test_user/venv/unittest-env/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.14.0-1048-oem-x86_64-with-glibc2.31', 'Packages': {'pytest': '6.0.1', 'py': '1.11.0', 'pluggy': '0.13.1'}, 'Plugins': {'cov': '3.0.0', 'trio': '0.7.0', 'metadata': '2.0.2', 'asyncio': '0.15.1', 'aiohttp': '0.3.0', 'html': '2.1.1'}}
rootdir: /home/test_user/git/wazuh
plugins: cov-3.0.0, trio-0.7.0, metadata-2.0.2, asyncio-0.15.1, aiohttp-0.3.0, html-2.1.1
collecting ... collected 38 items

wodles/aws/tests/test_aws.py::test_metadata_version_buckets[AWSCloudTrailBucket] PASSED [  2%]
wodles/aws/tests/test_aws.py::test_metadata_version_buckets[AWSConfigBucket] PASSED [  5%]
wodles/aws/tests/test_aws.py::test_metadata_version_buckets[AWSVPCFlowBucket] PASSED [  7%]
wodles/aws/tests/test_aws.py::test_metadata_version_buckets[AWSCustomBucket] PASSED [ 10%]
wodles/aws/tests/test_aws.py::test_metadata_version_buckets[AWSGuardDutyBucket] PASSED [ 13%]
wodles/aws/tests/test_aws.py::test_metadata_version_services[AWSInspector] PASSED [ 15%]
wodles/aws/tests/test_aws.py::test_db_maintenance[AWSCloudTrailBucket-schema_cloudtrail_test.sql-cloudtrail] PASSED [ 18%]
wodles/aws/tests/test_aws.py::test_db_maintenance[AWSConfigBucket-schema_config_test.sql-config] PASSED [ 21%]
wodles/aws/tests/test_aws.py::test_db_maintenance[AWSVPCFlowBucket-schema_vpcflow_test.sql-vpcflow] PASSED [ 23%]
wodles/aws/tests/test_aws.py::test_db_maintenance[AWSCustomBucket-schema_custom_test.sql-custom] PASSED [ 26%]
wodles/aws/tests/test_aws.py::test_db_maintenance[AWSGuardDutyBucket-schema_guardduty_test.sql-guardduty] PASSED [ 28%]
wodles/aws/tests/test_aws.py::test_decompress_file_gz[aws_bucket0-test.gz-gzip.open] PASSED [ 31%]
wodles/aws/tests/test_aws.py::test_decompress_file_gz[aws_bucket0-test.zip-zipfile.ZipFile] PASSED [ 34%]
wodles/aws/tests/test_aws.py::test_decompress_file_snappy_skip[aws_bucket0-test.snappy] PASSED [ 36%]
wodles/aws/tests/test_aws.py::test_decompress_snappy_ko[aws_bucket0-test.snappy-False-SystemExit] PASSED [ 39%]
wodles/aws/tests/test_aws.py::test_decompress_file_ko[.gz-aws_bucket0] PASSED [ 42%]
wodles/aws/tests/test_aws.py::test_decompress_file_ko[.zip-aws_bucket0] PASSED [ 44%]
wodles/aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-False] PASSED [ 47%]
wodles/aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-True] PASSED [ 50%]
wodles/aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-invalid-json-True] PASSED [ 52%]
wodles/aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-wrong-structure-True] PASSED [ 55%]
wodles/aws/tests/test_aws.py::test_aws_waf_load_information_from_file_ko[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-invalid-json-False-SystemExit] PASSED [ 57%]
wodles/aws/tests/test_aws.py::test_aws_waf_load_information_from_file_ko[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-wrong-structure-False-SystemExit] PASSED [ 60%]
wodles/aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2021/1/19-20210119] PASSED [ 63%]
wodles/aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2021/1/1-20210101] PASSED [ 65%]
wodles/aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2021/01/01-20210101] PASSED [ 68%]
wodles/aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2000/2/12-20000212] PASSED [ 71%]
wodles/aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2022/02/1-20220201] PASSED [ 73%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file0-20211221] PASSED [ 76%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file1-20200103] PASSED [ 78%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file2-20200920] PASSED [ 81%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file3-20210118] PASSED [ 84%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file4-20200930] PASSED [ 86%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file5-20201015] PASSED [ 89%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file6-20210318] PASSED [ 92%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file7-20210906] PASSED [ 94%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file8-20211112] PASSED [ 97%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file9-20210123] PASSED [100%]

============================== 38 passed in 0.33s ==============================
```

## Manual `discard_regex` functionality test
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-guardduty -t guardduty -s 2021-JUN-18 --discard-field partition --discard-regex aws -p dev -d2 | grep -v "Skipping file with another prefix"
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Marker: 2021/06/18
DEBUG: ++ Found new log: 2021/06/18/08/firehose_guardduty-1-2021-06-18-08-45-01-e559a8cf-3eec-49de-805f-704ba7c6e71c.zip
DEBUG: +++ The "aws" regex found a match in the "partition" field. The event will be skipped.
DEBUG: ++ Found new log: 2021/06/19/06/firehose_guardduty-1-2021-06-19-06-00-05-baf62d64-fe46-40f9-a087-e4048c73119b.zip
DEBUG: +++ The "aws" regex found a match in the "partition" field. The event will be skipped.
DEBUG: ++ Found new log: 2021/06/22/16/firehose_guardduty-1-2021-06-22-16-15-05-872e154c-1fd8-4369-a151-947ec0438d8d.zip
DEBUG: +++ The "aws" regex found a match in the "partition" field. The event will be skipped.
DEBUG: ++ Found new log: 2021/07/08/03/firehose_guardduty-1-2021-07-08-03-46-07-12788dc1-723b-4e2b-9d12-07885e967524.zip
DEBUG: +++ The "aws" regex found a match in the "partition" field. The event will be skipped.
DEBUG: ++ Found new log: 2021/12/24/03/firehose_guardduty-1-2021-12-24-03-46-07-12788dc1-723b-4e2b-9d12-07885e967524.zip
DEBUG: +++ The "aws" regex found a match in the "partition" field. The event will be skipped.
DEBUG: +++ DB Maintenance
```
