### PR TITLE
Use less generic exceptions when waiting for files in cluster

### DIFF
--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -757,13 +757,15 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         try:
             await asyncio.wait_for(received_file.wait(),
                                    timeout=self.cluster_items['intervals']['communication']['timeout_receiving_file'])
-        except Exception:
+        except Exception as e:
+            if isinstance(e, asyncio.TimeoutError):
+                exc = exception.WazuhClusterError(3039)
+            else:
+                exc = exception.WazuhClusterError(3040, extra_message=str(e))
             # Notify the sending node to stop its task.
-            await self.send_request(
-                command=b'cancel_task',
-                data=task_id.encode() + b' ' + json.dumps(timeout_exc := exception.WazuhClusterError(3039),
-                                                          cls=c_common.WazuhJSONEncoder).encode())
-            raise timeout_exc
+            await self.send_request(command=b"cancel_task",
+                                    data=f"{task_id} {json.dumps(exc, cls=c_common.WazuhJSONEncoder)}".encode())
+            raise exc
 
         # Full path where the zip sent by the worker is located.
         received_filename = self.sync_tasks[task_id].filename
@@ -928,13 +930,15 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         try:
             await asyncio.wait_for(received_file.wait(),
                                    timeout=self.cluster_items['intervals']['communication']['timeout_receiving_file'])
-        except Exception:
+        except Exception as e:
+            if isinstance(e, asyncio.TimeoutError):
+                exc = exception.WazuhClusterError(3039)
+            else:
+                exc = exception.WazuhClusterError(3040, extra_message=str(e))
             # Notify the sending node to stop its task.
-            await self.send_request(
-                command=b'cancel_task',
-                data=task_id.encode() + b' ' + json.dumps(timeout_exc := exception.WazuhClusterError(3039),
-                                                          cls=c_common.WazuhJSONEncoder).encode())
-            raise timeout_exc
+            await self.send_request(command=b"cancel_task",
+                                    data=f"{task_id} {json.dumps(exc, cls=c_common.WazuhJSONEncoder)}".encode())
+            raise exc
 
         # Full path where the zip sent by the worker is located.
         received_filename = self.sync_tasks[task_id].filename

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -1544,9 +1544,15 @@ async def test_master_handler_sync_integrity_ko(send_request_mock, wait_for_mock
             await master_handler.sync_integrity("task_id", EventMock())
     send_request_mock.assert_called_once_with(command=b'cancel_task', data=ANY)
 
-    with pytest.raises(Exception):
+    wait_for_mock.side_effect = asyncio.TimeoutError
+    with pytest.raises(exception.WazuhClusterError, match=r".* 3039 .*"):
         await master_handler.sync_integrity("task_id", EventMock())
-        wait_for_mock.assert_called_once()
+    send_request_mock.assert_called_with(command=b'cancel_task', data=ANY)
+
+    wait_for_mock.side_effect = Exception
+    with pytest.raises(exception.WazuhClusterError, match=r".* 3040 .*"):
+        await master_handler.sync_integrity("task_id", EventMock())
+    send_request_mock.assert_called_with(command=b'cancel_task', data=ANY)
 
 
 @freeze_time("1970-01-01")

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -1194,8 +1194,13 @@ async def test_worker_handler_process_files_from_master_ko(send_request_mock, js
     wait_mock.assert_called_once_with(event_mock.wait(),
                                       timeout=cluster_items['intervals']['communication']['timeout_receiving_file'])
 
-    wait_mock.side_effect = Exception
+    wait_mock.side_effect = asyncio.TimeoutError
     with pytest.raises(exception.WazuhClusterError, match=r".* 3039 .*"):
+        await worker_handler.process_files_from_master(name="task_id", file_received=event_mock)
+    send_request_mock.assert_called_with(command=b'cancel_task', data=b'task_id ')
+
+    wait_mock.side_effect = Exception
+    with pytest.raises(exception.WazuhClusterError, match=r".* 3040 .*"):
         await worker_handler.process_files_from_master(name="task_id", file_received=event_mock)
     send_request_mock.assert_called_with(command=b'cancel_task', data=b'task_id ')
 

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -442,6 +442,7 @@ class WazuhException(Exception):
         3037: 'Error while processing Agent-info chunks',
         3038: "Error while processing extra-valid files",
         3039: "Timeout while waiting to receive a file",
+        3040: "Error while waiting to receive a file",
 
         # RBAC exceptions
         # The messages of these exceptions are provisional until the RBAC documentation is published.


### PR DESCRIPTION
|Related issue|
|---|
| Closes #14735 |

## Description

This PR improves how exceptions are handled when receiving a file in cluster tasks. Until now, any exception cought while waiting for an async Event to be `true` (using `asyncio.wait_for`) was considered a Timeout, which could not be true in some cases.

Now, if the exception is different from `asyncio.TimeoutError`, the error message is printed in the cluster log so we can get more information about the source of the error. In any case, the `send_file` task is still canceled no matter what exception is raised.

## Logs/Alerts example
Timeout error while waiting to receive a file:
```
2022/09/15 09:12:56 INFO: [Worker worker1] [Integrity sync] Starting.
2022/09/15 09:12:56 INFO: [Worker worker1] [Integrity sync] Files to create in worker: 1 | Files to update in worker: 0 | Files to delete in worker: 0
2022/09/15 09:12:59 ERROR: [Worker worker1] [Main] The task was canceled due to the following error on the remote node: Error 3039 - Timeout while waiting to receive a file
2022/09/15 09:12:59 ERROR: [Worker worker1] [Main] Error sending files information: Error 3027 - Unknown received task name: 718614fe-0a75-413e-a979-6fc95d1f9907
2022/09/15 09:12:59 INFO: [Worker worker1] [Integrity sync] Finished in 3.361s.
```

Different exception than Timeout raised while waiting to receive a file:
```
2022/09/15 09:15:44 INFO: [Master] [Local integrity] Starting.
2022/09/15 09:15:44 INFO: [Master] [Local integrity] Finished in 0.003s. Calculated metadata of 35 files.
2022/09/15 09:15:44 ERROR: [Worker worker1] [Main] The task was canceled due to the following error on the remote node: Error 3040 - Error while waiting to receive a file: invalid literal for int() with base 10: 'abc'
2022/09/15 09:15:44 ERROR: [Worker worker1] [Main] Error sending files information: Error 3027 - Unknown received task name: d3dc00de-64a2-4002-a99e-22e3246d55da
2022/09/15 09:15:44 INFO: [Worker worker1] [Integrity sync] Finished in 6.393s.
```

## Tests
```
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.9.5, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/selu/Git/wazuh/framework
plugins: anyio-3.5.0, asyncio-0.18.1, aiohttp-1.0.4, cov-3.0.0
asyncio: mode=auto
collected 1970 items                                                                                                                                                                                        

framework/scripts/tests/test_agent_groups.py ..............                                                                                                                                           [  0%]
framework/scripts/tests/test_agent_upgrade.py ...............                                                                                                                                         [  1%]
framework/scripts/tests/test_cluster_control.py ......                                                                                                                                                [  1%]
framework/scripts/tests/test_wazuh_clusterd.py .......                                                                                                                                                [  2%]
framework/scripts/tests/test_wazuh_logtest.py ......................                                                                                                                                  [  3%]
framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................................                                                                                                                 [  4%]
framework/wazuh/core/cluster/tests/test_client.py ................                                                                                                                                    [  5%]
framework/wazuh/core/cluster/tests/test_cluster.py ..................................                                                                                                                 [  7%]
framework/wazuh/core/cluster/tests/test_common.py .............................................................................                                                                       [ 11%]
framework/wazuh/core/cluster/tests/test_control.py .....                                                                                                                                              [ 11%]
framework/wazuh/core/cluster/tests/test_local_client.py .............                                                                                                                                 [ 12%]
framework/wazuh/core/cluster/tests/test_local_server.py .......................                                                                                                                       [ 13%]
framework/wazuh/core/cluster/tests/test_master.py .................................................                                                                                                   [ 15%]
framework/wazuh/core/cluster/tests/test_server.py ...................                                                                                                                                 [ 16%]
framework/wazuh/core/cluster/tests/test_utils.py ...........                                                                                                                                          [ 17%]
framework/wazuh/core/cluster/tests/test_worker.py .....................................                                                                                                               [ 19%]
framework/wazuh/core/tests/test_active_response.py ..............                                                                                                                                     [ 20%]
framework/wazuh/core/tests/test_agent.py ................................................................................................................................................             [ 27%]
framework/wazuh/core/tests/test_cdb_list.py ......................................                                                                                                                    [ 29%]
framework/wazuh/core/tests/test_common.py .......                                                                                                                                                     [ 29%]
framework/wazuh/core/tests/test_configuration.py ....................................                                                                                                                 [ 31%]
framework/wazuh/core/tests/test_database.py .............                                                                                                                                             [ 32%]
framework/wazuh/core/tests/test_decoder.py ................                                                                                                                                           [ 32%]
framework/wazuh/core/tests/test_exception.py ...                                                                                                                                                      [ 33%]
framework/wazuh/core/tests/test_input_validator.py ...                                                                                                                                                [ 33%]
framework/wazuh/core/tests/test_logtest.py ..                                                                                                                                                         [ 33%]
framework/wazuh/core/tests/test_manager.py ...............                                                                                                                                            [ 34%]
framework/wazuh/core/tests/test_mitre.py .............                                                                                                                                                [ 34%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                                                                                                                                               [ 34%]
framework/wazuh/core/tests/test_results.py ........................................                                                                                                                   [ 37%]
framework/wazuh/core/tests/test_rootcheck.py .............                                                                                                                                            [ 37%]
framework/wazuh/core/tests/test_rule.py ......................                                                                                                                                        [ 38%]
framework/wazuh/core/tests/test_sca.py ............                                                                                                                                                   [ 39%]
framework/wazuh/core/tests/test_security.py ............                                                                                                                                              [ 40%]
framework/wazuh/core/tests/test_stats.py ............                                                                                                                                                 [ 40%]
framework/wazuh/core/tests/test_syscheck.py .......                                                                                                                                                   [ 40%]
framework/wazuh/core/tests/test_syscollector.py ...                                                                                                                                                   [ 41%]
framework/wazuh/core/tests/test_task.py ........                                                                                                                                                      [ 41%]
framework/wazuh/core/tests/test_utils.py ............................................................................................................................................................ [ 49%]
.................................................................................                                                                                                                     [ 53%]
framework/wazuh/core/tests/test_vulnerability.py ..                                                                                                                                                   [ 53%]
framework/wazuh/core/tests/test_wazuh_queue.py ....................                                                                                                                                   [ 54%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                                                  [ 55%]
framework/wazuh/core/tests/test_wdb.py .........................                                                                                                                                      [ 56%]
framework/wazuh/core/tests/test_wlogging.py .........                                                                                                                                                 [ 57%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                                                                                                                                    [ 57%]
framework/wazuh/rbac/tests/test_decorators.py .........................................................................................................                                               [ 62%]
framework/wazuh/rbac/tests/test_default_configuration.py .......................................................                                                                                      [ 65%]
framework/wazuh/rbac/tests/test_orm.py ......................................................                                                                                                         [ 68%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                           [ 68%]
framework/wazuh/tests/test_active_response.py ............                                                                                                                                            [ 69%]
framework/wazuh/tests/test_agent.py ......................................................................................................................                                            [ 75%]
framework/wazuh/tests/test_cdb_list.py .....................................................                                                                                                          [ 78%]
framework/wazuh/tests/test_ciscat.py .................................                                                                                                                                [ 79%]
framework/wazuh/tests/test_cluster.py ..........                                                                                                                                                      [ 80%]
framework/wazuh/tests/test_decoder.py ...................................                                                                                                                             [ 82%]
framework/wazuh/tests/test_group.py .......                                                                                                                                                           [ 82%]
framework/wazuh/tests/test_logtest.py ......                                                                                                                                                          [ 82%]
framework/wazuh/tests/test_manager.py ....................................                                                                                                                            [ 84%]
framework/wazuh/tests/test_mitre.py .......                                                                                                                                                           [ 85%]
framework/wazuh/tests/test_rootcheck.py ..................................................                                                                                                            [ 87%]
framework/wazuh/tests/test_rule.py ........................................................                                                                                                           [ 90%]
framework/wazuh/tests/test_sca.py .......                                                                                                                                                             [ 90%]
framework/wazuh/tests/test_security.py .........................................................................                                                                                      [ 94%]
framework/wazuh/tests/test_stats.py .......                                                                                                                                                           [ 94%]
framework/wazuh/tests/test_syscheck.py ..........................                                                                                                                                     [ 96%]
framework/wazuh/tests/test_syscollector.py ............                                                                                                                                               [ 96%]
framework/wazuh/tests/test_task.py ............................                                                                                                                                       [ 98%]
framework/wazuh/tests/test_vulnerability.py ....................................                                                                                                                      [100%]

============================================================================== 1970 passed, 3778 warnings in 293.00s (0:04:52) ==============================================================================
```