### PR TITLE
Add new settings ignore and restrict to logcollector

### DIFF
--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -54,6 +54,8 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     const char *xml_localfile_age = "age";
     const char *xml_localfile_exclude = "exclude";
     const char *xml_localfile_binaries = "ignore_binaries";
+    const char *xml_localfile_ignore = "ignore_log";
+    const char *xml_localfile_restrict = "restrict_log";
     const char *xml_localfile_multiline_regex =  "multiline_regex";
 
     logreader *logf;
@@ -99,6 +101,8 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     logf[pl].exists = 1;
     logf[pl].future = 1;
     logf[pl].reconnect_time = DEFAULT_EVENTCHANNEL_REC_TIME;
+    logf[pl].regex_ignore = NULL;
+    logf[pl].regex_restrict = NULL;
 
     /* Search for entries related to files */
     i = 0;
@@ -447,6 +451,22 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                 return (OS_INVALID);
             }
 
+        } else if (strcasecmp(node[i]->element, xml_localfile_ignore) == 0) {
+            w_calloc_expression_t(&logf[pl].regex_ignore, EXP_TYPE_PCRE2);
+
+            if (!w_expression_compile(logf[pl].regex_ignore, node[i]->content, 0)) {
+                merror(LF_LOG_REGEX, "ignore", node[i]->content);
+                w_free_expression_t(&logf[pl].regex_ignore);
+                return (OS_INVALID);
+            }
+        } else if (strcasecmp(node[i]->element, xml_localfile_restrict) == 0) {
+            w_calloc_expression_t(&logf[pl].regex_restrict, EXP_TYPE_PCRE2);
+
+            if (!w_expression_compile(logf[pl].regex_restrict, node[i]->content, 0)) {
+                merror(LF_LOG_REGEX, "restrict", node[i]->content);
+                w_free_expression_t(&logf[pl].regex_restrict);
+                return (OS_INVALID);
+            }
         } else {
             merror(XML_INVELEM, node[i]->element);
             return (OS_INVALID);

--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -765,6 +765,9 @@ void Free_Logreader(logreader * logf) {
         os_free(logf->exclude);
         os_free(logf->query_level);
 
+        w_free_expression_t(&logf->regex_ignore);
+        w_free_expression_t(&logf->regex_restrict);
+
         if (logf->target) {
             for (i = 0; logf->target[i]; i++) {
                 free(logf->target[i]);

--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -30,6 +30,14 @@ int total_files;
  */
 STATIC int w_logcollector_get_macos_log_type(const char * content);
 
+/**
+ * @brief Check the regex type configured in localfile, the allowed types are osmatch, osregex and pcre2
+ * @param node Current configuration node being edited
+ * @param element Configuration element tag name
+ * @return Returns the variable associated with the specified regex type
+ */
+w_exp_type_t w_check_regex_type(xml_node * node, const char * element);
+
 int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
 {
     unsigned int pl = 0;

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -95,7 +95,7 @@ typedef enum {
 
 /**
  * @brief Context of a multiline log that was not completely written.
- * 
+ *
  * An instance of w_multiline_timeout_ctxt_t allow save the context of a log that have not yet matched with the regex.
  */
 typedef struct {
@@ -136,7 +136,7 @@ typedef struct {
 
 /**
  * @brief Stores `log` process instance info.
- * 
+ *
  */
 typedef struct {
     wfd_t * wfd;        ///< IPC connector
@@ -145,7 +145,7 @@ typedef struct {
 
 /**
  * @brief Store references of two main excecution of `log` process.
- * 
+ *
  */
 typedef struct {
     w_macos_log_pinfo_t stream;     ///< `log stream` process info
@@ -205,6 +205,8 @@ typedef struct _logreader {
     logtarget * log_target;
     int duplicated;
     char *exclude;
+    w_expression_t * regex_ignore;
+    w_expression_t * regex_restrict;
     wlabel_t *labels;
     pthread_mutex_t mutex;
     int exists;

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -47,6 +47,7 @@
 #include "expression.h"
 #include "os_xml/os_xml.h"
 #include "exec_op.h"
+#include "list_op.h"
 
 extern int maximum_files;
 extern int total_files;
@@ -205,8 +206,8 @@ typedef struct _logreader {
     logtarget * log_target;
     int duplicated;
     char *exclude;
-    w_expression_t * regex_ignore;
-    w_expression_t * regex_restrict;
+    OSList *regex_ignore;
+    OSList *regex_restrict;
     wlabel_t *labels;
     pthread_mutex_t mutex;
     int exists;

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -244,6 +244,8 @@
 #define GET_FLAGS_ERROR "(1972): The flags couldn't be obtained from the file descriptor: %s (%d)."
 #define SET_FLAGS_ERROR "(1973): The flags couldn't be set in the file descriptor: %s (%d)."
 #define WPOPENV_ERROR   "(1974): An error ocurred while calling wpopenv(): %s (%d)."
+#define LF_LOG_REGEX    "(1975): Syntax error on regex %s: '%s'"
+#define LF_MATCH_REGEX  "(1976): Avoiding the log line '%s' due to %s config: '%s'."
 
 /* Encryption/auth errors */
 #define INVALID_KEY     "(1401): Error reading authentication key: '%s'."

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -161,7 +161,6 @@
 #define LOGCOLLECTOR_MACOS_LOG_SHOW_EXEC_ERROR      "(1605): Error while trying to execute `log show` as follows: %s."
 #define LOGCOLLECTOR_MACOS_LOG_STREAM_EXEC_ERROR    "(1606): Error while trying to execute `log stream` as follows: %s."
 #define LOGCOLLECTOR_MACOS_LOG_CHILD_EXITED         "(1607): macOS 'log %s' process exited, pid: %d, exit value: %d."
-#define LOGCOLLECTOR_IGNORE_AND_RESTRICT_ERROR      "(1608): Invalid configuration in logcollector, ignore and restrict patterns are the same."
 
 /* remoted */
 #define NO_REM_CONN     "(1750): No remote connection configured. Exiting."

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -161,6 +161,7 @@
 #define LOGCOLLECTOR_MACOS_LOG_SHOW_EXEC_ERROR      "(1605): Error while trying to execute `log show` as follows: %s."
 #define LOGCOLLECTOR_MACOS_LOG_STREAM_EXEC_ERROR    "(1606): Error while trying to execute `log stream` as follows: %s."
 #define LOGCOLLECTOR_MACOS_LOG_CHILD_EXITED         "(1607): macOS 'log %s' process exited, pid: %d, exit value: %d."
+#define LOGCOLLECTOR_IGNORE_AND_RESTRICT_ERROR      "(1608): Invalid configuration in logcollector, ignore and restrict patterns are the same."
 
 /* remoted */
 #define NO_REM_CONN     "(1750): No remote connection configured. Exiting."
@@ -245,7 +246,7 @@
 #define SET_FLAGS_ERROR "(1973): The flags couldn't be set in the file descriptor: %s (%d)."
 #define WPOPENV_ERROR   "(1974): An error ocurred while calling wpopenv(): %s (%d)."
 #define LF_LOG_REGEX    "(1975): Syntax error on regex %s: '%s'"
-#define LF_MATCH_REGEX  "(1976): Avoiding the log line '%s' due to %s config: '%s'."
+#define LF_MATCH_REGEX  "(1976): Ignoring the log line '%s' due to %s config: '%s'"
 
 /* Encryption/auth errors */
 #define INVALID_KEY     "(1401): Error reading authentication key: '%s'."

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -133,6 +133,7 @@
                                                 "'log_format'. Default value will be used."
 #define LOGCOLLECTOR_MISSING_LOCATION_MACOS     "(8006): Missing 'location' element when using 'macos' as " \
                                                 "'log_format'. Default value will be used."
+#define LOGCOLLECTOR_DEFAULT_REGEX_TYPE         "(8007): Invalid type in %s regex '%d', setting by default pcre2 regex."
 
 /* Remoted */
 #define REMOTED_NET_PROTOCOL_ERROR              "(9000): Error getting protocol. Default value (%s) will be used."

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -133,7 +133,7 @@
                                                 "'log_format'. Default value will be used."
 #define LOGCOLLECTOR_MISSING_LOCATION_MACOS     "(8006): Missing 'location' element when using 'macos' as " \
                                                 "'log_format'. Default value will be used."
-#define LOGCOLLECTOR_DEFAULT_REGEX_TYPE         "(8007): Invalid type in '%s' regex '%d', setting by default PCRE2 regex."
+#define LOGCOLLECTOR_DEFAULT_REGEX_TYPE         "(8007): Invalid type in '%s' regex '%s', setting by default PCRE2 regex."
 
 /* Remoted */
 #define REMOTED_NET_PROTOCOL_ERROR              "(9000): Error getting protocol. Default value (%s) will be used."

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -133,7 +133,7 @@
                                                 "'log_format'. Default value will be used."
 #define LOGCOLLECTOR_MISSING_LOCATION_MACOS     "(8006): Missing 'location' element when using 'macos' as " \
                                                 "'log_format'. Default value will be used."
-#define LOGCOLLECTOR_DEFAULT_REGEX_TYPE         "(8007): Invalid type in %s regex '%d', setting by default pcre2 regex."
+#define LOGCOLLECTOR_DEFAULT_REGEX_TYPE         "(8007): Invalid type in '%s' regex '%d', setting by default PCRE2 regex."
 
 /* Remoted */
 #define REMOTED_NET_PROTOCOL_ERROR              "(9000): Error getting protocol. Default value (%s) will be used."

--- a/src/headers/expression.h
+++ b/src/headers/expression.h
@@ -75,6 +75,12 @@ void w_calloc_expression_t(w_expression_t ** var, w_exp_type_t type);
 void w_free_expression_t(w_expression_t ** var);
 
 /**
+ * @brief Call the free function w_free_expression_t with expression type reference
+ * @param var variable to free
+ */
+void w_free_expression(w_expression_t * var);
+
+/**
  * @brief add ip to os_ip array
  * @param ips array which save ip
  * @param ip ip to save

--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -195,6 +195,9 @@ void _getLocalfilesListJSON(logreader *list, cJSON *array, int gl) {
             cJSON_AddNumberToObject(multiline, "timeout", list[i].multiline->timeout);
             cJSON_AddItemToObject(file, "multiline_regex", multiline);
         }
+        if (list[i].regex_ignore) cJSON_AddStringToObject(file, "regex_ignore", list[i].regex_ignore);
+        if (list[i].regex_restrict) cJSON_AddStringToObject(file, "regex_restrict", list[i].regex_restrict);
+
         cJSON_AddItemToArray(array, file);
         i++;
     }

--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -195,8 +195,8 @@ void _getLocalfilesListJSON(logreader *list, cJSON *array, int gl) {
             cJSON_AddNumberToObject(multiline, "timeout", list[i].multiline->timeout);
             cJSON_AddItemToObject(file, "multiline_regex", multiline);
         }
-        if (list[i].regex_ignore) cJSON_AddStringToObject(file, "regex_ignore", list[i].regex_ignore);
-        if (list[i].regex_restrict) cJSON_AddStringToObject(file, "regex_restrict", list[i].regex_restrict);
+        if (list[i].regex_ignore) cJSON_AddStringToObject(file, "regex_ignore", w_expression_get_regex_pattern(list[i].regex_ignore));
+        if (list[i].regex_restrict) cJSON_AddStringToObject(file, "regex_restrict", w_expression_get_regex_pattern(list[i].regex_restrict));
 
         cJSON_AddItemToArray(array, file);
         i++;

--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -195,8 +195,8 @@ void _getLocalfilesListJSON(logreader *list, cJSON *array, int gl) {
             cJSON_AddNumberToObject(multiline, "timeout", list[i].multiline->timeout);
             cJSON_AddItemToObject(file, "multiline_regex", multiline);
         }
-        if (list[i].regex_ignore) cJSON_AddStringToObject(file, "regex_ignore", w_expression_get_regex_pattern(list[i].regex_ignore));
-        if (list[i].regex_restrict) cJSON_AddStringToObject(file, "regex_restrict", w_expression_get_regex_pattern(list[i].regex_restrict));
+        if (list[i].regex_ignore) cJSON_AddStringToObject(file, "ignore", w_expression_get_regex_pattern(list[i].regex_ignore));
+        if (list[i].regex_restrict) cJSON_AddStringToObject(file, "restrict", w_expression_get_regex_pattern(list[i].regex_restrict));
 
         cJSON_AddItemToArray(array, file);
         i++;

--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -10,6 +10,7 @@
 
 #include "shared.h"
 #include "logcollector.h"
+#include "list_op.h"
 
 /* To string size of max-size option */
 #define OFFSET_SIZE 11
@@ -105,6 +106,8 @@ void _getLocalfilesListJSON(logreader *list, cJSON *array, int gl) {
 
     unsigned int i = 0;
     unsigned int j;
+    OSListNode *node_it;
+    w_expression_t *dir_it;
 
     while ((!gl && list[i].target) || (gl && list[i].file)) {
         cJSON *file = cJSON_CreateObject();
@@ -195,8 +198,18 @@ void _getLocalfilesListJSON(logreader *list, cJSON *array, int gl) {
             cJSON_AddNumberToObject(multiline, "timeout", list[i].multiline->timeout);
             cJSON_AddItemToObject(file, "multiline_regex", multiline);
         }
-        if (list[i].regex_ignore) cJSON_AddStringToObject(file, "ignore", w_expression_get_regex_pattern(list[i].regex_ignore));
-        if (list[i].regex_restrict) cJSON_AddStringToObject(file, "restrict", w_expression_get_regex_pattern(list[i].regex_restrict));
+        if (list[i].regex_ignore) {
+            OSList_foreach(node_it, list[i].regex_ignore) {
+                dir_it = node_it->data;
+                cJSON_AddStringToObject(file, "ignore", w_expression_get_regex_pattern(dir_it));
+            }
+        }
+        if (list[i].regex_restrict) {
+            OSList_foreach(node_it, list[i].regex_restrict) {
+                dir_it = node_it->data;
+                cJSON_AddStringToObject(file, "restrict", w_expression_get_regex_pattern(dir_it));
+            }
+        }
 
         cJSON_AddItemToArray(array, file);
         i++;

--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -106,8 +106,6 @@ void _getLocalfilesListJSON(logreader *list, cJSON *array, int gl) {
 
     unsigned int i = 0;
     unsigned int j;
-    OSListNode *node_it;
-    w_expression_t *dir_it;
 
     while ((!gl && list[i].target) || (gl && list[i].file)) {
         cJSON *file = cJSON_CreateObject();
@@ -198,16 +196,46 @@ void _getLocalfilesListJSON(logreader *list, cJSON *array, int gl) {
             cJSON_AddNumberToObject(multiline, "timeout", list[i].multiline->timeout);
             cJSON_AddItemToObject(file, "multiline_regex", multiline);
         }
-        if (list[i].regex_ignore) {
+        if (list[i].regex_ignore != NULL) {
+            OSListNode *node_it;
+            w_expression_t *exp_it;
+            cJSON * ignore_array = cJSON_CreateArray();
+
             OSList_foreach(node_it, list[i].regex_ignore) {
-                dir_it = node_it->data;
-                cJSON_AddStringToObject(file, "ignore", w_expression_get_regex_pattern(dir_it));
+                exp_it = node_it->data;
+                cJSON * ignore_object = cJSON_CreateObject();
+
+                cJSON_AddStringToObject(ignore_object, "value", w_expression_get_regex_pattern(exp_it));
+                cJSON_AddStringToObject(ignore_object, "type", w_expression_get_regex_type(exp_it));
+
+                cJSON_AddItemToArray(ignore_array, ignore_object);
+            }
+
+            if (cJSON_GetArraySize(ignore_array) > 0) {
+                cJSON_AddItemToObject(file, "ignore", ignore_array);
+            } else {
+                cJSON_free(ignore_array);
             }
         }
-        if (list[i].regex_restrict) {
+        if (list[i].regex_restrict != NULL) {
+            OSListNode *node_it;
+            w_expression_t *exp_it;
+            cJSON * restrict_array = cJSON_CreateArray();
+
             OSList_foreach(node_it, list[i].regex_restrict) {
-                dir_it = node_it->data;
-                cJSON_AddStringToObject(file, "restrict", w_expression_get_regex_pattern(dir_it));
+                exp_it = node_it->data;
+                cJSON * restrict_object = cJSON_CreateObject();
+
+                cJSON_AddStringToObject(restrict_object, "value", w_expression_get_regex_pattern(exp_it));
+                cJSON_AddStringToObject(restrict_object, "type", w_expression_get_regex_type(exp_it));
+
+                cJSON_AddItemToArray(restrict_array, restrict_object);
+            }
+
+            if (cJSON_GetArraySize(restrict_array) > 0) {
+                cJSON_AddItemToObject(file, "restrict", restrict_array);
+            } else {
+                cJSON_free(restrict_array);
             }
         }
 

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -133,6 +133,27 @@ STATIC w_macos_log_procceses_t * macos_processes = NULL;
 
 #endif
 
+int check_log_regex(w_expression_t * ignore_exp, w_expression_t * restrict_exp, const char *log_line) {
+
+    if (ignore_exp) {
+        /* Check ignore regex, if it matches, do not process the log */
+        if (w_expression_match(ignore_exp, log_line, NULL, NULL)) {
+            mdebug2(LF_MATCH_REGEX, log_line, "ignore", w_expression_get_regex_pattern(ignore_exp));
+            return true;
+        }
+    }
+
+    if (restrict_exp) {
+        /* Check restrict regex, only if match log is processed */
+        if (!w_expression_match(restrict_exp, log_line, NULL, NULL)) {
+            mdebug2(LF_MATCH_REGEX, log_line, "restrict", w_expression_get_regex_pattern(restrict_exp));
+            return true;
+        }
+    }
+
+    return false;
+}
+
 /* Handle file management */
 void LogCollectorStart()
 {

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -135,14 +135,14 @@ STATIC w_macos_log_procceses_t * macos_processes = NULL;
 
 int check_ignore_and_restrict(OSList * ignore_exp_list, OSList * restrict_exp_list, const char *log_line) {
     OSListNode *node_it;
-    w_expression_t *dir_it;
+    w_expression_t *exp_it;
 
     if (ignore_exp_list) {
         OSList_foreach(node_it, ignore_exp_list) {
-            dir_it = node_it->data;
+            exp_it = node_it->data;
             /* Check ignore regex, if it matches, do not process the log */
-            if (w_expression_match(dir_it, log_line, NULL, NULL)) {
-                mdebug2(LF_MATCH_REGEX, log_line, "ignore", w_expression_get_regex_pattern(dir_it));
+            if (w_expression_match(exp_it, log_line, NULL, NULL)) {
+                mdebug2(LF_MATCH_REGEX, log_line, "ignore", w_expression_get_regex_pattern(exp_it));
                 return true;
             }
         }
@@ -150,10 +150,10 @@ int check_ignore_and_restrict(OSList * ignore_exp_list, OSList * restrict_exp_li
 
     if (restrict_exp_list) {
         OSList_foreach(node_it, restrict_exp_list) {
-            dir_it = node_it->data;
+            exp_it = node_it->data;
             /* Check restrict regex, only if match every log is processed */
-            if (!w_expression_match(dir_it, log_line, NULL, NULL)) {
-                mdebug2(LF_MATCH_REGEX, log_line, "restrict", w_expression_get_regex_pattern(dir_it));
+            if (!w_expression_match(exp_it, log_line, NULL, NULL)) {
+                mdebug2(LF_MATCH_REGEX, log_line, "restrict", w_expression_get_regex_pattern(exp_it));
                 return true;
             }
         }

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -133,21 +133,29 @@ STATIC w_macos_log_procceses_t * macos_processes = NULL;
 
 #endif
 
-int check_ignore_and_restrict(w_expression_t * ignore_exp, w_expression_t * restrict_exp, const char *log_line) {
+int check_ignore_and_restrict(OSList * ignore_exp_list, OSList * restrict_exp_list, const char *log_line) {
+    OSListNode *node_it;
+    w_expression_t *dir_it;
 
-    if (ignore_exp) {
-        /* Check ignore regex, if it matches, do not process the log */
-        if (w_expression_match(ignore_exp, log_line, NULL, NULL)) {
-            mdebug2(LF_MATCH_REGEX, log_line, "ignore", w_expression_get_regex_pattern(ignore_exp));
-            return true;
+    if (ignore_exp_list) {
+        OSList_foreach(node_it, ignore_exp_list) {
+            dir_it = node_it->data;
+            /* Check ignore regex, if it matches, do not process the log */
+            if (w_expression_match(dir_it, log_line, NULL, NULL)) {
+                mdebug2(LF_MATCH_REGEX, log_line, "ignore", w_expression_get_regex_pattern(dir_it));
+                return true;
+            }
         }
     }
 
-    if (restrict_exp) {
-        /* Check restrict regex, only if match log is processed */
-        if (!w_expression_match(restrict_exp, log_line, NULL, NULL)) {
-            mdebug2(LF_MATCH_REGEX, log_line, "restrict", w_expression_get_regex_pattern(restrict_exp));
-            return true;
+    if (restrict_exp_list) {
+        OSList_foreach(node_it, ignore_exp_list) {
+            dir_it = node_it->data;
+            /* Check restrict regex, only if match every log is processed */
+            if (!w_expression_match(dir_it, log_line, NULL, NULL)) {
+                mdebug2(LF_MATCH_REGEX, log_line, "restrict", w_expression_get_regex_pattern(dir_it));
+                return true;
+            }
         }
     }
 

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -149,7 +149,7 @@ int check_ignore_and_restrict(OSList * ignore_exp_list, OSList * restrict_exp_li
     }
 
     if (restrict_exp_list) {
-        OSList_foreach(node_it, ignore_exp_list) {
+        OSList_foreach(node_it, restrict_exp_list) {
             dir_it = node_it->data;
             /* Check restrict regex, only if match every log is processed */
             if (!w_expression_match(dir_it, log_line, NULL, NULL)) {

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -133,7 +133,7 @@ STATIC w_macos_log_procceses_t * macos_processes = NULL;
 
 #endif
 
-int check_log_regex(w_expression_t * ignore_exp, w_expression_t * restrict_exp, const char *log_line) {
+int check_ignore_and_restrict(w_expression_t * ignore_exp, w_expression_t * restrict_exp, const char *log_line) {
 
     if (ignore_exp) {
         /* Check ignore regex, if it matches, do not process the log */

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -95,8 +95,11 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it);
 /* Read postgresql log format */
 void *read_postgresql_log(logreader *lf, int *rc, int drop_it);
 
-/* read multi line logs */
+/* Read multi line logs */
 void *read_multiline(logreader *lf, int *rc, int drop_it);
+
+/* Check ignore and restrict setting with pcre2 regex */
+int check_log_regex(w_expression_t * ignore_exp, w_expression_t * restrict_exp, const char *log_line);
 
 /**
  * @brief Read multi line logs with variable lenght

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -98,8 +98,15 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it);
 /* Read multi line logs */
 void *read_multiline(logreader *lf, int *rc, int drop_it);
 
-/* Check ignore and restrict setting with pcre2 regex */
-int check_log_regex(w_expression_t * ignore_exp, w_expression_t * restrict_exp, const char *log_line);
+/**
+ * @brief Check if any logs should be ignored
+ *
+ * @param ignore_exp Ignore regex expression to be checked
+ * @param restrict_exp Restrict regex expression to be checked
+ * @param log_line Log where to search for a match
+ * @return 0 if log should be processed, 1 if log should be ignored
+ */
+int check_ignore_and_restrict(w_expression_t * ignore_exp, w_expression_t * restrict_exp, const char *log_line);
 
 /**
  * @brief Read multi line logs with variable lenght

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -101,12 +101,12 @@ void *read_multiline(logreader *lf, int *rc, int drop_it);
 /**
  * @brief Check if any logs should be ignored
  *
- * @param ignore_exp Ignore regex expression to be checked
- * @param restrict_exp Restrict regex expression to be checked
+ * @param ignore_exp List of ignore regex expressions to be checked
+ * @param restrict_exp List of restrict regex expressions to be checked
  * @param log_line Log where to search for a match
  * @return 0 if log should be processed, 1 if log should be ignored
  */
-int check_ignore_and_restrict(w_expression_t * ignore_exp, w_expression_t * restrict_exp, const char *log_line);
+int check_ignore_and_restrict(OSList * ignore_exp, OSList * restrict_exp, const char *log_line);
 
 /**
  * @brief Read multi line logs with variable lenght

--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -113,6 +113,11 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
             break;
         }
 
+        /* Check ignore and restrict log regex, if configured. */
+        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, buffer)) {
+            continue;
+        }
+
         // Extract header: "\.*type=\.* msg=audit(.*):"
         //                                        --
 

--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -15,7 +15,7 @@
 #define MAX_HEADER 64
 
 /* Compile message from cache and send through queue */
-static void audit_send_msg(char **cache, int top, const char *file, int drop_it, logtarget * targets) {
+static void audit_send_msg(char **cache, int top, int drop_it, logreader *lf) {
     int i;
     size_t n = 0;
     size_t z;
@@ -34,10 +34,12 @@ static void audit_send_msg(char **cache, int top, const char *file, int drop_it,
 
         free(cache[i]);
     }
+    message[n] = '\0';
 
-    if (!drop_it) {
-        message[n] = '\0';
-        w_msg_hash_queues_push(message, (char *)file, strlen(message) + 1, targets, LOCALFILE_MQ);
+    /* Check ignore and restrict log regex, if configured. */
+    if (drop_it == 0 && !check_log_regex(lf->regex_ignore, lf->regex_restrict, message)) {
+        /* Send message to queue */
+        w_msg_hash_queues_push(message, (char *)lf->file, strlen(message) + 1, lf->log_target, LOCALFILE_MQ);
     }
 }
 
@@ -113,11 +115,6 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
             break;
         }
 
-        /* Check ignore and restrict log regex, if configured. */
-        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, buffer)) {
-            continue;
-        }
-
         // Extract header: "\.*type=\.* msg=audit(.*):"
         //                                        --
 
@@ -131,7 +128,7 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
         if (strncmp(id, header, z)) {
             // Current message belongs to another event: send cached messages
             if (icache > 0)
-                audit_send_msg(cache, icache, lf->file, drop_it, lf->log_target);
+                audit_send_msg(cache, icache, drop_it, lf);
 
             // Store current event
             *cache = strdup(buffer);
@@ -147,7 +144,7 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
     }
 
     if (icache > 0)
-        audit_send_msg(cache, icache, lf->file, drop_it, lf->log_target);
+        audit_send_msg(cache, icache, drop_it, lf);
     if (is_valid_context_file) {
         w_update_file_status(lf->file, offset, &context);
     }

--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -37,7 +37,7 @@ static void audit_send_msg(char **cache, int top, int drop_it, logreader *lf) {
     message[n] = '\0';
 
     /* Check ignore and restrict log regex, if configured. */
-    if (drop_it == 0 && !check_log_regex(lf->regex_ignore, lf->regex_restrict, message)) {
+    if (drop_it == 0 && !check_ignore_and_restrict(lf->regex_ignore, lf->regex_restrict, message)) {
         /* Send message to queue */
         w_msg_hash_queues_push(message, (char *)lf->file, strlen(message) + 1, lf->log_target, LOCALFILE_MQ);
     }

--- a/src/logcollector/read_command.c
+++ b/src/logcollector/read_command.c
@@ -58,6 +58,11 @@ void *read_command(logreader *lf, int *rc, int drop_it) {
             continue;
         }
 
+        /* Check ignore and restrict log regex, if configured. */
+        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
+            continue;
+        }
+
         mdebug2("Reading command message: '%s'", str);
 
         /* Send message to queue */

--- a/src/logcollector/read_command.c
+++ b/src/logcollector/read_command.c
@@ -59,7 +59,7 @@ void *read_command(logreader *lf, int *rc, int drop_it) {
         }
 
         /* Check ignore and restrict log regex, if configured. */
-        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
+        if (check_ignore_and_restrict(lf->regex_ignore, lf->regex_restrict, str)) {
             continue;
         }
 

--- a/src/logcollector/read_djb_multilog.c
+++ b/src/logcollector/read_djb_multilog.c
@@ -120,6 +120,11 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
             need_clear = 1;
         }
 
+        /* Check ignore and restrict log regex, if configured. */
+        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
+            continue;
+        }
+
         /* Multilog messages have the following format:
          * @40000000463246020c2ca16c xx...
          */

--- a/src/logcollector/read_djb_multilog.c
+++ b/src/logcollector/read_djb_multilog.c
@@ -178,7 +178,7 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
         }
 
         /* Check ignore and restrict log regex, if configured. */
-        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
+        if (check_ignore_and_restrict(lf->regex_ignore, lf->regex_restrict, str)) {
             continue;
         }
 

--- a/src/logcollector/read_djb_multilog.c
+++ b/src/logcollector/read_djb_multilog.c
@@ -120,11 +120,6 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
             need_clear = 1;
         }
 
-        /* Check ignore and restrict log regex, if configured. */
-        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
-            continue;
-        }
-
         /* Multilog messages have the following format:
          * @40000000463246020c2ca16c xx...
          */
@@ -179,6 +174,11 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
 
         else {
             mdebug2("Invalid DJB log: '%s'", str);
+            continue;
+        }
+
+        /* Check ignore and restrict log regex, if configured. */
+        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
             continue;
         }
 

--- a/src/logcollector/read_fullcommand.c
+++ b/src/logcollector/read_fullcommand.c
@@ -71,8 +71,9 @@ void *read_fullcommand(logreader *lf, int *rc, int drop_it) {
         }
         strfinal[n] = '\0';
 
-        /* Send message to queue */
-        if (drop_it == 0) {
+        /* Check ignore and restrict log regex, if configured. */
+        if (drop_it == 0 && !check_log_regex(lf->regex_ignore, lf->regex_restrict, strfinal)) {
+            /* Send message to queue */
             w_msg_hash_queues_push(strfinal, lf->alias ? lf->alias : lf->command, strlen(strfinal) + 1, lf->log_target, LOCALFILE_MQ);
         }
     }

--- a/src/logcollector/read_fullcommand.c
+++ b/src/logcollector/read_fullcommand.c
@@ -72,7 +72,7 @@ void *read_fullcommand(logreader *lf, int *rc, int drop_it) {
         strfinal[n] = '\0';
 
         /* Check ignore and restrict log regex, if configured. */
-        if (drop_it == 0 && !check_log_regex(lf->regex_ignore, lf->regex_restrict, strfinal)) {
+        if (drop_it == 0 && !check_ignore_and_restrict(lf->regex_ignore, lf->regex_restrict, strfinal)) {
             /* Send message to queue */
             w_msg_hash_queues_push(strfinal, lf->alias ? lf->alias : lf->command, strlen(strfinal) + 1, lf->log_target, LOCALFILE_MQ);
         }

--- a/src/logcollector/read_json.c
+++ b/src/logcollector/read_json.c
@@ -95,6 +95,12 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
             continue;
         }
 #endif
+
+        /* Check ignore and restrict log regex, if configured. */
+        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
+            continue;
+        }
+
         const char *jsonErrPtr;
         if (obj = cJSON_ParseWithOpts(str, &jsonErrPtr, 0), obj && cJSON_IsObject(obj)) {
           for (i = 0; lf->labels && lf->labels[i].key; i++) {

--- a/src/logcollector/read_json.c
+++ b/src/logcollector/read_json.c
@@ -97,7 +97,7 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
 #endif
 
         /* Check ignore and restrict log regex, if configured. */
-        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
+        if (check_ignore_and_restrict(lf->regex_ignore, lf->regex_restrict, str)) {
             continue;
         }
 

--- a/src/logcollector/read_macos.c
+++ b/src/logcollector/read_macos.c
@@ -129,6 +129,11 @@ void * read_macos(logreader * lf, int * rc, __attribute__((unused)) int drop_it)
 
         size = strlen(read_buffer);
         if (size > 0) {
+            /* Check ignore and restrict log regex, if configured. */
+            if (check_log_regex(lf->regex_ignore, lf->regex_restrict, read_buffer)) {
+                continue;
+            }
+
             w_msg_hash_queues_push(read_buffer, MACOS_LOG_NAME, size + 1, lf->log_target, LOCALFILE_MQ);
             memcpy(full_timestamp, read_buffer, OS_LOGCOLLECTOR_TIMESTAMP_FULL_LEN);
         } else {

--- a/src/logcollector/read_macos.c
+++ b/src/logcollector/read_macos.c
@@ -130,7 +130,7 @@ void * read_macos(logreader * lf, int * rc, __attribute__((unused)) int drop_it)
         size = strlen(read_buffer);
         if (size > 0) {
             /* Check ignore and restrict log regex, if configured. */
-            if (check_log_regex(lf->regex_ignore, lf->regex_restrict, read_buffer)) {
+            if (check_ignore_and_restrict(lf->regex_ignore, lf->regex_restrict, read_buffer)) {
                 continue;
             }
 

--- a/src/logcollector/read_mssql_log.c
+++ b/src/logcollector/read_mssql_log.c
@@ -87,6 +87,11 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
         }
 #endif
 
+        /* Check ignore and restrict log regex, if configured. */
+        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
+            continue;
+        }
+
         /* MS SQL messages have the following formats:
          * 2009-03-25 04:47:30.01 Server
          * 2003-10-09 00:00:06.68 sys1

--- a/src/logcollector/read_mssql_log.c
+++ b/src/logcollector/read_mssql_log.c
@@ -20,7 +20,7 @@ static void __send_mssql_msg(logreader *lf, int drop_it, char *buffer) {
     mdebug2("Reading MSSQL message: '%s'", buffer);
 
     /* Check ignore and restrict log regex, if configured. */
-    if (drop_it == 0 && !check_log_regex(lf->regex_ignore, lf->regex_restrict, buffer)) {
+    if (drop_it == 0 && !check_ignore_and_restrict(lf->regex_ignore, lf->regex_restrict, buffer)) {
         /* Send message to queue */
         w_msg_hash_queues_push(buffer, lf->file, strlen(buffer) + 1, lf->log_target, LOCALFILE_MQ);
     }

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -83,11 +83,6 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
         }
 #endif
 
-        /* Check ignore and restrict log regex, if configured. */
-        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
-            continue;
-        }
-
         /* Add to buffer */
         buffer_size = strlen(buffer);
         if (buffer[0] != '\0') {
@@ -107,7 +102,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
         linesgot = 0;
 
         /* Send message to queue */
-        if (drop_it == 0) {
+        if (!check_log_regex(lf->regex_ignore, lf->regex_restrict, str) && drop_it == 0) {
             mdebug2("Reading message: '%.*s'%s", sample_log_length, buffer, strlen(buffer) > (size_t)sample_log_length ? "..." : "");
             w_msg_hash_queues_push(buffer, lf->file, strlen(buffer) + 1, lf->log_target, LOCALFILE_MQ);
         }

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -83,6 +83,10 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
         }
 #endif
 
+        /* Check ignore and restrict log regex, if configured. */
+        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
+            continue;
+        }
 
         /* Add to buffer */
         buffer_size = strlen(buffer);

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -102,7 +102,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
         linesgot = 0;
 
         /* Check ignore and restrict log regex, if configured. */
-        if (drop_it == 0 && !check_log_regex(lf->regex_ignore, lf->regex_restrict, buffer)) {
+        if (drop_it == 0 && !check_ignore_and_restrict(lf->regex_ignore, lf->regex_restrict, buffer)) {
             /* Send message to queue */
             mdebug2("Reading message: '%.*s'%s", sample_log_length, buffer, strlen(buffer) > (size_t)sample_log_length ? "..." : "");
             w_msg_hash_queues_push(buffer, lf->file, strlen(buffer) + 1, lf->log_target, LOCALFILE_MQ);

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -101,8 +101,9 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
         }
         linesgot = 0;
 
-        /* Send message to queue */
-        if (!check_log_regex(lf->regex_ignore, lf->regex_restrict, str) && drop_it == 0) {
+        /* Check ignore and restrict log regex, if configured. */
+        if (drop_it == 0 && !check_log_regex(lf->regex_ignore, lf->regex_restrict, buffer)) {
+            /* Send message to queue */
             mdebug2("Reading message: '%.*s'%s", sample_log_length, buffer, strlen(buffer) > (size_t)sample_log_length ? "..." : "");
             w_msg_hash_queues_push(buffer, lf->file, strlen(buffer) + 1, lf->log_target, LOCALFILE_MQ);
         }

--- a/src/logcollector/read_multiline_regex.c
+++ b/src/logcollector/read_multiline_regex.c
@@ -107,9 +107,9 @@ STATIC int multiline_getlog_all(char * buffer, int length, FILE * stream, w_mult
 
 /**
  * @brief Get specific chunk of file between two positions
- * 
- * @param stream File stream 
- * @param initial_pos initial position 
+ *
+ * @param stream File stream
+ * @param initial_pos initial position
  * @param final_pos final position
  * @return allocated buffer containing the readed chunk. NULL on error
  */
@@ -154,6 +154,11 @@ void * read_multiline_regex(logreader * lf, int * rc, int drop_it) {
 
     while (rlines = multiline_getlog(read_buffer, max_line_len, lf->fp, lf->multiline),
            rlines > 0 && (maximum_lines == 0 || count_lines < maximum_lines)) {
+
+        /* Check ignore and restrict log regex, if configured. */
+        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, read_buffer)) {
+            continue;
+        }
 
         if (drop_it == 0) {
             w_msg_hash_queues_push(read_buffer, lf->file, strlen(read_buffer) + 1, lf->log_target, LOCALFILE_MQ);

--- a/src/logcollector/read_multiline_regex.c
+++ b/src/logcollector/read_multiline_regex.c
@@ -160,7 +160,9 @@ void * read_multiline_regex(logreader * lf, int * rc, int drop_it) {
             continue;
         }
 
-        if (drop_it == 0) {
+        /* Check ignore and restrict log regex, if configured. */
+        if (drop_it == 0 && !check_log_regex(lf->regex_ignore, lf->regex_restrict, read_buffer)) {
+            /* Send message to queue */
             w_msg_hash_queues_push(read_buffer, lf->file, strlen(read_buffer) + 1, lf->log_target, LOCALFILE_MQ);
         }
         count_lines += rlines;

--- a/src/logcollector/read_multiline_regex.c
+++ b/src/logcollector/read_multiline_regex.c
@@ -156,7 +156,7 @@ void * read_multiline_regex(logreader * lf, int * rc, int drop_it) {
            rlines > 0 && (maximum_lines == 0 || count_lines < maximum_lines)) {
 
         /* Check ignore and restrict log regex, if configured. */
-        if (drop_it == 0 && !check_log_regex(lf->regex_ignore, lf->regex_restrict, read_buffer)) {
+        if (drop_it == 0 && !check_ignore_and_restrict(lf->regex_ignore, lf->regex_restrict, read_buffer)) {
             /* Send message to queue */
             w_msg_hash_queues_push(read_buffer, lf->file, strlen(read_buffer) + 1, lf->log_target, LOCALFILE_MQ);
         }

--- a/src/logcollector/read_multiline_regex.c
+++ b/src/logcollector/read_multiline_regex.c
@@ -156,11 +156,6 @@ void * read_multiline_regex(logreader * lf, int * rc, int drop_it) {
            rlines > 0 && (maximum_lines == 0 || count_lines < maximum_lines)) {
 
         /* Check ignore and restrict log regex, if configured. */
-        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, read_buffer)) {
-            continue;
-        }
-
-        /* Check ignore and restrict log regex, if configured. */
         if (drop_it == 0 && !check_log_regex(lf->regex_ignore, lf->regex_restrict, read_buffer)) {
             /* Send message to queue */
             w_msg_hash_queues_push(read_buffer, lf->file, strlen(read_buffer) + 1, lf->log_target, LOCALFILE_MQ);

--- a/src/logcollector/read_mysql_log.c
+++ b/src/logcollector/read_mysql_log.c
@@ -75,6 +75,11 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
         }
 #endif
 
+        /* Check ignore and restrict log regex, if configured. */
+        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
+            continue;
+        }
+
         /* MySQL messages have the following format:
          * 070823 21:01:30 xx
          */

--- a/src/logcollector/read_mysql_log.c
+++ b/src/logcollector/read_mysql_log.c
@@ -242,7 +242,7 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
         mdebug2("Reading mysql messages: '%s'", buffer);
 
         /* Check ignore and restrict log regex, if configured. */
-        if (drop_it == 0 && !check_log_regex(lf->regex_ignore, lf->regex_restrict, buffer)) {
+        if (drop_it == 0 && !check_ignore_and_restrict(lf->regex_ignore, lf->regex_restrict, buffer)) {
             /* Send message to queue */
             w_msg_hash_queues_push(buffer, lf->file, strlen(buffer) + 1, lf->log_target, LOCALFILE_MQ);
         }

--- a/src/logcollector/read_mysql_log.c
+++ b/src/logcollector/read_mysql_log.c
@@ -75,11 +75,6 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
         }
 #endif
 
-        /* Check ignore and restrict log regex, if configured. */
-        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
-            continue;
-        }
-
         /* MySQL messages have the following format:
          * 070823 21:01:30 xx
          */
@@ -246,8 +241,9 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
 
         mdebug2("Reading mysql messages: '%s'", buffer);
 
-        /* Send message to queue */
-        if (drop_it == 0) {
+        /* Check ignore and restrict log regex, if configured. */
+        if (drop_it == 0 && !check_log_regex(lf->regex_ignore, lf->regex_restrict, buffer)) {
+            /* Send message to queue */
             w_msg_hash_queues_push(buffer, lf->file, strlen(buffer) + 1, lf->log_target, LOCALFILE_MQ);
         }
     }

--- a/src/logcollector/read_nmapg.c
+++ b/src/logcollector/read_nmapg.c
@@ -176,6 +176,11 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
             continue;
         }
 
+        /* Check ignore and restrict log regex, if configured. */
+        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
+            continue;
+        }
+
         /* Get host */
         q = __go_after(str, NMAPG_HOST);
         if (!q) {

--- a/src/logcollector/read_nmapg.c
+++ b/src/logcollector/read_nmapg.c
@@ -176,11 +176,6 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
             continue;
         }
 
-        /* Check ignore and restrict log regex, if configured. */
-        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
-            continue;
-        }
-
         /* Get host */
         q = __go_after(str, NMAPG_HOST);
         if (!q) {
@@ -258,7 +253,8 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
 
         } while (*p == ',' && (p++));
 
-        if (drop_it == 0) {
+        /* Check ignore and restrict log regex, if configured. */
+        if (drop_it == 0 && !check_log_regex(lf->regex_ignore, lf->regex_restrict, final_msg)) {
             /* Send message to queue */
             w_msg_hash_queues_push(final_msg, lf->file, strlen(final_msg) + 1, lf->log_target, HOSTINFO_MQ);
         }

--- a/src/logcollector/read_nmapg.c
+++ b/src/logcollector/read_nmapg.c
@@ -254,7 +254,7 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
         } while (*p == ',' && (p++));
 
         /* Check ignore and restrict log regex, if configured. */
-        if (drop_it == 0 && !check_log_regex(lf->regex_ignore, lf->regex_restrict, final_msg)) {
+        if (drop_it == 0 && !check_ignore_and_restrict(lf->regex_ignore, lf->regex_restrict, final_msg)) {
             /* Send message to queue */
             w_msg_hash_queues_push(final_msg, lf->file, strlen(final_msg) + 1, lf->log_target, HOSTINFO_MQ);
         }

--- a/src/logcollector/read_ossecalert.c
+++ b/src/logcollector/read_ossecalert.c
@@ -110,8 +110,9 @@ void *read_ossecalert(logreader *lf, __attribute__((unused)) int *rc, int drop_i
     /* Clear the memory */
     FreeAlertData(al_data);
 
-    /* Send message to queue */
-    if (drop_it == 0) {
+    /* Check ignore and restrict log regex, if configured. */
+    if (drop_it == 0 && !check_log_regex(lf->regex_ignore, lf->regex_restrict, syslog_msg)) {
+        /* Send message to queue */
         w_msg_hash_queues_push(syslog_msg, lf->file, strlen(syslog_msg) + 1, lf->log_target, LOCALFILE_MQ);
     }
 

--- a/src/logcollector/read_ossecalert.c
+++ b/src/logcollector/read_ossecalert.c
@@ -111,7 +111,7 @@ void *read_ossecalert(logreader *lf, __attribute__((unused)) int *rc, int drop_i
     FreeAlertData(al_data);
 
     /* Check ignore and restrict log regex, if configured. */
-    if (drop_it == 0 && !check_log_regex(lf->regex_ignore, lf->regex_restrict, syslog_msg)) {
+    if (drop_it == 0 && !check_ignore_and_restrict(lf->regex_ignore, lf->regex_restrict, syslog_msg)) {
         /* Send message to queue */
         w_msg_hash_queues_push(syslog_msg, lf->file, strlen(syslog_msg) + 1, lf->log_target, LOCALFILE_MQ);
     }

--- a/src/logcollector/read_postgresql_log.c
+++ b/src/logcollector/read_postgresql_log.c
@@ -84,6 +84,11 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
         }
 #endif
 
+        /* Check ignore and restrict log regex, if configured. */
+        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
+            continue;
+        }
+
         /* PostgreSQL messages have the following format:
          * [2007-08-31 19:17:32.186 ADT] 192.168.2.99:db_name
          */

--- a/src/logcollector/read_postgresql_log.c
+++ b/src/logcollector/read_postgresql_log.c
@@ -20,7 +20,7 @@ static void __send_pgsql_msg(logreader *lf, int drop_it, char *buffer) {
     mdebug2("Reading PostgreSQL message: '%s'", buffer);
 
     /* Check ignore and restrict log regex, if configured. */
-    if (drop_it == 0 && !check_log_regex(lf->regex_ignore, lf->regex_restrict, buffer)) {
+    if (drop_it == 0 && !check_ignore_and_restrict(lf->regex_ignore, lf->regex_restrict, buffer)) {
         /* Send message to queue */
         w_msg_hash_queues_push(buffer, lf->file, strlen(buffer) + 1, lf->log_target, LOCALFILE_MQ);
     }

--- a/src/logcollector/read_snortfull.c
+++ b/src/logcollector/read_snortfull.c
@@ -47,6 +47,11 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
             goto file_error;
         }
 
+        /* Check ignore and restrict log regex, if configured. */
+        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
+            continue;
+        }
+
         /* First part of the message */
         if (p == NULL) {
             if (strncmp(str, "[**] [", 6) == 0) {

--- a/src/logcollector/read_snortfull.c
+++ b/src/logcollector/read_snortfull.c
@@ -79,7 +79,7 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
                     p = NULL;
 
                     /* Check ignore and restrict log regex, if configured. */
-                    if (drop_it == 0 && !check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
+                    if (drop_it == 0 && !check_ignore_and_restrict(lf->regex_ignore, lf->regex_restrict, str)) {
                         /* Send message to queue */
                         w_msg_hash_queues_push(str, lf->file, strlen(f_msg), lf->log_target, LOCALFILE_MQ);
                     }
@@ -97,7 +97,7 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
                     p = NULL;
 
                     /* Check ignore and restrict log regex, if configured. */
-                    if (drop_it == 0 && !check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
+                    if (drop_it == 0 && !check_ignore_and_restrict(lf->regex_ignore, lf->regex_restrict, str)) {
                         /* Send message to queue */
                         w_msg_hash_queues_push(str, lf->file, strlen(str) + 1, lf->log_target, LOCALFILE_MQ);
                     }

--- a/src/logcollector/read_snortfull.c
+++ b/src/logcollector/read_snortfull.c
@@ -47,11 +47,6 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
             goto file_error;
         }
 
-        /* Check ignore and restrict log regex, if configured. */
-        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
-            continue;
-        }
-
         /* First part of the message */
         if (p == NULL) {
             if (strncmp(str, "[**] [", 6) == 0) {
@@ -83,8 +78,9 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
                     /* Clean for next event */
                     p = NULL;
 
-                    /* Send the message */
-                    if (drop_it == 0) {
+                    /* Check ignore and restrict log regex, if configured. */
+                    if (drop_it == 0 && !check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
+                        /* Send message to queue */
                         w_msg_hash_queues_push(str, lf->file, strlen(f_msg), lf->log_target, LOCALFILE_MQ);
                     }
 
@@ -100,8 +96,9 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
                     strncat(f_msg, ++q, f_msg_size);
                     p = NULL;
 
-                    /* Send the message */
-                    if (drop_it == 0) {
+                    /* Check ignore and restrict log regex, if configured. */
+                    if (drop_it == 0 && !check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
+                        /* Send message to queue */
                         w_msg_hash_queues_push(str, lf->file, strlen(str) + 1, lf->log_target, LOCALFILE_MQ);
                     }
 

--- a/src/logcollector/read_syslog.c
+++ b/src/logcollector/read_syslog.c
@@ -101,6 +101,11 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
         }
 #endif
 
+        /* Check ignore and restrict log regex, if configured. */
+        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
+            continue;
+        }
+
         mdebug2("Reading syslog message: '%.*s'%s", sample_log_length, str, rbytes > sample_log_length ? "..." : "");
 
         /* Send message to queue */

--- a/src/logcollector/read_syslog.c
+++ b/src/logcollector/read_syslog.c
@@ -101,17 +101,14 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
         }
 #endif
 
-        /* Check ignore and restrict log regex, if configured. */
-        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
-            continue;
-        }
-
         mdebug2("Reading syslog message: '%.*s'%s", sample_log_length, str, rbytes > sample_log_length ? "..." : "");
 
-        /* Send message to queue */
-        if (drop_it == 0) {
+        /* Check ignore and restrict log regex, if configured. */
+        if (drop_it == 0 && !check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
+            /* Send message to queue */
             w_msg_hash_queues_push(str, lf->file, rbytes, lf->log_target, LOCALFILE_MQ);
         }
+
         /* Incorrect message size */
         if (__ms) {
             // strlen(str) >= (OS_MAXSTR - OS_LOG_HEADER - 2)

--- a/src/logcollector/read_syslog.c
+++ b/src/logcollector/read_syslog.c
@@ -104,7 +104,7 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
         mdebug2("Reading syslog message: '%.*s'%s", sample_log_length, str, rbytes > sample_log_length ? "..." : "");
 
         /* Check ignore and restrict log regex, if configured. */
-        if (drop_it == 0 && !check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
+        if (drop_it == 0 && !check_ignore_and_restrict(lf->regex_ignore, lf->regex_restrict, str)) {
             /* Send message to queue */
             w_msg_hash_queues_push(str, lf->file, rbytes, lf->log_target, LOCALFILE_MQ);
         }

--- a/src/logcollector/read_ucs2_be.c
+++ b/src/logcollector/read_ucs2_be.c
@@ -91,6 +91,11 @@ void *read_ucs2_be(logreader *lf, int *rc, int drop_it) {
             continue;
         }
 
+        /* Check ignore and restrict log regex, if configured. */
+        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
+            continue;
+        }
+
         mdebug2("Reading syslog message: '%.*s'%s", sample_log_length, str, rbytes > sample_log_length ? "..." : "");
 
         /* Send message to queue */

--- a/src/logcollector/read_ucs2_be.c
+++ b/src/logcollector/read_ucs2_be.c
@@ -122,7 +122,7 @@ void *read_ucs2_be(logreader *lf, int *rc, int drop_it) {
                 continue;
             }
 
-            if (!check_log_regex(lf->regex_ignore, lf->regex_restrict, utf8_string)) {
+            if (!check_ignore_and_restrict(lf->regex_ignore, lf->regex_restrict, utf8_string)) {
                 w_msg_hash_queues_push(utf8_string, lf->file, utf8_bytes, lf->log_target, LOCALFILE_MQ);
             }
 

--- a/src/logcollector/read_ucs2_be.c
+++ b/src/logcollector/read_ucs2_be.c
@@ -91,11 +91,6 @@ void *read_ucs2_be(logreader *lf, int *rc, int drop_it) {
             continue;
         }
 
-        /* Check ignore and restrict log regex, if configured. */
-        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
-            continue;
-        }
-
         mdebug2("Reading syslog message: '%.*s'%s", sample_log_length, str, rbytes > sample_log_length ? "..." : "");
 
         /* Send message to queue */
@@ -127,7 +122,10 @@ void *read_ucs2_be(logreader *lf, int *rc, int drop_it) {
                 continue;
             }
 
-            w_msg_hash_queues_push(utf8_string, lf->file, utf8_bytes, lf->log_target, LOCALFILE_MQ);
+            if (!check_log_regex(lf->regex_ignore, lf->regex_restrict, utf8_string)) {
+                w_msg_hash_queues_push(utf8_string, lf->file, utf8_bytes, lf->log_target, LOCALFILE_MQ);
+            }
+
             os_free(utf8_string);
         }
         /* Incorrect message size */

--- a/src/logcollector/read_ucs2_le.c
+++ b/src/logcollector/read_ucs2_le.c
@@ -92,6 +92,11 @@ void *read_ucs2_le(logreader *lf, int *rc, int drop_it) {
             continue;
         }
 
+        /* Check ignore and restrict log regex, if configured. */
+        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
+            continue;
+        }
+
         mdebug2("Reading syslog message: '%.*s'%s", sample_log_length, (char * )str, rbytes > sample_log_length ? "..." : "");
 
         /* Send message to queue */

--- a/src/logcollector/read_ucs2_le.c
+++ b/src/logcollector/read_ucs2_le.c
@@ -113,7 +113,7 @@ void *read_ucs2_le(logreader *lf, int *rc, int drop_it) {
                 continue;
             }
 
-            if (!check_log_regex(lf->regex_ignore, lf->regex_restrict, utf8_string)) {
+            if (!check_ignore_and_restrict(lf->regex_ignore, lf->regex_restrict, utf8_string)) {
                 w_msg_hash_queues_push(utf8_string, lf->file, utf8_bytes, lf->log_target, LOCALFILE_MQ);
             }
 

--- a/src/logcollector/read_ucs2_le.c
+++ b/src/logcollector/read_ucs2_le.c
@@ -92,11 +92,6 @@ void *read_ucs2_le(logreader *lf, int *rc, int drop_it) {
             continue;
         }
 
-        /* Check ignore and restrict log regex, if configured. */
-        if (check_log_regex(lf->regex_ignore, lf->regex_restrict, str)) {
-            continue;
-        }
-
         mdebug2("Reading syslog message: '%.*s'%s", sample_log_length, (char * )str, rbytes > sample_log_length ? "..." : "");
 
         /* Send message to queue */
@@ -118,7 +113,10 @@ void *read_ucs2_le(logreader *lf, int *rc, int drop_it) {
                 continue;
             }
 
-            w_msg_hash_queues_push(utf8_string, lf->file, utf8_bytes, lf->log_target, LOCALFILE_MQ);
+            if (!check_log_regex(lf->regex_ignore, lf->regex_restrict, utf8_string)) {
+                w_msg_hash_queues_push(utf8_string, lf->file, utf8_bytes, lf->log_target, LOCALFILE_MQ);
+            }
+
             os_free(utf8_string);
         }
         /* Incorrect message size */

--- a/src/shared/expression.c
+++ b/src/shared/expression.c
@@ -83,6 +83,10 @@ void w_free_expression_t(w_expression_t ** var) {
     os_free(*var);
 }
 
+void w_free_expression(w_expression_t * var) {
+    w_free_expression_t(&var);
+}
+
 bool w_expression_add_osip(w_expression_t ** var, char * ip) {
 
     unsigned int ip_s = 0;
@@ -190,7 +194,7 @@ bool w_expression_match(w_expression_t * expression, const char * str_test, cons
             if (match_data = pcre2_match_data_create_from_pattern(expression->pcre2->code, NULL), !match_data) {
                 break;
             }
-            captured_groups = pcre2_match(expression->pcre2->code, (PCRE2_SPTR) str_test, 
+            captured_groups = pcre2_match(expression->pcre2->code, (PCRE2_SPTR) str_test,
                                           strlen(str_test), 0, 0, match_data, NULL);
 
             /* successful match */
@@ -308,7 +312,7 @@ const char * w_expression_get_regex_type(w_expression_t * expression) {
         case EXP_TYPE_PCRE2:
             retval = PCRE2_STR;
             break;
-        
+
         case EXP_TYPE_STRING:
             retval = STRING_STR;
             break;

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -41,7 +41,7 @@ list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,ff
                                 -Wl,--wrap,time -Wl,--wrap,can_read -Wl,--wrap,w_ftell -Wl,--wrap,w_expression_match \
                                 -Wl,--wrap,w_msg_hash_queues_push -Wl,--wrap,fgetpos -Wl,--wrap=w_update_file_status \
                                 -Wl,--wrap=w_get_hash_context -Wl,--wrap=_fseeki64 -Wl,--wrap=OS_SHA1_Stream \
-                                -Wl,--wrap=w_fseek")
+                                -Wl,--wrap=w_fseek -Wl,--wrap,_mdebug2")
 
 list(APPEND logcollector_names "test_localfile-config")
 list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \

--- a/src/unit_tests/logcollector/test_logcollector.c
+++ b/src/unit_tests/logcollector/test_logcollector.c
@@ -155,6 +155,20 @@ static int setup_regex(void **state) {
     regex_config->regex_ignore = NULL;
     regex_config->regex_restrict = NULL;
 
+    regex_config->regex_ignore = OSList_Create();
+    if (regex_config->regex_ignore == NULL) {
+        merror(MEM_ERROR, errno, strerror(errno));
+        return -1;
+    }
+    OSList_SetFreeDataPointer(regex_config->regex_ignore, (void (*)(void *))w_free_expression);
+
+    regex_config->regex_restrict = OSList_Create();
+    if (regex_config->regex_restrict == NULL) {
+        merror(MEM_ERROR, errno, strerror(errno));
+        return -1;
+    }
+    OSList_SetFreeDataPointer(regex_config->regex_restrict, (void (*)(void *))w_free_expression);
+
     *state = regex_config;
 
     return 0;
@@ -163,8 +177,14 @@ static int setup_regex(void **state) {
 static int teardown_regex(void **state) {
     logreader *regex_config = *state;
 
-    w_free_expression_t(&regex_config->regex_ignore);
-    w_free_expression_t(&regex_config->regex_restrict);
+    if (regex_config->regex_ignore) {
+        OSList_Destroy(regex_config->regex_ignore);
+        regex_config->regex_ignore = NULL;
+    }
+    if (regex_config->regex_restrict) {
+        OSList_Destroy(regex_config->regex_restrict);
+        regex_config->regex_restrict = NULL;
+    }
 
     os_free(regex_config);
 

--- a/src/unit_tests/logcollector/test_logcollector.c
+++ b/src/unit_tests/logcollector/test_logcollector.c
@@ -2297,8 +2297,6 @@ void check_log_regex_not_ignored(void ** state) {
 
     int ret = check_log_regex(regex_config->regex_ignore, regex_config->regex_restrict, str_test);
 
-    w_free_expression_t(&regex_config->regex_ignore);
-
     assert_false(ret);
 }
 
@@ -2306,7 +2304,7 @@ void check_log_regex_ignored(void ** state) {
 
     logreader *regex_config = *state;
     char *str_test = "testing log with ignore word";
-    char *aux[2]   ;
+    char *aux[2];
     aux[0] = str_test;
     aux[1] = str_test+1;
 
@@ -2321,8 +2319,6 @@ void check_log_regex_ignored(void ** state) {
 
     int ret = check_log_regex(regex_config->regex_ignore, regex_config->regex_restrict, str_test);
 
-    w_free_expression_t(&regex_config->regex_ignore);
-
     assert_true(ret);
 }
 
@@ -2330,7 +2326,7 @@ void check_log_regex_not_restricted(void ** state) {
 
     logreader *regex_config = *state;
     char *str_test = "testing log with restrict word";
-    char *aux[2]   ;
+    char *aux[2];
     aux[0] = str_test;
     aux[1] = str_test+1;
 

--- a/src/unit_tests/logcollector/test_read_macos.c
+++ b/src/unit_tests/logcollector/test_read_macos.c
@@ -1823,6 +1823,7 @@ void test_read_macos_faulty_waitpid(void ** state) {
 void test_read_macos_log_ignored(void ** state) {
     logreader lf;
     int dummy_rc;
+    char log_str[PATH_MAX + 1] = {0};
 
     os_calloc(1, sizeof(w_macos_log_config_t), lf.macos_log);
     os_calloc(1, sizeof(wfd_t), lf.macos_log->processes.stream.wfd);
@@ -1840,7 +1841,10 @@ void test_read_macos_log_ignored(void ** state) {
     will_return(__wrap_can_read, 1);
     will_return(__wrap_time, 1000 + MACOS_LOG_TIMEOUT + 1);
     will_return(__wrap_w_expression_match, true);
-    expect_string(__wrap__mdebug2, formatted_msg, "(1976): Avoiding the log line '2021-05-17 15:31:53.586313-0700  localhost sshd[880]: (libsystem_info.dylib) Created Activity ID: 0x2040, Description: Retrieve User by Name' due to ignore config: 'ignore.*'.");
+
+    snprintf(log_str, PATH_MAX, LF_MATCH_REGEX, "2021-05-17 15:31:53.586313-0700  localhost sshd[880]: (libsystem_info.dylib) Created Activity ID: 0x2040, Description: Retrieve User by Name", "ignore", "ignore.*");
+    expect_string(__wrap__mdebug2, formatted_msg, log_str);
+
     will_return(__wrap_can_read, 0);
 
     expect_any(__wrap_waitpid, __pid);

--- a/src/unit_tests/logcollector/test_read_macos.c
+++ b/src/unit_tests/logcollector/test_read_macos.c
@@ -1380,6 +1380,8 @@ void test_read_macos_single_full_log_store_timestamp_and_setting(void ** state) 
     lf.macos_log->store_current_settings = false;
     lf.macos_log->current_settings = "some log command with predicate and stuff";
     lf.macos_log->ctxt.timestamp = 1000;
+    lf.regex_ignore = NULL;
+    lf.regex_restrict = NULL;
     strcpy(lf.macos_log->ctxt.buffer, "2021-05-17 15:31:53.586313-0700  localhost sshd[880]: (libsystem_info.dylib) Created Activity ID: 0x2040, Description: Retrieve User by Name\n");
 
     will_return(__wrap_can_read, 1);
@@ -1413,6 +1415,8 @@ void test_read_macos_more_logs_than_maximum(void ** state) {
     lf.macos_log->is_header_processed = true;
     lf.macos_log->store_current_settings = true;
     lf.macos_log->ctxt.timestamp = TIMESTAMP_TIME;
+    lf.regex_ignore = NULL;
+    lf.regex_restrict = NULL;
     maximum_lines = 3;
 
     will_return(__wrap_can_read, 1);
@@ -1479,6 +1483,8 @@ void test_read_macos_disable_maximum_lines(void ** state) {
     lf.macos_log->is_header_processed = true;
     lf.macos_log->store_current_settings = true;
     lf.macos_log->ctxt.timestamp = TIMESTAMP_TIME;
+    lf.regex_ignore = NULL;
+    lf.regex_restrict = NULL;
     maximum_lines = 0;
 
     will_return(__wrap_can_read, 1);
@@ -1554,6 +1560,8 @@ void test_read_macos_toggle_correctly_ended_show_to_stream(void ** state) {
     macos_processes = &lf.macos_log->processes;
     lf.macos_log->store_current_settings = true;
     lf.macos_log->is_header_processed = true;
+    lf.regex_ignore = NULL;
+    lf.regex_restrict = NULL;
 
     // Save an expired context to send it immediately
     strcpy(lf.macos_log->ctxt.buffer, "2021-05-17 15:31:53.586313-0700  localhost sshd[880]: (libsystem_info.dylib)\n");
@@ -1610,7 +1618,8 @@ void test_read_macos_toggle_faulty_ended_show_to_stream(void ** state) {
     macos_processes = &lf.macos_log->processes;
     lf.macos_log->store_current_settings = true;
     lf.macos_log->is_header_processed = true;
-
+    lf.regex_ignore = NULL;
+    lf.regex_restrict = NULL;
 
     // Save an expired context to send it immediately
     strcpy(lf.macos_log->ctxt.buffer, "2021-05-17 15:31:53.586313-0700  localhost sshd[880]: (libsystem_info.dylib)\n");
@@ -1665,7 +1674,8 @@ void test_read_macos_toggle_correctly_ended_show_to_faulty_stream(void ** state)
     macos_processes = &lf.macos_log->processes;
     lf.macos_log->store_current_settings = true;
     lf.macos_log->is_header_processed = true;
-
+    lf.regex_ignore = NULL;
+    lf.regex_restrict = NULL;
 
     // Save an expired context to send it immediately
     strcpy(lf.macos_log->ctxt.buffer, "2021-05-17 15:31:53.586313-0700  localhost sshd[880]: (libsystem_info.dylib)\n");
@@ -1717,6 +1727,8 @@ void test_read_macos_faulty_ended_stream(void ** state) {
     macos_processes = &lf.macos_log->processes;
     lf.macos_log->store_current_settings = true;
     lf.macos_log->is_header_processed = true;
+    lf.regex_ignore = NULL;
+    lf.regex_restrict = NULL;
 
     // Save an expired context to send it immediately
     strcpy(lf.macos_log->ctxt.buffer, "2021-05-17 15:31:53.586313-0700  localhost sshd[880]: (libsystem_info.dylib)\n");
@@ -1772,6 +1784,8 @@ void test_read_macos_faulty_waitpid(void ** state) {
     macos_processes = &lf.macos_log->processes;
     lf.macos_log->store_current_settings = true;
     lf.macos_log->is_header_processed = true;
+    lf.regex_ignore = NULL;
+    lf.regex_restrict = NULL;
 
     // Save an expired context to send it immediately
     strcpy(lf.macos_log->ctxt.buffer, "2021-05-17 15:31:53.586313-0700  localhost sshd[880]: (libsystem_info.dylib)\n");
@@ -1804,6 +1818,41 @@ void test_read_macos_faulty_waitpid(void ** state) {
 
     os_free(lf.macos_log->processes.stream.wfd);
     os_free(lf.macos_log);
+}
+
+void test_read_macos_log_ignored(void ** state) {
+    logreader lf;
+    int dummy_rc;
+
+    os_calloc(1, sizeof(w_macos_log_config_t), lf.macos_log);
+    os_calloc(1, sizeof(wfd_t), lf.macos_log->processes.stream.wfd);
+    w_calloc_expression_t(&lf.regex_ignore, EXP_TYPE_PCRE2);
+    w_expression_compile(lf.regex_ignore, "ignore.*", 0);
+    lf.macos_log->state = LOG_RUNNING_STREAM;
+    lf.macos_log->processes.stream.wfd->pid = getpid();
+    lf.macos_log->is_header_processed = true;
+    lf.macos_log->store_current_settings = false;
+    lf.macos_log->current_settings = "some log command with predicate and stuff";
+    lf.macos_log->ctxt.timestamp = 1000;
+    lf.regex_restrict = NULL;
+    strcpy(lf.macos_log->ctxt.buffer, "2021-05-17 15:31:53.586313-0700  localhost sshd[880]: (libsystem_info.dylib) Created Activity ID: 0x2040, Description: Retrieve User by Name\n");
+
+    will_return(__wrap_can_read, 1);
+    will_return(__wrap_time, 1000 + MACOS_LOG_TIMEOUT + 1);
+    will_return(__wrap_w_expression_match, true);
+    expect_string(__wrap__mdebug2, formatted_msg, "(1976): Avoiding the log line '2021-05-17 15:31:53.586313-0700  localhost sshd[880]: (libsystem_info.dylib) Created Activity ID: 0x2040, Description: Retrieve User by Name' due to ignore config: 'ignore.*'.");
+    will_return(__wrap_can_read, 0);
+
+    expect_any(__wrap_waitpid, __pid);
+    expect_any(__wrap_waitpid, __options);
+    will_return(__wrap_waitpid, 0);
+    will_return(__wrap_waitpid, 0);
+
+    assert_null(read_macos(&lf, &dummy_rc, 0));
+
+    os_free(lf.macos_log->processes.stream.wfd);
+    os_free(lf.macos_log);
+    w_free_expression_t(&lf.regex_ignore);
 }
 
 int main(void) {
@@ -1874,6 +1923,7 @@ int main(void) {
         cmocka_unit_test(test_read_macos_toggle_correctly_ended_show_to_faulty_stream),
         cmocka_unit_test(test_read_macos_faulty_ended_stream),
         cmocka_unit_test(test_read_macos_faulty_waitpid),
+        cmocka_unit_test(test_read_macos_log_ignored),
     };
 
     return cmocka_run_group_tests(tests, group_setup, group_teardown);

--- a/src/unit_tests/logcollector/test_read_multiline_regex.c
+++ b/src/unit_tests/logcollector/test_read_multiline_regex.c
@@ -1683,6 +1683,8 @@ void test_read_multiline_regex_log_ignored(void ** state) {
     logreader lf = {0};
     int rc = 0;
     int drop_it = 0;
+    char log_str[PATH_MAX + 1] = {0};
+
     w_calloc_expression_t(&lf.regex_ignore, EXP_TYPE_PCRE2);
     w_expression_compile(lf.regex_ignore, "ignore.*", 0);
 
@@ -1705,7 +1707,9 @@ void test_read_multiline_regex_log_ignored(void ** state) {
     will_return(__wrap_w_expression_match, true);
 
     will_return(__wrap_w_expression_match, true);
-    expect_string(__wrap__mdebug2, formatted_msg, "(1976): Avoiding the log line 'ignore this log' due to ignore config: 'ignore.*'.");
+
+    snprintf(log_str, PATH_MAX, LF_MATCH_REGEX, "ignore this log", "ignore", "ignore.*");
+    expect_string(__wrap__mdebug2, formatted_msg, log_str);
 
     expect_any(__wrap_w_ftell, x);
     will_return(__wrap_w_ftell, (int64_t) 10);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/5628|


## Description
Hello team,
this PR is the implementation needed in the logcollector module to add the new settings ignore and restrict.
These settings allow configuring with pcre2 some expressions to ignore or restrict the processing of the logs read with logcollector.

- `ignore`: If the expression matches, the log will be ignored. 

- `restrict`: The log will only be processed if the expression matches.

In the case of `multi-line` and `multi-line-regex`, as long as one of the logs matches in ignore case, the entire multi-line log will be discarded. For restrict, only one match in restrict will be necessary.

Also added the related unit tests.

## Configuration options
```
  <localfile>
    <log_format>json</log_format>
    <location>/testignore.log</location>
    <ignore>ignore.+</ignore>
  </localfile>

  <localfile>
    <log_format>syslog</log_format>
    <location>/testrestrict.log</location>
    <restrict>restrict.+</restrict>
  </localfile>
```

## Logs/Alerts example

`2022/07/25 03:47:38 wazuh-agent[3152] logcollector.c:141 at check_log_regex(): DEBUG: (1976): Avoiding the log line 'ignore log ' due to ignore config: 'ignore.+'.
`

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Configuration on demand reports new parameters
- [x] Added unit tests (for new features)
