### PR TITLE
Fix mean-difference error and update logs

### DIFF
--- a/framework/wazuh/core/cluster/agents_reconnect.py
+++ b/framework/wazuh/core/cluster/agents_reconnect.py
@@ -518,11 +518,11 @@ class AgentsReconnect:
             total_active_agents = sum(info['total'] for info in self.env_status.values())
             max_assigns = max(min(total_active_agents * 0.05, max_assignments_per_node), 1)
             predict_info = self.predict_distribution(self.env_status, max_assigns)
+            self.logger.info(f'It can take up to {self.expected_rounds} rounds to reconnect {total_reconnect} agents.')
             # If test round is as big as a normal round, count itself as a normal round.
             self.round_counter += 1 if len(predict_info["agents"]) in [max_assignments_per_node, total_reconnect] else 0
-            self.logger.info(f'It can take up to {self.expected_rounds} rounds to reconnect {total_reconnect} agents.')
             self.logger.info(f'Reconnecting {len(predict_info["agents"])} agents (' +
-                             (f'test round' if self.round_counter != self.expected_rounds else
+                             (f'test round' if self.round_counter == 0 else
                               f'round {self.round_counter}/{self.expected_rounds}') + ').')
 
         elif self.round_counter < self.expected_rounds:

--- a/framework/wazuh/core/cluster/agents_reconnect.py
+++ b/framework/wazuh/core/cluster/agents_reconnect.py
@@ -515,12 +515,15 @@ class AgentsReconnect:
             if predict_info['partial_balance']:
                 self.logger.warning('Not all agents that should reconnect support that feature (introduced in v4.3.0). '
                                     'The cluster could remain unbalanced.')
+
             total_active_agents = sum(info['total'] for info in self.env_status.values())
-            max_assigns = max(min(total_active_agents * 0.05, max_assignments_per_node), 1)
-            predict_info = self.predict_distribution(self.env_status, max_assigns)
+            max_test_assigns = max(min(total_active_agents * 0.05, max_assignments_per_node), 1)
+            predict_info = self.predict_distribution(self.env_status, max_test_assigns)
             self.logger.info(f'It can take up to {self.expected_rounds} rounds to reconnect {total_reconnect} agents.')
             # If test round is as big as a normal round, count itself as a normal round.
-            self.round_counter += 1 if len(predict_info["agents"]) in [max_assignments_per_node, total_reconnect] else 0
+            if max_test_assigns == max_assignments_per_node or len(predict_info["agents"]) == total_reconnect:
+                self.round_counter += 1
+
             self.logger.info(f'Reconnecting {len(predict_info["agents"])} agents (' +
                              (f'test round' if self.round_counter == 0 else
                               f'round {self.round_counter}/{self.expected_rounds}') + ').')

--- a/framework/wazuh/core/cluster/agents_reconnect.py
+++ b/framework/wazuh/core/cluster/agents_reconnect.py
@@ -492,7 +492,7 @@ class AgentsReconnect:
             """
             agents_per_worker = [worker['total'] for worker in self.env_status.values()]
             mean = sum(agents_per_worker) / len(agents_per_worker)
-            tolerance_window = max(floor(mean * tolerance), 2)
+            tolerance_window = max(floor(mean * tolerance), 3)
             biggest_node = max(self.env_status.keys(), key=lambda x: self.env_status[x]['total'])
             smallest_node = min(self.env_status.keys(), key=lambda x: self.env_status[x]['total'])
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #14799 |

## Description

This PR solves the 3 main problems reported at #14799:
- Fixed the issue where an unbalanced environment was incorrectly estimated to be balanced, even when tolerance was not applying.
- Data of all cluster nodes is used to calculate the mean in the `is_balanced_based_tolerance` function.
- Testing rounds that are the same size as a normal round are counted as a normal round.

## Logs/Alerts example

In an example environment with 40 agents, this distribution was incorrectly estimated as balanced:
```
- Worker1: 11
- Worker2: 11
- Worker3: 11
- Worker4: 7
```

It will now trigger the balancing mechanism. In addition, and as it can be seen in the logs below, logs related to rounds have been updated:
```
2022/09/07 11:32:12 INFO: [Master] [Cluster balance] Checking cluster stability (3/3). Cluster is stable.
2022/09/07 11:32:12 INFO: [Master] [Cluster balance] It can take up to 1 rounds to reconnect 3 agents.
2022/09/07 11:32:12 INFO: [Master] [Cluster balance] Reconnecting 2 agents (test round).
2022/09/07 11:32:12 INFO: [Master] [Cluster balance] Iteration complete. Sleeping 60 seconds.
2022/09/07 11:33:12 INFO: [Master] [Cluster balance] Checking cluster stability (3/3). Cluster is stable.
2022/09/07 11:33:12 INFO: [Master] [Cluster balance] Reconnecting 1 agents (round 1/1).
2022/09/07 11:33:12 INFO: [Master] [Cluster balance] Iteration complete. Sleeping 60 seconds.
```

And if test round is as big as a normal round, there won't be `test round` log:
```
2022/09/07 11:30:32 INFO: [Master] [Cluster balance] Checking cluster stability (3/3). Cluster is stable.
2022/09/07 11:30:32 INFO: [Master] [Cluster balance] It can take up to 1 rounds to reconnect 3 agents.
2022/09/07 11:30:32 INFO: [Master] [Cluster balance] Reconnecting 3 agents (round 1/1).
2022/09/07 11:30:32 INFO: [Master] [Cluster balance] Iteration complete. Sleeping 60 seconds.
```
