### PR TITLE
Fix logger tag and path separator

### DIFF
--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -27,8 +27,8 @@ from wazuh.core.utils import blake2b, mkdir_with_mode, get_utc_now, get_date_fro
 logger = logging.getLogger('wazuh')
 
 # Separators used in compression/decompression functions to delimit files.
-FILE_SEP = '|@!@|'
-PATH_SEP = '|!@!|'
+FILE_SEP = '|@@//@@|'
+PATH_SEP = '|//@@//|'
 
 
 #

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -842,12 +842,12 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                     raise exception.WazuhClusterError(3016, extra_message=result.decode())
             except exception.WazuhException as e:
                 # Notify error to worker and delete its received file.
-                self.logger.error(f"Error sending files information: {e}")
+                logger.error(f"Error sending files information: {e}")
                 await self.send_request(
                     command=b'syn_m_c_r', data=task_id + b' ' + json.dumps(e, cls=c_common.WazuhJSONEncoder).encode())
             except Exception as e:
                 # Notify error to worker and delete its received file.
-                self.logger.error(f"Error sending files information: {e}")
+                logger.error(f"Error sending files information: {e}")
                 exc_info = json.dumps(exception.WazuhClusterError(1000, extra_message=str(e)),
                                       cls=c_common.WazuhJSONEncoder).encode()
                 await self.send_request(command=b'syn_m_c_r', data=task_id + b' ' + exc_info)
@@ -859,7 +859,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                         self.cluster_items['intervals']['communication']['min_zip_size'],
                         sent_size * (1 - self.cluster_items['intervals']['communication']['zip_limit_tolerance'])
                     )
-                    self.logger.debug(f"Decreasing sync size limit to {self.current_zip_limit / (1024 ** 2):.2f} MB.")
+                    logger.debug(f"Decreasing sync size limit to {self.current_zip_limit / (1024 ** 2):.2f} MB.")
                 except KeyError:
                     # Increase max zip size if two conditions are met:
                     #   1. Current zip limit is lower than default.
@@ -872,8 +872,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                             self.current_zip_limit * (
                                     1 / (1 - self.cluster_items['intervals']['communication']['zip_limit_tolerance'])
                             ))
-                        self.logger.debug(
-                            f"Increasing sync size limit to {self.current_zip_limit / (1024 ** 2):.2f} MB.")
+                        logger.debug(f"Increasing sync size limit to {self.current_zip_limit / (1024 ** 2):.2f} MB.")
 
                 # Remove local file.
                 os.unlink(compressed_data)


### PR DESCRIPTION
|Related issue|
|---|
| Closes #14817 |

## Description

This PR fixes both of the problems reported at #14817. 

First, now the log tag shown when increasing or decreasing the zip size is `Integrity sync`. Some error logs now use said tag too:
```
2022/09/13 10:40:12 INFO: [Worker worker1] [Integrity sync] Starting.
2022/09/13 10:40:12 INFO: [Worker worker1] [Integrity sync] Files to create in worker: 2214 | Files to update in worker: 0 | Files to delete in worker: 0
2022/09/13 10:40:12 DEBUG: [Worker worker1] [Integrity sync] Compressing files to be synced in worker.
2022/09/13 10:40:12 INFO: [Master] [Local integrity] Finished in 0.148s. Calculated metadata of 2248 files.
2022/09/13 10:40:13 DEBUG: [Worker worker1] [Main] Command received: b'syn_a_w_m_p'
2022/09/13 10:40:16 WARNING: [Local Server] [Main] Maximum zip size exceeded. Not all files will be compressed during this sync.
2022/09/13 10:40:19 DEBUG: [Worker worker1] [Main] Command received: b'cancel_task'
2022/09/13 10:40:19 ERROR: [Worker worker1] [Main] The task was canceled due to the following error on the remote node: Error 3039 - Timeout while waiting to receive a file
2022/09/13 10:40:19 DEBUG: [Worker worker1] [Integrity sync] Zip with files to be synced sent to worker.
2022/09/13 10:40:19 ERROR: [Worker worker1] [Integrity sync] Error sending files information: Error 3027 - Unknown received task name: 5c709f11-7207-4da3-910f-a5b914ac4264
2022/09/13 10:40:19 DEBUG: [Worker worker1] [Integrity sync] Decreasing sync size limit to 88.00 MB.
2022/09/13 10:40:19 DEBUG: [Worker worker1] [Integrity sync] Finished sending files to worker.
2022/09/13 10:40:19 INFO: [Worker worker1] [Integrity sync] Finished in 6.501s.
```

Second, the path separators used to split the compressed strings include slash (`/`). That symbol cannot be used in filenames since it would be interpreted as a nested file:
https://github.com/wazuh/wazuh/blob/4a992c6b5783eaeb820cd15cc849a0f3a63fbbcd/framework/wazuh/core/cluster/cluster.py#L29-L31

A double slash has been used since otherwise the separator could be mimicked by creating nested directories:
```
root@wazuh-master:/var/ossec/etc/rules/# mkdir "|@"
root@wazuh-master:/var/ossec/etc/rules/# mkdir "|@"/"@|"
root@wazuh-master:/var/ossec/etc/rules/# mkdir "|@"/"@|"/test_dir 
root@wazuh-master:/var/ossec/etc/rules/# touch "|@"/"@|"/test_dir/test_rule.xml
root@wazuh-master:/var/ossec/etc/rules/# cd "|@"/"@|"/test_dir
root@wazuh-master:/var/ossec/etc/rules/|@/@|/test_dir# pwd
/var/ossec/etc/rules/|@/@|/test_dir
```

Which would raise this error in synchronization, making it unable to complete:
```
2022/09/13 11:08:09 INFO: [Worker worker1] [Integrity sync] Starting.
2022/09/13 11:08:09 INFO: [Worker worker1] [Integrity sync] Files to create in worker: 1 | Files to update in worker: 0 | Files to delete in worker: 0
2022/09/13 11:08:09 INFO: [Worker worker1] [Integrity sync] Finished in 0.004s.
2022/09/13 11:08:09 ERROR: [Worker worker1] [Main] Error in synchronization process: Error 1000 - Wazuh Internal Error: not enough values to unpack (expected 2, got 1)
```

## Tests
### Unit tests
```
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.9.5, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/selu/Git/wazuh/framework
plugins: anyio-3.5.0, asyncio-0.18.1, aiohttp-1.0.4, cov-3.0.0
asyncio: mode=auto
collected 1970 items                                                                                                                                                                                        

framework/scripts/tests/test_agent_groups.py ..............                                                                                                                                           [  0%]
framework/scripts/tests/test_agent_upgrade.py ...............                                                                                                                                         [  1%]
framework/scripts/tests/test_cluster_control.py ......                                                                                                                                                [  1%]
framework/scripts/tests/test_wazuh_clusterd.py .......                                                                                                                                                [  2%]
framework/scripts/tests/test_wazuh_logtest.py ......................                                                                                                                                  [  3%]
framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................................                                                                                                                 [  4%]
framework/wazuh/core/cluster/tests/test_client.py ................                                                                                                                                    [  5%]
framework/wazuh/core/cluster/tests/test_cluster.py ..................................                                                                                                                 [  7%]
framework/wazuh/core/cluster/tests/test_common.py .............................................................................                                                                       [ 11%]
framework/wazuh/core/cluster/tests/test_control.py .....                                                                                                                                              [ 11%]
framework/wazuh/core/cluster/tests/test_local_client.py .............                                                                                                                                 [ 12%]
framework/wazuh/core/cluster/tests/test_local_server.py .......................                                                                                                                       [ 13%]
framework/wazuh/core/cluster/tests/test_master.py .................................................                                                                                                   [ 15%]
framework/wazuh/core/cluster/tests/test_server.py ...................                                                                                                                                 [ 16%]
framework/wazuh/core/cluster/tests/test_utils.py ...........                                                                                                                                          [ 17%]
framework/wazuh/core/cluster/tests/test_worker.py .....................................                                                                                                               [ 19%]
framework/wazuh/core/tests/test_active_response.py ..............                                                                                                                                     [ 20%]
framework/wazuh/core/tests/test_agent.py ................................................................................................................................................             [ 27%]
framework/wazuh/core/tests/test_cdb_list.py ......................................                                                                                                                    [ 29%]
framework/wazuh/core/tests/test_common.py .......                                                                                                                                                     [ 29%]
framework/wazuh/core/tests/test_configuration.py ....................................                                                                                                                 [ 31%]
framework/wazuh/core/tests/test_database.py .............                                                                                                                                             [ 32%]
framework/wazuh/core/tests/test_decoder.py ................                                                                                                                                           [ 32%]
framework/wazuh/core/tests/test_exception.py ...                                                                                                                                                      [ 33%]
framework/wazuh/core/tests/test_input_validator.py ...                                                                                                                                                [ 33%]
framework/wazuh/core/tests/test_logtest.py ..                                                                                                                                                         [ 33%]
framework/wazuh/core/tests/test_manager.py ...............                                                                                                                                            [ 34%]
framework/wazuh/core/tests/test_mitre.py .............                                                                                                                                                [ 34%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                                                                                                                                               [ 34%]
framework/wazuh/core/tests/test_results.py ........................................                                                                                                                   [ 37%]
framework/wazuh/core/tests/test_rootcheck.py .............                                                                                                                                            [ 37%]
framework/wazuh/core/tests/test_rule.py ......................                                                                                                                                        [ 38%]
framework/wazuh/core/tests/test_sca.py ............                                                                                                                                                   [ 39%]
framework/wazuh/core/tests/test_security.py ............                                                                                                                                              [ 40%]
framework/wazuh/core/tests/test_stats.py ............                                                                                                                                                 [ 40%]
framework/wazuh/core/tests/test_syscheck.py .......                                                                                                                                                   [ 40%]
framework/wazuh/core/tests/test_syscollector.py ...                                                                                                                                                   [ 41%]
framework/wazuh/core/tests/test_task.py ........                                                                                                                                                      [ 41%]
framework/wazuh/core/tests/test_utils.py ............................................................................................................................................................ [ 49%]
.................................................................................                                                                                                                     [ 53%]
framework/wazuh/core/tests/test_vulnerability.py ..                                                                                                                                                   [ 53%]
framework/wazuh/core/tests/test_wazuh_queue.py ....................                                                                                                                                   [ 54%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                                                  [ 55%]
framework/wazuh/core/tests/test_wdb.py .........................                                                                                                                                      [ 56%]
framework/wazuh/core/tests/test_wlogging.py .........                                                                                                                                                 [ 57%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                                                                                                                                    [ 57%]
framework/wazuh/rbac/tests/test_decorators.py .........................................................................................................                                               [ 62%]
framework/wazuh/rbac/tests/test_default_configuration.py .......................................................                                                                                      [ 65%]
framework/wazuh/rbac/tests/test_orm.py ......................................................                                                                                                         [ 68%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                           [ 68%]
framework/wazuh/tests/test_active_response.py ............                                                                                                                                            [ 69%]
framework/wazuh/tests/test_agent.py ......................................................................................................................                                            [ 75%]
framework/wazuh/tests/test_cdb_list.py .....................................................                                                                                                          [ 78%]
framework/wazuh/tests/test_ciscat.py .................................                                                                                                                                [ 79%]
framework/wazuh/tests/test_cluster.py ..........                                                                                                                                                      [ 80%]
framework/wazuh/tests/test_decoder.py ...................................                                                                                                                             [ 82%]
framework/wazuh/tests/test_group.py .......                                                                                                                                                           [ 82%]
framework/wazuh/tests/test_logtest.py ......                                                                                                                                                          [ 82%]
framework/wazuh/tests/test_manager.py ....................................                                                                                                                            [ 84%]
framework/wazuh/tests/test_mitre.py .......                                                                                                                                                           [ 85%]
framework/wazuh/tests/test_rootcheck.py ..................................................                                                                                                            [ 87%]
framework/wazuh/tests/test_rule.py ........................................................                                                                                                           [ 90%]
framework/wazuh/tests/test_sca.py .......                                                                                                                                                             [ 90%]
framework/wazuh/tests/test_security.py .........................................................................                                                                                      [ 94%]
framework/wazuh/tests/test_stats.py .......                                                                                                                                                           [ 94%]
framework/wazuh/tests/test_syscheck.py ..........................                                                                                                                                     [ 96%]
framework/wazuh/tests/test_syscollector.py ............                                                                                                                                               [ 96%]
framework/wazuh/tests/test_task.py ............................                                                                                                                                       [ 98%]
framework/wazuh/tests/test_vulnerability.py ....................................                                                                                                                      [100%]

============================================================================== 1970 passed, 3781 warnings in 252.35s (0:04:12) ==============================================================================
```

### System test:
```
pytest -vv test_cluster/test_integrity_sync/
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.8.10, pytest-5.0.0, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.10', 'Platform': 'Linux-5.4.0-125-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.0.0', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'html': '3.1.1', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'pep8': '1.0.6', 'cov': '2.10.0', 'asyncio': '0.14.0'}}
rootdir: /home/selu/Git/wazuh-qa/tests/system
plugins: metadata-1.10.0, html-3.1.1, testinfra-5.0.0, tavern-1.2.2, pep8-1.0.6, cov-2.10.0, asyncio-0.14.0
collected 4 items                                                                                                                                                                                           

test_cluster/test_integrity_sync/test_integrity_sync.py::test_missing_file PASSED                                                                                                                     [ 25%]
test_cluster/test_integrity_sync/test_integrity_sync.py::test_shared_files PASSED                                                                                                                     [ 50%]
test_cluster/test_integrity_sync/test_integrity_sync.py::test_extra_files PASSED                                                                                                                      [ 75%]
test_cluster/test_integrity_sync/test_integrity_sync.py::test_zip_size_limit PASSED                                                                                                                   [100%]

======================================================================================== 4 passed in 652.74 seconds =========================================================================================
```