### PR TITLE
Fix arbitrary code execution flaw in Active Response

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1327,6 +1327,7 @@ components:
           description: "Command running in the agent. If this value starts by `!`, then it refers to a script name
           instead of a command name"
           type: string
+          format: active_response_command
         custom:
           description: "Whether the specified command is a custom command or not"
           type: boolean

--- a/api/api/test/test_validator.py
+++ b/api/api/test/test_validator.py
@@ -14,7 +14,7 @@ from api.validator import (check_exp, check_xml, _alphanumeric_param,
                            _sort_param, _timeframe_type, _type_format, _yes_no_boolean, _get_dirnames_path,
                            allowed_fields, is_safe_path, _wazuh_version, _symbols_alphanumeric_param, _base64,
                            _group_names, _group_names_or_all, _iso8601_date, _iso8601_date_time, _numbers_or_all,
-                           _cdb_filename_path, _xml_filename_path, _xml_filename)
+                           _cdb_filename_path, _xml_filename_path, _xml_filename, _active_response_command)
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
@@ -72,6 +72,8 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
     ('security-eventchannel', _cdb_filename_path),
     ('local_rules.xml', _xml_filename_path),
     ('local_rules1.xml,local_rules2.xml', _xml_filename),
+    ('scripts/active_response', _active_response_command),
+    ('!scripts/active_response', _active_response_command),
     # relative paths
     ('etc/lists/new_lists3', _get_dirnames_path),
     # version
@@ -129,6 +131,8 @@ def test_validation_check_exp_ok(exp, regex_name):
     # paths
     ('/var/ossec/etc/internal_options$', _paths),
     ('/var/ossec/etc/rules/local_rules.xml()', _paths),
+    ('!scripts/active_response()', _active_response_command),
+    ('scripts\\active_response$', _active_response_command),
     # relative paths
     ('etc/internal_options', _get_dirnames_path),
     ('../../path', _get_dirnames_path),
@@ -179,13 +183,16 @@ def test_allowed_fields():
 def test_is_safe_path():
     """Verify that is_safe_path() works as expected"""
     assert is_safe_path('/api/configuration/api.yaml')
+    assert is_safe_path('c:\\api\\configuration\\api.yaml')
     assert is_safe_path('etc/rules/local_rules.xml', relative=False)
     assert is_safe_path('etc/ossec.conf', relative=True)
     assert is_safe_path('ruleset/decoders/decoder.xml', relative=False)
     assert not is_safe_path('/api/configuration/api.yaml', basedir='non-existent', relative=False)
     assert not is_safe_path('etc/lists/../../../../../../var/ossec/api/scripts/wazuh-apid.py', relative=True)
-    assert not is_safe_path('./etc/rules/rule.xml', relative=False)
-    assert not is_safe_path('./ruleset/decoders/decoder.xml./', relative=False)
+    assert not is_safe_path('../etc/rules/rule.xml', relative=False)
+    assert not is_safe_path('../etc/rules/rule.xml')
+    assert not is_safe_path('..\\etc\\rules\\rule.xml')
+    assert not is_safe_path('../ruleset/decoders/decoder.xml./', relative=False)
 
 
 @pytest.mark.parametrize('value, format', [

--- a/api/api/test/test_validator.py
+++ b/api/api/test/test_validator.py
@@ -191,6 +191,8 @@ def test_is_safe_path():
     assert not is_safe_path('etc/lists/../../../../../../var/ossec/api/scripts/wazuh-apid.py', relative=True)
     assert not is_safe_path('../etc/rules/rule.xml', relative=False)
     assert not is_safe_path('../etc/rules/rule.xml')
+    assert not is_safe_path('/..')
+    assert not is_safe_path('\\..')
     assert not is_safe_path('..\\etc\\rules\\rule.xml')
     assert not is_safe_path('../ruleset/decoders/decoder.xml./', relative=False)
 

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -241,7 +241,7 @@ def is_safe_path(path: str, basedir: str = common.wazuh_path, relative: bool = T
         True if path is correct. False otherwise.
     """
     # Protect path
-    forbidden_paths = ["../", "..\\"]
+    forbidden_paths = ["../", "..\\", "/..", "\\.."]
     if any([forbidden_path in path for forbidden_path in forbidden_paths]):
         return False
 

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -47,6 +47,7 @@ _sort_param = re.compile(r'^[\w_\-,\s+.]+$')
 _timeframe_type = re.compile(r'^(\d+[dhms]?)$')
 _type_format = re.compile(r'^xml$|^json$')
 _yes_no_boolean = re.compile(r'^yes$|^no$')
+_active_response_command = re.compile(f"^!?{_paths.pattern.lstrip('^')}")
 
 security_config_schema = {
     "type": "object",
@@ -240,7 +241,8 @@ def is_safe_path(path: str, basedir: str = common.wazuh_path, relative: bool = T
         True if path is correct. False otherwise.
     """
     # Protect path
-    if './' in path or '../' in path:
+    forbidden_paths = ["../", "..\\"]
+    if any([forbidden_path in path for forbidden_path in forbidden_paths]):
         return False
 
     # Resolve symbolic links if present
@@ -320,6 +322,13 @@ def format_wazuh_path(value):
     if not is_safe_path(value, relative=False):
         return False
     return check_exp(value, _paths)
+
+
+@draft4_format_checker.checks("active_response_command")
+def format_active_response_command(command):
+    if not is_safe_path(command):
+        return False
+    return check_exp(command, _active_response_command)
 
 
 @draft4_format_checker.checks("query")

--- a/src/os_execd/exec.c
+++ b/src/os_execd/exec.c
@@ -83,10 +83,10 @@ int ReadExecConfig()
         *tmp_str = '\0';
         tmp_str += 3;
 
-        // Directory transversal test
+        // Directory traversal test
 
         if (w_ref_parent_folder(str_pt)) {
-            merror("Active response command '%s' vulnerable to directory transversal attack. Ignoring.", str_pt);
+            merror("Active response command '%s' vulnerable to directory traversal attack. Ignoring.", str_pt);
             exec_cmd[exec_size][0] = '\0';
         } else {
             /* Write the full command path */

--- a/src/os_execd/exec.c
+++ b/src/os_execd/exec.c
@@ -159,6 +159,11 @@ char *GetCommandbyName(const char *name, int *timeout)
     // Filter custom commands
 
     if (name[0] == '!') {
+        if (w_ref_parent_folder(name + 1)) {
+            mwarn("Active response command '%s' vulnerable to directory traversal attack. Ignoring.", name + 1);
+            return NULL;
+        }
+
         static char command[OS_FLSIZE];
 
         if (snprintf(command, sizeof(command), "%s/%s", AR_BINDIR, name + 1) >= (int)sizeof(command)) {

--- a/src/unit_tests/os_execd/CMakeLists.txt
+++ b/src/unit_tests/os_execd/CMakeLists.txt
@@ -30,6 +30,9 @@ if(${TARGET} STREQUAL "winagent")
                              -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek \
                              -Wl,--wrap,remove -Wl,--wrap,fgetpos -Wl,--wrap=fgetc -Wl,--wrap,fwrite \
                              ${DEBUG_OP_WRAPPERS}")
+
+    list(APPEND execd_names "test_get_command_by_name")
+    list(APPEND execd_flags "${DEBUG_OP_WRAPPERS}")
 else()
     list(APPEND execd_names "test_execd")
     list(APPEND execd_flags "-Wl,--wrap,time -Wl,--wrap,select -Wl,--wrap,OS_RecvUnix \
@@ -37,6 +40,9 @@ else()
                              -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek \
                              -Wl,--wrap,remove -Wl,--wrap,fgetpos -Wl,--wrap=fgetc -Wl,--wrap,fwrite \
                              -Wl,--wrap,fprintf ${DEBUG_OP_WRAPPERS}")
+
+    list(APPEND execd_names "test_get_command_by_name")
+    list(APPEND execd_flags "${DEBUG_OP_WRAPPERS}")
 endif()
 
 list(LENGTH execd_names count)

--- a/src/unit_tests/os_execd/test_get_command_by_name.c
+++ b/src/unit_tests/os_execd/test_get_command_by_name.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "shared.h"
+#include "../../os_execd/execd.h"
+
+static void test_custom_command(void **state) {
+    (void)state;
+
+    int timeout = 100;
+    char * r = GetCommandbyName("!custom.sh", &timeout);
+
+    assert_int_equal(timeout, 0);
+    assert_string_equal(r, AR_BINDIR "/custom.sh");
+}
+
+static void test_path_traversal(void **state) {
+    (void)state;
+    int timeout = 100;
+
+    expect_string(__wrap__mwarn, formatted_msg, "Active response command '../custom.sh' vulnerable to directory traversal attack. Ignoring.");
+
+    char * r = GetCommandbyName("!../custom.sh", &timeout);
+    assert_null(r);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_custom_command),
+        cmocka_unit_test(test_path_traversal),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
|Affected versions|Module|Component|Cause|Credits|
|---|---|---|---|---|
|3.6.1 - 3.13.5, 4.0.0 - 4.2.7, 4.3.0 - 4.3.7|Active Response|Agent & manager|#1217| All credits to Roshan Guragain|


Thanks to **Roshan Guragain** for reporting the flaw and helping us improve the product!

## Flaw

References to a parent folder are possible in a custom AR API request:
|Method|Endpoint|Data|
|---|---|---|
|PUT|/active-response|`{"command":"!../../../../../../bin/ls"}`|

## Impact

A manager administrator with RBAC permissions `active-response:command` might execute a program outside the Active Response binary folder (_/var/ossec/active-response/bin_).

- In versions below 4.2.0, the target command would receive the extra arguments (`extra_args`) as a command-line parameter list.
- In 4.2.0 and higher, the target command receives all data (including the extra arguments) in a JSON string via standard input.

### Agents from 3.6.1 to 4.1.5

Running a custom Active Response with these parameters:

|Command|Custom|Arguments|
|---|---|---|
|`../../../../root/test.sh`|`true`|`[arg1, arg2, arg3]`|

This will cause the agent to run `/root/test.sh` with the following arguments:
```shell
/var/ossec/active-response/bin/../../../../root/test.sh add arg1 arg2 arg3
```

### Agents from 4.2.0 to 4.3.7

Running a custom Active Response with these parameters:

|Command|Arguments|
|---|---|
|`!../../../../root/test.sh`|`[arg1, arg2, arg3]`|

This will cause the agent to run `/root/test.sh` with no extra arguments, but the agent will send the following string via _stdin_:
```shell
{"version":1,"origin":{"name":null,"module":"wazuh-execd"},"command":"add","parameters":{"extra_args":["arg1","arg2","arg3"],"alert":{},"program":"active-response/bin/../../../../root/test.sh"}}
```

## Proposed fix

We're implementing protection at two levels:

1. Prevent the agent (wazuh-execd) from running a custom AR outside _active-response/bin_.
2. Filter custom Active Response commands by the API and reject those whose member `command` contains any reference to a parent folder (`../`).

## Tests

- [x] Send a custom AR command to Execd containing a reference to the parent folder:
```sh
echo -n '{"version": 1, "origin": {"name": null, "module": "framework"}, "command": "!../../../../../../bin/ls", "parameters": {"extra_args": [], "alert": {}}}' | nc -w0 -Uu /var/ossec/queue/alerts/execq
```
```
2022/09/05 14:48:51 wazuh-execd[6848] exec.c:163 at GetCommandbyName(): WARNING: Active response command '../../../../../../bin/ls' vulnerable to directory traversal attack. Ignoring.
2022/09/05 14:48:51 wazuh-execd[6848] execd.c:465 at ExecdStart(): ERROR: (1311): Invalid command name '!../../../../../../bin/ls' provided.
```
- [x] Unit tests to check that `GetCommandbyName` rejects custom commands with path traversal.
- [x] The API rejects custom ARs with commands referring to the parent folder:
```sh
curl -H "Content-Type: application/json" -X PUT https://localhost:55000/active-response?agents_list=001 --data '{"command":"!../../../../../../bin/ls"}'
```
```
{"title": "Bad Request", "detail": "'!../../../../../../bin/l' is not a 'active_response_command' - 'command'"}
```