### PR TITLE
Update deprecated value of `KillMode` option in systemd service

### DIFF
--- a/src/init/templates/wazuh-agent.service
+++ b/src/init/templates/wazuh-agent.service
@@ -9,7 +9,9 @@ Type=forking
 ExecStart=/usr/bin/env WAZUH_HOME_TMP/bin/wazuh-control start
 ExecStop=/usr/bin/env WAZUH_HOME_TMP/bin/wazuh-control stop
 ExecReload=/usr/bin/env WAZUH_HOME_TMP/bin/wazuh-control reload
-KillMode=none
+
+KillMode=mixed
+SendSIGKILL=no
 RemainAfterExit=yes
 
 [Install]

--- a/src/init/templates/wazuh-agent.service
+++ b/src/init/templates/wazuh-agent.service
@@ -10,8 +10,7 @@ ExecStart=/usr/bin/env WAZUH_HOME_TMP/bin/wazuh-control start
 ExecStop=/usr/bin/env WAZUH_HOME_TMP/bin/wazuh-control stop
 ExecReload=/usr/bin/env WAZUH_HOME_TMP/bin/wazuh-control reload
 
-KillMode=mixed
-SendSIGKILL=no
+KillMode=process
 RemainAfterExit=yes
 
 [Install]

--- a/src/init/templates/wazuh-manager.service
+++ b/src/init/templates/wazuh-manager.service
@@ -10,7 +10,9 @@ LimitNOFILE=65536
 ExecStart=/usr/bin/env WAZUH_HOME_TMP/bin/wazuh-control start
 ExecStop=/usr/bin/env WAZUH_HOME_TMP/bin/wazuh-control stop
 ExecReload=/usr/bin/env WAZUH_HOME_TMP/bin/wazuh-control reload
-KillMode=none
+
+KillMode=mixed
+SendSIGKILL=no
 RemainAfterExit=yes
 
 [Install]

--- a/src/init/templates/wazuh-manager.service
+++ b/src/init/templates/wazuh-manager.service
@@ -11,8 +11,7 @@ ExecStart=/usr/bin/env WAZUH_HOME_TMP/bin/wazuh-control start
 ExecStop=/usr/bin/env WAZUH_HOME_TMP/bin/wazuh-control stop
 ExecReload=/usr/bin/env WAZUH_HOME_TMP/bin/wazuh-control reload
 
-KillMode=mixed
-SendSIGKILL=no
+KillMode=process
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
|Related issue|
|---|
|#11408|

## Description
This PR aims to solve the usage of a deprecated parameter (KillMode=none) on the systemd unit files for the manager and agent.

The changes are minimal, and is to change `KillMode` from `none` to `process`.

## Logs/Alerts example
```
# systemctl status wazuh-agent | cat -
● wazuh-agent.service - Wazuh agent
     Loaded: loaded (/lib/systemd/system/wazuh-agent.service; enabled; vendor preset: enabled)
     Active: active (running) since Mon 2021-11-29 13:41:47 UTC; 2 weeks 5 days ago
      Tasks: 31 (limit: 9413)
     Memory: 712.5M
     CGroup: /system.slice/wazuh-agent.service
             ├─777819 /var/ossec/bin/wazuh-execd
             ├─777830 /var/ossec/bin/wazuh-agentd
             ├─777844 /var/ossec/bin/wazuh-syscheckd
             ├─777858 /var/ossec/bin/wazuh-logcollector
             └─777876 /var/ossec/bin/wazuh-modulesd
             
Unit configured to use KillMode=none. This is unsafe, as it disables systemd's process lifecycle management for the service. Please update your service to use a safer KillMode=, such as 'mixed' or 'control-group'. Support for KillMode=none is deprecated and will eventually be removed.
```

## Rationale

### Option previously used:
- none:
  - No process is killed (strongly recommended against!).
  - Only the stop command will be executed on unit stop, but no process will be killed otherwise.
  - Processes remaining alive after stop are left in their control group and the control group continues to exist after stop unless empty.

### [Why?](https://github.com/wazuh/wazuh/issues/11408#issuecomment-1000015318)

> Wazuh (both manager and agent) manages its daemons with wazuh-control. This tool finds each daemon's PID, tries to stop it with a one-minute timeout gracefully, and kills if it does not respond.
> We set KillMode to None in [3.0.0](https://github.com/wazuh/wazuh/commit/4ae03506288ed079e50535e46c2e4a4a1f59b6fc9), in order to prevent the agent to kill itself when upgrading via WPK.
  
### Option proposed:
- process:
  - Only the main process itself is killed

**NOTE**
`process` value was added in systemd documentation in [v187](https://github.com/systemd/systemd/blob/v187/man/systemd.kill.xml), but the code support it since [v12](https://github.com/systemd/systemd/blob/v12/src/execute.c#L1821).

### Why?

The main process, in this case, has always assigned the ID 0. 
```
# systemctl show wazuh-manager.service | grep PID
GuessMainPID=yes
MainPID=0
ControlPID=0
ExecMainPID=0
```

Sending a kill signal to PID 0 kills the caller. For example in the following script:
```
echo "Entry"
kill -9 0
echo "Exit"
```

If we execute it, it kill itself:
```
# ./test.sh 
Entry
Killed
```

So we don't have any way to indicate from the outside to kill the parent process of wazuh-agent (unless we kill all its childen PID by PID, just as we do it on the wazuh-control script).
___

If we remove from wazuh-control the ability to kill all child processes (wazuh-execd, agentd, etc):
```
stop_service()
{
  return
  checkpid;
...
```

And stop the service via systemctl. We see that the agent is and its Control Group process are alive:
```
# systemctl status wazuh-agent.service 
● wazuh-agent.service - Wazuh agent
     Loaded: loaded (/etc/systemd/system/wazuh-agent.service; enabled; vendor preset: enabled)
     Active: inactive (dead) since Tue 2022-09-06 13:48:00 -03; 1min 12s ago
    Process: 3243 ExecStop=/usr/bin/env /var/ossec/bin/wazuh-control stop (code=exited, status=0/SUCCESS)
      Tasks: 37 (limit: 1034)
     Memory: 314.6M
     CGroup: /system.slice/wazuh-agent.service
             ├─1593 /var/ossec/bin/wazuh-execd
             ├─1601 /var/ossec/bin/wazuh-agentd
             ├─1615 /var/ossec/bin/wazuh-syscheckd
             ├─1627 /var/ossec/bin/wazuh-logcollector
             └─1644 /var/ossec/bin/wazuh-modulesd

Sep 06 09:22:17 ubuntu21 env[1561]: Completed.
Sep 06 09:22:17 ubuntu21 systemd[1]: Started Wazuh agent.
Sep 06 13:48:00 ubuntu21 systemd[1]: Stopping Wazuh agent...
Sep 06 13:48:00 ubuntu21 systemd[1]: wazuh-agent.service: Succeeded.
Sep 06 13:48:00 ubuntu21 systemd[1]: wazuh-agent.service: Unit process 1593 (wazuh-execd) remains running after unit stopped.
Sep 06 13:48:00 ubuntu21 systemd[1]: wazuh-agent.service: Unit process 1601 (wazuh-agentd) remains running after unit stopped.
Sep 06 13:48:00 ubuntu21 systemd[1]: wazuh-agent.service: Unit process 1615 (wazuh-syscheckd) remains running after unit stopped.
Sep 06 13:48:00 ubuntu21 systemd[1]: wazuh-agent.service: Unit process 1627 (wazuh-logcollec) remains running after unit stopped.
Sep 06 13:48:00 ubuntu21 systemd[1]: wazuh-agent.service: Unit process 1644 (wazuh-modulesd) remains running after unit stopped.
```

On the manager:
```
# /var/ossec/bin/agent_control -l

Wazuh agent_control. List of available agents:
   ID: 000, Name: ubuntu22 (server), IP: 127.0.0.1, Active/Local
   ID: 006, Name: ubuntu21, IP: any, Active

List of agentless devices:
```

We have full control of the kill process.


## Tests
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade