### PR TITLE
Add unit tests to json_op.c

### DIFF
--- a/src/headers/json_op.h
+++ b/src/headers/json_op.h
@@ -16,10 +16,33 @@
 
 #include <external/cJSON/cJSON.h>
 
+/**
+ * @brief It temporarily saves in memory the content of the file located in path.
+ * It also allows requesting and verifying that the JSON has a null termination 
+ * and recovers the pointer to the last parsed byte.
+ * 
+ * @param path  location of the file to be read.
+ * @param retry if set to 1, allows the operation to be retried if json parsing fails. It also removes C/C++ type comments. 
+ * If it is set to 0, it does not perform the retry.
+ * @return cJSON* 
+ */
 cJSON * json_fread(const char * path, char retry);
+
+/**
+ * @brief Represent a cJSON entity in plain text for storage in the file located at path.
+ * 
+ * @param path location of the file to be write.
+ * @param item json entity to be represented in text.
+ * @return int stores the result of the write operation. If it returns -1 it indicates that the operation was not carried out correctly.
+ * If it returns 0, it indicates that the operation was successful.
+ */
 int json_fwrite(const char * path, const cJSON * item);
 
-// Clear C/C++ style comments from a JSON string
+/**
+ * @brief Clear C/C++ style comments from a JSON string.
+ * 
+ * @param json json to which comment stripping is applied.
+ */
 void json_strip(char * json);
 
 // Check if a JSON object is tagged

--- a/src/shared/json_op.c
+++ b/src/shared/json_op.c
@@ -71,7 +71,6 @@ end:
     return retval;
 }
 
-// Clear C/C++ style comments from a JSON string
 void json_strip(char * json) {
     char * line;
     char * cursor;
@@ -113,4 +112,5 @@ void json_strip(char * json) {
             *next++ = '\n';
         }
     }
+
 }

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -129,6 +129,15 @@ else()
 endif()
 
 if(NOT ${TARGET} STREQUAL "winagent")
+list(APPEND shared_tests_names "test_json_op")
+list(APPEND shared_tests_flags "-Wl,--wrap,w_get_file_content -Wl,--wrap,cJSON_ParseWithOpts \
+                                -Wl,--wrap,cJSON_PrintUnformatted -Wl,--wrap,fopen \
+                                -Wl,--wrap,fwrite -Wl,--wrap,fclose \
+                                -Wl,--wrap,fflush -Wl,--wrap,fgets \
+                                -Wl,--wrap,fgetpos -Wl,--wrap,fgetc \
+                                -Wl,--wrap,fread -Wl,--wrap,remove \
+                                -Wl,--wrap,fseek ${DEBUG_OP_WRAPPERS}")
+                                
 list(APPEND shared_tests_names "test_audit_op")
 list(APPEND shared_tests_flags "-Wl,--wrap,audit_send \
                                 -Wl,--wrap,select -Wl,--wrap,audit_get_reply -Wl,--wrap,wpopenv -Wl,--wrap,fgets \

--- a/src/unit_tests/shared/test_json_op.c
+++ b/src/unit_tests/shared/test_json_op.c
@@ -1,0 +1,246 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+
+
+#include "../../headers/json_op.h"
+#include "../wrappers/externals/cJSON/cJSON_wrappers.h"
+#include "../wrappers/wazuh/shared/file_op_wrappers.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+#include "../wrappers/libc/stdio_wrappers.h"
+#include "../wrappers/common.h"
+#include "../../headers/shared.h"
+
+#define PATH_EXAMPLE "/home/test"
+#define BUFFER_EXAMPLE "//This is a comment"
+
+static void test_json_fread_buffer_null(void **state) {
+    (void) state;
+    const char * DEBUG_MESSAGE_FREAD_BUFFER_NULL = "Cannot get the content of the file: /home/test";
+    char * path;
+    os_strdup(PATH_EXAMPLE, path); 
+    
+    expect_w_get_file_content(NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, DEBUG_MESSAGE_FREAD_BUFFER_NULL);
+    
+    assert_ptr_equal(json_fread(path, 1), NULL);
+
+    os_free(path);
+}
+
+static void test_json_fread_no_retry(void **state) {
+    (void) state;
+    char * buffer;
+    os_strdup(BUFFER_EXAMPLE, buffer);
+    expect_w_get_file_content(buffer);
+    char * path;
+    os_strdup(PATH_EXAMPLE, path); 
+
+    will_return(__wrap_cJSON_ParseWithOpts, (cJSON*)1);
+    will_return(__wrap_cJSON_ParseWithOpts, (cJSON*)1);
+    
+    assert_ptr_equal(json_fread(path, 0), 0X1);
+    
+    os_free(path);
+}
+
+static void test_json_fread_with_retry(void **state) {
+    (void) state;
+    const char * DEBUG_MESSAGE_FREAD_TRYING_CLEAR_COMMENTS = "Couldn't parse JSON file '/home/test'. Trying to clear comments.";
+    const char * DEBUG_MESSAGE_FREAD_COULD_NOT_PARSE_JSON = "Couldn't parse JSON file '/home/test'.";
+    char * buffer;
+    os_strdup(BUFFER_EXAMPLE, buffer);
+    char * path;
+    os_strdup(PATH_EXAMPLE, path);
+
+    expect_w_get_file_content(buffer);
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, DEBUG_MESSAGE_FREAD_TRYING_CLEAR_COMMENTS);
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, DEBUG_MESSAGE_FREAD_COULD_NOT_PARSE_JSON);
+    
+    assert_ptr_equal(json_fread(path, 1), NULL);
+
+    os_free(path);
+}
+
+static void test_json_fread_successfully(void **state) {
+    (void) state;
+    char * buffer;
+    os_strdup(BUFFER_EXAMPLE, buffer);
+    char * path;
+    os_strdup(PATH_EXAMPLE, path);
+
+    expect_w_get_file_content(buffer);
+    will_return(__wrap_cJSON_ParseWithOpts, (cJSON*)8);
+    will_return(__wrap_cJSON_ParseWithOpts, (cJSON*)8);
+    
+    assert_ptr_equal(json_fread(path, 0), 0X8);
+
+    os_free(path);
+}
+
+static void test_json_fwrite_buffer_null(void **state) {
+    (void) state;
+    test_mode = 1;
+    const char * DEBUG_MESSAGE_FWRITE_DUMPING_JSON = "Internal error dumping JSON into file '/home/test'";
+    cJSON * item = NULL;
+    FILE *fp = NULL;
+    char *buffer = NULL;
+    char * path;
+    os_strdup(PATH_EXAMPLE, path);
+
+    will_return(__wrap_cJSON_PrintUnformatted, buffer);
+    expect_string(__wrap__mdebug1, formatted_msg, DEBUG_MESSAGE_FWRITE_DUMPING_JSON);
+    
+    assert_int_equal(json_fwrite(path, item), -1);
+
+    test_mode = 0;
+    os_free(path);
+}
+
+static void test_json_fwrite_fail_open(void **state) {
+    (void) state;
+    test_mode = 1;
+    const char * JSON_EXAMPLE_WITH_COMMENT_DOBLE_BAR = "//This is a comment \n{\"fruit\":[{\"lemon\":200},{\"banana\":100}]}";
+    const char * DEBUG_MESSAGE_FWRITE_COULD_NOT_OPEN_FILE = "(1103): Could not open file '/home/test' due to";
+    cJSON * item = NULL;
+    FILE *fp = NULL;
+    char * buffer;
+    os_strdup(JSON_EXAMPLE_WITH_COMMENT_DOBLE_BAR, buffer);
+    char * path;
+    os_strdup(PATH_EXAMPLE, path);
+    
+    will_return(__wrap_cJSON_PrintUnformatted, buffer);
+    expect_fopen(path, "w", fp);
+    expect_memory(__wrap__mdebug1, formatted_msg, DEBUG_MESSAGE_FWRITE_COULD_NOT_OPEN_FILE, strlen(DEBUG_MESSAGE_FWRITE_COULD_NOT_OPEN_FILE));
+    
+    assert_int_equal(json_fwrite(path, item), -1);
+
+    test_mode = 0;
+    os_free(path);
+}
+
+static void test_json_fwrite_fail_write(void **state) {
+    (void) state;
+    test_mode = 1;
+    const char * DEBUG_MESSAGE_FWRITE_COULD_NOT_WRITE = "Couldn't write JSON into '/home/test'";
+    cJSON * item = NULL;
+    FILE *fp = (FILE*)1;    
+    char * buffer;
+    os_strdup(BUFFER_EXAMPLE, buffer);
+    char * path;
+    os_strdup(PATH_EXAMPLE, path);
+
+    will_return(__wrap_cJSON_PrintUnformatted, buffer);
+    test_mode = 0;
+    expect_fopen(path, "w", fp);
+    test_mode = 1;
+    will_return(__wrap_fwrite, strlen(buffer)-1);
+    expect_memory(__wrap__mdebug1, formatted_msg, DEBUG_MESSAGE_FWRITE_COULD_NOT_WRITE, strlen(DEBUG_MESSAGE_FWRITE_COULD_NOT_WRITE));
+    expect_fclose(fp, 1);
+    
+    assert_int_equal(json_fwrite(path, item), -1);
+
+    test_mode = 0;
+    os_free(path);
+}
+
+static void test_json_fwrite_successfully(void **state) {
+    (void) state;
+    const char * JSON_EXAMPLE_WITH_COMMENT_DOBLE_BAR = "//This is a comment \n{\"fruit\":[{\"lemon\":200},{\"banana\":100}]}";
+    cJSON * item = (cJSON*)2;
+    FILE *fp = (FILE*)2;
+    char * buffer;
+    os_strdup(JSON_EXAMPLE_WITH_COMMENT_DOBLE_BAR, buffer);
+    char * path;
+    os_strdup(PATH_EXAMPLE, path);
+    
+    will_return(__wrap_cJSON_PrintUnformatted, buffer);
+    test_mode = 0;
+    expect_fopen(path, "w", fp);
+    will_return(__wrap_fwrite, strlen(buffer));
+    test_mode = 1;
+    expect_fclose(fp, 1);
+    assert_int_equal(json_fwrite(path, item), 0);
+
+    test_mode = 0;
+    os_free(path);
+}
+
+static void test_json_strip_delete_comment_single_bar(void **state) {
+    (void) state;
+    const char * JSON_EXAMPLE_WITH_COMMENT_SINGLE_BAR = "/*This is a comment*/{\"fruit\":[{\"lemon\":200},{\"banana\":100}]}";
+    const char * EXPECTED_JSON_EXAMPLE_WITH_COMMENT_SINGLE_BAR = "{\"fruit\":[{\"lemon\":200},{\"banana\":100}]}";
+    char * buffer;
+    os_strdup(JSON_EXAMPLE_WITH_COMMENT_SINGLE_BAR, buffer);
+    
+    json_strip(buffer);
+    
+    assert_string_equal(buffer, EXPECTED_JSON_EXAMPLE_WITH_COMMENT_SINGLE_BAR);
+
+    os_free(buffer);
+}
+
+static void test_json_strip_delete_comment_double_bar(void **state) {
+    (void) state;
+    const char * EXPECTED_JSON_EXAMPLE_WITH_COMMENT_DOBLE_BAR = "\n{\"fruit\":[{\"lemon\":200},{\"banana\":100}]}";
+    const char * JSON_EXAMPLE_WITH_COMMENT_DOBLE_BAR = "//This is a comment \n{\"fruit\":[{\"lemon\":200},{\"banana\":100}]}";
+    char * buffer;
+    os_strdup(JSON_EXAMPLE_WITH_COMMENT_DOBLE_BAR, buffer);
+    
+    json_strip(buffer);
+    
+    assert_string_equal(buffer, EXPECTED_JSON_EXAMPLE_WITH_COMMENT_DOBLE_BAR);
+
+    os_free(buffer);
+}
+
+static void test_json_strip_file_without_json_content(void **state) {
+    (void) state;
+    const char * FILE_WITHOUT_JSON_CONTENT = "/*this is a comment*/ \0";
+    const char * STRING_EMPTY = " ";
+    char * buffer;
+    os_strdup(FILE_WITHOUT_JSON_CONTENT, buffer);
+    
+    json_strip(buffer);
+    
+    assert_string_equal(buffer, STRING_EMPTY);
+
+    os_free(buffer);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_json_fread_buffer_null),
+        cmocka_unit_test(test_json_fread_no_retry),
+        cmocka_unit_test(test_json_fread_with_retry),
+        cmocka_unit_test(test_json_fread_successfully),
+        cmocka_unit_test(test_json_fwrite_buffer_null),
+        cmocka_unit_test(test_json_fwrite_fail_open),
+        cmocka_unit_test(test_json_fwrite_fail_write),
+        cmocka_unit_test(test_json_fwrite_successfully),
+        cmocka_unit_test(test_json_strip_delete_comment_double_bar),
+        cmocka_unit_test(test_json_strip_delete_comment_single_bar),
+        cmocka_unit_test(test_json_strip_file_without_json_content),
+        };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.c
@@ -245,3 +245,12 @@ char *__wrap_GetRandomNoise() {
 const char *__wrap_getuname() {
     return mock_ptr_type(char*);
 }
+
+char * __wrap_w_get_file_content(__attribute__ ((__unused__)) const char * path,
+                                 __attribute__ ((__unused__)) int max_size) {
+    return mock_type(char *);
+}
+
+void expect_w_get_file_content(const char *buffer) {
+    will_return(__wrap_w_get_file_content, buffer);
+}

--- a/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.h
@@ -96,3 +96,6 @@ int __wrap_TestUnmergeFiles(const char *finalpath, int mode);
 int __wrap_checkBinaryFile(const char *f_name);
 
 int __wrap_w_copy_file(const char *src, const char *dst, char mode, __attribute__((unused)) char * message, int silent);
+
+char * __wrap_w_get_file_content(__attribute__ ((__unused__)) const char * path, __attribute__ ((__unused__)) int max_size);
+void expect_w_get_file_content(const char *buffer);

--- a/src/unit_tests/wrappers/wazuh/shared/json_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/json_op_wrappers.c
@@ -17,3 +17,9 @@ cJSON * __wrap_json_fread(const char * path, __attribute__((unused)) char retry)
     if (path) check_expected(path);
     return mock_type(cJSON *);
 }
+
+int __wrap_json_fwrite(const char * path, const cJSON * item) {
+    check_expected(path);
+    check_expected(item);
+    return mock_type(int);
+}

--- a/src/unit_tests/wrappers/wazuh/shared/json_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/json_op_wrappers.h
@@ -14,5 +14,6 @@
 #include "headers/shared.h"
 
 cJSON * __wrap_json_fread(const char * path, char retry);
+int __wrap_json_fwrite(const char * path, const cJSON * item);
 
 #endif


### PR DESCRIPTION
|Wazuh version|Component|Install type|Install method|Platform|
|---|---|---|---|---|
| master | C unit tests | Manager/Agent | - | Windows - Linux |

## Description

This issue aims to add 100% UT coverage to json_op.c file.

![image](https://user-images.githubusercontent.com/1791430/187288020-953f8f8b-e698-430f-9325-3f4a538c0737.png)

## DoD
- [x] Add Doxygen comment to covered functions based on the caller's functions
- [x] Develop test **based on functional specs**, trying to cover all cases and branches
- [x] Add test to CMakeLists.txt
- [x] Add wrapper of calling functions if necessary
- [x] Create issue if any bug was found
- [x] Validate that tests follows [C code guideline](https://github.com/wazuh/wazuh/wiki/Coding-style-guide-%28C%29)
- [x] PR review
- [x] ~QA coverage issue https://github.com/wazuh/wazuh-qa/issues/3311~

## Result

After applying unit tests to the json_op.c file, the coverage is as follows:

![Captura de pantalla de 2022-09-05 16-43-37](https://user-images.githubusercontent.com/63238635/188512068-e5f2ee7d-a247-456c-9579-99dc1f2d4d98.png)


