### PR TITLE
Engine main commands

### DIFF
--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -101,10 +101,10 @@ CPMAddPackage(
 )
 
 CPMAddPackage(
-  NAME argparse
-  GITHUB_REPOSITORY p-ranav/argparse
-  GIT_TAG v2.2
-  VERSION 2.2
+  NAME CLI11
+  GITHUB_REPOSITORY CLIUtils/CLI11
+  GIT_TAG v2.2.0
+  VERSION 2.2.0
   DOWNLOAD_ONLY YES
 )
 ####################################################################################################
@@ -118,7 +118,7 @@ target_include_directories(main
     ${ENGINE_SOURCE_DIR}/router
     ${ENGINE_SOURCE_DIR}/rxcppBackend
     ${CameronQueue_SOURCE_DIR}
-    ${argparse_SOURCE_DIR}/include
+    ${CLI11_SOURCE_DIR}/include
 )
 
 

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -115,12 +115,8 @@ add_executable(main ${ENGINE_SOURCE_DIR}/main.cpp)
 
 target_include_directories(main
     PRIVATE
-    ${ENGINE_SOURCE_DIR}/router
-    ${ENGINE_SOURCE_DIR}/rxcppBackend
-    ${CameronQueue_SOURCE_DIR}
     ${CLI11_SOURCE_DIR}/include
 )
-
 
 add_subdirectory(${ENGINE_SOURCE_DIR}/base)
 add_subdirectory(${ENGINE_SOURCE_DIR}/builder)
@@ -132,9 +128,10 @@ add_subdirectory(${ENGINE_SOURCE_DIR}/server)
 add_subdirectory(${ENGINE_SOURCE_DIR}/rxbk)
 add_subdirectory(${ENGINE_SOURCE_DIR}/json)
 add_subdirectory(${ENGINE_SOURCE_DIR}/wdb)
+add_subdirectory(${ENGINE_SOURCE_DIR}/cmds)
 
 #TODO isolate rxcpp
-target_link_libraries(main base builders catalog rxbk json wdb server)
+target_link_libraries(main base cmds)
 
 # Build test
 if(ENGINE_BUILD_TEST)

--- a/src/engine/source/base/expression.cpp
+++ b/src/engine/source/base/expression.cpp
@@ -6,7 +6,7 @@ using Expression = std::shared_ptr<Formula>;
 
 unsigned int Formula::generateId()
 {
-    unsigned int id = 0;
+    static unsigned int id = 0;
     return id++;
 }
 
@@ -230,14 +230,18 @@ std::string toGraphvizStr(Expression expression)
             int i = 0;
             for (auto& child : operation->getOperands())
             {
-                ss << fmt::format("{} -> {} [ltail=cluster_{} lhead=cluster_{} label={} "
-                                  "fontcolor=\"red\"];\n",
-                                  current->getId(),
-                                  child->getId(),
-                                  current->getId(),
-                                  child->getId(),
-                                  i++);
-                visitRef(child, visitRef);
+                if (child)
+                {
+                    ss << fmt::format(
+                        "{} -> {} [ltail=cluster_{} lhead=cluster_{} label={} "
+                        "fontcolor=\"red\"];\n",
+                        current->getId(),
+                        child->getId(),
+                        current->getId(),
+                        child->getId(),
+                        i++);
+                    visitRef(child, visitRef);
+                }
             }
         }
     };

--- a/src/engine/source/base/utils/getExceptionStack.hpp
+++ b/src/engine/source/base/utils/getExceptionStack.hpp
@@ -1,0 +1,37 @@
+#ifndef _GET_EXCEPTION_STACK_HPP
+#define _GET_EXCEPTION_STACK_HPP
+
+#include <exception>
+#include <sstream>
+#include <string>
+
+namespace utils
+{
+/**
+ * @brief Get the exception stack as a string.
+ *
+ * @param e Exception to get the stack from.
+ * @param level Level of the exception to get the stack from.
+ * @return String with the exception stack.
+ */
+inline std::string getExceptionStack(const std::exception& e, int level = 0)
+{
+    std::stringstream ss;
+    ss << std::string(level, ' ') << "exception: " << e.what() << '\n';
+    try
+    {
+        std::rethrow_if_nested(e);
+    }
+    catch (const std::exception& nestedException)
+    {
+        ss << getExceptionStack(nestedException, level + 1);
+    }
+    catch (...)
+    {
+    }
+
+    return ss.str();
+}
+} // namespace utils
+
+#endif // _GET_EXCEPTION_STACK_HPP

--- a/src/engine/source/base/utils/getExceptionStack.hpp
+++ b/src/engine/source/base/utils/getExceptionStack.hpp
@@ -26,9 +26,6 @@ inline std::string getExceptionStack(const std::exception& e, int level = 0)
     {
         ss << getExceptionStack(nestedException, level + 1);
     }
-    catch (...)
-    {
-    }
 
     return ss.str();
 }

--- a/src/engine/source/builder/environment.cpp
+++ b/src/engine/source/builder/environment.cpp
@@ -34,9 +34,9 @@ void Environment::buildGraph(
     Asset::Type type)
 {
     auto graphPos = std::find_if(m_graphs.begin(),
-                                     m_graphs.end(),
-                                     [&graphName](const auto& graph)
-                                     { return std::get<0>(graph) == graphName; });
+                                 m_graphs.end(),
+                                 [&graphName](const auto& graph)
+                                 { return std::get<0>(graph) == graphName; });
     auto& graph = std::get<1>(*graphPos);
     for (auto& [name, json] : assetsDefinitons)
     {
@@ -119,6 +119,19 @@ std::string Environment::getGraphivzStr()
        << std::endl;
     ss << "environment [label=\"" << m_name << "\", shape=Mdiamond];" << std::endl;
 
+    auto removeHyphen = [](const std::string& text)
+    {
+        auto ret = text;
+        auto pos = ret.find("-");
+        while (pos != std::string::npos)
+        {
+            ret.erase(pos, 1);
+            pos = ret.find("-");
+        }
+
+        return ret;
+    };
+
     for (auto& [name, graph] : m_graphs)
     {
         ss << std::endl;
@@ -129,13 +142,14 @@ std::string Environment::getGraphivzStr()
         ss << fmt::format("node [style=filled,color=white];") << std::endl;
         for (auto& [name, asset] : graph.nodes())
         {
-            ss << name << " [label=\"" << name << "\"];" << std::endl;
+            ss << removeHyphen(name) << " [label=\"" << name << "\"];" << std::endl;
         }
         for (auto& [parent, children] : graph.edges())
         {
             for (auto& child : children)
             {
-                ss << parent << " -> " << child << ";" << std::endl;
+                ss << removeHyphen(parent) << " -> " << removeHyphen(child) << ";"
+                   << std::endl;
             }
         }
         ss << "}" << std::endl;

--- a/src/engine/source/cmds/CMakeLists.txt
+++ b/src/engine/source/cmds/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_library(cmds STATIC
+    src/cmdGraph.cpp
+    src/cmdRun.cpp
+    src/cmdTest.cpp
+)
+
+target_link_libraries(cmds PRIVATE
+    base
+    json
+    builders
+    catalog
+    rxbk
+    server
+)
+
+target_include_directories(cmds PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+target_include_directories(cmds PRIVATE
+    ${CameronQueue_SOURCE_DIR}
+)

--- a/src/engine/source/cmds/include/cmds/cmdGraph.hpp
+++ b/src/engine/source/cmds/include/cmds/cmdGraph.hpp
@@ -1,0 +1,23 @@
+#ifndef _CMD_GRAPH_HPP
+#define _CMD_GRAPH_HPP
+
+#include <string>
+
+namespace cmd
+{
+/**
+ * @brief Load and build environment to generate environment graph and environment
+ * expression graph.
+ *
+ * @param kvdbPath Path to KVDB folder.
+ * @param fileStorage Path to asset folders.
+ * @param environment Name of the environment to be loaded.
+ * @param graphOutDir Directory where the graphs will be saved.
+ */
+void graph(const std::string& kvdbPath,
+           const std::string& fileStorage,
+           const std::string& environment,
+           const std::string& graphOutDir);
+} // namespace cmd
+
+#endif // _CMD_GRAPH_HPP

--- a/src/engine/source/cmds/include/cmds/cmdRun.hpp
+++ b/src/engine/source/cmds/include/cmds/cmdRun.hpp
@@ -1,0 +1,28 @@
+#ifndef _CMD_RUN_HPP
+#define _CMD_RUN_HPP
+
+#include <string>
+
+namespace cmd
+{
+
+/**
+ * @brief Run environment.
+ *
+ * @param kvdbPath Path to KVDB folder.
+ * @param endpoint Endpoint of the server.
+ * @param queueSize Size of the event ingestion queue.
+ * @param threads Number of environment threads.
+ * @param fileStorage Path to asset folders.
+ * @param environment Name of the environment to be loaded.
+ */
+void run(const std::string& kvdbPath,
+         const std::string& endpoint,
+         const int queueSize,
+         const int threads,
+         const std::string& fileStorage,
+         const std::string& environment,
+         const int logLevel);
+} // namespace cmd
+
+#endif // _CMD_RUN_HPP

--- a/src/engine/source/cmds/include/cmds/cmdRun.hpp
+++ b/src/engine/source/cmds/include/cmds/cmdRun.hpp
@@ -15,6 +15,7 @@ namespace cmd
  * @param threads Number of environment threads.
  * @param fileStorage Path to asset folders.
  * @param environment Name of the environment to be loaded.
+ * @param logLevel Log level.
  */
 void run(const std::string& kvdbPath,
          const std::string& endpoint,

--- a/src/engine/source/cmds/include/cmds/cmdTest.hpp
+++ b/src/engine/source/cmds/include/cmds/cmdTest.hpp
@@ -1,0 +1,20 @@
+#ifndef _CMD_TEST_HPP
+#define _CMD_TEST_HPP
+
+#include <string>
+#include <vector>
+
+namespace cmd
+{
+
+void test(const std::string& kvdbPath,
+          const std::string& fileStorage,
+          const std::string& environment,
+          int debugLevel,
+          bool traceAll,
+          const std::vector<std::string>& assetTrace,
+          int protocolQueue,
+          const std::string& protocolLocation);
+} // namespace cmd
+
+#endif // _CMD_TEST_HPP

--- a/src/engine/source/cmds/include/cmds/cmdTest.hpp
+++ b/src/engine/source/cmds/include/cmds/cmdTest.hpp
@@ -7,9 +7,24 @@
 namespace cmd
 {
 
+/**
+ * @brief Run environment in test mode. Inputs from stdin, outputs event to stdout and
+ * debug to stderr.
+ *
+ * @param kvdbPath Path to KVDB folder.
+ * @param fileStorage Path to asset folders.
+ * @param environment Name of the environment to be loaded.
+ * @param logLevel Log level.
+ * @param debugLevel Debug level.
+ * @param traceAll Trace all assets.
+ * @param assetTrace Trace specific assets.
+ * @param protocolQueue Queue of the protocol.
+ * @param protocolLocation Location of the protocol.
+ */
 void test(const std::string& kvdbPath,
           const std::string& fileStorage,
           const std::string& environment,
+          int logLevel,
           int debugLevel,
           bool traceAll,
           const std::vector<std::string>& assetTrace,

--- a/src/engine/source/cmds/src/cmdGraph.cpp
+++ b/src/engine/source/cmds/src/cmdGraph.cpp
@@ -1,0 +1,103 @@
+#include "cmds/cmdGraph.hpp"
+
+#include <filesystem>
+#include <fstream>
+
+#include <hlp/hlp.hpp>
+#include <kvdb/kvdbManager.hpp>
+#include <logging/logging.hpp>
+#include <rxbk/rxFactory.hpp>
+
+#include "base/utils/getExceptionStack.hpp"
+#include "builder.hpp"
+#include "catalog.hpp"
+#include "register.hpp"
+
+namespace
+{
+constexpr auto ENV_GRAPH = "env_graph.dot";
+constexpr auto ENV_EXPR_GRAPH = "env_expr_graph.dot";
+} // namespace
+
+namespace cmd
+{
+void graph(const std::string& kvdbPath,
+           const std::string& fileStorage,
+           const std::string& environment,
+           const std::string& graphOutDir)
+{
+    // Init logging
+    // TODO: add cmd to config logging level
+    logging::LoggingConfig logConfig;
+    logConfig.logLevel = logging::LogLevel::Debug;
+    logging::loggingInit(logConfig);
+
+    KVDBManager::init(kvdbPath);
+
+    catalog::Catalog _catalog(catalog::StorageType::Local, fileStorage);
+
+    auto hlpParsers =
+        _catalog.getFileContents(catalog::AssetType::Schema, "wazuh-logql-types");
+    // TODO because builders don't have access to the catalog we are configuring
+    // the parser mappings on start up for now
+    hlp::configureParserMappings(hlpParsers);
+
+    try
+    {
+        builder::internals::registerBuilders();
+    }
+    catch (const std::exception& e)
+    {
+        WAZUH_LOG_ERROR("Exception while registering builders: [{}]",
+                        utils::getExceptionStack(e));
+        return;
+    }
+
+    // TODO: Handle errors on construction
+    builder::Builder<catalog::Catalog> _builder(_catalog);
+    decltype(_builder.buildEnvironment(environment)) env;
+    try
+    {
+        env = _builder.buildEnvironment(environment);
+    }
+    catch (const std::exception& e)
+    {
+        WAZUH_LOG_ERROR("Exception while building environment: [{}]",
+                        utils::getExceptionStack(e));
+        return;
+    }
+
+    base::Expression envExpression;
+    try
+    {
+        envExpression = env.getExpression();
+    }
+    catch (const std::exception& e)
+    {
+        WAZUH_LOG_ERROR("Exception while building environment Expression: [{}]",
+                        utils::getExceptionStack(e));
+        return;
+    }
+
+    // Save both graphs
+    std::filesystem::path envGraph {graphOutDir};
+    envGraph.append(ENV_GRAPH);
+
+    std::filesystem::path envExprGraph {graphOutDir};
+    envExprGraph.append(ENV_EXPR_GRAPH);
+
+    std::ofstream graphFile;
+
+    graphFile.open(envGraph.string());
+    graphFile << env.getGraphivzStr();
+    std::cout << std::endl
+              << "Environment graph saved on " << envGraph.string() << std::endl;
+    graphFile.close();
+
+    graphFile.open(envExprGraph.string());
+    graphFile << base::toGraphvizStr(envExpression);
+    std::cout << "Environment expression graph saved on " << envExprGraph.string()
+              << std::endl;
+    graphFile.close();
+}
+} // namespace cmd

--- a/src/engine/source/cmds/src/cmdRun.cpp
+++ b/src/engine/source/cmds/src/cmdRun.cpp
@@ -1,0 +1,163 @@
+#include "cmds/cmdRun.hpp"
+
+#include <atomic>
+#include <csignal>
+#include <thread>
+#include <vector>
+
+#include <hlp/hlp.hpp>
+#include <kvdb/kvdbManager.hpp>
+#include <logging/logging.hpp>
+#include <rxbk/rxFactory.hpp>
+
+#include "base/utils/getExceptionStack.hpp"
+#include "builder.hpp"
+#include "catalog.hpp"
+#include "engineServer.hpp"
+#include "protocolHandler.hpp"
+#include "register.hpp"
+
+namespace
+{
+constexpr auto WAIT_DEQUEUE_TIMEOUT_USEC = 1 * 1000000;
+
+// variables for handling threads
+std::atomic<bool> gs_doRun = true;
+std::vector<std::thread> gs_threadList;
+
+void sigint_handler(const int signum)
+{
+    // Inform threads that they must exit
+    gs_doRun = false;
+
+    for (auto& t : gs_threadList)
+    {
+        t.join();
+    };
+
+    // TODO: this should not be necessary, but server threads are not terminating.
+    exit(0);
+}
+} // namespace
+
+namespace cmd
+{
+void run(const std::string& kvdbPath,
+         const std::string& endpoint,
+         const int queueSize,
+         const int threads,
+         const std::string& fileStorage,
+         const std::string& environment,
+         const int logLevel)
+{
+
+    // Set Crt+C handler
+    sigset_t sig_empty_mask;
+    sigemptyset(&sig_empty_mask);
+
+    struct sigaction sigintAction;
+    sigintAction.sa_handler = sigint_handler;
+    sigintAction.sa_mask = sig_empty_mask;
+
+    sigaction(SIGINT, &sigintAction, NULL);
+
+    // Init logging
+    logging::LoggingConfig logConfig;
+    switch (logLevel)
+    {
+        case 0: logConfig.logLevel = logging::LogLevel::Debug; break;
+        case 1: logConfig.logLevel = logging::LogLevel::Info; break;
+        case 2: logConfig.logLevel = logging::LogLevel::Warn; break;
+        case 3: logConfig.logLevel = logging::LogLevel::Error; break;
+        default: WAZUH_LOG_ERROR("Invalid log level: {}", logLevel);
+    }
+    logging::loggingInit(logConfig);
+
+    KVDBManager::init(kvdbPath);
+
+    engineserver::EngineServer server {{endpoint}, static_cast<size_t>(queueSize)};
+    if (!server.isConfigured())
+    {
+        WAZUH_LOG_ERROR("Could not configure server for endpoint [{}], engine "
+                        "inizialization aborted.",
+                        endpoint);
+        return;
+    }
+
+    catalog::Catalog _catalog(catalog::StorageType::Local, fileStorage);
+
+    auto hlpParsers =
+        _catalog.getFileContents(catalog::AssetType::Schema, "wazuh-logql-types");
+    // TODO because builders don't have access to the catalog we are configuring
+    // the parser mappings on start up for now
+    hlp::configureParserMappings(hlpParsers);
+
+    try
+    {
+        builder::internals::registerBuilders();
+    }
+    catch (const std::exception& e)
+    {
+        WAZUH_LOG_ERROR("Exception while registering builders: [{}]",
+                        utils::getExceptionStack(e));
+        return;
+    }
+    // TODO: Handle errors on construction
+    builder::Builder<catalog::Catalog> _builder(_catalog);
+    decltype(_builder.buildEnvironment(environment)) env;
+    try
+    {
+        env = _builder.buildEnvironment(environment);
+    }
+    catch (const std::exception& e)
+    {
+        WAZUH_LOG_ERROR("Exception while building environment: [{}]",
+                        utils::getExceptionStack(e));
+        return;
+    }
+
+    // Processing Workers (Router), Router is replicated in each thread
+    // TODO: handle hot modification of routes
+    for (auto i = 0; i < threads; ++i)
+    {
+        std::thread t {
+            [=, &eventBuffer = server.output()]()
+            {
+                auto controller = rxbk::buildRxPipeline(env);
+
+                // Thread loop
+                while (gs_doRun)
+                {
+                    std::string event;
+
+                    if (eventBuffer.wait_dequeue_timed(event, WAIT_DEQUEUE_TIMEOUT_USEC))
+                    {
+                        try
+                        {
+                            auto result = base::result::makeSuccess(
+                                engineserver::ProtocolHandler::parse(event));
+                            controller.ingestEvent(
+                                std::make_shared<base::result::Result<base::Event>>(
+                                    std::move(result)));
+                        }
+                        catch (const std::exception& e)
+                        {
+                            WAZUH_LOG_ERROR(
+                                "An error ocurred while parsing a message: [{}]",
+                                e.what());
+                        }
+                    }
+                }
+
+                controller.complete();
+                return 0;
+            }};
+
+        gs_threadList.push_back(std::move(t));
+    }
+
+    server.run();
+
+    logging::loggingTerm();
+}
+} // namespace cmd

--- a/src/engine/source/cmds/src/cmdTest.cpp
+++ b/src/engine/source/cmds/src/cmdTest.cpp
@@ -143,10 +143,10 @@ void test(const std::string& kvdbPath,
         {
             auto assetNamePattern = std::make_shared<RE2>(R"(^\[([^\]]+)\].+)");
             controller.listenOnAllTrace(rxcpp::make_subscriber<std::string>(
-                [&](const std::string& trace)
+                [assetNamePattern, &traceBuffer](const std::string& trace)
                 {
                     std::string asset;
-                    auto matched = RE2::FullMatch(trace, *assetNamePattern, &asset);
+                    auto matched = RE2::PartialMatch(trace, *assetNamePattern, &asset);
                     traceBuffer[asset] << trace << std::endl;
                 }));
         }

--- a/src/engine/source/cmds/src/cmdTest.cpp
+++ b/src/engine/source/cmds/src/cmdTest.cpp
@@ -1,0 +1,267 @@
+#include "cmds/cmdTest.hpp"
+
+#include <atomic>
+
+#include <re2/re2.h>
+
+#include <hlp/hlp.hpp>
+#include <kvdb/kvdbManager.hpp>
+#include <logging/logging.hpp>
+#include <rxbk/rxFactory.hpp>
+
+#include "base/utils/getExceptionStack.hpp"
+#include "builder.hpp"
+#include "catalog.hpp"
+#include "protocolHandler.hpp"
+#include "register.hpp"
+
+namespace
+{
+std::atomic<bool> gs_doRun = true;
+} // namespace
+
+namespace cmd
+{
+void test(const std::string& kvdbPath,
+          const std::string& fileStorage,
+          const std::string& environment,
+          int debugLevel,
+          bool traceAll,
+          const std::vector<std::string>& assetTrace,
+          int protocolQueue,
+          const std::string& protocolLocation)
+{
+    // Init logging
+    // TODO: add cmd to config logging level
+    logging::LoggingConfig logConfig;
+    logConfig.logLevel = logging::LogLevel::Debug;
+    logging::loggingInit(logConfig);
+
+    KVDBManager::init(kvdbPath);
+
+    catalog::Catalog _catalog(catalog::StorageType::Local, fileStorage);
+
+    auto hlpParsers =
+        _catalog.getFileContents(catalog::AssetType::Schema, "wazuh-logql-types");
+    // TODO because builders don't have access to the catalog we are configuring
+    // the parser mappings on start up for now
+    hlp::configureParserMappings(hlpParsers);
+
+    try
+    {
+        builder::internals::registerBuilders();
+    }
+    catch (const std::exception& e)
+    {
+        WAZUH_LOG_ERROR("Exception while registering builders: [{}]",
+                        utils::getExceptionStack(e));
+        return;
+    }
+
+    // Delete outputs
+    json::Json envTmp {_catalog.getAsset("environment", environment)};
+    envTmp.erase("/outputs");
+
+    // Fake catalog for testing
+    struct TestCatalog
+    {
+        catalog::Catalog _catalog;
+        std::string testEnvironment;
+
+        rapidjson::Document getAsset(const std::string& type,
+                                     const std::string& name) const
+        {
+            if (type == "environment")
+            {
+                rapidjson::Document doc;
+                doc.Parse(testEnvironment.c_str());
+                return doc;
+            }
+            else
+            {
+                return _catalog.getAsset(type, name);
+            }
+        }
+    };
+    TestCatalog _testCatalog {_catalog, envTmp.str()};
+
+    // TODO: Handle errors on construction
+    builder::Builder<TestCatalog> _builder(_testCatalog);
+    decltype(_builder.buildEnvironment(environment)) env;
+    try
+    {
+        env = _builder.buildEnvironment(environment);
+    }
+    catch (const std::exception& e)
+    {
+        WAZUH_LOG_ERROR("Exception while building environment: [{}]",
+                        utils::getExceptionStack(e));
+        return;
+    }
+
+    // Create rxbackend
+    auto controller = rxbk::buildRxPipeline(env);
+
+    // output
+    std::stringstream output;
+    auto stderrSubscriber = rxcpp::make_subscriber<rxbk::RxEvent>(
+        [&](const rxbk::RxEvent& event)
+        {
+            output << event->payload()->prettyStr() << std::endl;
+        });
+    controller.getOutput().subscribe(stderrSubscriber);
+
+    // Tracer subscriber for history
+    // TODO: update once proper tracing is implemented
+    std::vector<std::pair<std::string, std::string>> history {};
+    if (debugLevel > 0)
+    {
+        auto conditionRegex = std::make_shared<RE2>(R"(\[([^\]]+)\] \[condition\]:(.+))");
+        controller.listenOnAllTrace(rxcpp::make_subscriber<std::string>(
+            [&history, conditionRegex](const std::string& trace)
+            {
+                std::string asset;
+                std::string result;
+                auto matched = RE2::FullMatch(trace, *conditionRegex, &asset, &result);
+                if (matched)
+                {
+                    history.push_back({asset, result});
+                }
+            }));
+    }
+
+    // Tracer subscriber for full debug
+    std::unordered_map<std::string, std::stringstream> traceBuffer;
+    if (debugLevel > 1)
+    {
+        if (traceAll)
+        {
+            auto assetNamePattern = std::make_shared<RE2>(R"(^\[([^\]]+)\].+)");
+            controller.listenOnAllTrace(rxcpp::make_subscriber<std::string>(
+                [&](const std::string& trace)
+                {
+                    std::string asset;
+                    auto matched = RE2::FullMatch(trace, *assetNamePattern, &asset);
+                    traceBuffer[asset] << trace << std::endl;
+                }));
+        }
+        else
+        {
+            for (auto& name : assetTrace)
+            {
+                try
+                {
+                    controller.listenOnTrace(name,
+                                             rxcpp::make_subscriber<std::string>(
+                                                 [&, name](const std::string& trace) {
+                                                     traceBuffer[name] << trace
+                                                                       << std::endl;
+                                                 }));
+                }
+                catch (const std::exception& e)
+                {
+                    WAZUH_LOG_WARN("Asset [{}] not found, skipping tracer: {}",
+                                   name,
+                                   utils::getExceptionStack(e));
+                }
+            }
+        }
+    }
+
+    // Stdin loop
+    while (gs_doRun)
+    {
+        std::cout << std::endl
+                  << std::endl
+                  << "Enter log in single line (Crtl+C to exit):" << std::endl
+                  << std::endl;
+        std::string line;
+        std::getline(std::cin, line);
+        if (line.empty())
+        {
+            continue;
+        }
+        try
+        {
+            // Clear outputs
+            history.clear();
+            output.str("");
+            output.clear();
+
+            // Send event
+            auto event = fmt::format("{}:{}:{}", protocolQueue, protocolLocation, line);
+            auto result =
+                base::result::makeSuccess(engineserver::ProtocolHandler::parse(event));
+            controller.ingestEvent(
+                std::make_shared<base::result::Result<base::Event>>(std::move(result)));
+
+            // Decoder history
+            if (debugLevel > 0)
+            {
+                std::cerr << std::endl << std::endl << "DECODERS:" << std::endl;
+                std::string indent = "  ";
+                for (auto& [asset, condition] : history)
+                {
+                    if (env.assets()[asset]->m_type == builder::Asset::Type::DECODER)
+                    {
+                        std::cerr << fmt::format("{}{}  ->  {}", indent, asset, condition)
+                                  << std::endl;
+                        if (traceBuffer.find(asset) != traceBuffer.end())
+                        {
+                            std::string line;
+                            while (std::getline(traceBuffer[asset], line))
+                            {
+                                std::cerr << indent << indent << line << std::endl;
+                            }
+                        }
+                        // Clear trace buffer
+                        traceBuffer[asset].str("");
+                        traceBuffer[asset].clear();
+                        if (condition == "success")
+                        {
+                            indent += indent;
+                        }
+                    }
+                }
+                // Rule history
+                std::cerr << std::endl << "RULES:" << std::endl;
+                indent = "  ";
+                for (auto& [asset, condition] : history)
+                {
+                    if (env.assets()[asset]->m_type == builder::Asset::Type::RULE)
+                    {
+                        std::cerr << fmt::format("{}{}  ->  {}", indent, asset, condition)
+                                  << std::endl;
+                        if (traceBuffer.find(asset) != traceBuffer.end())
+                        {
+                            std::string line;
+                            while (std::getline(traceBuffer[asset], line))
+                            {
+                                std::cerr << indent << indent << line << std::endl;
+                            }
+                        }
+
+                        // Clear trace buffer
+                        traceBuffer[asset].str("");
+                        traceBuffer[asset].clear();
+                        if (condition == "success")
+                        {
+                            indent += indent;
+                        }
+                    }
+                }
+            }
+
+            // Output
+            std::cerr << std::endl << std::endl << "OUTPUT:" << std::endl << std::endl;
+            std::cerr << output.str() << std::endl;
+        }
+        catch (const std::exception& e)
+        {
+            WAZUH_LOG_ERROR("An error ocurred while parsing a message: [{}]", e.what());
+        }
+    }
+
+    controller.complete();
+}
+} // namespace cmd

--- a/src/engine/source/cmds/src/cmdTest.cpp
+++ b/src/engine/source/cmds/src/cmdTest.cpp
@@ -25,6 +25,7 @@ namespace cmd
 void test(const std::string& kvdbPath,
           const std::string& fileStorage,
           const std::string& environment,
+          int logLevel,
           int debugLevel,
           bool traceAll,
           const std::vector<std::string>& assetTrace,
@@ -32,9 +33,15 @@ void test(const std::string& kvdbPath,
           const std::string& protocolLocation)
 {
     // Init logging
-    // TODO: add cmd to config logging level
     logging::LoggingConfig logConfig;
-    logConfig.logLevel = logging::LogLevel::Debug;
+    switch (logLevel)
+    {
+        case 0: logConfig.logLevel = logging::LogLevel::Debug; break;
+        case 1: logConfig.logLevel = logging::LogLevel::Info; break;
+        case 2: logConfig.logLevel = logging::LogLevel::Warn; break;
+        case 3: logConfig.logLevel = logging::LogLevel::Error; break;
+        default: WAZUH_LOG_ERROR("Invalid log level: {}", logLevel);
+    }
     logging::loggingInit(logConfig);
 
     KVDBManager::init(kvdbPath);
@@ -106,9 +113,7 @@ void test(const std::string& kvdbPath,
     std::stringstream output;
     auto stderrSubscriber = rxcpp::make_subscriber<rxbk::RxEvent>(
         [&](const rxbk::RxEvent& event)
-        {
-            output << event->payload()->prettyStr() << std::endl;
-        });
+        { output << event->payload()->prettyStr() << std::endl; });
     controller.getOutput().subscribe(stderrSubscriber);
 
     // Tracer subscriber for history

--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -123,12 +123,20 @@ void configureSubcommandLogtest(std::shared_ptr<CLI::App> app)
             "-l, --protocol_location", args::protocol_location, "Protocol location.")
         ->default_val("/dev/stdin");
 
+    // Log level
+    logtest
+        ->add_option("--log_level",
+                     args::log_level,
+                     "Log level. 0 = Debug, 1 = Info, 2 = Warning, 3 = Error")
+        ->default_val(3);
+
     // Debug levels
-    auto debug = logtest->add_flag("-d, --debug",
-                                   args::debug_level,
-                                   "Enable debug mode [0-2]. "
-                                   "0: No debug, 1: Asset history, 2: 1 + "
-                                   "Full tracing.");
+    auto debug =
+        logtest->add_flag("-d, --debug",
+                          args::debug_level,
+                          "Enable debug mode [0-2]. Flag can appear multiple times. "
+                          "No flag[0]: No debug, d[1]: Asset history, dd[2]: 1 + "
+                          "Full tracing.");
 
     // Trace
     logtest
@@ -219,6 +227,7 @@ int main(int argc, char* argv[])
         cmd::test(args::kvdb_path,
                   args::file_storage,
                   args::environment,
+                  args::log_level,
                   args::debug_level,
                   TraceAll,
                   assetTrace,

--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -1,58 +1,45 @@
-/* Copyright (C) 2015-2022, Wazuh Inc.
- * All rights reserved.
- *
- * This program is free software; you can redistribute it
- * and/or modify it under the terms of the GNU General Public
- * License (version 2) as published by the FSF - Free Software
- * Foundation.
- */
-
-#include <atomic>
-#include <csignal>
 #include <memory>
-#include <sstream>
 #include <string>
-#include <thread>
 #include <vector>
 
 #include <CLI/CLI.hpp>
 
-#include <builder.hpp>
-#include <catalog.hpp>
-#include <engineServer.hpp>
-#include <graph.hpp>
-#include <json/json.hpp>
-#include <kvdb/kvdbManager.hpp>
+#include <cmds/cmdGraph.hpp>
+#include <cmds/cmdRun.hpp>
+#include <cmds/cmdTest.hpp>
 #include <logging/logging.hpp>
-#include <profile/profile.hpp>
-#include <protocolHandler.hpp>
-#include <register.hpp>
-// #include <router.hpp>
-#include <hlp/hlp.hpp>
-#include <rxbk/rxFactory.hpp>
-#include <wdb/wdb.hpp>
 
-constexpr auto WAIT_DEQUEUE_TIMEOUT_USEC = 1 * 1000000;
-
-// Static global variables for handling threads
-static std::atomic<bool> gs_doRun = true;
-static std::vector<std::thread> gs_threadList;
+#include "base/utils/stringUtils.hpp"
 
 // Arguments configuration
 namespace args
 {
 // Subcommand names
 constexpr auto SUBCOMMAND_RUN = "run";
-constexpr auto SUBCOMMAND_LOGTEST = "logtest";
-constexpr auto SUBCOMMAND_GRAPH = "generate_graph";
+constexpr auto SUBCOMMAND_LOGTEST = "test";
+constexpr auto SUBCOMMAND_GRAPH = "graph";
+
+// Graph file names
+constexpr auto ENV_DEF_DIR = ".";
+constexpr auto ENV_GRAPH = "env_graph.dot";
+constexpr auto ENV_EXPR_GRAPH = "env_expr_graph.dot";
+
+// Trace all string
+constexpr auto TRACE_ALL = "ALL";
 
 // Arguments
-static std::string endpoint;
-static std::string file_storage;
-static unsigned int queue_size;
-static unsigned int threads;
-static std::string kvdb_path;
-static std::string environment;
+std::string endpoint;
+std::string file_storage;
+unsigned int queue_size;
+unsigned int threads;
+std::string kvdb_path;
+std::string environment;
+std::string graph_out_dir;
+int protocol_queue;
+std::string protocol_location;
+int debug_level;
+std::string asset_trace;
+int log_level;
 
 void configureSubcommandRun(std::shared_ptr<CLI::App> app)
 {
@@ -93,14 +80,64 @@ void configureSubcommandRun(std::shared_ptr<CLI::App> app)
         ->check(CLI::ExistingDirectory);
 
     // Environment
-    run->add_option("--environment", args::environment, "Environment name.")
-        ->required();
+    run->add_option("--environment", args::environment, "Environment name.")->required();
+
+    // Log level
+    run->add_option("-l, --log_level",
+                    args::log_level,
+                    "Log level. 0 = Debug, 1 = Info, 2 = Warning, 3 = Error")
+        ->default_val(3);
 }
 
 void configureSubcommandLogtest(std::shared_ptr<CLI::App> app)
 {
     CLI::App* logtest = app->add_subcommand(args::SUBCOMMAND_LOGTEST,
                                             "Run the Wazuh engine module in test mode.");
+    // KVDB path
+    logtest->add_option("-k, --kvdb_path", args::kvdb_path, "Path to KVDB folder.")
+        ->default_val("/var/ossec/queue/db/kvdb/")
+        ->check(CLI::ExistingDirectory);
+
+    // File storage
+    logtest
+        ->add_option("-f, --file_storage",
+                     args::file_storage,
+                     "Path to folder where assets are located.")
+        ->required()
+        ->check(CLI::ExistingDirectory);
+
+    // Environment
+    logtest->add_option("--environment", args::environment, "Environment name.")
+        ->required();
+
+    // Protocol queue
+    logtest
+        ->add_option("-q, --protocol_queue",
+                     args::protocol_queue,
+                     "Protocol queue number of the event.")
+        ->default_val(1);
+
+    // Protocol location
+    logtest
+        ->add_option(
+            "-l, --protocol_location", args::protocol_location, "Protocol location.")
+        ->default_val("/dev/stdin");
+
+    // Debug levels
+    auto debug = logtest->add_flag("-d, --debug",
+                                   args::debug_level,
+                                   "Enable debug mode [0-2]. "
+                                   "0: No debug, 1: Asset history, 2: 1 + "
+                                   "Full tracing.");
+
+    // Trace
+    logtest
+        ->add_option(
+            "-t, --trace",
+            args::asset_trace,
+            "Assets to be traced, separated by commas. Only effective if debug=2.")
+        ->needs(debug)
+        ->default_val(args::TRACE_ALL);
 }
 
 void configureSubcommandGraph(std::shared_ptr<CLI::App> app)
@@ -108,6 +145,29 @@ void configureSubcommandGraph(std::shared_ptr<CLI::App> app)
     CLI::App* graph = app->add_subcommand(
         args::SUBCOMMAND_GRAPH,
         "Validate and generate environment graph and expression graph.");
+
+    // KVDB path
+    graph->add_option("-k, --kvdb_path", args::kvdb_path, "Path to KVDB folder.")
+        ->default_val("/var/ossec/queue/db/kvdb/")
+        ->check(CLI::ExistingDirectory);
+
+    // File storage
+    graph
+        ->add_option("-f, --file_storage",
+                     args::file_storage,
+                     "Path to folder where assets are located.")
+        ->required()
+        ->check(CLI::ExistingDirectory);
+
+    // Environment
+    graph->add_option("--environment", args::environment, "Environment name.")
+        ->required();
+
+    // Graph dir
+    graph
+        ->add_option(
+            "-o, --output_dir", args::graph_out_dir, "Directory to save graph files")
+        ->default_str(args::ENV_DEF_DIR);
 }
 
 std::shared_ptr<CLI::App> configureCliApp()
@@ -125,164 +185,8 @@ std::shared_ptr<CLI::App> configureCliApp()
 }
 } // namespace args
 
-static void sigint_handler(const int signum)
-{
-    // Inform threads that they must exit
-    gs_doRun = false;
-
-    for (auto& t : gs_threadList)
-    {
-        t.join();
-    };
-
-    exit(0);
-}
-
-// Get all exceptions nested also
-static std::string getFullException(const std::exception& e, int level = 0)
-{
-    std::stringstream ss;
-    ss << std::string(level, ' ') << "exception: " << e.what() << '\n';
-    try
-    {
-        std::rethrow_if_nested(e);
-    }
-    catch (const std::exception& nestedException)
-    {
-        ss << getFullException(nestedException, level + 1);
-    }
-    catch (...)
-    {
-    }
-
-    return ss.str();
-}
-
-static void run()
-{
-    // Init logging
-    // TODO: add cmd to config logging level
-    logging::LoggingConfig logConfig;
-    logConfig.logLevel = logging::LogLevel::Debug;
-    logging::loggingInit(logConfig);
-
-    KVDBManager::init(args::kvdb_path);
-
-    engineserver::EngineServer server {{args::endpoint},
-                                       static_cast<size_t>(args::queue_size)};
-    if (!server.isConfigured())
-    {
-        WAZUH_LOG_ERROR("Could not configure server for endpoint [{}], engine "
-                        "inizialization aborted.",
-                        args::endpoint);
-        return;
-    }
-
-    catalog::Catalog _catalog(catalog::StorageType::Local, args::file_storage);
-
-    auto hlpParsers =
-        _catalog.getFileContents(catalog::AssetType::Schema, "wazuh-logql-types");
-    // TODO because builders don't have access to the catalog we are configuring
-    // the parser mappings on start up for now
-    hlp::configureParserMappings(hlpParsers);
-
-    try
-    {
-        builder::internals::registerBuilders();
-    }
-    catch (const std::exception& e)
-    {
-        WAZUH_LOG_ERROR("Exception while registering builders: [{}]",
-                        getFullException(e));
-        return;
-    }
-    // TODO: Handle errors on construction
-    builder::Builder<catalog::Catalog> _builder(_catalog);
-    decltype(_builder.buildEnvironment(args::environment)) env;
-    try
-    {
-        env = _builder.buildEnvironment(args::environment);
-    }
-    catch (const std::exception& e)
-    {
-        WAZUH_LOG_ERROR("Exception while building environment: [{}]",
-                        getFullException(e));
-        return;
-    }
-
-    // Processing Workers (Router), Router is replicated in each thread
-    // TODO: handle hot modification of routes
-    for (auto i = 0; i < args::threads; ++i)
-    {
-        std::thread t {
-            [=, &eventBuffer = server.output()]()
-            {
-                auto controller = rxbk::buildRxPipeline(env);
-
-                // else if (trace)
-                // {
-                //     for (auto assetName : traceNames)
-                //     {
-                //         router.subscribeTraceSink(
-                //             "test_environment", assetName, cerrLogger);
-                //     }
-                // }
-
-                // Thread loop
-                while (gs_doRun)
-                {
-                    std::string event;
-
-                    if (eventBuffer.wait_dequeue_timed(event, WAIT_DEQUEUE_TIMEOUT_USEC))
-                    {
-                        WAZUH_TRACE_SCOPE("Router on-next");
-                        try
-                        {
-                            auto result = base::result::makeSuccess(
-                                engineserver::ProtocolHandler::parse(event));
-                            controller.ingestEvent(
-                                std::make_shared<base::result::Result<base::Event>>(
-                                    std::move(result)));
-                        }
-                        catch (const std::exception& e)
-                        {
-                            WAZUH_LOG_ERROR(
-                                "An error ocurred while parsing a message: [{}]",
-                                e.what());
-                        }
-                    }
-                }
-
-                controller.complete();
-                return 0;
-            }};
-
-        gs_threadList.push_back(std::move(t));
-    }
-
-    server.run();
-
-    logging::loggingTerm();
-
-    return;
-}
-
-static void logtest() {}
-
-static void graph() {}
-
 int main(int argc, char* argv[])
 {
-    // Set Crt+C handler
-    sigset_t sig_empty_mask;
-    sigemptyset(&sig_empty_mask);
-
-    struct sigaction sigintAction;
-    sigintAction.sa_handler = sigint_handler;
-    sigintAction.sa_mask = sig_empty_mask;
-
-    sigaction(SIGINT, &sigintAction, NULL);
-
     // Configure argument parsers
     auto app = args::configureCliApp();
     CLI11_PARSE(*app, argc, argv);
@@ -290,15 +194,41 @@ int main(int argc, char* argv[])
     // Launch parsed subcommand
     if (app->get_subcommand(args::SUBCOMMAND_RUN)->parsed())
     {
-        run();
+        cmd::run(args::kvdb_path,
+                 args::endpoint,
+                 args::queue_size,
+                 args::threads,
+                 args::file_storage,
+                 args::environment,
+                 args::log_level);
     }
     else if (app->get_subcommand(args::SUBCOMMAND_LOGTEST)->parsed())
     {
-        logtest();
+        std::vector<std::string> assetTrace;
+        bool TraceAll = false;
+
+        if (args::TRACE_ALL == args::asset_trace)
+        {
+            TraceAll = true;
+        }
+        else
+        {
+            assetTrace = utils::string::split(args::asset_trace, ',');
+        }
+
+        cmd::test(args::kvdb_path,
+                  args::file_storage,
+                  args::environment,
+                  args::debug_level,
+                  TraceAll,
+                  assetTrace,
+                  args::protocol_queue,
+                  args::protocol_location);
     }
     else if (app->get_subcommand(args::SUBCOMMAND_GRAPH)->parsed())
     {
-        graph();
+        cmd::graph(
+            args::kvdb_path, args::file_storage, args::environment, args::graph_out_dir);
     }
     else
     {

--- a/src/engine/source/rxbk/include/rxbk/rxFactory.hpp
+++ b/src/engine/source/rxbk/include/rxbk/rxFactory.hpp
@@ -57,7 +57,7 @@ public:
      * @return std::function<void(const std::string&)> A function that can be used to log
      * a trace message.
      */
-    std::function<void(const std::string&)> getTracerFn(std::string name);
+    std::function<void(const std::string&)> getTracerFn(std::string name) const;
 
     /**
      * @brief Subscribe to the output of the tracer.
@@ -163,6 +163,24 @@ public:
      * @return rx::composite_subscription Aggregated subscription to the outputs.
      */
     rx::composite_subscription listenOnAllTrace(rxcpp::subscriber<std::string> s);
+
+    /**
+     * @brief Check if controller has specific tracer.
+     *
+     * @param name Name of the tracer to check.
+     * @return true if controller has tracer.
+     * @return false otherwise.
+     */
+    bool hasTracer(const std::string& name) const;
+
+    /**
+     * @brief Get the Tracer object
+     *
+     * @param name Name of the tracer to get.
+     * @return const Tracer& The tracer object.
+     * @throw std::out_of_range If the tracer does not exist.
+     */
+    const Tracer& getTracer(const std::string& name) const;
 };
 
 /**


### PR DESCRIPTION
|Related issue|
|---|
|Closes #14745 |

Added three commands to the engine executable:
```
$ ./main -h
Wazuh engine module. Check Subcommands for more information.
Usage: ./main [OPTIONS] SUBCOMMAND

Options:
  -h,--help                   Print this help message and exit

Subcommands:
  run                         Run the Wazuh engine module.
  test                        Run the Wazuh engine module in test mode.
  graph                       Validate and generate environment graph and expression graph.
```

Other changes:
- Fixed multiple parents on same named expression tracer duplication.
- Removed hyphens when getting graphviz environment string.
- Fixed rxbak Or expression output when it fails.

## Tests (local)
![Screenshot from 2022-09-02 10-40-45](https://user-images.githubusercontent.com/32262972/188100446-27712244-177f-4c74-8584-f71bc5fa0d36.png)


