### PR TITLE
Add `--prefix` parameter to azure module

### DIFF
--- a/src/config/wmodules-azure.c
+++ b/src/config/wmodules-azure.c
@@ -33,7 +33,7 @@ static const char *XML_CONTAINER = "container";
 static const char *XML_CONTAINER_NAME = "name";
 static const char *XML_CONTAINER_BLOBS = "blobs";
 static const char *XML_CONTAINER_TYPE="content_type";
-static const char *XML_PREFIX = "prefix";
+static const char *XML_PATH = "path";
 
 static const char *XML_REQUEST_QUERY = "query";
 static const char *XML_TIME_OFFSET = "time_offset";
@@ -533,7 +533,7 @@ int wm_azure_container_read(XML_NODE nodes, wm_azure_container_t * container) {
     container->blobs = NULL;
     container->time_offset = NULL;
     container->content_type = NULL;
-    container->prefix = NULL;
+    container->path = NULL;
 
     for (i = 0; nodes[i]; i++) {
 
@@ -578,11 +578,11 @@ int wm_azure_container_read(XML_NODE nodes, wm_azure_container_t * container) {
                 return OS_INVALID;
             }
 
-        } else if (!strcmp(nodes[i]->element, XML_PREFIX)) {
+        } else if (!strcmp(nodes[i]->element, XML_PATH)) {
             if (strlen(nodes[i]->content) != 0) {
-                os_strdup(nodes[i]->content, container->prefix);
+                os_strdup(nodes[i]->content, container->path);
             } else if (strlen(nodes[i]->content) == 0) {
-                merror("Empty content for tag '%s' at module '%s'", XML_PREFIX, WM_AZURE_CONTEXT.name);
+                merror("Empty content for tag '%s' at module '%s'", XML_PATH, WM_AZURE_CONTEXT.name);
                 return OS_INVALID;
             }
 

--- a/src/config/wmodules-azure.c
+++ b/src/config/wmodules-azure.c
@@ -33,6 +33,7 @@ static const char *XML_CONTAINER = "container";
 static const char *XML_CONTAINER_NAME = "name";
 static const char *XML_CONTAINER_BLOBS = "blobs";
 static const char *XML_CONTAINER_TYPE="content_type";
+static const char *XML_PREFIX = "prefix";
 
 static const char *XML_REQUEST_QUERY = "query";
 static const char *XML_TIME_OFFSET = "time_offset";
@@ -203,7 +204,7 @@ int wm_azure_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
         } else if (is_sched_tag(nodes[i]->element)) {
             // Do nothing
         } else {
-            merror("No such tag '%s' at module '%s'.", nodes[i]->element, WM_AZURE_CONTEXT.name);	
+            merror("No such tag '%s' at module '%s'.", nodes[i]->element, WM_AZURE_CONTEXT.name);
             return OS_INVALID;
         }
     }
@@ -532,6 +533,7 @@ int wm_azure_container_read(XML_NODE nodes, wm_azure_container_t * container) {
     container->blobs = NULL;
     container->time_offset = NULL;
     container->content_type = NULL;
+    container->prefix = NULL;
 
     for (i = 0; nodes[i]; i++) {
 
@@ -575,6 +577,15 @@ int wm_azure_container_read(XML_NODE nodes, wm_azure_container_t * container) {
                 merror("At module '%s': Invalid timeout.", WM_AZURE_CONTEXT.name);
                 return OS_INVALID;
             }
+
+        } else if (!strcmp(nodes[i]->element, XML_PREFIX)) {
+            if (strlen(nodes[i]->content) != 0) {
+                os_strdup(nodes[i]->content, container->prefix);
+            } else if (strlen(nodes[i]->content) == 0) {
+                merror("Empty content for tag '%s' at module '%s'", XML_PREFIX, WM_AZURE_CONTEXT.name);
+                return OS_INVALID;
+            }
+
         } else {
             merror(XML_INVELEM, nodes[i]->element);
             return OS_INVALID;

--- a/src/wazuh_modules/wm_azure.c
+++ b/src/wazuh_modules/wm_azure.c
@@ -339,6 +339,11 @@ void wm_azure_storage(wm_azure_storage_t *storage) {
             wm_strcat(&command, curr_container->time_offset, ' ');
         }
 
+        if (curr_container->prefix) {
+            wm_strcat(&command, "--prefix", ' ');
+            wm_strcat(&command, curr_container->prefix, ' ');
+        }
+
         if (isDebug()) {
             char *int_to_string;
             os_malloc(OS_SIZE_1024, int_to_string);
@@ -493,6 +498,7 @@ void wm_azure_destroy(wm_azure_t *azure_config) {
             free(curr_container->blobs);
             free(curr_container->content_type);
             free(curr_container->time_offset);
+            free(curr_container->prefix);
             free(curr_container);
 
         }
@@ -557,6 +563,7 @@ cJSON *wm_azure_dump(const wm_azure_t * azure) {
                     cJSON_AddStringToObject(container, "blobs", container_conf->blobs);
                     cJSON_AddStringToObject(container, "content_type", container_conf->content_type);
                     cJSON_AddStringToObject(container, "time_offset", container_conf->time_offset);
+                    cJSON_AddStringToObject(container, "prefix", container_conf->prefix);
                     if (container_conf->timeout) cJSON_AddNumberToObject(container, "timeout", container_conf->timeout);
                     cJSON_AddItemToArray(containers, container);
                 }

--- a/src/wazuh_modules/wm_azure.c
+++ b/src/wazuh_modules/wm_azure.c
@@ -339,9 +339,9 @@ void wm_azure_storage(wm_azure_storage_t *storage) {
             wm_strcat(&command, curr_container->time_offset, ' ');
         }
 
-        if (curr_container->prefix) {
+        if (curr_container->path) {
             wm_strcat(&command, "--prefix", ' ');
-            wm_strcat(&command, curr_container->prefix, ' ');
+            wm_strcat(&command, curr_container->path, ' ');
         }
 
         if (isDebug()) {
@@ -498,7 +498,7 @@ void wm_azure_destroy(wm_azure_t *azure_config) {
             free(curr_container->blobs);
             free(curr_container->content_type);
             free(curr_container->time_offset);
-            free(curr_container->prefix);
+            free(curr_container->path);
             free(curr_container);
 
         }
@@ -563,7 +563,7 @@ cJSON *wm_azure_dump(const wm_azure_t * azure) {
                     cJSON_AddStringToObject(container, "blobs", container_conf->blobs);
                     cJSON_AddStringToObject(container, "content_type", container_conf->content_type);
                     cJSON_AddStringToObject(container, "time_offset", container_conf->time_offset);
-                    cJSON_AddStringToObject(container, "prefix", container_conf->prefix);
+                    cJSON_AddStringToObject(container, "prefix", container_conf->path);
                     if (container_conf->timeout) cJSON_AddNumberToObject(container, "timeout", container_conf->timeout);
                     cJSON_AddItemToArray(containers, container);
                 }

--- a/src/wazuh_modules/wm_azure.h
+++ b/src/wazuh_modules/wm_azure.h
@@ -53,7 +53,7 @@ typedef struct wm_azure_container_t {
     char * blobs;           // Blobs
     char * content_type;    // Content type (plain | inline | file)
     char * time_offset;     // Offset to look for logs (minutes, hours, days)
-    char * prefix;          // Prefix to search into
+    char * path;          // Prefix to search into
     unsigned int timeout;   // Timeout for a single container
     struct wm_azure_container_t *next;
 } wm_azure_container_t;

--- a/src/wazuh_modules/wm_azure.h
+++ b/src/wazuh_modules/wm_azure.h
@@ -53,6 +53,7 @@ typedef struct wm_azure_container_t {
     char * blobs;           // Blobs
     char * content_type;    // Content type (plain | inline | file)
     char * time_offset;     // Offset to look for logs (minutes, hours, days)
+    char * prefix;          // Prefix to search into
     unsigned int timeout;   // Timeout for a single container
     struct wm_azure_container_t *next;
 } wm_azure_container_t;

--- a/wodles/azure/azure-logs.py
+++ b/wodles/azure/azure-logs.py
@@ -695,7 +695,7 @@ def get_blobs(
     try:
         # Get the blob list
         logging.info("Storage: Getting blobs.")
-        blobs = blob_service.list_blobs(container_name, prefix, marker=next_marker)
+        blobs = blob_service.list_blobs(container_name, prefix=prefix, marker=next_marker)
     except AzureException as e:
         logging.error(f"Storage: Error getting blobs from '{container_name}': '{e}'.")
         raise e
@@ -706,7 +706,6 @@ def get_blobs(
         for blob in blobs:
             # Skip the blob if nested under prefix but prefix is not setted
             if prefix is None and len(blob.name.split("/")) > 1:
-                logging.debug(f"Skipping {blob.name}")
                 continue
             # Skip the blob if its name has not the expected format
             if args.blobs and args.blobs not in blob.name:

--- a/wodles/azure/azure-logs.py
+++ b/wodles/azure/azure-logs.py
@@ -24,7 +24,6 @@ from hashlib import md5
 from json import dumps, loads, JSONDecodeError
 from os.path import abspath, dirname
 from socket import socket, AF_UNIX, SOCK_DGRAM, error as socket_error
-from typing import Optional
 
 from azure.common import AzureException, AzureHttpError
 from azure.storage.blob import BlockBlobService
@@ -666,7 +665,7 @@ def start_storage():
 
 def get_blobs(
     container_name: str, blob_service: BlockBlobService, md5_hash: str, min_datetime: datetime, max_datetime: datetime,
-    desired_datetime: datetime, next_marker: Optional[str] = None, prefix: Optional[str] = None
+    desired_datetime: datetime, next_marker: str = None, prefix: str = None
 ):
     """Get the blobs from a container and send their content.
 
@@ -686,6 +685,8 @@ def get_blobs(
         md5 value used to search the container in the file containing the dates.
     next_marker : str
         Token used as a marker to continue from previous iteration.
+    prefix : str, optional
+        Prefix value to search blobs that match with it.
 
     Raises
     ------

--- a/wodles/azure/tests/test_azure.py
+++ b/wodles/azure/tests/test_azure.py
@@ -627,30 +627,31 @@ def test_start_storage_ko_credentials(mock_logging):
     mock_logging.assert_called_once()
 
 
-@pytest.mark.parametrize('blob_date, min_date, max_date, desired_date, extension, reparse, json_file, inline, send_events', [
+@pytest.mark.parametrize(
+    'blob_date, min_date, max_date, desired_date, extension, reparse, json_file, inline, send_events, prefix', [
     # blob_date < desired_date - Blobs should be skipped
-    (PRESENT_DATE, PAST_DATE, PAST_DATE, FUTURE_DATE, None, False, False, False, False),
+    (PRESENT_DATE, PAST_DATE, PAST_DATE, FUTURE_DATE, None, False, False, False, False, None),
     # blob_date > desired_date, min_date == blob_date and blob_date < max_date - Blobs should be skipped
-    (PRESENT_DATE, PRESENT_DATE, FUTURE_DATE, PAST_DATE, None, False, False, False, False),
+    (PRESENT_DATE, PRESENT_DATE, FUTURE_DATE, PAST_DATE, None, False, False, False, False, None),
     # blob_date > desired_date, min_date < blob_date and blob_date == max_date - Blobs should be skipped
-    (FUTURE_DATE, PRESENT_DATE, FUTURE_DATE, PAST_DATE, None, False, False, False, False),
+    (FUTURE_DATE, PRESENT_DATE, FUTURE_DATE, PAST_DATE, None, False, False, False, False, None),
     # blob_date > desired_date, min_date < blob_date and blob_date < max_date - Blobs should be skipped
-    (PAST_DATE, PRESENT_DATE, FUTURE_DATE, PAST_DATE, None, False, False, False, False),
+    (PAST_DATE, PRESENT_DATE, FUTURE_DATE, PAST_DATE, None, False, False, False, False, None),
     # blob_date < min_datetime - Blobs must be processed
-    (PAST_DATE, PRESENT_DATE, FUTURE_DATE, PAST_DATE, None, False, False, False, True),
+    (PAST_DATE, PRESENT_DATE, FUTURE_DATE, PAST_DATE, None, False, False, False, True, None),
     # blob_date > max_datetime - Blobs must be processed
-    (FUTURE_DATE, PAST_DATE, PRESENT_DATE, FUTURE_DATE, None, False, False, True, True),
+    (FUTURE_DATE, PAST_DATE, PRESENT_DATE, FUTURE_DATE, None, False, False, True, True, None),
     # Reparse old logs
-    (FUTURE_DATE, FUTURE_DATE, FUTURE_DATE, FUTURE_DATE, None, True, False, True, True),
+    (FUTURE_DATE, FUTURE_DATE, FUTURE_DATE, FUTURE_DATE, None, True, False, True, True, None),
     # Only .json files must be processed
-    (FUTURE_DATE, PAST_DATE, PRESENT_DATE, FUTURE_DATE, ".json", False, False, False, True),
-    (FUTURE_DATE, PAST_DATE, PRESENT_DATE, FUTURE_DATE, ".json", False, False, True, True),
-    (FUTURE_DATE, PAST_DATE, PRESENT_DATE, FUTURE_DATE, ".json", False, True, False, True),
+    (FUTURE_DATE, PAST_DATE, PRESENT_DATE, FUTURE_DATE, ".json", False, False, False, True, None),
+    (FUTURE_DATE, PAST_DATE, PRESENT_DATE, FUTURE_DATE, ".json", False, False, True, True, None),
+    (FUTURE_DATE, PAST_DATE, PRESENT_DATE, FUTURE_DATE, ".json", False, True, False, True, None),
 ])
 @patch('azure-logs.update_row_object')
 @patch('azure-logs.send_message')
 def test_get_blobs(mock_send, mock_update, blob_date, min_date, max_date, desired_date, extension, reparse, json_file,
-                   inline, send_events):
+                   inline, send_events, prefix):
     """Test get_blobs obtains the blobs from a container and send their content to the socket."""
     azure.args = MagicMock(blobs=extension, json_file=json_file, json_inline=inline, reparse=reparse,
                            storage_tag="tag")
@@ -684,7 +685,7 @@ def test_get_blobs(mock_send, mock_update, blob_date, min_date, max_date, desire
     azure.get_blobs(container_name=container_name, blob_service=blob_service, md5_hash=md5_hash, next_marker=marker,
                     min_datetime=parse(min_date), max_datetime=parse(max_date), desired_datetime=parse(desired_date))
 
-    blob_service.list_blobs.assert_called_with(container_name, marker=marker)
+    blob_service.list_blobs.assert_called_with(container_name, prefix=prefix, marker=marker)
     blob_service.get_blob_to_text.assert_has_calls(
         [call(container_name, blob.name) for blob in blob_list if extension and extension in blob.name])
     if send_events:
@@ -706,6 +707,47 @@ def test_get_blobs(mock_send, mock_update, blob_date, min_date, max_date, desire
         mock_send.assert_has_calls(calls)
         assert mock_update.call_count == len(blob_list) if not extension else len(
             [blob.name for blob in blob_list if extension in blob.name])
+
+
+@patch('azure-logs.update_row_object')
+@patch('azure-logs.send_message')
+def test_get_blobs_only_with_prefix(mock_send, mock_update):
+    """Test get_blobs obtains the blobs only with prefix from a container and send their content to the socket."""
+    azure.args = MagicMock(
+        blobs=None, json_file=False, json_inline=False, reparse=False
+    )
+
+    prefix = "test_prefix"
+    blob_date_str = parse(FUTURE_DATE)
+
+    blob_list = [create_mocked_blob(blob_name=f"blob_{i}", last_modified=blob_date_str) for i in range(5)] + [
+        create_mocked_blob(blob_name=f"{prefix}/blob_{i}", last_modified=blob_date_str) for i in range(5)
+    ]
+
+    # The first iteration will contain a full blob list and a none next_marker
+    blob_service_iter_1 = MagicMock(next_marker=None)
+    blob_service_iter_1.__iter__ = MagicMock(return_value=iter(blob_list))
+    blob_service = MagicMock()
+    blob_service.list_blobs.return_value = blob_service_iter_1
+
+
+    with open(os.path.join(TEST_DATA_PATH, "storage_events_plain")) as f:
+        contents = f.read()
+        blob_service.get_blob_to_text.return_value = MagicMock(content=contents)
+
+    container_name = "container"
+    md5_hash = "hash"
+
+
+    azure.get_blobs(
+        container_name=container_name, blob_service=blob_service, md5_hash=md5_hash, min_datetime=parse(PAST_DATE),
+        max_datetime=parse(PRESENT_DATE), desired_datetime=parse(FUTURE_DATE), prefix=prefix
+    )
+
+    blob_service.list_blobs.assert_called_with(container_name, prefix=prefix, marker=None)
+    blob_service.get_blob_to_text.assert_has_calls(
+        [call(container_name, blob.name) for blob in blob_list if prefix in blob.name]
+    )
 
 
 @patch('azure-logs.logging.error')


### PR DESCRIPTION
|Related issue|
|---|
|#11147|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR closes #11147. Adds `--prefix` parameter to azure module in order to add more flexibility and possibilities to the user.
If the parameter is present the module will take the blobs under the indicated prefix. But is not, the blobs under any prefix will be skipped and only will be collected the blobs at root level in a container.

## Tests

### Python

```bash
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.10.4, pytest-6.2.5, py-1.11.0, pluggy-0.13.1
rootdir: /home/nstefani/git/wazuh
collected 268 items

wodles/aws/tests/test_aws.py ......................................                                                                                                                                           [ 14%]
wodles/azure/tests/test_azure.py ....................................................................................................................                                                         [ 57%]
wodles/azure/tests/test_orm.py .......................                                                                                                                                                        [ 66%]
wodles/docker-listener/tests/test_docker_listener.py ...................                                                                                                                                      [ 73%]
wodles/gcloud/tests/test_bucket.py .................................                                                                                                                                          [ 85%]
wodles/gcloud/tests/test_gcloud.py .........                                                                                                                                                                  [ 88%]
wodles/gcloud/tests/test_integration.py ........                                                                                                                                                              [ 91%]
wodles/gcloud/tests/test_subscriber.py ..............                                                                                                                                                         [ 97%]
wodles/gcloud/tests/test_tools.py ........                                                                                                                                                                    [100%]

================================================================================================ 268 passed in 1.49s ================================================================================================
```

### C

```bash
Test project /wazuh/src/unit_tests/build
        Start   1: test_analysisd_syscheck
  1/145 Test   #1: test_analysisd_syscheck .................   Passed    0.07 sec
        Start   2: test_dbsync
  2/145 Test   #2: test_dbsync .............................   Passed    0.06 sec
        Start   3: test_exec
  3/145 Test   #3: test_exec ...............................   Passed    0.06 sec
        Start   4: test_log
  4/145 Test   #4: test_log ................................   Passed    0.05 sec
        Start   5: test_labels
  5/145 Test   #5: test_labels .............................   Passed    0.05 sec
        Start   6: test_mitre
  6/145 Test   #6: test_mitre ..............................   Passed    0.02 sec
        Start   7: test_rules
  7/145 Test   #7: test_rules ..............................   Passed    0.05 sec
        Start   8: test_same_different_loop
  8/145 Test   #8: test_same_different_loop ................   Passed    0.06 sec
        Start   9: test_logtest
  9/145 Test   #9: test_logtest ............................   Passed    0.04 sec
        Start  10: test_logtest-config
 10/145 Test  #10: test_logtest-config .....................   Passed    0.02 sec
        Start  11: test_decoder_list
 11/145 Test  #11: test_decoder_list .......................   Passed    0.02 sec
        Start  12: test_decode-xml
 12/145 Test  #12: test_decode-xml .........................   Passed    0.05 sec
        Start  13: test_lists_list
 13/145 Test  #13: test_lists_list .........................   Passed    0.02 sec
        Start  14: test_rule_list
 14/145 Test  #14: test_rule_list ..........................   Passed    0.02 sec
        Start  15: test_eventinfo_list
 15/145 Test  #15: test_eventinfo_list .....................   Passed    0.02 sec
        Start  16: test_logmsg
 16/145 Test  #16: test_logmsg .............................   Passed    0.02 sec
        Start  17: test_decoder_rootcheck
 17/145 Test  #17: test_decoder_rootcheck ..................   Passed    0.06 sec
        Start  18: test_decoder_syscollector
 18/145 Test  #18: test_decoder_syscollector ...............   Passed    0.07 sec
        Start  19: test_manager
 19/145 Test  #19: test_manager ............................   Passed    0.06 sec
        Start  20: test_secure
 20/145 Test  #20: test_secure .............................   Passed    0.05 sec
        Start  21: test_netbuffer
 21/145 Test  #21: test_netbuffer ..........................   Passed    0.06 sec
        Start  22: test_sendmsg
 22/145 Test  #22: test_sendmsg ............................   Passed    0.05 sec
        Start  23: test_remote-config
 23/145 Test  #23: test_remote-config ......................   Passed    0.02 sec
        Start  24: test_syslogtcp
 24/145 Test  #24: test_syslogtcp ..........................   Passed    0.05 sec
        Start  25: test_wdb_integrity
 25/145 Test  #25: test_wdb_integrity ......................   Passed    0.02 sec
        Start  26: test_wdb_fim
 26/145 Test  #26: test_wdb_fim ............................   Passed    0.02 sec
        Start  27: test_wdb_parser
 27/145 Test  #27: test_wdb_parser .........................   Passed    0.03 sec
        Start  28: test_wdb_global_parser
 28/145 Test  #28: test_wdb_global_parser ..................   Passed    0.04 sec
        Start  29: test_wdb_global
 29/145 Test  #29: test_wdb_global .........................   Passed    0.21 sec
        Start  30: test_wdb_agents
 30/145 Test  #30: test_wdb_agents .........................   Passed    0.02 sec
        Start  31: test_wdb_global_helpers
 31/145 Test  #31: test_wdb_global_helpers .................   Passed    0.03 sec
        Start  32: test_wdb_agents_helpers
 32/145 Test  #32: test_wdb_agents_helpers .................   Passed    0.02 sec
        Start  33: test_wdb
 33/145 Test  #33: test_wdb ................................   Passed    0.03 sec
        Start  34: test_wdb_upgrade
 34/145 Test  #34: test_wdb_upgrade ........................   Passed    0.02 sec
        Start  35: test_wdb_metadata
 35/145 Test  #35: test_wdb_metadata .......................   Passed    0.02 sec
        Start  36: test_wdb_task_parser
 36/145 Test  #36: test_wdb_task_parser ....................   Passed    0.02 sec
        Start  37: test_wdb_rootcheck
 37/145 Test  #37: test_wdb_rootcheck ......................   Passed    0.01 sec
        Start  38: test_wdb_syscollector
 38/145 Test  #38: test_wdb_syscollector ...................   Passed    0.03 sec
        Start  39: test_wdb_task
 39/145 Test  #39: test_wdb_task ...........................   Passed    0.02 sec
        Start  40: test_wdb_delta_event
 40/145 Test  #40: test_wdb_delta_event ....................   Passed    0.02 sec
        Start  41: test_wazuh_db-config
 41/145 Test  #41: test_wazuh_db-config ....................   Passed    0.03 sec
        Start  42: test_auth_parse
 42/145 Test  #42: test_auth_parse .........................   Passed    0.02 sec
        Start  43: test_auth_validate
 43/145 Test  #43: test_auth_validate ......................   Passed    0.03 sec
        Start  44: test_auth_add
 44/145 Test  #44: test_auth_add ...........................   Passed    0.03 sec
        Start  45: test_ssl
 45/145 Test  #45: test_ssl ................................   Passed    0.02 sec
        Start  46: test_auth_key_request
 46/145 Test  #46: test_auth_key_request ...................   Passed    0.03 sec
        Start  47: test_auth
 47/145 Test  #47: test_auth ...............................   Passed    0.02 sec
        Start  48: test_msgs
 48/145 Test  #48: test_msgs ...............................   Passed    0.02 sec
        Start  49: test_keys
 49/145 Test  #49: test_keys ...............................   Passed    0.02 sec
        Start  50: test_sha1_op
 50/145 Test  #50: test_sha1_op ............................   Passed    0.02 sec
        Start  51: test_blowfish_op
 51/145 Test  #51: test_blowfish_op ........................   Passed    0.01 sec
        Start  52: test_md5_op
 52/145 Test  #52: test_md5_op .............................   Passed    0.02 sec
        Start  53: test_md5_sha1_op
 53/145 Test  #53: test_md5_sha1_op ........................   Passed    0.02 sec
        Start  54: test_md5_sha1_sha256_op
 54/145 Test  #54: test_md5_sha1_sha256_op .................   Passed    0.02 sec
        Start  55: test_sha256_op
 55/145 Test  #55: test_sha256_op ..........................   Passed    0.02 sec
        Start  56: test_wm_aws
 56/145 Test  #56: test_wm_aws .............................   Passed    0.05 sec
        Start  57: test_wm_azure
 57/145 Test  #57: test_wm_azure ...........................   Passed    0.05 sec
        Start  58: test_wm_ciscat
 58/145 Test  #58: test_wm_ciscat ..........................   Passed    0.05 sec
        Start  59: test_wm_command
 59/145 Test  #59: test_wm_command .........................   Passed    0.05 sec
        Start  60: test_wm_database
 60/145 Test  #60: test_wm_database ........................   Passed    0.03 sec
        Start  61: test_wm_docker
 61/145 Test  #61: test_wm_docker ..........................   Passed    0.04 sec
        Start  62: test_wm_gcp
 62/145 Test  #62: test_wm_gcp .............................   Passed    0.22 sec
        Start  63: test_wmodules_gcp
 63/145 Test  #63: test_wmodules_gcp .......................   Passed    0.06 sec
        Start  64: test_wm_oscap
 64/145 Test  #64: test_wm_oscap ...........................   Passed    0.04 sec
        Start  65: test_wm_sca
 65/145 Test  #65: test_wm_sca .............................   Passed    0.04 sec
        Start  66: test_wmodules_scheduling
 66/145 Test  #66: test_wmodules_scheduling ................   Passed    0.02 sec
        Start  67: test_wm_vuln_detector
 67/145 Test  #67: test_wm_vuln_detector ...................   Passed    0.08 sec
        Start  68: test_wm_vuln_detector_evr
 68/145 Test  #68: test_wm_vuln_detector_evr ...............   Passed    0.02 sec
        Start  69: test_wm_vuln_detector_nvd
 69/145 Test  #69: test_wm_vuln_detector_nvd ...............   Passed    0.05 sec
        Start  70: test_wm_task_manager
 70/145 Test  #70: test_wm_task_manager ....................   Passed    0.04 sec
        Start  71: test_wm_task_manager_parsing
 71/145 Test  #71: test_wm_task_manager_parsing ............   Passed    0.02 sec
        Start  72: test_wm_task_manager_commands
 72/145 Test  #72: test_wm_task_manager_commands ...........   Passed    0.02 sec
        Start  73: test_wm_agent_upgrade
 73/145 Test  #73: test_wm_agent_upgrade ...................   Passed    0.02 sec
        Start  74: test_wm_agent_upgrade_manager
 74/145 Test  #74: test_wm_agent_upgrade_manager ...........   Passed    0.04 sec
        Start  75: test_wm_agent_upgrade_parsing
 75/145 Test  #75: test_wm_agent_upgrade_parsing ...........   Passed    0.04 sec
        Start  76: test_wm_agent_upgrade_validate
 76/145 Test  #76: test_wm_agent_upgrade_validate ..........   Passed    0.02 sec
        Start  77: test_wm_agent_upgrade_tasks
 77/145 Test  #77: test_wm_agent_upgrade_tasks .............   Passed    0.02 sec
        Start  78: test_wm_agent_upgrade_tasks_callbacks
 78/145 Test  #78: test_wm_agent_upgrade_tasks_callbacks ...   Passed    0.04 sec
        Start  79: test_wm_agent_upgrade_commands
 79/145 Test  #79: test_wm_agent_upgrade_commands ..........   Passed    0.04 sec
        Start  80: test_wm_agent_upgrade_upgrades
 80/145 Test  #80: test_wm_agent_upgrade_upgrades ..........   Passed    0.05 sec
        Start  81: test_wm_github
 81/145 Test  #81: test_wm_github ..........................   Passed    0.05 sec
        Start  82: test_wm_office365
 82/145 Test  #82: test_wm_office365 .......................   Passed    0.07 sec
        Start  83: test_monitord
 83/145 Test  #83: test_monitord ...........................   Passed    0.02 sec
        Start  84: test_monitor_actions
 84/145 Test  #84: test_monitor_actions ....................   Passed    0.04 sec
        Start  85: test_logcollector
 85/145 Test  #85: test_logcollector .......................   Passed    0.04 sec
        Start  86: test_read_multiline_regex
 86/145 Test  #86: test_read_multiline_regex ...............   Passed    0.04 sec
        Start  87: test_localfile-config
 87/145 Test  #87: test_localfile-config ...................   Passed    0.04 sec
        Start  88: test_state
 88/145 Test  #88: test_state ..............................   Passed    0.02 sec
        Start  89: test_lccom
 89/145 Test  #89: test_lccom ..............................   Passed    0.04 sec
        Start  90: test_macos_log
 90/145 Test  #90: test_macos_log ..........................   Passed    0.02 sec
        Start  91: test_read_macos
 91/145 Test  #91: test_read_macos .........................   Passed    0.04 sec
        Start  92: test_execd
 92/145 Test  #92: test_execd ..............................   Passed    0.02 sec
        Start  93: test_create_db
 93/145 Test  #93: test_create_db ..........................   Passed    0.06 sec
        Start  94: test_syscom
 94/145 Test  #94: test_syscom .............................   Passed    0.02 sec
        Start  95: test_fim_diff_changes
 95/145 Test  #95: test_fim_diff_changes ...................   Passed    0.04 sec
        Start  96: test_run_realtime
 96/145 Test  #96: test_run_realtime .......................   Passed    0.05 sec
        Start  97: test_syscheck_config
 97/145 Test  #97: test_syscheck_config ....................   Passed    0.06 sec
        Start  98: test_syscheck
 98/145 Test  #98: test_syscheck ...........................   Passed    0.02 sec
        Start  99: test_fim_sync
 99/145 Test  #99: test_fim_sync ...........................   Passed    0.08 sec
        Start 100: test_run_check
100/145 Test #100: test_run_check ..........................   Passed    0.08 sec
        Start 101: test_fim_db
101/145 Test #101: test_fim_db .............................   Passed    0.05 sec
        Start 102: test_fim_db_files
102/145 Test #102: test_fim_db_files .......................   Passed    0.05 sec
        Start 103: test_audit_healthcheck
103/145 Test #103: test_audit_healthcheck ..................   Passed    0.04 sec
        Start 104: test_audit_rule_handling
104/145 Test #104: test_audit_rule_handling ................   Passed    0.04 sec
        Start 105: test_syscheck_audit
105/145 Test #105: test_syscheck_audit .....................   Passed    0.06 sec
        Start 106: test_audit_parse
106/145 Test #106: test_audit_parse ........................   Passed    0.05 sec
        Start 107: test_list_op
107/145 Test #107: test_list_op ............................   Passed    0.04 sec
        Start 108: test_file_op
108/145 Test #108: test_file_op ............................   Passed    0.02 sec
        Start 109: test_integrity_op
109/145 Test #109: test_integrity_op .......................   Passed    0.01 sec
        Start 110: test_rbtree_op
110/145 Test #110: test_rbtree_op ..........................   Passed    0.02 sec
        Start 111: test_validate_op
111/145 Test #111: test_validate_op ........................   Passed    0.02 sec
        Start 112: test_string_op
112/145 Test #112: test_string_op ..........................   Passed    0.02 sec
        Start 113: test_expression
113/145 Test #113: test_expression .........................   Passed    0.02 sec
        Start 114: test_version_op
114/145 Test #114: test_version_op .........................   Passed    0.03 sec
        Start 115: test_queue_op
115/145 Test #115: test_queue_op ...........................   Passed    0.02 sec
        Start 116: test_queue_linked_op
116/145 Test #116: test_queue_linked_op ....................   Passed    0.02 sec
        Start 117: test_agent_op
117/145 Test #117: test_agent_op ...........................   Passed    0.02 sec
        Start 118: test_enrollment_op
118/145 Test #118: test_enrollment_op ......................   Passed    0.03 sec
        Start 119: test_time_op
119/145 Test #119: test_time_op ............................   Passed    0.02 sec
        Start 120: test_buffer_op
120/145 Test #120: test_buffer_op ..........................   Passed    0.02 sec
        Start 121: test_utf8_op
121/145 Test #121: test_utf8_op ............................   Passed    0.02 sec
        Start 122: test_log_builder
122/145 Test #122: test_log_builder ........................   Passed    0.02 sec
        Start 123: test_custom_output_search_replace
123/145 Test #123: test_custom_output_search_replace .......   Passed    0.02 sec
        Start 124: test_bzip2_op
124/145 Test #124: test_bzip2_op ...........................   Passed    0.02 sec
        Start 125: test_schedule_scan
125/145 Test #125: test_schedule_scan ......................   Passed    0.02 sec
        Start 126: test_rootcheck_op
126/145 Test #126: test_rootcheck_op .......................   Passed    0.02 sec
        Start 127: test_fs_op
127/145 Test #127: test_fs_op ..............................   Passed    0.02 sec
        Start 128: test_wazuhdb_op
128/145 Test #128: test_wazuhdb_op .........................   Passed    0.02 sec
        Start 129: test_syscheck_op
129/145 Test #129: test_syscheck_op ........................   Passed    0.06 sec
        Start 130: test_audit_op
130/145 Test #130: test_audit_op ...........................   Passed    0.02 sec
        Start 131: test_privsep_op
131/145 Test #131: test_privsep_op .........................   Passed    0.01 sec
        Start 132: test_mq_op
132/145 Test #132: test_mq_op ..............................   Passed    0.02 sec
        Start 133: test_remoted_op
133/145 Test #133: test_remoted_op .........................   Passed    0.02 sec
        Start 134: test_json-queue
134/145 Test #134: test_json-queue .........................   Passed    0.02 sec
        Start 135: test_bqueue
135/145 Test #135: test_bqueue .............................   Passed    0.02 sec
        Start 136: test_atomic
136/145 Test #136: test_atomic .............................   Passed    0.01 sec
        Start 137: test_url
137/145 Test #137: test_url ................................   Passed    0.02 sec
        Start 138: test_sysinfo_utils
138/145 Test #138: test_sysinfo_utils ......................   Passed    0.02 sec
        Start 139: test_os_xml
139/145 Test #139: test_os_xml .............................   Passed    0.07 sec
        Start 140: test_os_regex
140/145 Test #140: test_os_regex ...........................   Passed    0.02 sec
        Start 141: test_os_regex_execute
141/145 Test #141: test_os_regex_execute ...................   Passed    0.03 sec
        Start 142: test_os_zlib
142/145 Test #142: test_os_zlib ............................   Passed    0.02 sec
        Start 143: test_os_net
143/145 Test #143: test_os_net .............................   Passed    0.02 sec
        Start 144: test_fluentd_forwarder
144/145 Test #144: test_fluentd_forwarder ..................   Passed    0.04 sec
        Start 145: test_active-response
145/145 Test #145: test_active-response ....................   Passed    0.02 sec

100% tests passed, 0 tests failed out of 145

Total Test time (real) =   5.11 sec

```