### PR TITLE
Update Ubuntu version for RTR tests

### DIFF
--- a/src/ci/utils.py
+++ b/src/ci/utils.py
@@ -528,12 +528,12 @@ def runScanBuild(targetName):
         makeDeps(targetName, True)
         makeTarget("winagent", False, True)
         cleanInternals()
-        scanBuildCommand = 'scan-build-10 --status-bugs --use-cc=/usr/bin/i686-w64-mingw32-gcc \
+        scanBuildCommand = 'scan-build-12 --status-bugs --use-cc=/usr/bin/i686-w64-mingw32-gcc \
                             --use-c++=/usr/bin/i686-w64-mingw32-g++-posix --analyzer-target=i686-w64-mingw32 \
                             --force-analyze-debug-code make TARGET=winagent DEBUG=1 -j4'
     else:
         makeDeps(targetName, False)
-        scanBuildCommand = 'scan-build-10 --status-bugs --force-analyze-debug-code --exclude external/ make TARGET=' + targetName + ' DEBUG=1 -j4'
+        scanBuildCommand = 'scan-build-12 --status-bugs --force-analyze-debug-code --exclude external/ make TARGET=' + targetName + ' DEBUG=1 -j4'
 
     out = subprocess.run(scanBuildCommand, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
 


### PR DESCRIPTION
|Related issue|
|---|
|Related https://github.com/wazuh/wazuh-jenkins/issues/3921|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
Those checks should run on Ubuntu 22.04 for the compiler to get libgcc_s_dw2-1.dll.
The motivation is that all those checks shall pass for us to merge the PR.

## Tests
https://devel.ci.wazuh.info/job/Test_RTR_fcaffieri/5/consoleFull

New SUFFIX added:
![image](https://user-images.githubusercontent.com/89791732/191608253-e1d6c59a-73a2-403d-911a-f39c4aa8c3e8.png)

The tests returned 2 errors, which must be corrected by the Core team, as mentioned in the following comment.
https://github.com/wazuh/wazuh-jenkins/issues/3921#issuecomment-1253893228

New task definition created:
![image](https://user-images.githubusercontent.com/89791732/191609538-9496bc6c-3388-4f3a-b8b3-0cfd41ecc95f.png)

New images uploaded:
![image](https://user-images.githubusercontent.com/89791732/191609661-35b5f14c-82f5-4198-a3d4-18e2f5d597cc.png)

