### PR TITLE
Avoid multigroup deletion in worker nodes

### DIFF
--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -1745,8 +1745,12 @@ void manager_init()
     os_calloc(1, sizeof(group_t *), groups);
     os_calloc(1, sizeof(group_t *), multi_groups);
 
-    /* Clean multigroups directory and run initial groups and multigroups scan */
-    cldir_ex(MULTIGROUPS_DIR);
+    /* Clean multigroups directory */
+    if (!logr.nocmerged) {
+        cldir_ex(MULTIGROUPS_DIR);
+    }
+
+    /* Run initial groups and multigroups scan */
     c_files();
 
     w_yaml_create_groups();


### PR DESCRIPTION
|Related issue|Manual testing|
|---|---|
|https://github.com/wazuh/wazuh/issues/14814|https://github.com/wazuh/wazuh-qa/issues/3269|

## Description

This PR solves a performance problem related with the synchronization of files through the cluster.

Avoiding the deletion of multigroup files in the worker nodes when the node restart, we ensure that the master node will synchronize the multigroup files with them only when something changes.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language