### PR TITLE
Improve command validation for `PUT /active-response`

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1327,6 +1327,7 @@ components:
           description: "Command running in the agent. If this value starts by `!`, then it refers to a script name
           instead of a command name"
           type: string
+          format: active_response_command
         custom:
           description: "Whether the specified command is a custom command or not"
           type: boolean

--- a/api/api/test/test_validator.py
+++ b/api/api/test/test_validator.py
@@ -14,7 +14,7 @@ from api.validator import (check_exp, check_xml, _alphanumeric_param,
                            _sort_param, _timeframe_type, _type_format, _yes_no_boolean, _get_dirnames_path,
                            allowed_fields, is_safe_path, _wazuh_version, _symbols_alphanumeric_param, _base64,
                            _group_names, _group_names_or_all, _iso8601_date, _iso8601_date_time, _numbers_or_all,
-                           _cdb_filename_path, _xml_filename_path, _xml_filename)
+                           _cdb_filename_path, _xml_filename_path, _xml_filename, _active_response_command)
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
@@ -72,6 +72,8 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
     ('security-eventchannel', _cdb_filename_path),
     ('local_rules.xml', _xml_filename_path),
     ('local_rules1.xml,local_rules2.xml', _xml_filename),
+    ('scripts/active_response', _active_response_command),
+    ('!scripts/active_response', _active_response_command),
     # relative paths
     ('etc/lists/new_lists3', _get_dirnames_path),
     # version
@@ -129,6 +131,8 @@ def test_validation_check_exp_ok(exp, regex_name):
     # paths
     ('/var/ossec/etc/internal_options$', _paths),
     ('/var/ossec/etc/rules/local_rules.xml()', _paths),
+    ('!scripts/active_response()', _active_response_command),
+    ('scripts\\active_response$', _active_response_command),
     # relative paths
     ('etc/internal_options', _get_dirnames_path),
     ('../../path', _get_dirnames_path),
@@ -179,13 +183,16 @@ def test_allowed_fields():
 def test_is_safe_path():
     """Verify that is_safe_path() works as expected"""
     assert is_safe_path('/api/configuration/api.yaml')
+    assert is_safe_path('c:\\api\\configuration\\api.yaml')
     assert is_safe_path('etc/rules/local_rules.xml', relative=False)
     assert is_safe_path('etc/ossec.conf', relative=True)
     assert is_safe_path('ruleset/decoders/decoder.xml', relative=False)
     assert not is_safe_path('/api/configuration/api.yaml', basedir='non-existent', relative=False)
     assert not is_safe_path('etc/lists/../../../../../../var/ossec/api/scripts/wazuh-apid.py', relative=True)
-    assert not is_safe_path('./etc/rules/rule.xml', relative=False)
-    assert not is_safe_path('./ruleset/decoders/decoder.xml./', relative=False)
+    assert not is_safe_path('../etc/rules/rule.xml', relative=False)
+    assert not is_safe_path('../etc/rules/rule.xml')
+    assert not is_safe_path('..\\etc\\rules\\rule.xml')
+    assert not is_safe_path('../ruleset/decoders/decoder.xml./', relative=False)
 
 
 @pytest.mark.parametrize('value, format', [

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -47,6 +47,7 @@ _sort_param = re.compile(r'^[\w_\-,\s+.]+$')
 _timeframe_type = re.compile(r'^(\d+[dhms]?)$')
 _type_format = re.compile(r'^xml$|^json$')
 _yes_no_boolean = re.compile(r'^yes$|^no$')
+_active_response_command = re.compile(f"^!?{_paths.pattern.lstrip('^')}")
 
 security_config_schema = {
     "type": "object",
@@ -240,7 +241,8 @@ def is_safe_path(path: str, basedir: str = common.wazuh_path, relative: bool = T
         True if path is correct. False otherwise.
     """
     # Protect path
-    if './' in path or '../' in path:
+    forbidden_paths = ["../", "..\\"]
+    if any([forbidden_path in path for forbidden_path in forbidden_paths]):
         return False
 
     # Resolve symbolic links if present
@@ -320,6 +322,13 @@ def format_wazuh_path(value):
     if not is_safe_path(value, relative=False):
         return False
     return check_exp(value, _paths)
+
+
+@draft4_format_checker.checks("active_response_command")
+def format_active_response_command(command):
+    if not is_safe_path(command):
+        return False
+    return check_exp(command, _active_response_command)
 
 
 @draft4_format_checker.checks("query")


### PR DESCRIPTION
## Description

This PR improves the command validation for the `active-response` API endpoint and adds new test cases.

## Examples

- `"command": "../../../test.sh"`

```json
{
  "title": "Bad Request",
  "detail": "'../../../test.sh' is not a 'active_response_command' - 'command'"
}
```

- `"command": "..\\..\\..\\test.ps1"`

```json
{
  "title": "Bad Request",
  "detail": "'..\\\\..\\\\..\\\\test.ps1' is not a 'active_response_command' - 'command'"
}
```

- `"command": "!../../../test.sh"`

```json
{
  "title": "Bad Request",
  "detail": "'!../../../test.sh' is not a 'active_response_command' - 'command'"
}
```

- `"command": "!..\\..\\..\\test.ps1"`

```json
{
  "title": "Bad Request",
  "detail": "'!..\\\\..\\\\..\\\\test.ps1' is not a 'active_response_command' - 'command'"
}
```

## Tests performed
### API unit tests

```
===================================================================== test session starts ======================================================================
platform linux -- Python 3.9.9, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: testinfra-5.0.0, metadata-1.11.0, cov-2.12.0, asyncio-0.18.3, aiohttp-0.3.0, html-3.1.1
asyncio: mode=legacy
collected 505 items                                                                                                                                            

api/api/controllers/test/test_active_response_controller.py .                                                                                            [  0%]
api/api/controllers/test/test_agent_controller.py ..........................................                                                             [  8%]
api/api/controllers/test/test_cdb_list_controller.py ......                                                                                              [  9%]
api/api/controllers/test/test_ciscat_controller.py .                                                                                                     [  9%]
api/api/controllers/test/test_cluster_controller.py .......................                                                                              [ 14%]
api/api/controllers/test/test_decoder_controller.py .......                                                                                              [ 15%]
api/api/controllers/test/test_default_controller.py .                                                                                                    [ 16%]
api/api/controllers/test/test_experimental_controller.py ...............                                                                                 [ 19%]
api/api/controllers/test/test_manager_controller.py .................                                                                                    [ 22%]
api/api/controllers/test/test_mitre_controller.py .......                                                                                                [ 23%]
api/api/controllers/test/test_overview_controller.py .                                                                                                   [ 23%]
api/api/controllers/test/test_rootcheck_controller.py ....                                                                                               [ 24%]
api/api/controllers/test/test_rule_controller.py ........                                                                                                [ 26%]
api/api/controllers/test/test_sca_controller.py ..                                                                                                       [ 26%]
api/api/controllers/test/test_security_controller.py ...................................................                                                 [ 36%]
api/api/controllers/test/test_syscheck_controller.py ....                                                                                                [ 37%]
api/api/controllers/test/test_syscollector_controller.py .........                                                                                       [ 39%]
api/api/controllers/test/test_task_controller.py .                                                                                                       [ 39%]
api/api/controllers/test/test_vulnerability_controller.py ...                                                                                            [ 40%]
api/api/models/test/test_model.py ...........................                                                                                            [ 45%]
api/api/test/test_alogging.py ..........                                                                                                                 [ 47%]
api/api/test/test_authentication.py ..........                                                                                                           [ 49%]
api/api/test/test_configuration.py .........................................                                                                             [ 57%]
api/api/test/test_encoder.py ...                                                                                                                         [ 58%]
api/api/test/test_middlewares.py ............                                                                                                            [ 60%]
api/api/test/test_uri_parser.py ...                                                                                                                      [ 61%]
api/api/test/test_util.py ......................................                                                                                         [ 68%]
api/api/test/test_validator.py ......................................................................................................................... [ 92%]
.....................................                                                                                                                    [100%]

=============================================================== 505 passed, 16 warnings in 2.77s ===============================================================

```

Regards,
Víctor