### PR TITLE
Replace pthread's rwlock with a FIFO-queueing read-write lock

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -107,6 +107,15 @@
 #define TCP_EPIPE       "(1248): Unable to send message. Connection has been closed by remote server."
 #define CONN_REF        "(1249): Unable to send message. Connection with remote server refused."
 #define ACCESS_ERROR    "(1250): Error trying to execute \"%s\": %s (%d)."
+#define MUTEX_INIT      "(1330) Cannot initialize mutex: %s (%d)."
+#define MUTEX_DESTROY   "(1331) Cannot destroy mutex: %s (%d)."
+#define MUTEX_LOCK      "(1332) Cannot lock mutex: %s (%d)."
+#define MUTEX_UNLOCK    "(1333) Cannot unlock mutex: %s (%d)."
+#define RWLOCK_INIT     "(1334) Cannot initialize rwlock: %s (%d)."
+#define RWLOCK_DESTROY  "(1335) Cannot destroy rwlock: %s (%d)."
+#define RWLOCK_LOCK_RD  "(1336) Cannot lock rwlock for reading: %s (%d)."
+#define RWLOCK_LOCK_WR  "(1337) Cannot lock rwlock for writing: %s (%d)."
+#define RWLOCK_UNLOCK   "(1338) Cannot unlock rwlock: %s (%d)."
 
 /* Mail errors */
 #define CHLDWAIT_ERROR  "(1261): Waiting for child process. (status: %d)."

--- a/src/headers/log_builder.h
+++ b/src/headers/log_builder.h
@@ -27,7 +27,7 @@
 typedef struct {
     char host_name[LOG_BUILDER_HOSTNAME_LEN];   ///< Host name
     char host_ip[IPSIZE];                       ///< Host's primary IP
-    pthread_rwlock_t rwlock;                    ///< Mutex
+    rwlock_t rwlock;                            ///< Read-write lock
 } log_builder_t;
 
 /**

--- a/src/headers/rwlock_op.h
+++ b/src/headers/rwlock_op.h
@@ -1,0 +1,74 @@
+/**
+ * @file rwlock_op.h
+ * @brief Read-write lock library declaration
+ * @date 2022-09-02
+ *
+ * @copyright Copyright (C) 2015 Wazuh, Inc.
+ */
+
+/*
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef RWLOCK_OP_H
+#define RWLOCK_OP_H
+
+#include <pthread.h>
+
+#define RWLOCK_LOCK_READ(rwlock, stmt) rwlock_lock_read(rwlock); stmt; rwlock_unlock(rwlock);
+#define RWLOCK_LOCK_WRITE(rwlock, stmt) rwlock_lock_write(rwlock); stmt; rwlock_unlock(rwlock);
+
+/**
+ * @brief Read-write lock
+ *
+ * This structure provides a read-write lock with FIFO queueing.
+ */
+typedef struct {
+    pthread_mutex_t mutex;
+    pthread_rwlock_t rwlock;
+} rwlock_t;
+
+/**
+ * @brief Initialize a read_write lock.
+ *
+ * @param rwlock Pointer to a rwlock_t structure.
+ * @post Dies with critical error if the lock is initialized twice.
+ */
+void rwlock_init(rwlock_t * rwlock);
+
+/**
+ * @brief Lock a read-write lock for reading.
+ *
+ * @param rwlock Pointer to a rwlock_t structure.
+ * @post Dies with critical error if a deadlock is detected.
+ */
+void rwlock_lock_read(rwlock_t * rwlock);
+
+/**
+ * @brief Lock a read-write lock for writing.
+ *
+ * @param rwlock Pointer to a rwlock_t structure.
+ * @post Dies with critical error if a deadlock is detected.
+ */
+void rwlock_lock_write(rwlock_t * rwlock);
+
+/**
+ * @brief Unlock a read-write lock.
+ *
+ * @param rwlock Pointer to a rwlock_t structure.
+ * @post Dies with critical error if the current thread does not lock this lock.
+ */
+void rwlock_unlock(rwlock_t * rwlock);
+
+/**
+ * @brief Free a read-write lock.
+ *
+ * @param rwlock Pointer to a rwlock_t structure.
+ * @post Dies with critical error if the lock is currently locked.
+ */
+void rwlock_destroy(rwlock_t * rwlock);
+
+#endif

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -276,7 +276,7 @@ extern const char *__local_name;
 #include "notify_op.h"
 #include "version_op.h"
 #include "utf8_op.h"
-#include "shared.h"
+#include "rwlock_op.h"
 #include "log_builder.h"
 
 #include "os_xml/os_xml.h"

--- a/src/remoted/sendmsg.c
+++ b/src/remoted/sendmsg.c
@@ -16,39 +16,26 @@
 extern netbuffer_t netbuffer_send;
 
 /* pthread key update mutex */
-static pthread_rwlock_t keyupdate_rwlock;
+static rwlock_t keyupdate_rwlock;
 
 void key_lock_init()
 {
-    pthread_rwlockattr_t attr;
-    pthread_rwlockattr_init(&attr);
-
-#ifdef __linux__
-#ifndef ALPINE
-    /* PTHREAD_RWLOCK_PREFER_WRITER_NP is ignored.
-     * Do not use recursive locking.
-     */
-    pthread_rwlockattr_setkind_np(&attr, PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
-#endif
-#endif
-
-    w_rwlock_init(&keyupdate_rwlock, &attr);
-    pthread_rwlockattr_destroy(&attr);
+    rwlock_init(&keyupdate_rwlock);
 }
 
 void key_lock_read()
 {
-    w_rwlock_rdlock(&keyupdate_rwlock);
+    rwlock_lock_read(&keyupdate_rwlock);
 }
 
 void key_lock_write()
 {
-    w_rwlock_wrlock(&keyupdate_rwlock);
+    rwlock_lock_write(&keyupdate_rwlock);
 }
 
 void key_unlock()
 {
-    w_rwlock_unlock(&keyupdate_rwlock);
+    rwlock_unlock(&keyupdate_rwlock);
 }
 
 /* Check for key updates */

--- a/src/shared/log_builder.c
+++ b/src/shared/log_builder.c
@@ -45,20 +45,8 @@ log_builder_t * log_builder_init(bool update) {
     os_calloc(1, sizeof(log_builder_t), builder);
 
     {
-        pthread_rwlockattr_t attr;
-        pthread_rwlockattr_init(&attr);
         g_ip_update_interval = getDefine_Int("logcollector","ip_update_interval", 0, 3600);
-#ifdef __linux__
-#ifndef ALPINE
-        /* PTHREAD_RWLOCK_PREFER_WRITER_NP is ignored.
-        * Do not use recursive locking.
-        */
-        pthread_rwlockattr_setkind_np(&attr, PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
-#endif
-#endif
-
-        w_rwlock_init(&builder->rwlock, &attr);
-        pthread_rwlockattr_destroy(&attr);
+        rwlock_init(&builder->rwlock);
     }
 
     if (update) {
@@ -73,7 +61,7 @@ log_builder_t * log_builder_init(bool update) {
 
 // Free a log builder structure.
 void log_builder_destroy(log_builder_t * builder) {
-    pthread_rwlock_destroy(&builder->rwlock);
+    rwlock_destroy(&builder->rwlock);
     free(builder);
 }
 
@@ -113,7 +101,7 @@ char * log_builder_build(log_builder_t * builder, const char * pattern, const ch
     os_malloc(OS_MAXSTR, final);
     os_strdup(pattern, _pattern);
 
-    w_rwlock_rdlock(&builder->rwlock);
+    rwlock_lock_read(&builder->rwlock);
 
     for (cur = _pattern; tok = strstr(cur, "$("), tok; cur = end) {
         field = NULL;
@@ -209,7 +197,7 @@ char * log_builder_build(log_builder_t * builder, const char * pattern, const ch
         goto fail;
     }
 
-    w_rwlock_unlock(&builder->rwlock);
+    rwlock_unlock(&builder->rwlock);
 
     strncpy(final + n, cur, OS_MAXSTR - n);
     final[n + z] = '\0';
@@ -218,7 +206,7 @@ char * log_builder_build(log_builder_t * builder, const char * pattern, const ch
     return final;
 
 fail:
-    w_rwlock_unlock(&builder->rwlock);
+    rwlock_unlock(&builder->rwlock);
 
     mdebug1("Too long message format");
     strncpy(final, logmsg ? logmsg : "Too long message format", OS_MAXSTR - 1);
@@ -232,7 +220,7 @@ fail:
 int log_builder_update_hostname(log_builder_t * builder) {
     int retval = 0;
 
-    w_rwlock_wrlock(&builder->rwlock);
+    rwlock_lock_write(&builder->rwlock);
 
     if (gethostname(builder->host_name, LOG_BUILDER_HOSTNAME_LEN) != 0) {
         strncpy(builder->host_name, "localhost", LOG_BUILDER_HOSTNAME_LEN - 1);
@@ -240,7 +228,7 @@ int log_builder_update_hostname(log_builder_t * builder) {
         retval = -1;
     }
 
-    w_rwlock_unlock(&builder->rwlock);
+    rwlock_unlock(&builder->rwlock);
     return retval;
 }
 
@@ -282,7 +270,7 @@ int log_builder_update_host_ip(log_builder_t * builder) {
         }
 #endif
     }
-    w_rwlock_wrlock(&builder->rwlock);
+    rwlock_lock_write(&builder->rwlock);
     if (*host_ip != '\0' && strcmp(host_ip, "Err")) {
         strcpy(builder->host_ip, host_ip);
     } else {
@@ -290,7 +278,7 @@ int log_builder_update_host_ip(log_builder_t * builder) {
     }
 
     builder->host_ip[IPSIZE - 1] = '\0';
-    w_rwlock_unlock(&builder->rwlock);
+    rwlock_unlock(&builder->rwlock);
 
     return 0;
 }

--- a/src/shared/rwlock_op.c
+++ b/src/shared/rwlock_op.c
@@ -1,0 +1,91 @@
+/**
+ * @file rwlock_op.c
+ * @brief Read-write lock library definition
+ * @date 2022-09-02
+ *
+ * @copyright Copyright (C) 2015 Wazuh, Inc.
+ */
+
+/*
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <shared.h>
+
+// Initialize a read_write lock.
+
+void rwlock_init(rwlock_t * rwlock) {
+    errno = pthread_mutex_init(&rwlock->mutex, NULL);
+    if (errno != 0) {
+        merror_exit(MUTEX_INIT, strerror(errno), errno);
+    }
+
+    errno = pthread_rwlock_init(&rwlock->rwlock, NULL);
+    if (errno != 0) {
+        merror_exit(RWLOCK_INIT, strerror(errno), errno);
+    }
+}
+
+// Lock a read-write lock for reading.
+
+void rwlock_lock_read(rwlock_t * rwlock) {
+    errno = pthread_mutex_lock(&rwlock->mutex);
+    if (errno != 0) {
+        merror_exit(MUTEX_LOCK, strerror(errno), errno);
+    }
+
+    errno = pthread_rwlock_rdlock(&rwlock->rwlock);
+    if (errno != 0) {
+        merror_exit(RWLOCK_LOCK_RD, strerror(errno), errno);
+    }
+
+    errno = pthread_mutex_unlock(&rwlock->mutex);
+    if (errno != 0) {
+        merror_exit(MUTEX_UNLOCK, strerror(errno), errno);
+    }
+}
+
+// Lock a read-write lock for writing.
+
+void rwlock_lock_write(rwlock_t * rwlock) {
+    errno = pthread_mutex_lock(&rwlock->mutex);
+    if (errno != 0) {
+        merror_exit(MUTEX_LOCK, strerror(errno), errno);
+    }
+
+    errno = pthread_rwlock_wrlock(&rwlock->rwlock);
+    if (errno != 0) {
+        merror_exit(RWLOCK_LOCK_WR, strerror(errno), errno);
+    }
+
+    errno = pthread_mutex_unlock(&rwlock->mutex);
+    if (errno != 0) {
+        merror_exit(MUTEX_UNLOCK, strerror(errno), errno);
+    }
+}
+
+// Unlock a read-write lock.
+
+void rwlock_unlock(rwlock_t * rwlock) {
+    errno = pthread_rwlock_unlock(&rwlock->rwlock);
+    if (errno != 0) {
+        merror_exit(RWLOCK_UNLOCK, strerror(errno), errno);
+    }
+}
+
+// Free a read-write lock.
+
+void rwlock_destroy(rwlock_t * rwlock) {
+    errno = pthread_mutex_destroy(&rwlock->mutex);
+    if (errno != 0) {
+        merror_exit(MUTEX_DESTROY, strerror(errno), errno);
+    }
+
+    errno = pthread_rwlock_destroy(&rwlock->rwlock);
+    if (errno != 0) {
+        merror_exit(RWLOCK_DESTROY, strerror(errno), errno);
+    }
+}

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -66,7 +66,7 @@ list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdeb
 
 list(APPEND remoted_names "test_sendmsg")
 list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mdebug1 -Wl,--wrap,OS_IsAllowedID -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock \
-                            -Wl,--wrap,pthread_rwlock_rdlock -Wl,--wrap,pthread_rwlock_unlock -Wl,--wrap,CreateSecMSG -Wl,--wrap,nb_queue -Wl,--wrap,time")
+                            -Wl,--wrap,rwlock_lock_read -Wl,--wrap,rwlock_unlock -Wl,--wrap,CreateSecMSG -Wl,--wrap,nb_queue -Wl,--wrap,time")
 
 list(APPEND remoted_names "test_remote-config")
 list(APPEND remoted_flags "${DEBUG_OP_WRAPPERS}")

--- a/src/unit_tests/remoted/test_sendmsg.c
+++ b/src/unit_tests/remoted/test_sendmsg.c
@@ -79,7 +79,7 @@ void test_send_msg_tcp_ok(void ** state) {
     logr.global.agents_disconnection_time = 0;
     remoted_state.queued_msgs = 0;
 
-    expect_function_call(__wrap_pthread_rwlock_rdlock);
+    expect_function_call(__wrap_rwlock_lock_read);
 
     expect_string(__wrap_OS_IsAllowedID, id, agent_id);
     will_return(__wrap_OS_IsAllowedID, key);
@@ -108,7 +108,7 @@ void test_send_msg_tcp_ok(void ** state) {
 
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    expect_function_call(__wrap_pthread_rwlock_unlock);
+    expect_function_call(__wrap_rwlock_unlock);
 
     int ret = send_msg(agent_id, msg, msg_length);
 
@@ -130,7 +130,7 @@ void test_send_msg_tcp_err(void ** state) {
     logr.global.agents_disconnection_time = 0;
     remoted_state.queued_msgs = 0;
 
-    expect_function_call(__wrap_pthread_rwlock_rdlock);
+    expect_function_call(__wrap_rwlock_lock_read);
 
     expect_string(__wrap_OS_IsAllowedID, id, agent_id);
     will_return(__wrap_OS_IsAllowedID, key);
@@ -156,7 +156,7 @@ void test_send_msg_tcp_err(void ** state) {
 
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    expect_function_call(__wrap_pthread_rwlock_unlock);
+    expect_function_call(__wrap_rwlock_unlock);
 
     int ret = send_msg(agent_id, msg, msg_length);
 

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -187,6 +187,9 @@ else()
                                 -Wl,--wrap,cJSON_GetObjectItem -Wl,--wrap,cJSON_GetStringValue")
 endif()
 
+list(APPEND shared_tests_names "test_rwlock_op")
+list(APPEND shared_tests_flags "${DEBUG_OP_WRAPPERS}")
+
 # Compiling tests
 list(LENGTH shared_tests_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/shared/test_rwlock_op.c
+++ b/src/unit_tests/shared/test_rwlock_op.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdlib.h>
+#include <pthread.h>
+
+#include "headers/shared.h"
+
+#define BUFFER_LEN 64
+#define N_READERS 4
+#define READ_CYCLES 10000
+#define WRITE_CYCLES 1000
+#define READER_DELAY_NSEC 10000
+#define WRITER_DELAY_NSEC 1000000
+
+typedef struct {
+    rwlock_t * rwlock;
+    char buffer[BUFFER_LEN];
+} thread_args_t;
+
+int test_rwlock_setup(void ** state) {
+    *state = malloc(sizeof(rwlock_t));
+    return 0;
+}
+
+int test_rwlock_teardown(void ** state) {
+    free(*state);
+    return 0;
+}
+
+static void * reader(thread_args_t * thread_args) {
+    char target[BUFFER_LEN];
+    struct timespec delay = {
+        .tv_sec = 0,
+        .tv_nsec = READER_DELAY_NSEC,
+    };
+
+    for (int i = 0; i < READ_CYCLES; i++) {
+        RWLOCK_LOCK_READ(thread_args->rwlock, {
+            memcpy(target, thread_args->buffer, BUFFER_LEN);
+            nanosleep(&delay, NULL);
+        })
+    }
+
+    return NULL;
+}
+
+static void * writer(thread_args_t * thread_args) {
+    int i = 0;
+     struct timespec delay = {
+        .tv_sec = 0,
+        .tv_nsec = WRITER_DELAY_NSEC,
+    };
+
+    for (int i = 0; i < WRITE_CYCLES; i++) {
+        RWLOCK_LOCK_WRITE(thread_args->rwlock, {
+            snprintf(thread_args->buffer, BUFFER_LEN, "%d", i);
+        })
+
+        nanosleep(&delay, NULL);
+    }
+
+    return NULL;
+}
+
+void test_rwlock_threads(void ** state) {
+    pthread_t thread_writer;
+    pthread_t thread_readers[N_READERS];
+    thread_args_t thread_args = {
+        .rwlock = *(rwlock_t **)state
+    };
+
+    rwlock_init(thread_args.rwlock);
+
+    for (int i = 0; i < N_READERS; i++) {
+        errno = pthread_create(&thread_readers[i], NULL, (void * (*)(void *))reader, (void *)&thread_args);
+        assert_int_equal(errno, 0);
+    }
+
+    errno = pthread_create(&thread_writer, NULL, (void * (*)(void *))writer, (void *)&thread_args);
+    assert_int_equal(errno, 0);
+
+    if (errno != 0) {
+        perror("pthread_start(writer)");
+        abort();
+    }
+
+    errno = pthread_join(thread_writer, NULL);
+    assert_int_equal(errno, 0);
+
+    for (int i = 0; i < N_READERS; i++) {
+        errno = pthread_join(thread_readers[i], NULL);
+        assert_int_equal(errno, 0);
+    }
+
+    rwlock_destroy(thread_args.rwlock);
+}
+
+int main() {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_rwlock_threads, test_rwlock_setup, test_rwlock_teardown),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/wrappers/wazuh/shared/rwlock_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/rwlock_op_wrappers.c
@@ -1,0 +1,30 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "rwlock_op_wrappers.h"
+
+void __wrap_rwlock_lock_read(rwlock_t * rwlock) {
+    (void)rwlock;
+    function_called();
+}
+
+void __wrap_rwlock_lock_write(rwlock_t * rwlock) {
+    (void)rwlock;
+    function_called();
+}
+
+void __wrap_rwlock_unlock(rwlock_t * rwlock) {
+    (void)rwlock;
+    function_called();
+}

--- a/src/unit_tests/wrappers/wazuh/shared/rwlock_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/rwlock_op_wrappers.h
@@ -1,0 +1,19 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#ifndef RWLOCK_OP_WRAPPERS_H
+#define RWLOCK_OP_WRAPPERS_H
+
+#include <rwlock_op.h>
+
+void __wrap_rwlock_lock_read(rwlock_t * rwlock);
+void __wrap_rwlock_lock_write(rwlock_t * rwlock);
+void __wrap_rwlock_unlock(rwlock_t * rwlock);
+
+#endif


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/4592|

This PR aims to introduce a FIFO-queueing read-write lock shared library, and replace the pthread's `rwlock` objects with this new structure.

## Rationale

Some modules in Wazuh, such as Remoted and Logcollector, are made up of several threads that access memory in different ways:

- **Remoted**:
  - Many threads decrypt messages from agents (read mode).
  - One thread reloads file _client.keys_ and updates the memory (write mode).
- **Logcollector**:
  - Many threads collect data from files, logging services, and commands (read mode).
  - One thread reloads files (write mode).

In order to prevent data access serialization in reading mode, those modules use read-write locks from the POSIX threads library. This implementation gives preference to readers, which may lead to **writer starvation** when those modules are highly loaded as there always be many readers working (see #2761).

We solved that problem using the following call, which sets the preference for writers:
```c
pthread_rwlockattr_setkind_np(PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
```

That function is non-portable (as the `_np` suffix indicates), and is available in the GNU C Library. However, this makes it impossible to compile with the musl library, thus porting Wazuh to platforms like Alpine Linux (avoiding writer starvation).

### Proof of concept

#### Code

<details><summary>main.c</summary>

```c
// Read-write lock starvation PoC
//
// Compile with -pthread
// Optional flag: -D PREVENT_STARVATION

#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <errno.h>
#include <stdbool.h>
#include <unistd.h>
#include <pthread.h>

#define BUFFER_LEN 64
#define N_READERS 80
#define WRITER_DELAY_SEC 1
#define READER_DELAY_NSEC 10000

#define LOCK_READ(rwlock, block) pthread_rwlock_rdlock(rwlock); block; pthread_rwlock_unlock(rwlock);
#define LOCK_WRITE(rwlock, block) pthread_rwlock_wrlock(rwlock); block; pthread_rwlock_unlock(rwlock);

static pthread_rwlock_t buffer_rwlock;

static void init_rwlock()
{
    pthread_rwlockattr_t attr;
    pthread_rwlockattr_init(&attr);

#ifdef PREVENT_STARVATION
    pthread_rwlockattr_setkind_np(&attr, PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
#endif

    errno = pthread_rwlock_init(&buffer_rwlock, &attr);

    if (errno != 0)
    {
        perror("pthread_rwlock_init");
        abort();
    }

    pthread_rwlockattr_destroy(&attr);
}

static void * reader(void * p)
{
    char * buffer = (char *)p;
    char target[BUFFER_LEN];
    struct timespec delay = {
        .tv_sec = 0,
        .tv_nsec = READER_DELAY_NSEC,
    };

    while (true)
    {
        LOCK_READ(&buffer_rwlock,
        {
            memcpy(target, buffer, BUFFER_LEN);
            nanosleep(&delay, NULL);
        })
    }

    return NULL;
}

static void * writer(void * p)
{
    char * buffer = (char *)p;
    int i = 0;

    while (true)
    {
        LOCK_WRITE(&buffer_rwlock,
        {
            snprintf(buffer, BUFFER_LEN, "%d", i++);
            printf("Writer %s\n", buffer);
        })

        sleep(WRITER_DELAY_SEC);
    }

    return NULL;
}

int main()
{
    pthread_t thread;
    char buffer[BUFFER_LEN];
    int i;

    init_rwlock();

    for (i = 0; i < N_READERS; i++)
    {
        errno = pthread_create(&thread, NULL, reader, (void *)buffer);

        if (errno != 0)
        {
            perror("pthread_start(reader)");
            abort();
        }
    }

    errno = pthread_create(&thread, NULL, writer, (void *)buffer);

    if (errno != 0)
    {
        perror("pthread_start(writer)");
        abort();
    }

    pthread_exit(NULL);
}

```

</details>

#### Test (starvation)

```shell
gcc -O2 -pthread -o rwtest_fail main.c
./rwtest_fail
```

There is no output: the writer is starved.

#### Test (prevent starvation)

```shell
gcc -O2 -DPREVENT_STARVATION -pthread -o rwtest_cur main.c
./rwtest_cur
```
```
Writer 0
Writer 1
Writer 2
(...)
```

The program prints precisely one line per second, indicating that the writer is working as expected.

## Proposed fix

Enclose calls to lock the read-writer locks either in read or write mode, pretending this behavior:
- Threads acquire the lock in the order they arrive, with no preference for readers or writers.
- If a reader tries to acquire the lock while it's locked in reader mode, then that reader also takes the lock.

This way, we implement a structure `rwlock_t` with its respective functions and replace the usage of `pthread_rwlock_t` with this new library in:

- Logcollector.
- Remoted.

We have decided to omit to refactor the structure `OSHash` due to its complexity and scope (Analysisd).

### Proof of concept (1)

#### Code

<details><summary>rwlock.h</summary>

```c
// Read-write lock library (proposal 1)

#ifndef RWLOCK_H
#define RWLOCK_h

#include <pthread.h>

#define RWLOCK_LOCK_READ(rwlock, block) rwlock_lock_read(rwlock); block; rwlock_unlock(rwlock);
#define RWLOCK_LOCK_WRITE(rwlock, block) rwlock_lock_write(rwlock); block; rwlock_unlock(rwlock);

typedef struct {
    pthread_mutex_t mutex;
    pthread_rwlock_t rwlock;
} rwlock_t;

void rwlock_init(rwlock_t * rwlock);
void rwlock_lock_read(rwlock_t * rwlock);
void rwlock_lock_write(rwlock_t * rwlock);
void rwlock_unlock(rwlock_t * rwlock);
void rwlock_destroy(rwlock_t * rwlock);

#endif
```

</details>


<details><summary>rwlock.c</summary>

```c
// Read-write lock library (proposal 1)

#include "rwlock.h"

void rwlock_init(rwlock_t * rwlock) {
    pthread_mutex_init(&rwlock->mutex, NULL);
    pthread_rwlock_init(&rwlock->rwlock, NULL);
}

void rwlock_lock_read(rwlock_t * rwlock) {
    pthread_mutex_lock(&rwlock->mutex);
    pthread_rwlock_rdlock(&rwlock->rwlock);
    pthread_mutex_unlock(&rwlock->mutex);
}

void rwlock_lock_write(rwlock_t * rwlock) {
    pthread_mutex_lock(&rwlock->mutex);
    pthread_rwlock_wrlock(&rwlock->rwlock);
    pthread_mutex_unlock(&rwlock->mutex);
}

void rwlock_unlock(rwlock_t * rwlock) {
    pthread_rwlock_unlock(&rwlock->rwlock);
}

void rwlock_destroy(rwlock_t * rwlock) {
    pthread_mutex_destroy(&rwlock->mutex);
    pthread_rwlock_destroy(&rwlock->rwlock);
}
```

</details>

<details><summary>main.c</summary>

```c
// Read-write lock starvation PoC (proposal 1)
//
// Compile with -pthread

#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <errno.h>
#include <stdbool.h>
#include <unistd.h>
#include <pthread.h>
#include "rwlock.h"

#define BUFFER_LEN 64
#define N_READERS 80
#define WRITER_DELAY_SEC 1
#define READER_DELAY_NSEC 10000

static rwlock_t buffer_rwlock;

static void * reader(void * p) {
    char * buffer = (char *)p;
    char target[BUFFER_LEN];
    struct timespec delay = {
        .tv_sec = 0,
        .tv_nsec = READER_DELAY_NSEC,
    };

    while (true) {
        RWLOCK_LOCK_READ(&buffer_rwlock, {
            memcpy(target, buffer, BUFFER_LEN);
            nanosleep(&delay, NULL);
        })
    }

    return NULL;
}

static void * writer(void * p) {
    char * buffer = (char *)p;
    int i = 0;

    while (true) {
        RWLOCK_LOCK_WRITE(&buffer_rwlock, {
            snprintf(buffer, BUFFER_LEN, "%d", i++);
            printf("Writer %s\n", buffer);
        })

        sleep(WRITER_DELAY_SEC);
    }

    return NULL;
}

int main() {
    pthread_t thread;
    char buffer[BUFFER_LEN];
    int i;

    rwlock_init(&buffer_rwlock);

    for (i = 0; i < N_READERS; i++) {
        errno = pthread_create(&thread, NULL, reader, (void *)buffer);

        if (errno != 0) {
            perror("pthread_start(reader)");
            abort();
        }
    }

    errno = pthread_create(&thread, NULL, writer, (void *)buffer);

    if (errno != 0) {
        perror("pthread_start(writer)");
        abort();
    }

    pthread_exit(NULL);
}
```

</details>

#### Test

```shell
gcc -O2 -pthread -o rwtest_1 *.c
./rwtest_1
```
```
Writer 0
Writer 1
Writer 2
(...)
```

### Proof of concept (2)

This is a variant with a custom implementation of the read-write lock, using a counter and a condition variable.

<details><summary>rwlock.h</summary>

```c
// Read-write lock library (proposal 2)

#ifndef RWLOCK_H
#define RWLOCK_h

#include <pthread.h>

#define RWLOCK_LOCK_READ(rwlock, block) rwlock_lock_read(rwlock); block; rwlock_unlock(rwlock);
#define RWLOCK_LOCK_WRITE(rwlock, block) rwlock_lock_write(rwlock); block; rwlock_unlock(rwlock);

typedef struct {
    pthread_mutex_t enter_lock;
    pthread_mutex_t data_lock;
    pthread_cond_t unlocked;
    long data;
} rwlock_t;

void rwlock_init(rwlock_t * rwlock);
void rwlock_lock_read(rwlock_t * rwlock);
void rwlock_lock_write(rwlock_t * rwlock);
void rwlock_unlock(rwlock_t * rwlock);
void rwlock_destroy(rwlock_t * rwlock);

#endif
```

</details>

<details><summary>rwlock.c</summary>

```c
// Read-write lock library (proposal 2)

#include "rwlock.h"

void rwlock_init(rwlock_t * rwlock) {
    pthread_mutex_init(&rwlock->enter_lock, NULL);
    pthread_mutex_init(&rwlock->data_lock, NULL);
    pthread_cond_init(&rwlock->unlocked, NULL);
    rwlock->data = 0;
}

void rwlock_lock_read(rwlock_t * rwlock) {
    pthread_mutex_lock(&rwlock->enter_lock);
    pthread_mutex_lock(&rwlock->data_lock);

    while (rwlock->data == -1) {
        pthread_cond_wait(&rwlock->unlocked, &rwlock->data_lock);
    }

    rwlock->data++;

    pthread_mutex_unlock(&rwlock->data_lock);
    pthread_mutex_unlock(&rwlock->enter_lock);
}

void rwlock_lock_write(rwlock_t * rwlock) {
    pthread_mutex_lock(&rwlock->enter_lock);
    pthread_mutex_lock(&rwlock->data_lock);

    while (rwlock->data != 0) {
        pthread_cond_wait(&rwlock->unlocked, &rwlock->data_lock);
    }

    rwlock->data = -1;

    pthread_mutex_unlock(&rwlock->data_lock);
    pthread_mutex_unlock(&rwlock->enter_lock);
}

void rwlock_unlock(rwlock_t * rwlock) {
    pthread_mutex_lock(&rwlock->data_lock);

    if (rwlock->data > 0) {
        // Locked for readers: decrement
        rwlock->data--;
    } else {
        // Locked for a writer: unset
        rwlock->data = 0;
    }

    pthread_cond_signal(&rwlock->unlocked);
    pthread_mutex_unlock(&rwlock->data_lock);
}

void rwlock_destroy(rwlock_t * rwlock) {
    pthread_mutex_destroy(&rwlock->enter_lock);
    pthread_mutex_destroy(&rwlock->data_lock);
    pthread_cond_destroy(&rwlock->unlocked);
}
```

</details>

<details><summary>main.c</summary>

```c
// Read-write lock starvation PoC (proposal 2)
//
// Compile with -pthread

#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <errno.h>
#include <stdbool.h>
#include <unistd.h>
#include <pthread.h>
#include "rwlock.h"

#define BUFFER_LEN 64
#define N_READERS 80
#define WRITER_DELAY_SEC 1
#define READER_DELAY_NSEC 10000

static rwlock_t buffer_rwlock;

static void * reader(void * p) {
    char * buffer = (char *)p;
    char target[BUFFER_LEN];
    struct timespec delay = {
        .tv_sec = 0,
        .tv_nsec = READER_DELAY_NSEC,
    };

    while (true) {
        RWLOCK_LOCK_READ(&buffer_rwlock, {
            memcpy(target, buffer, BUFFER_LEN);
            nanosleep(&delay, NULL);
        })
    }

    return NULL;
}

static void * writer(void * p) {
    char * buffer = (char *)p;
    int i = 0;

    while (true) {
        RWLOCK_LOCK_WRITE(&buffer_rwlock, {
            snprintf(buffer, BUFFER_LEN, "%d", i++);
            printf("Writer %s\n", buffer);
        })

        sleep(WRITER_DELAY_SEC);
    }

    return NULL;
}

int main() {
    pthread_t thread;
    char buffer[BUFFER_LEN];
    int i;

    rwlock_init(&buffer_rwlock);

    for (i = 0; i < N_READERS; i++) {
        errno = pthread_create(&thread, NULL, reader, (void *)buffer);

        if (errno != 0) {
            perror("pthread_start(reader)");
            abort();
        }
    }

    errno = pthread_create(&thread, NULL, writer, (void *)buffer);

    if (errno != 0) {
        perror("pthread_start(writer)");
        abort();
    }

    pthread_exit(NULL);
}
```

</details>

#### Test

```shell
gcc -O2 -pthread -o rwtest_2 *.c
./rwtest_2
```
```
Writer 0
Writer 1
Writer 2
(...)
```

## Footprint test

We ran the three implementations, having the following CPU usage:

|Implementation|CPU|Overhead|
|---|---|---|
|`rwtest_cur` (current)|657.3 %||
|`rwtest_1` (proposal 1)|660.0 %|0.41 %|
|`rwtest_2` (proposal 2)|752.3 %|14.5 %|

Having that both fixes meet the functional expectations, and the first one adds an imperceptible overhead, we decided to apply the **first fix**.

## Tests

- [x] Functional and stress test with PoC.
- [x] Port the PoC test to the CMocka tests.
- [x] Memory test with AddressSanitizer on PoC.
- [x] Memory test with AddressSanitizer on CMocka test.
- [x] Race condition test with ThreadSanitizer on PoC.