### PR TITLE
Fix interpretation of <disabled> labels in the Cluster configuration

### DIFF
--- a/framework/wazuh/task.py
+++ b/framework/wazuh/task.py
@@ -5,12 +5,9 @@
 import logging
 from typing import Dict
 
-from wazuh.core.cluster.cluster import get_node
-from wazuh.core.cluster.utils import read_cluster_config
 from wazuh.core.common import DATABASE_LIMIT
 from wazuh.core.results import AffectedItemsWazuhResult
 from wazuh.core.task import WazuhDBQueryTask
-from wazuh.core.utils import sort_array
 from wazuh.rbac.decorators import expose_resources
 
 logger = logging.getLogger('wazuh')

--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -305,16 +305,27 @@ start_service()
         fi
         ## If wazuh-clusterd is disabled, don't try to start it.
         if [ X"$i" = "Xwazuh-clusterd" ]; then
-             start_config="$(grep -n "<cluster>" ${DIR}/etc/ossec.conf | cut -d':' -f 1)"
-             end_config="$(grep -n "</cluster>" ${DIR}/etc/ossec.conf | cut -d':' -f 1)"
-             if [ -n "${start_config}" ] && [ -n "${end_config}" ]; then
-                sed -n "${start_config},${end_config}p" ${DIR}/etc/ossec.conf | grep "<disabled>yes" >/dev/null 2>&1
-                if [ $? = 0 ]; then
-                    continue
+            start_config="$(grep -n "<cluster>" ${DIR}/etc/ossec.conf | cut -d':' -f 1)"
+            end_config="$(grep -n "</cluster>" ${DIR}/etc/ossec.conf | cut -d':' -f 1)"
+            if [ -n "${start_config}" ] && [ -n "${end_config}" ]; then
+                start_agent_reconnect="$(grep -n "<agent_reconnection>" ${DIR}/etc/ossec.conf | cut -d':' -f 1)"
+                end_agent_reconnect="$(grep -n "</agent_reconnection>" ${DIR}/etc/ossec.conf | cut -d':' -f 1)"
+                if [ -n "${start_agent_reconnect}" ] && [ -n "${end_agent_reconnect}" ]; then
+                    sed -n "${start_config},${start_agent_reconnect}p" ${DIR}/etc/ossec.conf | grep "<disabled>yes" >/dev/null 2>&1
+                    if [ $? = 0 ]; then
+                        continue
+                    fi
+                    sed -n "${end_agent_reconnect},${end_config}p" ${DIR}/etc/ossec.conf | grep "<disabled>yes" >/dev/null 2>&1
+                    if [ $? = 0 ]; then
+                        continue
+                    fi
+                else
+                    sed -n "${start_config},${end_config}p" ${DIR}/etc/ossec.conf | grep "<disabled>yes" >/dev/null 2>&1
+                    if [ $? = 0 ]; then
+                        continue
+                    fi
                 fi
-             else
-                continue
-             fi
+            fi
         fi
         ## If wazuh-authd is disabled, don't try to start it.
         if [ X"$i" = "Xwazuh-authd" ]; then


### PR DESCRIPTION
|Related issue|
|---|
|#14293|

This PR closes #14293. In this PR we have fixed an error that caused that if inside the <cluster> tag there was more than one <disabled> tag (disabled of the cluster and disabled of the balancing algorithm), the cluster was retained the value of the last one, regardless of whether it is the cluster balance tag or the main one.

Here we can see an example that demonstrates the proper functioning of the fix:
```
<cluster>
	<name>wazuh</name>
	<node_name>master-node</node_name>
	<node_type>master</node_type>
	<key>9d273b53510fef702b54a92e9cffc82e</key>
	<port>1516</port>
	<bind_addr>0.0.0.0</bind_addr>
	<nodes>
		<node>wazuh-master</node>
	</nodes>
	<hidden>no</hidden>
	<disabled>no</disabled>
	<agent_reconnection>
		<disabled>yes</disabled>
		<node_blacklist></node_blacklist>
	</agent_reconnection>
 </cluster>
```

```
root@wazuh-master:/# service wazuh-manager restart
Killing wazuh-clusterd...
Killing wazuh-modulesd...
Killing wazuh-monitord...
Killing wazuh-logcollector...
Killing wazuh-remoted...
Killing wazuh-syscheckd...
Killing wazuh-analysisd...
wazuh-maild not running...
Killing wazuh-execd...
Killing wazuh-db...
Killing wazuh-authd...
wazuh-agentlessd not running...
wazuh-integratord not running...
wazuh-dbd not running...
wazuh-csyslogd not running...
Killing wazuh-apid...
Wazuh v4.4.0 Stopped
2022/09/09 10:45:38 wazuh-db[8030] debug_op.c:70 at _log(): DEBUG: Logging module auto-initialized
2022/09/09 10:45:38 wazuh-db[8030] main.c:111 at main(): DEBUG: Wazuh home directory: /var/ossec
2022/09/09 10:45:39 wazuh-remoted[8035] debug_op.c:70 at _log(): DEBUG: Logging module auto-initialized
2022/09/09 10:45:39 wazuh-remoted[8035] main.c:130 at main(): DEBUG: Wazuh home directory: /var/ossec
2022/09/09 10:45:39 wazuh-remoted[8035] main.c:148 at main(): DEBUG: This is not a worker
Starting Wazuh v4.4.0...
Started wazuh-apid...
Started wazuh-csyslogd...
Started wazuh-dbd...
2022/09/09 10:45:40 wazuh-integratord: INFO: Remote integrations not configured. Clean exit.
Started wazuh-integratord...
Started wazuh-agentlessd...
Started wazuh-authd...
2022/09/09 10:45:40 wazuh-db[8114] debug_op.c:70 at _log(): DEBUG: Logging module auto-initialized
2022/09/09 10:45:40 wazuh-db[8114] main.c:111 at main(): DEBUG: Wazuh home directory: /var/ossec
Started wazuh-db...
Started wazuh-execd...
Started wazuh-analysisd...
Started wazuh-syscheckd...
2022/09/09 10:45:43 wazuh-remoted[8349] debug_op.c:70 at _log(): DEBUG: Logging module auto-initialized
2022/09/09 10:45:43 wazuh-remoted[8349] main.c:130 at main(): DEBUG: Wazuh home directory: /var/ossec
2022/09/09 10:45:43 wazuh-remoted[8349] main.c:148 at main(): DEBUG: This is not a worker
Started wazuh-remoted...
Started wazuh-logcollector...
Started wazuh-monitord...
Started wazuh-modulesd...
Started wazuh-clusterd...
Completed.
root@wazuh-master:/# service wazuh-manager status
wazuh-clusterd is running...
wazuh-modulesd is running...
wazuh-monitord is running...
wazuh-logcollector is running...
wazuh-remoted is running...
wazuh-syscheckd is running...
wazuh-analysisd is running...
wazuh-maild not running...
wazuh-execd is running...
wazuh-db is running...
wazuh-authd is running...
wazuh-agentlessd not running...
wazuh-integratord not running...
wazuh-dbd not running...
wazuh-csyslogd not running...
wazuh-apid is running...
```