### PR TITLE
Improved AWS ThrottlingException handling

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2837,7 +2837,7 @@ class AWSInspector(AWSService):
                                                                                'endDate': date_current}})
             self.send_describe_findings(response['findingArns'])
 
-        if self.sent_events:        
+        if self.sent_events:
             debug(f"+++ {self.sent_events} events collected and processed in {self.inspector_region}", 1)
         else:
             debug(f'+++ There are no new events in the "{self.inspector_region}" region', 1)
@@ -3027,9 +3027,9 @@ class AWSCloudWatchLogs(AWSService):
                     token = None
 
                     if db_values:
-                        if self.reparse: 
+                        if self.reparse:
                             result_before = self.get_alerts_within_range(log_group=log_group, log_stream=log_stream,
-                                                                         token=None, start_time=start_time, 
+                                                                         token=None, start_time=start_time,
                                                                          end_time=None)
 
                         elif db_values['start_time'] and db_values['start_time'] > start_time:
@@ -3286,10 +3286,9 @@ class AWSCloudWatchLogs(AWSService):
         """
 
         result_list = list()
+        debug('Getting log streams for "{}" log group'.format(log_group), 1)
         for _ in range(AWSCloudWatchLogs.CONNECTION_ATTEMPTS_ALLOWED):
             try:
-                debug('Getting log streams for "{}" log group'.format(log_group), 1)
-
                 # Get all log streams using the token of the previous call to describe_log_streams
                 response = self.client.describe_log_streams(logGroupName=log_group)
                 log_streams = response['logStreams']

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -230,7 +230,7 @@ class WazuhIntegration:
                 self.db_connector.execute(self.sql_drop_table.format(table='trail_progress'))
 
     def default_config(self, args):
-        if path.exists("".join([path.expanduser('~'), '/.aws/config'])):
+        if not path.exists("".join([path.expanduser('~'), '/.aws/config'])):
             args['config'] = Config(
                 retries={
                     'max_attempts': 10,

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -3199,7 +3199,6 @@ class AWSCloudWatchLogs(AWSService):
                   '"{}" and end_time "{}"'.format(log_stream, log_group, token, start_time, end_time), 1)
 
             # Try to get CloudWatch Log events until the request succeeds or the allowed number of attempts is reached
-
             try:
                 response = self.client.get_log_events(
                     **{param: value for param, value in parameters.items() if value is not None})

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -241,11 +241,9 @@ class WazuhIntegration:
                     'mode': 'standard'
                 }
             )
-            debug('Generating default configuration for retries: mode {} - max_attempts {}'.format(
-                args['config'].retries['mode'],
-                args['config'].retries['max_attempts']), 2)
+            debug(f"Generating default configuration for retries: mode {args['config'].retries['mode']} - max_attempts {args['config'].retries['max_attempts']}",2)
         else:
-            debug('Found configuration for connection retries in ~/.aws/config', 2)
+            debug(f'Found configuration for connection retries in {path.join(path.expanduser("~"), ".aws", "config")}', 2)
 
         return args
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -3161,7 +3161,7 @@ class AWSCloudWatchLogs(AWSService):
             try:
                 response = self.client.get_log_events(
                     **{param: value for param, value in parameters.items() if value is not None})
-                break
+
             except botocore.exceptions.EndpointConnectionError:
                 debug(f'WARNING: The "get_log_events" request was denied because the endpoint URL was not '
                       f'available. Attempting again.', 1)

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -37,7 +37,6 @@ except ImportError:
     print('ERROR: boto3 module is required.')
     sys.exit(4)
 import botocore
-from botocore.config import Config
 import json
 import csv
 import gzip
@@ -236,7 +235,7 @@ class WazuhIntegration:
     def default_config():
         args = {}
         if not path.exists("".join([path.expanduser('~'), '/.aws/config'])):
-            args['config'] = Config(
+            args['config'] = botocore.config.Config(
                 retries={
                     'max_attempts': 10,
                     'mode': 'standard'


### PR DESCRIPTION
|Related issue|
|---|
|#14754|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR closes #14754. It deprecates previous `ThrottlingException` handling in favor of the [Boto3 retries](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html) mechanism, setting specific default values for retries (instantiating a `Config` object) in case no `~/.aws/config` file is present. 
Also, a debug message has been added for each case to describe how the retries will be handled when the module is executed.
The documentation is being updated in https://github.com/wazuh/wazuh-documentation/pull/5559 .

## AWS Wodle Unit tests
```
============================= test session starts ==============================
platform linux -- Python 3.9.5, pytest-6.0.1, py-1.11.0, pluggy-0.13.1 -- /home/test_user/venv/unittest-env/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.14.0-1050-oem-x86_64-with-glibc2.31', 'Packages': {'pytest': '6.0.1', 'py': '1.11.0', 'pluggy': '0.13.1'}, 'Plugins': {'cov': '3.0.0', 'trio': '0.7.0', 'metadata': '2.0.2', 'asyncio': '0.15.1', 'aiohttp': '0.3.0', 'html': '2.1.1'}}
rootdir: /home/test_user/git/wazuh
plugins: cov-3.0.0, trio-0.7.0, metadata-2.0.2, asyncio-0.15.1, aiohttp-0.3.0, html-2.1.1
collecting ... collected 38 items

wodles/aws/tests/test_aws.py::test_metadata_version_buckets[AWSCloudTrailBucket] PASSED [  2%]
wodles/aws/tests/test_aws.py::test_metadata_version_buckets[AWSConfigBucket] PASSED [  5%]
wodles/aws/tests/test_aws.py::test_metadata_version_buckets[AWSVPCFlowBucket] PASSED [  7%]
wodles/aws/tests/test_aws.py::test_metadata_version_buckets[AWSCustomBucket] PASSED [ 10%]
wodles/aws/tests/test_aws.py::test_metadata_version_buckets[AWSGuardDutyBucket] PASSED [ 13%]
wodles/aws/tests/test_aws.py::test_metadata_version_services[AWSInspector] PASSED [ 15%]
wodles/aws/tests/test_aws.py::test_db_maintenance[AWSCloudTrailBucket-schema_cloudtrail_test.sql-cloudtrail] PASSED [ 18%]
wodles/aws/tests/test_aws.py::test_db_maintenance[AWSConfigBucket-schema_config_test.sql-config] PASSED [ 21%]
wodles/aws/tests/test_aws.py::test_db_maintenance[AWSVPCFlowBucket-schema_vpcflow_test.sql-vpcflow] PASSED [ 23%]
wodles/aws/tests/test_aws.py::test_db_maintenance[AWSCustomBucket-schema_custom_test.sql-custom] PASSED [ 26%]
wodles/aws/tests/test_aws.py::test_db_maintenance[AWSGuardDutyBucket-schema_guardduty_test.sql-guardduty] PASSED [ 28%]
wodles/aws/tests/test_aws.py::test_decompress_file_gz[aws_bucket0-test.gz-gzip.open] PASSED [ 31%]
wodles/aws/tests/test_aws.py::test_decompress_file_gz[aws_bucket0-test.zip-zipfile.ZipFile] PASSED [ 34%]
wodles/aws/tests/test_aws.py::test_decompress_file_snappy_skip[aws_bucket0-test.snappy] PASSED [ 36%]
wodles/aws/tests/test_aws.py::test_decompress_snappy_ko[aws_bucket0-test.snappy-False-SystemExit] PASSED [ 39%]
wodles/aws/tests/test_aws.py::test_decompress_file_ko[.gz-aws_bucket0] PASSED [ 42%]
wodles/aws/tests/test_aws.py::test_decompress_file_ko[.zip-aws_bucket0] PASSED [ 44%]
wodles/aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-False] PASSED [ 47%]
wodles/aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-True] PASSED [ 50%]
wodles/aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-invalid-json-True] PASSED [ 52%]
wodles/aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-wrong-structure-True] PASSED [ 55%]
wodles/aws/tests/test_aws.py::test_aws_waf_load_information_from_file_ko[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-invalid-json-False-SystemExit] PASSED [ 57%]
wodles/aws/tests/test_aws.py::test_aws_waf_load_information_from_file_ko[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-wrong-structure-False-SystemExit] PASSED [ 60%]
wodles/aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2021/1/19-20210119] PASSED [ 63%]
wodles/aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2021/1/1-20210101] PASSED [ 65%]
wodles/aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2021/01/01-20210101] PASSED [ 68%]
wodles/aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2000/2/12-20000212] PASSED [ 71%]
wodles/aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2022/02/1-20220201] PASSED [ 73%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file0-20211221] PASSED [ 76%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file1-20200103] PASSED [ 78%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file2-20200920] PASSED [ 81%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file3-20210118] PASSED [ 84%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file4-20200930] PASSED [ 86%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file5-20201015] PASSED [ 89%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file6-20210318] PASSED [ 92%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file7-20210906] PASSED [ 94%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file8-20211112] PASSED [ 97%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file9-20210123] PASSED [100%]

============================== 38 passed in 0.27s ==============================
```

## Manual retry configuration test
### Without setting `~/.aws/config`
```
/var/ossec/wodles/aws/aws-s3 -sr cloudwatchlogs -g 4_4_test -d 2 -s 2022-JUN-26 -p dev -r us-east-1
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Getting alerts from "us-east-1" region.
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: only logs: 1656201600000
DEBUG: +++ Table does not exist; create
DEBUG: Getting log streams for "4_4_test" log group
DEBUG: Found "test_stream" log stream in 4_4_test
DEBUG: Getting data from DB for log stream "test_stream" in log group "4_4_test"
DEBUG: Token: "None", start_time: "None", end_time: "None"
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "4_4_test" using token "None", start_time "1656201600000" and end_time "None"
DEBUG: +++ Sending events to Analysisd...
DEBUG: The message is "test log 01"
DEBUG: +++ Sending events to Analysisd...
DEBUG: The message is "test log 02"
DEBUG: +++ Sending events to Analysisd...
DEBUG: The message is "test log 03"
DEBUG: +++ Sending events to Analysisd...
DEBUG: The message is "test log 04"
DEBUG: +++ Sending events to Analysisd...
DEBUG: The message is "test log 05"
DEBUG: +++ Sending events to Analysisd...
DEBUG: The message is "test log 06"
DEBUG: +++ Sending events to Analysisd...
DEBUG: The message is "test log 07"
DEBUG: +++ Sending events to Analysisd...
DEBUG: The message is "test log 08"
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "4_4_test" using token "f/37005045211641564753592332036677569118654559889967742976/s", start_time "1656201600000" and end_time "None"
DEBUG: Saving data for log group "4_4_test" and log stream "test_stream".
DEBUG: The saved values are "{'token': 'f/37005045211675015869384080449614511648105350264348704767/s', 'start_time': 1656201600000, 'end_time': 1659363616875}"
DEBUG: Purging the BD
DEBUG: Getting log streams for "4_4_test" log group
DEBUG: Found "test_stream" log stream in 4_4_test
DEBUG: committing changes and closing the DB
```

### Setting `~/.aws/config`
```
/var/ossec/wodles/aws/aws-s3 -sr cloudwatchlogs -g 4_4_test -d 2 -s 2022-JUN-26 -p dev -r us-east-1
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Getting alerts from "us-east-1" region.
DEBUG: Found configuration for connection retries in ~/.aws/config
DEBUG: only logs: 1656201600000
DEBUG: +++ Table does not exist; create
DEBUG: Getting log streams for "4_4_test" log group
DEBUG: Found "test_stream" log stream in 4_4_test
DEBUG: Getting data from DB for log stream "test_stream" in log group "4_4_test"
DEBUG: Token: "None", start_time: "None", end_time: "None"
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "4_4_test" using token "None", start_time "1656201600000" and end_time "None"
DEBUG: +++ Sending events to Analysisd...
DEBUG: The message is "test log 01"
DEBUG: +++ Sending events to Analysisd...
DEBUG: The message is "test log 02"
DEBUG: +++ Sending events to Analysisd...
DEBUG: The message is "test log 03"
DEBUG: +++ Sending events to Analysisd...
DEBUG: The message is "test log 04"
DEBUG: +++ Sending events to Analysisd...
DEBUG: The message is "test log 05"
DEBUG: +++ Sending events to Analysisd...
DEBUG: The message is "test log 06"
DEBUG: +++ Sending events to Analysisd...
DEBUG: The message is "test log 07"
DEBUG: +++ Sending events to Analysisd...
DEBUG: The message is "test log 08"
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "4_4_test" using token "f/37005045211641564753592332036677569118654559889967742976/s", start_time "1656201600000" and end_time "None"
DEBUG: Saving data for log group "4_4_test" and log stream "test_stream".
DEBUG: The saved values are "{'token': 'f/37005045211675015869384080449614511648105350264348704767/s', 'start_time': 1656201600000, 'end_time': 1659363616875}"
DEBUG: Purging the BD
DEBUG: Getting log streams for "4_4_test" log group
DEBUG: Found "test_stream" log stream in 4_4_test
DEBUG: committing changes and closing the DB
```

#### Execution with `ThrottlingException` 
```
/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -sr cloudwatchlogs -g 4_4_test -d 2 -s 2022-JUN-26 -p dev -r us-east-1
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Getting alerts from "us-east-1" region.
DEBUG: Found configuration for connection retries in ~/.aws/config
DEBUG: only logs: 1656201600000
DEBUG: Getting log streams for "4_4_test" log group
DEBUG: ERROR: The "get_log_streams" request failed: An error occurred (ThrottlingException) when calling the DescribeLogStreams operation (reached max retries: 1): Rate exceeded
DEBUG: committing changes and closing the DB
```