### PR TITLE
Engine update json parser

### DIFF
--- a/src/engine/source/hlp/src/hlpDetails.cpp
+++ b/src/engine/source/hlp/src/hlpDetails.cpp
@@ -8,7 +8,7 @@ const parserConfigFuncPtr kParsersConfig[] = {
     nullptr,
     configureTsParser,
     nullptr,
-    nullptr,
+    configureJsonParser,
     configureMapParser,
     configureDomainParser,
     configureFilepathParser,

--- a/src/engine/source/hlp/src/logQLParser.cpp
+++ b/src/engine/source/hlp/src/logQLParser.cpp
@@ -106,7 +106,7 @@ static std::vector<std::string> splitSlashSeparatedField(std::string_view str)
 static bool parseCapture(Tokenizer& tk, ExpressionList& expresions)
 {
     // Available options: <name> || <?name> || <name1>?<name2>
-    // Forbidden options: <name  || <name>? || <name><name>
+    // Forbidden options: <name  || <name>? || TODO: <name><name>
     Token token = getToken(tk);
     bool optional = false;
     if (token.type == TokenType::QuestionMark)
@@ -156,13 +156,6 @@ static bool parseCapture(Tokenizer& tk, ExpressionList& expresions)
             auto& currentCapture = expresions.back();
             currentCapture.endToken = endToken;
             prevCapture.endToken = endToken;
-        }
-        else if (peekToken(tk).type == TokenType::OpenAngle)
-        {
-            // By definition can't have two consecutive fields
-            // TODO: we should specify what's causing the error
-            return false;
-
         }
         else
         {

--- a/src/engine/source/hlp/src/logQLParser.cpp
+++ b/src/engine/source/hlp/src/logQLParser.cpp
@@ -105,7 +105,8 @@ static std::vector<std::string> splitSlashSeparatedField(std::string_view str)
 
 static bool parseCapture(Tokenizer& tk, ExpressionList& expresions)
 {
-    //<name> || <?name> || <name1>?<name2>
+    // Available options: <name> || <?name> || <name1>?<name2>
+    // Forbidden options: <name  || <name>? || <name><name>
     Token token = getToken(tk);
     bool optional = false;
     if (token.type == TokenType::QuestionMark)
@@ -155,6 +156,13 @@ static bool parseCapture(Tokenizer& tk, ExpressionList& expresions)
             auto& currentCapture = expresions.back();
             currentCapture.endToken = endToken;
             prevCapture.endToken = endToken;
+        }
+        else if (peekToken(tk).type == TokenType::OpenAngle)
+        {
+            // By definition can't have two consecutive fields
+            // TODO: we should specify what's causing the error
+            return false;
+
         }
         else
         {

--- a/src/engine/source/hlp/src/specificParsers.cpp
+++ b/src/engine/source/hlp/src/specificParsers.cpp
@@ -33,7 +33,7 @@ enum class JSON_TYPE
     J_NULL
 };
 
-static const std::unordered_map<std::string, JSON_TYPE> jsonTypes = {
+static const std::unordered_map<std::string_view, JSON_TYPE> jsonTypes = {
     {"string", JSON_TYPE::J_STRING},
     {"bool", JSON_TYPE::J_BOOL},
     {"number", JSON_TYPE::J_NUMBER},
@@ -42,7 +42,7 @@ static const std::unordered_map<std::string, JSON_TYPE> jsonTypes = {
     {"null", JSON_TYPE::J_NULL},
     {"any", JSON_TYPE::J_ANY}};
 
-bool validJsonType(const std::string& type)
+bool validJsonType(std::string_view type)
 {
     return jsonTypes.find(type) != jsonTypes.end();
 }
@@ -222,7 +222,7 @@ bool configureJsonParser(Parser& parser, std::vector<std::string_view> const& ar
         // If one argument, it must be a valid json type or "any"
         if (args.size() == 1)
         {
-            if (validJsonType(std::string {args[0]}))
+            if (validJsonType(args[0]))
             {
                 parser.options.push_back(std::string {args[0]});
             }
@@ -385,42 +385,12 @@ bool parseJson(const char** it, Parser const& parser, ParseResult& result)
     switch (jsonTypes.at(parser.options[0]))
     {
         case JSON_TYPE::J_ANY: valid = true; break;
-        case JSON_TYPE::J_STRING:
-            if (doc.IsString())
-            {
-                valid = true;
-            }
-            break;
-        case JSON_TYPE::J_BOOL:
-            if (doc.IsBool())
-            {
-                valid = true;
-            }
-            break;
-        case JSON_TYPE::J_NUMBER:
-            if (doc.IsNumber())
-            {
-                valid = true;
-            }
-            break;
-        case JSON_TYPE::J_OBJECT:
-            if (doc.IsObject())
-            {
-                valid = true;
-            }
-            break;
-        case JSON_TYPE::J_ARRAY:
-            if (doc.IsArray())
-            {
-                valid = true;
-            }
-            break;
-        case JSON_TYPE::J_NULL:
-            if (doc.IsNull())
-            {
-                valid = true;
-            }
-            break;
+        case JSON_TYPE::J_STRING: valid = doc.IsString(); break;
+        case JSON_TYPE::J_BOOL: valid = doc.IsBool(); break;
+        case JSON_TYPE::J_NUMBER: valid = doc.IsNumber(); break;
+        case JSON_TYPE::J_OBJECT: valid = doc.IsObject(); break;
+        case JSON_TYPE::J_ARRAY: valid = doc.IsArray(); break;
+        case JSON_TYPE::J_NULL: valid = doc.IsNull(); break;
     }
 
     // Extract the json string and update the pointer

--- a/src/engine/source/hlp/src/specificParsers.cpp
+++ b/src/engine/source/hlp/src/specificParsers.cpp
@@ -308,12 +308,9 @@ bool parseAny(const char** it, Parser const& parser, ParseResult& result)
 bool matchLiteral(const char** it, Parser const& parser, ParseResult&)
 {
     size_t i = 0;
-    bool escaped = false;
     for (; (**it) && (i < parser.name.size());)
     {
-        // Skip over the escaping '\'
-        escaped = *it[0] == '\\';
-        if (!escaped && **it != parser.name[i])
+        if (**it != parser.name[i])
         {
             return false;
         }

--- a/src/engine/source/hlp/src/specificParsers.cpp
+++ b/src/engine/source/hlp/src/specificParsers.cpp
@@ -308,15 +308,12 @@ bool parseAny(const char** it, Parser const& parser, ParseResult& result)
 bool matchLiteral(const char** it, Parser const& parser, ParseResult&)
 {
     size_t i = 0;
+    bool escaped = false;
     for (; (**it) && (i < parser.name.size());)
     {
         // Skip over the escaping '\'
-        if (**it == '\\')
-        {
-            continue;
-        }
-
-        if (**it != parser.name[i])
+        escaped = *it[0] == '\\';
+        if (!escaped && **it != parser.name[i])
         {
             return false;
         }

--- a/src/engine/source/hlp/src/specificParsers.hpp
+++ b/src/engine/source/hlp/src/specificParsers.hpp
@@ -67,6 +67,16 @@ bool configureQuotedString(Parser& parser, std::vector<std::string_view> const& 
  * @return always true
  */
 bool configureBooleanParser(Parser& parser, std::vector<std::string_view> const& args);
+
+/**
+ * @brief Method for pre-configure JSON parsing
+ *
+ * @param args json type format being the possibilities: "string", "bool", "number",
+ * "object", "array", "null" or "any".
+ * @return true if one of the possibles types was matched.
+ * @throws std::runtime_error if args not in list or wrong quantity.
+ */
+bool configureJsonParser(Parser& parser, std::vector<std::string_view> const& args);
 /**
  * @brief Parse an unspecified element until an endtoken character is found
  *

--- a/src/engine/test/source/hlp/hlp_test.cpp
+++ b/src/engine/test/source/hlp/hlp_test.cpp
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+#include "rapidjson/document.h"
+
 using namespace hlp;
 
 TEST(hlpTests_logQL, logQL_expression)
@@ -106,7 +108,7 @@ TEST(hlpTests_logQL, optional_Field_Not_Found)
 
 TEST(hlpTests_logQL, optional_Or)
 {
-    //TODO: this should be fixed and tested in other aspects
+    // TODO: this should be fixed and tested in other aspects
     static const char* logQl = "<_url/url>?<_field/json>";
     static const char* eventjson = "{\"String\":\"SomeValue\"}";
     static const char* eventURL = "https://user:password@wazuh.com:8080/path"
@@ -241,8 +243,56 @@ TEST(hlpTests_IPaddress, IPV6_failed)
     ASSERT_TRUE(result.find("_ip") == result.end());
 }
 
-// Test: parsing json objects
-TEST(hlpTests_json, success_parsing)
+// Test: parsing json
+TEST(hlpTests_json, parameters_failure_cases)
+{
+    const char* logQl1 = "<_json/json/param1/param2>";
+    const char* logQl2 = "<_json/json/wrongType>";
+
+    const char* event = "{\"key1\":\"value1\",\"key2\":\"value2\"}";
+
+    ASSERT_THROW(getParserOp(logQl1), std::runtime_error);
+    ASSERT_THROW(getParserOp(logQl2), std::runtime_error);
+}
+
+TEST(hlpTests_json, object_success)
+{
+    const char* logQl = "<_json/json/object>";
+
+    const char* event = "{\"key1\":\"value1\",\"key2\":\"value2\"}";
+
+    auto parseOp = getParserOp(logQl);
+    ParseResult result;
+    bool ret = parseOp(event, result);
+
+    ASSERT_EQ(true, static_cast<bool>(parseOp));
+    ASSERT_EQ("{\"key1\":\"value1\",\"key2\":\"value2\"}",
+              std::any_cast<JsonString>(result["_json"]).jsonString);
+}
+
+TEST(hlpTests_json, object_failure_cases)
+{
+    const char* logQl = "<_json/json/object>";
+
+    const char* eventNotClosed = "{\"key1\":\"value1\",\"key2\":\"value2\"";
+    const char* eventNumber = "1234";
+    const char* eventString = "\"string\"";
+    const char* eventArray = "[1,2,3,4]";
+    const char* eventBool = "true";
+    const char* eventNull = "null";
+
+    auto parseOp = getParserOp(logQl);
+    ParseResult result;
+
+    ASSERT_FALSE(parseOp(eventNotClosed, result));
+    ASSERT_FALSE(parseOp(eventNumber, result));
+    ASSERT_FALSE(parseOp(eventString, result));
+    ASSERT_FALSE(parseOp(eventArray, result));
+    ASSERT_FALSE(parseOp(eventBool, result));
+    ASSERT_FALSE(parseOp(eventNull, result));
+}
+
+TEST(hlpTests_json, success_parsing_object_by_default)
 {
     const char* logQl = "<_field1/json> - <_field2/json>";
     const char* event = "{\"String\":\"This is a string\"} - "
@@ -259,20 +309,62 @@ TEST(hlpTests_json, success_parsing)
               std::any_cast<JsonString>(result["_field2"]).jsonString);
 }
 
-TEST(hlpTests_json, failed_incomplete_json)
+TEST(hlpTests_json, several_results_different_types)
 {
-    const char* logQl = "<_json/json>";
-    const char* event = "{\"String\":{\"This is a string\"}";
+    const char* logQlObject = " <_json1/json> ";
+    const char* logQlAny = " <_json2/json/any> ";
+    const char* logQlString = " <_json3/json/string> ";
+    const char* event = " {\"String\":\"This is a string\"} ";
 
-    auto parseOp = getParserOp(logQl);
+    auto parseOpObj = getParserOp(logQlObject);
+    auto parseOpString = getParserOp(logQlString);
+    auto parseOpAny = getParserOp(logQlAny);
+
     ParseResult result;
-    bool ret = parseOp(event, result);
+    bool retObj = parseOpObj(event, result);
+    ASSERT_TRUE(retObj);
+    ASSERT_FALSE(result.find("_json1") == result.end());
+    ASSERT_EQ("{\"String\":\"This is a string\"}", std::any_cast<JsonString>(result["_json1"]).jsonString);
 
-    ASSERT_EQ(true, static_cast<bool>(parseOp));
-    ASSERT_TRUE(result.find("_json") == result.end());
+    bool retAny = parseOpAny(event, result);
+    ASSERT_TRUE(retAny);
+    ASSERT_FALSE(result.find("_json2") == result.end());
+    ASSERT_EQ("{\"String\":\"This is a string\"}", std::any_cast<JsonString>(result["_json2"]).jsonString);
+
+    bool retString = parseOpString(event, result);
+    ASSERT_FALSE(retString);
+    ASSERT_TRUE(result.find("_json3") == result.end());
 }
 
-TEST(hlpTests_json, success_array)
+TEST(hlpTests_json, success_matching_string_and_any)
+{
+    const char* logQlObject = "<_json1/json>";
+    const char* logQlAny = "<_json2/json/any>";
+    const char* logQlString = "<_json3/json/string>";
+    const char* event = "\"String\"{\"This is a string\"}";
+
+    auto parseOpObj = getParserOp(logQlObject);
+    auto parseOpString = getParserOp(logQlString);
+    auto parseOpAny = getParserOp(logQlAny);
+
+    ParseResult result;
+    bool retObj = parseOpObj(event, result);
+    ASSERT_FALSE(retObj);
+    ASSERT_TRUE(result.find("_json1") == result.end());
+    // ASSERT_EQ("{\"String\":\"This is a string\"}", std::any_cast<JsonString>(result["_json1"]).jsonString);
+
+    bool retAny = parseOpAny(event, result);
+    ASSERT_TRUE(retAny);
+    ASSERT_FALSE(result.find("_json2") == result.end());
+    ASSERT_EQ("\"String\"", std::any_cast<JsonString>(result["_json2"]).jsonString);
+
+    bool retString = parseOpString(event, result);
+    ASSERT_TRUE(retString);
+    ASSERT_FALSE(result.find("_json3") == result.end());
+    ASSERT_EQ("\"String\"", std::any_cast<JsonString>(result["_json3"]).jsonString);
+}
+
+TEST(hlpTests_json, success_array_in_object)
 {
     const char* logQl = "<_json/json>";
     const char* event = "{\"String\": [ {\"SecondString\":\"This is a "
@@ -299,6 +391,91 @@ TEST(hlpTests_json, failed_not_string)
 
     ASSERT_EQ(true, static_cast<bool>(parseOp));
     ASSERT_TRUE(result.find("_json") == result.end());
+}
+
+TEST(hlpTests_json, success_array)
+{
+    const char* logQl = "<_json/json/array>";
+    const char* event = "[ {\"A\":\"1\"}, {\"B\":\"2\"}, {\"C\":\"3\"} ]";
+
+    auto parseOp = getParserOp(logQl);
+    ParseResult result;
+    bool ret = parseOp(event, result);
+
+    ASSERT_EQ(true, static_cast<bool>(parseOp));
+    //Isarray
+    ASSERT_EQ("[ {\"A\":\"1\"}, {\"B\":\"2\"}, {\"C\":\"3\"} ]",
+              std::any_cast<JsonString>(result["_json"]).jsonString);
+}
+
+TEST(hlpTests_json, success_any)
+{
+    const char* logQl = " <_json/json/any> ";
+    const char* event = " {\"C\":\"3\"} ";
+
+    auto parseOp = getParserOp(logQl);
+    ParseResult result;
+    bool ret = parseOp(event, result);
+
+    ASSERT_EQ(true, static_cast<bool>(parseOp));
+    //Isarray
+    ASSERT_EQ("{\"C\":\"3\"}", std::any_cast<JsonString>(result["_json"]).jsonString);
+}
+
+TEST(hlpTests_json, success_string)
+{
+    const char* logQl = " <_json/json/string> ";
+    const char* event = " \"string\" ";
+
+    auto parseOp = getParserOp(logQl);
+    ParseResult result;
+    bool ret = parseOp(event, result);
+
+    ASSERT_EQ(true, static_cast<bool>(parseOp));
+    //Isarray
+    ASSERT_EQ("\"string\"", std::any_cast<JsonString>(result["_json"]).jsonString);
+}
+
+TEST(hlpTests_json, success_bool)
+{
+    const char* logQl = " <_json/json/bool> ";
+    const char* event = " true ";
+
+    auto parseOp = getParserOp(logQl);
+    ParseResult result;
+    bool ret = parseOp(event, result);
+
+    ASSERT_EQ(true, static_cast<bool>(parseOp));
+    //Isarray
+    ASSERT_EQ("true", std::any_cast<JsonString>(result["_json"]).jsonString);
+}
+
+TEST(hlpTests_json, success_number)
+{
+    const char* logQl = " <_json/json/number> ";
+    const char* event = " 123 ";
+
+    auto parseOp = getParserOp(logQl);
+    ParseResult result;
+    bool ret = parseOp(event, result);
+
+    ASSERT_EQ(true, static_cast<bool>(parseOp));
+    //Isarray
+    ASSERT_EQ("123", std::any_cast<JsonString>(result["_json"]).jsonString);
+}
+
+TEST(hlpTests_json, success_null)
+{
+    const char* logQl = " <_json/json/null> ";
+    const char* event = " null ";
+
+    auto parseOp = getParserOp(logQl);
+    ParseResult result;
+    bool ret = parseOp(event, result);
+
+    ASSERT_EQ(true, static_cast<bool>(parseOp));
+    //Isarray
+    ASSERT_EQ("null", std::any_cast<JsonString>(result["_json"]).jsonString);
 }
 
 // Test: parsing maps objects

--- a/src/engine/test/source/hlp/hlp_test.cpp
+++ b/src/engine/test/source/hlp/hlp_test.cpp
@@ -255,9 +255,10 @@ TEST(hlpTests_json, object_success)
     ParseResult result;
     bool ret = parseOp(event, result);
 
-    ASSERT_EQ(true, static_cast<bool>(parseOp));
-    ASSERT_EQ("{\"key1\":\"value1\",\"key2\":\"value2\"}",
-              std::any_cast<JsonString>(result["_json"]).jsonString);
+    ASSERT_TRUE(static_cast<bool>(parseOp));
+    const auto expectedResult {R"({"key1":"value1","key2":"value2"})"};
+    ASSERT_STREQ(expectedResult,
+                 std::any_cast<JsonString>(result["_json"]).jsonString.data());
 }
 
 TEST(hlpTests_json, object_failure_cases)
@@ -292,11 +293,11 @@ TEST(hlpTests_json, success_parsing_object_by_default)
     ParseResult result;
     bool ret = parseOp(event, result);
 
-    ASSERT_EQ(true, static_cast<bool>(parseOp));
-    ASSERT_EQ("{\"String\":\"This is a string\"}",
-              std::any_cast<JsonString>(result["_field1"]).jsonString);
-    ASSERT_EQ("{\"String\":\"This is another string\"}",
-              std::any_cast<JsonString>(result["_field2"]).jsonString);
+    ASSERT_TRUE(static_cast<bool>(parseOp));
+    ASSERT_STREQ("{\"String\":\"This is a string\"}",
+              std::any_cast<JsonString>(result["_field1"]).jsonString.data());
+    ASSERT_STREQ("{\"String\":\"This is another string\"}",
+              std::any_cast<JsonString>(result["_field2"]).jsonString.data());
 }
 
 TEST(hlpTests_json, several_results_different_types)
@@ -314,12 +315,14 @@ TEST(hlpTests_json, several_results_different_types)
     bool retObj = parseOpObj(event, result);
     ASSERT_TRUE(retObj);
     ASSERT_FALSE(result.find("_json1") == result.end());
-    ASSERT_EQ("{\"String\":\"This is a string\"}", std::any_cast<JsonString>(result["_json1"]).jsonString);
+    ASSERT_STREQ("{\"String\":\"This is a string\"}",
+                 std::any_cast<JsonString>(result["_json1"]).jsonString.data());
 
     bool retAny = parseOpAny(event, result);
     ASSERT_TRUE(retAny);
     ASSERT_FALSE(result.find("_json2") == result.end());
-    ASSERT_EQ("{\"String\":\"This is a string\"}", std::any_cast<JsonString>(result["_json2"]).jsonString);
+    ASSERT_STREQ("{\"String\":\"This is a string\"}",
+                 std::any_cast<JsonString>(result["_json2"]).jsonString.data());
 
     bool retString = parseOpString(event, result);
     ASSERT_FALSE(retString);
@@ -341,17 +344,18 @@ TEST(hlpTests_json, success_matching_string_and_any)
     bool retObj = parseOpObj(event, result);
     ASSERT_FALSE(retObj);
     ASSERT_TRUE(result.find("_json1") == result.end());
-    // ASSERT_EQ("{\"String\":\"This is a string\"}", std::any_cast<JsonString>(result["_json1"]).jsonString);
 
     bool retAny = parseOpAny(event, result);
     ASSERT_TRUE(retAny);
     ASSERT_FALSE(result.find("_json2") == result.end());
-    ASSERT_EQ("\"String\"", std::any_cast<JsonString>(result["_json2"]).jsonString);
+    ASSERT_STREQ("\"String\"",
+                 std::any_cast<JsonString>(result["_json2"]).jsonString.data());
 
     bool retString = parseOpString(event, result);
     ASSERT_TRUE(retString);
     ASSERT_FALSE(result.find("_json3") == result.end());
-    ASSERT_EQ("\"String\"", std::any_cast<JsonString>(result["_json3"]).jsonString);
+    ASSERT_STREQ("\"String\"",
+                 std::any_cast<JsonString>(result["_json3"]).jsonString.data());
 }
 
 TEST(hlpTests_json, success_array_in_object)
@@ -364,10 +368,10 @@ TEST(hlpTests_json, success_array_in_object)
     ParseResult result;
     bool ret = parseOp(event, result);
 
-    ASSERT_EQ(true, static_cast<bool>(parseOp));
-    ASSERT_EQ("{\"String\": [ {\"SecondString\":\"This is a "
+    ASSERT_TRUE(static_cast<bool>(parseOp));
+    ASSERT_STREQ("{\"String\": [ {\"SecondString\":\"This is a "
               "string\"}, {\"ThirdString\":\"This is a string\"} ] }",
-              std::any_cast<JsonString>(result["_json"]).jsonString);
+              std::any_cast<JsonString>(result["_json"]).jsonString.data());
 }
 
 TEST(hlpTests_json, failed_not_string)
@@ -379,7 +383,7 @@ TEST(hlpTests_json, failed_not_string)
     ParseResult result;
     bool ret = parseOp(event, result);
 
-    ASSERT_EQ(true, static_cast<bool>(parseOp));
+    ASSERT_TRUE(static_cast<bool>(parseOp));
     ASSERT_TRUE(result.find("_json") == result.end());
 }
 
@@ -392,10 +396,9 @@ TEST(hlpTests_json, success_array)
     ParseResult result;
     bool ret = parseOp(event, result);
 
-    ASSERT_EQ(true, static_cast<bool>(parseOp));
-    //Isarray
-    ASSERT_EQ("[ {\"A\":\"1\"}, {\"B\":\"2\"}, {\"C\":\"3\"} ]",
-              std::any_cast<JsonString>(result["_json"]).jsonString);
+    ASSERT_TRUE(static_cast<bool>(parseOp));
+    ASSERT_STREQ("[ {\"A\":\"1\"}, {\"B\":\"2\"}, {\"C\":\"3\"} ]",
+              std::any_cast<JsonString>(result["_json"]).jsonString.data());
 }
 
 TEST(hlpTests_json, success_any)
@@ -407,9 +410,9 @@ TEST(hlpTests_json, success_any)
     ParseResult result;
     bool ret = parseOp(event, result);
 
-    ASSERT_EQ(true, static_cast<bool>(parseOp));
-    //Isarray
-    ASSERT_EQ("{\"C\":\"3\"}", std::any_cast<JsonString>(result["_json"]).jsonString);
+    ASSERT_TRUE(static_cast<bool>(parseOp));
+    ASSERT_STREQ("{\"C\":\"3\"}",
+                 std::any_cast<JsonString>(result["_json"]).jsonString.data());
 }
 
 TEST(hlpTests_json, success_string)
@@ -421,9 +424,9 @@ TEST(hlpTests_json, success_string)
     ParseResult result;
     bool ret = parseOp(event, result);
 
-    ASSERT_EQ(true, static_cast<bool>(parseOp));
-    //Isarray
-    ASSERT_EQ("\"string\"", std::any_cast<JsonString>(result["_json"]).jsonString);
+    ASSERT_TRUE(static_cast<bool>(parseOp));
+    ASSERT_STREQ("\"string\"",
+                 std::any_cast<JsonString>(result["_json"]).jsonString.data());
 }
 
 TEST(hlpTests_json, success_bool)
@@ -435,9 +438,8 @@ TEST(hlpTests_json, success_bool)
     ParseResult result;
     bool ret = parseOp(event, result);
 
-    ASSERT_EQ(true, static_cast<bool>(parseOp));
-    //Isarray
-    ASSERT_EQ("true", std::any_cast<JsonString>(result["_json"]).jsonString);
+    ASSERT_TRUE(static_cast<bool>(parseOp));
+    ASSERT_STREQ("true", std::any_cast<JsonString>(result["_json"]).jsonString.data());
 }
 
 TEST(hlpTests_json, success_number)
@@ -449,9 +451,8 @@ TEST(hlpTests_json, success_number)
     ParseResult result;
     bool ret = parseOp(event, result);
 
-    ASSERT_EQ(true, static_cast<bool>(parseOp));
-    //Isarray
-    ASSERT_EQ("123", std::any_cast<JsonString>(result["_json"]).jsonString);
+    ASSERT_TRUE(static_cast<bool>(parseOp));
+    ASSERT_STREQ("123", std::any_cast<JsonString>(result["_json"]).jsonString.data());
 }
 
 TEST(hlpTests_json, success_null)
@@ -463,9 +464,8 @@ TEST(hlpTests_json, success_null)
     ParseResult result;
     bool ret = parseOp(event, result);
 
-    ASSERT_EQ(true, static_cast<bool>(parseOp));
-    //Isarray
-    ASSERT_EQ("null", std::any_cast<JsonString>(result["_json"]).jsonString);
+    ASSERT_TRUE(static_cast<bool>(parseOp));
+    ASSERT_STREQ("null", std::any_cast<JsonString>(result["_json"]).jsonString.data());
 }
 
 // Test: parsing maps objects


### PR DESCRIPTION
|Related issue|
|---|
|Epic #13803 |

## Description
JSON parser parses all valid JSONs, including primitives types. This means that the JSON decoder will accept and decode every log starting with a `"string"` or plain number.

Normally, a log in JSON format or containing some JSON string will be an object, so we are proposing that the JSON parser will extract objects by default and allows other types with parametrization. 

Regardless if we use parametrization or multiple parsers we need the ability to parse specific types of JSON.

Additional fixes:

- Escaped issue: If in the literal matching there was a '\\' the parser was remaining block in an infinite loop
