### PR TITLE
Avoid double counter reset after manager disconnection

### DIFF
--- a/framework/wazuh/core/cluster/agents_reconnect.py
+++ b/framework/wazuh/core/cluster/agents_reconnect.py
@@ -113,6 +113,7 @@ class AgentsReconnect:
         """
         if node_name not in self.blacklisted_nodes:
             if hard_reset:
+                self.previous_nodes = set()
                 self.nodes_stability_counter = 0
             self.expected_rounds = 0
             self.round_counter = 0
@@ -137,7 +138,6 @@ class AgentsReconnect:
 
         if len(node_list) <= 1:
             self.reset_counters()
-            self.previous_nodes = set()
             self.current_phase = AgentsReconnectionPhases.NOT_ENOUGH_NODES
 
             return False
@@ -159,9 +159,7 @@ class AgentsReconnect:
 
         else:
             self.logger.info("Nodes changed, restarting cluster stability phase.")
-            self.previous_nodes = node_list.copy()
             self.reset_counters()
-            return False
 
         return False
 
@@ -493,10 +491,7 @@ class AgentsReconnect:
             biggest_node = max(self.env_status.keys(), key=lambda x: self.env_status[x]['total'])
             smallest_node = min(self.env_status.keys(), key=lambda x: self.env_status[x]['total'])
             mean = (self.env_status[biggest_node]['total'] + self.env_status[smallest_node]['total']) / 2
-            tolerance_window = floor(mean * tolerance)
-
-            if tolerance_window < 3:
-                tolerance_window = 3
+            tolerance_window = max(floor(mean * tolerance), 3)
 
             return self.env_status[biggest_node]['total'] - self.env_status[smallest_node]['total'] <= tolerance_window
 


### PR DESCRIPTION
In this PR we have fixed a bug related to the double reset of counters in the algorithm. 

```
2022/08/30 07:47:24 INFO: [Master] [Cluster balance] Iteration complete. Sleeping 60 seconds.
2022/08/30 07:48:18 DEBUG: [Worker CLUSTER_Workload_benchmarks_metrics_3834_B45_manager_1] [Cluster balance] Reset all counters.  <-------
2022/08/30 07:48:24 DEBUG: [Master] [Cluster balance] Current detected nodes: {'CLUSTER_Workload_benchmarks_metrics_3834_B45_manager_3', 'CLUSTER_Workload_benchmarks_metrics_3834_B45_manager_2', 'CLUSTER_Workload_benchmarks_metrics_3834_B45_manager_5', 'CLUSTER_Workload_benchmarks_metrics_3834_B45_manager_4'}.
2022/08/30 07:48:24 INFO: [Master] [Cluster balance] Nodes changed, restarting cluster stability phase.
2022/08/30 07:48:24 DEBUG: [Master] [Cluster balance] Reset all counters.  <-------
2022/08/30 07:48:54 DEBUG: [Master] [Cluster balance] Current detected nodes: {'CLUSTER_Workload_benchmarks_metrics_3834_B45_manager_3', 'CLUSTER_Workload_benchmarks_metrics_3834_B45_manager_2', 'CLUSTER_Workload_benchmarks_metrics_3834_B45_manager_5', 'CLUSTER_Workload_benchmarks_metrics_3834_B45_manager_4'}.
2022/08/30 07:48:54 INFO: [Master] [Cluster balance] Checking cluster stability (1/3).
```

Before this PR, when the node stability phase was complete and a node was disconnected, this caused all the counters to be reset, after this, the stability phase returned and detected the change of nodes, so a reset of the counters was produced as well.

Therefore, when a node is restarted it will call reset_counter, the "previous_nodes" variable will be deleted, thus avoiding the double restart.

```
2022/08/30 02:39:47 INFO: [Master] [Cluster balance] Iteration complete. Sleeping 60 seconds.
2022/08/30 02:39:59 DEBUG: [Worker worker1] [Cluster balance] Reset all counters.  <-------
2022/08/30 02:40:47 DEBUG: [Master] [Cluster balance] Current detected nodes: {'worker2', 'master-node', 'worker1'}.
2022/08/30 02:40:47 INFO: [Master] [Cluster balance] Checking cluster stability (1/3).
```