### PR TITLE
columns out of order

### DIFF
--- a/ruleset/decoders/0040-auditd_decoders.xml
+++ b/ruleset/decoders/0040-auditd_decoders.xml
@@ -166,7 +166,7 @@
 <decoder name="auditd-promiscuous">
   <parent>auditd</parent>
   <regex offset="after_regex">^dev=(\S+) prom=(\S+) old_prom=(\S+) auid=(\S+) uid=(\S+) gid=(\S+) ses=(\S+)</regex>
-  <order>audit.auid,audit.dev,audit.gid,audit.old_prom,audit.prom,audit.session,audit.uid</order>
+  <order>audit.dev,audit.prom,audit.old_prom,audit.auid,audit.uid,audit.gid,audit.session</order>
 </decoder>
 
 <!--


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/commit/bb415f86d3924b5cd58909ada05dbe6ae1a8b5fc#diff-e2f1141a6833b61ba442e2446b97118f1cf91c5f1382603329a18fab9a4ceb50|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
decode rule for ANOM_PROMISCUOUS is injected bug when update 4.3 and then I fixed it.

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

```
**Phase 1: Completed pre-decoding.                                                                                                                                                          
       full event: 'type=ANOM_PROMISCUOUS msg=audit(1657766847.767:32459): dev=tap39428fc9-21 prom=0 old_prom=256 auid=4294967295 uid=64055 gid=119 ses=4294967295'                         
       timestamp: '(null)'                                                                                                                                                                  
       hostname: 'd42808b8a73b'                                                                                                                                                             
       program_name: '(null)'                                                                                                                                                               
       log: 'type=ANOM_PROMISCUOUS msg=audit(1657766847.767:32459): dev=tap39428fc9-21 prom=0 old_prom=256 auid=4294967295 uid=64055 gid=119 ses=4294967295'                                
                                                                                                                                                                                            
**Phase 2: Completed decoding.                                                                                                                                                              
       decoder: 'auditd'                                                                                                                                                                    
       audit.type: 'ANOM_PROMISCUOUS'                                                                                                                                                       
       audit.id: '32459'                                                                                                                                                                    
       audit.auid: 'tap39428fc9-21'     # for example, tap is interface.                                                                                                                                                  
       audit.dev: '0'                                                                                                                                                                       
       audit.gid: '256'                                                                                                                                                                     
       audit.old_prom: '4294967295'                                                                                                                                                         
       audit.prom: '64055'                                                                                                                                                                  
       audit.session: '119'                                                                                                                                                                 
       audit.uid: '4294967295'                                                                                                                                                              
                                                                                                                                                                                            
**Phase 3: Completed filtering (rules).                                                                                                                                                     
       Rule id: '80710'                                                                                                                                                                     
       Level: '10'                                                                                                                                                                          
       Description: 'Auditd: Device enables promiscuous mode.'                                                                                                                              
**Alert to be generated.                                                                                                                                                                    
                               
```
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors