### PR TITLE
 Use AWS code No. 2 correctly

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -3382,7 +3382,7 @@ class AWSCloudWatchLogs(AWSService):
 
 def handler(signal, frame):
     print("ERROR: SIGINT received.")
-    sys.exit(12)
+    sys.exit(2)
 
 
 def debug(msg, msg_level):

--- a/wodles/aws/tests/test_aws.py
+++ b/wodles/aws/tests/test_aws.py
@@ -369,3 +369,13 @@ def test_custom_get_creation_date(log_file: dict, expected_date: int, aws_custom
         Instance of the AWSCustomBucket class.
     """
     assert aws_custom_bucket.get_creation_date(log_file) == expected_date
+
+
+@pytest.mark.parametrize("error,message_map,expected_message", [
+    ({"Error": {"Code": "Foo", "Message": "Bar"}}, {"Foo": "Baz"}, "Baz"),
+    ({"Error": {"Code": "Foo", "Message": "Bar"}}, {}, "Bar"),
+])
+def test_get_client_error_message_return_a_valid_message(error: {}, message_map: dict, expected_message: str):
+    client_error_mock = MagicMock()
+    client_error_mock.response = error
+    assert aws_s3.AWSBucket._get_client_error_message(client_error_mock, message_map) == expected_message

--- a/wodles/aws/tests/test_aws.py
+++ b/wodles/aws/tests/test_aws.py
@@ -369,13 +369,3 @@ def test_custom_get_creation_date(log_file: dict, expected_date: int, aws_custom
         Instance of the AWSCustomBucket class.
     """
     assert aws_custom_bucket.get_creation_date(log_file) == expected_date
-
-
-@pytest.mark.parametrize("error,message_map,expected_message", [
-    ({"Error": {"Code": "Foo", "Message": "Bar"}}, {"Foo": "Baz"}, "Baz"),
-    ({"Error": {"Code": "Foo", "Message": "Bar"}}, {}, "Bar"),
-])
-def test_get_client_error_message_return_a_valid_message(error: {}, message_map: dict, expected_message: str):
-    client_error_mock = MagicMock()
-    client_error_mock.response = error
-    assert aws_s3.AWSBucket._get_client_error_message(client_error_mock, message_map) == expected_message


### PR DESCRIPTION
|Related issue|
|---|
|#13600|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR closes #13600. Reviews exit codes for AWS module and fix No. 2 that was not in use.

## Tests

```bash
(framework) ➜  wazuh git:(enhacement/13600-review-aws-error-codes) ✗ pytest wodles/aws
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.9.9, pytest-5.4.3, py-1.11.0, pluggy-0.13.1
rootdir: /home/nstefani/git/wazuh
plugins: tavern-1.2.2, aiohttp-0.3.0, trio-0.7.0, cov-3.0.0, html-2.1.1, asyncio-0.15.1, metadata-2.0.1
collected 38 items

wodles/aws/tests/test_aws.py ......................................                                                                                                                                           [100%]

================================================================================================ 38 passed in 0.24s =================================================================================================
```
