### PR TITLE
Fix data race conditions reported by ThreadSanitizer

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -141,6 +141,7 @@ endif
 		AR_LDFLAGS+=-pthread -lrt -ldl
 		OSSEC_CFLAGS+=-Wl,--start-group
 		USE_AUDIT=yes
+		CC=gcc
 ifneq (,$(filter ${USE_AUDIT},YES yes y Y 1))
 		OSSEC_CFLAGS+=-I$(EXTERNAL_AUDIT)lib
 endif
@@ -1187,7 +1188,7 @@ endif
 else
 ifneq (,$(filter ${uname_S},SunOS AIX))
 	cpu_arch := ${uname_P}
-ifeq (${cpu_arch},powerpc)  
+ifeq (${cpu_arch},powerpc)
 	PRECOMPILED_ARCH := /powerpc
 else
 ifneq (,$(filter ${cpu_arch},sparc sun4u))

--- a/src/headers/sec.h
+++ b/src/headers/sec.h
@@ -54,7 +54,7 @@ typedef struct _keyentry {
     pthread_mutex_t mutex;
     struct sockaddr_storage peer_info;
     FILE *fp;
-    crypt_method crypto_method;
+    _Atomic (crypt_method) crypto_method;
 
     w_linked_queue_node_t *rids_node;
 } keyentry;

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -96,6 +96,11 @@
 #include <direct.h>
 #endif
 
+#ifdef __cplusplus
+#include <atomic>
+#define _Atomic(T) std::atomic<T>
+#endif
+
 #include <time.h>
 #include <errno.h>
 #include <libgen.h>

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -702,7 +702,6 @@ int OS_AddSocket(keystore * keys, unsigned int i, int sock) {
     char strsock[16] = "";
 
     snprintf(strsock, sizeof(strsock), "%d", sock);
-    keys->keyentries[i]->sock = sock;
 
     w_mutex_lock(&keys->keytree_sock_mutex);
     int r = rbtree_insert(keys->keytree_sock, strsock, keys->keyentries[i]) ? 2 : rbtree_replace(keys->keytree_sock, strsock, keys->keyentries[i]) ? 1 : 0;

--- a/src/os_crypto/shared/msgs.c
+++ b/src/os_crypto/shared/msgs.c
@@ -32,7 +32,7 @@ static unsigned int local_count  = 0;
 
 /* Average compression rates */
 static unsigned int evt_count = 0;
-static unsigned int rcv_count = 0;
+static _Atomic unsigned int rcv_count = 0;
 static size_t c_orig_size = 0;
 static size_t c_comp_size = 0;
 

--- a/src/os_crypto/shared/msgs.c
+++ b/src/os_crypto/shared/msgs.c
@@ -27,14 +27,14 @@ static void ReloadCounter(const keystore *keys, unsigned int id, const char * ci
 static char *CheckSum(char *msg, size_t length) __attribute((nonnull));
 
 /* Sending counts */
-static unsigned int global_count = 0;
-static unsigned int local_count  = 0;
+static _Atomic unsigned int global_count = 0;
+static _Atomic unsigned int local_count  = 0;
 
 /* Average compression rates */
-static unsigned int evt_count = 0;
+static _Atomic unsigned int evt_count = 0;
 static _Atomic unsigned int rcv_count = 0;
-static size_t c_orig_size = 0;
-static size_t c_comp_size = 0;
+static _Atomic size_t c_orig_size = 0;
+static _Atomic size_t c_comp_size = 0;
 
 /* Global variables (read from define file) */
 unsigned int _s_comp_print = 0;
@@ -321,7 +321,7 @@ int ReadSecMSG(keystore *keys, char *buffer, char *cleartext, int id, unsigned i
     }
 
     /* Decrypt message */
-    switch(keys->keyentries[id]->crypto_method){
+    switch((crypt_method)keys->keyentries[id]->crypto_method){
         case W_METH_BLOWFISH:
             if (!OS_BF_Str(buffer, cleartext, keys->keyentries[id]->encryption_key,
                         buffer_size, OS_DECRYPT)) {

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -486,12 +486,12 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
                     }
                 }
 
-                w_mutex_unlock(&files_mutex);
-
                 if (aux && aux->f_sum && aux->f_sum[0] && *(aux->f_sum[0]->sum)) {
                     // Copy sum before unlock mutex
                     memcpy(data->merged_sum, aux->f_sum[0]->sum, sizeof(os_md5));
                 }
+
+                w_mutex_unlock(&files_mutex);
             } else {
                 merror("Error getting group for agent '%s'", key->id);
             }

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -610,7 +610,10 @@ STATIC void HandleSecureMessage(const message_t *message, int *wdb_sock) {
         keyentry * key = OS_DupKeyEntry(keys.keyentries[agentid]);
 
         if (protocol == REMOTED_NET_PROTOCOL_TCP) {
-            keys.keyentries[agentid]->sock = message->sock;
+            if (message->counter > rem_getCounter(message->sock)) {
+                keys.keyentries[agentid]->sock = message->sock;
+            }
+
             w_mutex_unlock(&keys.keyentries[agentid]->mutex);
 
             r = OS_AddSocket(&keys, agentid, message->sock);

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -37,7 +37,7 @@ extern wnotify_t * notify;
 
 /* Forward declarations */
 void * close_fp_main(void * args);
-void HandleSecureMessage(char *buffer, int recv_b, struct sockaddr_storage *peer_info, int sock_client, int *wdb_sock);
+void HandleSecureMessage(const message_t *message, int *wdb_sock);
 
 /* Setup/teardown */
 
@@ -384,9 +384,8 @@ void test_close_fp_main_close_fp_null(void **state)
 void test_HandleSecureMessage_unvalid_message(void **state)
 {
     char buffer[OS_MAXSTR + 1] = "!1234!";
-    int recv_b = 4;
+    message_t message = { .buffer = buffer, .size = 6, .sock = 1};
     struct sockaddr_in peer_info;
-    int sock_client = 1;
     int wdb_sock;
 
     keyentry** keyentries;
@@ -406,6 +405,7 @@ void test_HandleSecureMessage_unvalid_message(void **state)
 
     peer_info.sin_family = AF_INET;
     peer_info.sin_addr.s_addr = 0x0100007F;
+    memcpy(&message.addr, &peer_info, sizeof(peer_info));
 
     expect_function_call(__wrap_key_lock_read);
 
@@ -421,7 +421,7 @@ void test_HandleSecureMessage_unvalid_message(void **state)
     expect_function_call(__wrap_key_lock_read);
 
     // OS_DeleteSocket
-    expect_value(__wrap_OS_DeleteSocket, sock, sock_client);
+    expect_value(__wrap_OS_DeleteSocket, sock, message.sock);
     will_return(__wrap_OS_DeleteSocket, 0);
 
     expect_function_call(__wrap_key_unlock);
@@ -429,8 +429,8 @@ void test_HandleSecureMessage_unvalid_message(void **state)
     will_return(__wrap_close, 0);
 
     // nb_close
-    expect_value(__wrap_nb_close, sock, sock_client);
-    expect_value(__wrap_nb_close, sock, sock_client);
+    expect_value(__wrap_nb_close, sock, message.sock);
+    expect_value(__wrap_nb_close, sock, message.sock);
     expect_function_call(__wrap_rem_dec_tcp);
 
     // rem_setCounter
@@ -439,7 +439,7 @@ void test_HandleSecureMessage_unvalid_message(void **state)
 
     expect_string(__wrap__mdebug1, formatted_msg, "TCP peer disconnected [1]");
 
-    HandleSecureMessage(buffer, recv_b, (struct sockaddr_storage *)&peer_info, sock_client, &wdb_sock);
+    HandleSecureMessage(&message, &wdb_sock);
 
     os_free(key->id);
     os_free(key);
@@ -449,9 +449,8 @@ void test_HandleSecureMessage_unvalid_message(void **state)
 void test_HandleSecureMessage_different_sock(void **state)
 {
     char buffer[OS_MAXSTR + 1] = "!12!";
-    int recv_b = 4;
+    message_t message = { .buffer = buffer, .size = 4, .sock = 1};
     struct sockaddr_in peer_info;
-    int sock_client = 1;
     int wdb_sock;
 
     keyentry** keyentries;
@@ -471,6 +470,7 @@ void test_HandleSecureMessage_different_sock(void **state)
 
     peer_info.sin_family = AF_INET;
     peer_info.sin_addr.s_addr = inet_addr("127.0.0.1");
+    memcpy(&message.addr, &peer_info, sizeof(peer_info));
 
     expect_function_call(__wrap_key_lock_read);
 
@@ -486,7 +486,7 @@ void test_HandleSecureMessage_different_sock(void **state)
     expect_function_call(__wrap_key_lock_read);
 
     // OS_DeleteSocket
-    expect_value(__wrap_OS_DeleteSocket, sock, sock_client);
+    expect_value(__wrap_OS_DeleteSocket, sock, message.sock);
     will_return(__wrap_OS_DeleteSocket, 0);
 
     expect_function_call(__wrap_key_unlock);
@@ -494,8 +494,8 @@ void test_HandleSecureMessage_different_sock(void **state)
     will_return(__wrap_close, 0);
 
     // nb_close
-    expect_value(__wrap_nb_close, sock, sock_client);
-    expect_value(__wrap_nb_close, sock, sock_client);
+    expect_value(__wrap_nb_close, sock, message.sock);
+    expect_value(__wrap_nb_close, sock, message.sock);
     expect_function_call(__wrap_rem_dec_tcp);
 
     // rem_setCounter
@@ -504,7 +504,7 @@ void test_HandleSecureMessage_different_sock(void **state)
 
     expect_string(__wrap__mdebug1, formatted_msg, "TCP peer disconnected [1]");
 
-    HandleSecureMessage(buffer, recv_b, (struct sockaddr_storage *)&peer_info, sock_client, &wdb_sock);
+    HandleSecureMessage(&message, &wdb_sock);
 
     os_free(key->id);
     os_free(key);
@@ -514,9 +514,8 @@ void test_HandleSecureMessage_different_sock(void **state)
 void test_HandleSecureMessage_different_sock_2(void **state)
 {
     char buffer[OS_MAXSTR + 1] = "12!";
-    int recv_b = 4;
+    message_t message = { .buffer = buffer, .size = 4, .sock = 1};
     struct sockaddr_in peer_info;
-    int sock_client = 1;
     int wdb_sock;
 
     keyentry** keyentries;
@@ -536,6 +535,7 @@ void test_HandleSecureMessage_different_sock_2(void **state)
 
     peer_info.sin_family = AF_INET;
     peer_info.sin_addr.s_addr = inet_addr("127.0.0.1");
+    memcpy(&message.addr, &peer_info, sizeof(peer_info));
 
     expect_function_call(__wrap_key_lock_read);
 
@@ -550,7 +550,7 @@ void test_HandleSecureMessage_different_sock_2(void **state)
     expect_function_call(__wrap_key_lock_read);
 
     // OS_DeleteSocket
-    expect_value(__wrap_OS_DeleteSocket, sock, sock_client);
+    expect_value(__wrap_OS_DeleteSocket, sock, message.sock);
     will_return(__wrap_OS_DeleteSocket, 0);
 
     expect_function_call(__wrap_key_unlock);
@@ -558,8 +558,8 @@ void test_HandleSecureMessage_different_sock_2(void **state)
     will_return(__wrap_close, 0);
 
     // nb_close
-    expect_value(__wrap_nb_close, sock, sock_client);
-    expect_value(__wrap_nb_close, sock, sock_client);
+    expect_value(__wrap_nb_close, sock, message.sock);
+    expect_value(__wrap_nb_close, sock, message.sock);
     expect_function_call(__wrap_rem_dec_tcp);
 
     // rem_setCounter
@@ -568,7 +568,7 @@ void test_HandleSecureMessage_different_sock_2(void **state)
 
     expect_string(__wrap__mdebug1, formatted_msg, "TCP peer disconnected [1]");
 
-    HandleSecureMessage(buffer, recv_b, (struct sockaddr_storage *)&peer_info, sock_client, &wdb_sock);
+    HandleSecureMessage(&message, &wdb_sock);
 
     os_free(key->id);
     os_free(key);


### PR DESCRIPTION
|Related issue|
|---|
|Fixes #12731|

This PR includes a series of changes that shall fix multiple race conditions detected by ThreadSanitizer.

### Report

This report corresponds to commit b678c56bc:

<details><summary>ThreadSanitizer: data race os_crypto/shared/msgs.c:398 in <code>ReadSecMSG</code></summary>

```
WARNING: ThreadSanitizer: data race (pid=19947)
  Read of size 4 at 0x557e79499984 by thread T16 (mutexes: read M19, write M56):
    #0 ReadSecMSG os_crypto/shared/msgs.c:398 (wazuh-remoted+0x1316bc)
    #1 HandleSecureMessage remoted/secure.c:566 (wazuh-remoted+0x25875)
    #2 rem_handler_main remoted/secure.c:346 (wazuh-remoted+0x248e8)

  Previous write of size 4 at 0x557e79499984 by thread T15 (mutexes: read M19, write M32):
    #0 ReadSecMSG os_crypto/shared/msgs.c:402 (wazuh-remoted+0x131733)
    #1 HandleSecureMessage remoted/secure.c:566 (wazuh-remoted+0x25875)
    #2 rem_handler_main remoted/secure.c:346 (wazuh-remoted+0x248e8)

  Location is global 'rcv_count' of size 4 at 0x557e79499984 (wazuh-remoted+0x25c984)

  Mutex M19 (0x557e79499080) created at:
    #0 pthread_rwlock_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1388 (libtsan.so.2+0x41bb4)
    #1 key_lock_init remoted/sendmsg.c:33 (wazuh-remoted+0x265a7)
    #2 HandleSecure remoted/secure.c:94 (wazuh-remoted+0x2370c)
    #3 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #4 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Mutex M56 (0x7b4400004160) created at:
    #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1295 (libtsan.so.2+0x50468)
    #1 OS_AddKey os_crypto/shared/keys.c:109 (wazuh-remoted+0x12a89b)
    #2 OS_ReadKeys os_crypto/shared/keys.c:318 (wazuh-remoted+0x12b9c3)
    #3 HandleSecure remoted/secure.c:155 (wazuh-remoted+0x23b60)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Mutex M32 (0x7b4400002360) created at:
    #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1295 (libtsan.so.2+0x50468)
    #1 OS_AddKey os_crypto/shared/keys.c:109 (wazuh-remoted+0x12a89b)
    #2 OS_ReadKeys os_crypto/shared/keys.c:318 (wazuh-remoted+0x12b9c3)
    #3 HandleSecure remoted/secure.c:155 (wazuh-remoted+0x23b60)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T16 (tid=19964, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:139 (wazuh-remoted+0x23a5d)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T15 (tid=19963, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:139 (wazuh-remoted+0x23a5d)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)
```

</details>

<details><summary>ThreadSanitizer: data race remoted/manager.c:835 in <code>process_groups</code></summary>

```
WARNING: ThreadSanitizer: data race (pid=19947)
  Write of size 8 at 0x7b0800000208 by thread T1 (mutexes: write M11):
    #0 process_groups remoted/manager.c:835 (wazuh-remoted+0x18fbd)
    #1 c_files remoted/manager.c:772 (wazuh-remoted+0x1895e)
    #2 update_shared_files remoted/manager.c:1654 (wazuh-remoted+0x1d994)

  Previous read of size 8 at 0x7b0800000208 by thread T17:
    [failed to restore the stack]

  As if synchronized via sleep:
    #0 sleep ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:344 (libtsan.so.2+0x61f80)
    #1 update_shared_files remoted/manager.c:1658 (wazuh-remoted+0x1d9b8)

  Location is heap block of size 24 at 0x7b0800000200 allocated by main thread:
    #0 calloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:667 (libtsan.so.2+0x3ee50)
    #1 process_groups remoted/manager.c:825 (wazuh-remoted+0x18d20)
    #2 c_files remoted/manager.c:772 (wazuh-remoted+0x1895e)
    #3 manager_init remoted/manager.c:1689 (wazuh-remoted+0x1dcbc)
    #4 HandleSecure remoted/secure.c:88 (wazuh-remoted+0x236e9)
    #5 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #6 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Mutex M11 (0x557e79498bc0) created at:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4324 (libtsan.so.2+0x558e1)
    #1 c_files remoted/manager.c:769 (wazuh-remoted+0x18911)
    #2 manager_init remoted/manager.c:1689 (wazuh-remoted+0x1dcbc)
    #3 HandleSecure remoted/secure.c:88 (wazuh-remoted+0x236e9)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T1 (tid=19949, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:97 (wazuh-remoted+0x23720)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T17 (tid=19965, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:139 (wazuh-remoted+0x23a5d)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)
```

</details>

<details><summary>ThreadSanitizer: data race remoted/manager.c:313 in <code>free_file_sum</code></summary>

```
WARNING: ThreadSanitizer: data race (pid=19947)
  Write of size 8 at 0x7b0c00000128 by thread T1 (mutexes: write M11):
    #0 free ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:706 (libtsan.so.2+0x47e82)
    #1 free_file_sum remoted/manager.c:313 (wazuh-remoted+0x1570c)
    #2 process_groups remoted/manager.c:849 (wazuh-remoted+0x190fa)
    #3 c_files remoted/manager.c:772 (wazuh-remoted+0x1895e)
    #4 update_shared_files remoted/manager.c:1654 (wazuh-remoted+0x1d994)

  Previous read of size 1 at 0x7b0c00000128 by thread T17:
    [failed to restore the stack]

  As if synchronized via sleep:
    #0 sleep ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:344 (libtsan.so.2+0x61f80)
    #1 update_shared_files remoted/manager.c:1658 (wazuh-remoted+0x1d9b8)

  Mutex M11 (0x557e79498bc0) created at:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4324 (libtsan.so.2+0x558e1)
    #1 c_files remoted/manager.c:769 (wazuh-remoted+0x18911)
    #2 manager_init remoted/manager.c:1689 (wazuh-remoted+0x1dcbc)
    #3 HandleSecure remoted/secure.c:88 (wazuh-remoted+0x236e9)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T1 (tid=19949, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:97 (wazuh-remoted+0x23720)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T17 (tid=19965, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:139 (wazuh-remoted+0x23a5d)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)
```

</details>

<details><summary>ThreadSanitizer: data race remoted/manager.c:313 in <code>free_file_sum</code></summary>

```
WARNING: ThreadSanitizer: data race (pid=19947)
  Write of size 8 at 0x7b3400000340 by thread T1 (mutexes: write M11):
    #0 free_file_sum remoted/manager.c:313 (wazuh-remoted+0x15727)
    #1 process_groups remoted/manager.c:849 (wazuh-remoted+0x190fa)
    #2 c_files remoted/manager.c:772 (wazuh-remoted+0x1895e)
    #3 update_shared_files remoted/manager.c:1654 (wazuh-remoted+0x1d994)

  Previous read of size 8 at 0x7b3400000340 by thread T17:
    [failed to restore the stack]

  As if synchronized via sleep:
    #0 sleep ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:344 (libtsan.so.2+0x61f80)
    #1 update_shared_files remoted/manager.c:1658 (wazuh-remoted+0x1d9b8)

  Location is heap block of size 200 at 0x7b3400000340 allocated by main thread:
    #0 realloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:680 (libtsan.so.2+0x4302f)
    #1 validate_shared_files remoted/manager.c:1175 (wazuh-remoted+0x1b2f4)
    #2 c_group remoted/manager.c:692 (wazuh-remoted+0x183f3)
    #3 process_groups remoted/manager.c:827 (wazuh-remoted+0x18e7a)
    #4 c_files remoted/manager.c:772 (wazuh-remoted+0x1895e)
    #5 manager_init remoted/manager.c:1689 (wazuh-remoted+0x1dcbc)
    #6 HandleSecure remoted/secure.c:88 (wazuh-remoted+0x236e9)
    #7 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #8 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Mutex M11 (0x557e79498bc0) created at:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4324 (libtsan.so.2+0x558e1)
    #1 c_files remoted/manager.c:769 (wazuh-remoted+0x18911)
    #2 manager_init remoted/manager.c:1689 (wazuh-remoted+0x1dcbc)
    #3 HandleSecure remoted/secure.c:88 (wazuh-remoted+0x236e9)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T1 (tid=19949, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:97 (wazuh-remoted+0x23720)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T17 (tid=19965, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:139 (wazuh-remoted+0x23a5d)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)
```

</details>

<details><summary>ThreadSanitizer: data race os_crypto/shared/msgs.c:396 in <code>ReadSecMSG</code></summary>

```
WARNING: ThreadSanitizer: data race (pid=19947)
  Write of size 4 at 0x7b44000058d0 by thread T18 (mutexes: read M19, write M75):
    #0 ReadSecMSG os_crypto/shared/msgs.c:396 (wazuh-remoted+0x131666)
    #1 HandleSecureMessage remoted/secure.c:566 (wazuh-remoted+0x25875)
    #2 rem_handler_main remoted/secure.c:346 (wazuh-remoted+0x248e8)

  Previous read of size 4 at 0x7b44000058d0 by thread T16 (mutexes: read M19):
    #0 OS_DupKeyEntry os_crypto/shared/keys.c:662 (wazuh-remoted+0x12d937)
    #1 HandleSecureMessage remoted/secure.c:594 (wazuh-remoted+0x25b0f)
    #2 rem_handler_main remoted/secure.c:346 (wazuh-remoted+0x248e8)

  Location is heap block of size 288 at 0x7b44000058c0 allocated by main thread:
    #0 calloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:667 (libtsan.so.2+0x3ee50)
    #1 OS_AddKey os_crypto/shared/keys.c:72 (wazuh-remoted+0x129e63)
    #2 OS_ReadKeys os_crypto/shared/keys.c:318 (wazuh-remoted+0x12b9c3)
    #3 HandleSecure remoted/secure.c:155 (wazuh-remoted+0x23b60)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Mutex M19 (0x557e79499080) created at:
    #0 pthread_rwlock_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1388 (libtsan.so.2+0x41bb4)
    #1 key_lock_init remoted/sendmsg.c:33 (wazuh-remoted+0x265a7)
    #2 HandleSecure remoted/secure.c:94 (wazuh-remoted+0x2370c)
    #3 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #4 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Mutex M75 (0x7b4400005920) created at:
    #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1295 (libtsan.so.2+0x50468)
    #1 OS_AddKey os_crypto/shared/keys.c:109 (wazuh-remoted+0x12a89b)
    #2 OS_ReadKeys os_crypto/shared/keys.c:318 (wazuh-remoted+0x12b9c3)
    #3 HandleSecure remoted/secure.c:155 (wazuh-remoted+0x23b60)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T18 (tid=19966, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:139 (wazuh-remoted+0x23a5d)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T16 (tid=19964, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:139 (wazuh-remoted+0x23a5d)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

```

</details>

<details><summary>ThreadSanitizer: data race os_crypto/shared/msgs.c:397 in <code>ReadSecMSG</code></summary>

```
WARNING: ThreadSanitizer: data race (pid=19947)
  Write of size 4 at 0x7b4400004608 by thread T15 (mutexes: read M19, write M60):
    #0 ReadSecMSG os_crypto/shared/msgs.c:397 (wazuh-remoted+0x1316a7)
    #1 HandleSecureMessage remoted/secure.c:566 (wazuh-remoted+0x25875)
    #2 rem_handler_main remoted/secure.c:346 (wazuh-remoted+0x248e8)

  Previous read of size 4 at 0x7b4400004608 by thread T17 (mutexes: read M19):
    #0 OS_DupKeyEntry os_crypto/shared/keys.c:660 (wazuh-remoted+0x12d8db)
    #1 HandleSecureMessage remoted/secure.c:594 (wazuh-remoted+0x25b0f)
    #2 rem_handler_main remoted/secure.c:346 (wazuh-remoted+0x248e8)

  Location is heap block of size 288 at 0x7b4400004600 allocated by main thread:
    #0 calloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:667 (libtsan.so.2+0x3ee50)
    #1 OS_AddKey os_crypto/shared/keys.c:72 (wazuh-remoted+0x129e63)
    #2 OS_ReadKeys os_crypto/shared/keys.c:318 (wazuh-remoted+0x12b9c3)
    #3 HandleSecure remoted/secure.c:155 (wazuh-remoted+0x23b60)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Mutex M19 (0x557e79499080) created at:
    #0 pthread_rwlock_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1388 (libtsan.so.2+0x41bb4)
    #1 key_lock_init remoted/sendmsg.c:33 (wazuh-remoted+0x265a7)
    #2 HandleSecure remoted/secure.c:94 (wazuh-remoted+0x2370c)
    #3 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #4 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Mutex M60 (0x7b4400004660) created at:
    #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1295 (libtsan.so.2+0x50468)
    #1 OS_AddKey os_crypto/shared/keys.c:109 (wazuh-remoted+0x12a89b)
    #2 OS_ReadKeys os_crypto/shared/keys.c:318 (wazuh-remoted+0x12b9c3)
    #3 HandleSecure remoted/secure.c:155 (wazuh-remoted+0x23b60)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T15 (tid=19963, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:139 (wazuh-remoted+0x23a5d)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T17 (tid=19965, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:139 (wazuh-remoted+0x23a5d)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)
```

</details>

<details><summary>ThreadSanitizer: data race remoted/secure.c:497 in <code>HandleSecureMessage</code></summary>

```
WARNING: ThreadSanitizer: data race (pid=19947)
  Read of size 4 at 0x7b4400005910 by thread T18 (mutexes: read M19):
    #0 HandleSecureMessage remoted/secure.c:497 (wazuh-remoted+0x253a2)
    #1 rem_handler_main remoted/secure.c:346 (wazuh-remoted+0x248e8)

  Previous write of size 4 at 0x7b4400005910 by thread T16 (mutexes: read M19):
    #0 OS_AddSocket os_crypto/shared/keys.c:705 (wazuh-remoted+0x12e213)
    #1 HandleSecureMessage remoted/secure.c:595 (wazuh-remoted+0x25b33)
    #2 rem_handler_main remoted/secure.c:346 (wazuh-remoted+0x248e8)

  Location is heap block of size 288 at 0x7b44000058c0 allocated by main thread:
    #0 calloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:667 (libtsan.so.2+0x3ee50)
    #1 OS_AddKey os_crypto/shared/keys.c:72 (wazuh-remoted+0x129e63)
    #2 OS_ReadKeys os_crypto/shared/keys.c:318 (wazuh-remoted+0x12b9c3)
    #3 HandleSecure remoted/secure.c:155 (wazuh-remoted+0x23b60)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Mutex M19 (0x557e79499080) created at:
    #0 pthread_rwlock_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1388 (libtsan.so.2+0x41bb4)
    #1 key_lock_init remoted/sendmsg.c:33 (wazuh-remoted+0x265a7)
    #2 HandleSecure remoted/secure.c:94 (wazuh-remoted+0x2370c)
    #3 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #4 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T18 (tid=19966, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:139 (wazuh-remoted+0x23a5d)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T16 (tid=19964, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:139 (wazuh-remoted+0x23a5d)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)
```

</details>

<details><summary>ThreadSanitizer: data race os_crypto/shared/msgs.c:305 in <code>ReadSecMSG</code></summary>

```
WARNING: ThreadSanitizer: data race (pid=19947)
  Write of size 4 at 0x7b4400004710 by thread T16 (mutexes: read M19, write M60):
    #0 ReadSecMSG os_crypto/shared/msgs.c:305 (wazuh-remoted+0x130c2e)
    #1 HandleSecureMessage remoted/secure.c:566 (wazuh-remoted+0x25875)
    #2 rem_handler_main remoted/secure.c:346 (wazuh-remoted+0x248e8)

  Previous read of size 4 at 0x7b4400004710 by thread T17 (mutexes: read M19):
    #0 CreateSecMSG os_crypto/shared/msgs.c:567 (wazuh-remoted+0x132a79)
    #1 send_msg remoted/sendmsg.c:100 (wazuh-remoted+0x26b70)
    #2 save_controlmsg remoted/manager.c:357 (wazuh-remoted+0x159fa)
    #3 HandleSecureMessage remoted/secure.c:618 (wazuh-remoted+0x25cf3)
    #4 rem_handler_main remoted/secure.c:346 (wazuh-remoted+0x248e8)

  Location is heap block of size 288 at 0x7b4400004600 allocated by main thread:
    #0 calloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:667 (libtsan.so.2+0x3ee50)
    #1 OS_AddKey os_crypto/shared/keys.c:72 (wazuh-remoted+0x129e63)
    #2 OS_ReadKeys os_crypto/shared/keys.c:318 (wazuh-remoted+0x12b9c3)
    #3 HandleSecure remoted/secure.c:155 (wazuh-remoted+0x23b60)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Mutex M19 (0x557e79499080) created at:
    #0 pthread_rwlock_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1388 (libtsan.so.2+0x41bb4)
    #1 key_lock_init remoted/sendmsg.c:33 (wazuh-remoted+0x265a7)
    #2 HandleSecure remoted/secure.c:94 (wazuh-remoted+0x2370c)
    #3 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #4 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Mutex M60 (0x7b4400004660) created at:
    #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1295 (libtsan.so.2+0x50468)
    #1 OS_AddKey os_crypto/shared/keys.c:109 (wazuh-remoted+0x12a89b)
    #2 OS_ReadKeys os_crypto/shared/keys.c:318 (wazuh-remoted+0x12b9c3)
    #3 HandleSecure remoted/secure.c:155 (wazuh-remoted+0x23b60)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T16 (tid=19964, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:139 (wazuh-remoted+0x23a5d)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T17 (tid=19965, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:139 (wazuh-remoted+0x23a5d)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)
```

</details>

<details><summary>ThreadSanitizer: data race remoted/manager.c:313 in <code>free_file_sum</code></summary>

```
WARNING: ThreadSanitizer: data race (pid=19947)
  Write of size 8 at 0x7b0c0000af28 by thread T1 (mutexes: write M11):
    #0 free ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:706 (libtsan.so.2+0x47e82)
    #1 free_file_sum remoted/manager.c:313 (wazuh-remoted+0x1570c)
    #2 process_groups remoted/manager.c:849 (wazuh-remoted+0x190fa)
    #3 c_files remoted/manager.c:772 (wazuh-remoted+0x1895e)
    #4 update_shared_files remoted/manager.c:1654 (wazuh-remoted+0x1d994)

  Previous read of size 1 at 0x7b0c0000af28 by thread T17 (mutexes: write M154):
    #0 save_controlmsg remoted/manager.c:491 (wazuh-remoted+0x16a4c)
    #1 HandleSecureMessage remoted/secure.c:618 (wazuh-remoted+0x25cf3)
    #2 rem_handler_main remoted/secure.c:346 (wazuh-remoted+0x248e8)

  As if synchronized via sleep:
    #0 sleep ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:344 (libtsan.so.2+0x61f80)
    #1 update_shared_files remoted/manager.c:1658 (wazuh-remoted+0x1d9b8)

  Mutex M11 (0x557e79498bc0) created at:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4324 (libtsan.so.2+0x558e1)
    #1 c_files remoted/manager.c:769 (wazuh-remoted+0x18911)
    #2 manager_init remoted/manager.c:1689 (wazuh-remoted+0x1dcbc)
    #3 HandleSecure remoted/secure.c:88 (wazuh-remoted+0x236e9)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Mutex M154 (0x557e79498b80) created at:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4324 (libtsan.so.2+0x558e1)
    #1 save_controlmsg remoted/manager.c:397 (wazuh-remoted+0x15d45)
    #2 HandleSecureMessage remoted/secure.c:618 (wazuh-remoted+0x25cf3)
    #3 rem_handler_main remoted/secure.c:346 (wazuh-remoted+0x248e8)

  Thread T1 (tid=19949, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:97 (wazuh-remoted+0x23720)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T17 (tid=19965, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:139 (wazuh-remoted+0x23a5d)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)
```

</details>

<details><summary>ThreadSanitizer: data race remoted/manager.c:313 in <code>free_file_sum</code></summary>

```
WARNING: ThreadSanitizer: data race (pid=19947)
  Write of size 8 at 0x7b0c0000af30 by thread T1 (mutexes: write M11):
    #0 free ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:706 (libtsan.so.2+0x47e82)
    #1 free_file_sum remoted/manager.c:313 (wazuh-remoted+0x1570c)
    #2 process_groups remoted/manager.c:849 (wazuh-remoted+0x190fa)
    #3 c_files remoted/manager.c:772 (wazuh-remoted+0x1895e)
    #4 update_shared_files remoted/manager.c:1654 (wazuh-remoted+0x1d994)

  Previous read of size 8 at 0x7b0c0000af30 by thread T17 (mutexes: write M154):
    #0 memcpy ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:827 (libtsan.so.2+0x5dda6)
    #1 memcpy ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:819 (libtsan.so.2+0x5dda6)
    #2 save_controlmsg remoted/manager.c:493 (wazuh-remoted+0x16a97)
    #3 HandleSecureMessage remoted/secure.c:618 (wazuh-remoted+0x25cf3)
    #4 rem_handler_main remoted/secure.c:346 (wazuh-remoted+0x248e8)

  As if synchronized via sleep:
    #0 sleep ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:344 (libtsan.so.2+0x61f80)
    #1 update_shared_files remoted/manager.c:1658 (wazuh-remoted+0x1d9b8)

  Mutex M11 (0x557e79498bc0) created at:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4324 (libtsan.so.2+0x558e1)
    #1 c_files remoted/manager.c:769 (wazuh-remoted+0x18911)
    #2 manager_init remoted/manager.c:1689 (wazuh-remoted+0x1dcbc)
    #3 HandleSecure remoted/secure.c:88 (wazuh-remoted+0x236e9)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Mutex M154 (0x557e79498b80) created at:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4324 (libtsan.so.2+0x558e1)
    #1 save_controlmsg remoted/manager.c:397 (wazuh-remoted+0x15d45)
    #2 HandleSecureMessage remoted/secure.c:618 (wazuh-remoted+0x25cf3)
    #3 rem_handler_main remoted/secure.c:346 (wazuh-remoted+0x248e8)

  Thread T1 (tid=19949, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:97 (wazuh-remoted+0x23720)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T17 (tid=19965, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:139 (wazuh-remoted+0x23a5d)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)
```

</details>

<details><summary>ThreadSanitizer: data race os_crypto/shared/msgs.c:305 in <code>ReadSecMSG</code></summary>

```
WARNING: ThreadSanitizer: data race (pid=19947)
  Write of size 4 at 0x7b44000027d0 by thread T18 (mutexes: read M19, write M35):
    #0 ReadSecMSG os_crypto/shared/msgs.c:305 (wazuh-remoted+0x130c2e)
    #1 HandleSecureMessage remoted/secure.c:566 (wazuh-remoted+0x25875)
    #2 rem_handler_main remoted/secure.c:346 (wazuh-remoted+0x248e8)

  Previous read of size 4 at 0x7b44000027d0 by thread T2 (mutexes: read M19):
    #0 CreateSecMSG os_crypto/shared/msgs.c:567 (wazuh-remoted+0x132a79)
    #1 send_msg remoted/sendmsg.c:100 (wazuh-remoted+0x26b70)
    #2 AR_Forward remoted/ar-forward.c:122 (wazuh-remoted+0x13161)

  Location is heap block of size 288 at 0x7b44000026c0 allocated by main thread:
    #0 calloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:667 (libtsan.so.2+0x3ee50)
    #1 OS_AddKey os_crypto/shared/keys.c:72 (wazuh-remoted+0x129e63)
    #2 OS_ReadKeys os_crypto/shared/keys.c:318 (wazuh-remoted+0x12b9c3)
    #3 HandleSecure remoted/secure.c:155 (wazuh-remoted+0x23b60)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Mutex M19 (0x557e79499080) created at:
    #0 pthread_rwlock_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1388 (libtsan.so.2+0x41bb4)
    #1 key_lock_init remoted/sendmsg.c:33 (wazuh-remoted+0x265a7)
    #2 HandleSecure remoted/secure.c:94 (wazuh-remoted+0x2370c)
    #3 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #4 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Mutex M35 (0x7b4400002720) created at:
    #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1295 (libtsan.so.2+0x50468)
    #1 OS_AddKey os_crypto/shared/keys.c:109 (wazuh-remoted+0x12a89b)
    #2 OS_ReadKeys os_crypto/shared/keys.c:318 (wazuh-remoted+0x12b9c3)
    #3 HandleSecure remoted/secure.c:155 (wazuh-remoted+0x23b60)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T18 (tid=19966, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:139 (wazuh-remoted+0x23a5d)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T2 (tid=19950, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:100 (wazuh-remoted+0x23765)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)
```

</details>

<details><summary>ThreadSanitizer: data race remoted/sendmsg.c:114 in <code>send_msg</code></summary>

```
WARNING: ThreadSanitizer: data race (pid=19947)
  Read of size 4 at 0x7b4400004514 by thread T2 (mutexes: read M19, write M58):
    #0 send_msg remoted/sendmsg.c:114 (wazuh-remoted+0x26d19)
    #1 AR_Forward remoted/ar-forward.c:122 (wazuh-remoted+0x13161)

  Previous write of size 4 at 0x7b4400004514 by thread T18 (mutexes: read M19):
    #0 HandleSecureMessage remoted/secure.c:591 (wazuh-remoted+0x25a6f)
    #1 rem_handler_main remoted/secure.c:346 (wazuh-remoted+0x248e8)

  Location is heap block of size 288 at 0x7b44000044c0 allocated by main thread:
    #0 calloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:667 (libtsan.so.2+0x3ee50)
    #1 OS_AddKey os_crypto/shared/keys.c:72 (wazuh-remoted+0x129e63)
    #2 OS_ReadKeys os_crypto/shared/keys.c:318 (wazuh-remoted+0x12b9c3)
    #3 HandleSecure remoted/secure.c:155 (wazuh-remoted+0x23b60)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Mutex M19 (0x557e79499080) created at:
    #0 pthread_rwlock_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1388 (libtsan.so.2+0x41bb4)
    #1 key_lock_init remoted/sendmsg.c:33 (wazuh-remoted+0x265a7)
    #2 HandleSecure remoted/secure.c:94 (wazuh-remoted+0x2370c)
    #3 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #4 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Mutex M58 (0x7b4400004520) created at:
    #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1295 (libtsan.so.2+0x50468)
    #1 OS_AddKey os_crypto/shared/keys.c:109 (wazuh-remoted+0x12a89b)
    #2 OS_ReadKeys os_crypto/shared/keys.c:318 (wazuh-remoted+0x12b9c3)
    #3 HandleSecure remoted/secure.c:155 (wazuh-remoted+0x23b60)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T2 (tid=19950, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:100 (wazuh-remoted+0x23765)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T18 (tid=19966, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:139 (wazuh-remoted+0x23a5d)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)
```

</details>

<details><summary>ThreadSanitizer: data race remoted/sendmsg.c:118 in <code>send_msg</code></summary>

```
WARNING: ThreadSanitizer: data race (pid=19947)
  Read of size 4 at 0x7b4400004510 by thread T2 (mutexes: read M19, write M58):
    #0 send_msg remoted/sendmsg.c:118 (wazuh-remoted+0x26e1c)
    #1 AR_Forward remoted/ar-forward.c:122 (wazuh-remoted+0x13161)

  Previous write of size 4 at 0x7b4400004510 by thread T18 (mutexes: read M19):
    #0 OS_AddSocket os_crypto/shared/keys.c:705 (wazuh-remoted+0x12e213)
    #1 HandleSecureMessage remoted/secure.c:595 (wazuh-remoted+0x25b33)
    #2 rem_handler_main remoted/secure.c:346 (wazuh-remoted+0x248e8)

  Location is heap block of size 288 at 0x7b44000044c0 allocated by main thread:
    #0 calloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:667 (libtsan.so.2+0x3ee50)
    #1 OS_AddKey os_crypto/shared/keys.c:72 (wazuh-remoted+0x129e63)
    #2 OS_ReadKeys os_crypto/shared/keys.c:318 (wazuh-remoted+0x12b9c3)
    #3 HandleSecure remoted/secure.c:155 (wazuh-remoted+0x23b60)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Mutex M19 (0x557e79499080) created at:
    #0 pthread_rwlock_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1388 (libtsan.so.2+0x41bb4)
    #1 key_lock_init remoted/sendmsg.c:33 (wazuh-remoted+0x265a7)
    #2 HandleSecure remoted/secure.c:94 (wazuh-remoted+0x2370c)
    #3 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #4 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Mutex M58 (0x7b4400004520) created at:
    #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1295 (libtsan.so.2+0x50468)
    #1 OS_AddKey os_crypto/shared/keys.c:109 (wazuh-remoted+0x12a89b)
    #2 OS_ReadKeys os_crypto/shared/keys.c:318 (wazuh-remoted+0x12b9c3)
    #3 HandleSecure remoted/secure.c:155 (wazuh-remoted+0x23b60)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T2 (tid=19950, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:100 (wazuh-remoted+0x23765)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T18 (tid=19966, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:139 (wazuh-remoted+0x23a5d)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)
```

</details>

<details><summary>ThreadSanitizer: data race os_crypto/shared/msgs.c:305 in <code>ReadSecMSG</code></summary>

```
WARNING: ThreadSanitizer: data race (pid=19947)
  Write of size 4 at 0x7b4400057cd0 by thread T15 (mutexes: read M19, write M1753):
    #0 ReadSecMSG os_crypto/shared/msgs.c:305 (wazuh-remoted+0x130c2e)
    #1 HandleSecureMessage remoted/secure.c:566 (wazuh-remoted+0x25875)
    #2 rem_handler_main remoted/secure.c:346 (wazuh-remoted+0x248e8)

  Previous read of size 4 at 0x7b4400057cd0 by thread T7 (mutexes: read M19):
    #0 CreateSecMSG os_crypto/shared/msgs.c:567 (wazuh-remoted+0x132a79)
    #1 send_msg remoted/sendmsg.c:100 (wazuh-remoted+0x26b70)
    #2 send_file_toagent remoted/manager.c:1543 (wazuh-remoted+0x1d1ce)
    #3 wait_for_msgs remoted/manager.c:1612 (wazuh-remoted+0x1d721)

  Location is heap block of size 288 at 0x7b4400057bc0 allocated by thread T19:
    #0 calloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:667 (libtsan.so.2+0x3ee50)
    #1 OS_AddKey os_crypto/shared/keys.c:72 (wazuh-remoted+0x129e63)
    #2 OS_ReadKeys os_crypto/shared/keys.c:318 (wazuh-remoted+0x12b9c3)
    #3 OS_UpdateKeys os_crypto/shared/keys.c:443 (wazuh-remoted+0x12c4a2)
    #4 check_keyupdate remoted/sendmsg.c:62 (wazuh-remoted+0x267b8)
    #5 rem_keyupdate_main remoted/secure.c:365 (wazuh-remoted+0x249a2)

  Mutex M19 (0x557e79499080) created at:
    #0 pthread_rwlock_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1388 (libtsan.so.2+0x41bb4)
    #1 key_lock_init remoted/sendmsg.c:33 (wazuh-remoted+0x265a7)
    #2 HandleSecure remoted/secure.c:94 (wazuh-remoted+0x2370c)
    #3 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #4 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Mutex M1753 (0x7b4400057c20) created at:
    #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1295 (libtsan.so.2+0x50468)
    #1 OS_AddKey os_crypto/shared/keys.c:109 (wazuh-remoted+0x12a89b)
    #2 OS_ReadKeys os_crypto/shared/keys.c:318 (wazuh-remoted+0x12b9c3)
    #3 OS_UpdateKeys os_crypto/shared/keys.c:443 (wazuh-remoted+0x12c4a2)
    #4 check_keyupdate remoted/sendmsg.c:62 (wazuh-remoted+0x267b8)
    #5 rem_keyupdate_main remoted/secure.c:365 (wazuh-remoted+0x249a2)

  Thread T15 (tid=19963, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:139 (wazuh-remoted+0x23a5d)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T7 (tid=19955, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:123 (wazuh-remoted+0x23969)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T19 (tid=19967, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:161 (wazuh-remoted+0x23b88)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)
```

</details>

<details><summary>ThreadSanitizer: data race remoted/secure.c:497 in <code>HandleSecureMessage</code></summary>

```
WARNING: ThreadSanitizer: data race (pid=19947)
  Read of size 4 at 0x7b440002f350 by thread T16 (mutexes: read M19):
    #0 HandleSecureMessage remoted/secure.c:497 (wazuh-remoted+0x253a2)
    #1 rem_handler_main remoted/secure.c:346 (wazuh-remoted+0x248e8)

  Previous write of size 4 at 0x7b440002f350 by main thread (mutexes: read M19, write M0, write M2149):
    #0 OS_DeleteSocket os_crypto/shared/keys.c:727 (wazuh-remoted+0x12e4f6)
    #1 _close_sock remoted/secure.c:658 (wazuh-remoted+0x26006)
    #2 handle_incoming_data_from_tcp_socket remoted/secure.c:299 (wazuh-remoted+0x245e8)
    #3 HandleSecure remoted/secure.c:220 (wazuh-remoted+0x24072)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Location is heap block of size 288 at 0x7b440002f300 allocated by thread T19:
    #0 calloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:667 (libtsan.so.2+0x3ee50)
    #1 OS_AddKey os_crypto/shared/keys.c:72 (wazuh-remoted+0x129e63)
    #2 OS_ReadKeys os_crypto/shared/keys.c:318 (wazuh-remoted+0x12b9c3)
    #3 OS_UpdateKeys os_crypto/shared/keys.c:443 (wazuh-remoted+0x12c4a2)
    #4 check_keyupdate remoted/sendmsg.c:62 (wazuh-remoted+0x267b8)
    #5 rem_keyupdate_main remoted/secure.c:365 (wazuh-remoted+0x249a2)

  Mutex M19 (0x557e79499080) created at:
    #0 pthread_rwlock_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1388 (libtsan.so.2+0x41bb4)
    #1 key_lock_init remoted/sendmsg.c:33 (wazuh-remoted+0x265a7)
    #2 HandleSecure remoted/secure.c:94 (wazuh-remoted+0x2370c)
    #3 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #4 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Mutex M0 (0x557e79498d98) created at:
    #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1295 (libtsan.so.2+0x50468)
    #1 OS_ReadKeys os_crypto/shared/keys.c:222 (wazuh-remoted+0x12b354)
    #2 OS_UpdateKeys os_crypto/shared/keys.c:443 (wazuh-remoted+0x12c4a2)
    #3 check_keyupdate remoted/sendmsg.c:62 (wazuh-remoted+0x267b8)
    #4 rem_keyupdate_main remoted/secure.c:365 (wazuh-remoted+0x249a2)

  Mutex M2149 (0x7b440002f360) created at:
    #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1295 (libtsan.so.2+0x50468)
    #1 OS_AddKey os_crypto/shared/keys.c:109 (wazuh-remoted+0x12a89b)
    #2 OS_ReadKeys os_crypto/shared/keys.c:318 (wazuh-remoted+0x12b9c3)
    #3 OS_UpdateKeys os_crypto/shared/keys.c:443 (wazuh-remoted+0x12c4a2)
    #4 check_keyupdate remoted/sendmsg.c:62 (wazuh-remoted+0x267b8)
    #5 rem_keyupdate_main remoted/secure.c:365 (wazuh-remoted+0x249a2)

  Thread T16 (tid=19964, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:139 (wazuh-remoted+0x23a5d)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)

  Thread T19 (tid=19967, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1001 (libtsan.so.2+0x5e686)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x14f18f)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x14f231)
    #3 HandleSecure remoted/secure.c:161 (wazuh-remoted+0x23b88)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x210d2)
    #5 main remoted/main.c:218 (wazuh-remoted+0x154ef)
```

</details>

## Tests

- [x] ThreadSanitizer reports no defects after applying these fixes.
- [x] Stress test with 20 agents.
- [x] Coverity.

### How to test

1. Build and install the manager.
2. Add `-fsanitize=thread -fno-omit-frame-pointer` to `OSSEC_CFLAGS`, `OSSEC_LDFLAGS` and `AR_LDFLAGS`
3. Remove the call to `fork` in Remoted.
4. Rebuild the manager in debug mode.
5. Copy `wazuh-remoted` into `/var/ossec/bin` and grant read permissions for the user `wazuh`.

### Docker container

<details><summary>Dockerfile</summary>

```dockerfile
FROM ubuntu

RUN apt-get update && \
    apt-get install -y curl gnupg2 && \
    curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add - && \
    echo "deb https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list && \
    apt-get update && \
    apt-get install -y wazuh-agent && \
    rm -rf /var/lib/apt/lists/*

RUN sed -i "s:</client>:  <enrollment>\n     <delay_after_enrollment>10</delay_after_enrollment>\n    </enrollment>\n  </client>:" /var/ossec/etc/ossec.conf

ADD run /usr/local/bin/run
CMD /usr/local/bin/run
```

</details>

<details><summary>run</summary>

```shell
#! /bin/bash

if [ -z "$1" ]
then
    2>&1 echo "ERROR: Undefined manager IP"
    2>&1 echo "Syntax: $0 <IP>"
    exit 1
fi

set -e

DIRECTORY="/var/ossec"

sed -i "s/MANAGER_IP/$1/" $DIRECTORY/etc/ossec.conf

$DIRECTORY/bin/wazuh-execd
$DIRECTORY/bin/wazuh-modulesd
$DIRECTORY/bin/wazuh-agentd

tail -f $DIRECTORY/logs/ossec.log
```

</details>

### Running the agents (Windows)

```powershell
docker build -t wazuh-agent .
1..20 | % { docker run -d wazuh-agent run 172.22.34.10 }
```