### PR TITLE
Fix and remove wmodules-azure.c warning message

### DIFF
--- a/src/config/wmodules-azure.c
+++ b/src/config/wmodules-azure.c
@@ -239,13 +239,15 @@ int wm_azure_api_read(const OS_XML *xml, XML_NODE nodes, wm_azure_api_t * api_co
             return OS_INVALID;
 
         } else if (!strcmp(nodes[i]->element, XML_APP_ID)) {
-            if (*nodes[i]->content != '\0')
+            if (*nodes[i]->content != '\0') {
                 mwarn(DEPRECATED_MESSAGE, nodes[i]->element, WM_AZURE_CONTEXT.name, "4.4", AUTHENTICATION_OPTIONS_URL);
                 os_strdup(nodes[i]->content, api_config->application_id);
+            }
         } else if (!strcmp(nodes[i]->element, XML_APP_KEY)) {
-            if (*nodes[i]->content != '\0')
+            if (*nodes[i]->content != '\0') {
                 mwarn(DEPRECATED_MESSAGE, nodes[i]->element, WM_AZURE_CONTEXT.name, "4.4", AUTHENTICATION_OPTIONS_URL);
                 os_strdup(nodes[i]->content, api_config->application_key);
+            }
         } else if (!strcmp(nodes[i]->element, XML_AUTH_PATH)) {
             if (*nodes[i]->content != '\0')
                 os_strdup(nodes[i]->content, api_config->auth_path);


### PR DESCRIPTION
## Description
In https://github.com/wazuh/wazuh/issues/14508 we added the required changes to deprecate the option that allows users to employ plain text credentials in the ossec.conf. With these changes we produced the following warning message when installing Wazuh:
```
config/wmodules-azure.c: In function 'wm_azure_api_read':
config/wmodules-azure.c:242:13: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
  242 |             if (*nodes[i]->content != '\0')
      |             ^~
In file included from ./wazuh_modules/wmodules.h:15,
                 from config/wmodules-azure.c:13:
./headers/shared.h:209:24: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
  209 | #define os_strdup(x,y) ((y = strdup(x)))?(void)1:merror_exit(MEM_ERROR, errno, strerror(errno))
      |                        ^
config/wmodules-azure.c:244:17: note: in expansion of macro 'os_strdup'
  244 |                 os_strdup(nodes[i]->content, api_config->application_id);
      |                 ^~~~~~~~~
config/wmodules-azure.c:246:13: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
  246 |             if (*nodes[i]->content != '\0')
      |             ^~
In file included from ./wazuh_modules/wmodules.h:15,
                 from config/wmodules-azure.c:13:
./headers/shared.h:209:24: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
  209 | #define os_strdup(x,y) ((y = strdup(x)))?(void)1:merror_exit(MEM_ERROR, errno, strerror(errno))
      |                        ^
config/wmodules-azure.c:248:17: note: in expansion of macro 'os_strdup'
  248 |                 os_strdup(nodes[i]->content, api_config->application_key);
      |                 ^~~~~~~~~
```

This warning message appears because some curly braces are missing after the new lines were added. This PR remove this warning message by adding them as intended.

In order to test this we compiled and installed Wazuh from sources after applying the change to ensure everything works as expected. No issues were found.