### PR TITLE
Make cluster wait for agent-info data from wdb asynchronously

### DIFF
--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -822,7 +822,7 @@ class Agent:
         """
         wdb = WazuhDBConnection()
         try:
-            _, payload = wdb.run_wdb_command(f'global select-group-belong {agent_id}')
+            _, payload = wdb.send(f'global select-group-belong {agent_id}', raw=True)
             return json.loads(payload)
         finally:
             wdb.close()
@@ -839,7 +839,7 @@ class Agent:
 
         wdb = WazuhDBConnection()
         try:
-            wdb.run_wdb_command(command)
+            wdb.send(command, raw=True)
         finally:
             wdb.close()
 
@@ -1063,7 +1063,7 @@ def expand_group(group_name):
             else:
                 command = f'global get-group-agents {group_name} last_id {last_id}'
 
-            status, payload = wdb_conn.run_wdb_command(command)
+            status, payload = wdb_conn.send(command, raw=True)
             agents = json.loads(payload)
 
             for agent in agents[0]['data'] if group_name == '*' else agents:

--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -1410,7 +1410,7 @@ class SyncWazuhdb(SyncTask):
             get_chunks_start_time = perf_counter()
             while status != 'ok':
                 command = self.get_data_command + json.dumps(self.get_payload)
-                result = self.data_retriever(command=command)
+                result = await self.data_retriever(command=command)
                 status = result[0]
                 if result[1] not in ['[]', '[{"data":[]}]']:
                     chunks.append(result[1])
@@ -1421,7 +1421,7 @@ class SyncWazuhdb(SyncTask):
                     except (IndexError, KeyError):
                         pass
         except exception.WazuhException as e:
-            self.logger.error(f"Error obtaining data from wazuh-db: {e}")
+            self.logger.error(f"Could not obtain data from wazuh-db: {e}")
             return []
 
         self.logger.debug(f"Obtained {len(chunks)} chunks of data in {(perf_counter() - get_chunks_start_time):.3f}s.")

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -23,7 +23,7 @@ from wazuh.core.cluster.dapi import dapi
 from wazuh.core.cluster.utils import context_tag
 from wazuh.core.common import DECIMALS_DATE_FORMAT
 from wazuh.core.utils import get_utc_now
-from wazuh.core.wdb import WazuhDBConnection
+from wazuh.core.wdb import AsyncWazuhDBConnection
 
 
 class ReceiveIntegrityTask(c_common.ReceiveFileTask):
@@ -687,14 +687,14 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         """
         logger = self.task_loggers['Agent-groups send full']
         sync_object = c_common.SyncWazuhdb(manager=self, logger=logger,
-                                           data_retriever=WazuhDBConnection().run_wdb_command,
+                                           data_retriever=AsyncWazuhDBConnection().run_wdb_command,
                                            get_data_command='global sync-agent-groups-get ',
                                            get_payload={"condition": "all", "set_synced": False,
                                                         "get_global_hash": False, "last_id": 0}, pivot_key='last_id')
         local_agent_groups_information = await sync_object.retrieve_information()
 
         sync_object = c_common.SyncWazuhdb(manager=self, logger=logger, cmd=b'syn_g_m_w_c',
-                                           data_retriever=WazuhDBConnection().run_wdb_command,
+                                           data_retriever=AsyncWazuhDBConnection().run_wdb_command,
                                            set_data_command='global set-agent-groups',
                                            set_payload={'mode': 'override', 'sync_status': 'synced'})
 
@@ -711,7 +711,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         A worker node cannot send two consecutive times the same group information.
         """
         logger = self.task_loggers['Agent-groups send']
-        wdb_conn = WazuhDBConnection()
+        wdb_conn = AsyncWazuhDBConnection()
         sync_object = c_common.SyncWazuhdb(manager=self, logger=logger, cmd=b'syn_g_m_w',
                                            data_retriever=wdb_conn.run_wdb_command,
                                            set_data_command='global set-agent-groups',
@@ -1176,7 +1176,7 @@ class Master(server.AbstractServer):
         It looks like this: ['[{"data":[{"id":1,"group":["default","group1"]}]}]'].
         """
         logger = self.setup_task_logger('Local agent-groups')
-        wdb_conn = WazuhDBConnection()
+        wdb_conn = AsyncWazuhDBConnection()
         sync_object = c_common.SyncWazuhdb(manager=self, logger=logger, cmd=b'syn_g_m_w',
                                            data_retriever=wdb_conn.run_wdb_command,
                                            get_data_command='global sync-agent-groups-get ',

--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -34,7 +34,7 @@ with patch('wazuh.common.wazuh_uid'):
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser
         import wazuh.core.cluster.common as cluster_common
         import wazuh.core.results as wresults
-        from wazuh.core.wdb import WazuhDBConnection
+        from wazuh.core.wdb import AsyncWazuhDBConnection
 
 # Globals
 
@@ -1371,7 +1371,7 @@ async def test_sync_wazuh_db_retrieve_information(socket_mock):
         else:
             return 'ok', {'id': counter}
 
-    wdb_conn = WazuhDBConnection()
+    wdb_conn = AsyncWazuhDBConnection()
     logger = logging.getLogger("wazuh")
     handler = cluster_common.Handler(fernet_key, cluster_items)
     sync_object = cluster_common.SyncWazuhdb(manager=handler, logger=logger, cmd=b'syn_a_w_m',
@@ -1401,7 +1401,7 @@ async def test_sync_wazuh_db_retrieve_information(socket_mock):
         with patch.object(sync_object.logger, 'error') as logger_error_mock:
             assert await sync_object.retrieve_information() == []
             logger_error_mock.assert_called_with(
-                'Error obtaining data from wazuh-db: Error 1000 - Wazuh Internal Error')
+                'Could not obtain data from wazuh-db: Error 1000 - Wazuh Internal Error')
 
 
 @pytest.mark.asyncio

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -992,8 +992,8 @@ async def test_master_handler_sync_wazuh_db_information_ok(sync_wazuh_db_informa
 
 
 @pytest.mark.asyncio
-@patch("wazuh.core.cluster.master.WazuhDBConnection")
-async def test_manager_handler_send_entire_agent_groups_information(WazuhDBConnection_mock):
+@patch("wazuh.core.cluster.master.AsyncWazuhDBConnection")
+async def test_manager_handler_send_entire_agent_groups_information(AsyncWazuhDBConnection_mock):
     """Check if the data chunks are being properly forward to the Wazuh-db socket."""
 
     class LoggerMock:
@@ -1036,8 +1036,8 @@ async def test_manager_handler_send_entire_agent_groups_information(WazuhDBConne
 
 
 @pytest.mark.asyncio
-@patch("wazuh.core.cluster.master.WazuhDBConnection")
-async def test_manager_handler_send_agent_groups_information(WazuhDBConnection_mock):
+@patch("wazuh.core.cluster.master.AsyncWazuhDBConnection")
+async def test_manager_handler_send_agent_groups_information(AsyncWazuhDBConnection_mock):
     """Check if the data chunks are being properly forward to the Wazuh-db socket."""
 
     class LoggerMock:
@@ -1064,7 +1064,7 @@ async def test_manager_handler_send_agent_groups_information(WazuhDBConnection_m
             self._error.append(data)
             raise Exception('Stop while True')
 
-    class WazuhDBConnectionMock:
+    class AsyncWazuhDBConnectionMock:
         """Auxiliary class."""
 
         def __init__(self):
@@ -1072,10 +1072,10 @@ async def test_manager_handler_send_agent_groups_information(WazuhDBConnection_m
             self.raw = []
             self.closed = False
 
-        def run_wdb_command(self, command):
+        async def run_wdb_command(self, command):
             return command
 
-        def send(self, data, raw):
+        async def send(self, data, raw):
             """Auxiliary method."""
             self.chunks.append(data)
             self.raw.append(raw)
@@ -1108,7 +1108,7 @@ async def test_manager_handler_send_agent_groups_information(WazuhDBConnection_m
     master_handler.server.agent_groups_control = 'testing'
     master_handler.task_loggers["Agent-groups send"] = LoggerMock()
     master_handler.server.get_agent_groups_info = get_agent_groups_info.__get__(master_handler.server)
-    WazuhDBConnection_mock.return_value = WazuhDBConnectionMock()
+    AsyncWazuhDBConnection_mock.return_value = AsyncWazuhDBConnectionMock()
 
     with patch('wazuh.core.cluster.master.c_common.SyncWazuhdb', SyncWazuhdbMock):
         with pytest.raises(Exception, match='Stop while True'):
@@ -1884,13 +1884,13 @@ async def test_agent_groups_update(sleep_mock):
             self._error.append(data)
             raise Exception('Stop while true')
 
-    class WazuhDBConnectionMock:
+    class AsyncWazuhDBConnectionMock:
         """Auxiliary class."""
 
         def __init__(self):
             pass
 
-        def run_wdb_command(self):
+        async def run_wdb_command(self):
             pass
 
     class SyncWazuhdbMock:
@@ -1912,7 +1912,7 @@ async def test_agent_groups_update(sleep_mock):
 
     with patch("wazuh.core.cluster.master.Master.setup_task_logger",
                return_value=logger_mock) as setup_task_logger_mock:
-        with patch('wazuh.core.cluster.master.WazuhDBConnection', WazuhDBConnectionMock):
+        with patch('wazuh.core.cluster.master.AsyncWazuhDBConnection', AsyncWazuhDBConnectionMock):
             with patch('wazuh.core.cluster.master.c_common.SyncWazuhdb', SyncWazuhdbMock):
                 with pytest.raises(Exception, match='Stop while true'):
                     master_class.clients = {'worker1': 'worker1'}

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -25,7 +25,7 @@ with patch('wazuh.core.common.wazuh_uid'):
 
         from wazuh.core.cluster import client, worker, common as cluster_common
         from wazuh.core import common as core_common
-        from wazuh.core.wdb import WazuhDBConnection
+        from wazuh.core.wdb import AsyncWazuhDBConnection
 
 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 loop = asyncio.new_event_loop()
@@ -670,7 +670,7 @@ async def test_worker_compare_agent_groups_checksums(socket_mock):
             self._debug2.append(debug2)
 
     logger = LoggerMock()
-    wdb_conn = WazuhDBConnection()
+    wdb_conn = AsyncWazuhDBConnection()
     w_handler = get_worker_handler()
     w_handler.connected = True
     sync_object = cluster_common.SyncWazuhdb(manager=w_handler, logger=logger, cmd=b'syn_g_m_w',
@@ -887,7 +887,7 @@ async def test_worker_handler_sync_integrity(request_permission_mock, run_in_poo
 @patch("wazuh.core.cluster.worker.WorkerHandler.general_agent_sync_task")
 async def test_worker_handler_setup_sync_agent_info(general_agent_sync_mock, socket_mock):
     """Check that the agent-info task is properly configured."""
-    wdb_conn = WazuhDBConnection()
+    wdb_conn = AsyncWazuhDBConnection()
     w_handler = get_worker_handler()
     sync_object = cluster_common.SyncWazuhdb(manager=w_handler, logger=logger, cmd=b'syn_a_w_m',
                                              data_retriever=wdb_conn.run_wdb_command,
@@ -906,7 +906,7 @@ async def test_worker_handler_setup_sync_agent_info(general_agent_sync_mock, soc
 @patch("wazuh.core.cluster.worker.WorkerHandler.general_agent_sync_task")
 async def test_worker_handler_setup_sync_agent_groups(general_agent_sync_mock, socket_mock):
     """Check that the agent-groups task is properly configured."""
-    wdb_conn = WazuhDBConnection()
+    wdb_conn = AsyncWazuhDBConnection()
     w_handler = get_worker_handler()
     sync_object = cluster_common.SyncWazuhdb(manager=w_handler, logger=logger, cmd=b'syn_a_w_m',
                                              data_retriever=wdb_conn.run_wdb_command,
@@ -952,7 +952,7 @@ async def test_worker_handler_general_agent_sync_task(socket_mock):
 
         return True
 
-    wdb_conn = WazuhDBConnection()
+    wdb_conn = AsyncWazuhDBConnection()
     w_handler = get_worker_handler()
     w_handler.connected = True
     sync_object = cluster_common.SyncWazuhdb(manager=w_handler, logger=logger, cmd=b'syn_a_w_m',

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -17,7 +17,7 @@ from wazuh.core.cluster import client, cluster, common as c_common
 from wazuh.core.cluster.dapi import dapi
 from wazuh.core.exception import WazuhClusterError
 from wazuh.core.utils import safe_move, get_utc_now
-from wazuh.core.wdb import WazuhDBConnection
+from wazuh.core.wdb import AsyncWazuhDBConnection
 
 
 class ReceiveAgentGroupsTask(c_common.ReceiveStringTask):
@@ -441,7 +441,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             True if both checksums are equal, False if these differ or cannot be
             compared because there are records that need to be synchronized in the local DB.
         """
-        wdb_conn = WazuhDBConnection()
+        wdb_conn = AsyncWazuhDBConnection()
         sync_object = c_common.SyncWazuhdb(manager=self, logger=logger, cmd=b'syn_g_m_w',
                                            data_retriever=wdb_conn.run_wdb_command,
                                            get_data_command='global sync-agent-groups-get ',
@@ -638,7 +638,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         and sent to the master's wazuh-db.
         """
         logger = self.task_loggers["Agent-info sync"]
-        wdb_conn = WazuhDBConnection()
+        wdb_conn = AsyncWazuhDBConnection()
         sync_object = c_common.SyncWazuhdb(manager=self, logger=logger, cmd=b'syn_a_w_m',
                                            data_retriever=wdb_conn.run_wdb_command,
                                            get_data_command='global sync-agent-info-get ',
@@ -657,7 +657,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         and sent to the master's wazuh-db.
         """
         logger = self.task_loggers["Agent-groups sync"]
-        wdb_conn = WazuhDBConnection()
+        wdb_conn = AsyncWazuhDBConnection()
         sync_object = c_common.SyncWazuhdb(manager=self, logger=logger, cmd=b'syn_g_w_m',
                                            data_retriever=wdb_conn.run_wdb_command,
                                            get_data_command='global sync-agent-groups-get ',

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -375,6 +375,7 @@ class WazuhException(Exception):
         2008: {'message': 'Corrupted RBAC database',
                'remediation': 'Restart the Wazuh service to restore the RBAC database to default'},
         2009: {'message': 'Pagination error. Response from wazuh-db was over the maximum socket buffer size'},
+        2010: {'message': 'The requested read operation did not complete fully'},
 
         # Cluster
         3000: 'Cluster',

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -1066,15 +1066,15 @@ def test_agent_group_exists_ko():
         Agent.group_exists('default**')
 
 
-@patch('wazuh.core.agent.WazuhDBConnection.run_wdb_command', return_value=('ok', '["payload"]'))
+@patch('wazuh.core.agent.WazuhDBConnection.send', return_value=('ok', '["payload"]'))
 @patch('socket.socket.connect')
-def test_agent_get_agent_groups(socket_connect_mock, wdb_command_mock):
+def test_agent_get_agent_groups(socket_connect_mock, send_mock):
     """Test if get_agent_groups() asks for agent's groups correctly."""
     agent_id = '001'
     agent_groups = Agent.get_agent_groups(agent_id)
 
     wdb_command = 'global select-group-belong :agent_id:'
-    wdb_command_mock.assert_called_once_with(wdb_command.replace(':agent_id:', agent_id))
+    send_mock.assert_called_once_with(wdb_command.replace(':agent_id:', agent_id), raw=True)
     assert agent_groups == ['payload']
 
 
@@ -1084,9 +1084,9 @@ def test_agent_get_agent_groups(socket_connect_mock, wdb_command_mock):
     (True, True, 'remove'),
     (False, True, 'override')
 ])
-@patch('wazuh.core.agent.WazuhDBConnection.run_wdb_command')
+@patch('wazuh.core.agent.WazuhDBConnection.send')
 @patch('socket.socket.connect')
-def test_agent_set_agent_group_relationship(socket_connect_mock, wdb_command_mock, remove, override, expected_mode):
+def test_agent_set_agent_group_relationship(socket_connect_mock, send_mock, remove, override, expected_mode):
     """Test if set_agent_group_relationship() uses the correct command to create/remove the relationship between
     an agent and a group.
 
@@ -1106,7 +1106,7 @@ def test_agent_set_agent_group_relationship(socket_connect_mock, wdb_command_moc
 
     # Default relationship -> add an agent to a group
     Agent.set_agent_group_relationship(agent_id, group_id, remove, override)
-    match = re.match(wdb_command, wdb_command_mock.call_args[0][0])
+    match = re.match(wdb_command, send_mock.call_args[0][0])
     assert match, 'WDB command has changed'
     assert (expected_mode, agent_id, group_id) == match.groups(), 'Unexpected mode when setting agent-group ' \
                                                                   'relationship'
@@ -1307,7 +1307,7 @@ def test_expand_group(socket_mock, group, wdb_response, expected_agents):
     group : str
         Name of the group to be expanded.
     wdb_response: list
-        Mock return values for the `WazuhDBConnection.run_wdb_command` method.
+        Mock return values for the `WazuhDBConnection.send` method.
     expected_agents : set
         Expected agent IDs for the selected group.
     """
@@ -1315,7 +1315,7 @@ def test_expand_group(socket_mock, group, wdb_response, expected_agents):
     reset_context_cache()
     test_get_agents_info()
 
-    with patch('wazuh.core.wdb.WazuhDBConnection.run_wdb_command', side_effect=wdb_response):
+    with patch('wazuh.core.wdb.WazuhDBConnection.send', side_effect=wdb_response):
         assert expand_group(group) == expected_agents, 'Agent IDs do not match with the expected result'
 
 

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -1097,20 +1097,19 @@ class WazuhDBBackend(AbstractDatabaseBackend):
     This class describes a wazuh db backend that executes database queries
     """
 
-    def __init__(self, agent_id=None, query_format='agent', max_size=6144, request_slice=500):
+    def __init__(self, agent_id=None, query_format='agent', request_slice=500):
         if query_format == 'agent' and not path.exists(path.join(common.WDB_PATH, f"{agent_id}.db")):
             raise WazuhError(2007, extra_message=f"There is no database for agent {agent_id}. "
                                                  "Please check if the agent has connected to the manager")
 
         self.agent_id = agent_id
         self.query_format = query_format
-        self.max_size = max_size
         self.request_slice = request_slice
 
         super().__init__()
 
     def connect_to_db(self):
-        return WazuhDBConnection(max_size=self.max_size, request_slice=self.request_slice)
+        return WazuhDBConnection(request_slice=self.request_slice)
 
     def close_connection(self):
         self.conn.close()

--- a/framework/wazuh/core/wdb.py
+++ b/framework/wazuh/core/wdb.py
@@ -2,6 +2,8 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
+import contextlib
+import asyncio
 import datetime
 import json
 import re
@@ -16,18 +18,131 @@ from wazuh.core.exception import WazuhInternalError, WazuhError
 DATE_FORMAT = re.compile(r'\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2}')
 
 
-class WazuhDBConnection:
+class AsyncWazuhDBConnection:
     """
-    Represents a connection to the wdb socket
+    Represent an async connection to the wdb socket.
     """
 
-    def __init__(self, request_slice=500, max_size=6144):
+    def __init__(self, loop: asyncio.AbstractEventLoopPolicy = None):
+        """Class constructor.
+
+        Parameters
+        ----------
+        loop : asyncio.AbstractEventLoopPolicy
+            Event loop. It's optional and can always be determined automatically when self.open_connection() is
+            awaited from a coroutine.
         """
-        Constructor
+        self.socket_path = common.WDB_SOCKET
+        self.loop = loop
+        self._reader = None
+        self._writer = None
+
+    async def open_connection(self):
+        """Establish a Unix socket connection."""
+        self._reader, self._writer = await asyncio.open_unix_connection(path=self.socket_path, loop=self.loop)
+
+    def close(self):
+        """Close writer socket."""
+        if self._writer is not None:
+            self._writer.close()
+
+    def __del__(self):
+        self.close()
+
+    async def _send(self, msg, raw=False):
+        """Format and send message to wazuh-db socket without blocking event loop.
+
+        Parameters
+        ----------
+        msg : str
+            Message to be sent to wazuh-db.
+        raw : bool
+            If `True`, the status message from wazuh-db is included in the response.
+
+        Returns
+        -------
+        str, list
+            Result for the request sent to wazuh-db.
+        """
+        try:
+            if None in [self._writer, self._reader]:
+                await self.open_connection()
+
+            # Send message.
+            encoded_msg = msg.encode(encoding='utf-8')
+            packed_msg = struct.pack('<I', len(encoded_msg)) + encoded_msg
+            self._writer.write(packed_msg)
+            await self._writer.drain()
+
+            # Read the response when it's ready.
+            try:
+                data = await self._reader.readexactly(4)
+                data_size = struct.unpack('<I', data[0:4])[0]
+                data = await self._reader.readexactly(data_size)
+                data = data.decode(encoding='utf-8', errors='ignore').split(" ", 1)
+            except asyncio.IncompleteReadError as e:
+                raise WazuhInternalError(2010, extra_message=e)
+
+            if raw:
+                return data
+            elif data[0] == "err":
+                raise WazuhError(2003, data[1])
+            else:
+                return json.loads(data[1], object_hook=WazuhDBConnection.json_decoder)
+        except (FileNotFoundError, ConnectionError) as e:
+            with contextlib.suppress(Exception):
+                await self.open_connection()
+            raise WazuhInternalError(2005, extra_message=e)
+
+    async def run_wdb_command(self, command):
+        """Run command in wdb and return list of retrieved information.
+
+        The response of wdb socket can contain 2 elements, a STATUS and a PAYLOAD.
+        State value can be:
+            ok {payload}    -> Successful query with no pending data
+            due {payload}   -> Successful query with pending data
+            err {message}   -> Unsuccessful query
+
+        Parameters
+        ----------
+        command : str
+            Command to be executed inside wazuh-db
+
+        Returns
+        -------
+        response : list
+            List with JSON results
+        """
+        result = await self._send(command, raw=True)
+
+        # result[0] -> status
+        # result[1] -> payload
+        if len(result) > 1:
+            if result[0] == 'err':
+                raise WazuhInternalError(2007, extra_message=result[1])
+
+        else:
+            if result[0] != 'ok':
+                raise WazuhInternalError(2007)
+
+        return result
+
+
+class WazuhDBConnection:
+    """
+    Represent a connection to the wdb socket.
+    """
+
+    def __init__(self, request_slice=500):
+        """Class constructor.
+
+        Parameters
+        ----------
+        request_slice : int
+            Maximum number of items to request from wazuh-db on the first call.
         """
         self.socket_path = common.WDB_SOCKET
         self.request_slice = request_slice
-        self.max_size = max_size
         try:
             self.__conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             self.__conn.connect(self.socket_path)
@@ -185,39 +300,6 @@ class WazuhDBConnection:
         - DB not found
         """
         return self._send(f"wazuhdb remove {' '.join(agents_id)}")
-
-    def run_wdb_command(self, command):
-        """Run command in wdb and return list of retrieved information.
-
-        The response of wdb socket can contain 2 elements, a STATUS and a PAYLOAD.
-        State value can be:
-            ok {payload}    -> Successful query with no pending data
-            due {payload}   -> Successful query with pending data
-            err {message}   -> Unsuccessful query
-
-        Parameters
-        ----------
-        command : str
-            Command to be executed inside wazuh-db
-
-        Returns
-        -------
-        response : list
-            List with JSON results
-        """
-        result = self._send(command, raw=True)
-
-        # result[0] -> status
-        # result[1] -> payload
-        if len(result) > 1:
-            if result[0] == 'err':
-                raise WazuhInternalError(2007, extra_message=result[1])
-
-        else:
-            if result[0] != 'ok':
-                raise WazuhInternalError(2007)
-
-        return result
 
     def send(self, query, raw=True):
         """Send a message to the wdb socket.


### PR DESCRIPTION
|Related issue|
|---|
| Closes #14765 |

## Description

This PR adds a new async version (`AsyncWazuhDBConnection`) of the [WazuhDBConnection](https://github.com/wazuh/wazuh/blob/bc39d6791fad8e629fbe8b8ef2e9713bca0affba/framework/wazuh/core/wdb.py#L19-L22) class used to send and retrieve information from `wazuh-db`. 

This class lets the cluster request agent-info data and do other tasks (like answering distributed API requests) while waiting for `wazuh-db` response to be ready. This greatly improves cluster performance in environments where the database is very busy.

## Logs/Alerts example

### Sync requests to wdb
This is how the cluster behaves when wazuh-db is slow to respond (in this case, 20 seconds). As can be seen, there has been no log between `10:47:10` and `10:47:30`, which means that the cluster has been blocked and all tasks have been delayed:
```
2022/09/01 10:47:10 INFO: [Worker worker1] [Agent-info sync] Starting.
2022/09/01 10:47:30 DEBUG: [Worker worker1] [Agent-info sync] Obtained 20 chunks of data in 20.248s.
2022/09/01 10:47:30 DEBUG: [Worker worker1] [Main] Command received: 'b'dapi''
2022/09/01 10:47:30 DEBUG: [Worker worker1] [D API] Received request: b'master*527235 {"f": {"__callable__": {"__name__": "get_api_config", "__module__": "wazuh.manager", "__qualname__": "get_api_config", "__type__": "function"}}, "f_kwargs": {}, "request_type": "distributed_master", "wait_for_complete": true, "from_cluster": true, "is_async": false, "local_client_arg": null, "basic_services": ["wazuh-modulesd", "wazuh-analysisd", "wazuh-execd", "wazuh-db", "wazuh-remoted"], "rbac_permissions": {"agent:create": {"*:*:*": "allow"}, "group:create": {"*:*:*": "allow"}, "agent:read": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:delete": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:modify_group": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:reconnect": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:restart": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:upgrade": {"agent:id:*": "allow", "agent:group:*": "allow"}, "group:read": {"group:id:*": "allow"}, "group:delete": {"group:id:*": "allow"}, "group:update_config": {"group:id:*": "allow"}, "group:modify_assignments": {"group:id:*": "allow"}, "active-response:command": {"agent:id:*": "allow"}, "security:create": {"*:*:*": "allow"}, "security:create_user": {"*:*:*": "allow"}, "security:read_config": {"*:*:*": "allow"}, "security:update_config": {"*:*:*": "allow"}, "security:revoke": {"*:*:*": "allow"}, "security:edit_run_as": {"*:*:*": "allow"}, "security:read": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "security:update": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "security:delete": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "cluster:status": {"*:*:*": "allow"}, "manager:read": {"*:*:*": "allow"}, "manager:read_api_config": {"*:*:*": "allow"}, "manager:update_config": {"*:*:*": "allow"}, "manager:restart": {"*:*:*": "allow"}, "cluster:read_api_config": {"node:id:*": "allow"}, "cluster:read": {"node:id:*": "allow"}, "cluster:restart": {"node:id:*": "allow"}, "cluster:update_config": {"node:id:*": "allow"}, "ciscat:read": {"agent:id:*": "allow"}, "decoders:read": {"decoder:file:*": "allow"}, "decoders:delete": {"decoder:file:*": "allow"}, "decoders:update": {"*:*:*": "allow"}, "lists:read": {"list:file:*": "allow"}, "lists:delete": {"list:file:*": "allow"}, "lists:update": {"*:*:*": "allow"}, "rootcheck:clear": {"agent:id:*": "allow"}, "rootcheck:read": {"agent:id:*": "allow"}, "rootcheck:run": {"agent:id:*": "allow"}, "rules:read": {"rule:file:*": "allow"}, "rules:delete": {"rule:file:*": "allow"}, "rules:update": {"*:*:*": "allow"}, "mitre:read": {"*:*:*": "allow"}, "sca:read": {"agent:id:*": "allow"}, "syscheck:clear": {"agent:id:*": "allow"}, "syscheck:read": {"agent:id:*": "allow"}, "syscheck:run": {"agent:id:*": "allow"}, "syscollector:read": {"agent:id:*": "allow"}, "logtest:run": {"*:*:*": "allow"}, "task:status": {"*:*:*": "allow"}, "vulnerability:read": {"agent:id:*": "allow"}, "rbac_mode": "white"}, "current_user": "", "broadcasting": false, "nodes": ["master-node", "worker1"], "api_timeout": 10}'
2022/09/01 10:47:30 INFO: [Worker worker1] [D API] Receiving request: get_api_config from master (527235)
2022/09/01 10:47:30 DEBUG: [Worker worker1] [D API] Receiving parameters {}
2022/09/01 10:47:30 DEBUG: [Worker worker1] [D API] Starting to execute request locally
2022/09/01 10:47:30 DEBUG: [Worker worker1] [D API] Finished executing request locally
2022/09/01 10:47:30 DEBUG: [Worker worker1] [D API] Time calculating request result: 0.032s
2022/09/01 10:47:30 DEBUG: [Worker worker1] [Integrity check] Permission to synchronize granted.
2022/09/01 10:47:30 INFO: [Worker worker1] [Integrity check] Starting.
2022/09/01 10:47:30 DEBUG: [Worker worker1] [Integrity check] Compressing 'files_metadata.json' of 36 files.
2022/09/01 10:47:30 DEBUG: [Worker worker1] [Integrity check] Sending zip file to master.
2022/09/01 10:47:30 DEBUG: [Worker worker1] [Agent-info sync] All chunks sent.
2022/09/01 10:47:30 DEBUG: [Worker worker1] [Integrity check] Zip file sent to master.
2022/09/01 10:47:30 DEBUG: [Worker worker1] [Main] Command received: 'b'syn_m_c_ok''
2022/09/01 10:47:30 INFO: [Worker worker1] [Integrity check] Finished in 0.068s. Sync not required.
2022/09/01 10:47:30 DEBUG: [Worker worker1] [Main] Command received: 'b'syn_m_a_e''
2022/09/01 10:47:30 INFO: [Worker worker1] [Agent-info sync] Finished in 20.462s (20 chunks updated).
```
Any API calls that have to be distributed to the affected node are also delayed, as in this case `GET /cluster/api/config`, which has taken 17 seconds to complete:
```
2022/09/01 10:47:30 INFO: wazuh 192.168.16.1 "GET /cluster/api/config" with parameters {"wait_for_complete": "true", "nodes_list": "worker1"} and body {} done in 17.185s: 200
```

### Async requests to wdb
Now, as the requests are async, other tasks are performed in the meantime even if `wazuh-db` is still taking 20 seconds to return a response (which occurred at `11:02:13`):
```
2022/09/01 11:01:53 INFO: [Worker worker1] [Agent-info sync] Starting.
2022/09/01 11:01:57 DEBUG: [Worker worker1] [Main] Command received: 'b'dapi''
2022/09/01 11:01:57 DEBUG: [Worker worker1] [D API] Received request: b'master*807364 {"f": {"__callable__": {"__name__": "get_api_config", "__module__": "wazuh.manager", "__qualname__": "get_api_config", "__type__": "function"}}, "f_kwargs": {}, "request_type": "distributed_master", "wait_for_complete": true, "from_cluster": true, "is_async": false, "local_client_arg": null, "basic_services": ["wazuh-modulesd", "wazuh-analysisd", "wazuh-execd", "wazuh-db", "wazuh-remoted"], "rbac_permissions": {"agent:create": {"*:*:*": "allow"}, "group:create": {"*:*:*": "allow"}, "agent:read": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:delete": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:modify_group": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:reconnect": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:restart": {"agent:id:*": "allow", "agent:group:*": "allow"}, "agent:upgrade": {"agent:id:*": "allow", "agent:group:*": "allow"}, "group:read": {"group:id:*": "allow"}, "group:delete": {"group:id:*": "allow"}, "group:update_config": {"group:id:*": "allow"}, "group:modify_assignments": {"group:id:*": "allow"}, "active-response:command": {"agent:id:*": "allow"}, "security:create": {"*:*:*": "allow"}, "security:create_user": {"*:*:*": "allow"}, "security:read_config": {"*:*:*": "allow"}, "security:update_config": {"*:*:*": "allow"}, "security:revoke": {"*:*:*": "allow"}, "security:edit_run_as": {"*:*:*": "allow"}, "security:read": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "security:update": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "security:delete": {"role:id:*": "allow", "policy:id:*": "allow", "user:id:*": "allow", "rule:id:*": "allow"}, "cluster:status": {"*:*:*": "allow"}, "manager:read": {"*:*:*": "allow"}, "manager:read_api_config": {"*:*:*": "allow"}, "manager:update_config": {"*:*:*": "allow"}, "manager:restart": {"*:*:*": "allow"}, "cluster:read_api_config": {"node:id:*": "allow"}, "cluster:read": {"node:id:*": "allow"}, "cluster:restart": {"node:id:*": "allow"}, "cluster:update_config": {"node:id:*": "allow"}, "ciscat:read": {"agent:id:*": "allow"}, "decoders:read": {"decoder:file:*": "allow"}, "decoders:delete": {"decoder:file:*": "allow"}, "decoders:update": {"*:*:*": "allow"}, "lists:read": {"list:file:*": "allow"}, "lists:delete": {"list:file:*": "allow"}, "lists:update": {"*:*:*": "allow"}, "rootcheck:clear": {"agent:id:*": "allow"}, "rootcheck:read": {"agent:id:*": "allow"}, "rootcheck:run": {"agent:id:*": "allow"}, "rules:read": {"rule:file:*": "allow"}, "rules:delete": {"rule:file:*": "allow"}, "rules:update": {"*:*:*": "allow"}, "mitre:read": {"*:*:*": "allow"}, "sca:read": {"agent:id:*": "allow"}, "syscheck:clear": {"agent:id:*": "allow"}, "syscheck:read": {"agent:id:*": "allow"}, "syscheck:run": {"agent:id:*": "allow"}, "syscollector:read": {"agent:id:*": "allow"}, "logtest:run": {"*:*:*": "allow"}, "task:status": {"*:*:*": "allow"}, "vulnerability:read": {"agent:id:*": "allow"}, "rbac_mode": "white"}, "current_user": "", "broadcasting": false, "nodes": ["master-node", "worker1"], "api_timeout": 10}'
2022/09/01 11:01:57 INFO: [Worker worker1] [D API] Receiving request: get_api_config from master (807364)
2022/09/01 11:01:57 DEBUG: [Worker worker1] [D API] Receiving parameters {}
2022/09/01 11:01:57 DEBUG: [Worker worker1] [D API] Starting to execute request locally
2022/09/01 11:01:57 DEBUG: [Worker worker1] [D API] Finished executing request locally
2022/09/01 11:01:57 DEBUG: [Worker worker1] [D API] Time calculating request result: 0.007s
2022/09/01 11:02:01 DEBUG: [Worker worker1] [Integrity check] Permission to synchronize granted.
2022/09/01 11:02:01 INFO: [Worker worker1] [Integrity check] Starting.
2022/09/01 11:02:01 DEBUG: [Worker worker1] [Integrity check] Compressing 'files_metadata.json' of 36 files.
2022/09/01 11:02:01 DEBUG: [Worker worker1] [Integrity check] Sending zip file to master.
2022/09/01 11:02:01 DEBUG: [Worker worker1] [Integrity check] Zip file sent to master.
2022/09/01 11:02:01 DEBUG: [Worker worker1] [Main] Command received: 'b'syn_m_c_ok''
2022/09/01 11:02:01 INFO: [Worker worker1] [Integrity check] Finished in 0.013s. Sync not required.
2022/09/01 11:02:10 DEBUG: [Worker worker1] [Integrity check] Permission to synchronize granted.
2022/09/01 11:02:10 INFO: [Worker worker1] [Integrity check] Starting.
2022/09/01 11:02:10 DEBUG: [Worker worker1] [Integrity check] Compressing 'files_metadata.json' of 36 files.
2022/09/01 11:02:10 DEBUG: [Worker worker1] [Integrity check] Sending zip file to master.
2022/09/01 11:02:10 DEBUG: [Worker worker1] [Integrity check] Zip file sent to master.
2022/09/01 11:02:10 DEBUG: [Worker worker1] [Main] Command received: 'b'syn_m_c_ok''
2022/09/01 11:02:10 INFO: [Worker worker1] [Integrity check] Finished in 0.038s. Sync not required.
2022/09/01 11:02:13 DEBUG: [Worker worker1] [Agent-info sync] Obtained 20 chunks of data in 20.240s.
2022/09/01 11:02:13 DEBUG: [Worker worker1] [Agent-info sync] All chunks sent.
2022/09/01 11:02:14 DEBUG: [Worker worker1] [Main] Command received: 'b'syn_m_a_e''
2022/09/01 11:02:14 INFO: [Worker worker1] [Agent-info sync] Finished in 20.434s (20 chunks updated).
```

The API request run while waiting for `wazuh-db` was much faster now:
```
2022/09/01 11:01:57 INFO: wazuh 192.168.16.1 "GET /cluster/api/config" with parameters {"wait_for_complete": "true", "nodes_list": "worker1"} and body {} done in 0.064s: 200
```
