### PR TITLE
New endpoints in wazuh-db 'vacuum' and 'get_fragmentation'

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -943,13 +943,14 @@ $(BZIP2_LIB):
 
 sqlite_c = ${EXTERNAL_SQLITE}sqlite3.c
 sqlite_o = ${EXTERNAL_SQLITE}sqlite3.o
+SQLITE_CFLAGS = -DSQLITE_ENABLE_DBSTAT_VTAB=1
 
 $(SQLITE_LIB): $(sqlite_o)
 	${OSSEC_LINK} $@ $^
 	${OSSEC_RANLIB} $@
 
 $(sqlite_o): $(sqlite_c)
-	${OSSEC_CC} ${OSSEC_CFLAGS} -w -fPIC -c $^ -o $@ -fPIC
+	${OSSEC_CC} ${OSSEC_CFLAGS} -w -fPIC ${SQLITE_CFLAGS} -c $^ -o $@ -fPIC
 
 #### cJSON #########
 

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -33,7 +33,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_scan_info_get -Wl,--wrap,wdb_fim_upd
                         -Wl,--wrap,sqlite3_clear_bindings -Wl,--wrap,wdb_get_cache_stmt -Wl,--wrap,sqlite3_column_text \
                         -Wl,--wrap,sqlite3_column_int -Wl,--wrap,sqlite3_column_double -Wl,--wrap,sqlite3_bind_null -Wl,--wrap,sqlite3_bind_int64\
                         -Wl,--wrap,wdb_get_config -Wl,--wrap,wdb_get_internal_config \
-                        -Wl,--wrap,wdb_global_create_backup \
+                        -Wl,--wrap,wdb_global_create_backup -Wl,--wrap,wdb_commit2 -Wl,--wrap,wdb_vacuum -Wl,--wrap,wdb_get_db_state\
                         ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_global_parser")
@@ -51,7 +51,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl
                              -Wl,--wrap,sqlite3_step -Wl,--wrap,wdb_global_get_groups_integrity -Wl,--wrap,wdb_global_get_backups \
                              -Wl,--wrap,wdb_global_restore_backup -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock \
                              -Wl,--wrap,wdb_global_select_group_belong -Wl,--wrap,wdb_global_set_agent_groups -Wl,--wrap,wdb_global_sync_agent_groups_get \
-                             -Wl,--wrap,wdb_global_get_group_agents \
+                             -Wl,--wrap,wdb_global_get_group_agents -Wl,--wrap,wdb_commit2 -Wl,--wrap,wdb_vacuum -Wl,--wrap,wdb_get_db_state \
                              ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_global")

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
@@ -366,3 +366,11 @@ int __wrap_wdb_commit2(__attribute__((unused))wdb_t * wdb) {
 void __wrap_wdb_finalize_all_statements(__attribute__((unused))wdb_t * wdb) {
     function_called();
 }
+
+int __wrap_wdb_vacuum(__attribute__((unused))sqlite3 * db) {
+    return mock();
+}
+
+int __wrap_wdb_get_db_state(__attribute__((unused))wdb_t * wdb) {
+    return mock();
+}

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
@@ -91,4 +91,8 @@ int __wrap_wdb_commit2(wdb_t * wdb);
 
 void __wrap_wdb_finalize_all_statements(__attribute__((unused))wdb_t * wdb);
 
+int __wrap_wdb_vacuum(__attribute__((unused))sqlite3 * db);
+
+int __wrap_wdb_get_db_state(__attribute__((unused))wdb_t * wdb);
+
 #endif

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -697,12 +697,6 @@ int wdb_vacuum(sqlite3 *db);
 /* Calculate the fragmentation state of a db. Returns 0-100 on success or OS_INVALID on error. */
 int wdb_get_db_state(wdb_t * wdb);
 
-/* Run a query without selecting any fields */
-int wdb_execute_non_select_query(sqlite3 *db, const char *query);
-
-/* Select from temp table */
-int wdb_select_from_temp_table(sqlite3 *db);
-
 /* Insert key-value pair into info table */
 int wdb_insert_info(const char *key, const char *value);
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -694,6 +694,21 @@ int wdb_rootcheck_delete(wdb_t * wdb);
 /* Rebuild database. Returns 0 on success or -1 on error. */
 int wdb_vacuum(sqlite3 *db);
 
+/* Calculate the fragmentation state of a db. Returns 0-100 on success or -1 on error. */
+int wdb_get_db_state(wdb_t * wdb);
+
+/* Create temp table */
+int wdb_create_temp_table(sqlite3 *db);
+
+/* Insert into temp table */
+int wdb_insert_into_temp_table(sqlite3 *db);
+
+/* Select from temp table */
+int wdb_select_from_temp_table(sqlite3 *db);
+
+/* Drop temp table */
+int wdb_drop_temp_table(sqlite3 *db);
+
 /* Insert key-value pair into info table */
 int wdb_insert_info(const char *key, const char *value);
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -694,20 +694,14 @@ int wdb_rootcheck_delete(wdb_t * wdb);
 /* Rebuild database. Returns 0 on success or -1 on error. */
 int wdb_vacuum(sqlite3 *db);
 
-/* Calculate the fragmentation state of a db. Returns 0-100 on success or -1 on error. */
+/* Calculate the fragmentation state of a db. Returns 0-100 on success or OS_INVALID on error. */
 int wdb_get_db_state(wdb_t * wdb);
 
-/* Create temp table */
-int wdb_create_temp_table(sqlite3 *db);
-
-/* Insert into temp table */
-int wdb_insert_into_temp_table(sqlite3 *db);
+/* Run a query without selecting any fields */
+int wdb_execute_non_select_query(sqlite3 *db, const char *query);
 
 /* Select from temp table */
 int wdb_select_from_temp_table(sqlite3 *db);
-
-/* Drop temp table */
-int wdb_drop_temp_table(sqlite3 *db);
 
 /* Insert key-value pair into info table */
 int wdb_insert_info(const char *key, const char *value);

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -588,7 +588,7 @@ int wdb_parse(char * input, char * output, int peer) {
             }
         } else if (strcmp(query, "get_fragmentation") == 0) {
             int state = wdb_get_db_state(wdb);
-            if ( state < 0) {
+            if (state < 0) {
                 mdebug1("DB(%s) Cannot get database fragmentation.", sagent_id);
                 snprintf(output, OS_MAXSTR + 1, "err Cannot get database fragmentation");
                 result = -1;
@@ -974,7 +974,7 @@ int wdb_parse(char * input, char * output, int peer) {
                 result = -1;
             }
 
-            if ( result != -1) {
+            if (result != -1) {
                 if (wdb_vacuum(wdb->db) < 0) {
                     mdebug1("Global DB Cannot vacuum database.");
                     snprintf(output, OS_MAXSTR + 1, "err Cannot vacuum database");
@@ -986,7 +986,7 @@ int wdb_parse(char * input, char * output, int peer) {
             }
         } else if (strcmp(query, "get_fragmentation") == 0) {
             int state = wdb_get_db_state(wdb);
-            if ( state < 0) {
+            if (state < 0) {
                 mdebug1("Global DB Cannot get database fragmentation.");
                 snprintf(output, OS_MAXSTR + 1, "err Cannot get database fragmentation");
                 result = -1;

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -576,13 +576,15 @@ int wdb_parse(char * input, char * output, int peer) {
                 result = -1;
             }
 
-            if (wdb_vacuum(wdb->db) < 0) {
-                mdebug1("DB(%s) Cannot vacuum database.", sagent_id);
-                snprintf(output, OS_MAXSTR + 1, "err Cannot vacuum database");
-                result = -1;
-            } else {
-                snprintf(output, OS_MAXSTR + 1, "ok");
-                result = 0;
+            if (result != -1) {
+                if (wdb_vacuum(wdb->db) < 0) {
+                    mdebug1("DB(%s) Cannot vacuum database.", sagent_id);
+                    snprintf(output, OS_MAXSTR + 1, "err Cannot vacuum database");
+                    result = -1;
+                } else {
+                    snprintf(output, OS_MAXSTR + 1, "ok");
+                    result = 0;
+                }
             }
         } else if (strcmp(query, "get_fragmentation") == 0) {
             int state = wdb_get_db_state(wdb);
@@ -972,13 +974,15 @@ int wdb_parse(char * input, char * output, int peer) {
                 result = -1;
             }
 
-            if (wdb_vacuum(wdb->db) < 0) {
-                mdebug1("Global DB Cannot vacuum database.");
-                snprintf(output, OS_MAXSTR + 1, "err Cannot vacuum database");
-                result = -1;
-            } else {
-                snprintf(output, OS_MAXSTR + 1, "ok");
-                result = 0;
+            if ( result != -1) {
+                if (wdb_vacuum(wdb->db) < 0) {
+                    mdebug1("Global DB Cannot vacuum database.");
+                    snprintf(output, OS_MAXSTR + 1, "err Cannot vacuum database");
+                    result = -1;
+                } else {
+                    snprintf(output, OS_MAXSTR + 1, "ok");
+                    result = 0;
+                }
             }
         } else if (strcmp(query, "get_fragmentation") == 0) {
             int state = wdb_get_db_state(wdb);


### PR DESCRIPTION
|Related issue|
|---|
|#14517|

## Description

This PR adds two new endpoints to **wazuh-db** `vacuum` and `get_fragmentation`, these are valid for actors `global` and `agent`. Also, it adds a new compilation flag to the external sqlite library, to be able to use the `dbstat `table of a database.

### Description of changes added:

#### New flag for `sqlite `compilation
The flag `"-DSQLITE_ENABLE_DBSTAT_VTAB=1"` is added to the `sqlite `compilation. This flag allows to use the `dbstat `table needed to get the fragmentation of a database.

```
Note:
Due to this change in the sqlite compilation, the precompiled sqlite library in the resource repository must be updated.
```

#### Actor 'global'

- Enpoint `'vacuum'`: perform `vacuum `to the `global `database. Before performing a `vacuum `it performs a `commit `of the transactions that may be pending.

    **Example of request:**
    `global vacuum`

    Response in case of success:
    `ok`

    Response in case of fail:
    `err Cannot end transaction`
    In case of not being able to `commit `before the `vacuum`.

    `err Cannot vacuum database`
    In case of not being able to perform the `vacuum`.

- Enpoint `'get_fragmentation'`: returns a value between **0** and **100** representing the degree of fragmentation of the `'global'` database. Where **0** is not fragmented and **100** is completely fragmented.

    **Example of request:**
    `global get_fragmentation`

    Response in case of success:
    `ok {"fragmentation":50}`

    Response in case of fail:
    `err Cannot get database fragmentation`


#### Actor 'agent'

- Enpoint `'vacuum'`: perform a `vacuum `to the database of a given agent. Before performing a `vacuum `it performs a `commit `of the transactions that may be pending.

    **Example of request:**
    `agent xxx vacuum`

    Response in case of success:
    `ok`

    Response in case of fail:
    `err Cannot end transaction`
    In case of not being able to `commit `before the `vacuum`.

    `err Cannot vacuum database`
    In case of not being able to perform the `vacuum`.

- Enpoint `'get_fragmentation'`: returns a value between **0** and **100** representing the degree of fragmentation of the database of a given agent. Where **0** is not fragmented and **100** is completely fragmented.

    **Example of request:**
    `agent xxx get_fragmentation`

    Response in case of success:
    `ok {"fragmentation":45}`

    Response in case of fail:
    `err Cannot get database fragmentation`


## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language

