### PR TITLE
Add the initial configuration of wazuh_table and pf to the .conf file…

### DIFF
--- a/src/active-response/firewalls/pf.c
+++ b/src/active-response/firewalls/pf.c
@@ -229,9 +229,14 @@ static int checking_if_its_configured(const char *path, const char *table) {
     return OS_INVALID;
 }
 
-/*
-   retVal = isEnabledFromPattern(output_buf, "Status: ", "Enabled");
-   return 1 if for example with patter1:"Status :" find "Enabled"
+/**
+ * @brief search a pair pattern1 and after pattern2
+ * @param output_buf buffer where search
+ * @param str_pattern_1 pattern search to match
+ * @param str_pattern_2 pattern search to match
+ * @return 1 or 0 
+ * @example retVal = isEnabledFromPattern(output_buf, "Status: ", "Enabled");
+ * @example if for example with patter1:"Status :" find "Enabled", its return 1
 */
 static int isEnabledFromPattern(const char * output_buf, const char * str_pattern_1, const char * str_pattern_2){
     int retVal = 0;
@@ -257,6 +262,12 @@ static int isEnabledFromPattern(const char * output_buf, const char * str_patter
     return  retVal;
 }
 
+/**
+ * @brief write to file path
+ * @param path path to file
+ * @param cmd command or text to write inside file
+ * @return 1 or 0 
+*/
 static int write_cmd_to_file(const char *path, const char *cmd) {
     int retVal = 0;
     if (path != NULL && cmd != NULL) {

--- a/src/active-response/firewalls/pf.c
+++ b/src/active-response/firewalls/pf.c
@@ -108,7 +108,6 @@ int main (int argc, char **argv) {
                 memset(log_msg, '\0', OS_MAXSTR);
                 snprintf(log_msg, OS_MAXSTR - 1, "Table '%s' does not exist", PFCTL_TABLE);
                 write_debug_file(argv[0], log_msg);
-                cJSON_Delete(input_json);
 
                 int retVal  = write_cmd_to_file(RCCONF, "pf_enable=\"YES\"\npf_rules=\"/etc/pf.conf\"\npflog_enable=\"YES\"\npflog_logfile=\"/var/log/pflog\"");
                 if (0 == retVal) {

--- a/src/active-response/firewalls/pf.c
+++ b/src/active-response/firewalls/pf.c
@@ -25,8 +25,6 @@ int main (int argc, char **argv) {
     char log_msg[OS_MAXSTR];
     char output_buf[OS_MAXSTR];
     int isEnabledFirewall = 0;
-    static int isEnabledFirewallPrevious = 0;
-    static int isFirstEntryEnabledFirewall = 0;
     int action = OS_INVALID;
     cJSON *input_json = NULL;
     struct utsname uname_buffer;
@@ -89,9 +87,9 @@ int main (int argc, char **argv) {
 
         char *exec_cmd1[7] = { NULL, NULL, NULL, NULL, NULL, NULL, NULL };
         char *exec_cmd2[4] = { NULL, NULL, NULL, NULL };
-        char *exec_cmd3[4] = { NULL, NULL, NULL, NULL };
-        char *exec_cmd4[4] = { NULL, NULL, NULL, NULL };
-        char *exec_cmd5[4] = { NULL, NULL, NULL, NULL };
+        char *exec_cmd3[4] = { PFCTL, "-s", "info", NULL };
+        char *exec_cmd4[4] = { LAUNCHCTL, "start", "/Library/LaunchDaemons/pf.plist", NULL };
+        char *exec_cmd5[4] = { PFCTL, "-f", PFCTL_RULES, NULL };
 
         // Checking if we have pf config file
         if (access(PFCTL_RULES, F_OK) == 0) {
@@ -103,15 +101,6 @@ int main (int argc, char **argv) {
 
                     const char *arg2[4] = { PFCTL, "-k", srcip, NULL };
                     memcpy(exec_cmd2, arg2, sizeof(exec_cmd2));
-
-                    const char *arg3[4] = { PFCTL, "-s", "info", NULL };
-                    memcpy(exec_cmd3, arg3, sizeof(exec_cmd3));
-
-                    const char *arg4[4] = { LAUNCHCTL, "start", "/Library/LaunchDaemons/pf.plist", NULL };
-                    memcpy(exec_cmd4, arg4, sizeof(exec_cmd4));
-                    
-                    const char *arg5[4] = { PFCTL, "-f", PFCTL_RULES, NULL };
-                    memcpy(exec_cmd5, arg5, sizeof(exec_cmd5));
                 } else {
                     const char *arg1[7] = { PFCTL, "-t", PFCTL_TABLE, "-T", "delete", srcip, NULL };
                     memcpy(exec_cmd1, arg1, sizeof(exec_cmd1));
@@ -121,26 +110,13 @@ int main (int argc, char **argv) {
                 snprintf(log_msg, OS_MAXSTR - 1, "Table '%s' does not exist", PFCTL_TABLE);
                 write_debug_file(argv[0], log_msg);
                 cJSON_Delete(input_json);
-                
-                int retVal = 0;
-                retVal = write_cmd_to_file(RCCONF, "pf_enable=\"YES\"");
-                retVal = write_cmd_to_file(RCCONF, "pf_rules=\"/etc/pf.conf\"");
-                retVal = write_cmd_to_file(RCCONF, "pflog_enable=\"YES\"");
-                retVal = write_cmd_to_file(RCCONF, "pflog_logfile=\"/var/log/pflog\"");
-                
-                memset(log_msg, '\0', OS_MAXSTR);
-                snprintf(log_msg, OS_MAXSTR - 1, "table <%s> persist #%s", PFCTL_TABLE, PFCTL_TABLE);
-                retVal = write_cmd_to_file(PFCTL_RULES, log_msg);
-                
-                memset(log_msg, '\0', OS_MAXSTR);
-                snprintf(log_msg, OS_MAXSTR - 1, "block in quick from <%s> to any", PFCTL_TABLE);
-                retVal = write_cmd_to_file(PFCTL_RULES, log_msg);
-                
-                memset(log_msg, '\0', OS_MAXSTR);
-                snprintf(log_msg, OS_MAXSTR - 1, "block out quick from any to <%s>", PFCTL_TABLE);
-                retVal = write_cmd_to_file(PFCTL_RULES, log_msg);
 
-                if (exec_cmd4[0] && strcmp(exec_cmd4[0], PFCTL) == 0) {
+                (void)write_cmd_to_file(RCCONF, "pf_enable=\"YES\"" "\n" "pf_rules=\"/etc/pf.conf\"" "\n" "pflog_enable=\"YES\"" "\n" "pflog_logfile=\"/var/log/pflog\"");
+                memset(log_msg, '\0', OS_MAXSTR);
+                snprintf(log_msg, OS_MAXSTR - 1, "table <%s> persist #%s\nblock in quick from <%s> to any\nblock out quick from any to <%s>", PFCTL_TABLE, PFCTL_TABLE, PFCTL_TABLE, PFCTL_TABLE);
+                (void)write_cmd_to_file(PFCTL_RULES, log_msg);
+
+                if (exec_cmd4[0] != NULL ) {
                     wfd = wpopenv(PFCTL, exec_cmd4, W_BIND_STDOUT);
                     if (!wfd) {
                         memset(log_msg, '\0', OS_MAXSTR);
@@ -152,7 +128,7 @@ int main (int argc, char **argv) {
                     wpclose(wfd);
                 }
 
-                if (exec_cmd5[0] && strcmp(exec_cmd5[0], PFCTL) == 0) {
+                if (exec_cmd5[0] != NULL) {
                     wfd = wpopenv(PFCTL, exec_cmd5, W_BIND_STDOUT);
                     if (!wfd) {
                         memset(log_msg, '\0', OS_MAXSTR);
@@ -175,7 +151,7 @@ int main (int argc, char **argv) {
 
         // Executing it
 
-        if (exec_cmd3[0] && strcmp(exec_cmd3[0], PFCTL) == 0) {
+        if (exec_cmd3[0] != NULL) {
             wfd = wpopenv(PFCTL, exec_cmd3, W_BIND_STDOUT);
             if (!wfd) {
                 memset(log_msg, '\0', OS_MAXSTR);
@@ -185,40 +161,22 @@ int main (int argc, char **argv) {
                 return OS_INVALID;
             }
             else {
-                while (fgets(output_buf, OS_MAXSTR -1, wfd->file_out) && 0  == isEnabledFirewall) {   
+                while (fgets(output_buf, OS_MAXSTR -1, wfd->file_out) && 0  == isEnabledFirewall) {
                     isEnabledFirewall = isEnabledFromPattern(output_buf, "Status: ", "Enabled");
                 }
 
                 if (( 0 == isEnabledFirewall )) {
                     memset(log_msg, '\0', OS_MAXSTR);
                     snprintf(log_msg, OS_MAXSTR -1, "{\"message\":\"Firewall is disabled\",\"profile\":\"%s\",\"status\":\"%s\"}",
-                            "undefined", 1 == isEnabledFirewall ? "active" : "inactive" 
+                            "undefined", 1 == isEnabledFirewall ? "active" : "inactive"
                     );
                     write_debug_file(argv[0], log_msg);
                 }
             }
             wpclose(wfd);
-
-
-            // reload pf.conf after detected that user turn on firewall
-            if ( 0 == isFirstEntryEnabledFirewall || (0 == isEnabledFirewallPrevious && 1 == isEnabledFirewall)){
-                if (exec_cmd5[0] && strcmp(exec_cmd5[0], PFCTL) == 0) {
-                    wfd = wpopenv(PFCTL, exec_cmd5, W_BIND_STDOUT);
-                    if (!wfd) {
-                        memset(log_msg, '\0', OS_MAXSTR);
-                        snprintf(log_msg, OS_MAXSTR - 1, "Error executing '%s' : %s", PFCTL, strerror(errno));
-                        write_debug_file(argv[0], log_msg);
-                        cJSON_Delete(input_json);
-                        return OS_INVALID;
-                    }
-                    wpclose(wfd);
-                }
-                isFirstEntryEnabledFirewall = 1;
-            }
-            isEnabledFirewallPrevious = isEnabledFirewall;
         }
-        
-        if (exec_cmd1[0] && strcmp(exec_cmd1[0], PFCTL) == 0) {
+
+        if (exec_cmd1[0] != NULL) {
             wfd = wpopenv(PFCTL, exec_cmd1, W_BIND_STDOUT);
             if (!wfd) {
                 memset(log_msg, '\0', OS_MAXSTR);
@@ -230,7 +188,7 @@ int main (int argc, char **argv) {
             wpclose(wfd);
         }
 
-        if (exec_cmd2[0] && strcmp(exec_cmd2[0], PFCTL) == 0) {
+        if (exec_cmd2[0] != NULL) {
             wfd = wpopenv(PFCTL, exec_cmd2, W_BIND_STDOUT);
             if (!wfd) {
                 memset(log_msg, '\0', OS_MAXSTR);
@@ -274,25 +232,24 @@ static int checking_if_its_configured(const char *path, const char *table) {
 /*
    retVal = isEnabledFromPattern(output_buf, "Status: ", "Enabled");
    return 1 if for example with patter1:"Status :" find "Enabled"
-   
 */
 static int isEnabledFromPattern(const char * output_buf, const char * str_pattern_1, const char * str_pattern_2){
     int retVal = 0;
     const char *pos = NULL;
-    if ( str_pattern_1 != NULL) {
+    if (str_pattern_1 != NULL) {
         pos = strstr(output_buf, str_pattern_1);
     }
-    
-    if ( pos != NULL) {
+
+    if (pos != NULL) {
         char state[OS_MAXSTR];
         char buffer[OS_MAXSTR];
         if (str_pattern_2 != NULL) {
             snprintf(buffer, OS_MAXSTR -1 , "%%*s %%%lds",strlen(str_pattern_2));
-            if (pos && sscanf(pos, buffer /*"%*s %7s"*/, state) == 1 ) {
+            if (pos && sscanf(pos, buffer /*"%*s %7s"*/, state) == 1) {
                 if (strcmp(state, str_pattern_2) == 0) {
-                    retVal = 1;       
+                    retVal = 1;
                 } else {
-                    retVal = 0; 
+                    retVal = 0;
                 }
             }
         }
@@ -305,8 +262,8 @@ static int write_cmd_to_file(const char *path, const char *cmd) {
     if (path != NULL && cmd != NULL) {
         FILE *fp = fopen(path, "a+");
         if (fp != NULL) {
-    	    fprintf(fp, "%s\n", cmd);
-	        retVal = 1;
+            fprintf(fp, "%s\n", cmd);
+            retVal = 1;
         }
         fclose(fp);
     }

--- a/src/active-response/firewalls/pf.c
+++ b/src/active-response/firewalls/pf.c
@@ -151,7 +151,7 @@ int main (int argc, char **argv) {
 
         // Executing it
 
-        if (exec_cmd3[0] != NULL) {
+        if (exec_cmd3[0] != NULL && action == ADD_COMMAND) {
             wfd = wpopenv(PFCTL, exec_cmd3, W_BIND_STDOUT);
             if (!wfd) {
                 memset(log_msg, '\0', OS_MAXSTR);
@@ -165,10 +165,10 @@ int main (int argc, char **argv) {
                     isEnabledFirewall = isEnabledFromPattern(output_buf, "Status: ", "Enabled");
                 }
 
-                if (( 0 == isEnabledFirewall )) {
+                if (( 0 == isEnabledFirewall)) {
                     memset(log_msg, '\0', OS_MAXSTR);
-                    snprintf(log_msg, OS_MAXSTR -1, "{\"message\":\"Firewall is disabled\",\"profile\":\"%s\",\"status\":\"%s\"}",
-                            "undefined", 1 == isEnabledFirewall ? "active" : "inactive"
+                    snprintf(log_msg, OS_MAXSTR -1, "{\"message\":\"Active response may not have an effect\",\"profile\":\"%s\",\"status\":\"%s\",\"script\":\"pf\"}",
+                        "default", 1 == isEnabledFirewall ? "active" : "inactive"
                     );
                     write_debug_file(argv[0], log_msg);
                 }
@@ -279,4 +279,4 @@ static int write_cmd_to_file(const char *path, const char *cmd) {
         fclose(fp);
     }
     return retVal;
- }
+}

--- a/src/active-response/firewalls/pf.c
+++ b/src/active-response/firewalls/pf.c
@@ -15,8 +15,20 @@
 #define PFCTL_RULES ("/etc/pf.conf")
 #define PFCTL_TABLE ("wazuh_fwtable")
 
+/**
+ * @brief check if firewall is configured
+ * @param path path to firewall configuration file
+ * @param table name of firewall table
+ * @return 0 if configured, -1 otherwise
+*/
 static int checking_if_its_configured(const char *path, const char *table);
-static int isEnabledFromPattern(const char * output_buf, const char * str_pattern_1, const char * str_pattern_2);
+
+/**
+ * @brief write to file path
+ * @param path path to file
+ * @param cmd command or text to write inside file
+ * @return 1 if successful, 0 otherwise
+*/
 static int write_cmd_to_file(const char *path, const char *cmd);
 
 int main (int argc, char **argv) {
@@ -226,50 +238,6 @@ static int checking_if_its_configured(const char *path, const char *table) {
     return OS_INVALID;
 }
 
-/**
- * @brief It looks for a string that matches pattern 1, if it finds it, it looks again for pattern 2, there should be spaces in the middle between the patterns.
- * @param output_buf buffer where search
- * @param str_pattern_1 pattern to match
- * @param str_pattern_2 pattern to match
- * @return 1 or 0
- * @example output_buf -> "... Status:    Disabled ..."
- *          isEnabledFromPattern(output_buf, "Status: ", "Enabled")
- *            if it matches pattern 1 look for pattern 2 and if found, it returns 1
- *          isEnabledFromPattern(output_buf, "Status: ", NULL)
- *            find only by "Status"
-*/
-static int isEnabledFromPattern(const char * output_buf, const char * str_pattern_1, const char * str_pattern_2) {
-    int retVal = 0;
-    const char *pos = NULL;
-    if (str_pattern_1 != NULL) {
-        pos = strstr(output_buf, str_pattern_1);
-    }
-
-    if (pos != NULL) {
-        char state[OS_MAXSTR];
-        char buffer[OS_MAXSTR];
-        if (str_pattern_2 != NULL) {
-            snprintf(buffer, OS_MAXSTR -1 , "%%*s %%%lds", strlen(str_pattern_2));
-            if (sscanf(pos, buffer /*"%*s %7s"*/, state) == 1) {
-                if (strcmp(state, str_pattern_2) == 0) {
-                    retVal = 1;
-                } else {
-                    retVal = 0;
-                }
-            }
-        } else {
-            retVal = 1;
-        }
-    }
-    return  retVal;
-}
-
-/**
- * @brief write to file path
- * @param path path to file
- * @param cmd command or text to write inside file
- * @return 1 or 0
-*/
 static int write_cmd_to_file(const char *path, const char *cmd) {
     int retVal = 0;
     if (path != NULL && cmd != NULL) {


### PR DESCRIPTION
|Related issues|Manual Testing|
|---|---|
|https://github.com/wazuh/wazuh/issues/14073|https://github.com/wazuh/wazuh-qa/issues/3330|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR solves the issue https://github.com/wazuh/wazuh/issues/14073, the proposed solution was that when a **wazuh_fwtable** does not exist, it is created , the configurations are added to the `pf.conf` files and `pf` rules are reload. Also  added an alert when `pf` services are not accessible, also added an alert when the firewall is disabled, it is verified if the firewall is down and if so, it is written in the active response log in order to be able to generate the alert, for this the rule (658) is used.

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
Agent ossec.conf :
```xml
<ossec_config>
  <localfile>
    <location>active-response\active-responses.log</location>
    <log_format>syslog</log_format>
  </localfile>
</ossec_config>
```
### Configuration option for test
Agent ossec.conf :
```xml
<ossec_config>
  <localfile>
    <log_format>apache</log_format>
    <location>/var/log/apache2/access_log</location>
  </localfile>
</ossec_config>
```
Manager ossec.conf:
```xml
<ossec_config>
   <active-response>
     <command>firewall-drop</command>
     <location>local</location>
     <rules_id>100100</rules_id>
     <timeout>60</timeout>
   </active-response>
 </ossec_config>
```

```xml
<ossec_config>
      <ruleset>
          <!-- Default ruleset -->
          <decoder_dir>ruleset/decoders</decoder_dir>
          <rule_dir>ruleset/rules</rule_dir>
          <rule_exclude>0215-policy_rules.xml</rule_exclude>
          <list>etc/lists/audit-keys</list>
         <list>etc/lists/blacklist-alienvault</list>
          <!-- User-defined ruleset -->
          <decoder_dir>etc/decoders</decoder_dir>
          <rule_dir>etc/rules</rule_dir>
      </ruleset>

      <active-response>
          <command>firewall-drop</command>
          <location>local</location>
          <rules_id>100100</rules_id>
          <timeout>60</timeout>
      </active-response>
</ossec_config>
```

Rules:
``` xml 
<rule id="658" level="5">
  <if_sid>650</if_sid>
    <status>inactive</status>
    <description>Active response related to $(script) has been activated, but may not have an effect because the firewall is $(status)</description>
    <group>active_response,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,tsc_CC7.4,</group>
</rule>
```
### Option test
1. Set configuration option for test
2. Configure Blocking a malicious actor PoC [(Link)](https://documentation.wazuh.com/current/proof-of-concept-guide/block-malicious-actor-ip-reputation.html)
3. Generate the alert
4. Try to access the agent from ssh when it has generated an alert blocking a malicious actor, so that it verifies that the firewall has its IP blocked
5. Disable firewall `pfctl -d` , reinstall agent and repeat test again.
6. Enable firewall  `pfctl -e` and repeat test again.
<!--
When proceed, this section should include new configuration parameters.
-->

<details><summary><b>Vagrantfile Mac OS (optional)</summary>
<p>

#### Steps:
1. vagrant up
2. if has error, disable usb  3.0 and set to 1.0
3. VBoxManage modifyvm "mojave_instance_bck" --cpu-profile "Intel Core i7-6700K"
4. vagrant up

```ruby
Vagrant.configure("2") do |config|
  config.vm.box = "danimaetrix/macOS-mojave"
  config.vm.box_version = "1.0"
  config.vm.network "private_network", ip: "192.168.56.80"
   config.vm.provider "virtualbox" do |vb|
     # Display the VirtualBox GUI when booting the machine
     vb.gui = true
     vb.name = "mojave_instance_bck"
     # Customize the amount of memory on the VM:
  #   vb.memory = "1024"
   end
 end
```
</p>
</details>

<details><summary><b>Vagrantfile freeBSD (optional)</summary>
<p>

#### Steps:
1. vagrant up
2. if has error, disable usb  3.0 and set to 1.0
3. vagrant up

```ruby
Vagrant.configure("2") do |config|
  config.vm.box = "bento/freebsd-13"
  config.vm.network "private_network", ip: "192.168.56.85"
end
```
</p>
</details>

<details><summary><b>Vagrantfile openBSD (optional)</summary>
<p>

#### Steps:
1. vagrant up
2. if has error, disable usb  3.0 and set to 1.0
3. vagrant up

```ruby
Vagrant.configure("2") do |config|
  config.vm.box = "twingly/openbsd-6.9-amd64"
  config.vm.box_version = "1.0.0"
  config.vm.network "private_network", ip: "192.168.56.86"
end
```
</p>
</details>
## Logs/Alerts example

<!--
Paste here related logs and alerts
-->
#### Alert when firewall is disabled
```vim
{"timestamp":"2022-09-22T14:45:11.365-0500","rule":{"level":5,"description":"Active response related to pf has been activated, but may not have an effect because the firewall is inactive","id":"658","firedtimes":2,"mail":false,"groups":["ossec","active_response"],"pci_dss":["11.4"],"gdpr":["IV_35.7.d"],"nist_800_53":["SI.4"],"tsc":["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]},"agent":{"id":"009","name":"Vagrants-MacBook-Pro-backup1.local","ip":"FE80:0000:0000:0000:003F:0A8E:91CB:9874"},"manager":{"name":"thejbte-ASUS-TUF-A15"},"id":"1663875911.1808273","full_log":"2022/09/22 14:45:11 active-response/bin/firewall-drop: {\"message\":\"Active response may not have an effect\",\"profile\":\"default\",\"status\":\"inactive\",\"script\":\"pf\"}","decoder":{"parent":"ar_log_json","name":"ar_log_json"},"data":{"status":"inactive","message":"Active response may not have an effect","profile":"default","script":"pf"},"location":"/Library/Ossec/logs/active-responses.log"}
```
#### Alert when blocking a malicious actor 
```vim
{"timestamp":"2022-09-17T14:20:08.552-0500","rule":{"level":10,"description":"IP address found in AlienVault reputation database.","id":"100100","firedtimes":4,"mail":false,"groups":["attack"]},"agent":{"id":"006","name":"Vagrants-MacBook-Pro-Bck.local","ip":"FE80:0000:0000:0000:1876:67B9:B5D4:0765"},"manager":{"name":"thejbte-ASUS-TUF-A15"},"id":"1663442408.1315007","full_log":"192.168.56.66 - - [17/Sep/2022:14:20:06 -0500] \"GET / HTTP/1.1\" 304 -","decoder":{"name":"web-accesslog"},"data":{"protocol":"GET","srcip":"192.168.56.66","id":"304","url":"/"},"location":"/var/log/apache2/access_log"}


{"timestamp":"2022-09-22T14:50:59.873-0500","rule":{"level":3,"description":"Host Blocked by firewall-drop Active Response","id":"651","firedtimes":8,"mail":false,"groups":["ossec","active_response"],"pci_dss":["11.4"],"gpg13":["4.13"],"gdpr":["IV_35.7.d"],"nist_800_53":["SI.4"],"tsc":["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]},"agent":{"id":"009","name":"Vagrants-MacBook-Pro-backup1.local","ip":"FE80:0000:0000:0000:003F:0A8E:91CB:9874"},"manager":{"name":"thejbte-ASUS-TUF-A15"},"id":"1663876259.1837832","full_log":"2022/09/22 14:50:57 active-response/bin/firewall-drop: {\"version\":1,\"origin\":{\"name\":\"node01\",\"module\":\"wazuh-execd\"},\"command\":\"add\",\"parameters\":{\"extra_args\":[],\"alert\":{\"timestamp\":\"2022-09-22T14:50:57.854-0500\",\"rule\":{\"level\":10,\"description\":\"IP address found in AlienVault reputation database.\",\"id\":\"100100\",\"firedtimes\":8,\"mail\":false,\"groups\":[\"attack\"]},\"agent\":{\"id\":\"009\",\"name\":\"Vagrants-MacBook-Pro-backup1.local\",\"ip\":\"FE80:0000:0000:0000:003F:0A8E:91CB:9874\"},\"manager\":{\"name\":\"thejbte-ASUS-TUF-A15\"},\"id\":\"1663876257.1837528\",\"full_log\":\"192.168.56.66 - - [22/Sep/2022:14:50:57 -0500] \\\"GET / HTTP/1.1\\\" 304 -\",\"decoder\":{\"name\":\"web-accesslog\"},\"data\":{\"protocol\":\"GET\",\"srcip\":\"192.168.56.66\",\"id\":\"304\",\"url\":\"/\"},\"location\":\"/var/log/apache2/access_log\"},\"program\":\"active-response/bin/firewall-drop\"}}","decoder":{"parent":"ar_log_json","name":"ar_log_json"},"data":{"version":"1","origin":{"name":"node01","module":"wazuh-execd"},"command":"add","parameters":{"extra_args":[],"alert":{"timestamp":"2022-09-22T14:50:57.854-0500","rule":{"level":"10","description":"IP address found in AlienVault reputation database.","id":"100100","firedtimes":"8","mail":"false","groups":["attack"]},"agent":{"id":"009","name":"Vagrants-MacBook-Pro-backup1.local","ip":"FE80:0000:0000:0000:003F:0A8E:91CB:9874"},"manager":{"name":"thejbte-ASUS-TUF-A15"},"id":"1663876257.1837528","full_log":"192.168.56.66 - - [22/Sep/2022:14:50:57 -0500] \"GET / HTTP/1.1\" 304 -","decoder":{"name":"web-accesslog"},"data":{"protocol":"GET","srcip":"192.168.56.66","id":"304","url":"/"},"location":"/var/log/apache2/access_log"},"program":"active-response/bin/firewall-drop"}},"location":"/Library/Ossec/logs/active-responses.log"}
```
#### Alert when unblocking a malicious actor 
```vim
{"timestamp":"2022-09-22T14:52:00.032-0500","rule":{"level":3,"description":"Host Unblocked by firewall-drop Active Response","id":"652","firedtimes":7,"mail":false,"groups":["ossec","active_response"],"pci_dss":["11.4"],"gpg13":["4.13"],"gdpr":["IV_35.7.d"],"nist_800_53":["SI.4"],"tsc":["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]},"agent":{"id":"009","name":"Vagrants-MacBook-Pro-backup1.local","ip":"FE80:0000:0000:0000:003F:0A8E:91CB:9874"},"manager":{"name":"thejbte-ASUS-TUF-A15"},"id":"1663876320.1840055","full_log":"2022/09/22 14:51:58 active-response/bin/firewall-drop: {\"version\":1,\"origin\":{\"name\":\"node01\",\"module\":\"wazuh-execd\"},\"command\":\"delete\",\"parameters\":{\"extra_args\":[],\"alert\":{\"timestamp\":\"2022-09-22T14:50:57.854-0500\",\"rule\":{\"level\":10,\"description\":\"IP address found in AlienVault reputation database.\",\"id\":\"100100\",\"firedtimes\":8,\"mail\":false,\"groups\":[\"attack\"]},\"agent\":{\"id\":\"009\",\"name\":\"Vagrants-MacBook-Pro-backup1.local\",\"ip\":\"FE80:0000:0000:0000:003F:0A8E:91CB:9874\"},\"manager\":{\"name\":\"thejbte-ASUS-TUF-A15\"},\"id\":\"1663876257.1837528\",\"full_log\":\"192.168.56.66 - - [22/Sep/2022:14:50:57 -0500] \\\"GET / HTTP/1.1\\\" 304 -\",\"decoder\":{\"name\":\"web-accesslog\"},\"data\":{\"protocol\":\"GET\",\"srcip\":\"192.168.56.66\",\"id\":\"304\",\"url\":\"/\"},\"location\":\"/var/log/apache2/access_log\"},\"program\":\"active-response/bin/firewall-drop\"}}","decoder":{"parent":"ar_log_json","name":"ar_log_json"},"data":{"version":"1","origin":{"name":"node01","module":"wazuh-execd"},"command":"delete","parameters":{"extra_args":[],"alert":{"timestamp":"2022-09-22T14:50:57.854-0500","rule":{"level":"10","description":"IP address found in AlienVault reputation database.","id":"100100","firedtimes":"8","mail":"false","groups":["attack"]},"agent":{"id":"009","name":"Vagrants-MacBook-Pro-backup1.local","ip":"FE80:0000:0000:0000:003F:0A8E:91CB:9874"},"manager":{"name":"thejbte-ASUS-TUF-A15"},"id":"1663876257.1837528","full_log":"192.168.56.66 - - [22/Sep/2022:14:50:57 -0500] \"GET / HTTP/1.1\" 304 -","decoder":{"name":"web-accesslog"},"data":{"protocol":"GET","srcip":"192.168.56.66","id":"304","url":"/"},"location":"/var/log/apache2/access_log"},"program":"active-response/bin/firewall-drop"}},"location":"/Library/Ossec/logs/active-responses.log"}
```


## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
