### PR TITLE
Add API validation for component and configuration pairs

### DIFF
--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -14,6 +14,7 @@ from api.models.agent_inserted_model import AgentInsertedModel
 from api.models.base_model_ import Body
 from api.models.group_added_model import GroupAddedModel
 from api.util import parse_api_param, remove_nones_to_dict, raise_if_exc, deprecate_endpoint
+from api.validator import check_component_configuration_pair
 from wazuh import agent, stats
 from wazuh.core.cluster.control import get_system_nodes
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
@@ -328,6 +329,8 @@ async def get_agent_config(request, pretty=False, wait_for_complete=False, agent
                 'component': component,
                 'config': kwargs.get('configuration', None)
                 }
+
+    raise_if_exc(check_component_configuration_pair(f_kwargs['component'], f_kwargs['config']))
 
     dapi = DistributedAPI(f=agent.get_agent_config,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/controllers/cluster_controller.py
+++ b/api/api/controllers/cluster_controller.py
@@ -16,6 +16,7 @@ import wazuh.stats as stats
 from api.encoder import dumps, prettify
 from api.models.base_model_ import Body
 from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc, deserialize_date
+from api.validator import check_component_configuration_pair
 from wazuh.core.cluster.control import get_system_nodes
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.core.results import AffectedItemsWazuhResult
@@ -606,6 +607,8 @@ async def get_node_config(request, node_id, component, wait_for_complete=False, 
                 }
 
     nodes = raise_if_exc(await get_system_nodes())
+    raise_if_exc(check_component_configuration_pair(f_kwargs['component'], f_kwargs['config']))
+
     dapi = DistributedAPI(f=manager.get_config,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
                           request_type='distributed_master',

--- a/api/api/controllers/manager_controller.py
+++ b/api/api/controllers/manager_controller.py
@@ -13,6 +13,7 @@ import wazuh.stats as stats
 from api.encoder import dumps, prettify
 from api.models.base_model_ import Body
 from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc, deserialize_date
+from api.validator import check_component_configuration_pair
 from wazuh.core import common
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.core.results import AffectedItemsWazuhResult
@@ -359,6 +360,8 @@ async def get_manager_config_ondemand(request, component, pretty=False, wait_for
     f_kwargs = {'component': component,
                 'config': kwargs.get('configuration', None)
                 }
+
+    raise_if_exc(check_component_configuration_pair(f_kwargs['component'], f_kwargs['config']))
 
     dapi = DistributedAPI(f=manager.get_config,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/controllers/test/test_agent_controller.py
+++ b/api/api/controllers/test/test_agent_controller.py
@@ -233,7 +233,8 @@ async def test_restart_agents_by_node(mock_exc, mock_dapi, mock_remove, mock_dfu
 @patch('api.controllers.agent_controller.remove_nones_to_dict')
 @patch('api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
 @patch('api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
-async def test_get_agent_config(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_exp, mock_request=MagicMock()):
+@patch('api.controllers.agent_controller.check_component_configuration_pair')
+async def test_get_agent_config(mock_check_pair, mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_exp, mock_request=MagicMock()):
     """Verify 'get_agent_config' endpoint is working as expected."""
     kwargs_param = {'configuration': 'configuration_value'
                     }
@@ -251,7 +252,7 @@ async def test_get_agent_config(mock_exc, mock_dapi, mock_remove, mock_dfunc, mo
                                       logger=ANY,
                                       rbac_permissions=mock_request['token_info']['rbac_policies']
                                       )
-    mock_exc.assert_called_once_with(mock_dfunc.return_value)
+    mock_exc.assert_called_with(mock_dfunc.return_value)
     mock_remove.assert_called_once_with(f_kwargs)
     assert isinstance(result, web_response.Response)
 

--- a/api/api/controllers/test/test_cluster_controller.py
+++ b/api/api/controllers/test/test_cluster_controller.py
@@ -591,7 +591,8 @@ async def test_get_conf_validation(mock_exc, mock_dapi, mock_remove, mock_dfunc,
 @patch('api.controllers.cluster_controller.remove_nones_to_dict')
 @patch('api.controllers.cluster_controller.DistributedAPI.__init__', return_value=None)
 @patch('api.controllers.cluster_controller.raise_if_exc', return_value=CustomAffectedItems())
-async def test_get_node_config(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request=MagicMock()):
+@patch('api.controllers.cluster_controller.check_component_configuration_pair')
+async def test_get_node_config(mock_check_pair, mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request=MagicMock()):
     """Verify 'get_node_config' endpoint is working as expected."""
     with patch('api.controllers.cluster_controller.get_system_nodes', return_value=AsyncMock()) as mock_snodes:
         kwargs_param = {'configuration': 'configuration_value'
@@ -615,8 +616,9 @@ async def test_get_node_config(mock_exc, mock_dapi, mock_remove, mock_dfunc, moc
                                           nodes=mock_exc.return_value
                                           )
         mock_exc.assert_has_calls([call(mock_snodes.return_value),
+                                   call(mock_check_pair.return_value),
                                    call(mock_dfunc.return_value)])
-        assert mock_exc.call_count == 2
+        assert mock_exc.call_count == 3
         mock_remove.assert_called_once_with(f_kwargs)
         assert isinstance(result, web_response.Response)
 

--- a/api/api/controllers/test/test_manager_controller.py
+++ b/api/api/controllers/test/test_manager_controller.py
@@ -334,7 +334,8 @@ async def test_get_conf_validation(mock_exc, mock_dapi, mock_remove, mock_dfunc,
 @patch('api.controllers.manager_controller.remove_nones_to_dict')
 @patch('api.controllers.manager_controller.DistributedAPI.__init__', return_value=None)
 @patch('api.controllers.manager_controller.raise_if_exc', return_value=CustomAffectedItems())
-async def test_get_manager_config_ondemand(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request=MagicMock()):
+@patch('api.controllers.manager_controller.check_component_configuration_pair')
+async def test_get_manager_config_ondemand(mock_check_pair, mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request=MagicMock()):
     """Verify 'get_manager_config_ondemand' endpoint is working as expected."""
     kwargs_param = {'configuration': 'configuration_value'
                     }
@@ -352,7 +353,7 @@ async def test_get_manager_config_ondemand(mock_exc, mock_dapi, mock_remove, moc
                                       logger=ANY,
                                       rbac_permissions=mock_request['token_info']['rbac_policies']
                                       )
-    mock_exc.assert_called_once_with(mock_dfunc.return_value)
+    mock_exc.assert_called_with(mock_dfunc.return_value)
     mock_remove.assert_called_once_with(f_kwargs)
     assert isinstance(result, web_response.Response)
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3708,6 +3708,11 @@ components:
         <td><code>&lt;analysisd&gt;</code></td>
         </tr>
         <tr>
+        <td>analysis</td>
+        <td>rule_test</td>
+        <td><code>&lt;rule_test&gt;</code></td>
+        </tr>
+        <tr>
         <td>auth</td>
         <td>auth</td>
         <td><code>&lt;auth&gt;</code></td>
@@ -3852,6 +3857,7 @@ components:
         - syscheck
         - rootcheck
         - wmodules
+        - rule_test
     cve:
       in: query
       name: cve

--- a/api/api/test/test_validator.py
+++ b/api/api/test/test_validator.py
@@ -14,7 +14,9 @@ from api.validator import (check_exp, check_xml, _alphanumeric_param,
                            _sort_param, _timeframe_type, _type_format, _yes_no_boolean, _get_dirnames_path,
                            allowed_fields, is_safe_path, _wazuh_version,
                            _symbols_alphanumeric_param, _base64, _group_names, _group_names_or_all, _iso8601_date,
-                           _iso8601_date_time, _numbers_or_all, _cdb_filename_path, _xml_filename_path, _xml_filename)
+                           _iso8601_date_time, _numbers_or_all, _cdb_filename_path, _xml_filename_path, _xml_filename,
+                           check_component_configuration_pair)
+from wazuh import WazuhError
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
@@ -277,3 +279,18 @@ def test_validation_json_ko(value, format):
                     schema={'type': 'object',
                             'properties': {'key': {'type': 'string', 'format': format}}},
                     format_checker=js.draft4_format_checker)
+
+
+@pytest.mark.parametrize("component, configuration, expected_response", [
+    ("agent", "client", None),
+    ("agent", "wmodules", WazuhError(1127))
+])
+def test_check_component_configuration_pair(component, configuration, expected_response):
+    """Verify that `check_component_configuration_pair` function returns an exception when the configuration does
+    not belong to a Wazuh component."""
+    response = check_component_configuration_pair(component, configuration)
+    if isinstance(response, Exception):
+        assert isinstance(response, expected_response.__class__)
+        assert response.code == expected_response.code
+    else:
+        assert response is expected_response

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -1987,6 +1987,18 @@ stages:
       json:
         <<: *error_spec
 
+  - name: Request error on invalid component and configuration pair
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/agent/wmodules"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 400
+      json:
+        error: 1127
+
 ---
 test_name: GET /agents/{agent_id}/config/{component}/{configuration} (only cluster configuration)
 

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -1434,6 +1434,18 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
+  - name: Try to show the invalid config of component in the master node
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/agent/wmodules"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: GET
+      response:
+        status_code: 400
+        json:
+          error: 1127
+
 ---
 test_name: GET /cluster/{node_id}/info
 

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -1441,10 +1441,10 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
-      response:
-        status_code: 400
-        json:
-          error: 1127
+    response:
+      status_code: 400
+      json:
+        error: 1127
 
 ---
 test_name: GET /cluster/{node_id}/info

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -1177,6 +1177,18 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
+  - name: Try to show the invalid config of component in the manager
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/agent/wmodules"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: GET
+    response:
+      status_code: 400
+      json:
+        error: 1127
+
 ---
 test_name: PUT /manager/configuration
 

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -110,6 +110,7 @@ class WazuhException(Exception):
         1126: {'message': 'Error updating ossec configuration',
                'remediation': 'Please, ensure `WAZUH_PATH/etc/ossec.conf` has the proper permissions and ownership.'
                },
+        1127: {'message': 'Invalid configuration for the given component'},
 
         # Rule: 1200 - 1299
         1200: {'message': 'Error reading rules from `WAZUH_HOME/etc/ossec.conf`',


### PR DESCRIPTION
|Related issue|
|---|
|closes #14473 |

## Description

This PR adds a new validation on API level for every endpoint that requires a pair of component and configuration, in addition to a new entry for the `analysis` component.

## Examples

### Invalid component or configuration

`/manager/configuration/test/rule_test`

```json
{
  "title": "Bad Request",
  "detail": "'test' is not one of ['agent', 'agentless', 'analysis', 'auth', 'com', 'csyslog', 'integrator', 'logcollector', 'mail', 'monitor', 'request', 'syscheck', 'wmodules']. Failed validating 'enum' in schema: {'enum': ['agent', 'agentless', 'analysis', 'auth', 'com', 'csyslog', 'integrator', 'logcollector', 'mail', 'monitor', 'request', 'syscheck', 'wmodules'], 'type': 'string'}. On instance: 'test'"
}
```

### Invalid pair but valid parameters

`/manager/configuration/agent/rule_test`

```json
{
  "title": "Bad Request",
  "detail": "Invalid configuration for the given component: Valid configuration values for 'agent': {'labels', 'buffer', 'client', 'internal'}",
  "error": 1127
}
```


Regards,
Víctor
