### PR TITLE
Fix arbitrary code execution in Active Response (backport to 3.13)

### DIFF
--- a/src/os_execd/exec.c
+++ b/src/os_execd/exec.c
@@ -83,10 +83,10 @@ int ReadExecConfig()
         *tmp_str = '\0';
         tmp_str += 3;
 
-        // Directory transversal test
+        // Directory traversal test
 
         if (w_ref_parent_folder(str_pt)) {
-            merror("Active response command '%s' vulnerable to directory transversal attack. Ignoring.", str_pt);
+            merror("Active response command '%s' vulnerable to directory traversal attack. Ignoring.", str_pt);
             exec_cmd[exec_size][0] = '\0';
         } else {
             /* Write the full command path */

--- a/src/os_execd/exec.c
+++ b/src/os_execd/exec.c
@@ -159,6 +159,11 @@ char *GetCommandbyName(const char *name, int *timeout)
     // Filter custom commands
 
     if (name[0] == '!') {
+        if (w_ref_parent_folder(name + 1)) {
+            mwarn("Active response command '%s' vulnerable to directory traversal attack. Ignoring.", name + 1);
+            return NULL;
+        }
+
         static char command[OS_FLSIZE];
 
         if (snprintf(command, sizeof(command), "%s/%s", AR_BINDIRPATH, name + 1) >= (int)sizeof(command)) {

--- a/src/unit_tests/os_execd/CMakeLists.txt
+++ b/src/unit_tests/os_execd/CMakeLists.txt
@@ -1,0 +1,58 @@
+# Generate execd library
+file(GLOB execd_files
+    ${SRC_FOLDER}/os_execd/*.o
+    ${SRC_FOLDER}/active-response/*.o)
+
+add_library(EXECD_O STATIC ${execd_files})
+
+set_source_files_properties(
+    ${execd_files}
+    PROPERTIES
+    EXTERNAL_OBJECT true
+    GENERATED true
+)
+
+set_target_properties(
+    EXECD_O
+    PROPERTIES
+    LINKER_LANGUAGE C
+)
+
+target_link_libraries(EXECD_O ${WAZUHLIB} ${WAZUHEXT} -lpthread)
+
+#include wrappers
+include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
+
+# Generate Execd tests
+if(${TARGET} STREQUAL "winagent")
+    list(APPEND execd_names "test_get_command_by_name")
+    list(APPEND execd_flags "${DEBUG_OP_WRAPPERS}")
+else()
+    list(APPEND execd_names "test_get_command_by_name")
+    list(APPEND execd_flags "${DEBUG_OP_WRAPPERS}")
+endif()
+
+list(LENGTH execd_names count)
+math(EXPR count "${count} - 1")
+foreach(counter RANGE ${count})
+    list(GET execd_names ${counter} execd_test_name)
+    list(GET execd_flags ${counter} execd_test_flags)
+
+    add_executable(${execd_test_name} ${execd_test_name}.c)
+
+    target_link_libraries(
+        ${execd_test_name}
+        ${WAZUHLIB}
+        ${WAZUHEXT}
+        EXECD_O
+        ${TEST_DEPS}
+    )
+
+    if(NOT execd_test_flags STREQUAL " ")
+        target_link_libraries(
+            ${execd_test_name}
+            ${execd_test_flags}
+        )
+    endif()
+    add_test(NAME ${execd_test_name} COMMAND ${execd_test_name})
+endforeach()

--- a/src/unit_tests/os_execd/test_get_command_by_name.c
+++ b/src/unit_tests/os_execd/test_get_command_by_name.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "shared.h"
+#include "../../os_execd/execd.h"
+
+static void test_custom_command(void **state) {
+    (void)state;
+
+    int timeout = 100;
+    char * r = GetCommandbyName("!custom.sh", &timeout);
+
+    assert_int_equal(timeout, 0);
+    assert_string_equal(r, AR_BINDIR "/custom.sh");
+}
+
+static void test_path_traversal(void **state) {
+    (void)state;
+    int timeout = 100;
+
+    expect_string(__wrap__mwarn, formatted_msg, "Active response command '../custom.sh' vulnerable to directory traversal attack. Ignoring.");
+
+    char * r = GetCommandbyName("!../custom.sh", &timeout);
+    assert_null(r);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_custom_command),
+        cmocka_unit_test(test_path_traversal),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
|Related PR|
|---|
|#14801|

This PR applies the same changes as #14801 into ossec-execd. Check that PR for more details.

## Proposed fix

Prevent the agent (wazuh-execd) from running a custom AR outside _active-response/bin_.

## Tests

- [x] Send a custom AR command to Execd containing a reference to the parent folder:
```sh
echo -n '!../../../../../../bin/ls' | nc -w0 -Uu /var/ossec/queue/alerts/execq
```
```
2022/09/07 16:38:33 ossec-execd[97673] exec.c:163 at GetCommandbyName(): WARNING: Active response command '../../../../../../bin/ls' vulnerable to directory traversal attack. Ignoring.
2022/09/07 16:38:33 ossec-execd[97673] execd.c:461 at ExecdStart(): ERROR: (1311): Invalid command name '!../../../../../../bin/ls' provided.
```
- [x] Unit tests to check that `GetCommandbyName` rejects custom commands with path traversal.