### PR TITLE
Prevent agents from lower version

### DIFF
--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -368,7 +368,7 @@ static bool agent_handshake_to_server(int server_id, bool is_startup) {
                         cJSON *error_info = NULL;
                         if (error_msg = cJSON_Parse(strchr(tmp_msg, '{')), error_msg) {
                             if (error_info = cJSON_GetObjectItem(error_msg, "message"), cJSON_IsString(error_info)) {
-                                    mwarn("%s",error_info->valuestring);
+                                mwarn("Couldn't connect to server '%s': '%s'", agt->server[server_id].rip, error_info->valuestring);
                             } else {
                                 merror("Error getting message from server '%s'", agt->server[server_id].rip);
                             }

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -334,7 +334,7 @@ static bool agent_handshake_to_server(int server_id, bool is_startup) {
     cJSON_Delete(agent_info);
 
     snprintf(msg, OS_MAXSTR, "%s%s%s", CONTROL_HEADER, HC_STARTUP, agent_info_string);
-    free(agent_info_string);
+    os_free(agent_info_string);
 
     if (connect_server(server_id, true)) {
         /* Send start up message */
@@ -363,8 +363,19 @@ static bool agent_handshake_to_server(int server_id, bool is_startup) {
                         }
 
                         return true;
-                    } else if (strcmp(tmp_msg, HC_INVALID_VERSION) == 0) {
-                        mwarn("Unable to connect to server '%s'. Incompatible version", agt->server[server_id].rip);
+                    } else if (strncmp(tmp_msg, HC_ERROR, strlen(HC_ERROR)) == 0) {
+                        cJSON *error_msg = NULL;
+                        cJSON *error_info = NULL;
+                        if (error_msg = cJSON_Parse(strchr(tmp_msg, '{')), error_msg) {
+                            if (error_info = cJSON_GetObjectItem(error_msg, "message"), cJSON_IsString(error_info)) {
+                                    mwarn("%s",error_info->valuestring);
+                            } else {
+                                merror("Error getting message from server '%s'", agt->server[server_id].rip);
+                            }
+                        } else {
+                            merror("Error getting message from server '%s'", agt->server[server_id].rip);
+                        }
+                        cJSON_Delete(error_msg);
                     }
                 }
             }

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -328,7 +328,12 @@ static bool agent_handshake_to_server(int server_id, bool is_startup) {
     char buffer[OS_MAXSTR + 1] = { '\0' };
     char cleartext[OS_MAXSTR + 1] = { '\0' };
 
-    snprintf(msg, OS_MAXSTR, "%s%s", CONTROL_HEADER, HC_STARTUP);
+    cJSON* agent_info = cJSON_CreateObject();
+    cJSON_AddStringToObject(agent_info, "version", __ossec_version);
+    char *agent_info_string = cJSON_PrintUnformatted(agent_info);
+    cJSON_Delete(agent_info);
+
+    snprintf(msg, OS_MAXSTR, "%s%s%s", CONTROL_HEADER, HC_STARTUP, agent_info_string);
 
     if (connect_server(server_id, true)) {
         /* Send start up message */

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -362,6 +362,8 @@ static bool agent_handshake_to_server(int server_id, bool is_startup) {
                         }
 
                         return true;
+                    } else if (strcmp(tmp_msg, HC_INVALID_VERSION) == 0) {
+                        mwarn("Unable to connect to server '%s'. Incompatible version", agt->server[server_id].rip);
                     }
                 }
             }

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -334,6 +334,7 @@ static bool agent_handshake_to_server(int server_id, bool is_startup) {
     cJSON_Delete(agent_info);
 
     snprintf(msg, OS_MAXSTR, "%s%s%s", CONTROL_HEADER, HC_STARTUP, agent_info_string);
+    free(agent_info_string);
 
     if (connect_server(server_id, true)) {
         /* Send start up message */

--- a/src/headers/rc.h
+++ b/src/headers/rc.h
@@ -43,6 +43,8 @@
 #define HC_FIM_FILE         "fim_file "
 #define HC_FIM_REGISTRY     "fim_registry "
 #define HC_FORCE_RECONNECT  "force_reconnect"
-#define HC_INVALID_VERSION  "err {\"message\": \"Incompatible version\"}"
+#define HC_ERROR            "err "
+#define HC_INVALID_VERSION  "Incompatible version"
+#define HC_RETRIEVE_VERSION "Couldn't retrieve version"
 
 #endif /* RC_H */

--- a/src/headers/rc.h
+++ b/src/headers/rc.h
@@ -43,5 +43,6 @@
 #define HC_FIM_FILE         "fim_file "
 #define HC_FIM_REGISTRY     "fim_registry "
 #define HC_FORCE_RECONNECT  "force_reconnect"
+#define HC_INVALID_VERSION  "err {\"message\": \"Incompatible version\"}"
 
 #endif /* RC_H */

--- a/src/headers/version_op.h
+++ b/src/headers/version_op.h
@@ -77,4 +77,15 @@ void free_osinfo(os_info * osinfo);
  */
 int get_nproc();
 
+/**
+ * Compare two versions with format v4.0.0
+ * @param version1 char * with the string version
+ * @param version2 char * with the string version
+ * @return return_code
+ * @retval 0 equals
+ * @retval 1 version1 > version2
+ * @retval -1 version1 < version2
+ * */
+int compare_wazuh_versions(const char *version1, const char *version2);
+
 #endif /* VERSION_H */

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -381,12 +381,15 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
                         char msg_err[OS_FLSIZE + 1] = "";
                         snprintf(msg_err, OS_FLSIZE, "%s%s", CONTROL_HEADER, HC_INVALID_VERSION);
                         send_msg(key->id, msg_err, -1);
+                        cJSON_Delete(agent_info);
+                        os_free(clean);
                         return;
                     }
                 } else {
                     merror("Error getting version from agent '%s'", key->id);
                 }
             }
+            cJSON_Delete(agent_info);
             is_startup = 1;
         } else {
             mdebug1("Agent %s sent HC_SHUTDOWN from '%s'", key->name, aux_ip);

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -371,22 +371,39 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
         if (strncmp(r_msg, HC_STARTUP, strlen(HC_STARTUP)) == 0) {
             mdebug1("Agent %s sent HC_STARTUP from '%s'", key->name, aux_ip);
 
-            const char *json_err;
             cJSON *agent_info = NULL;
             cJSON *version = NULL;
-            if (agent_info = cJSON_ParseWithOpts(strchr(r_msg, '{'), &json_err, 0), agent_info) {
+            if (agent_info = cJSON_Parse(strchr(r_msg, '{')), agent_info) {
+                char *error_msg_string = NULL;
                 if (version = cJSON_GetObjectItem(agent_info, "version"), cJSON_IsString(version)) {
                     if (compare_wazuh_versions(__ossec_version, version->valuestring) < 0) {
                         /* Reply to the agent */
+                        cJSON *error_msg = cJSON_CreateObject();
+                        cJSON_AddStringToObject(error_msg, "message", HC_INVALID_VERSION);
+                        error_msg_string = cJSON_PrintUnformatted(error_msg);
                         char msg_err[OS_FLSIZE + 1] = "";
-                        snprintf(msg_err, OS_FLSIZE, "%s%s", CONTROL_HEADER, HC_INVALID_VERSION);
+                        snprintf(msg_err, OS_FLSIZE, "%s%s%s", CONTROL_HEADER, HC_ERROR, error_msg_string);
                         send_msg(key->id, msg_err, -1);
                         cJSON_Delete(agent_info);
+                        cJSON_Delete(error_msg);
+                        os_free(error_msg_string);
                         os_free(clean);
                         return;
                     }
                 } else {
                     merror("Error getting version from agent '%s'", key->id);
+
+                    cJSON *error_msg = cJSON_CreateObject();
+                    cJSON_AddStringToObject(error_msg, "message", HC_RETRIEVE_VERSION);
+                    error_msg_string = cJSON_PrintUnformatted(error_msg);
+                    char msg_err[OS_FLSIZE + 1] = "";
+                    snprintf(msg_err, OS_FLSIZE, "%s%s%s", CONTROL_HEADER, HC_ERROR, error_msg_string);
+                    send_msg(key->id, msg_err, -1);
+                    cJSON_Delete(agent_info);
+                    cJSON_Delete(error_msg);
+                    os_free(error_msg_string);
+                    os_free(clean);
+                    return;
                 }
             }
             cJSON_Delete(agent_info);
@@ -522,13 +539,14 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
             os_calloc(1, sizeof(agent_info_data), agent_data);
 
             result = parse_agent_update_msg(msg, agent_data);
+
             if (OS_SUCCESS != result) {
                 merror("Error parsing message for agent '%s'", key->id);
                 wdb_free_agent_info_data(agent_data);
                 os_free(clean);
                 return;
             }
-// mwarn("------------------------------------ '%s'", agent_data->version);
+
             // Appending system labels
             os_calloc(HOST_NAME_MAX, sizeof(char), agent_data->manager_host);
 

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -352,15 +352,11 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
         return;
     }
 
-    /* Reply to the agent */
-    snprintf(msg_ack, OS_FLSIZE, "%s%s", CONTROL_HEADER, HC_ACK);
-    send_msg(key->id, msg_ack, -1);
-
     /* Filter UTF-8 characters */
     char * clean = w_utf8_filter(r_msg, true);
     r_msg = clean;
 
-    if ((strcmp(r_msg, HC_STARTUP) == 0) || (strcmp(r_msg, HC_SHUTDOWN) == 0)) {
+    if ((strncmp(r_msg, HC_STARTUP, strlen(HC_STARTUP)) == 0) || (strcmp(r_msg, HC_SHUTDOWN) == 0)) {
         char aux_ip[IPSIZE + 1] = {0};
         switch (key->peer_info.ss_family) {
         case AF_INET:
@@ -372,8 +368,25 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
         default:
             break;
         }
-        if (strcmp(r_msg, HC_STARTUP) == 0) {
+        if (strncmp(r_msg, HC_STARTUP, strlen(HC_STARTUP)) == 0) {
             mdebug1("Agent %s sent HC_STARTUP from '%s'", key->name, aux_ip);
+
+            const char *json_err;
+            cJSON *agent_info = NULL;
+            cJSON *version = NULL;
+            if (agent_info = cJSON_ParseWithOpts(strchr(r_msg, '{'), &json_err, 0), agent_info) {
+                if (version = cJSON_GetObjectItem(agent_info, "version"), cJSON_IsString(version)) {
+                    if (compare_wazuh_versions(__ossec_version, version->valuestring) < 0) {
+                        /* Reply to the agent */
+                        char msg_err[OS_FLSIZE + 1] = "";
+                        snprintf(msg_err, OS_FLSIZE, "%s%s", CONTROL_HEADER, HC_INVALID_VERSION);
+                        send_msg(key->id, msg_err, -1);
+                        return;
+                    }
+                } else {
+                    merror("Error getting version from agent '%s'", key->id);
+                }
+            }
             is_startup = 1;
         } else {
             mdebug1("Agent %s sent HC_SHUTDOWN from '%s'", key->name, aux_ip);
@@ -393,6 +406,10 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
             return;
         }
     }
+
+    /* Reply to the agent */
+    snprintf(msg_ack, OS_FLSIZE, "%s%s", CONTROL_HEADER, HC_ACK);
+    send_msg(key->id, msg_ack, -1);
 
     w_mutex_lock(&lastmsg_mutex);
 
@@ -502,14 +519,13 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
             os_calloc(1, sizeof(agent_info_data), agent_data);
 
             result = parse_agent_update_msg(msg, agent_data);
-
             if (OS_SUCCESS != result) {
                 merror("Error parsing message for agent '%s'", key->id);
                 wdb_free_agent_info_data(agent_data);
                 os_free(clean);
                 return;
             }
-
+// mwarn("------------------------------------ '%s'", agent_data->version);
             // Appending system labels
             os_calloc(HOST_NAME_MAX, sizeof(char), agent_data->manager_host);
 

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -931,3 +931,84 @@ int get_nproc() {
     return 1;
 #endif
 }
+
+int compare_wazuh_versions(const char *version1, const char *version2) {
+    char ver1[10];
+    char ver2[10];
+    char *tmp_v1 = NULL;
+    char *tmp_v2 = NULL;
+    char *token = NULL;
+    int patch1 = 0;
+    int major1 = 0;
+    int minor1 = 0;
+    int patch2 = 0;
+    int major2 = 0;
+    int minor2 = 0;
+    int result = 0;
+
+    if (version1) {
+        strncpy(ver1, version1, 9);
+
+        if (tmp_v1 = strchr(ver1, 'v'), tmp_v1) {
+            tmp_v1++;
+        } else {
+            tmp_v1 = ver1;
+        }
+
+        if (token = strtok(tmp_v1, "."), token) {
+            major1 = atoi(token);
+
+            if (token = strtok(NULL, "."), token) {
+                minor1 = atoi(token);
+
+                if (token = strtok(NULL, "."), token) {
+                    patch1 = atoi(token);
+                }
+            }
+        }
+    }
+
+    if (version2) {
+        strncpy(ver2, version2, 9);
+
+        if (tmp_v2 = strchr(ver2, 'v'), tmp_v2) {
+            tmp_v2++;
+        } else {
+            tmp_v2 = ver2;
+        }
+
+        if (token = strtok(tmp_v2, "."), token) {
+            major2 = atoi(token);
+
+            if (token = strtok(NULL, "."), token) {
+                minor2 = atoi(token);
+
+                if (token = strtok(NULL, "."), token) {
+                    patch2 = atoi(token);
+                }
+            }
+        }
+    }
+
+    if (major1 > major2) {
+        result = 1;
+    } else if (major1 < major2){
+        result = -1;
+    } else {
+        if(minor1 > minor2) {
+            result = 1;
+        } else if (minor1 < minor2) {
+            result = -1;
+        } else {
+            if (patch1 > patch2) {
+                result = 1;
+            } else if (patch1 < patch2) {
+                result = -1;
+            } else {
+                result = 0;
+            }
+        }
+    }
+
+    return result;
+}

--- a/src/unit_tests/client-agent/test_start_agent.c
+++ b/src/unit_tests/client-agent/test_start_agent.c
@@ -397,7 +397,7 @@ static void test_agent_handshake_to_server_invalid_version(void **state) {
 
     expect_any_count(__wrap__minfo, formatted_msg, 1);
 
-    expect_string(__wrap__mwarn, formatted_msg ,"Incompatible version");
+    expect_string(__wrap__mwarn, formatted_msg ,"Couldn't connect to server '127.0.0.1': 'Incompatible version'");
 
     handshaked = agent_handshake_to_server(0, false);
     assert_false(handshaked);

--- a/src/unit_tests/client-agent/test_start_agent.c
+++ b/src/unit_tests/client-agent/test_start_agent.c
@@ -375,6 +375,34 @@ static void test_agent_handshake_to_server(void **state) {
     return;
 }
 
+
+static void test_agent_handshake_to_server_invalid_version(void **state) {
+    bool handshaked = false;
+
+    /* Handshake with first server (UDP) */
+    will_return(__wrap_getDefine_Int, 5);
+    expect_string(__wrap_OS_GetHost, host, agt->server[0].rip);
+    will_return(__wrap_OS_GetHost, strdup("127.0.0.1"));
+    will_return(__wrap_OS_ConnectUDP, 21);
+    #ifndef TEST_WINAGENT
+    will_return(__wrap_recv, SERVER_ENC_ACK);
+    #else
+    will_return(wrap_recv, SERVER_ENC_ACK);
+    #endif
+    will_return(__wrap_wnet_select, 1);
+    expect_string(__wrap_send_msg, msg, "#!-agent startup {\"version\":\"v4.5.0\"}");
+    expect_string(__wrap_ReadSecMSG, buffer, SERVER_ENC_ACK);
+    will_return(__wrap_ReadSecMSG, "#!-err {\"message\": \"Incompatible version\"}");
+    will_return(__wrap_ReadSecMSG, KS_VALID);
+
+    expect_any_count(__wrap__minfo, formatted_msg, 1);
+
+    expect_string(__wrap__mwarn, formatted_msg ,"Unable to connect to server '127.0.0.1'. Incompatible version");
+
+    handshaked = agent_handshake_to_server(0, false);
+    assert_false(handshaked);
+}
+
 /* agent_start_up_to_server */
 static void test_send_msg_on_startup(void **state) {
     expect_string(__wrap_send_msg, msg, "1:ossec:ossec: Agent started: 'agent0->any'.");
@@ -393,10 +421,11 @@ static void test_send_agent_stopped_message(void **state) {
 
 int main(void) {
     const struct CMUnitTest tests[] = {
-        // cmocka_unit_test_setup_teardown(test_connect_server, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_connect_server, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_agent_handshake_to_server, setup_test, teardown_test),
-        // cmocka_unit_test_setup_teardown(test_send_msg_on_startup, setup_test, teardown_test),
-        // cmocka_unit_test_setup_teardown(test_send_agent_stopped_message, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_agent_handshake_to_server_invalid_version, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_send_msg_on_startup, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_send_agent_stopped_message, setup_test, teardown_test),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/client-agent/test_start_agent.c
+++ b/src/unit_tests/client-agent/test_start_agent.c
@@ -251,7 +251,7 @@ static void test_agent_handshake_to_server(void **state) {
     will_return(wrap_recv, SERVER_ENC_ACK);
     #endif
     will_return(__wrap_wnet_select, 1);
-    expect_string(__wrap_send_msg, msg, "#!-agent startup ");
+    expect_string(__wrap_send_msg, msg, "#!-agent startup {\"version\":\"v4.5.0\"}");
     expect_string(__wrap_ReadSecMSG, buffer, SERVER_ENC_ACK);
     will_return(__wrap_ReadSecMSG, "#!-agent ack ");
     will_return(__wrap_ReadSecMSG, KS_VALID);
@@ -280,7 +280,8 @@ static void test_agent_handshake_to_server(void **state) {
     expect_any(__wrap_OS_RecvSecureTCP, size);
     will_return(__wrap_OS_RecvSecureTCP, SERVER_ENC_ACK);
     will_return(__wrap_OS_RecvSecureTCP, strlen(SERVER_ENC_ACK));
-    expect_string(__wrap_send_msg, msg, "#!-agent startup ");
+    // expect_string(__wrap_send_msg, msg, startup_msg);
+    expect_string(__wrap_send_msg, msg, "#!-agent startup {\"version\":\"v4.5.0\"}");
     expect_string(__wrap_ReadSecMSG, buffer, SERVER_ENC_ACK);
     will_return(__wrap_ReadSecMSG, "#!-agent ack ");
     will_return(__wrap_ReadSecMSG, KS_VALID);
@@ -309,7 +310,7 @@ static void test_agent_handshake_to_server(void **state) {
     expect_any(__wrap_OS_RecvSecureTCP, size);
     will_return(__wrap_OS_RecvSecureTCP, SERVER_ENC_ACK);
     will_return(__wrap_OS_RecvSecureTCP, strlen(SERVER_ENC_ACK));
-    expect_string(__wrap_send_msg, msg, "#!-agent startup ");
+    expect_string(__wrap_send_msg, msg, "#!-agent startup {\"version\":\"v4.5.0\"}");
     expect_string(__wrap_send_msg, msg, "1:ossec:ossec: Agent started: 'agent0->any'.");
     expect_string(__wrap_ReadSecMSG, buffer, SERVER_ENC_ACK);
     will_return(__wrap_ReadSecMSG, "#!-agent ack ");
@@ -343,7 +344,7 @@ static void test_agent_handshake_to_server(void **state) {
     will_return(__wrap_OS_GetHost, strdup("127.0.0.1"));
     will_return(__wrap_OS_ConnectUDP, 23);
     will_return(__wrap_wnet_select, 0);
-    expect_string(__wrap_send_msg, msg, "#!-agent startup ");
+    expect_string(__wrap_send_msg, msg, "#!-agent startup {\"version\":\"v4.5.0\"}");
 
     expect_any(__wrap__mwarn, formatted_msg);
 
@@ -363,7 +364,7 @@ static void test_agent_handshake_to_server(void **state) {
     will_return(wrap_recv, SERVER_WRONG_ACK);
 #endif
     will_return(__wrap_wnet_select, 1);
-    expect_string(__wrap_send_msg, msg, "#!-agent startup ");
+    expect_string(__wrap_send_msg, msg, "#!-agent startup {\"version\":\"v4.5.0\"}");
     expect_string(__wrap_ReadSecMSG, buffer, SERVER_WRONG_ACK);
     will_return(__wrap_ReadSecMSG, SERVER_WRONG_ACK);
     will_return(__wrap_ReadSecMSG, KS_CORRUPT);
@@ -392,10 +393,10 @@ static void test_send_agent_stopped_message(void **state) {
 
 int main(void) {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test_setup_teardown(test_connect_server, setup_test, teardown_test),
+        // cmocka_unit_test_setup_teardown(test_connect_server, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_agent_handshake_to_server, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_send_msg_on_startup, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_send_agent_stopped_message, setup_test, teardown_test),
+        // cmocka_unit_test_setup_teardown(test_send_msg_on_startup, setup_test, teardown_test),
+        // cmocka_unit_test_setup_teardown(test_send_agent_stopped_message, setup_test, teardown_test),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -43,7 +43,7 @@ list(APPEND remoted_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,w_
                             -Wl,--wrap,wdb_update_agent_data -Wl,--wrap,linked_queue_push_ex \
                             -Wl,--wrap,wdb_update_agent_connection_status -Wl,--wrap,SendMSG -Wl,--wrap,StartMQ \
                             -Wl,--wrap,get_ipv4_string -Wl,--wrap,get_ipv6_string \
-                            -Wl,--wrap,wdb_get_agent_group \
+                            -Wl,--wrap,wdb_get_agent_group -Wl,--wrap,compare_wazuh_versions \
                             -Wl,--wrap,wdb_set_agent_groups_csv -Wl,--wrap,w_is_single_node \
                             -Wl,--wrap,wdb_remove_group_db -Wl,--wrap,wdb_get_all_agents -Wl,--wrap,wdb_get_agent_info")
 

--- a/src/unit_tests/remoted/test_manager.c
+++ b/src/unit_tests/remoted/test_manager.c
@@ -3375,7 +3375,7 @@ void test_save_controlmsg_agent_invalid_version(void **state)
     char r_msg[OS_SIZE_128] = {0};
     char s_msg[OS_FLSIZE + 1] = {0};
     strcpy(r_msg, "agent startup {\"version\":\"v4.5.1\"}");
-    snprintf(s_msg, OS_FLSIZE, "%s%s", CONTROL_HEADER, HC_INVALID_VERSION);
+    snprintf(s_msg, OS_FLSIZE, "%s%s%s%s%s", CONTROL_HEADER, HC_ERROR, "{\"message\":\"", HC_INVALID_VERSION, "\"}");
 
     keyentry key;
     keyentry_init(&key, "NEW_AGENT", "001", "10.2.2.5", NULL);
@@ -3402,7 +3402,9 @@ void test_save_controlmsg_get_agent_version_fail(void **state)
 {
 
     char r_msg[OS_SIZE_128] = {0};
+    char s_msg[OS_FLSIZE + 1] = {0};
     strcpy(r_msg, "agent startup {\"test\":\"fail\"}");
+    snprintf(s_msg, OS_FLSIZE, "%s%s%s%s%s", CONTROL_HEADER, HC_ERROR, "{\"message\":\"", HC_RETRIEVE_VERSION, "\"}");
 
     keyentry key;
     keyentry_init(&key, "NEW_AGENT", "001", "10.2.2.5", NULL);
@@ -3415,32 +3417,11 @@ void test_save_controlmsg_get_agent_version_fail(void **state)
     expect_string(__wrap__merror, formatted_msg, "Error getting version from agent '001'");
 
     expect_string(__wrap_send_msg, agent_id, "001");
-    expect_string(__wrap_send_msg, msg, "#!-agent ack ");
-
-    expect_function_call(__wrap_OSHash_Create);
-    will_return(__wrap_OSHash_Create, 1);
-    pending_data = OSHash_Create();
-
-    pending_data_t data;
-    char * message = strdup("startup message \n");
-    data.changed = false;
-    data.message = message;
-
-    expect_value(__wrap_OSHash_Get, self, pending_data);
-    expect_string(__wrap_OSHash_Get, key, "001");
-    will_return(__wrap_OSHash_Get, &data);
-
-    expect_value(__wrap_wdb_update_agent_keepalive, id, 1);
-    expect_string(__wrap_wdb_update_agent_keepalive, connection_status, AGENT_CS_PENDING);
-    expect_string(__wrap_wdb_update_agent_keepalive, sync_status, "synced");
-    will_return(__wrap_wdb_update_agent_keepalive, OS_INVALID);
-
-    expect_string(__wrap__mwarn, formatted_msg, "Unable to save last keepalive and set connection status as pending for agent: 001");
+    expect_string(__wrap_send_msg, msg, s_msg);
 
     save_controlmsg(&key, r_msg, msg_length, wdb_sock);
 
     free_keyentry(&key);
-    os_free(message);
 }
 
 void test_save_controlmsg_could_not_add_pending_data(void **state)

--- a/src/unit_tests/shared/test_version_op.c
+++ b/src/unit_tests/shared/test_version_op.c
@@ -1446,6 +1446,116 @@ void test_OSX_ReleaseName(void **state) {
     assert_string_equal(OSX_ReleaseName(23), "Unknown");
 }
 
+void test_compare_wazuh_versions_equal_patch(void **state)
+{
+    (void) state;
+    char *v1 = "v4.0.0";
+    char *v2 = "v4.0.0";
+
+    int ret = compare_wazuh_versions(v1, v2);
+
+    assert_int_equal(ret, 0);
+}
+
+void test_compare_wazuh_versions_equal_minor(void **state)
+{
+    (void) state;
+    char *v1 = "3.13";
+    char *v2 = "3.13";
+
+    int ret = compare_wazuh_versions(v1, v2);
+
+    assert_int_equal(ret, 0);
+}
+
+void test_compare_wazuh_versions_equal_major(void **state)
+{
+    (void) state;
+    char *v1 = "4";
+    char *v2 = "v4";
+
+    int ret = compare_wazuh_versions(v1, v2);
+
+    assert_int_equal(ret, 0);
+}
+
+void test_compare_wazuh_versions_greater_patch(void **state)
+{
+    (void) state;
+    char *v1 = "4.0.1";
+    char *v2 = "v4.0.0";
+
+    int ret = compare_wazuh_versions(v1, v2);
+
+    assert_int_equal(ret, 1);
+}
+
+void test_compare_wazuh_versions_greater_minor(void **state)
+{
+    (void) state;
+    char *v1 = "2.15";
+    char *v2 = "2";
+
+    int ret = compare_wazuh_versions(v1, v2);
+
+    assert_int_equal(ret, 1);
+}
+
+void test_compare_wazuh_versions_greater_major(void **state)
+{
+    (void) state;
+    char *v1 = "v5";
+    char *v2 = "4.9";
+
+    int ret = compare_wazuh_versions(v1, v2);
+
+    assert_int_equal(ret, 1);
+}
+
+void test_compare_wazuh_versions_lower_patch(void **state)
+{
+    (void) state;
+    char *v1 = "v4.0.1";
+    char *v2 = "v4.0.3";
+
+    int ret = compare_wazuh_versions(v1, v2);
+
+    assert_int_equal(ret, -1);
+}
+
+void test_compare_wazuh_versions_lower_minor(void **state)
+{
+    (void) state;
+    char *v1 = "2.15.1";
+    char *v2 = "2.18";
+
+    int ret = compare_wazuh_versions(v1, v2);
+
+    assert_int_equal(ret, -1);
+}
+
+void test_compare_wazuh_versions_lower_major(void **state)
+{
+    (void) state;
+    char *v1 = "v5";
+    char *v2 = "v6.1";
+
+    int ret = compare_wazuh_versions(v1, v2);
+
+    assert_int_equal(ret, -1);
+}
+
+void test_compare_wazuh_versions_null(void **state)
+{
+    (void) state;
+    char *v1 = NULL;
+    char *v2 = NULL;
+
+    int ret = compare_wazuh_versions(v1, v2);
+
+    assert_int_equal(ret, 0);
+}
+
 #endif
 
 int main(void) {
@@ -1474,6 +1584,17 @@ int main(void) {
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_aix, delete_os_info),
             cmocka_unit_test(test_OSX_ReleaseName),
 #endif
+            // compare_wazuh_versions
+            cmocka_unit_test(test_compare_wazuh_versions_equal_patch),
+            cmocka_unit_test(test_compare_wazuh_versions_equal_minor),
+            cmocka_unit_test(test_compare_wazuh_versions_equal_major),
+            cmocka_unit_test(test_compare_wazuh_versions_greater_patch),
+            cmocka_unit_test(test_compare_wazuh_versions_greater_minor),
+            cmocka_unit_test(test_compare_wazuh_versions_greater_major),
+            cmocka_unit_test(test_compare_wazuh_versions_lower_patch),
+            cmocka_unit_test(test_compare_wazuh_versions_lower_minor),
+            cmocka_unit_test(test_compare_wazuh_versions_lower_major),
+            cmocka_unit_test(test_compare_wazuh_versions_null)
     };
     return cmocka_run_group_tests(tests, setup_group, teardown_group);
 }

--- a/src/unit_tests/shared/test_version_op.c
+++ b/src/unit_tests/shared/test_version_op.c
@@ -1446,6 +1446,8 @@ void test_OSX_ReleaseName(void **state) {
     assert_string_equal(OSX_ReleaseName(23), "Unknown");
 }
 
+#endif
+
 void test_compare_wazuh_versions_equal_patch(void **state)
 {
     (void) state;
@@ -1555,8 +1557,6 @@ void test_compare_wazuh_versions_null(void **state)
 
     assert_int_equal(ret, 0);
 }
-
-#endif
 
 int main(void) {
     const struct CMUnitTest tests[] = {

--- a/src/unit_tests/wazuh_modules/agent_upgrade/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/CMakeLists.txt
@@ -63,7 +63,7 @@ if(${TARGET} STREQUAL "server")
     list(APPEND upgrade_names "test_wm_agent_upgrade_upgrades")
     list(APPEND upgrade_flags "-Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,OS_RecvSecureTCP -Wl,--wrap,close \
                             -Wl,--wrap,wm_agent_upgrade_parse_task_module_request -Wl,--wrap,wm_agent_upgrade_task_module_callback -Wl,--wrap,wm_agent_upgrade_parse_agent_response -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fclose \
-                            -Wl,--wrap,OS_SHA1_File -Wl,--wrap,wm_agent_upgrade_get_first_node -Wl,--wrap,wm_agent_upgrade_get_next_node -Wl,--wrap,wm_agent_upgrade_compare_versions -Wl,--wrap,wm_agent_upgrade_remove_entry \
+                            -Wl,--wrap,OS_SHA1_File -Wl,--wrap,wm_agent_upgrade_get_first_node -Wl,--wrap,wm_agent_upgrade_get_next_node -Wl,--wrap,compare_wazuh_versions -Wl,--wrap,wm_agent_upgrade_remove_entry \
                             -Wl,--wrap,wm_agent_upgrade_validate_task_status_message -Wl,--wrap,wm_agent_upgrade_validate_wpk -Wl,--wrap,wm_agent_upgrade_validate_wpk_custom -Wl,--wrap,wm_agent_upgrade_validate_wpk_version \
                             -Wl,--wrap,linked_queue_push_ex -Wl,--wrap,linked_queue_pop_ex -Wl,--wrap,pthread_cond_signal -Wl,--wrap,pthread_cond_wait -Wl,--wrap,CreateThread \
                             -Wl,--wrap,wm_agent_upgrade_parse_agent_upgrade_command_response -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,getpid -Wl,--wrap,fgetpos -Wl,--wrap=fgetc \

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_upgrades.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_upgrades.c
@@ -19,6 +19,7 @@
 #include "../../wrappers/posix/unistd_wrappers.h"
 #include "../../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../../wrappers/wazuh/shared/queue_linked_op_wrappers.h"
+#include "../../wrappers/wazuh/shared/version_op_wrappers.h"
 #include "../../wrappers/wazuh/os_crypto/sha1_op_wrappers.h"
 #include "../../wrappers/wazuh/os_net/os_net_wrappers.h"
 #include "../../wrappers/wazuh/wazuh_modules/wm_agent_upgrade_wrappers.h"
@@ -1387,9 +1388,9 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_linux_ok(void **state)
 
     // Format
 
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version1, agent_task->agent_info->wazuh_version);
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
-    will_return(__wrap_wm_agent_upgrade_compare_versions, -1);
+    expect_string(__wrap_compare_wazuh_versions, version1, agent_task->agent_info->wazuh_version);
+    expect_string(__wrap_compare_wazuh_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
+    will_return(__wrap_compare_wazuh_versions, -1);
 
     // Open file
 
@@ -1553,9 +1554,9 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_windows_ok(void **state)
 
     // Format
 
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version1, agent_task->agent_info->wazuh_version);
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
-    will_return(__wrap_wm_agent_upgrade_compare_versions, -1);
+    expect_string(__wrap_compare_wazuh_versions, version1, agent_task->agent_info->wazuh_version);
+    expect_string(__wrap_compare_wazuh_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
+    will_return(__wrap_compare_wazuh_versions, -1);
 
     // Open file
 
@@ -1717,9 +1718,9 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_custom_custom_installer_ok(
 
     // Format
 
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version1, agent_task->agent_info->wazuh_version);
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
-    will_return(__wrap_wm_agent_upgrade_compare_versions, -1);
+    expect_string(__wrap_compare_wazuh_versions, version1, agent_task->agent_info->wazuh_version);
+    expect_string(__wrap_compare_wazuh_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
+    will_return(__wrap_compare_wazuh_versions, -1);
 
     // Open file
 
@@ -1880,9 +1881,9 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_custom_default_installer_ok
 
     // Format
 
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version1, agent_task->agent_info->wazuh_version);
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
-    will_return(__wrap_wm_agent_upgrade_compare_versions, -1);
+    expect_string(__wrap_compare_wazuh_versions, version1, agent_task->agent_info->wazuh_version);
+    expect_string(__wrap_compare_wazuh_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
+    will_return(__wrap_compare_wazuh_versions, -1);
 
     // Open file
 
@@ -2046,9 +2047,9 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_run_upgrade_err(void **stat
 
     // Format
 
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version1, agent_task->agent_info->wazuh_version);
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
-    will_return(__wrap_wm_agent_upgrade_compare_versions, -1);
+    expect_string(__wrap_compare_wazuh_versions, version1, agent_task->agent_info->wazuh_version);
+    expect_string(__wrap_compare_wazuh_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
+    will_return(__wrap_compare_wazuh_versions, -1);
 
     // Open file
 
@@ -2211,9 +2212,9 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_send_sha1_err(void **state)
 
     // Format
 
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version1, agent_task->agent_info->wazuh_version);
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
-    will_return(__wrap_wm_agent_upgrade_compare_versions, -1);
+    expect_string(__wrap_compare_wazuh_versions, version1, agent_task->agent_info->wazuh_version);
+    expect_string(__wrap_compare_wazuh_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
+    will_return(__wrap_compare_wazuh_versions, -1);
 
     // Open file
 
@@ -2362,9 +2363,9 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_close_file_err(void **state
 
     // Format
 
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version1, agent_task->agent_info->wazuh_version);
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
-    will_return(__wrap_wm_agent_upgrade_compare_versions, -1);
+    expect_string(__wrap_compare_wazuh_versions, version1, agent_task->agent_info->wazuh_version);
+    expect_string(__wrap_compare_wazuh_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
+    will_return(__wrap_compare_wazuh_versions, -1);
 
     // Open file
 
@@ -2495,9 +2496,9 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_write_file_err(void **state
 
     // Format
 
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version1, agent_task->agent_info->wazuh_version);
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
-    will_return(__wrap_wm_agent_upgrade_compare_versions, -1);
+    expect_string(__wrap_compare_wazuh_versions, version1, agent_task->agent_info->wazuh_version);
+    expect_string(__wrap_compare_wazuh_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
+    will_return(__wrap_compare_wazuh_versions, -1);
 
     // Open file
 
@@ -2609,9 +2610,9 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_open_file_err(void **state)
 
     // Format
 
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version1, agent_task->agent_info->wazuh_version);
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
-    will_return(__wrap_wm_agent_upgrade_compare_versions, -1);
+    expect_string(__wrap_compare_wazuh_versions, version1, agent_task->agent_info->wazuh_version);
+    expect_string(__wrap_compare_wazuh_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
+    will_return(__wrap_compare_wazuh_versions, -1);
 
     // Open file
 
@@ -2759,9 +2760,9 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_lock_restart_err(void **sta
 
     // Format
 
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version1, agent_task->agent_info->wazuh_version);
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
-    will_return(__wrap_wm_agent_upgrade_compare_versions, -1);
+    expect_string(__wrap_compare_wazuh_versions, version1, agent_task->agent_info->wazuh_version);
+    expect_string(__wrap_compare_wazuh_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
+    will_return(__wrap_compare_wazuh_versions, -1);
 
     expect_string_count(__wrap__mtdebug2, tag, "wazuh-modulesd:agent-upgrade", 2);
     expect_string(__wrap__mtdebug2, formatted_msg, "(8165): Sending message to agent: '111 com lock_restart -1'");
@@ -2969,9 +2970,9 @@ void test_wm_agent_upgrade_start_upgrade_upgrade_ok(void **state)
 
     // Format
 
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version1, agent_task->agent_info->wazuh_version);
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
-    will_return(__wrap_wm_agent_upgrade_compare_versions, -1);
+    expect_string(__wrap_compare_wazuh_versions, version1, agent_task->agent_info->wazuh_version);
+    expect_string(__wrap_compare_wazuh_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
+    will_return(__wrap_compare_wazuh_versions, -1);
 
     // Open file
 
@@ -3200,9 +3201,9 @@ void test_wm_agent_upgrade_start_upgrade_upgrade_legacy_ok(void **state)
 
     // Format
 
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version1, agent_task->agent_info->wazuh_version);
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
-    will_return(__wrap_wm_agent_upgrade_compare_versions, -1);
+    expect_string(__wrap_compare_wazuh_versions, version1, agent_task->agent_info->wazuh_version);
+    expect_string(__wrap_compare_wazuh_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
+    will_return(__wrap_compare_wazuh_versions, -1);
 
     // Open file
 
@@ -3299,11 +3300,11 @@ void test_wm_agent_upgrade_start_upgrade_upgrade_legacy_ok(void **state)
     expect_string(__wrap_wm_agent_upgrade_parse_agent_response, agent_response, agent_res_ok_0);
     will_return_count(__wrap_wm_agent_upgrade_parse_agent_response, 0, 6);
 
-    // wm_agent_upgrade_compare_versions
+    // compare_wazuh_versions
 
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version1, "v3.13.1");
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
-    will_return(__wrap_wm_agent_upgrade_compare_versions, -1);
+    expect_string(__wrap_compare_wazuh_versions, version1, "v3.13.1");
+    expect_string(__wrap_compare_wazuh_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
+    will_return(__wrap_compare_wazuh_versions, -1);
 
     // wm_agent_upgrade_parse_task_module_request
 
@@ -3431,9 +3432,9 @@ void test_wm_agent_upgrade_start_upgrade_upgrade_custom_ok(void **state)
 
     // Format
 
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version1, agent_task->agent_info->wazuh_version);
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
-    will_return(__wrap_wm_agent_upgrade_compare_versions, -1);
+    expect_string(__wrap_compare_wazuh_versions, version1, agent_task->agent_info->wazuh_version);
+    expect_string(__wrap_compare_wazuh_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
+    will_return(__wrap_compare_wazuh_versions, -1);
 
     // Open file
 
@@ -3661,9 +3662,9 @@ void test_wm_agent_upgrade_start_upgrade_upgrade_err(void **state)
 
     // Format
 
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version1, agent_task->agent_info->wazuh_version);
-    expect_string(__wrap_wm_agent_upgrade_compare_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
-    will_return(__wrap_wm_agent_upgrade_compare_versions, -1);
+    expect_string(__wrap_compare_wazuh_versions, version1, agent_task->agent_info->wazuh_version);
+    expect_string(__wrap_compare_wazuh_versions, version2, WM_UPGRADE_NEW_UPGRADE_MECHANISM);
+    will_return(__wrap_compare_wazuh_versions, -1);
 
     expect_string_count(__wrap__mtdebug2, tag, "wazuh-modulesd:agent-upgrade", 2);
     expect_string(__wrap__mtdebug2, formatted_msg, "(8165): Sending message to agent: '025 com lock_restart -1'");

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
@@ -286,116 +286,6 @@ void test_wm_agent_upgrade_validate_system_rolling_archlinux(void **state)
     assert_int_equal(ret, WM_UPGRADE_SUCCESS);
 }
 
-void test_wm_agent_upgrade_compare_versions_equal_patch(void **state)
-{
-    (void) state;
-    char *v1 = "v4.0.0";
-    char *v2 = "v4.0.0";
-
-    int ret = wm_agent_upgrade_compare_versions(v1, v2);
-
-    assert_int_equal(ret, 0);
-}
-
-void test_wm_agent_upgrade_compare_versions_equal_minor(void **state)
-{
-    (void) state;
-    char *v1 = "3.13";
-    char *v2 = "3.13";
-
-    int ret = wm_agent_upgrade_compare_versions(v1, v2);
-
-    assert_int_equal(ret, 0);
-}
-
-void test_wm_agent_upgrade_compare_versions_equal_major(void **state)
-{
-    (void) state;
-    char *v1 = "4";
-    char *v2 = "v4";
-
-    int ret = wm_agent_upgrade_compare_versions(v1, v2);
-
-    assert_int_equal(ret, 0);
-}
-
-void test_wm_agent_upgrade_compare_versions_greater_patch(void **state)
-{
-    (void) state;
-    char *v1 = "4.0.1";
-    char *v2 = "v4.0.0";
-
-    int ret = wm_agent_upgrade_compare_versions(v1, v2);
-
-    assert_int_equal(ret, 1);
-}
-
-void test_wm_agent_upgrade_compare_versions_greater_minor(void **state)
-{
-    (void) state;
-    char *v1 = "2.15";
-    char *v2 = "2";
-
-    int ret = wm_agent_upgrade_compare_versions(v1, v2);
-
-    assert_int_equal(ret, 1);
-}
-
-void test_wm_agent_upgrade_compare_versions_greater_major(void **state)
-{
-    (void) state;
-    char *v1 = "v5";
-    char *v2 = "4.9";
-
-    int ret = wm_agent_upgrade_compare_versions(v1, v2);
-
-    assert_int_equal(ret, 1);
-}
-
-void test_wm_agent_upgrade_compare_versions_lower_patch(void **state)
-{
-    (void) state;
-    char *v1 = "v4.0.1";
-    char *v2 = "v4.0.3";
-
-    int ret = wm_agent_upgrade_compare_versions(v1, v2);
-
-    assert_int_equal(ret, -1);
-}
-
-void test_wm_agent_upgrade_compare_versions_lower_minor(void **state)
-{
-    (void) state;
-    char *v1 = "2.15.1";
-    char *v2 = "2.18";
-
-    int ret = wm_agent_upgrade_compare_versions(v1, v2);
-
-    assert_int_equal(ret, -1);
-}
-
-void test_wm_agent_upgrade_compare_versions_lower_major(void **state)
-{
-    (void) state;
-    char *v1 = "v5";
-    char *v2 = "v6.1";
-
-    int ret = wm_agent_upgrade_compare_versions(v1, v2);
-
-    assert_int_equal(ret, -1);
-}
-
-void test_wm_agent_upgrade_compare_versions_null(void **state)
-{
-    (void) state;
-    char *v1 = NULL;
-    char *v2 = NULL;
-
-    int ret = wm_agent_upgrade_compare_versions(v1, v2);
-
-    assert_int_equal(ret, 0);
-}
-
 void test_wm_agent_upgrade_validate_wpk_version_windows_https_ok(void **state)
 {
     wm_agent_info *agent = state[0];
@@ -1335,17 +1225,6 @@ int main(void) {
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_invalid_arch),
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_rolling_opensuse),
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_rolling_archlinux),
-        // wm_agent_upgrade_compare_versions
-        cmocka_unit_test(test_wm_agent_upgrade_compare_versions_equal_patch),
-        cmocka_unit_test(test_wm_agent_upgrade_compare_versions_equal_minor),
-        cmocka_unit_test(test_wm_agent_upgrade_compare_versions_equal_major),
-        cmocka_unit_test(test_wm_agent_upgrade_compare_versions_greater_patch),
-        cmocka_unit_test(test_wm_agent_upgrade_compare_versions_greater_minor),
-        cmocka_unit_test(test_wm_agent_upgrade_compare_versions_greater_major),
-        cmocka_unit_test(test_wm_agent_upgrade_compare_versions_lower_patch),
-        cmocka_unit_test(test_wm_agent_upgrade_compare_versions_lower_minor),
-        cmocka_unit_test(test_wm_agent_upgrade_compare_versions_lower_major),
-        cmocka_unit_test(test_wm_agent_upgrade_compare_versions_null),
         // wm_agent_upgrade_validate_wpk_version
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_wpk_version_windows_https_ok, setup_validate_wpk_version, teardown_validate_wpk_version),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_wpk_version_windows_http_ok, setup_validate_wpk_version, teardown_validate_wpk_version),

--- a/src/unit_tests/wrappers/wazuh/shared/version_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/version_op_wrappers.c
@@ -1,0 +1,20 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+int __wrap_compare_wazuh_versions(const char *version1, const char *version2) {
+    check_expected(version1);
+    check_expected(version2);
+
+    return mock();
+}

--- a/src/unit_tests/wrappers/wazuh/shared/version_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/version_op_wrappers.h
@@ -1,0 +1,16 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+
+#ifndef VERSION_OP_WRAPPERS_H
+#define VERSION_OP_WRAPPERS_H
+
+int __wrap_compare_wazuh_versions(const char *version1, const char *version2);
+
+#endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_agent_upgrade_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_agent_upgrade_wrappers.c
@@ -138,13 +138,6 @@ cJSON* __wrap_wm_agent_upgrade_get_agent_ids() {
     return mock_type(cJSON*);
 }
 
-int __wrap_wm_agent_upgrade_compare_versions(const char *version1, const char *version2) {
-    check_expected(version1);
-    check_expected(version2);
-
-    return mock();
-}
-
 bool __wrap_wm_agent_upgrade_validate_task_status_message(const cJSON *input_json, char **status, int *agent_id) {
     check_expected(input_json);
     if (status) os_strdup(mock_type(char *), *status);

--- a/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_agent_upgrade_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_agent_upgrade_wrappers.h
@@ -47,8 +47,6 @@ OSHashNode* __wrap_wm_agent_upgrade_get_next_node(unsigned int *index, OSHashNod
 
 cJSON* __wrap_wm_agent_upgrade_get_agent_ids();
 
-int __wrap_wm_agent_upgrade_compare_versions(const char *version1, const char *version2);
-
 bool __wrap_wm_agent_upgrade_validate_task_status_message(const cJSON *input_json, char **status, int *agent_id);
 
 int __wrap_wm_agent_upgrade_validate_id(int agent_id);

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_upgrades.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_upgrades.c
@@ -206,7 +206,7 @@ STATIC void* wm_agent_upgrade_start_upgrade(void *arg) {
             if (WM_UPGRADE_UPGRADE == agent_task->task_info->command) {
                 wm_upgrade_task *upgrade_task = agent_task->task_info->task;
 
-                if (upgrade_task->custom_version && (wm_agent_upgrade_compare_versions(upgrade_task->custom_version, WM_UPGRADE_NEW_UPGRADE_MECHANISM) < 0)) {
+                if (upgrade_task->custom_version && (compare_wazuh_versions(upgrade_task->custom_version, WM_UPGRADE_NEW_UPGRADE_MECHANISM) < 0)) {
 
                     cJSON_Delete(status_request);
                     cJSON_Delete(status_response);
@@ -320,7 +320,7 @@ STATIC int wm_agent_upgrade_send_wpk_to_agent(const wm_agent_task *agent_task, c
     }
 
     // Compare actual agent version to know which command format to use
-    int wpk_message_format = wm_agent_upgrade_compare_versions(strchr(agent_task->agent_info->wazuh_version, 'v'), WM_UPGRADE_NEW_UPGRADE_MECHANISM);
+    int wpk_message_format = compare_wazuh_versions(strchr(agent_task->agent_info->wazuh_version, 'v'), WM_UPGRADE_NEW_UPGRADE_MECHANISM);
 
     // open wb
     if ((result == WM_UPGRADE_SUCCESS) && wm_agent_upgrade_send_open(agent_task->agent_info->agent_id, wpk_message_format, wpk_path)) {

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
@@ -103,9 +103,9 @@ int wm_agent_upgrade_validate_version(const char *wazuh_version, const char *pla
     if (wazuh_version) {
         if (tmp_agent_version = strchr(wazuh_version, 'v'), tmp_agent_version) {
 
-            if (wm_agent_upgrade_compare_versions(tmp_agent_version, WM_UPGRADE_MINIMAL_VERSION_SUPPORT) < 0) {
+            if (compare_wazuh_versions(tmp_agent_version, WM_UPGRADE_MINIMAL_VERSION_SUPPORT) < 0) {
                 return_code = WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED;
-            } else if (wm_agent_upgrade_compare_versions(tmp_agent_version, WM_UPGRADE_MINIMAL_VERSION_SUPPORT_MACOS) < 0 && !strcmp(platform, "darwin")) {
+            } else if (compare_wazuh_versions(tmp_agent_version, WM_UPGRADE_MINIMAL_VERSION_SUPPORT_MACOS) < 0 && !strcmp(platform, "darwin")) {
                 return_code = WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED;
             } else if (WM_UPGRADE_UPGRADE == command) {
                 wm_upgrade_task *upgrade_task = (wm_upgrade_task *)task;
@@ -116,9 +116,9 @@ int wm_agent_upgrade_validate_version(const char *wazuh_version, const char *pla
                     os_strdup(upgrade_task->custom_version ? upgrade_task->custom_version : manager_version, upgrade_task->wpk_version);
 
                     if (!upgrade_task->force_upgrade) {
-                        if (wm_agent_upgrade_compare_versions(tmp_agent_version, upgrade_task->wpk_version) >= 0) {
+                        if (compare_wazuh_versions(tmp_agent_version, upgrade_task->wpk_version) >= 0) {
                             return_code = WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT;
-                        } else if (wm_agent_upgrade_compare_versions(upgrade_task->wpk_version, manager_version) > 0) {
+                        } else if (compare_wazuh_versions(upgrade_task->wpk_version, manager_version) > 0) {
                             return_code = WM_UPGRADE_NEW_VERSION_GREATER_MASTER;
                         }
                     }
@@ -152,7 +152,7 @@ int wm_agent_upgrade_validate_wpk_version(const wm_agent_info *agent_info, wm_up
     if (!task->wpk_repository) {
         if (wpk_repository_config) {
             os_strdup(wpk_repository_config, task->wpk_repository);
-        } else if (wm_agent_upgrade_compare_versions(task->wpk_version, "v4.0.0") < 0) {
+        } else if (compare_wazuh_versions(task->wpk_version, "v4.0.0") < 0) {
             os_strdup(WM_UPGRADE_WPK_REPO_URL_3_X, task->wpk_repository);
         } else {
             if (sscanf(task->wpk_version, "v%d.%*d.%*d", &ver) != 1 &&
@@ -196,7 +196,7 @@ int wm_agent_upgrade_validate_wpk_version(const wm_agent_info *agent_info, wm_up
         snprintf(file_url, OS_SIZE_2048, "wazuh_agent_%s_macos_%s.wpk",
                  task->wpk_version, agent_info->architecture);
     } else {
-        if (wm_agent_upgrade_compare_versions(task->wpk_version, WM_UPGRADE_NEW_VERSION_REPOSITORY) >= 0) {
+        if (compare_wazuh_versions(task->wpk_version, WM_UPGRADE_NEW_VERSION_REPOSITORY) >= 0) {
             snprintf(path_url, OS_SIZE_2048, "%slinux/%s/",
                      repository_url, agent_info->architecture);
             snprintf(file_url, OS_SIZE_2048, "wazuh_agent_%s_linux_%s.wpk",
@@ -229,7 +229,7 @@ int wm_agent_upgrade_validate_wpk_version(const wm_agent_info *agent_info, wm_up
                 *next_line = '\0';
                 if (sha1 = strchr(version, ' '), sha1) {
                     *sha1 = '\0';
-                    if (wm_agent_upgrade_compare_versions(task->wpk_version, version) == 0) {
+                    if (compare_wazuh_versions(task->wpk_version, version) == 0) {
                         // Save WPK url, file name and sha1
                         os_strdup(sha1 + 1, task->wpk_sha1);
                         os_strdup(file_url, task->wpk_file);
@@ -246,7 +246,7 @@ int wm_agent_upgrade_validate_wpk_version(const wm_agent_info *agent_info, wm_up
         if (version) {
             if (sha1 = strchr(version, ' '), sha1) {
                 *sha1 = '\0';
-                if (wm_agent_upgrade_compare_versions(task->wpk_version, version) == 0) {
+                if (compare_wazuh_versions(task->wpk_version, version) == 0) {
                     // Save WPK url, file name and sha1
                     os_strdup(sha1 + 1, task->wpk_sha1);
                     os_strdup(file_url, task->wpk_file);
@@ -347,87 +347,6 @@ int wm_agent_upgrade_validate_wpk_custom(const wm_upgrade_custom_task *task) {
     }
 
     return return_code;
-}
-
-int wm_agent_upgrade_compare_versions(const char *version1, const char *version2) {
-    char ver1[10];
-    char ver2[10];
-    char *tmp_v1 = NULL;
-    char *tmp_v2 = NULL;
-    char *token = NULL;
-    int patch1 = 0;
-    int major1 = 0;
-    int minor1 = 0;
-    int patch2 = 0;
-    int major2 = 0;
-    int minor2 = 0;
-    int result = 0;
-
-    if (version1) {
-        strncpy(ver1, version1, 9);
-
-        if (tmp_v1 = strchr(ver1, 'v'), tmp_v1) {
-            tmp_v1++;
-        } else {
-            tmp_v1 = ver1;
-        }
-
-        if (token = strtok(tmp_v1, "."), token) {
-            major1 = atoi(token);
-
-            if (token = strtok(NULL, "."), token) {
-                minor1 = atoi(token);
-
-                if (token = strtok(NULL, "."), token) {
-                    patch1 = atoi(token);
-                }
-            }
-        }
-    }
-
-    if (version2) {
-        strncpy(ver2, version2, 9);
-
-        if (tmp_v2 = strchr(ver2, 'v'), tmp_v2) {
-            tmp_v2++;
-        } else {
-            tmp_v2 = ver2;
-        }
-
-        if (token = strtok(tmp_v2, "."), token) {
-            major2 = atoi(token);
-
-            if (token = strtok(NULL, "."), token) {
-                minor2 = atoi(token);
-
-                if (token = strtok(NULL, "."), token) {
-                    patch2 = atoi(token);
-                }
-            }
-        }
-    }
-
-    if (major1 > major2) {
-        result = 1;
-    } else if (major1 < major2){
-        result = -1;
-    } else {
-        if(minor1 > minor2) {
-            result = 1;
-        } else if (minor1 < minor2) {
-            result = -1;
-        } else {
-            if (patch1 > patch2) {
-                result = 1;
-            } else if (patch1 < patch2) {
-                result = -1;
-            } else {
-                result = 0;
-            }
-        }
-    }
-
-    return result;
 }
 
 bool wm_agent_upgrade_validate_task_status_message(const cJSON *input_json, char **status, int *agent_id) {

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.h
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.h
@@ -91,17 +91,6 @@ int wm_agent_upgrade_validate_wpk(const wm_upgrade_task *task) __attribute__((no
 int wm_agent_upgrade_validate_wpk_custom(const wm_upgrade_custom_task *task) __attribute__((nonnull));
 
 /**
- * Compare two versions with format v4.0.0
- * @param version1 char * with the string version
- * @param version2 char * with the string version
- * @return return_code
- * @retval 0 equals
- * @retval 1 version1 > version2
- * @retval -1 version1 < version2
- * */
-int wm_agent_upgrade_compare_versions(const char *version1, const char *version2);
-
-/**
  * Validate a status response from the task manager module
  * @param response JSON to be validated
  * @param status string to save the status of the task


### PR DESCRIPTION
|Related issue|
|---|
https://github.com/wazuh/wazuh/issues/11011


<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

New logic is added to prevent conections from agents with higher versions than the manager. Also new message is logged in agent ossec.log file informing this.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] macOS
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Working on cluster environments
- [x] Added unit tests (for new features)