### PR TITLE
Fixes rule skipping when if_sid option is invalid

### DIFF
--- a/ruleset/testing/ruleset/test_decoders.xml
+++ b/ruleset/testing/ruleset/test_decoders.xml
@@ -21,3 +21,7 @@
   <regex>Test noalert=(\d)$</regex>
   <order>noalert</order>
 </decoder>
+
+<decoder name="test_wrong_ifsid">
+  <program_name>^test_wrong_ifsid</program_name>
+</decoder>

--- a/ruleset/testing/ruleset/test_rules.xml
+++ b/ruleset/testing/ruleset/test_rules.xml
@@ -464,4 +464,17 @@
   <description>No-alerting disabled.</description>
 </rule>
 
+<!-- Trigger parent rule, do not crash -->
+<!-- Sep  5 13:14:00 User test_wrong_ifsid[12345]:Test -->
+
+<rule id="999275" level="3">
+  <decoded_as>test_wrong_ifsid</decoded_as>
+  <description>Wrong ifsid test.</description>
+</rule>
+
+<rule id="999276" level="3">
+  <if_sid>999275|1</if_sid>
+  <description>Wrong ifsid test.</description>
+</rule>
+
 </group>

--- a/ruleset/testing/tests/test_features.ini
+++ b/ruleset/testing/tests/test_features.ini
@@ -30,3 +30,9 @@ log 1 pass = Dec 19 17:20:08 User test_noalert[12345]:Test noalert=0
 rule = 999274
 alert = 3
 decoder = test_noalert
+
+[wrong ifsid]
+log 1 pass = Sep  5 13:14:00 User test_wrong_ifsid[12345]:Test
+rule = 999275
+alert = 3
+decoder = test_wrong_ifsid

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -1609,6 +1609,20 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                     }
                 }
 
+                /* Check syntax if_sid */
+                if (config_ruleinfo->if_sid) {
+                    w_expression_t * invalidation_regex = NULL;
+                    w_calloc_expression_t(&invalidation_regex, EXP_TYPE_PCRE2);
+                    // matches if it contains any invalid characters
+                    w_expression_compile(invalidation_regex, "[^\\d, ]", 0);
+
+                    if (w_expression_match(invalidation_regex, config_ruleinfo->if_sid, NULL, NULL)) {
+                        do_skip_rule = true;
+                        smwarn(log_msg, ANALYSISD_INVALID_IF_SID, config_ruleinfo->if_sid, config_ruleinfo->sigid);
+                    }
+                    w_free_expression_t(&invalidation_regex);
+                }
+
                 // Skip rule, without having to abort analysisd execution
                 if (do_skip_rule) {
                     w_free_rules_tmp_params(&rule_tmp_params);

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -1611,16 +1611,16 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
                 /* Check syntax if_sid */
                 if (config_ruleinfo->if_sid) {
-                    w_expression_t * invalidation_regex = NULL;
-                    w_calloc_expression_t(&invalidation_regex, EXP_TYPE_PCRE2);
-                    // matches if it contains any invalid characters
-                    w_expression_compile(invalidation_regex, "[^\\d, ]", 0);
+                    w_expression_t * validation_regex = NULL;
+                    w_calloc_expression_t(&validation_regex, EXP_TYPE_PCRE2);
+                    // matches if all characters are valid
+                    w_expression_compile(validation_regex, "^[\\d, ]+$", 0);
 
-                    if (w_expression_match(invalidation_regex, config_ruleinfo->if_sid, NULL, NULL)) {
+                    if (!w_expression_match(validation_regex, config_ruleinfo->if_sid, NULL, NULL)) {
                         do_skip_rule = true;
                         smwarn(log_msg, ANALYSISD_INVALID_IF_SID, config_ruleinfo->if_sid, config_ruleinfo->sigid);
                     }
-                    w_free_expression_t(&invalidation_regex);
+                    w_free_expression_t(&validation_regex);
                 }
 
                 // Skip rule, without having to abort analysisd execution

--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -130,37 +130,37 @@ int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, OSList* log_msg)
 
     /* Adding for if_sid */
     if (read_rule->if_sid != NULL) {
-        int val = 0;
+
         const char * sid_ptr = read_rule->if_sid;
+        bool id_found = false;     // True if sid_ptr points to a sid (number)
+        bool addedAsChild = false; // True if the rule was added as a child of at least one rule
 
         /* Loop to read all the rules (comma or space separated) */
         do {
             if ((*sid_ptr == ',') || (*sid_ptr == ' ')) {
-                val = 0;
+                id_found = false;
                 continue;
-            } else if ((isdigit((int)*sid_ptr)) || (*sid_ptr == '\0')) {
+            } else if ((isdigit((int) *sid_ptr)) || (*sid_ptr == '\0')) {
 
-                if (val == 0) {
+                if (!id_found) {
+                    id_found = true;
 
                     int if_sid_rule_id = atoi(sid_ptr);
 
                     if (_AddtoRule(if_sid_rule_id, 0, 0, NULL, *r_node, read_rule) == 0) {
 
-                        smwarn(log_msg, ANALYSISD_SIG_ID_NOT_FOUND,
-                               if_sid_rule_id, read_rule->if_matched_sid != 0 ?
-                                                    "if_matched_sid" : "if_sid",
-                               read_rule->sigid);
-                        return -1;
+                        smwarn(log_msg, ANALYSISD_SIG_ID_NOT_FOUND, if_sid_rule_id,
+                               read_rule->if_matched_sid != 0 ? "if_matched_sid" : "if_sid", read_rule->sigid);
+                    } else {
+                        addedAsChild = true;
                     }
-                    val = 1;
                 }
-            } else {
 
-                smwarn(log_msg, ANALYSISD_INV_SIG_ID,
-                        read_rule->if_matched_sid != 0 ? "if_matched_sid"
-                                                       : "if_sid",
-                        read_rule->sigid);
-                return -1;
+            } else {
+                // This should not happen if the if_sid was validated on loading
+                smwarn(log_msg, ANALYSISD_INV_SIG_ID, read_rule->if_matched_sid != 0 ? "if_matched_sid" : "if_sid",
+                       read_rule->sigid);
+                return addedAsChild ? 0 : -1;
             }
         } while (*sid_ptr++ != '\0');
     }

--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -163,6 +163,13 @@ int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, OSList* log_msg)
                 return addedAsChild ? 0 : -1;
             }
         } while (*sid_ptr++ != '\0');
+
+        // If the rule was not added as a child of at least one rule, return error
+        if (!addedAsChild) {
+            smwarn(log_msg, ANALYSISD_EMPTY_SID, read_rule->if_matched_sid != 0 ? "if_matched_sid" : "if_sid",
+                   read_rule->sigid);
+            return -1;
+        }
     }
 
     /* Adding for if_level */

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -115,6 +115,7 @@
 #define ANALYSISD_SIG_ID_NOT_FOUND              "(7617): Signature ID '%d' was not found and will be ignored "\
                                                         "in the '%s' option of rule '%d'."
 #define ANALYSISD_INVALID_IF_SID                "(7618): Invalid 'if_sid' value: '%s'. Rule '%d' will be ignored."
+#define ANALYSISD_EMPTY_SID                     "(7619): Empty '%s' value. Rule '%d' will be ignored."
 
 /* Logcollector */
 #define LOGCOLLECTOR_INV_VALUE_DEFAULT          "(8000): Invalid value '%s' for attribute '%s' in '%s' option. " \

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -114,6 +114,7 @@
 #define ANALYSISD_LIST_NOT_LOADED               "(7616): List '%s' could not be loaded. Rule '%d' will be ignored."
 #define ANALYSISD_SIG_ID_NOT_FOUND              "(7617): Signature ID '%d' was not found and will be ignored "\
                                                         "in the '%s' option of rule '%d'."
+#define ANALYSISD_INVALID_IF_SID                "(7618): Invalid 'if_sid' value: '%s'. Rule '%d' will be ignored."
 
 /* Logcollector */
 #define LOGCOLLECTOR_INV_VALUE_DEFAULT          "(8000): Invalid value '%s' for attribute '%s' in '%s' option. " \

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -94,7 +94,7 @@
 #define ANALYSISD_IGNORE_RULE                   "(7604): Rule '%d' will be ignored."
 #define ANALYSISD_INV_OVERWRITE                 "(7605): It is not possible to overwrite '%s' value " \
                                                         "in rule '%d'. The original value is retained."
-#define ANALYSISD_SIG_ID_NOT_FOUND              "(7606): Signature ID '%d' was not found. Invalid '%s'. " \
+#define ANALYSISD_SIG_ID_NOT_FOUND_DEPRECATED   "(7606): Signature ID '%d' was not found. Invalid '%s'. " \
                                                         "Rule '%d' will be ignored."
 #define ANALYSISD_INV_SIG_ID                    "(7607): Invalid '%s'. Signature ID must be an integer. " \
                                                         "Rule '%d' will be ignored."
@@ -112,6 +112,8 @@
 #define ANALYSISD_NULL_RULE                     "(7614): Rule pointer is NULL. Skipping."
 #define ANALYSISD_INV_IF_MATCHED_SID            "(7615): Invalid 'if_matched_sid' value: '%s'. Rule '%d' will be ignored."
 #define ANALYSISD_LIST_NOT_LOADED               "(7616): List '%s' could not be loaded. Rule '%d' will be ignored."
+#define ANALYSISD_SIG_ID_NOT_FOUND              "(7617): Signature ID '%d' was not found and will be ignored "\
+                                                        "in the '%s' option of rule '%d'."
 
 /* Logcollector */
 #define LOGCOLLECTOR_INV_VALUE_DEFAULT          "(8000): Invalid value '%s' for attribute '%s' in '%s' option. " \

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -94,8 +94,6 @@
 #define ANALYSISD_IGNORE_RULE                   "(7604): Rule '%d' will be ignored."
 #define ANALYSISD_INV_OVERWRITE                 "(7605): It is not possible to overwrite '%s' value " \
                                                         "in rule '%d'. The original value is retained."
-#define ANALYSISD_SIG_ID_NOT_FOUND_DEPRECATED   "(7606): Signature ID '%d' was not found. Invalid '%s'. " \
-                                                        "Rule '%d' will be ignored."
 #define ANALYSISD_INV_SIG_ID                    "(7607): Invalid '%s'. Signature ID must be an integer. " \
                                                         "Rule '%d' will be ignored."
 #define ANALYSISD_LEVEL_NOT_FOUND               "(7608): Level ID '%d' was not found. Invalid 'if_level'. " \
@@ -113,9 +111,11 @@
 #define ANALYSISD_INV_IF_MATCHED_SID            "(7615): Invalid 'if_matched_sid' value: '%s'. Rule '%d' will be ignored."
 #define ANALYSISD_LIST_NOT_LOADED               "(7616): List '%s' could not be loaded. Rule '%d' will be ignored."
 #define ANALYSISD_SIG_ID_NOT_FOUND              "(7617): Signature ID '%d' was not found and will be ignored "\
-                                                        "in the '%s' option of rule '%d'."
+                                                        "in the 'if_sid' option of rule '%d'."
 #define ANALYSISD_INVALID_IF_SID                "(7618): Invalid 'if_sid' value: '%s'. Rule '%d' will be ignored."
-#define ANALYSISD_EMPTY_SID                     "(7619): Empty '%s' value. Rule '%d' will be ignored."
+#define ANALYSISD_EMPTY_SID                     "(7619): Empty 'if_sid' value. Rule '%d' will be ignored."
+#define ANALYSISD_SIG_ID_NOT_FOUND_MID          "(7620): Signature ID '%d' was not found. Invalid 'if_matched_sid'."\
+                                                         "Rule '%d' will be ignored."
 
 /* Logcollector */
 #define LOGCOLLECTOR_INV_VALUE_DEFAULT          "(8000): Invalid value '%s' for attribute '%s' in '%s' option. " \


### PR DESCRIPTION
|Related issue|
|---|
|#14767|

## Description

This PR fixes the memory problems of issue #14767 but also brings a change in requirements.
The `if_sid` only accepts rule ids separated by spaces ('` `') or commas ('`,`').

## Configuration options

### Syntax validation
Now when the syntax of the label is not valid, a warning message will be displayed and the rule will be skipped:

For example, for the following rule:
```xml
<rule id="100001" level="5">
  <if_sid>5716|5717</if_sid>
  <srcip>1.1.1.1</srcip>
  <description>sshd: authentication failed from IP 1.1.1.1.</description>
  <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
</rule>
```
Wazuh-Analysisd output:
```
2022/08/30 18:55:45 wazuh-analysisd: WARNING: (7618): Invalid 'if_sid' value: ' 1000100| 100099 '. Rule '100001' will be ignored.
2022/08/30 18:55:45 wazuh-analysisd: INFO: Total rules enabled: '6326'
2022/08/30 18:55:45 wazuh-analysisd: INFO: Started (pid: 91106).
2022/08/30 18:55:45 wazuh-analysisd: INFO: (7200): Logtest started

```

And then in Wazuh-Logtest:

```
╰─# /var/ossec/bin/wazuh-logtest                                                                                                                                                                                      
Starting wazuh-logtest v4.4.0
Type one log per line

test_log

** Wazuh-Logtest: WARNING: (7618): Invalid 'if_sid' value: ' 1000100| 100099 '. Rule '100001' will be ignored.

**Phase 1: Completed pre-decoding.
        full event: 'test_log'

**Phase 2: Completed decoding.
        No decoder matched.


```

### Best effort to find a parent
There is a possibility that you have a list of parent rules, then it will parse the ids one by one. It will be added as a child of the parents that exist and will ignore the parents that do not exist showing a warning.

For example with the following configuration:

#### Rule
```xml
<rule id="100001" level="5">
  <if_sid> 100099, 5716</if_sid>
  <program_name>asd|ssh</program_name>
  <srcip>1.1.1.1</srcip>
  <description>sshd: authentication failed from IP 1.1.1.1.</description>
  <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
</rule>
```

#### Decoder
```xml
<decoder name="asdasd">
    <program_name>asd</program_name>
    <regex>(\d+.\d+.\d+.\d+)</regex>
    <order>srcip</order>
</decoder>
```
Logtest output when starting the session and the triggering of rule 100001:
```
╭─root@200-u20-dev-manager ~/repos/wazuh ‹14767-fix-skip-invalid-ifsid●› 
╰─# /var/ossec/bin/wazuh-logtest                                                                                                                                                                                     130 ↵
Starting wazuh-logtest v4.4.0
Type one log per line

test_log

** Wazuh-Logtest: WARNING: (7617): Signature ID '100099' was not found and will be ignored in the 'if_sid' option of rule '100001'.

**Phase 1: Completed pre-decoding.
        full event: 'test_log'

**Phase 2: Completed decoding.
        No decoder matched.

Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2

**Phase 1: Completed pre-decoding.
        full event: 'Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2'
        timestamp: 'Dec 10 01:02:02'
        hostname: 'host'
        program_name: 'sshd'

**Phase 2: Completed decoding.
        name: 'sshd'
        parent: 'sshd'
        dstuser: 'root'
        srcip: '1.1.1.1'
        srcport: '1066'

**Phase 3: Completed filtering (rules).
        id: '100001'
        level: '5'
        description: 'sshd: authentication failed from IP 1.1.1.1.'
        groups: '['local', 'syslog', 'sshd', 'authentication_failed']'
        firedtimes: '1'
        mail: 'False'
        pci_dss: '['10.2.4', '10.2.5']'
**Alert to be generated.

Dec 10 01:02:02 host asd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2

**Phase 1: Completed pre-decoding.
        full event: 'Dec 10 01:02:02 host asd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2'
        timestamp: 'Dec 10 01:02:02'
        hostname: 'host'
        program_name: 'asd'

**Phase 2: Completed decoding.
        name: 'asdasd'
        srcip: '1.1.1.1'

**Phase 3: Completed filtering (rules).
        id: '1002'
        level: '2'
        description: 'Unknown problem somewhere in the system.'
        groups: '['syslog', 'errors']'
        firedtimes: '1'
        gpg13: '['4.3']'
        mail: 'False'

```

## Test / Use case

### Test 1

- The rule 100099 does not exist, and the rule that does exist is found first
- The 100001 rule does not trigger by the log:
Dec 10 01:02:02 host asd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2

- Rule 100001 is triggered as a child rule with log:
Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2

```xml
<rule id="100001" level="5">
  <if_sid> 5716, 100099 </if_sid>
  <program_name>asd|ssh</program_name>
  <srcip>1.1.1.1</srcip>
  <description>sshd: authentication failed from IP 1.1.1.1.</description>
  <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
</rule>
```

<details><summary>Logtest output</summary>

```
╰─# /var/ossec/bin/wazuh-logtest                                                                                                                                                                                                                                                    130 ↵
Starting wazuh-logtest v4.4.0
Type one log per line

Dec 10 01:02:02 host asd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2

** Wazuh-Logtest: WARNING: (7617): Signature ID '100099' was not found and will be ignored in the 'if_sid' option of rule '100001'.

**Phase 1: Completed pre-decoding.
        full event: 'Dec 10 01:02:02 host asd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2'
        timestamp: 'Dec 10 01:02:02'
        hostname: 'host'
        program_name: 'asd'

**Phase 2: Completed decoding.
        name: 'asdasd'
        srcip: '1.1.1.1'

**Phase 3: Completed filtering (rules).
        id: '1002'
        level: '2'
        description: 'Unknown problem somewhere in the system.'
        groups: '['syslog', 'errors']'
        firedtimes: '1'
        gpg13: '['4.3']'
        mail: 'False'

Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2

**Phase 1: Completed pre-decoding.
        full event: 'Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2'
        timestamp: 'Dec 10 01:02:02'
        hostname: 'host'
        program_name: 'sshd'

**Phase 2: Completed decoding.
        name: 'sshd'
        parent: 'sshd'
        dstuser: 'root'
        srcip: '1.1.1.1'
        srcport: '1066'

**Phase 3: Completed filtering (rules).
        id: '100001'
        level: '5'
        description: 'sshd: authentication failed from IP 1.1.1.1.'
        groups: '['local', 'syslog', 'sshd', 'authentication_failed']'
        firedtimes: '1'
        mail: 'False'
        pci_dss: '['10.2.4', '10.2.5']'
**Alert to be generated.

```

</details>


<details><summary>Valgrind report</summary>

```
==117393== Memcheck, a memory error detector
==117393== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==117393== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==117393== Command: /var/ossec/bin/wazuh-analysisd -f
==117393== Parent PID: 3054
==117393== 
==117393== 
==117393== FILE DESCRIPTORS: 37 open at exit.
==117393== Open file descriptor 35: queue/fts/ig-queue
==117393==    at 0x52A5DE4: open (open64.c:48)
==117393==    by 0x5228045: _IO_file_open (fileops.c:189)
==117393==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==117393==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==117393==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==117393==    by 0x124728: FTS_Init (fts.c:163)
==117393==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==117393==    by 0x149418: main (analysisd.c:823)
==117393== 
==117393== Open file descriptor 34: queue/fts/ig-queue
==117393==    at 0x52A5DE4: open (open64.c:48)
==117393==    by 0x5228045: _IO_file_open (fileops.c:189)
==117393==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==117393==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==117393==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==117393==    by 0x124728: FTS_Init (fts.c:163)
==117393==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==117393==    by 0x149418: main (analysisd.c:823)
==117393== 
==117393== Open file descriptor 33: queue/fts/ig-queue
==117393==    at 0x52A5DE4: open (open64.c:48)
==117393==    by 0x5228045: _IO_file_open (fileops.c:189)
==117393==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==117393==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==117393==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==117393==    by 0x124728: FTS_Init (fts.c:163)
==117393==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==117393==    by 0x149418: main (analysisd.c:823)
==117393== 
==117393== Open file descriptor 32: queue/fts/ig-queue
==117393==    at 0x52A5DE4: open (open64.c:48)
==117393==    by 0x5228045: _IO_file_open (fileops.c:189)
==117393==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==117393==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==117393==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==117393==    by 0x124728: FTS_Init (fts.c:163)
==117393==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==117393==    by 0x149418: main (analysisd.c:823)
==117393== 
==117393== Open file descriptor 31: queue/fts/ig-queue
==117393==    at 0x52A5DE4: open (open64.c:48)
==117393==    by 0x5228045: _IO_file_open (fileops.c:189)
==117393==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==117393==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==117393==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==117393==    by 0x124728: FTS_Init (fts.c:163)
==117393==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==117393==    by 0x149418: main (analysisd.c:823)
==117393== 
==117393== Open file descriptor 30: queue/fts/ig-queue
==117393==    at 0x52A5DE4: open (open64.c:48)
==117393==    by 0x5228045: _IO_file_open (fileops.c:189)
==117393==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==117393==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==117393==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==117393==    by 0x124728: FTS_Init (fts.c:163)
==117393==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==117393==    by 0x149418: main (analysisd.c:823)
==117393== 
==117393== Open file descriptor 29: queue/fts/ig-queue
==117393==    at 0x52A5DE4: open (open64.c:48)
==117393==    by 0x5228045: _IO_file_open (fileops.c:189)
==117393==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==117393==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==117393==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==117393==    by 0x124728: FTS_Init (fts.c:163)
==117393==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==117393==    by 0x149418: main (analysisd.c:823)
==117393== 
==117393== Open file descriptor 28: queue/fts/ig-queue
==117393==    at 0x52A5DE4: open (open64.c:48)
==117393==    by 0x5228045: _IO_file_open (fileops.c:189)
==117393==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==117393==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==117393==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==117393==    by 0x124728: FTS_Init (fts.c:163)
==117393==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==117393==    by 0x149418: main (analysisd.c:823)
==117393== 
==117393== Open file descriptor 27: queue/fts/ig-queue
==117393==    at 0x52A5DE4: open (open64.c:48)
==117393==    by 0x5228045: _IO_file_open (fileops.c:189)
==117393==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==117393==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==117393==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==117393==    by 0x124728: FTS_Init (fts.c:163)
==117393==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==117393==    by 0x149418: main (analysisd.c:823)
==117393== 
==117393== Open file descriptor 25: queue/fts/ig-queue
==117393==    at 0x52A5DE4: open (open64.c:48)
==117393==    by 0x5228045: _IO_file_open (fileops.c:189)
==117393==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==117393==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==117393==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==117393==    by 0x124728: FTS_Init (fts.c:163)
==117393==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==117393==    by 0x149418: main (analysisd.c:823)
==117393== 
==117393== Open file descriptor 24: queue/fts/ig-queue
==117393==    at 0x52A5DE4: open (open64.c:48)
==117393==    by 0x5228045: _IO_file_open (fileops.c:189)
==117393==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==117393==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==117393==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==117393==    by 0x124728: FTS_Init (fts.c:163)
==117393==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==117393==    by 0x149418: main (analysisd.c:823)
==117393== 
==117393== Open file descriptor 23: queue/fts/ig-queue
==117393==    at 0x52A5DE4: open (open64.c:48)
==117393==    by 0x5228045: _IO_file_open (fileops.c:189)
==117393==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==117393==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==117393==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==117393==    by 0x124728: FTS_Init (fts.c:163)
==117393==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==117393==    by 0x149418: main (analysisd.c:823)
==117393== 
==117393== Open file descriptor 22: queue/fts/ig-queue
==117393==    at 0x52A5DE4: open (open64.c:48)
==117393==    by 0x5228045: _IO_file_open (fileops.c:189)
==117393==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==117393==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==117393==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==117393==    by 0x124728: FTS_Init (fts.c:163)
==117393==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==117393==    by 0x149418: main (analysisd.c:823)
==117393== 
==117393== Open file descriptor 21: queue/fts/ig-queue
==117393==    at 0x52A5DE4: open (open64.c:48)
==117393==    by 0x5228045: _IO_file_open (fileops.c:189)
==117393==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==117393==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==117393==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==117393==    by 0x124728: FTS_Init (fts.c:163)
==117393==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==117393==    by 0x149418: main (analysisd.c:823)
==117393== 
==117393== Open file descriptor 18: queue/fts/ig-queue
==117393==    at 0x52A5DE4: open (open64.c:48)
==117393==    by 0x5228045: _IO_file_open (fileops.c:189)
==117393==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==117393==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==117393==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==117393==    by 0x124728: FTS_Init (fts.c:163)
==117393==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==117393==    by 0x149418: main (analysisd.c:823)
==117393== 
==117393== Open file descriptor 17: queue/fts/ig-queue
==117393==    at 0x52A5DE4: open (open64.c:48)
==117393==    by 0x5228045: _IO_file_open (fileops.c:189)
==117393==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==117393==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==117393==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==117393==    by 0x1244FA: FTS_Init (fts.c:133)
==117393==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==117393==    by 0x149418: main (analysisd.c:823)
==117393== 
==117393== Open file descriptor 16: queue/fts/fts-queue
==117393==    at 0x52A5DE4: open (open64.c:48)
==117393==    by 0x5228045: _IO_file_open (fileops.c:189)
==117393==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==117393==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==117393==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==117393==    by 0x1241BB: FTS_Init (fts.c:81)
==117393==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==117393==    by 0x149418: main (analysisd.c:823)
==117393== 
==117393== Open file descriptor 15: logs/firewall/2022/Aug/ossec-firewall-30.log
==117393==    at 0x52A5DE4: open (open64.c:48)
==117393==    by 0x5228045: _IO_file_open (fileops.c:189)
==117393==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==117393==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==117393==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==117393==    by 0x1582D3: openlog (getloglocation.c:139)
==117393==    by 0x157EBE: OS_GetLogLocation (getloglocation.c:91)
==117393==    by 0x149772: OS_ReadMSG (analysisd.c:912)
==117393==    by 0x149418: main (analysisd.c:823)
==117393== 
==117393== Open file descriptor 14: logs/alerts/2022/Aug/ossec-alerts-30.json
==117393==    at 0x52A5DE4: open (open64.c:48)
==117393==    by 0x5228045: _IO_file_open (fileops.c:189)
==117393==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==117393==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==117393==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==117393==    by 0x1582D3: openlog (getloglocation.c:139)
==117393==    by 0x157E61: OS_GetLogLocation (getloglocation.c:87)
==117393==    by 0x149772: OS_ReadMSG (analysisd.c:912)
==117393==    by 0x149418: main (analysisd.c:823)
==117393== 
==117393== Open file descriptor 13: logs/alerts/2022/Aug/ossec-alerts-30.log
==117393==    at 0x52A5DE4: open (open64.c:48)
==117393==    by 0x5228045: _IO_file_open (fileops.c:189)
==117393==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==117393==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==117393==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==117393==    by 0x1582D3: openlog (getloglocation.c:139)
==117393==    by 0x157DF9: OS_GetLogLocation (getloglocation.c:84)
==117393==    by 0x149772: OS_ReadMSG (analysisd.c:912)
==117393==    by 0x149418: main (analysisd.c:823)
==117393== 
==117393== Open file descriptor 12: logs/archives/2022/Aug/ossec-archive-30.json
==117393==    at 0x52A5DE4: open (open64.c:48)
==117393==    by 0x5228045: _IO_file_open (fileops.c:189)
==117393==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==117393==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==117393==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==117393==    by 0x1582D3: openlog (getloglocation.c:139)
==117393==    by 0x157D9C: OS_GetLogLocation (getloglocation.c:80)
==117393==    by 0x149772: OS_ReadMSG (analysisd.c:912)
==117393==    by 0x149418: main (analysisd.c:823)
==117393== 
==117393== Open file descriptor 9: logs/archives/2022/Aug/ossec-archive-30.log
==117393==    at 0x52A5DE4: open (open64.c:48)
==117393==    by 0x5228045: _IO_file_open (fileops.c:189)
==117393==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==117393==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==117393==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==117393==    by 0x1582D3: openlog (getloglocation.c:139)
==117393==    by 0x157D34: OS_GetLogLocation (getloglocation.c:76)
==117393==    by 0x149772: OS_ReadMSG (analysisd.c:912)
==117393==    by 0x149418: main (analysisd.c:823)
==117393== 
==117393== Open AF_UNIX socket 10: queue/sockets/logtest
==117393==    at 0x52B87DB: socket (syscall-template.S:78)
==117393==    by 0x268ACD: OS_BindUnixDomainWithPerms (os_net.c:149)
==117393==    by 0x268CC5: OS_BindUnixDomain (os_net.c:192)
==117393==    by 0x11F4A0: w_logtest_init (logtest.c:32)
==117393==    by 0x517D608: start_thread (pthread_create.c:477)
==117393==    by 0x52B7162: clone (clone.S:95)
==117393== 
==117393== Open file descriptor 8: queue/fts/hostinfo
==117393==    at 0x52A5DE4: open (open64.c:48)
==117393==    by 0x5228045: _IO_file_open (fileops.c:189)
==117393==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==117393==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==117393==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==117393==    by 0x15AAED: HostinfoInit (hostinfo.c:86)
==117393==    by 0x149476: OS_ReadMSG (analysisd.c:856)
==117393==    by 0x149418: main (analysisd.c:823)
==117393== 
==117393== Open AF_UNIX socket 7: queue/sockets/analysis
==117393==    at 0x52B87DB: socket (syscall-template.S:78)
==117393==    by 0x268ACD: OS_BindUnixDomainWithPerms (os_net.c:149)
==117393==    by 0x268CC5: OS_BindUnixDomain (os_net.c:192)
==117393==    by 0x12D8F4: asyscom_main (asyscom.c:175)
==117393==    by 0x517D608: start_thread (pthread_create.c:477)
==117393==    by 0x52B7162: clone (clone.S:95)
==117393== 
==117393== Open AF_UNIX socket 6: <unknown>
==117393==    at 0x52B87DB: socket (syscall-template.S:78)
==117393==    by 0x268D63: OS_ConnectUnixDomain (os_net.c:211)
==117393==    by 0x267E95: wdbc_connect (wazuhdb_op.c:29)
==117393==    by 0x2680CB: wdbc_query_ex (wazuhdb_op.c:120)
==117393==    by 0x268399: wdbc_query_parse_json (wazuhdb_op.c:208)
==117393==    by 0x11E007: mitre_load (mitre.c:66)
==117393==    by 0x1493CF: main (analysisd.c:817)
==117393== 
==117393== Open AF_UNIX socket 5: queue/sockets/queue
==117393==    at 0x52B87DB: socket (syscall-template.S:78)
==117393==    by 0x268ACD: OS_BindUnixDomainWithPerms (os_net.c:149)
==117393==    by 0x2519D9: StartMQWithSpecificOwnerAndPerms (mq_op.c:24)
==117393==    by 0x251B60: StartMQ (mq_op.c:55)
==117393==    by 0x1486F7: main (analysisd.c:520)
==117393== 
==117393== Open file descriptor 4: /dev/urandom
==117393==    at 0x5188A5B: open (open64.c:48)
==117393==    by 0x267AAF: randombytes (randombytes.c:62)
==117393==    by 0x267B8B: srandom_init (randombytes.c:82)
==117393==    by 0x1481D9: main (analysisd.c:380)
==117393== 
==117393== Open file descriptor 99: /root/.vscode-server/bin/e4503b30fc78200f846c62cf8091b76ff5547662/vscode-remote-lock.root.e4503b30fc78200f846c62cf8091b76ff5547662
==117393==    <inherited from parent>
==117393== 
==117393== Open file descriptor 98: /root/.vscode-server/bin/4af164ea3a06f701fe3e89a2bcbb421d2026b68f/vscode-remote-lock.root.4af164ea3a06f701fe3e89a2bcbb421d2026b68f (deleted)
==117393==    <inherited from parent>
==117393== 
==117393== Open file descriptor 26: /dev/ptmx
==117393==    <inherited from parent>
==117393== 
==117393== Open file descriptor 20: /root/.vscode-server/data/logs/20220830T132312/ptyhost.log
==117393==    <inherited from parent>
==117393== 
==117393== Open file descriptor 19: /root/.vscode-server/data/logs/20220830T132312/remoteagent.log
==117393==    <inherited from parent>
==117393== 
==117393== Open file descriptor 3: /root/repos/wazuh/ValgrindPRs.log
==117393==    <inherited from parent>
==117393== 
==117393== Open file descriptor 2: /dev/pts/5
==117393==    <inherited from parent>
==117393== 
==117393== Open file descriptor 1: /dev/pts/5
==117393==    <inherited from parent>
==117393== 
==117393== Open file descriptor 0: /dev/pts/5
==117393==    <inherited from parent>
==117393== 
==117393== 
==117393== HEAP SUMMARY:
==117393==     in use at exit: 21,734,840 bytes in 118,089 blocks
==117393==   total heap usage: 1,584,788 allocs, 1,466,699 frees, 4,968,444,323 bytes allocated
==117393== 
==117393== LEAK SUMMARY:
==117393==    definitely lost: 0 bytes in 0 blocks
==117393==    indirectly lost: 0 bytes in 0 blocks
==117393==      possibly lost: 45,216 bytes in 157 blocks
==117393==    still reachable: 21,689,624 bytes in 117,932 blocks
==117393==         suppressed: 0 bytes in 0 blocks
==117393== Reachable blocks (those to which a pointer was found) are not shown.
==117393== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==117393== 
==117393== For lists of detected and suppressed errors, rerun with: -s
==117393== ERROR SUMMARY: 22 errors from 22 contexts (suppressed: 0 from 0)
==117393== could not unlink /tmp/vgdb-pipe-from-vgdb-to-117393-by-root-on-???
==117393== could not unlink /tmp/vgdb-pipe-to-vgdb-from-117393-by-root-on-???
==117393== could not unlink /tmp/vgdb-pipe-shared-mem-vgdb-117393-by-root-on-???


```

</details>


### Test 2

- The rule 100099 does not exist, and the rule that does exist is found last
- The 100001 rule does not trigger by the log:
Dec 10 01:02:02 host asd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2

- Rule 100001 is triggered as a child rule with log:
Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2

```xml
<rule id="100001" level="5">
  <if_sid>100099, 5716</if_sid>
  <program_name>asd|ssh</program_name>
  <srcip>1.1.1.1</srcip>
  <description>sshd: authentication failed from IP 1.1.1.1.</description>
  <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
</rule>
```


<details><summary>Logtest output</summary>

```
╰─# /var/ossec/bin/wazuh-logtest                                                                                                                                                                                                                                                    130 ↵
Starting wazuh-logtest v4.4.0
Type one log per line

Dec 10 01:02:02 host asd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2

** Wazuh-Logtest: WARNING: (7617): Signature ID '100099' was not found and will be ignored in the 'if_sid' option of rule '100001'.

**Phase 1: Completed pre-decoding.
        full event: 'Dec 10 01:02:02 host asd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2'
        timestamp: 'Dec 10 01:02:02'
        hostname: 'host'
        program_name: 'asd'

**Phase 2: Completed decoding.
        name: 'asdasd'
        srcip: '1.1.1.1'

**Phase 3: Completed filtering (rules).
        id: '1002'
        level: '2'
        description: 'Unknown problem somewhere in the system.'
        groups: '['syslog', 'errors']'
        firedtimes: '1'
        gpg13: '['4.3']'
        mail: 'False'

Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2

**Phase 1: Completed pre-decoding.
        full event: 'Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2'
        timestamp: 'Dec 10 01:02:02'
        hostname: 'host'
        program_name: 'sshd'

**Phase 2: Completed decoding.
        name: 'sshd'
        parent: 'sshd'
        dstuser: 'root'
        srcip: '1.1.1.1'
        srcport: '1066'

**Phase 3: Completed filtering (rules).
        id: '100001'
        level: '5'
        description: 'sshd: authentication failed from IP 1.1.1.1.'
        groups: '['local', 'syslog', 'sshd', 'authentication_failed']'
        firedtimes: '1'
        mail: 'False'
        pci_dss: '['10.2.4', '10.2.5']'
**Alert to be generated.
```

</details>
<details><summary>Valgrind</summary>

```
==118947== Memcheck, a memory error detector
==118947== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==118947== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==118947== Command: /var/ossec/bin/wazuh-analysisd -f
==118947== Parent PID: 3054
==118947== 
==118947== 
==118947== FILE DESCRIPTORS: 37 open at exit.
==118947== Open file descriptor 35: queue/fts/ig-queue
==118947==    at 0x52A5DE4: open (open64.c:48)
==118947==    by 0x5228045: _IO_file_open (fileops.c:189)
==118947==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==118947==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==118947==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==118947==    by 0x124728: FTS_Init (fts.c:163)
==118947==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==118947==    by 0x149418: main (analysisd.c:823)
==118947== 
==118947== Open file descriptor 34: queue/fts/ig-queue
==118947==    at 0x52A5DE4: open (open64.c:48)
==118947==    by 0x5228045: _IO_file_open (fileops.c:189)
==118947==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==118947==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==118947==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==118947==    by 0x124728: FTS_Init (fts.c:163)
==118947==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==118947==    by 0x149418: main (analysisd.c:823)
==118947== 
==118947== Open file descriptor 33: queue/fts/ig-queue
==118947==    at 0x52A5DE4: open (open64.c:48)
==118947==    by 0x5228045: _IO_file_open (fileops.c:189)
==118947==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==118947==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==118947==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==118947==    by 0x124728: FTS_Init (fts.c:163)
==118947==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==118947==    by 0x149418: main (analysisd.c:823)
==118947== 
==118947== Open file descriptor 32: queue/fts/ig-queue
==118947==    at 0x52A5DE4: open (open64.c:48)
==118947==    by 0x5228045: _IO_file_open (fileops.c:189)
==118947==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==118947==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==118947==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==118947==    by 0x124728: FTS_Init (fts.c:163)
==118947==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==118947==    by 0x149418: main (analysisd.c:823)
==118947== 
==118947== Open file descriptor 31: queue/fts/ig-queue
==118947==    at 0x52A5DE4: open (open64.c:48)
==118947==    by 0x5228045: _IO_file_open (fileops.c:189)
==118947==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==118947==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==118947==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==118947==    by 0x124728: FTS_Init (fts.c:163)
==118947==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==118947==    by 0x149418: main (analysisd.c:823)
==118947== 
==118947== Open file descriptor 30: queue/fts/ig-queue
==118947==    at 0x52A5DE4: open (open64.c:48)
==118947==    by 0x5228045: _IO_file_open (fileops.c:189)
==118947==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==118947==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==118947==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==118947==    by 0x124728: FTS_Init (fts.c:163)
==118947==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==118947==    by 0x149418: main (analysisd.c:823)
==118947== 
==118947== Open file descriptor 29: queue/fts/ig-queue
==118947==    at 0x52A5DE4: open (open64.c:48)
==118947==    by 0x5228045: _IO_file_open (fileops.c:189)
==118947==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==118947==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==118947==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==118947==    by 0x124728: FTS_Init (fts.c:163)
==118947==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==118947==    by 0x149418: main (analysisd.c:823)
==118947== 
==118947== Open file descriptor 28: queue/fts/ig-queue
==118947==    at 0x52A5DE4: open (open64.c:48)
==118947==    by 0x5228045: _IO_file_open (fileops.c:189)
==118947==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==118947==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==118947==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==118947==    by 0x124728: FTS_Init (fts.c:163)
==118947==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==118947==    by 0x149418: main (analysisd.c:823)
==118947== 
==118947== Open file descriptor 27: queue/fts/ig-queue
==118947==    at 0x52A5DE4: open (open64.c:48)
==118947==    by 0x5228045: _IO_file_open (fileops.c:189)
==118947==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==118947==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==118947==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==118947==    by 0x124728: FTS_Init (fts.c:163)
==118947==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==118947==    by 0x149418: main (analysisd.c:823)
==118947== 
==118947== Open file descriptor 25: queue/fts/ig-queue
==118947==    at 0x52A5DE4: open (open64.c:48)
==118947==    by 0x5228045: _IO_file_open (fileops.c:189)
==118947==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==118947==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==118947==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==118947==    by 0x124728: FTS_Init (fts.c:163)
==118947==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==118947==    by 0x149418: main (analysisd.c:823)
==118947== 
==118947== Open file descriptor 24: queue/fts/ig-queue
==118947==    at 0x52A5DE4: open (open64.c:48)
==118947==    by 0x5228045: _IO_file_open (fileops.c:189)
==118947==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==118947==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==118947==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==118947==    by 0x124728: FTS_Init (fts.c:163)
==118947==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==118947==    by 0x149418: main (analysisd.c:823)
==118947== 
==118947== Open file descriptor 23: queue/fts/ig-queue
==118947==    at 0x52A5DE4: open (open64.c:48)
==118947==    by 0x5228045: _IO_file_open (fileops.c:189)
==118947==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==118947==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==118947==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==118947==    by 0x124728: FTS_Init (fts.c:163)
==118947==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==118947==    by 0x149418: main (analysisd.c:823)
==118947== 
==118947== Open file descriptor 22: queue/fts/ig-queue
==118947==    at 0x52A5DE4: open (open64.c:48)
==118947==    by 0x5228045: _IO_file_open (fileops.c:189)
==118947==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==118947==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==118947==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==118947==    by 0x124728: FTS_Init (fts.c:163)
==118947==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==118947==    by 0x149418: main (analysisd.c:823)
==118947== 
==118947== Open file descriptor 21: queue/fts/ig-queue
==118947==    at 0x52A5DE4: open (open64.c:48)
==118947==    by 0x5228045: _IO_file_open (fileops.c:189)
==118947==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==118947==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==118947==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==118947==    by 0x124728: FTS_Init (fts.c:163)
==118947==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==118947==    by 0x149418: main (analysisd.c:823)
==118947== 
==118947== Open file descriptor 18: queue/fts/ig-queue
==118947==    at 0x52A5DE4: open (open64.c:48)
==118947==    by 0x5228045: _IO_file_open (fileops.c:189)
==118947==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==118947==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==118947==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==118947==    by 0x124728: FTS_Init (fts.c:163)
==118947==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==118947==    by 0x149418: main (analysisd.c:823)
==118947== 
==118947== Open file descriptor 17: queue/fts/ig-queue
==118947==    at 0x52A5DE4: open (open64.c:48)
==118947==    by 0x5228045: _IO_file_open (fileops.c:189)
==118947==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==118947==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==118947==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==118947==    by 0x1244FA: FTS_Init (fts.c:133)
==118947==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==118947==    by 0x149418: main (analysisd.c:823)
==118947== 
==118947== Open file descriptor 16: queue/fts/fts-queue
==118947==    at 0x52A5DE4: open (open64.c:48)
==118947==    by 0x5228045: _IO_file_open (fileops.c:189)
==118947==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==118947==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==118947==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==118947==    by 0x1241BB: FTS_Init (fts.c:81)
==118947==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==118947==    by 0x149418: main (analysisd.c:823)
==118947== 
==118947== Open file descriptor 15: logs/firewall/2022/Aug/ossec-firewall-30.log
==118947==    at 0x52A5DE4: open (open64.c:48)
==118947==    by 0x5228045: _IO_file_open (fileops.c:189)
==118947==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==118947==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==118947==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==118947==    by 0x1582D3: openlog (getloglocation.c:139)
==118947==    by 0x157EBE: OS_GetLogLocation (getloglocation.c:91)
==118947==    by 0x149772: OS_ReadMSG (analysisd.c:912)
==118947==    by 0x149418: main (analysisd.c:823)
==118947== 
==118947== Open file descriptor 14: logs/alerts/2022/Aug/ossec-alerts-30.json
==118947==    at 0x52A5DE4: open (open64.c:48)
==118947==    by 0x5228045: _IO_file_open (fileops.c:189)
==118947==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==118947==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==118947==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==118947==    by 0x1582D3: openlog (getloglocation.c:139)
==118947==    by 0x157E61: OS_GetLogLocation (getloglocation.c:87)
==118947==    by 0x149772: OS_ReadMSG (analysisd.c:912)
==118947==    by 0x149418: main (analysisd.c:823)
==118947== 
==118947== Open file descriptor 13: logs/alerts/2022/Aug/ossec-alerts-30.log
==118947==    at 0x52A5DE4: open (open64.c:48)
==118947==    by 0x5228045: _IO_file_open (fileops.c:189)
==118947==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==118947==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==118947==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==118947==    by 0x1582D3: openlog (getloglocation.c:139)
==118947==    by 0x157DF9: OS_GetLogLocation (getloglocation.c:84)
==118947==    by 0x149772: OS_ReadMSG (analysisd.c:912)
==118947==    by 0x149418: main (analysisd.c:823)
==118947== 
==118947== Open file descriptor 12: logs/archives/2022/Aug/ossec-archive-30.json
==118947==    at 0x52A5DE4: open (open64.c:48)
==118947==    by 0x5228045: _IO_file_open (fileops.c:189)
==118947==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==118947==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==118947==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==118947==    by 0x1582D3: openlog (getloglocation.c:139)
==118947==    by 0x157D9C: OS_GetLogLocation (getloglocation.c:80)
==118947==    by 0x149772: OS_ReadMSG (analysisd.c:912)
==118947==    by 0x149418: main (analysisd.c:823)
==118947== 
==118947== Open file descriptor 9: logs/archives/2022/Aug/ossec-archive-30.log
==118947==    at 0x52A5DE4: open (open64.c:48)
==118947==    by 0x5228045: _IO_file_open (fileops.c:189)
==118947==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==118947==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==118947==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==118947==    by 0x1582D3: openlog (getloglocation.c:139)
==118947==    by 0x157D34: OS_GetLogLocation (getloglocation.c:76)
==118947==    by 0x149772: OS_ReadMSG (analysisd.c:912)
==118947==    by 0x149418: main (analysisd.c:823)
==118947== 
==118947== Open AF_UNIX socket 10: queue/sockets/logtest
==118947==    at 0x52B87DB: socket (syscall-template.S:78)
==118947==    by 0x268ACD: OS_BindUnixDomainWithPerms (os_net.c:149)
==118947==    by 0x268CC5: OS_BindUnixDomain (os_net.c:192)
==118947==    by 0x11F4A0: w_logtest_init (logtest.c:32)
==118947==    by 0x517D608: start_thread (pthread_create.c:477)
==118947==    by 0x52B7162: clone (clone.S:95)
==118947== 
==118947== Open file descriptor 8: queue/fts/hostinfo
==118947==    at 0x52A5DE4: open (open64.c:48)
==118947==    by 0x5228045: _IO_file_open (fileops.c:189)
==118947==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==118947==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==118947==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==118947==    by 0x15AAED: HostinfoInit (hostinfo.c:86)
==118947==    by 0x149476: OS_ReadMSG (analysisd.c:856)
==118947==    by 0x149418: main (analysisd.c:823)
==118947== 
==118947== Open AF_UNIX socket 7: queue/sockets/analysis
==118947==    at 0x52B87DB: socket (syscall-template.S:78)
==118947==    by 0x268ACD: OS_BindUnixDomainWithPerms (os_net.c:149)
==118947==    by 0x268CC5: OS_BindUnixDomain (os_net.c:192)
==118947==    by 0x12D8F4: asyscom_main (asyscom.c:175)
==118947==    by 0x517D608: start_thread (pthread_create.c:477)
==118947==    by 0x52B7162: clone (clone.S:95)
==118947== 
==118947== Open AF_UNIX socket 6: <unknown>
==118947==    at 0x52B87DB: socket (syscall-template.S:78)
==118947==    by 0x268D63: OS_ConnectUnixDomain (os_net.c:211)
==118947==    by 0x267E95: wdbc_connect (wazuhdb_op.c:29)
==118947==    by 0x2680CB: wdbc_query_ex (wazuhdb_op.c:120)
==118947==    by 0x268399: wdbc_query_parse_json (wazuhdb_op.c:208)
==118947==    by 0x11E007: mitre_load (mitre.c:66)
==118947==    by 0x1493CF: main (analysisd.c:817)
==118947== 
==118947== Open AF_UNIX socket 5: queue/sockets/queue
==118947==    at 0x52B87DB: socket (syscall-template.S:78)
==118947==    by 0x268ACD: OS_BindUnixDomainWithPerms (os_net.c:149)
==118947==    by 0x2519D9: StartMQWithSpecificOwnerAndPerms (mq_op.c:24)
==118947==    by 0x251B60: StartMQ (mq_op.c:55)
==118947==    by 0x1486F7: main (analysisd.c:520)
==118947== 
==118947== Open file descriptor 4: /dev/urandom
==118947==    at 0x5188A5B: open (open64.c:48)
==118947==    by 0x267AAF: randombytes (randombytes.c:62)
==118947==    by 0x267B8B: srandom_init (randombytes.c:82)
==118947==    by 0x1481D9: main (analysisd.c:380)
==118947== 
==118947== Open file descriptor 99: /root/.vscode-server/bin/e4503b30fc78200f846c62cf8091b76ff5547662/vscode-remote-lock.root.e4503b30fc78200f846c62cf8091b76ff5547662
==118947==    <inherited from parent>
==118947== 
==118947== Open file descriptor 98: /root/.vscode-server/bin/4af164ea3a06f701fe3e89a2bcbb421d2026b68f/vscode-remote-lock.root.4af164ea3a06f701fe3e89a2bcbb421d2026b68f (deleted)
==118947==    <inherited from parent>
==118947== 
==118947== Open file descriptor 26: /dev/ptmx
==118947==    <inherited from parent>
==118947== 
==118947== Open file descriptor 20: /root/.vscode-server/data/logs/20220830T132312/ptyhost.log
==118947==    <inherited from parent>
==118947== 
==118947== Open file descriptor 19: /root/.vscode-server/data/logs/20220830T132312/remoteagent.log
==118947==    <inherited from parent>
==118947== 
==118947== Open file descriptor 3: /root/repos/wazuh/ValgrindPRs.log
==118947==    <inherited from parent>
==118947== 
==118947== Open file descriptor 2: /dev/pts/5
==118947==    <inherited from parent>
==118947== 
==118947== Open file descriptor 1: /dev/pts/5
==118947==    <inherited from parent>
==118947== 
==118947== Open file descriptor 0: /dev/pts/5
==118947==    <inherited from parent>
==118947== 
==118947== 
==118947== HEAP SUMMARY:
==118947==     in use at exit: 21,734,839 bytes in 118,089 blocks
==118947==   total heap usage: 1,584,694 allocs, 1,466,605 frees, 4,968,229,621 bytes allocated
==118947== 
==118947== LEAK SUMMARY:
==118947==    definitely lost: 0 bytes in 0 blocks
==118947==    indirectly lost: 0 bytes in 0 blocks
==118947==      possibly lost: 45,216 bytes in 157 blocks
==118947==    still reachable: 21,689,623 bytes in 117,932 blocks
==118947==         suppressed: 0 bytes in 0 blocks
==118947== Reachable blocks (those to which a pointer was found) are not shown.
==118947== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==118947== 
==118947== For lists of detected and suppressed errors, rerun with: -s
==118947== ERROR SUMMARY: 22 errors from 22 contexts (suppressed: 0 from 0)
==118947== could not unlink /tmp/vgdb-pipe-from-vgdb-to-118947-by-root-on-???
==118947== could not unlink /tmp/vgdb-pipe-to-vgdb-from-118947-by-root-on-???
==118947== could not unlink /tmp/vgdb-pipe-shared-mem-vgdb-118947-by-root-on-???

```

</details>



### Test 3

- Rules 100099 and 100100 do not exist, and the rule that does exist is somewhere in between.
- The 100001 rule does not trigger by the log:
Dec 10 01:02:02 host asd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2

- Rule 100001 is triggered as a child rule with log:
Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2


```xml
<rule id="100001" level="5">
  <if_sid>1000100, 5716, 100099</if_sid>
  <program_name>asd|ssh</program_name>
  <srcip>1.1.1.1</srcip>
  <description>sshd: authentication failed from IP 1.1.1.1.</description>
  <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
</rule>
```


<details><summary>Logtest output</summary>

```
╰─# /var/ossec/bin/wazuh-logtest                                                                                                                                                                                                                                                    130 ↵
Starting wazuh-logtest v4.4.0
Type one log per line

Dec 10 01:02:02 host asd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2

** Wazuh-Logtest: WARNING: (7617): Signature ID '1000100' was not found and will be ignored in the 'if_sid' option of rule '100001'.
** Wazuh-Logtest: WARNING: (7617): Signature ID '100099' was not found and will be ignored in the 'if_sid' option of rule '100001'.

**Phase 1: Completed pre-decoding.
        full event: 'Dec 10 01:02:02 host asd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2'
        timestamp: 'Dec 10 01:02:02'
        hostname: 'host'
        program_name: 'asd'

**Phase 2: Completed decoding.
        name: 'asdasd'
        srcip: '1.1.1.1'

**Phase 3: Completed filtering (rules).
        id: '1002'
        level: '2'
        description: 'Unknown problem somewhere in the system.'
        groups: '['syslog', 'errors']'
        firedtimes: '1'
        gpg13: '['4.3']'
        mail: 'False'

Dec 10 01:02:02 host asd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2

**Phase 1: Completed pre-decoding.
        full event: 'Dec 10 01:02:02 host asd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2'
        timestamp: 'Dec 10 01:02:02'
        hostname: 'host'
        program_name: 'asd'

**Phase 2: Completed decoding.
        name: 'asdasd'
        srcip: '1.1.1.1'

**Phase 3: Completed filtering (rules).
        id: '1002'
        level: '2'
        description: 'Unknown problem somewhere in the system.'
        groups: '['syslog', 'errors']'
        firedtimes: '2'
        gpg13: '['4.3']'
        mail: 'False'

Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2

**Phase 1: Completed pre-decoding.
        full event: 'Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2'
        timestamp: 'Dec 10 01:02:02'
        hostname: 'host'
        program_name: 'sshd'

**Phase 2: Completed decoding.
        name: 'sshd'
        parent: 'sshd'
        dstuser: 'root'
        srcip: '1.1.1.1'
        srcport: '1066'

**Phase 3: Completed filtering (rules).
        id: '100001'
        level: '5'
        description: 'sshd: authentication failed from IP 1.1.1.1.'
        groups: '['local', 'syslog', 'sshd', 'authentication_failed']'
        firedtimes: '1'
        mail: 'False'
        pci_dss: '['10.2.4', '10.2.5']'
**Alert to be generated.
```

</details>


<details><summary>Valgrind</summary>

```
==120193== Memcheck, a memory error detector
==120193== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==120193== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==120193== Command: /var/ossec/bin/wazuh-analysisd -f
==120193== Parent PID: 3054
==120193== 
==120193== 
==120193== FILE DESCRIPTORS: 37 open at exit.
==120193== Open file descriptor 35: queue/fts/ig-queue
==120193==    at 0x52A5DE4: open (open64.c:48)
==120193==    by 0x5228045: _IO_file_open (fileops.c:189)
==120193==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==120193==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==120193==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==120193==    by 0x124728: FTS_Init (fts.c:163)
==120193==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==120193==    by 0x149418: main (analysisd.c:823)
==120193== 
==120193== Open file descriptor 34: queue/fts/ig-queue
==120193==    at 0x52A5DE4: open (open64.c:48)
==120193==    by 0x5228045: _IO_file_open (fileops.c:189)
==120193==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==120193==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==120193==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==120193==    by 0x124728: FTS_Init (fts.c:163)
==120193==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==120193==    by 0x149418: main (analysisd.c:823)
==120193== 
==120193== Open file descriptor 33: queue/fts/ig-queue
==120193==    at 0x52A5DE4: open (open64.c:48)
==120193==    by 0x5228045: _IO_file_open (fileops.c:189)
==120193==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==120193==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==120193==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==120193==    by 0x124728: FTS_Init (fts.c:163)
==120193==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==120193==    by 0x149418: main (analysisd.c:823)
==120193== 
==120193== Open file descriptor 32: queue/fts/ig-queue
==120193==    at 0x52A5DE4: open (open64.c:48)
==120193==    by 0x5228045: _IO_file_open (fileops.c:189)
==120193==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==120193==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==120193==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==120193==    by 0x124728: FTS_Init (fts.c:163)
==120193==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==120193==    by 0x149418: main (analysisd.c:823)
==120193== 
==120193== Open file descriptor 31: queue/fts/ig-queue
==120193==    at 0x52A5DE4: open (open64.c:48)
==120193==    by 0x5228045: _IO_file_open (fileops.c:189)
==120193==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==120193==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==120193==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==120193==    by 0x124728: FTS_Init (fts.c:163)
==120193==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==120193==    by 0x149418: main (analysisd.c:823)
==120193== 
==120193== Open file descriptor 30: queue/fts/ig-queue
==120193==    at 0x52A5DE4: open (open64.c:48)
==120193==    by 0x5228045: _IO_file_open (fileops.c:189)
==120193==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==120193==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==120193==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==120193==    by 0x124728: FTS_Init (fts.c:163)
==120193==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==120193==    by 0x149418: main (analysisd.c:823)
==120193== 
==120193== Open file descriptor 29: queue/fts/ig-queue
==120193==    at 0x52A5DE4: open (open64.c:48)
==120193==    by 0x5228045: _IO_file_open (fileops.c:189)
==120193==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==120193==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==120193==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==120193==    by 0x124728: FTS_Init (fts.c:163)
==120193==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==120193==    by 0x149418: main (analysisd.c:823)
==120193== 
==120193== Open file descriptor 28: queue/fts/ig-queue
==120193==    at 0x52A5DE4: open (open64.c:48)
==120193==    by 0x5228045: _IO_file_open (fileops.c:189)
==120193==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==120193==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==120193==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==120193==    by 0x124728: FTS_Init (fts.c:163)
==120193==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==120193==    by 0x149418: main (analysisd.c:823)
==120193== 
==120193== Open file descriptor 27: queue/fts/ig-queue
==120193==    at 0x52A5DE4: open (open64.c:48)
==120193==    by 0x5228045: _IO_file_open (fileops.c:189)
==120193==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==120193==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==120193==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==120193==    by 0x124728: FTS_Init (fts.c:163)
==120193==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==120193==    by 0x149418: main (analysisd.c:823)
==120193== 
==120193== Open file descriptor 25: queue/fts/ig-queue
==120193==    at 0x52A5DE4: open (open64.c:48)
==120193==    by 0x5228045: _IO_file_open (fileops.c:189)
==120193==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==120193==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==120193==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==120193==    by 0x124728: FTS_Init (fts.c:163)
==120193==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==120193==    by 0x149418: main (analysisd.c:823)
==120193== 
==120193== Open file descriptor 24: queue/fts/ig-queue
==120193==    at 0x52A5DE4: open (open64.c:48)
==120193==    by 0x5228045: _IO_file_open (fileops.c:189)
==120193==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==120193==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==120193==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==120193==    by 0x124728: FTS_Init (fts.c:163)
==120193==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==120193==    by 0x149418: main (analysisd.c:823)
==120193== 
==120193== Open file descriptor 23: queue/fts/ig-queue
==120193==    at 0x52A5DE4: open (open64.c:48)
==120193==    by 0x5228045: _IO_file_open (fileops.c:189)
==120193==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==120193==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==120193==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==120193==    by 0x124728: FTS_Init (fts.c:163)
==120193==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==120193==    by 0x149418: main (analysisd.c:823)
==120193== 
==120193== Open file descriptor 22: queue/fts/ig-queue
==120193==    at 0x52A5DE4: open (open64.c:48)
==120193==    by 0x5228045: _IO_file_open (fileops.c:189)
==120193==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==120193==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==120193==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==120193==    by 0x124728: FTS_Init (fts.c:163)
==120193==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==120193==    by 0x149418: main (analysisd.c:823)
==120193== 
==120193== Open file descriptor 21: queue/fts/ig-queue
==120193==    at 0x52A5DE4: open (open64.c:48)
==120193==    by 0x5228045: _IO_file_open (fileops.c:189)
==120193==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==120193==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==120193==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==120193==    by 0x124728: FTS_Init (fts.c:163)
==120193==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==120193==    by 0x149418: main (analysisd.c:823)
==120193== 
==120193== Open file descriptor 18: queue/fts/ig-queue
==120193==    at 0x52A5DE4: open (open64.c:48)
==120193==    by 0x5228045: _IO_file_open (fileops.c:189)
==120193==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==120193==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==120193==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==120193==    by 0x124728: FTS_Init (fts.c:163)
==120193==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==120193==    by 0x149418: main (analysisd.c:823)
==120193== 
==120193== Open file descriptor 17: queue/fts/ig-queue
==120193==    at 0x52A5DE4: open (open64.c:48)
==120193==    by 0x5228045: _IO_file_open (fileops.c:189)
==120193==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==120193==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==120193==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==120193==    by 0x1244FA: FTS_Init (fts.c:133)
==120193==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==120193==    by 0x149418: main (analysisd.c:823)
==120193== 
==120193== Open file descriptor 16: queue/fts/fts-queue
==120193==    at 0x52A5DE4: open (open64.c:48)
==120193==    by 0x5228045: _IO_file_open (fileops.c:189)
==120193==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==120193==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==120193==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==120193==    by 0x1241BB: FTS_Init (fts.c:81)
==120193==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==120193==    by 0x149418: main (analysisd.c:823)
==120193== 
==120193== Open file descriptor 15: logs/firewall/2022/Aug/ossec-firewall-30.log
==120193==    at 0x52A5DE4: open (open64.c:48)
==120193==    by 0x5228045: _IO_file_open (fileops.c:189)
==120193==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==120193==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==120193==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==120193==    by 0x1582D3: openlog (getloglocation.c:139)
==120193==    by 0x157EBE: OS_GetLogLocation (getloglocation.c:91)
==120193==    by 0x149772: OS_ReadMSG (analysisd.c:912)
==120193==    by 0x149418: main (analysisd.c:823)
==120193== 
==120193== Open file descriptor 14: logs/alerts/2022/Aug/ossec-alerts-30.json
==120193==    at 0x52A5DE4: open (open64.c:48)
==120193==    by 0x5228045: _IO_file_open (fileops.c:189)
==120193==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==120193==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==120193==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==120193==    by 0x1582D3: openlog (getloglocation.c:139)
==120193==    by 0x157E61: OS_GetLogLocation (getloglocation.c:87)
==120193==    by 0x149772: OS_ReadMSG (analysisd.c:912)
==120193==    by 0x149418: main (analysisd.c:823)
==120193== 
==120193== Open file descriptor 13: logs/alerts/2022/Aug/ossec-alerts-30.log
==120193==    at 0x52A5DE4: open (open64.c:48)
==120193==    by 0x5228045: _IO_file_open (fileops.c:189)
==120193==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==120193==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==120193==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==120193==    by 0x1582D3: openlog (getloglocation.c:139)
==120193==    by 0x157DF9: OS_GetLogLocation (getloglocation.c:84)
==120193==    by 0x149772: OS_ReadMSG (analysisd.c:912)
==120193==    by 0x149418: main (analysisd.c:823)
==120193== 
==120193== Open file descriptor 12: logs/archives/2022/Aug/ossec-archive-30.json
==120193==    at 0x52A5DE4: open (open64.c:48)
==120193==    by 0x5228045: _IO_file_open (fileops.c:189)
==120193==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==120193==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==120193==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==120193==    by 0x1582D3: openlog (getloglocation.c:139)
==120193==    by 0x157D9C: OS_GetLogLocation (getloglocation.c:80)
==120193==    by 0x149772: OS_ReadMSG (analysisd.c:912)
==120193==    by 0x149418: main (analysisd.c:823)
==120193== 
==120193== Open file descriptor 10: logs/archives/2022/Aug/ossec-archive-30.log
==120193==    at 0x52A5DE4: open (open64.c:48)
==120193==    by 0x5228045: _IO_file_open (fileops.c:189)
==120193==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==120193==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==120193==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==120193==    by 0x1582D3: openlog (getloglocation.c:139)
==120193==    by 0x157D34: OS_GetLogLocation (getloglocation.c:76)
==120193==    by 0x149772: OS_ReadMSG (analysisd.c:912)
==120193==    by 0x149418: main (analysisd.c:823)
==120193== 
==120193== Open AF_UNIX socket 8: queue/sockets/logtest
==120193==    at 0x52B87DB: socket (syscall-template.S:78)
==120193==    by 0x268ACD: OS_BindUnixDomainWithPerms (os_net.c:149)
==120193==    by 0x268CC5: OS_BindUnixDomain (os_net.c:192)
==120193==    by 0x11F4A0: w_logtest_init (logtest.c:32)
==120193==    by 0x517D608: start_thread (pthread_create.c:477)
==120193==    by 0x52B7162: clone (clone.S:95)
==120193== 
==120193== Open file descriptor 9: queue/fts/hostinfo
==120193==    at 0x52A5DE4: open (open64.c:48)
==120193==    by 0x5228045: _IO_file_open (fileops.c:189)
==120193==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==120193==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==120193==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==120193==    by 0x15AAED: HostinfoInit (hostinfo.c:86)
==120193==    by 0x149476: OS_ReadMSG (analysisd.c:856)
==120193==    by 0x149418: main (analysisd.c:823)
==120193== 
==120193== Open AF_UNIX socket 7: queue/sockets/analysis
==120193==    at 0x52B87DB: socket (syscall-template.S:78)
==120193==    by 0x268ACD: OS_BindUnixDomainWithPerms (os_net.c:149)
==120193==    by 0x268CC5: OS_BindUnixDomain (os_net.c:192)
==120193==    by 0x12D8F4: asyscom_main (asyscom.c:175)
==120193==    by 0x517D608: start_thread (pthread_create.c:477)
==120193==    by 0x52B7162: clone (clone.S:95)
==120193== 
==120193== Open AF_UNIX socket 6: <unknown>
==120193==    at 0x52B87DB: socket (syscall-template.S:78)
==120193==    by 0x268D63: OS_ConnectUnixDomain (os_net.c:211)
==120193==    by 0x267E95: wdbc_connect (wazuhdb_op.c:29)
==120193==    by 0x2680CB: wdbc_query_ex (wazuhdb_op.c:120)
==120193==    by 0x268399: wdbc_query_parse_json (wazuhdb_op.c:208)
==120193==    by 0x11E007: mitre_load (mitre.c:66)
==120193==    by 0x1493CF: main (analysisd.c:817)
==120193== 
==120193== Open AF_UNIX socket 5: queue/sockets/queue
==120193==    at 0x52B87DB: socket (syscall-template.S:78)
==120193==    by 0x268ACD: OS_BindUnixDomainWithPerms (os_net.c:149)
==120193==    by 0x2519D9: StartMQWithSpecificOwnerAndPerms (mq_op.c:24)
==120193==    by 0x251B60: StartMQ (mq_op.c:55)
==120193==    by 0x1486F7: main (analysisd.c:520)
==120193== 
==120193== Open file descriptor 4: /dev/urandom
==120193==    at 0x5188A5B: open (open64.c:48)
==120193==    by 0x267AAF: randombytes (randombytes.c:62)
==120193==    by 0x267B8B: srandom_init (randombytes.c:82)
==120193==    by 0x1481D9: main (analysisd.c:380)
==120193== 
==120193== Open file descriptor 99: /root/.vscode-server/bin/e4503b30fc78200f846c62cf8091b76ff5547662/vscode-remote-lock.root.e4503b30fc78200f846c62cf8091b76ff5547662
==120193==    <inherited from parent>
==120193== 
==120193== Open file descriptor 98: /root/.vscode-server/bin/4af164ea3a06f701fe3e89a2bcbb421d2026b68f/vscode-remote-lock.root.4af164ea3a06f701fe3e89a2bcbb421d2026b68f (deleted)
==120193==    <inherited from parent>
==120193== 
==120193== Open file descriptor 26: /dev/ptmx
==120193==    <inherited from parent>
==120193== 
==120193== Open file descriptor 20: /root/.vscode-server/data/logs/20220830T132312/ptyhost.log
==120193==    <inherited from parent>
==120193== 
==120193== Open file descriptor 19: /root/.vscode-server/data/logs/20220830T132312/remoteagent.log
==120193==    <inherited from parent>
==120193== 
==120193== Open file descriptor 3: /root/repos/wazuh/ValgrindPRs.log
==120193==    <inherited from parent>
==120193== 
==120193== Open file descriptor 2: /dev/pts/5
==120193==    <inherited from parent>
==120193== 
==120193== Open file descriptor 1: /dev/pts/5
==120193==    <inherited from parent>
==120193== 
==120193== Open file descriptor 0: /dev/pts/5
==120193==    <inherited from parent>
==120193== 
==120193== 
==120193== HEAP SUMMARY:
==120193==     in use at exit: 21,734,848 bytes in 118,089 blocks
==120193==   total heap usage: 1,584,933 allocs, 1,466,844 frees, 4,968,266,186 bytes allocated
==120193== 
==120193== LEAK SUMMARY:
==120193==    definitely lost: 0 bytes in 0 blocks
==120193==    indirectly lost: 0 bytes in 0 blocks
==120193==      possibly lost: 45,216 bytes in 157 blocks
==120193==    still reachable: 21,689,632 bytes in 117,932 blocks
==120193==         suppressed: 0 bytes in 0 blocks
==120193== Reachable blocks (those to which a pointer was found) are not shown.
==120193== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==120193== 
==120193== For lists of detected and suppressed errors, rerun with: -s
==120193== ERROR SUMMARY: 22 errors from 22 contexts (suppressed: 0 from 0)
==120193== could not unlink /tmp/vgdb-pipe-from-vgdb-to-120193-by-root-on-???
==120193== could not unlink /tmp/vgdb-pipe-to-vgdb-from-120193-by-root-on-???
==120193== could not unlink /tmp/vgdb-pipe-shared-mem-vgdb-120193-by-root-on-???

```

</details>

### Test 4
- Invalid syntax, the rule is ignored

```xml
<rule id="100001" level="5">
  <if_sid>1000100| 5716 | 100099</if_sid>
  <program_name>asd|ssh</program_name>
  <srcip>1.1.1.1</srcip>
  <description>sshd: authentication failed from IP 1.1.1.1.</description>
  <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
</rule>
```

<details><summary>Logtest output</summary>

```
# /var/ossec/bin/wazuh-logtest                                                                                                                                                                                                                                                    130 ↵
Starting wazuh-logtest v4.4.0
Type one log per line

Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2

** Wazuh-Logtest: WARNING: (7618): Invalid 'if_sid' value: '1000100| 5716 | 100099'. Rule '100001' will be ignored.

**Phase 1: Completed pre-decoding.
        full event: 'Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2'
        timestamp: 'Dec 10 01:02:02'
        hostname: 'host'
        program_name: 'sshd'

**Phase 2: Completed decoding.
        name: 'sshd'
        parent: 'sshd'
        dstuser: 'root'
        srcip: '1.1.1.1'
        srcport: '1066'

**Phase 3: Completed filtering (rules).
        id: '5716'
        level: '5'
        description: 'sshd: authentication failed.'
        groups: '['syslog', 'sshd', 'authentication_failed']'
        firedtimes: '1'
        gdpr: '['IV_35.7.d', 'IV_32.2']'
        gpg13: '['7.1']'
        hipaa: '['164.312.b']'
        mail: 'False'
        mitre.id: '['T1110']'
        mitre.tactic: '['Credential Access']'
        mitre.technique: '['Brute Force']'
        nist_800_53: '['AU.14', 'AC.7']'
        pci_dss: '['10.2.4', '10.2.5']'
        tsc: '['CC6.1', 'CC6.8', 'CC7.2', 'CC7.3']'
**Alert to be generated.

Dec 10 01:02:02 host asd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2

**Phase 1: Completed pre-decoding.
        full event: 'Dec 10 01:02:02 host asd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2'
        timestamp: 'Dec 10 01:02:02'
        hostname: 'host'
        program_name: 'asd'

**Phase 2: Completed decoding.
        name: 'asdasd'
        srcip: '1.1.1.1'

**Phase 3: Completed filtering (rules).
        id: '1002'
        level: '2'
        description: 'Unknown problem somewhere in the system.'
        groups: '['syslog', 'errors']'
        firedtimes: '1'
        gpg13: '['4.3']'
        mail: 'False'
```

</details>


<details><summary>Valgrind</summary>

```
==121404== Memcheck, a memory error detector
==121404== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==121404== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==121404== Command: /var/ossec/bin/wazuh-analysisd -f
==121404== Parent PID: 3054
==121404== 
==121404== 
==121404== FILE DESCRIPTORS: 37 open at exit.
==121404== Open file descriptor 35: queue/fts/ig-queue
==121404==    at 0x52A5DE4: open (open64.c:48)
==121404==    by 0x5228045: _IO_file_open (fileops.c:189)
==121404==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==121404==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==121404==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==121404==    by 0x124728: FTS_Init (fts.c:163)
==121404==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==121404==    by 0x149418: main (analysisd.c:823)
==121404== 
==121404== Open file descriptor 34: queue/fts/ig-queue
==121404==    at 0x52A5DE4: open (open64.c:48)
==121404==    by 0x5228045: _IO_file_open (fileops.c:189)
==121404==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==121404==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==121404==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==121404==    by 0x124728: FTS_Init (fts.c:163)
==121404==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==121404==    by 0x149418: main (analysisd.c:823)
==121404== 
==121404== Open file descriptor 33: queue/fts/ig-queue
==121404==    at 0x52A5DE4: open (open64.c:48)
==121404==    by 0x5228045: _IO_file_open (fileops.c:189)
==121404==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==121404==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==121404==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==121404==    by 0x124728: FTS_Init (fts.c:163)
==121404==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==121404==    by 0x149418: main (analysisd.c:823)
==121404== 
==121404== Open file descriptor 32: queue/fts/ig-queue
==121404==    at 0x52A5DE4: open (open64.c:48)
==121404==    by 0x5228045: _IO_file_open (fileops.c:189)
==121404==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==121404==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==121404==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==121404==    by 0x124728: FTS_Init (fts.c:163)
==121404==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==121404==    by 0x149418: main (analysisd.c:823)
==121404== 
==121404== Open file descriptor 31: queue/fts/ig-queue
==121404==    at 0x52A5DE4: open (open64.c:48)
==121404==    by 0x5228045: _IO_file_open (fileops.c:189)
==121404==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==121404==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==121404==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==121404==    by 0x124728: FTS_Init (fts.c:163)
==121404==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==121404==    by 0x149418: main (analysisd.c:823)
==121404== 
==121404== Open file descriptor 30: queue/fts/ig-queue
==121404==    at 0x52A5DE4: open (open64.c:48)
==121404==    by 0x5228045: _IO_file_open (fileops.c:189)
==121404==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==121404==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==121404==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==121404==    by 0x124728: FTS_Init (fts.c:163)
==121404==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==121404==    by 0x149418: main (analysisd.c:823)
==121404== 
==121404== Open file descriptor 29: queue/fts/ig-queue
==121404==    at 0x52A5DE4: open (open64.c:48)
==121404==    by 0x5228045: _IO_file_open (fileops.c:189)
==121404==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==121404==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==121404==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==121404==    by 0x124728: FTS_Init (fts.c:163)
==121404==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==121404==    by 0x149418: main (analysisd.c:823)
==121404== 
==121404== Open file descriptor 28: queue/fts/ig-queue
==121404==    at 0x52A5DE4: open (open64.c:48)
==121404==    by 0x5228045: _IO_file_open (fileops.c:189)
==121404==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==121404==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==121404==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==121404==    by 0x124728: FTS_Init (fts.c:163)
==121404==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==121404==    by 0x149418: main (analysisd.c:823)
==121404== 
==121404== Open file descriptor 27: queue/fts/ig-queue
==121404==    at 0x52A5DE4: open (open64.c:48)
==121404==    by 0x5228045: _IO_file_open (fileops.c:189)
==121404==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==121404==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==121404==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==121404==    by 0x124728: FTS_Init (fts.c:163)
==121404==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==121404==    by 0x149418: main (analysisd.c:823)
==121404== 
==121404== Open file descriptor 25: queue/fts/ig-queue
==121404==    at 0x52A5DE4: open (open64.c:48)
==121404==    by 0x5228045: _IO_file_open (fileops.c:189)
==121404==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==121404==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==121404==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==121404==    by 0x124728: FTS_Init (fts.c:163)
==121404==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==121404==    by 0x149418: main (analysisd.c:823)
==121404== 
==121404== Open file descriptor 24: queue/fts/ig-queue
==121404==    at 0x52A5DE4: open (open64.c:48)
==121404==    by 0x5228045: _IO_file_open (fileops.c:189)
==121404==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==121404==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==121404==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==121404==    by 0x124728: FTS_Init (fts.c:163)
==121404==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==121404==    by 0x149418: main (analysisd.c:823)
==121404== 
==121404== Open file descriptor 23: queue/fts/ig-queue
==121404==    at 0x52A5DE4: open (open64.c:48)
==121404==    by 0x5228045: _IO_file_open (fileops.c:189)
==121404==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==121404==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==121404==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==121404==    by 0x124728: FTS_Init (fts.c:163)
==121404==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==121404==    by 0x149418: main (analysisd.c:823)
==121404== 
==121404== Open file descriptor 22: queue/fts/ig-queue
==121404==    at 0x52A5DE4: open (open64.c:48)
==121404==    by 0x5228045: _IO_file_open (fileops.c:189)
==121404==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==121404==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==121404==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==121404==    by 0x124728: FTS_Init (fts.c:163)
==121404==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==121404==    by 0x149418: main (analysisd.c:823)
==121404== 
==121404== Open file descriptor 21: queue/fts/ig-queue
==121404==    at 0x52A5DE4: open (open64.c:48)
==121404==    by 0x5228045: _IO_file_open (fileops.c:189)
==121404==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==121404==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==121404==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==121404==    by 0x124728: FTS_Init (fts.c:163)
==121404==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==121404==    by 0x149418: main (analysisd.c:823)
==121404== 
==121404== Open file descriptor 18: queue/fts/ig-queue
==121404==    at 0x52A5DE4: open (open64.c:48)
==121404==    by 0x5228045: _IO_file_open (fileops.c:189)
==121404==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==121404==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==121404==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==121404==    by 0x124728: FTS_Init (fts.c:163)
==121404==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==121404==    by 0x149418: main (analysisd.c:823)
==121404== 
==121404== Open file descriptor 17: queue/fts/ig-queue
==121404==    at 0x52A5DE4: open (open64.c:48)
==121404==    by 0x5228045: _IO_file_open (fileops.c:189)
==121404==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==121404==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==121404==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==121404==    by 0x1244FA: FTS_Init (fts.c:133)
==121404==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==121404==    by 0x149418: main (analysisd.c:823)
==121404== 
==121404== Open file descriptor 16: queue/fts/fts-queue
==121404==    at 0x52A5DE4: open (open64.c:48)
==121404==    by 0x5228045: _IO_file_open (fileops.c:189)
==121404==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==121404==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==121404==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==121404==    by 0x1241BB: FTS_Init (fts.c:81)
==121404==    by 0x1499FA: OS_ReadMSG (analysisd.c:974)
==121404==    by 0x149418: main (analysisd.c:823)
==121404== 
==121404== Open file descriptor 15: logs/firewall/2022/Aug/ossec-firewall-30.log
==121404==    at 0x52A5DE4: open (open64.c:48)
==121404==    by 0x5228045: _IO_file_open (fileops.c:189)
==121404==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==121404==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==121404==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==121404==    by 0x1582D3: openlog (getloglocation.c:139)
==121404==    by 0x157EBE: OS_GetLogLocation (getloglocation.c:91)
==121404==    by 0x149772: OS_ReadMSG (analysisd.c:912)
==121404==    by 0x149418: main (analysisd.c:823)
==121404== 
==121404== Open file descriptor 14: logs/alerts/2022/Aug/ossec-alerts-30.json
==121404==    at 0x52A5DE4: open (open64.c:48)
==121404==    by 0x5228045: _IO_file_open (fileops.c:189)
==121404==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==121404==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==121404==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==121404==    by 0x1582D3: openlog (getloglocation.c:139)
==121404==    by 0x157E61: OS_GetLogLocation (getloglocation.c:87)
==121404==    by 0x149772: OS_ReadMSG (analysisd.c:912)
==121404==    by 0x149418: main (analysisd.c:823)
==121404== 
==121404== Open file descriptor 11: logs/alerts/2022/Aug/ossec-alerts-30.log
==121404==    at 0x52A5DE4: open (open64.c:48)
==121404==    by 0x5228045: _IO_file_open (fileops.c:189)
==121404==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==121404==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==121404==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==121404==    by 0x1582D3: openlog (getloglocation.c:139)
==121404==    by 0x157DF9: OS_GetLogLocation (getloglocation.c:84)
==121404==    by 0x149772: OS_ReadMSG (analysisd.c:912)
==121404==    by 0x149418: main (analysisd.c:823)
==121404== 
==121404== Open file descriptor 12: logs/archives/2022/Aug/ossec-archive-30.json
==121404==    at 0x52A5DE4: open (open64.c:48)
==121404==    by 0x5228045: _IO_file_open (fileops.c:189)
==121404==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==121404==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==121404==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==121404==    by 0x1582D3: openlog (getloglocation.c:139)
==121404==    by 0x157D9C: OS_GetLogLocation (getloglocation.c:80)
==121404==    by 0x149772: OS_ReadMSG (analysisd.c:912)
==121404==    by 0x149418: main (analysisd.c:823)
==121404== 
==121404== Open file descriptor 9: logs/archives/2022/Aug/ossec-archive-30.log
==121404==    at 0x52A5DE4: open (open64.c:48)
==121404==    by 0x5228045: _IO_file_open (fileops.c:189)
==121404==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==121404==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==121404==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==121404==    by 0x1582D3: openlog (getloglocation.c:139)
==121404==    by 0x157D34: OS_GetLogLocation (getloglocation.c:76)
==121404==    by 0x149772: OS_ReadMSG (analysisd.c:912)
==121404==    by 0x149418: main (analysisd.c:823)
==121404== 
==121404== Open AF_UNIX socket 10: queue/sockets/logtest
==121404==    at 0x52B87DB: socket (syscall-template.S:78)
==121404==    by 0x268ACD: OS_BindUnixDomainWithPerms (os_net.c:149)
==121404==    by 0x268CC5: OS_BindUnixDomain (os_net.c:192)
==121404==    by 0x11F4A0: w_logtest_init (logtest.c:32)
==121404==    by 0x517D608: start_thread (pthread_create.c:477)
==121404==    by 0x52B7162: clone (clone.S:95)
==121404== 
==121404== Open file descriptor 8: queue/fts/hostinfo
==121404==    at 0x52A5DE4: open (open64.c:48)
==121404==    by 0x5228045: _IO_file_open (fileops.c:189)
==121404==    by 0x5228309: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==121404==    by 0x521A9BD: __fopen_internal (iofopen.c:75)
==121404==    by 0x521A9BD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==121404==    by 0x15AAED: HostinfoInit (hostinfo.c:86)
==121404==    by 0x149476: OS_ReadMSG (analysisd.c:856)
==121404==    by 0x149418: main (analysisd.c:823)
==121404== 
==121404== Open AF_UNIX socket 7: queue/sockets/analysis
==121404==    at 0x52B87DB: socket (syscall-template.S:78)
==121404==    by 0x268ACD: OS_BindUnixDomainWithPerms (os_net.c:149)
==121404==    by 0x268CC5: OS_BindUnixDomain (os_net.c:192)
==121404==    by 0x12D8F4: asyscom_main (asyscom.c:175)
==121404==    by 0x517D608: start_thread (pthread_create.c:477)
==121404==    by 0x52B7162: clone (clone.S:95)
==121404== 
==121404== Open AF_UNIX socket 6: <unknown>
==121404==    at 0x52B87DB: socket (syscall-template.S:78)
==121404==    by 0x268D63: OS_ConnectUnixDomain (os_net.c:211)
==121404==    by 0x267E95: wdbc_connect (wazuhdb_op.c:29)
==121404==    by 0x2680CB: wdbc_query_ex (wazuhdb_op.c:120)
==121404==    by 0x268399: wdbc_query_parse_json (wazuhdb_op.c:208)
==121404==    by 0x11E007: mitre_load (mitre.c:66)
==121404==    by 0x1493CF: main (analysisd.c:817)
==121404== 
==121404== Open AF_UNIX socket 5: queue/sockets/queue
==121404==    at 0x52B87DB: socket (syscall-template.S:78)
==121404==    by 0x268ACD: OS_BindUnixDomainWithPerms (os_net.c:149)
==121404==    by 0x2519D9: StartMQWithSpecificOwnerAndPerms (mq_op.c:24)
==121404==    by 0x251B60: StartMQ (mq_op.c:55)
==121404==    by 0x1486F7: main (analysisd.c:520)
==121404== 
==121404== Open file descriptor 4: /dev/urandom
==121404==    at 0x5188A5B: open (open64.c:48)
==121404==    by 0x267AAF: randombytes (randombytes.c:62)
==121404==    by 0x267B8B: srandom_init (randombytes.c:82)
==121404==    by 0x1481D9: main (analysisd.c:380)
==121404== 
==121404== Open file descriptor 99: /root/.vscode-server/bin/e4503b30fc78200f846c62cf8091b76ff5547662/vscode-remote-lock.root.e4503b30fc78200f846c62cf8091b76ff5547662
==121404==    <inherited from parent>
==121404== 
==121404== Open file descriptor 98: /root/.vscode-server/bin/4af164ea3a06f701fe3e89a2bcbb421d2026b68f/vscode-remote-lock.root.4af164ea3a06f701fe3e89a2bcbb421d2026b68f (deleted)
==121404==    <inherited from parent>
==121404== 
==121404== Open file descriptor 26: /dev/ptmx
==121404==    <inherited from parent>
==121404== 
==121404== Open file descriptor 20: /root/.vscode-server/data/logs/20220830T132312/ptyhost.log
==121404==    <inherited from parent>
==121404== 
==121404== Open file descriptor 19: /root/.vscode-server/data/logs/20220830T132312/remoteagent.log
==121404==    <inherited from parent>
==121404== 
==121404== Open file descriptor 3: /root/repos/wazuh/ValgrindPRs.log
==121404==    <inherited from parent>
==121404== 
==121404== Open file descriptor 2: /dev/pts/5
==121404==    <inherited from parent>
==121404== 
==121404== Open file descriptor 1: /dev/pts/5
==121404==    <inherited from parent>
==121404== 
==121404== Open file descriptor 0: /dev/pts/5
==121404==    <inherited from parent>
==121404== 
==121404== 
==121404== HEAP SUMMARY:
==121404==     in use at exit: 21,731,750 bytes in 118,067 blocks
==121404==   total heap usage: 1,584,728 allocs, 1,466,661 frees, 4,968,152,287 bytes allocated
==121404== 
==121404== LEAK SUMMARY:
==121404==    definitely lost: 0 bytes in 0 blocks
==121404==    indirectly lost: 0 bytes in 0 blocks
==121404==      possibly lost: 45,216 bytes in 157 blocks
==121404==    still reachable: 21,686,534 bytes in 117,910 blocks
==121404==         suppressed: 0 bytes in 0 blocks
==121404== Reachable blocks (those to which a pointer was found) are not shown.
==121404== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==121404== 
==121404== For lists of detected and suppressed errors, rerun with: -s
==121404== ERROR SUMMARY: 22 errors from 22 contexts (suppressed: 0 from 0)
==121404== could not unlink /tmp/vgdb-pipe-from-vgdb-to-121404-by-root-on-???
==121404== could not unlink /tmp/vgdb-pipe-to-vgdb-from-121404-by-root-on-???
==121404== could not unlink /tmp/vgdb-pipe-shared-mem-vgdb-121404-by-root-on-???

```

</details>


[Scanbuild report](https://github.com/wazuh/wazuh/files/9456645/scan.zip)



## Other tests


<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors