### PR TITLE
Make cluster wait for agent-info data from wdb asynchronously

### DIFF
--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -648,7 +648,10 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         """
         logger = self.task_loggers["Agent-info sync"]
         wdb_conn = AsyncWazuhDBConnection(self.loop)
-        await wdb_conn.open_connection()
+        try:
+            await wdb_conn.open_connection()
+        except FileNotFoundError:
+            logger.error('Could not connect to wazuh-db.')
         synced = True
         agent_info = SyncWazuhdb(worker=self, logger=logger, cmd=b'syn_a_w_m', data_retriever=wdb_conn.run_wdb_command,
                                  get_data_command='global sync-agent-info-get ',

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -407,6 +407,7 @@ class WazuhException(Exception):
         2008: {'message': 'Corrupted RBAC database',
                'remediation': 'Restart the Wazuh service to restore the RBAC database to default'},
         2009: {'message': 'Pagination error. Response from wazuh-db was over the maximum socket buffer size'},
+        2010: {'message': 'The requested read operation did not complete fully'},
 
         # Cluster
         3000: 'Cluster',

--- a/framework/wazuh/core/tests/test_wdb.py
+++ b/framework/wazuh/core/tests/test_wdb.py
@@ -1,19 +1,112 @@
 # Copyright (C) 2015, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
-
-from struct import pack
-from unittest.mock import patch
+import struct
+from unittest.mock import patch, AsyncMock, MagicMock, call
 
 import pytest
 
+from wazuh.core import common
 from wazuh.core import exception
-from wazuh.core.wdb import WazuhDBConnection
 from wazuh.core.common import MAX_SOCKET_BUFFER_SIZE
+from wazuh.core.wdb import AsyncWazuhDBConnection, WazuhDBConnection
 
 
 def format_msg(msg):
-    return pack('<I', len(bytes(msg)))
+    return struct.pack('<I', len(bytes(msg)))
+
+
+def test_async_init():
+    """Verify that AsyncWazuhDBConnection attributes are correct."""
+    async_wdb = AsyncWazuhDBConnection('test')
+    assert async_wdb.socket_path == common.wdb_socket_path
+    assert async_wdb.loop == 'test'
+    assert async_wdb._reader is None
+    assert async_wdb._writer is None
+
+
+@patch('asyncio.open_unix_connection', return_value=[AsyncMock(), MagicMock()])
+async def test_async_open_connection(open_unix_connection_mock):
+    """Verify that open_unix_connection is called with expected parameters."""
+    async_wdb = AsyncWazuhDBConnection(loop='test_loop')
+    await async_wdb.open_connection()
+    assert async_wdb._reader is not None
+    assert async_wdb._writer is not None
+    open_unix_connection_mock.assert_called_once_with(path=common.wdb_socket_path, loop='test_loop')
+
+
+def test_async_close():
+    """Check whether stream close method is called."""
+    async_wdb = AsyncWazuhDBConnection()
+    async_wdb._writer = MagicMock()
+    async_wdb.close()
+    async_wdb._writer.close.assert_called_once_with()
+
+
+@pytest.mark.parametrize('raw, expected_response', [
+    (False, {'test': 'test response'}),
+    (True, ['ok', '{"test": "test response"}'])
+])
+async def test_async_send(raw, expected_response):
+    """Assert that expected response is returned and methods are called with expected parameters."""
+    msg = 'test message'
+    encoded_response = 'ok {"test": "test response"}'.encode(encoding='utf-8')
+    async_wdb = AsyncWazuhDBConnection()
+    async_wdb._reader = AsyncMock()
+    async_wdb._reader.readexactly.side_effect = [struct.pack('<I', len(encoded_response)), encoded_response]
+    async_wdb._writer = MagicMock()
+    async_wdb._writer.drain = AsyncMock()
+
+    result = await async_wdb._send(msg, raw=raw)
+
+    assert result == expected_response
+    async_wdb._writer.write.assert_called_once_with(
+        struct.pack('<I', len(msg.encode(encoding='utf-8'))) + msg.encode(encoding='utf-8'))
+    async_wdb._writer.drain.assert_called_once_with()
+    async_wdb._reader.readexactly.assert_has_calls([call(4), call(28)])
+
+
+async def test_async_send_ko():
+    """Verify that expected exception codes are raised."""
+    async_wdb = AsyncWazuhDBConnection()
+
+    # Reader and writer are None.
+    with pytest.raises(exception.WazuhInternalError, match=r'\b2005\b'):
+        await async_wdb._send('test')
+
+    # EOF reached before n can be read.
+    async_wdb._writer = MagicMock()
+    async_wdb._writer.drain = AsyncMock()
+    async_wdb._reader = AsyncMock()
+    async_wdb._reader.readexactly.side_effect = lambda x: exec('raise(asyncio.IncompleteReadError("test", 5))')
+    with pytest.raises(exception.WazuhInternalError, match=r'\b2010\b'):
+        await async_wdb._send('test')
+
+    # Wazuh-db error response.
+    encoded_response = 'err Error message'.encode(encoding='utf-8')
+    async_wdb._reader.readexactly.side_effect = [struct.pack('<I', len(encoded_response)), encoded_response]
+    with pytest.raises(exception.WazuhError, match=r'\b2003\b'):
+        await async_wdb._send('test')
+
+
+@pytest.mark.asyncio
+async def test_async_run_wdb_command():
+    """Check whether expected chunks are returned according to their status code."""
+    with patch('wazuh.core.wdb.AsyncWazuhDBConnection._send', side_effect=[['due', 'chunk1'], ['due', 'chunk2'],
+                                                                           ['ok', 'chunk3'], ['due', 'chunk4']]):
+        mywdb = AsyncWazuhDBConnection()
+        result = await mywdb.run_wdb_command("global sync-agent-info-get ")
+        assert result == ['chunk1', 'chunk2', 'chunk3']
+
+
+@pytest.mark.asyncio
+async def test_run_wdb_command_ko():
+    """Verify that exception is raised when error status code is obtained."""
+    with patch('wazuh.core.wdb.AsyncWazuhDBConnection._send', side_effect=[['due', 'chunk1'], ['err', 'chunk2'],
+                                                                           ['ok', 'chunk3'], ['due', 'chunk4']]):
+        mywdb = AsyncWazuhDBConnection()
+        with pytest.raises(exception.WazuhInternalError, match=".* 2007 .* chunk2"):
+            await mywdb.run_wdb_command("global sync-agent-info-get ")
 
 
 def test_failed_connection():
@@ -127,24 +220,6 @@ def test_query_lower_private(send_mock, connect_mock):
     mywdb = WazuhDBConnection()
     with pytest.raises(exception.WazuhException, match=".* 2004 .*"):
         mywdb.execute("Agent sql select 'test'")
-
-
-@patch("socket.socket.connect")
-def test_run_wdb_command(connect_mock):
-    with patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=[['due', 'chunk1'], ['due', 'chunk2'],
-                                                                      ['ok', 'chunk3'], ['due', 'chunk4']]):
-        mywdb = WazuhDBConnection()
-        result = mywdb.run_wdb_command("global sync-agent-info-get ")
-        assert result == ['chunk1', 'chunk2', 'chunk3']
-
-
-@patch("socket.socket.connect")
-def test_run_wdb_command_ko(connect_mock):
-    with patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=[['due', 'chunk1'], ['err', 'chunk2'],
-                                                                      ['ok', 'chunk3'], ['due', 'chunk4']]):
-        mywdb = WazuhDBConnection()
-        with pytest.raises(exception.WazuhInternalError, match=".* 2007 .* chunk2"):
-            mywdb.run_wdb_command("global sync-agent-info-get ")
 
 
 @patch("socket.socket.connect")

--- a/framework/wazuh/core/tests/test_wdb.py
+++ b/framework/wazuh/core/tests/test_wdb.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2015, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+import asyncio  # noqa
 import struct
 from unittest.mock import patch, AsyncMock, MagicMock, call
 
@@ -71,7 +72,7 @@ async def test_async_send_ko():
     async_wdb = AsyncWazuhDBConnection()
 
     # Reader and writer are None.
-    with pytest.raises(exception.WazuhInternalError, match=r'\b2005\b'):
+    with pytest.raises(ConnectionError):
         await async_wdb._send('test')
 
     # EOF reached before n can be read.

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -1119,20 +1119,19 @@ class WazuhDBBackend(AbstractDatabaseBackend):
     This class describes a wazuh db backend that executes database queries
     """
 
-    def __init__(self, agent_id=None, query_format='agent', max_size=6144, request_slice=500):
+    def __init__(self, agent_id=None, query_format='agent', request_slice=500):
         if query_format == 'agent' and not path.exists(path.join(common.wdb_path, f"{agent_id}.db")):
             raise WazuhError(2007, extra_message=f"There is no database for agent {agent_id}. "
                                                  "Please check if the agent has connected to the manager")
 
         self.agent_id = agent_id
         self.query_format = query_format
-        self.max_size = max_size
         self.request_slice = request_slice
 
         super().__init__()
 
     def connect_to_db(self):
-        return WazuhDBConnection(max_size=self.max_size, request_slice=self.request_slice)
+        return WazuhDBConnection(request_slice=self.request_slice)
 
     def close_connection(self):
         self.conn.close()

--- a/framework/wazuh/core/wdb.py
+++ b/framework/wazuh/core/wdb.py
@@ -41,6 +41,7 @@ class AsyncWazuhDBConnection:
         self._reader, self._writer = await asyncio.open_unix_connection(path=self.socket_path, loop=self.loop)
 
     def close(self):
+        """Close writer socket."""
         if self._writer is not None:
             self._writer.close()
 
@@ -63,7 +64,7 @@ class AsyncWazuhDBConnection:
             Result for the request sent to wazuh-db.
         """
         if None in [self._writer, self._reader]:
-            raise WazuhInternalError(2005)
+            raise ConnectionError('There is no connection established with the socket')
 
         # Send message.
         encoded_msg = msg.encode(encoding='utf-8')

--- a/framework/wazuh/core/wdb.py
+++ b/framework/wazuh/core/wdb.py
@@ -19,7 +19,7 @@ DATE_FORMAT = re.compile(r'\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2}')
 
 class AsyncWazuhDBConnection:
     """
-    Represents an async connection to the wdb socket.
+    Represent an async connection to the wdb socket.
     """
 
     def __init__(self, loop: asyncio.AbstractEventLoopPolicy = None):
@@ -124,7 +124,7 @@ class AsyncWazuhDBConnection:
 
 class WazuhDBConnection:
     """
-    Represents a connection to the wdb socket
+    Represent a connection to the wdb socket.
     """
 
     def __init__(self, request_slice=500):


### PR DESCRIPTION
|Related issue|
|---|
| Closes #14765 |

## Description

This PR adds a new async version (`AsyncWazuhDBConnection`) of the [WazuhDBConnection](https://github.com/wazuh/wazuh/blob/bc39d6791fad8e629fbe8b8ef2e9713bca0affba/framework/wazuh/core/wdb.py#L19-L22) class used to send and retrieve information from `wazuh-db`. 

This class lets the cluster request agent-info data and do other tasks (like answering distributed API requests) while waiting for `wazuh-db` response to be ready. This greatly improves cluster performance in environments where the database is very busy.

## Logs/Alerts example

### Sync requests to wdb
This is how the cluster behaves when wazuh-db is slow to respond (in this case, 20 seconds). As can be seen, there has been no log between `10:47:10` and `10:47:30`, which means that the cluster has been blocked and all tasks have been delayed:
```
2022/09/01 10:47:10 INFO: [Worker worker1] [Agent-info sync] Starting.
2022/09/01 10:47:30 DEBUG: [Worker worker1] [Agent-info sync] Obtained 20 chunks of data in 20.248s.
2022/09/01 10:47:30 DEBUG: [Worker worker1] [Main] Command received: 'b'dapi''
2022/09/01 10:47:30 DEBUG: [Worker worker1] [D API] Received request: b'master*527235 {"f": {"__callable__": {"__name__": "get_api_config", "__module__": "wazuh.manager", "__qualname__": "get_api_config", "__type__": "function"}}, "f_kwargs": {}, "request_type": "distributed_master", "wait_for_complete": true, "from_cluster": true, "is_async": false, "local_client_arg": null, "basic_services": ["wazuh-modulesd", "wazuh-analysisd", "wazuh-execd", "wazuh-db", "wazuh-remoted"], "rbac_permissions": {"agent:create": {"*:*:*": "allow"}, "group:create": {"*:*:*": "allow"}, "agent:read": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:delete": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:modify_group": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:reconnect": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:restart": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:upgrade": {"agent:id:*": "allow", "agent:group:*": "allow"}, "group:read": {"group:id:*": "allow"}, "group:delete": {"group:id:*": "allow"}, "group:update_config": {"group:id:*": "allow"}, "group:modify_assignments": {"group:id:*": "allow"}, "active-response:command": {"agent:id:*": "allow"}, "security:create": {"*:*:*": "allow"}, "security:create_user": {"*:*:*": "allow"}, "security:read_config": {"*:*:*": "allow"}, "security:update_config": {"*:*:*": "allow"}, "security:revoke": {"*:*:*": "allow"}, "security:edit_run_as": {"*:*:*": "allow"}, "security:read": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "security:update": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "security:delete": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "cluster:status": {"*:*:*": "allow"}, "manager:read": {"*:*:*": "allow"}, "manager:read_api_config": {"*:*:*": "allow"}, "manager:update_config": {"*:*:*": "allow"}, "manager:restart": {"*:*:*": "allow"}, "cluster:read_api_config": {"node:id:*": "allow"}, "cluster:read": {"node:id:*": "allow"}, "cluster:restart": {"node:id:*": "allow"}, "cluster:update_config": {"node:id:*": "allow"}, "ciscat:read": {"agent:id:*": "allow"}, "decoders:read": {"decoder:file:*": "allow"}, "decoders:delete": {"decoder:file:*": "allow"}, "decoders:update": {"*:*:*": "allow"}, "lists:read": {"list:file:*": "allow"}, "lists:delete": {"list:file:*": "allow"}, "lists:update": {"*:*:*": "allow"}, "rootcheck:clear": {"agent:id:*": "allow"}, "rootcheck:read": {"agent:id:*": "allow"}, "rootcheck:run": {"agent:id:*": "allow"}, "rules:read": {"rule:file:*": "allow"}, "rules:delete": {"rule:file:*": "allow"}, "rules:update": {"*:*:*": "allow"}, "mitre:read": {"*:*:*": "allow"}, "sca:read": {"agent:id:*": "allow"}, "syscheck:clear": {"agent:id:*": "allow"}, "syscheck:read": {"agent:id:*": "allow"}, "syscheck:run": {"agent:id:*": "allow"}, "syscollector:read": {"agent:id:*": "allow"}, "logtest:run": {"*:*:*": "allow"}, "task:status": {"*:*:*": "allow"}, "vulnerability:read": {"agent:id:*": "allow"}, "rbac_mode": "white"}, "current_user": "", "broadcasting": false, "nodes": ["master-node", "worker1"], "api_timeout": 10}'
2022/09/01 10:47:30 INFO: [Worker worker1] [D API] Receiving request: get_api_config from master (527235)
2022/09/01 10:47:30 DEBUG: [Worker worker1] [D API] Receiving parameters {}
2022/09/01 10:47:30 DEBUG: [Worker worker1] [D API] Starting to execute request locally
2022/09/01 10:47:30 DEBUG: [Worker worker1] [D API] Finished executing request locally
2022/09/01 10:47:30 DEBUG: [Worker worker1] [D API] Time calculating request result: 0.032s
2022/09/01 10:47:30 DEBUG: [Worker worker1] [Integrity check] Permission to synchronize granted.
2022/09/01 10:47:30 INFO: [Worker worker1] [Integrity check] Starting.
2022/09/01 10:47:30 DEBUG: [Worker worker1] [Integrity check] Compressing 'files_metadata.json' of 36 files.
2022/09/01 10:47:30 DEBUG: [Worker worker1] [Integrity check] Sending zip file to master.
2022/09/01 10:47:30 DEBUG: [Worker worker1] [Agent-info sync] All chunks sent.
2022/09/01 10:47:30 DEBUG: [Worker worker1] [Integrity check] Zip file sent to master.
2022/09/01 10:47:30 DEBUG: [Worker worker1] [Main] Command received: 'b'syn_m_c_ok''
2022/09/01 10:47:30 INFO: [Worker worker1] [Integrity check] Finished in 0.068s. Sync not required.
2022/09/01 10:47:30 DEBUG: [Worker worker1] [Main] Command received: 'b'syn_m_a_e''
2022/09/01 10:47:30 INFO: [Worker worker1] [Agent-info sync] Finished in 20.462s (20 chunks updated).
```
Any API calls that have to be distributed to the affected node are also delayed, as in this case `GET /cluster/api/config`, which has taken 17 seconds to complete:
```
2022/09/01 10:47:30 INFO: wazuh 192.168.16.1 "GET /cluster/api/config" with parameters {"wait_for_complete": "true", "nodes_list": "worker1"} and body {} done in 17.185s: 200
```

### Async requests to wdb
Now, as the requests are async, other tasks are performed in the meantime even if `wazuh-db` is still taking 20 seconds to return a response (which occurred at `11:02:13`):
```
2022/09/01 11:01:53 INFO: [Worker worker1] [Agent-info sync] Starting.
2022/09/01 11:01:57 DEBUG: [Worker worker1] [Main] Command received: 'b'dapi''
2022/09/01 11:01:57 DEBUG: [Worker worker1] [D API] Received request: b'master*807364 {"f": {"__callable__": {"__name__": "get_api_config", "__module__": "wazuh.manager", "__qualname__": "get_api_config", "__type__": "function"}}, "f_kwargs": {}, "request_type": "distributed_master", "wait_for_complete": true, "from_cluster": true, "is_async": false, "local_client_arg": null, "basic_services": ["wazuh-modulesd", "wazuh-analysisd", "wazuh-execd", "wazuh-db", "wazuh-remoted"], "rbac_permissions": {"agent:create": {"*:*:*": "allow"}, "group:create": {"*:*:*": "allow"}, "agent:read": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:delete": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:modify_group": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:reconnect": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:restart": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:upgrade": {"agent:id:*": "allow", "agent:group:*": "allow"}, "group:read": {"group:id:*": "allow"}, "group:delete": {"group:id:*": "allow"}, "group:update_config": {"group:id:*": "allow"}, "group:modify_assignments": {"group:id:*": "allow"}, "active-response:command": {"agent:id:*": "allow"}, "security:create": {"*:*:*": "allow"}, "security:create_user": {"*:*:*": "allow"}, "security:read_config": {"*:*:*": "allow"}, "security:update_config": {"*:*:*": "allow"}, "security:revoke": {"*:*:*": "allow"}, "security:edit_run_as": {"*:*:*": "allow"}, "security:read": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "security:update": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "security:delete": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "cluster:status": {"*:*:*": "allow"}, "manager:read": {"*:*:*": "allow"}, "manager:read_api_config": {"*:*:*": "allow"}, "manager:update_config": {"*:*:*": "allow"}, "manager:restart": {"*:*:*": "allow"}, "cluster:read_api_config": {"node:id:*": "allow"}, "cluster:read": {"node:id:*": "allow"}, "cluster:restart": {"node:id:*": "allow"}, "cluster:update_config": {"node:id:*": "allow"}, "ciscat:read": {"agent:id:*": "allow"}, "decoders:read": {"decoder:file:*": "allow"}, "decoders:delete": {"decoder:file:*": "allow"}, "decoders:update": {"*:*:*": "allow"}, "lists:read": {"list:file:*": "allow"}, "lists:delete": {"list:file:*": "allow"}, "lists:update": {"*:*:*": "allow"}, "rootcheck:clear": {"agent:id:*": "allow"}, "rootcheck:read": {"agent:id:*": "allow"}, "rootcheck:run": {"agent:id:*": "allow"}, "rules:read": {"rule:file:*": "allow"}, "rules:delete": {"rule:file:*": "allow"}, "rules:update": {"*:*:*": "allow"}, "mitre:read": {"*:*:*": "allow"}, "sca:read": {"agent:id:*": "allow"}, "syscheck:clear": {"agent:id:*": "allow"}, "syscheck:read": {"agent:id:*": "allow"}, "syscheck:run": {"agent:id:*": "allow"}, "syscollector:read": {"agent:id:*": "allow"}, "logtest:run": {"*:*:*": "allow"}, "task:status": {"*:*:*": "allow"}, "vulnerability:read": {"agent:id:*": "allow"}, "rbac_mode": "white"}, "current_user": "", "broadcasting": false, "nodes": ["master-node", "worker1"], "api_timeout": 10}'
2022/09/01 11:01:57 INFO: [Worker worker1] [D API] Receiving request: get_api_config from master (807364)
2022/09/01 11:01:57 DEBUG: [Worker worker1] [D API] Receiving parameters {}
2022/09/01 11:01:57 DEBUG: [Worker worker1] [D API] Starting to execute request locally
2022/09/01 11:01:57 DEBUG: [Worker worker1] [D API] Finished executing request locally
2022/09/01 11:01:57 DEBUG: [Worker worker1] [D API] Time calculating request result: 0.007s
2022/09/01 11:02:01 DEBUG: [Worker worker1] [Integrity check] Permission to synchronize granted.
2022/09/01 11:02:01 INFO: [Worker worker1] [Integrity check] Starting.
2022/09/01 11:02:01 DEBUG: [Worker worker1] [Integrity check] Compressing 'files_metadata.json' of 36 files.
2022/09/01 11:02:01 DEBUG: [Worker worker1] [Integrity check] Sending zip file to master.
2022/09/01 11:02:01 DEBUG: [Worker worker1] [Integrity check] Zip file sent to master.
2022/09/01 11:02:01 DEBUG: [Worker worker1] [Main] Command received: 'b'syn_m_c_ok''
2022/09/01 11:02:01 INFO: [Worker worker1] [Integrity check] Finished in 0.013s. Sync not required.
2022/09/01 11:02:10 DEBUG: [Worker worker1] [Integrity check] Permission to synchronize granted.
2022/09/01 11:02:10 INFO: [Worker worker1] [Integrity check] Starting.
2022/09/01 11:02:10 DEBUG: [Worker worker1] [Integrity check] Compressing 'files_metadata.json' of 36 files.
2022/09/01 11:02:10 DEBUG: [Worker worker1] [Integrity check] Sending zip file to master.
2022/09/01 11:02:10 DEBUG: [Worker worker1] [Integrity check] Zip file sent to master.
2022/09/01 11:02:10 DEBUG: [Worker worker1] [Main] Command received: 'b'syn_m_c_ok''
2022/09/01 11:02:10 INFO: [Worker worker1] [Integrity check] Finished in 0.038s. Sync not required.
2022/09/01 11:02:13 DEBUG: [Worker worker1] [Agent-info sync] Obtained 20 chunks of data in 20.240s.
2022/09/01 11:02:13 DEBUG: [Worker worker1] [Agent-info sync] All chunks sent.
2022/09/01 11:02:14 DEBUG: [Worker worker1] [Main] Command received: 'b'syn_m_a_e''
2022/09/01 11:02:14 INFO: [Worker worker1] [Agent-info sync] Finished in 20.434s (20 chunks updated).
```

The API request run while waiting for `wazuh-db` was much faster now:
```
2022/09/01 11:01:57 INFO: wazuh 192.168.16.1 "GET /cluster/api/config" with parameters {"wait_for_complete": "true", "nodes_list": "worker1"} and body {} done in 0.064s: 200
```
