### PR TITLE
Mark atomic operations

### DIFF
--- a/src/shared_modules/dbsync/tests/interface/dbsync_test.cpp
+++ b/src/shared_modules/dbsync/tests/interface/dbsync_test.cpp
@@ -1873,3 +1873,70 @@ TEST_F(DBSyncTest, teardown)
 {
     EXPECT_NO_THROW(DBSync::teardown());
 }
+
+
+TEST_F(DBSyncTest, createTxnAtomicOperation)
+{
+    const auto sql{ "CREATE TABLE processes(`pid` BIGINT, `name` TEXT, `time` BIGINT, PRIMARY KEY (`pid`, `time`)) WITHOUT ROWID;"};
+    const auto tables { R"({"table": "processes"})" };
+    const std::unique_ptr<DummyContext> dummyCtx { std::make_unique<DummyContext>()};
+    std::unique_ptr<DBSync> dbSync;
+
+    EXPECT_NO_THROW(dbSync = std::make_unique<DBSync>(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql));
+
+    CallbackMock wrapper;
+    EXPECT_CALL(wrapper, callbackMock(INSERTED, nlohmann::json::parse(R"([{"name":"System","pid":4, "time":100100}])"))).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(INSERTED, nlohmann::json::parse(R"([{"name":"Guake","pid":7,"time":100101}])"))).Times(1);
+
+    ResultCallbackData callbackData
+    {
+        [&wrapper](ReturnTypeCallback type, const nlohmann::json & jsonResult)
+        {
+            wrapper.callbackMock(type, jsonResult);
+        }
+    };
+
+    const auto insertionSqlStmt1{ R"(
+        {
+            "table":"processes",
+            "data":
+                [
+                    {"pid":4,"name":"System", "time":100100}
+                ]
+        })"}; // Insert
+
+
+    std::unique_ptr<DBSyncTxn> dbSyncTxn;
+    EXPECT_NO_THROW(dbSyncTxn = std::make_unique<DBSyncTxn>(dbSync->handle(), nlohmann::json::parse(tables), 0, 100, callbackData));
+
+    const auto insertionSqlStmt2{ R"({"table":"processes","data":[{"pid":7,"name":"Guake","time":100101}]})" }; // Insert
+    EXPECT_NO_THROW(dbSyncTxn->syncTxnRow(nlohmann::json::parse(insertionSqlStmt2)));
+
+    EXPECT_NO_THROW(dbSync->syncRow(nlohmann::json::parse(insertionSqlStmt1), callbackData));  // Expect an insert event
+
+    EXPECT_NO_THROW(dbSyncTxn->getDeletedRows(callbackData));
+
+    dbSyncTxn.reset();
+
+    EXPECT_CALL(wrapper, callbackMock(SELECTED, nlohmann::json::parse(R"({"count":2})"))).Times(1);
+
+    ResultCallbackData selectCallbackData
+    {
+        [&wrapper](ReturnTypeCallback type, const nlohmann::json & jsonResult)
+        {
+            wrapper.callbackMock(type, jsonResult);
+        }
+    };
+
+    const auto selectData
+    {
+        R"({"table":"processes",
+           "query":{"column_list":["count(*) AS count"],
+           "row_filter":"",
+           "distinct_opt":false,
+           "order_by_opt":"",
+           "count_opt":100}})"
+    };
+
+    EXPECT_NO_THROW(dbSync->selectRows(nlohmann::json::parse(selectData), selectCallbackData));
+}

--- a/src/shared_modules/dbsync/tests/interface/dbsync_test.cpp
+++ b/src/shared_modules/dbsync/tests/interface/dbsync_test.cpp
@@ -1879,7 +1879,6 @@ TEST_F(DBSyncTest, createTxnAtomicOperation)
 {
     const auto sql{ "CREATE TABLE processes(`pid` BIGINT, `name` TEXT, `time` BIGINT, PRIMARY KEY (`pid`, `time`)) WITHOUT ROWID;"};
     const auto tables { R"({"table": "processes"})" };
-    const std::unique_ptr<DummyContext> dummyCtx { std::make_unique<DummyContext>()};
     std::unique_ptr<DBSync> dbSync;
 
     EXPECT_NO_THROW(dbSync = std::make_unique<DBSync>(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql));
@@ -1896,37 +1895,19 @@ TEST_F(DBSyncTest, createTxnAtomicOperation)
         }
     };
 
-    const auto insertionSqlStmt1{ R"(
-        {
-            "table":"processes",
-            "data":
-                [
-                    {"pid":4,"name":"System", "time":100100}
-                ]
-        })"}; // Insert
-
-
+    const auto insertionSqlStmt1{ R"({"table":"processes","data":[{"pid":4,"name":"System", "time":100100}]})"}; // Insert
     std::unique_ptr<DBSyncTxn> dbSyncTxn;
     EXPECT_NO_THROW(dbSyncTxn = std::make_unique<DBSyncTxn>(dbSync->handle(), nlohmann::json::parse(tables), 0, 100, callbackData));
+    EXPECT_NO_THROW(dbSyncTxn->syncTxnRow(nlohmann::json::parse(insertionSqlStmt1)));
 
     const auto insertionSqlStmt2{ R"({"table":"processes","data":[{"pid":7,"name":"Guake","time":100101}]})" }; // Insert
-    EXPECT_NO_THROW(dbSyncTxn->syncTxnRow(nlohmann::json::parse(insertionSqlStmt2)));
-
-    EXPECT_NO_THROW(dbSync->syncRow(nlohmann::json::parse(insertionSqlStmt1), callbackData));  // Expect an insert event
+    EXPECT_NO_THROW(dbSync->syncRow(nlohmann::json::parse(insertionSqlStmt2), callbackData));  // Expect an insert event
 
     EXPECT_NO_THROW(dbSyncTxn->getDeletedRows(callbackData));
 
     dbSyncTxn.reset();
 
     EXPECT_CALL(wrapper, callbackMock(SELECTED, nlohmann::json::parse(R"({"count":2})"))).Times(1);
-
-    ResultCallbackData selectCallbackData
-    {
-        [&wrapper](ReturnTypeCallback type, const nlohmann::json & jsonResult)
-        {
-            wrapper.callbackMock(type, jsonResult);
-        }
-    };
 
     const auto selectData
     {
@@ -1938,5 +1919,5 @@ TEST_F(DBSyncTest, createTxnAtomicOperation)
            "count_opt":100}})"
     };
 
-    EXPECT_NO_THROW(dbSync->selectRows(nlohmann::json::parse(selectData), selectCallbackData));
+    EXPECT_NO_THROW(dbSync->selectRows(nlohmann::json::parse(selectData), callbackData));
 }


### PR DESCRIPTION
|Related issue|
|---|
|#12788|

## Description
The objective of this PR is to add a test to verify that the behavior is correct and to validate that what the issue asks for is already implemented.

## Test result
![image](https://user-images.githubusercontent.com/106940255/190431185-f988d178-9136-420c-85fb-d6b0755f2fb6.png)

A summary of the steps executed in the test are: 
1. A transaction is opened
2. An element is added with syncTxnRow
3. An element is added (atomic operations) with syncRow
4. The transaction is closed and finally it is verified that the two elements exist