### PR TITLE
Modify OS name's source for macOS

### DIFF
--- a/src/data_provider/src/osinfo/sysOsParsers.cpp
+++ b/src/data_provider/src/osinfo/sysOsParsers.cpp
@@ -406,6 +406,7 @@ bool MacOsParser::parseSystemProfiler(const std::string& in, nlohmann::json& out
         constexpr auto PATTERN_MATCH{R"(([^\s]+) ([^\s]+) ([^\s]+))"};
         std::string match;
         std::regex pattern{PATTERN_MATCH};
+
         if (Utils::findRegexInString(output["os_name"], match, pattern, 1))
         {
             output["os_name"] = match;

--- a/src/data_provider/src/osinfo/sysOsParsers.cpp
+++ b/src/data_provider/src/osinfo/sysOsParsers.cpp
@@ -376,7 +376,6 @@ bool MacOsParser::parseSwVersion(const std::string& in, nlohmann::json& output)
     constexpr auto SEPARATOR{':'};
     static const std::map<std::string, std::string> KEY_MAP
     {
-        {"ProductName",     "os_name"},
         {"ProductVersion",  "os_version"},
         {"BuildVersion",    "os_build"},
     };
@@ -388,6 +387,20 @@ bool MacOsParser::parseSwVersion(const std::string& in, nlohmann::json& output)
     {
         findMajorMinorVersionInString(output["os_version"], output);
     }
+
+    return ret;
+}
+
+bool MacOsParser::parseSystemProfiler(const std::string& in, nlohmann::json& output)
+{
+    constexpr auto SEPARATOR{':'};
+    static const std::map<std::string, std::string> KEY_MAP
+    {
+        {"System Version", "os_name"},
+    };
+    std::stringstream data{in};
+    const auto ret{ parseUnixFile(KEY_MAP, SEPARATOR, data, output) };
+    output["os_name"] = Utils::split(output["os_name"].get<std::string>(), ' ').at(0);
 
     return ret;
 }

--- a/src/data_provider/src/osinfo/sysOsParsers.cpp
+++ b/src/data_provider/src/osinfo/sysOsParsers.cpp
@@ -400,7 +400,21 @@ bool MacOsParser::parseSystemProfiler(const std::string& in, nlohmann::json& out
     };
     std::stringstream data{in};
     const auto ret{ parseUnixFile(KEY_MAP, SEPARATOR, data, output) };
-    output["os_name"] = Utils::split(output["os_name"].get_ref<const std::string&>(), ' ').at(0);
+
+    if (ret)
+    {
+        constexpr auto PATTERN_MATCH{R"(([^\s]+) ([^\s]+) ([^\s]+))"};
+        std::string match;
+        std::regex pattern{PATTERN_MATCH};
+        if (Utils::findRegexInString(output["os_name"], match, pattern, 1))
+        {
+            output["os_name"] = match;
+        }
+        else
+        {
+            return false;
+        }
+    }
 
     return ret;
 }

--- a/src/data_provider/src/osinfo/sysOsParsers.cpp
+++ b/src/data_provider/src/osinfo/sysOsParsers.cpp
@@ -399,7 +399,7 @@ bool MacOsParser::parseSystemProfiler(const std::string& in, nlohmann::json& out
         {"System Version", "os_name"},
     };
     std::stringstream data{in};
-    const auto ret{ parseUnixFile(KEY_MAP, SEPARATOR, data, output) };
+    auto ret{ parseUnixFile(KEY_MAP, SEPARATOR, data, output) };
 
     if (ret)
     {
@@ -412,7 +412,8 @@ bool MacOsParser::parseSystemProfiler(const std::string& in, nlohmann::json& out
         }
         else
         {
-            return false;
+            output["os_name"] = "macOS";
+            ret = false;
         }
     }
 

--- a/src/data_provider/src/osinfo/sysOsParsers.cpp
+++ b/src/data_provider/src/osinfo/sysOsParsers.cpp
@@ -400,7 +400,7 @@ bool MacOsParser::parseSystemProfiler(const std::string& in, nlohmann::json& out
     };
     std::stringstream data{in};
     const auto ret{ parseUnixFile(KEY_MAP, SEPARATOR, data, output) };
-    output["os_name"] = Utils::split(output["os_name"].get<std::string>(), ' ').at(0);
+    output["os_name"] = Utils::split(output["os_name"].get_ref<const std::string&>(), ' ').at(0);
 
     return ret;
 }

--- a/src/data_provider/src/osinfo/sysOsParsers.cpp
+++ b/src/data_provider/src/osinfo/sysOsParsers.cpp
@@ -399,16 +399,16 @@ bool MacOsParser::parseSystemProfiler(const std::string& in, nlohmann::json& out
         {"System Version", "os_name"},
     };
     std::stringstream data{in};
-    nlohmann::json tmp;
-    auto ret{ parseUnixFile(KEY_MAP, SEPARATOR, data, tmp) };
+    nlohmann::json info;
+    auto ret{ parseUnixFile(KEY_MAP, SEPARATOR, data, info) };
 
     if (ret)
     {
-        constexpr auto PATTERN_MATCH{R"(([^\s]+) ([^\s]+) ([^\s]+))"};
+        constexpr auto PATTERN_MATCH{R"(^([^\s]+) [^\s]+ [^\s]+$)"};
         std::string match;
         std::regex pattern{PATTERN_MATCH};
 
-        if (Utils::findRegexInString(tmp["os_name"], match, pattern, 1))
+        if (Utils::findRegexInString(info["os_name"], match, pattern, 1))
         {
             output["os_name"] = std::move(match);
         }

--- a/src/data_provider/src/osinfo/sysOsParsers.cpp
+++ b/src/data_provider/src/osinfo/sysOsParsers.cpp
@@ -399,7 +399,8 @@ bool MacOsParser::parseSystemProfiler(const std::string& in, nlohmann::json& out
         {"System Version", "os_name"},
     };
     std::stringstream data{in};
-    auto ret{ parseUnixFile(KEY_MAP, SEPARATOR, data, output) };
+    nlohmann::json tmp;
+    auto ret{ parseUnixFile(KEY_MAP, SEPARATOR, data, tmp) };
 
     if (ret)
     {
@@ -407,13 +408,12 @@ bool MacOsParser::parseSystemProfiler(const std::string& in, nlohmann::json& out
         std::string match;
         std::regex pattern{PATTERN_MATCH};
 
-        if (Utils::findRegexInString(output["os_name"], match, pattern, 1))
+        if (Utils::findRegexInString(tmp["os_name"], match, pattern, 1))
         {
-            output["os_name"] = match;
+            output["os_name"] = std::move(match);
         }
         else
         {
-            output["os_name"] = "macOS";
             ret = false;
         }
     }

--- a/src/data_provider/src/osinfo/sysOsParsers.h
+++ b/src/data_provider/src/osinfo/sysOsParsers.h
@@ -140,6 +140,7 @@ class MacOsParser
         MacOsParser() = default;
         ~MacOsParser() = default;
         bool parseSwVersion(const std::string& in, nlohmann::json& output);
+        bool parseSystemProfiler(const std::string& in, nlohmann::json& output);
         bool parseUname(const std::string& in, nlohmann::json& output);
 };
 

--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -243,8 +243,12 @@ nlohmann::json SysInfo::getOsInfo() const
     struct utsname uts {};
     MacOsParser parser;
     parser.parseSwVersion(Utils::exec("sw_vers"), ret);
-    parser.parseSystemProfiler(Utils::exec("system_profiler SPSoftwareDataType"), ret);
     parser.parseUname(Utils::exec("uname -r"), ret);
+
+    if (!parser.parseSystemProfiler(Utils::exec("system_profiler SPSoftwareDataType"), ret))
+    {
+        ret["os_name"] = "macOS";
+    }
 
     if (uname(&uts) >= 0)
     {

--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -243,6 +243,7 @@ nlohmann::json SysInfo::getOsInfo() const
     struct utsname uts {};
     MacOsParser parser;
     parser.parseSwVersion(Utils::exec("sw_vers"), ret);
+    parser.parseSystemProfiler(Utils::exec("system_profiler SPSoftwareDataType"), ret);
     parser.parseUname(Utils::exec("uname -r"), ret);
 
     if (uname(&uts) >= 0)

--- a/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
@@ -515,7 +515,8 @@ TEST_F(SysInfoParsersTest, MacOSOsDefaultName)
     EXPECT_TRUE(parser.parseSwVersion(MACOS_SW_VERSION, output));
     EXPECT_FALSE(parser.parseSystemProfiler(MACOS_SYSTEM_PROFILER, output));
     EXPECT_TRUE(parser.parseUname(MACOS_UNAME, output));
-    EXPECT_TRUE(output["os_name"] == nullptr);
+    // default name is responsability of the caller
+    EXPECT_EQ(output["os_name"], nullptr);
     EXPECT_EQ("10.14.6", output["os_version"]);
     EXPECT_EQ("darwin", output["os_platform"]);
     EXPECT_EQ("18G103", output["os_build"]);

--- a/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
@@ -441,6 +441,24 @@ TEST_F(SysInfoParsersTest, MacOS)
         BuildVersion:   16G29
         )"
     };
+    constexpr auto MACOS_SYSTEM_PROFILER
+    {
+        R"(
+        Software:
+
+          System Software Overview:
+
+            System Version: macOS 10.15.5 (19F101)
+            Kernel Version: Darwin 19.5.0
+            Boot Volume: catalina
+            Boot Mode: Normal
+            Computer Name: User’s iMac (2)
+            User Name: User (macos-catalina)
+            Secure Virtual Memory: Enabled
+            System Integrity Protection: Enabled
+            Time since boot: 3 minutes
+        )"
+    };
     constexpr auto MACOS_UNAME
     {
         "16.7.0"
@@ -448,9 +466,10 @@ TEST_F(SysInfoParsersTest, MacOS)
     nlohmann::json output;
     MacOsParser parser;
     EXPECT_TRUE(parser.parseSwVersion(MACOS_SW_VERSION, output));
+    EXPECT_TRUE(parser.parseSystemProfiler(MACOS_SYSTEM_PROFILER, output));
     EXPECT_TRUE(parser.parseUname(MACOS_UNAME, output));
     EXPECT_EQ("10.12.6", output["os_version"]);
-    EXPECT_EQ("Mac OS X", output["os_name"]);
+    EXPECT_EQ("macOS", output["os_name"]);
     EXPECT_EQ("darwin", output["os_platform"]);
     EXPECT_EQ("16G29", output["os_build"]);
     EXPECT_EQ("Sierra", output["os_codename"]);

--- a/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
@@ -436,9 +436,9 @@ TEST_F(SysInfoParsersTest, MacOS)
     constexpr auto MACOS_SW_VERSION
     {
         R"(
-        ProductName:    Mac OS X
-        ProductVersion: 10.12.6
-        BuildVersion:   16G29
+        ProductName:	Mac OS X
+        ProductVersion:	10.14.6
+        BuildVersion:	18G103
         )"
     };
     constexpr auto MACOS_SYSTEM_PROFILER
@@ -448,32 +448,32 @@ TEST_F(SysInfoParsersTest, MacOS)
 
           System Software Overview:
 
-            System Version: macOS 10.15.5 (19F101)
-            Kernel Version: Darwin 19.5.0
-            Boot Volume: catalina
+            System Version: macOS 10.14.6 (18G103)
+            Kernel Version: Darwin 18.7.0
+            Boot Volume: mojave
             Boot Mode: Normal
-            Computer Name: User’s iMac (2)
-            User Name: User (macos-catalina)
+            Computer Name: macos-mojave-vm
+            User Name: System Administrator (root)
             Secure Virtual Memory: Enabled
             System Integrity Protection: Enabled
-            Time since boot: 3 minutes
+            Time since boot: 58 minutes
         )"
     };
     constexpr auto MACOS_UNAME
     {
-        "16.7.0"
+        "18.7.0"
     };
     nlohmann::json output;
     MacOsParser parser;
     EXPECT_TRUE(parser.parseSwVersion(MACOS_SW_VERSION, output));
     EXPECT_TRUE(parser.parseSystemProfiler(MACOS_SYSTEM_PROFILER, output));
     EXPECT_TRUE(parser.parseUname(MACOS_UNAME, output));
-    EXPECT_EQ("10.12.6", output["os_version"]);
+    EXPECT_EQ("10.14.6", output["os_version"]);
     EXPECT_EQ("macOS", output["os_name"]);
     EXPECT_EQ("darwin", output["os_platform"]);
-    EXPECT_EQ("16G29", output["os_build"]);
-    EXPECT_EQ("Sierra", output["os_codename"]);
+    EXPECT_EQ("18G103", output["os_build"]);
+    EXPECT_EQ("Mojave", output["os_codename"]);
     EXPECT_EQ("10", output["os_major"]);
-    EXPECT_EQ("12", output["os_minor"]);
+    EXPECT_EQ("14", output["os_minor"]);
     EXPECT_EQ("6", output["os_patch"]);
 }

--- a/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
@@ -477,3 +477,50 @@ TEST_F(SysInfoParsersTest, MacOS)
     EXPECT_EQ("14", output["os_minor"]);
     EXPECT_EQ("6", output["os_patch"]);
 }
+
+TEST_F(SysInfoParsersTest, MacOSOsDefaultName)
+{
+    constexpr auto MACOS_SW_VERSION
+    {
+        R"(
+        ProductName:	Mac OS X
+        ProductVersion:	10.14.6
+        BuildVersion:	18G103
+        )"
+    };
+    constexpr auto MACOS_SYSTEM_PROFILER
+    {
+        R"(
+        Software:
+
+          System Software Overview:
+
+            System Version: macOS (18G103)
+            Kernel Version: Darwin 18.7.0
+            Boot Volume: mojave
+            Boot Mode: Normal
+            Computer Name: macos-mojave-vm
+            User Name: System Administrator (root)
+            Secure Virtual Memory: Enabled
+            System Integrity Protection: Enabled
+            Time since boot: 58 minutes
+        )"
+    };
+    constexpr auto MACOS_UNAME
+    {
+        "18.7.0"
+    };
+    nlohmann::json output;
+    MacOsParser parser;
+    EXPECT_TRUE(parser.parseSwVersion(MACOS_SW_VERSION, output));
+    EXPECT_FALSE(parser.parseSystemProfiler(MACOS_SYSTEM_PROFILER, output));
+    EXPECT_TRUE(parser.parseUname(MACOS_UNAME, output));
+    EXPECT_TRUE(output["os_name"] == nullptr);
+    EXPECT_EQ("10.14.6", output["os_version"]);
+    EXPECT_EQ("darwin", output["os_platform"]);
+    EXPECT_EQ("18G103", output["os_build"]);
+    EXPECT_EQ("Mojave", output["os_codename"]);
+    EXPECT_EQ("10", output["os_major"]);
+    EXPECT_EQ("14", output["os_minor"]);
+    EXPECT_EQ("6", output["os_patch"]);
+}

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -661,12 +661,14 @@ os_info *get_unix_version()
             } else if(strcmp(strtok_r(buff, "\n", &save_ptr),"Darwin") == 0){
                 info->os_platform = strdup("darwin");
 
-                if (cmd_output_ver = popen("sw_vers -productName", "r"), cmd_output_ver) {
-                    if(fgets(buff, sizeof(buff) - 1, cmd_output_ver) == NULL){
-                        mdebug1("Cannot read from command output (sw_vers -productName).");
-                    } else {
-                        w_strdup(strtok_r(buff, "\n", &save_ptr), info->os_name);
-                    }
+                if (cmd_output_ver = popen("system_profiler SPSoftwareDataType -detailLevel mini", "r"), cmd_output_ver)
+                {
+                    fread(buff, 1, sizeof(buff), cmd_output_ver);
+                    char *aux = strtok(buff, "\n");
+                    aux = strtok(NULL, "\n");
+                    aux = strtok(NULL, ":");
+                    aux = strtok(NULL, " ");
+                    w_strdup(aux, info->os_name);
                     pclose(cmd_output_ver);
                 }
                 if (cmd_output_ver = popen("sw_vers -productVersion", "r"), cmd_output_ver) {

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -661,27 +661,26 @@ os_info *get_unix_version()
             } else if(strcmp(strtok_r(buff, "\n", &save_ptr),"Darwin") == 0){
                 info->os_platform = strdup("darwin");
 
-                if (cmd_output_ver = popen("system_profiler SPSoftwareDataType", "r"), cmd_output_ver)
-                {
-                    while (fgets(buff, sizeof(buff) - 1, cmd_output_ver))
-                    {
+                if (cmd_output_ver = popen("system_profiler SPSoftwareDataType", "r"), cmd_output_ver) {
+                    while (fgets(buff, sizeof(buff) - 1, cmd_output_ver)) {
                         char *key = strtok_r(buff, ":", &save_ptr);
-                        if (key && strcmp(os_strip_char(key, ' '), "SystemVersion") == 0)
-                        {
-                            char *value = strtok_r(NULL, " ", &save_ptr);
-                            if (value)
-                            {
-                                w_strdup(value, info->os_name);
+                        if (key) {
+                            char *trimed_key = os_strip_char(key, ' ');
+                            if (strcmp(trimed_key, "SystemVersion") == 0) {
+                                char *value = strtok_r(NULL, " ", &save_ptr);
+                                if (value) {
+                                    w_strdup(value, info->os_name);
+                                } else {
+                                    mdebug1("Cannot parse System Version value (system_profiler SPSoftwareDataType).");
+                                }
                             }
-                            else
-                            {
-                                mdebug1("Cannot parse System Version value (system_profiler SPSoftwareDataType).");
+                            free (trimed_key);
+                            if(info->os_name) {
+                                break;
                             }
-                            break;
                         }
                     }
-                    if (!info->os_name)
-                    {
+                    if (NULL == info->os_name) {
                         mdebug1("Cannot read from command output (system_profiler SPSoftwareDataType).");
                     }
                     pclose(cmd_output_ver);

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -665,22 +665,22 @@ os_info *get_unix_version()
                 {
                     if (fread(buff, 1, sizeof(buff), cmd_output_ver) > 0)
                     {
-                        char *aux = strtok_r(buff, "\n", &save_ptr);
-                        aux = strtok_r(NULL, "\n", &save_ptr);
-                        aux = strtok_r(NULL, ":", &save_ptr);
-                        aux = strtok_r(NULL, " ", &save_ptr);
+                        strtok_r(buff, "\n", &save_ptr);
+                        strtok_r(NULL, "\n", &save_ptr);
+                        strtok_r(NULL, ":", &save_ptr);
+                        char *aux = strtok_r(NULL, " ", &save_ptr);
                         if (aux && strlen(aux) > 0)
                         {
                             w_strdup(aux, info->os_name);
                         }
                         else
                         {
-                            mdebug1("Cannot parse System Version (system_profiler SPSoftwareDataType -detailLevel mini).");
+                            mdebug1("Cannot parse System Version (system_profiler SPSoftwareDataType).");
                         }
                     }
                     else
                     {
-                        mdebug1("Cannot read from command output (system_profiler SPSoftwareDataType -detailLevel mini).");
+                        mdebug1("Cannot read from command output (system_profiler SPSoftwareDataType).");
                     }
                     pclose(cmd_output_ver);
                 }

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -663,12 +663,18 @@ os_info *get_unix_version()
 
                 if (cmd_output_ver = popen("system_profiler SPSoftwareDataType -detailLevel mini", "r"), cmd_output_ver)
                 {
-                    fread(buff, 1, sizeof(buff), cmd_output_ver);
-                    char *aux = strtok(buff, "\n");
-                    aux = strtok(NULL, "\n");
-                    aux = strtok(NULL, ":");
-                    aux = strtok(NULL, " ");
-                    w_strdup(aux, info->os_name);
+                    if (fread(buff, 1, sizeof(buff), cmd_output_ver) > 0)
+                    {
+                        char *aux = strtok(buff, "\n");
+                        aux = strtok(NULL, "\n");
+                        aux = strtok(NULL, ":");
+                        aux = strtok(NULL, " ");
+                        w_strdup(aux, info->os_name);
+                    }
+                    else
+                    {
+                        mdebug1("Cannot read from command output (system_profiler SPSoftwareDataType -detailLevel mini).");
+                    }
                     pclose(cmd_output_ver);
                 }
                 if (cmd_output_ver = popen("sw_vers -productVersion", "r"), cmd_output_ver) {

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -661,15 +661,22 @@ os_info *get_unix_version()
             } else if(strcmp(strtok_r(buff, "\n", &save_ptr),"Darwin") == 0){
                 info->os_platform = strdup("darwin");
 
-                if (cmd_output_ver = popen("system_profiler SPSoftwareDataType -detailLevel mini", "r"), cmd_output_ver)
+                if (cmd_output_ver = popen("system_profiler SPSoftwareDataType", "r"), cmd_output_ver)
                 {
                     if (fread(buff, 1, sizeof(buff), cmd_output_ver) > 0)
                     {
-                        char *aux = strtok(buff, "\n");
-                        aux = strtok(NULL, "\n");
-                        aux = strtok(NULL, ":");
-                        aux = strtok(NULL, " ");
-                        w_strdup(aux, info->os_name);
+                        char *aux = strtok_r(buff, "\n", &save_ptr);
+                        aux = strtok_r(NULL, "\n", &save_ptr);
+                        aux = strtok_r(NULL, ":", &save_ptr);
+                        aux = strtok_r(NULL, " ", &save_ptr);
+                        if (aux && strlen(aux) > 0)
+                        {
+                            w_strdup(aux, info->os_name);
+                        }
+                        else
+                        {
+                            mdebug1("Cannot parse System Version (system_profiler SPSoftwareDataType -detailLevel mini).");
+                        }
                     }
                     else
                     {

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -663,22 +663,24 @@ os_info *get_unix_version()
 
                 if (cmd_output_ver = popen("system_profiler SPSoftwareDataType", "r"), cmd_output_ver)
                 {
-                    if (fread(buff, 1, sizeof(buff), cmd_output_ver) > 0)
+                    while (fgets(buff, sizeof(buff) - 1, cmd_output_ver))
                     {
-                        strtok_r(buff, "\n", &save_ptr);
-                        strtok_r(NULL, "\n", &save_ptr);
-                        strtok_r(NULL, ":", &save_ptr);
-                        char *aux = strtok_r(NULL, " ", &save_ptr);
-                        if (aux && strlen(aux) > 0)
+                        char *key = strtok_r(buff, ":", &save_ptr);
+                        if (key && strcmp(os_strip_char(key, ' '), "SystemVersion") == 0)
                         {
-                            w_strdup(aux, info->os_name);
-                        }
-                        else
-                        {
-                            mdebug1("Cannot parse System Version (system_profiler SPSoftwareDataType).");
+                            char *value = strtok_r(NULL, " ", &save_ptr);
+                            if (value)
+                            {
+                                w_strdup(value, info->os_name);
+                            }
+                            else
+                            {
+                                mdebug1("Cannot parse System Version value (system_profiler SPSoftwareDataType).");
+                            }
+                            break;
                         }
                     }
-                    else
+                    if (!info->os_name)
                     {
                         mdebug1("Cannot read from command output (system_profiler SPSoftwareDataType).");
                     }

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -662,11 +662,12 @@ os_info *get_unix_version()
                 info->os_platform = strdup("darwin");
 
                 if (cmd_output_ver = popen("system_profiler SPSoftwareDataType", "r"), cmd_output_ver) {
-                    while (fgets(buff, sizeof(buff) - 1, cmd_output_ver)) {
+                    while (fgets(buff, sizeof(buff), cmd_output_ver) != NULL) {
                         char *key = strtok_r(buff, ":", &save_ptr);
                         if (key) {
-                            char *trimed_key = os_strip_char(key, ' ');
-                            if (strcmp(trimed_key, "SystemVersion") == 0) {
+                            static const char *expected_key = "SystemVersion";
+                            char *trimmed_key = os_strip_char(key, ' ');
+                            if (trimmed_key && strncmp(trimmed_key, expected_key, strlen(expected_key)) == 0) {
                                 char *value = strtok_r(NULL, " ", &save_ptr);
                                 if (value) {
                                     w_strdup(value, info->os_name);
@@ -674,7 +675,7 @@ os_info *get_unix_version()
                                     mdebug1("Cannot parse System Version value (system_profiler SPSoftwareDataType).");
                                 }
                             }
-                            free (trimed_key);
+                            os_free (trimmed_key);
                             if(info->os_name) {
                                 break;
                             }

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -665,9 +665,9 @@ os_info *get_unix_version()
                     while (fgets(buff, sizeof(buff), cmd_output_ver) != NULL) {
                         char *key = strtok_r(buff, ":", &save_ptr);
                         if (key) {
-                            const char *expected_key = "SystemVersion";
-                            char *trimmed_key = os_strip_char(key, ' ');
-                            if (trimmed_key && strncmp(trimmed_key, expected_key, strlen(expected_key)) == 0) {
+                            const char *expected_key = "System Version";
+                            char *trimmed_key = w_strtrim(key);
+                            if (NULL != trimmed_key && strncmp(trimmed_key, expected_key, strlen(expected_key)) == 0) {
                                 char *value = strtok_r(NULL, " ", &save_ptr);
                                 if (value) {
                                     w_strdup(value, info->os_name);
@@ -675,7 +675,6 @@ os_info *get_unix_version()
                                     mdebug1("Cannot parse System Version value (system_profiler SPSoftwareDataType).");
                                 }
                             }
-                            os_free (trimmed_key);
                             if(info->os_name) {
                                 break;
                             }

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -665,7 +665,7 @@ os_info *get_unix_version()
                     while (fgets(buff, sizeof(buff), cmd_output_ver) != NULL) {
                         char *key = strtok_r(buff, ":", &save_ptr);
                         if (key) {
-                            static const char *expected_key = "SystemVersion";
+                            const char *expected_key = "SystemVersion";
                             char *trimmed_key = os_strip_char(key, ' ');
                             if (trimmed_key && strncmp(trimmed_key, expected_key, strlen(expected_key)) == 0) {
                                 char *value = strtok_r(NULL, " ", &save_ptr);

--- a/src/unit_tests/shared/test_version_op.c
+++ b/src/unit_tests/shared/test_version_op.c
@@ -912,7 +912,7 @@ void test_get_unix_version_fail_os_release_uname_darwin(void **state)
     will_return(__wrap_fgets, "\n");
 
     expect_value(__wrap_fgets, __stream, 1);
-    will_return(__wrap_fgets, "System Version: macOS 10.12 (16A323)\n");
+    will_return(__wrap_fgets, "    System Version: macOS 10.12 (16A323)\n");
 
     expect_value(__wrap_pclose, stream, 1);
     will_return(__wrap_pclose, 1);

--- a/src/unit_tests/shared/test_version_op.c
+++ b/src/unit_tests/shared/test_version_op.c
@@ -894,13 +894,17 @@ void test_get_unix_version_fail_os_release_uname_darwin(void **state)
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "Darwin\n");
 
-    // sw_vers -productName
-    expect_string(__wrap_popen, command, "sw_vers -productName");
+    // system_profiler SPSoftwareDataType
+    expect_string(__wrap_popen, command, "system_profiler SPSoftwareDataType");
     expect_string(__wrap_popen, type, "r");
     will_return(__wrap_popen, 1);
 
-    expect_value(__wrap_fgets, __stream, 1);
-    will_return(__wrap_fgets, "macOS Catalina\n");
+    char *SP_OUT =
+        "Software:\n\n\
+          System Software Overview:\n\n\
+            System Version: macOS 10.12 (16A323)\n\
+            Kernel Version: Darwin 16.0.0\n";
+    expect_fread(SP_OUT, 1);
 
     expect_value(__wrap_pclose, stream, 1);
     will_return(__wrap_pclose, 1);
@@ -946,7 +950,7 @@ void test_get_unix_version_fail_os_release_uname_darwin(void **state)
     *state = ret;
 
     assert_non_null(ret);
-    assert_string_equal(ret->os_name, "macOS Catalina");
+    assert_string_equal(ret->os_name, "macOS");
     assert_string_equal(ret->os_major, "10");
     assert_string_equal(ret->os_minor, "2");
     assert_string_equal(ret->os_version, "10.2");

--- a/src/unit_tests/shared/test_version_op.c
+++ b/src/unit_tests/shared/test_version_op.c
@@ -899,12 +899,20 @@ void test_get_unix_version_fail_os_release_uname_darwin(void **state)
     expect_string(__wrap_popen, type, "r");
     will_return(__wrap_popen, 1);
 
-    char *SP_OUT =
-        "Software:\n\n\
-          System Software Overview:\n\n\
-            System Version: macOS 10.12 (16A323)\n\
-            Kernel Version: Darwin 16.0.0\n";
-    expect_fread(SP_OUT, 1);
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "Software:\n");
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "\n");
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "System Software Overview:\n");
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "\n");
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "System Version: macOS 10.12 (16A323)\n");
 
     expect_value(__wrap_pclose, stream, 1);
     will_return(__wrap_pclose, 1);
@@ -951,6 +959,140 @@ void test_get_unix_version_fail_os_release_uname_darwin(void **state)
 
     assert_non_null(ret);
     assert_string_equal(ret->os_name, "macOS");
+    assert_string_equal(ret->os_major, "10");
+    assert_string_equal(ret->os_minor, "2");
+    assert_string_equal(ret->os_version, "10.2");
+    assert_string_equal(ret->os_platform, "darwin");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
+void test_get_unix_version_fail_os_release_uname_darwin_no_key(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Fail to open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /usr/lib/os-release
+    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/centos-release
+    expect_string(__wrap_fopen, path, "/etc/centos-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/fedora-release
+    expect_string(__wrap_fopen, path, "/etc/fedora-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/redhat-release
+    expect_string(__wrap_fopen, path, "/etc/redhat-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/arch-release
+    expect_string(__wrap_fopen, path, "/etc/arch-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_fopen, path, "/etc/lsb-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/gentoo-release
+    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/SuSE-release
+    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/debian_version
+    expect_string(__wrap_fopen, path, "/etc/debian_version");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/slackware-version
+    expect_string(__wrap_fopen, path, "/etc/slackware-version");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // uname
+    expect_string(__wrap_popen, command, "uname");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "Darwin\n");
+
+    // system_profiler SPSoftwareDataType
+    expect_string(__wrap_popen, command, "system_profiler SPSoftwareDataType");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "Software:\n");
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "System Software Overview:\n");
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, NULL);
+
+    expect_value(__wrap_pclose, stream, 1);
+    will_return(__wrap_pclose, 1);
+
+    // sw_vers -productVersion
+    expect_string(__wrap_popen, command, "sw_vers -productVersion");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "10.2\n");
+
+    expect_value(__wrap_pclose, stream, 1);
+    will_return(__wrap_pclose, 1);
+
+    // sw_vers -buildVersion
+    expect_string(__wrap_popen, command, "sw_vers -buildVersion");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "10\n");
+
+    expect_value(__wrap_pclose, stream, 1);
+    will_return(__wrap_pclose, 1);
+
+    // uname -r
+    expect_string(__wrap_popen, command, "uname -r");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "macos\n");
+
+    expect_value(__wrap_pclose, stream, 1);
+    will_return(__wrap_pclose, 1);
+
+
+    expect_value(__wrap_pclose, stream, 1);
+    will_return(__wrap_pclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_null(ret->os_name);
     assert_string_equal(ret->os_major, "10");
     assert_string_equal(ret->os_minor, "2");
     assert_string_equal(ret->os_version, "10.2");
@@ -1471,6 +1613,7 @@ int main(void) {
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_debian, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_slackware, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_darwin, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_darwin_no_key, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_sunos, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_hp_ux, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_bsd, delete_os_info),


### PR DESCRIPTION
|Related issue|
|---|
|#14729|

## Description
This PR aims to solve the inconsistence, between macOS agents, of obtaining the agent's OS name. It's been discovered that Wazuh sets the OS name as `macOS` for some releases and `Mac OS X` for some others (like Mojave). The target of this PR is to normalize the macOS agent's OS name to just `macOS`.

For this purpose, it's necessary to change the source of this data. Currently, Wazuh uses the macOS's system command `sw_vers` to accomplish this, whose output differs between macOS releases.

The first approach will be to replace this command for `system_profiler`, which seems to have the same output info for all the supported macOS releases

## Results
A Wazuh package from this branch was generated on Mojave and ported to the other releases. This is due to #14240.
### Wazuh Dashboard agents
![image](https://user-images.githubusercontent.com/42682247/189138860-6fcab616-e0f5-4260-8c08-13e44aa06393.png)

### High Sierra inventory data
![image](https://user-images.githubusercontent.com/42682247/189139522-729c1978-f69b-4d17-a3ea-0bb3355e6f4a.png)

### High Sierra notify message
```
DEBUG: Sending keep alive: #!-Darwin |macos-highsierra-vm |17.7.0 |Darwin Kernel Version 17.7.0: Thu Jun 21 22:53:14 PDT 2018; root:xnu-4570.71.2~1/RELEASE_X86_64 |x86_64 [macOS|darwin: 10.13.6 (High Sierra)] - Wazuh v4.5.0 / ab73af41699f13fdd81903b5f23d8d00
4a8724b20dee0124ff9656783c490c4e merged.mg
#"_agent_ip":FE80:0000:0000:0000:0436:C878:3877:0108
```

## Tests
<!-- Minimum checks required -->
* Compilation without warnings in every supported platform
  - [x] MAC OS X
- [x]   Source installation
- [x]   Package installation
- [x]   Source upgrade
- [x]   Package upgrade

<!-- Depending on the affected OS -->
* Memory tests for macOS
  - [x] Scan-build report
  - [x] Leaks
  - [x] AddressSanitizer
