### PR TITLE
Windows Whodata: Detect policy changes

### DIFF
--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -414,7 +414,7 @@ typedef struct _config {
     registry_ignore_regex *value_ignore_regex;         /* Regex of registry values to ignore */
     registry *registry;                                /* array of registry entries to be scanned */
     unsigned int max_fd_win_rt;                        /* Maximum number of descriptors in realtime */
-    whodata wdata;
+    whodata wdata;                                     /* Whodata struct */
     registry *registry_nodiff;                         /* list of values/registries to never output diff */
     registry_ignore_regex *registry_nodiff_regex;      /* regex of values/registries to never output diff */
 #endif

--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -271,7 +271,9 @@
 #define FIM_REALTIME_MAXNUM_WATCHES         "(6364): Unable to add directory to real time monitoring: '%s' - Maximum size permitted."
 #define FIM_ADDED_RULE_TO_FILE              "(6365): Added directory '%s' to audit rules file."
 #define FIM_WHODATA_STATE_CHECKER           "(6366): Starting check of Windows Audit Policies and SACLs."
-
+#define FIM_WHODATA_POLICY_OPENED           "(6367): Audit policy opened correctly. AuditingMode enabled."
+#define FIM_WHODATA_OBJECT_ACCESS           "(6368): Detected Audit Object Access category, checking subcategories. GUID: %s"
+#define FIM_WHODATA_SUCCESS_POLICY          "(6369): Found Audit %s subcategory configured to success. GUID: %s"
 
 /* Modules messages */
 #define WM_UPGRADE_RESULT_AGENT_INFO         "(8151): Agent Information obtained: '%s'"

--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -270,6 +270,7 @@
 #define FIM_WILDCARDS_UPDATE_FINALIZE       "(6363): Configuration wildcards update finalize."
 #define FIM_REALTIME_MAXNUM_WATCHES         "(6364): Unable to add directory to real time monitoring: '%s' - Maximum size permitted."
 #define FIM_ADDED_RULE_TO_FILE              "(6365): Added directory '%s' to audit rules file."
+#define FIM_WHODATA_STATE_CHECKER           "(6366): Starting check of Windows Audit Policies and SACLs."
 
 
 /* Modules messages */

--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -271,7 +271,7 @@
 #define FIM_REALTIME_MAXNUM_WATCHES         "(6364): Unable to add directory to real time monitoring: '%s' - Maximum size permitted."
 #define FIM_ADDED_RULE_TO_FILE              "(6365): Added directory '%s' to audit rules file."
 #define FIM_WHODATA_STATE_CHECKER           "(6366): Starting check of Windows Audit Policies and SACLs."
-#define FIM_WHODATA_POLICY_OPENED           "(6367): Audit policy opened correctly. AuditingMode enabled."
+#define FIM_WHODATA_POLICY_OPENED           "(6367): Audit policy opened successfully. Audit mode enabled."
 #define FIM_WHODATA_OBJECT_ACCESS           "(6368): Detected Audit Object Access category, checking subcategories. GUID: %s"
 #define FIM_WHODATA_SUCCESS_POLICY          "(6369): Found Audit %s subcategory configured to success. GUID: %s"
 

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -520,6 +520,7 @@
 #define FIM_INVALID_ATTRIBUTE                       "(6679): Invalid attribute '%s' for '%s' option."
 #define FIM_INVALID_OPTION                          "(6680): Invalid option '%s' for attribute '%s'"
 
+#define FIM_ERROR_WHODATA_WIN_POL_CH                "(6681): Audit policy change detected. Switching directories to realtime."
 #define FIM_ERROR_WHODATA_WIN_ARCH                  "(6682): Error reading 'Architecture' from Windows registry. (Error %u)"
 #define FIM_ERROR_WHODATA_WIN_SIDERROR              "(6683): Could not obtain the sid of Everyone. Error '%lu'."
 #define FIM_ERROR_WHODATA_OPEN_TOKEN                "(6684): OpenProcessToken() failed. Error '%lu'."

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -520,7 +520,7 @@
 #define FIM_INVALID_ATTRIBUTE                       "(6679): Invalid attribute '%s' for '%s' option."
 #define FIM_INVALID_OPTION                          "(6680): Invalid option '%s' for attribute '%s'"
 
-#define FIM_ERROR_WHODATA_WIN_POL_CH                "(6681): Audit policy change detected. Switching directories to realtime."
+
 #define FIM_ERROR_WHODATA_WIN_ARCH                  "(6682): Error reading 'Architecture' from Windows registry. (Error %u)"
 #define FIM_ERROR_WHODATA_WIN_SIDERROR              "(6683): Could not obtain the sid of Everyone. Error '%lu'."
 #define FIM_ERROR_WHODATA_OPEN_TOKEN                "(6684): OpenProcessToken() failed. Error '%lu'."

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -520,7 +520,6 @@
 #define FIM_INVALID_ATTRIBUTE                       "(6679): Invalid attribute '%s' for '%s' option."
 #define FIM_INVALID_OPTION                          "(6680): Invalid option '%s' for attribute '%s'"
 
-
 #define FIM_ERROR_WHODATA_WIN_ARCH                  "(6682): Error reading 'Architecture' from Windows registry. (Error %u)"
 #define FIM_ERROR_WHODATA_WIN_SIDERROR              "(6683): Could not obtain the sid of Everyone. Error '%lu'."
 #define FIM_ERROR_WHODATA_OPEN_TOKEN                "(6684): OpenProcessToken() failed. Error '%lu'."

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -66,7 +66,8 @@
 #define FIM_DATABASE_NODES_COUNT_FAIL           "(6948): Unable to get the number of entries in database."
 #define FIM_CJSON_ERROR_CREATE_ITEM             "(6949): Cannot create a cJSON item"
 #define FIM_REGISTRY_ACC_SID                    "(6950): Error in LookupAccountSid getting %s. (%ld): %s"
-
+#define FIM_WHODATA_ERROR_CHECKING_POL          "(6951): Unable to check the necessary policies for whodata: %s (%lu)."
+#define FIM_WHODATA_POLICY_CHANGE               "(6952): Audit policy change detected. Switching directories to realtime."
 
 /* Monitord warning messages */
 #define ROTATE_LOG_LONG_PATH                    "(7500): The path of the rotated log is too long."

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -67,7 +67,8 @@
 #define FIM_CJSON_ERROR_CREATE_ITEM             "(6949): Cannot create a cJSON item"
 #define FIM_REGISTRY_ACC_SID                    "(6950): Error in LookupAccountSid getting %s. (%ld): %s"
 #define FIM_WHODATA_ERROR_CHECKING_POL          "(6951): Unable to check the necessary policies for whodata: %s (%lu)."
-#define FIM_WHODATA_POLICY_CHANGE               "(6952): Audit policy change detected. Switching directories to realtime."
+#define FIM_WHODATA_POLICY_CHANGE_CHECKER       "(6952): Audit policy change detected. Switching directories to realtime."
+#define FIM_WHODATA_POLICY_CHANGE_CHANNEL       "(6953): Event 4719 received due to changes in audit policy. Switching directories to realtime."
 
 /* Monitord warning messages */
 #define ROTATE_LOG_LONG_PATH                    "(7500): The path of the rotated log is too long."

--- a/src/syscheckd/whodata/win_whodata.c
+++ b/src/syscheckd/whodata/win_whodata.c
@@ -174,18 +174,22 @@ STATIC void win_whodata_release_resources(whodata *wdata) {
 
     if (wdata->fd != NULL) {
         OSHash_Free(wdata->fd);
+        wdata->fd = NULL;
     }
 
     if (wdata->directories != NULL) {
         OSHash_Free(wdata->directories);
+        wdata->directories = NULL;
     }
 
     if (wdata->device != NULL) {
         free_strarray(wdata->device);
+        wdata->device = NULL;
     }
 
     if (wdata->drive != NULL) {
         free_strarray(wdata->drive);
+        wdata->drive = NULL;
     }
 
     atomic_int_set(&whodata_end, 1);

--- a/src/syscheckd/whodata/win_whodata.c
+++ b/src/syscheckd/whodata/win_whodata.c
@@ -951,7 +951,7 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
                 free_whodata_event(w_evt);
                 break;
 
-            case 224719:
+            case 4719:
                 merror(FIM_ERROR_WHODATA_WIN_POL_CH);
                 win_whodata_release_resources(&syscheck.wdata);
 

--- a/src/syscheckd/whodata/win_whodata.c
+++ b/src/syscheckd/whodata/win_whodata.c
@@ -1004,11 +1004,9 @@ int policy_check() {
     BOOL open_policy = FALSE;
     NTSTATUS Status;
     DWORD err_code;
-    char err_msg[OS_SIZE_1024 + 1];
-    err_msg[OS_SIZE_1024] = '\0';
+    LPSTR err_msg = NULL;
 
     ZeroMemory(&ObjectAttributes, sizeof(ObjectAttributes));
-
     Status = LsaOpenPolicy(NULL, &ObjectAttributes, POLICY_VIEW_AUDIT_INFORMATION, &PolicyHandle);
 
     if(!Status) {

--- a/src/syscheckd/whodata/win_whodata.c
+++ b/src/syscheckd/whodata/win_whodata.c
@@ -31,7 +31,6 @@
 #define criteria (DELETE | modify_criteria)
 #define WHODATA_DIR_REMOVE_INTERVAL 2
 #define FILETIME_SECOND 10000000
-#define WHODATA_START_DELAY 10
 #ifdef WAZUH_UNIT_TESTING
 #ifdef WIN32
 #include "unit_tests/wrappers/windows/aclapi_wrappers.h"
@@ -436,7 +435,6 @@ int run_whodata_scan() {
     }
 
     set_subscription_query(query);
-    sleep(WHODATA_START_DELAY); // sleep to avoid processing policy change events.
     // Set the whodata callback
 
     evt_subscribe_handle = EvtSubscribe(NULL,
@@ -1264,6 +1262,10 @@ void set_subscription_query(wchar_t *query) {
                                                         "EventData/Data[@Name='SubcategoryGuid'] = '{0CCE921D-69AE-11D9-BED3-505054503030}'" \
                                                     "or " \
                                                         "EventData/Data[@Name='SubcategoryGuid'] = '{0CCE922F-69AE-11D9-BED3-505054503030}'" \
+                                                    ")" \
+                                                "and " \
+                                                    "( " \
+                                                        "EventData/Data[@Name='AuditPolicyChanges'] = '%%%%8448'" \
                                                     ")" \
                                             ") " \
                                         ") " \

--- a/src/syscheckd/whodata/win_whodata.c
+++ b/src/syscheckd/whodata/win_whodata.c
@@ -687,10 +687,12 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
             goto clean;
         }
 
-        if (whodata_get_handle_id(buffer, &handle_id)) {
-            goto clean;
+        if (event_id == 4656 || event_id == 4663 || event_id == 4658) {
+            if (whodata_get_handle_id(buffer, &handle_id)) {
+                goto clean;
+            }
+            snprintf(hash_id, 21, "%llu", handle_id);
         }
-        snprintf(hash_id, 21, "%llu", handle_id);
 
         switch(event_id) {
 
@@ -888,6 +890,9 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
                 free_whodata_event(w_evt);
                 break;
 
+            case 4719:
+                merror(FIM_ERROR_WHODATA_WIN_POL_CH);
+            break;
             default:
                 merror(FIM_ERROR_WHODATA_EVENTID);
                 goto clean;
@@ -1133,7 +1138,21 @@ void set_subscription_query(wchar_t *query) {
                                                 ") " \
                                             ") " \
                                         "or " \
-                                            "System/EventID = 4658 " \
+                                            "( " \
+                                                "System/EventID = 4658 " \
+                                            ") " \
+                                        "or " \
+                                            "( " \
+                                                "System/EventID = 4719 " \
+                                                "and " \
+                                                    "(" \
+                                                        "EventData/Data[@Name='SubcategoryGuid'] = '{0CCE9223-69AE-11D9-BED3-505054503030}'" \
+                                                    "or " \
+                                                        "EventData/Data[@Name='SubcategoryGuid'] = '{0CCE921D-69AE-11D9-BED3-505054503030}'" \
+                                                    "or " \
+                                                        "EventData/Data[@Name='SubcategoryGuid'] = '{0CCE922F-69AE-11D9-BED3-505054503030}'" \
+                                                    ")" \
+                                            ") " \
                                         ") " \
                                     "]",
             AUDIT_SUCCESS, // Only successful events

--- a/src/syscheckd/whodata/win_whodata.c
+++ b/src/syscheckd/whodata/win_whodata.c
@@ -1054,6 +1054,7 @@ int set_policies() {
     int retval = 1;
     static const char *WPOL_FILE_SYSTEM_SUC = ",System,File System,{0CCE921D-69AE-11D9-BED3-505054503030},,,1\n";
     static const char *WPOL_HANDLE_SUC = ",System,Handle Manipulation,{0CCE9223-69AE-11D9-BED3-505054503030},,,1\n";
+    static const char *WPOL_AUDIT_POL_CH = ",System,Audit Policy Change,{0CCE922F-69AE-11D9-BED3-505054503030},,,1\n";
 
     if (!IsFile(WPOL_BACKUP_FILE) && remove(WPOL_BACKUP_FILE)) {
         merror(FIM_ERROR_WPOL_BACKUP_FILE_REMOVE, WPOL_BACKUP_FILE, strerror(errno), errno);
@@ -1087,6 +1088,7 @@ int set_policies() {
     // Add the new policies
     fprintf(f_new, WPOL_FILE_SYSTEM_SUC);
     fprintf(f_new, WPOL_HANDLE_SUC);
+    fprintf(f_new, WPOL_AUDIT_POL_CH);
 
     fclose(f_new);
 

--- a/src/syscheckd/whodata/win_whodata.c
+++ b/src/syscheckd/whodata/win_whodata.c
@@ -1120,6 +1120,8 @@ long unsigned int WINAPI state_checker(__attribute__((unused)) void *_void) {
     mdebug1(FIM_WHODATA_CHECKTHREAD, interval);
 
     while (atomic_int_get(&whodata_end) == 0) {
+        mdebug2(FIM_WHODATA_STATE_CHECKER);
+
         // Check File System and Handle Manipulation policies. Switch to realtime in case these policies are disabled.
         if (policy_check() == 1) {
             mwarn(FIM_WHODATA_POLICY_CHANGE);

--- a/src/unit_tests/syscheckd/whodata/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/whodata/CMakeLists.txt
@@ -99,8 +99,8 @@ else()
                            -Wl,--wrap,free_whodata_event -Wl,--wrap,IsFile -Wl,--wrap=remove \
                            -Wl,--wrap,wm_exec -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,atexit \
                            -Wl,--wrap,check_path_type -Wl,--wrap,pthread_rwlock_unlock -Wl,--wrap,fim_whodata_event \
-                           -Wl,--wrap,fim_checker -Wl,--wrap,os_random \
-                           -Wl,--wrap,convert_windows_string -Wl,--wrap,FOREVER \
+                           -Wl,--wrap,fim_checker -Wl,--wrap,os_random -Wl,--wrap,wpopenv -Wl,--wrap,atomic_int_get\
+                           -Wl,--wrap,convert_windows_string -Wl,--wrap,FOREVER -Wl,--wrap,wpclose \
                            -Wl,--wrap,fflush -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,fprintf \
                            -Wl,--wrap,fgets -Wl,--wrap,wstr_split -Wl,--wrap,pthread_rwlock_wrlock \
                            -Wl,--wrap,fgetpos -Wl,--wrap,fgetc -Wl,--wrap,getDefine_Int -Wl,--wrap,pthread_rwlock_rdlock \

--- a/src/unit_tests/syscheckd/whodata/test_win_whodata.c
+++ b/src/unit_tests/syscheckd/whodata/test_win_whodata.c
@@ -5321,7 +5321,7 @@ void test_whodata_callback_4719_success(void **state) {
 
     successful_whodata_event_render(event, raw_data);
 
-    expect_string(__wrap__merror, formatted_msg, FIM_ERROR_WHODATA_WIN_POL_CH);
+    expect_string(__wrap__mwarn, formatted_msg, FIM_WHODATA_POLICY_CHANGE);
 
     result = whodata_callback(action, NULL, event);
     assert_int_equal(result, 0);

--- a/src/unit_tests/syscheckd/whodata/test_win_whodata.c
+++ b/src/unit_tests/syscheckd/whodata/test_win_whodata.c
@@ -86,6 +86,10 @@ int SIZE_EVENTS;
 const PWCHAR WCS_TEST_PATH = L"C:\\Windows\\a\\path";
 const char *STR_TEST_PATH = "c:\\windows\\a\\path";
 
+static const char *guid_ObjectAccess = "{6997984A-797A-11D9-BED3-505054503030}";
+static const char *guid_FileSystem = "{0CCE921D-69AE-11D9-BED3-505054503030}";
+static const char *guid_Handle =  "{0CCE9223-69AE-11D9-BED3-505054503030}";
+
 typedef struct PolicyInfo {
     GUID *category_guid;
     GUID *subcategory_guid1;
@@ -6855,6 +6859,10 @@ void test_state_checker_no_files_to_check(void **state) {
     policy_info *pol_data = *state;
     int ret;
     void *input = NULL;
+    char debug_msg1[OS_SIZE_1024];
+    char debug_msg2[OS_SIZE_1024];
+    char debug_msg3[OS_SIZE_1024];
+    char debug_msg4[OS_SIZE_1024];
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
@@ -6862,12 +6870,21 @@ void test_state_checker_no_files_to_check(void **state) {
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
     OSList_CleanNodes(syscheck.directories);
-    expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
+
+    snprintf(debug_msg1, OS_SIZE_1024, FIM_WHODATA_CHECKTHREAD, 300);
+    expect_string(__wrap__mdebug1, formatted_msg, debug_msg1);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_POLICY_OPENED);
+    snprintf(debug_msg2, OS_SIZE_1024, FIM_WHODATA_OBJECT_ACCESS, guid_ObjectAccess);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg2);
+    snprintf(debug_msg3, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "File System", guid_FileSystem);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg3);
+    snprintf(debug_msg4, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "Handle Manipulation", guid_Handle);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg4);
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
-
-    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -6889,6 +6906,10 @@ void test_state_checker_file_not_whodata(void **state) {
     policy_info *pol_data = *state;
     int ret;
     void *input = NULL;
+    char debug_msg1[OS_SIZE_1024];
+    char debug_msg2[OS_SIZE_1024];
+    char debug_msg3[OS_SIZE_1024];
+    char debug_msg4[OS_SIZE_1024];
 
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
@@ -6899,12 +6920,20 @@ void test_state_checker_file_not_whodata(void **state) {
     // Leverage Free_Syscheck not free the wdata struct
     ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.status &= ~WD_CHECK_WHODATA;
 
-    expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
+    snprintf(debug_msg1, OS_SIZE_1024, FIM_WHODATA_CHECKTHREAD, 300);
+    expect_string(__wrap__mdebug1, formatted_msg, debug_msg1);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_POLICY_OPENED);
+    snprintf(debug_msg2, OS_SIZE_1024, FIM_WHODATA_OBJECT_ACCESS, guid_ObjectAccess);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg2);
+    snprintf(debug_msg3, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "File System", guid_FileSystem);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg3);
+    snprintf(debug_msg4, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "Handle Manipulation", guid_Handle);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg4);
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
-
-    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -6927,6 +6956,10 @@ void test_state_checker_file_does_not_exist(void **state) {
     int ret;
     void *input = NULL;
     SYSTEMTIME st;
+    char debug_msg1[OS_SIZE_1024];
+    char debug_msg2[OS_SIZE_1024];
+    char debug_msg3[OS_SIZE_1024];
+    char debug_msg4[OS_SIZE_1024];
 
     memset(&st, 0, sizeof(SYSTEMTIME));
     st.wYear = 2020;
@@ -6939,12 +6972,20 @@ void test_state_checker_file_does_not_exist(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
+    snprintf(debug_msg1, OS_SIZE_1024, FIM_WHODATA_CHECKTHREAD, 300);
+    expect_string(__wrap__mdebug1, formatted_msg, debug_msg1);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_POLICY_OPENED);
+    snprintf(debug_msg2, OS_SIZE_1024, FIM_WHODATA_OBJECT_ACCESS, guid_ObjectAccess);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg2);
+    snprintf(debug_msg3, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "File System", guid_FileSystem);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg3);
+    snprintf(debug_msg4, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "Handle Manipulation", guid_Handle);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg4);
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
-
-    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -6979,6 +7020,10 @@ void test_state_checker_file_with_invalid_sacl(void **state) {
     void *input = NULL;
     ACL acl;
     SID_IDENTIFIER_AUTHORITY world_auth = {SECURITY_WORLD_SID_AUTHORITY};
+    char debug_msg1[OS_SIZE_1024];
+    char debug_msg2[OS_SIZE_1024];
+    char debug_msg3[OS_SIZE_1024];
+    char debug_msg4[OS_SIZE_1024];
 
     acl.AceCount = 1;
 
@@ -6988,12 +7033,20 @@ void test_state_checker_file_with_invalid_sacl(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
+    snprintf(debug_msg1, OS_SIZE_1024, FIM_WHODATA_CHECKTHREAD, 300);
+    expect_string(__wrap__mdebug1, formatted_msg, debug_msg1);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_POLICY_OPENED);
+    snprintf(debug_msg2, OS_SIZE_1024, FIM_WHODATA_OBJECT_ACCESS, guid_ObjectAccess);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg2);
+    snprintf(debug_msg3, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "File System", guid_FileSystem);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg3);
+    snprintf(debug_msg4, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "Handle Manipulation", guid_Handle);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg4);
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
-
-    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -7094,6 +7147,10 @@ void test_state_checker_file_with_valid_sacl(void **state) {
     void *input = NULL;
     SYSTEMTIME st;
     ACL acl;
+    char debug_msg1[OS_SIZE_1024];
+    char debug_msg2[OS_SIZE_1024];
+    char debug_msg3[OS_SIZE_1024];
+    char debug_msg4[OS_SIZE_1024];
 
     memset(&st, 0, sizeof(SYSTEMTIME));
     st.wYear = 2020;
@@ -7108,12 +7165,20 @@ void test_state_checker_file_with_valid_sacl(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
+    snprintf(debug_msg1, OS_SIZE_1024, FIM_WHODATA_CHECKTHREAD, 300);
+    expect_string(__wrap__mdebug1, formatted_msg, debug_msg1);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_POLICY_OPENED);
+    snprintf(debug_msg2, OS_SIZE_1024, FIM_WHODATA_OBJECT_ACCESS, guid_ObjectAccess);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg2);
+    snprintf(debug_msg3, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "File System", guid_FileSystem);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg3);
+    snprintf(debug_msg4, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "Handle Manipulation", guid_Handle);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg4);
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
-
-    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -7211,6 +7276,10 @@ void test_state_checker_dir_readded_error(void **state) {
     int ret;
     void *input = NULL;
     char debug_msg[OS_MAXSTR];
+    char debug_msg1[OS_SIZE_1024];
+    char debug_msg2[OS_SIZE_1024];
+    char debug_msg3[OS_SIZE_1024];
+    char debug_msg4[OS_SIZE_1024];
 
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
@@ -7220,12 +7289,20 @@ void test_state_checker_dir_readded_error(void **state) {
 
     ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.status &= ~WD_STATUS_EXISTS;
 
-    expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
+    snprintf(debug_msg1, OS_SIZE_1024, FIM_WHODATA_CHECKTHREAD, 300);
+    expect_string(__wrap__mdebug1, formatted_msg, debug_msg1);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_POLICY_OPENED);
+    snprintf(debug_msg2, OS_SIZE_1024, FIM_WHODATA_OBJECT_ACCESS, guid_ObjectAccess);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg2);
+    snprintf(debug_msg3, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "File System", guid_FileSystem);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg3);
+    snprintf(debug_msg4, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "Handle Manipulation", guid_Handle);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg4);
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
-
-    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -7279,6 +7356,10 @@ void test_state_checker_dir_readded_succesful(void **state) {
     SECURITY_DESCRIPTOR security_descriptor;
     SID_IDENTIFIER_AUTHORITY world_auth = {SECURITY_WORLD_SID_AUTHORITY};
     SYSTEMTIME st;
+    char debug_msg1[OS_SIZE_1024];
+    char debug_msg2[OS_SIZE_1024];
+    char debug_msg3[OS_SIZE_1024];
+    char debug_msg4[OS_SIZE_1024];
 
     acl.AceCount = 1;
 
@@ -7296,12 +7377,20 @@ void test_state_checker_dir_readded_succesful(void **state) {
     st.wMonth = 3;
     st.wDay = 3;
 
-    expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
+    snprintf(debug_msg1, OS_SIZE_1024, FIM_WHODATA_CHECKTHREAD, 300);
+    expect_string(__wrap__mdebug1, formatted_msg, debug_msg1);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_POLICY_OPENED);
+    snprintf(debug_msg2, OS_SIZE_1024, FIM_WHODATA_OBJECT_ACCESS, guid_ObjectAccess);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg2);
+    snprintf(debug_msg3, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "File System", guid_FileSystem);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg3);
+    snprintf(debug_msg4, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "Handle Manipulation", guid_Handle);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg4);
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
-
-    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -7434,6 +7523,9 @@ void test_state_checker_not_match_policy(void **state) {
     policy_info *pol_data = *state;
     int ret;
     void *input = NULL;
+    char debug_msg1[OS_SIZE_1024];
+    char debug_msg2[OS_SIZE_1024];
+    char debug_msg4[OS_SIZE_1024];
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
@@ -7441,12 +7533,19 @@ void test_state_checker_not_match_policy(void **state) {
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
     OSList_CleanNodes(syscheck.directories);
-    expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
+
+    snprintf(debug_msg1, OS_SIZE_1024, FIM_WHODATA_CHECKTHREAD, 300);
+    expect_string(__wrap__mdebug1, formatted_msg, debug_msg1);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_POLICY_OPENED);
+    snprintf(debug_msg2, OS_SIZE_1024, FIM_WHODATA_OBJECT_ACCESS, guid_ObjectAccess);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg2);
+    snprintf(debug_msg4, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "Handle Manipulation", guid_Handle);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg4);
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
-
-    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     pol_data->paudit_policy[0].AuditingInformation = POLICY_AUDIT_EVENT_FAILURE;
     expect_policy_check_match_call((NTSTATUS)0,
@@ -7467,16 +7566,28 @@ void test_state_checker_not_match_policy(void **state) {
 void test_state_checker_dirs_cleanup_no_nodes(void ** state) {
     policy_info *pol_data = *state;
     int ret;
+    char debug_msg1[OS_SIZE_1024];
+    char debug_msg2[OS_SIZE_1024];
+    char debug_msg3[OS_SIZE_1024];
+    char debug_msg4[OS_SIZE_1024];
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
+    snprintf(debug_msg1, OS_SIZE_1024, FIM_WHODATA_CHECKTHREAD, 300);
+    expect_string(__wrap__mdebug1, formatted_msg, debug_msg1);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_POLICY_OPENED);
+    snprintf(debug_msg2, OS_SIZE_1024, FIM_WHODATA_OBJECT_ACCESS, guid_ObjectAccess);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg2);
+    snprintf(debug_msg3, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "File System", guid_FileSystem);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg3);
+    snprintf(debug_msg4, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "Handle Manipulation", guid_Handle);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg4);
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
-
-    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -7500,16 +7611,28 @@ void test_state_checker_dirs_cleanup_single_non_stale_node(void ** state) {
     int ret;
     whodata_directory * w_dir;
     FILETIME current_time;
+    char debug_msg1[OS_SIZE_1024];
+    char debug_msg2[OS_SIZE_1024];
+    char debug_msg3[OS_SIZE_1024];
+    char debug_msg4[OS_SIZE_1024];
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
+    snprintf(debug_msg1, OS_SIZE_1024, FIM_WHODATA_CHECKTHREAD, 300);
+    expect_string(__wrap__mdebug1, formatted_msg, debug_msg1);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_POLICY_OPENED);
+    snprintf(debug_msg2, OS_SIZE_1024, FIM_WHODATA_OBJECT_ACCESS, guid_ObjectAccess);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg2);
+    snprintf(debug_msg3, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "File System", guid_FileSystem);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg3);
+    snprintf(debug_msg4, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "Handle Manipulation", guid_Handle);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg4);
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
-
-    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -7544,16 +7667,28 @@ void test_state_checker_dirs_cleanup_single_stale_node(void ** state) {
     policy_info *pol_data = *state;
     int ret;
     whodata_directory * w_dir;
+    char debug_msg1[OS_SIZE_1024];
+    char debug_msg2[OS_SIZE_1024];
+    char debug_msg3[OS_SIZE_1024];
+    char debug_msg4[OS_SIZE_1024];
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
+    snprintf(debug_msg1, OS_SIZE_1024, FIM_WHODATA_CHECKTHREAD, 300);
+    expect_string(__wrap__mdebug1, formatted_msg, debug_msg1);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_POLICY_OPENED);
+    snprintf(debug_msg2, OS_SIZE_1024, FIM_WHODATA_OBJECT_ACCESS, guid_ObjectAccess);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg2);
+    snprintf(debug_msg3, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "File System", guid_FileSystem);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg3);
+    snprintf(debug_msg4, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "Handle Manipulation", guid_Handle);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg4);
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
-
-    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -7593,16 +7728,28 @@ void test_state_checker_dirs_cleanup_multiple_nodes_none_stale(void ** state) {
     int ret;
     FILETIME current_time;
     int i;
+    char debug_msg1[OS_SIZE_1024];
+    char debug_msg2[OS_SIZE_1024];
+    char debug_msg3[OS_SIZE_1024];
+    char debug_msg4[OS_SIZE_1024];
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
+    snprintf(debug_msg1, OS_SIZE_1024, FIM_WHODATA_CHECKTHREAD, 300);
+    expect_string(__wrap__mdebug1, formatted_msg, debug_msg1);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_POLICY_OPENED);
+    snprintf(debug_msg2, OS_SIZE_1024, FIM_WHODATA_OBJECT_ACCESS, guid_ObjectAccess);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg2);
+    snprintf(debug_msg3, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "File System", guid_FileSystem);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg3);
+    snprintf(debug_msg4, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "Handle Manipulation", guid_Handle);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg4);
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
-
-    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -7647,16 +7794,28 @@ void test_state_checker_dirs_cleanup_multiple_nodes_some_stale(void ** state) {
     int ret;
     FILETIME current_time;
     int i;
+    char debug_msg1[OS_SIZE_1024];
+    char debug_msg2[OS_SIZE_1024];
+    char debug_msg3[OS_SIZE_1024];
+    char debug_msg4[OS_SIZE_1024];
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
+    snprintf(debug_msg1, OS_SIZE_1024, FIM_WHODATA_CHECKTHREAD, 300);
+    expect_string(__wrap__mdebug1, formatted_msg, debug_msg1);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_POLICY_OPENED);
+    snprintf(debug_msg2, OS_SIZE_1024, FIM_WHODATA_OBJECT_ACCESS, guid_ObjectAccess);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg2);
+    snprintf(debug_msg3, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "File System", guid_FileSystem);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg3);
+    snprintf(debug_msg4, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "Handle Manipulation", guid_Handle);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg4);
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
-
-    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -7714,16 +7873,28 @@ void test_state_checker_dirs_cleanup_multiple_nodes_all_stale(void ** state) {
     policy_info *pol_data = *state;
     int ret;
     int i;
+    char debug_msg1[OS_SIZE_1024];
+    char debug_msg2[OS_SIZE_1024];
+    char debug_msg3[OS_SIZE_1024];
+    char debug_msg4[OS_SIZE_1024];
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
+    snprintf(debug_msg1, OS_SIZE_1024, FIM_WHODATA_CHECKTHREAD, 300);
+    expect_string(__wrap__mdebug1, formatted_msg, debug_msg1);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_POLICY_OPENED);
+    snprintf(debug_msg2, OS_SIZE_1024, FIM_WHODATA_OBJECT_ACCESS, guid_ObjectAccess);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg2);
+    snprintf(debug_msg3, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "File System", guid_FileSystem);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg3);
+    snprintf(debug_msg4, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "Handle Manipulation", guid_Handle);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg4);
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
-
-    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -7853,6 +8024,17 @@ void test_whodata_audit_start_success(void **state) {
 void test_policy_check_match(void **state) {
     policy_info *pol_data = *state;
     int ret;
+    char debug_msg2[OS_SIZE_1024];
+    char debug_msg3[OS_SIZE_1024];
+    char debug_msg4[OS_SIZE_1024];
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_POLICY_OPENED);
+    snprintf(debug_msg2, OS_SIZE_1024, FIM_WHODATA_OBJECT_ACCESS, guid_ObjectAccess);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg2);
+    snprintf(debug_msg3, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "File System", guid_FileSystem);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg3);
+    snprintf(debug_msg4, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "Handle Manipulation", guid_Handle);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg4);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -7868,6 +8050,14 @@ void test_policy_check_match(void **state) {
 void test_policy_check_not_match(void **state) {
     policy_info *pol_data = *state;
     int ret;
+    char debug_msg2[OS_SIZE_1024];
+    char debug_msg4[OS_SIZE_1024];
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_POLICY_OPENED);
+    snprintf(debug_msg2, OS_SIZE_1024, FIM_WHODATA_OBJECT_ACCESS, guid_ObjectAccess);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg2);
+    snprintf(debug_msg4, OS_SIZE_1024, FIM_WHODATA_SUCCESS_POLICY, "Handle Manipulation", guid_Handle);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg4);
 
     pol_data->paudit_policy[0].AuditingInformation = POLICY_AUDIT_EVENT_FAILURE;
     expect_policy_check_match_call((NTSTATUS)0,
@@ -7917,6 +8107,8 @@ void test_policy_check_AuditLookupCategoryGuidFromCategoryId_fail(void **state) 
     policy_info *pol_data = *state;
     int ret;
 
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_POLICY_OPENED);
+
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
                                    pol_data->category_guid, FALSE,
@@ -7931,6 +8123,11 @@ void test_policy_check_AuditLookupCategoryGuidFromCategoryId_fail(void **state) 
 void test_policy_check_AuditEnumerateSubCategories_fail(void **state) {
     policy_info *pol_data = *state;
     int ret;
+    char debug_msg2[OS_SIZE_1024];
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_POLICY_OPENED);
+    snprintf(debug_msg2, OS_SIZE_1024, FIM_WHODATA_OBJECT_ACCESS, guid_ObjectAccess);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg2);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -7946,6 +8143,11 @@ void test_policy_check_AuditEnumerateSubCategories_fail(void **state) {
 void test_policy_check_AuditQuerySystemPolicy_fail(void **state) {
     policy_info *pol_data = *state;
     int ret;
+    char debug_msg2[OS_SIZE_1024];
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_POLICY_OPENED);
+    snprintf(debug_msg2, OS_SIZE_1024, FIM_WHODATA_OBJECT_ACCESS, guid_ObjectAccess);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg2);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,

--- a/src/unit_tests/syscheckd/whodata/test_win_whodata.c
+++ b/src/unit_tests/syscheckd/whodata/test_win_whodata.c
@@ -5384,11 +5384,11 @@ void test_whodata_callback_4719_success(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
 
-    policies_checked = 2;
+    policies_checked = 1;
 
     successful_whodata_event_render(event, raw_data);
 
-    expect_string(__wrap__mwarn, formatted_msg, FIM_WHODATA_POLICY_CHANGE);
+    expect_string(__wrap__mwarn, formatted_msg, FIM_WHODATA_POLICY_CHANGE_CHANNEL);
 
     result = whodata_callback(action, NULL, event);
     assert_int_equal(result, 0);
@@ -7455,7 +7455,7 @@ void test_state_checker_not_match_policy(void **state) {
                                    2, TRUE,
                                    pol_data->paudit_policy, TRUE);
 
-    expect_string(__wrap__mwarn, formatted_msg, "(6952): Audit policy change detected. Switching directories to realtime.");
+    expect_string(__wrap__mwarn, formatted_msg, FIM_WHODATA_POLICY_CHANGE_CHECKER);
 
     ret = state_checker(input);
 

--- a/src/unit_tests/syscheckd/whodata/test_win_whodata.c
+++ b/src/unit_tests/syscheckd/whodata/test_win_whodata.c
@@ -74,6 +74,7 @@ extern char sys_64;
 extern PSID everyone_sid;
 extern size_t ev_sid_size;
 extern int restore_policies;
+extern int policies_checked;
 extern EVT_HANDLE context;
 extern atomic_int_t whodata_end;
 
@@ -151,7 +152,7 @@ void expect_policy_check_match_call(NTSTATUS status1,
 
     will_return(wrap_GetLastError, ERROR_ACCESS_DENIED);
     will_return(wrap_FormatMessage, "Access is denied");
-    expect_string(__wrap__mwarn, formatted_msg, "(6950): Unable to check the necessary policies for whodata: Access is denied (5).");
+    expect_string(__wrap__mwarn, formatted_msg, "(6951): Unable to check the necessary policies for whodata: Access is denied (5).");
 }
 
 /**************************************************************************/
@@ -5383,6 +5384,8 @@ void test_whodata_callback_4719_success(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
 
+    policies_checked = 2;
+
     successful_whodata_event_render(event, raw_data);
 
     expect_string(__wrap__mwarn, formatted_msg, FIM_WHODATA_POLICY_CHANGE);
@@ -6864,6 +6867,8 @@ void test_state_checker_no_files_to_check(void **state) {
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
 
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
+
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
                                    pol_data->category_guid, TRUE,
@@ -6898,6 +6903,8 @@ void test_state_checker_file_not_whodata(void **state) {
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -6936,6 +6943,8 @@ void test_state_checker_file_does_not_exist(void **state) {
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -6983,6 +6992,8 @@ void test_state_checker_file_with_invalid_sacl(void **state) {
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -7102,6 +7113,8 @@ void test_state_checker_file_with_valid_sacl(void **state) {
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
 
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
+
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
                                    pol_data->category_guid, TRUE,
@@ -7212,6 +7225,8 @@ void test_state_checker_dir_readded_error(void **state) {
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
 
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
+
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
                                    pol_data->category_guid, TRUE,
@@ -7285,6 +7300,8 @@ void test_state_checker_dir_readded_succesful(void **state) {
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -7429,6 +7446,8 @@ void test_state_checker_not_match_policy(void **state) {
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
 
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
+
     pol_data->paudit_policy[0].AuditingInformation = POLICY_AUDIT_EVENT_FAILURE;
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -7436,7 +7455,7 @@ void test_state_checker_not_match_policy(void **state) {
                                    2, TRUE,
                                    pol_data->paudit_policy, TRUE);
 
-    expect_string(__wrap__mwarn, formatted_msg, "(6951): Audit policy change detected. Switching directories to realtime.");
+    expect_string(__wrap__mwarn, formatted_msg, "(6952): Audit policy change detected. Switching directories to realtime.");
 
     ret = state_checker(input);
 
@@ -7456,6 +7475,8 @@ void test_state_checker_dirs_cleanup_no_nodes(void ** state) {
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -7487,6 +7508,8 @@ void test_state_checker_dirs_cleanup_single_non_stale_node(void ** state) {
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -7529,6 +7552,8 @@ void test_state_checker_dirs_cleanup_single_stale_node(void ** state) {
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -7576,6 +7601,8 @@ void test_state_checker_dirs_cleanup_multiple_nodes_none_stale(void ** state) {
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -7628,6 +7655,8 @@ void test_state_checker_dirs_cleanup_multiple_nodes_some_stale(void ** state) {
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,
@@ -7693,6 +7722,8 @@ void test_state_checker_dirs_cleanup_multiple_nodes_all_stale(void ** state) {
 
     expect_value(__wrap_atomic_int_get, atomic, &whodata_end);
     will_return(__wrap_atomic_int_get, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg, FIM_WHODATA_STATE_CHECKER);
 
     expect_policy_check_match_call((NTSTATUS)0,
                                    pol_data->audit_event_info, (NTSTATUS)0,

--- a/src/unit_tests/wrappers/windows/ntsecapi_wrappers.c
+++ b/src/unit_tests/wrappers/windows/ntsecapi_wrappers.c
@@ -1,0 +1,59 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "ntsecapi_wrappers.h"
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+
+NTSTATUS wrap_LsaOpenPolicy(__UNUSED_PARAM(PLSA_UNICODE_STRING    SystemName),
+                            __UNUSED_PARAM(PLSA_OBJECT_ATTRIBUTES ObjectAttributes),
+                            __UNUSED_PARAM(ACCESS_MASK            DesiredAccess),
+                            __UNUSED_PARAM(PLSA_HANDLE            PolicyHandle)) {
+    return mock();
+}
+
+NTSTATUS wrap_LsaQueryInformationPolicy(__UNUSED_PARAM(LSA_HANDLE               PolicyHandle),
+                                        __UNUSED_PARAM(POLICY_INFORMATION_CLASS InformationClass),
+                                        PVOID                                   *Buffer) {
+    *Buffer = mock_type(PPOLICY_AUDIT_EVENTS_INFO);
+    return mock();
+}
+
+BOOLEAN wrap_AuditLookupCategoryGuidFromCategoryId(__UNUSED_PARAM(POLICY_AUDIT_EVENT_TYPE AuditCategoryId),
+                                                   GUID                    *pAuditCategoryGuid) {
+    GUID *guid = mock_type(GUID *);
+    *pAuditCategoryGuid = *guid;
+    return mock();
+}
+
+BOOLEAN wrap_AuditEnumerateSubCategories(__UNUSED_PARAM(const GUID *pAuditCategoryGuid),
+                                         __UNUSED_PARAM(BOOLEAN    bRetrieveAllSubCategories),
+                                         __UNUSED_PARAM(GUID       **ppAuditSubCategoriesArray),
+                                         PULONG                    pdwCountReturned) {
+    *pdwCountReturned = mock_type(ULONG);
+    return mock();
+}
+
+BOOLEAN wrap_AuditQuerySystemPolicy(__UNUSED_PARAM(const GUID                *pSubCategoryGuids),
+                                    __UNUSED_PARAM(ULONG                     dwPolicyCount),
+                                    PAUDIT_POLICY_INFORMATION                *ppAuditPolicy) {
+    *ppAuditPolicy = mock_type(AUDIT_POLICY_INFORMATION *);
+    return mock();
+}
+
+NTSTATUS wrap_LsaFreeMemory(__UNUSED_PARAM(PVOID Buffer)) {
+    return 0;
+}
+
+NTSTATUS wrap_LsaClose(__UNUSED_PARAM(LSA_HANDLE ObjectHandle)) {
+    return 0;
+}

--- a/src/unit_tests/wrappers/windows/ntsecapi_wrappers.h
+++ b/src/unit_tests/wrappers/windows/ntsecapi_wrappers.h
@@ -1,0 +1,58 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+
+#ifndef NTSECAPI_WRAPPERS_H
+#define NTSECAPI_WRAPPERS_H
+
+#include <windows.h>
+#include <ntsecapi.h>
+
+#undef LsaOpenPolicy
+#define LsaOpenPolicy wrap_LsaOpenPolicy
+#undef LsaQueryInformationPolicy
+#define LsaQueryInformationPolicy wrap_LsaQueryInformationPolicy
+#undef AuditLookupCategoryGuidFromCategoryId
+#define AuditLookupCategoryGuidFromCategoryId wrap_AuditLookupCategoryGuidFromCategoryId
+#undef AuditEnumerateSubCategories
+#define AuditEnumerateSubCategories wrap_AuditEnumerateSubCategories
+#undef AuditQuerySystemPolicy
+#define AuditQuerySystemPolicy wrap_AuditQuerySystemPolicy
+#undef LsaFreeMemory
+#define LsaFreeMemory wrap_LsaFreeMemory
+#undef LsaClose
+#define LsaClose wrap_LsaClose
+
+NTSTATUS wrap_LsaOpenPolicy(PLSA_UNICODE_STRING    SystemName,
+                            PLSA_OBJECT_ATTRIBUTES ObjectAttributes,
+                            ACCESS_MASK            DesiredAccess,
+                            PLSA_HANDLE            PolicyHandle);
+
+NTSTATUS wrap_LsaQueryInformationPolicy(LSA_HANDLE                PolicyHandle,
+                                        POLICY_INFORMATION_CLASS  InformationClass,
+                                        PVOID                     *Buffer);
+
+BOOLEAN wrap_AuditLookupCategoryGuidFromCategoryId(POLICY_AUDIT_EVENT_TYPE AuditCategoryId,
+                                                   GUID                    *pAuditCategoryGuid);
+
+BOOLEAN wrap_AuditEnumerateSubCategories(const GUID *pAuditCategoryGuid,
+                                         BOOLEAN    bRetrieveAllSubCategories,
+                                         GUID       **ppAuditSubCategoriesArray,
+                                         PULONG     pdwCountReturned);
+
+BOOLEAN wrap_AuditQuerySystemPolicy(const GUID                *pSubCategoryGuids,
+                                    ULONG                     dwPolicyCount,
+                                    PAUDIT_POLICY_INFORMATION *ppAuditPolicy);
+
+NTSTATUS wrap_LsaFreeMemory(PVOID Buffer);
+
+NTSTATUS wrap_LsaClose(LSA_HANDLE ObjectHandle);
+
+
+#endif

--- a/src/unit_tests/wrappers/windows/winevt_wrappers.c
+++ b/src/unit_tests/wrappers/windows/winevt_wrappers.c
@@ -59,3 +59,7 @@ EVT_HANDLE wrap_EvtSubscribe(EVT_HANDLE             Session,
     check_expected(Flags);
     return mock_type(EVT_HANDLE);
 }
+
+BOOL wrap_EvtClose(EVT_HANDLE object) {
+    return mock_type(BOOL);
+}

--- a/src/unit_tests/wrappers/windows/winevt_wrappers.c
+++ b/src/unit_tests/wrappers/windows/winevt_wrappers.c
@@ -60,6 +60,6 @@ EVT_HANDLE wrap_EvtSubscribe(EVT_HANDLE             Session,
     return mock_type(EVT_HANDLE);
 }
 
-BOOL wrap_EvtClose(EVT_HANDLE object) {
+BOOL wrap_EvtClose(__UNUSED_PARAM(EVT_HANDLE object)) {
     return mock_type(BOOL);
 }

--- a/src/unit_tests/wrappers/windows/winevt_wrappers.h
+++ b/src/unit_tests/wrappers/windows/winevt_wrappers.h
@@ -17,6 +17,8 @@
 #define EvtRender wrap_EvtRender
 #define EvtCreateRenderContext wrap_EvtCreateRenderContext
 #define EvtSubscribe wrap_EvtSubscribe
+#define EvtClose wrap_EvtClose
+
 
 BOOL wrap_EvtRender(EVT_HANDLE Context,
                     EVT_HANDLE Fragment,
@@ -38,5 +40,7 @@ EVT_HANDLE wrap_EvtSubscribe(EVT_HANDLE             Session,
                              PVOID                  Context,
                              EVT_SUBSCRIBE_CALLBACK Callback,
                              DWORD                  Flags);
+
+BOOL wrap_EvtClose(EVT_HANDLE object);
 
 #endif


### PR DESCRIPTION
|Related issue|
|---|
|Closes #14507 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Hi team! 
In this PR we aim to add a new feature to the Windows Whodata engine: to detect policy changes and switch those directories to realtime if a change is detected. This will avoid the problem described in #14507
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
```xml
  <syscheck>

    <disabled>no</disabled>

    <!-- Frequency that syscheck is executed default every 12 hours -->
    <frequency>43200</frequency>

    <!-- Default files to be monitored. -->
    <directories whodata="yes">C:\test</directories>

    <!-- Frequency for ACL checking (seconds) -->
    <windows_audit_interval>60</windows_audit_interval>

    <!-- Nice value for Syscheck module -->
    <process_priority>10</process_priority>

    <!-- Maximum output throughput -->
    <max_eps>100</max_eps>
</syscheck>
```
<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example
Different log traces in debug mode:
- `state_checker` flow completed successfully:
```
2022/10/28 18:55:21 wazuh-agent[6516] win_whodata.c:1127 at state_checker(): DEBUG: (6366): Starting check of Windows Audit Policies and SACLs.
2022/10/28 18:55:21 wazuh-agent[6516] win_whodata.c:1025 at policy_check(): DEBUG: (6367): Audit policy opened correctly. AuditingMode enabled.
2022/10/28 18:55:21 wazuh-agent[6516] win_whodata.c:1037 at policy_check(): DEBUG: (6368): Detected Audit Object Access category, checking subcategories. GUID: {6997984A-797A-11D9-BED3-505054503030}
2022/10/28 18:55:21 wazuh-agent[6516] win_whodata.c:1059 at policy_check(): DEBUG: (6369): Found Audit File System subcategory configured to success. GUID: {0CCE921D-69AE-11D9-BED3-505054503030}
2022/10/28 18:55:21 wazuh-agent[6516] win_whodata.c:1063 at policy_check(): DEBUG: (6369): Found Audit Handle Manipulation subcategory configured to success. GUID: {0CCE9223-69AE-11D9-BED3-505054503030}
```
- `state_checker` flow failing due to a change in audit policies:
```
2022/10/28 18:56:21 wazuh-agent[6516] win_whodata.c:1127 at state_checker(): DEBUG: (6366): Starting check of Windows Audit Policies and SACLs.
2022/10/28 18:56:21 wazuh-agent[6516] win_whodata.c:1025 at policy_check(): DEBUG: (6367): Audit policy opened correctly. AuditingMode enabled.
2022/10/28 18:56:21 wazuh-agent[6516] win_whodata.c:1037 at policy_check(): DEBUG: (6368): Detected Audit Object Access category, checking subcategories. GUID: {6997984A-797A-11D9-BED3-505054503030}
2022/10/28 18:56:21 wazuh-agent[6516] win_whodata.c:1059 at policy_check(): DEBUG: (6369): Found Audit File System subcategory configured to success. GUID: {0CCE921D-69AE-11D9-BED3-505054503030}
2022/10/28 18:56:21 wazuh-agent[6516] win_whodata.c:1131 at state_checker(): WARNING: (6952): Audit policy change detected. Switching directories to realtime.
```
- Event 4719 detected:
```
2022/10/28 18:58:47 wazuh-agent[2428] win_whodata.c:960 at whodata_callback(): WARNING: (6953): Event 4719 received due to changes in audit policy. Switching directories to realtime.
```

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language


<!-- Depending on the affected OS -->

- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory