### PR TITLE
Take region from .aws/config file for AWS cloudwatch

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -3570,8 +3570,10 @@ def main(argv):
             if not options.regions:
                 aws_config = get_aws_config_params()
 
-                if aws_config.has_option(options.aws_profile, "region"):
-                    options.regions.append(aws_config.get(options.aws_profile, "region"))
+                aws_profile = options.aws_profile or "default"
+
+                if aws_config.has_option(aws_profile, "region"):
+                    options.regions.append(aws_config.get(aws_profile, "region"))
                 else:
                     debug("+++ Warning: No regions were specified, trying to get events from all regions", 1)
                     options.regions = ['us-east-1', 'us-east-2', 'us-west-1', 'us-west-2',


### PR DESCRIPTION
|Related issue|
|---|
|#12937|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->


This PR closes #12937. Take account of `region` field configured in `~/.aws/config` for a profile and use to filter cloudwatch log groups.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

### Unittest

```bash
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.9.9, pytest-5.4.3, py-1.11.0, pluggy-0.13.1
rootdir: /home/nstefani/git/wazuh
plugins: tavern-1.2.2, aiohttp-0.3.0, trio-0.7.0, cov-3.0.0, html-2.1.1, asyncio-0.15.1, metadata-2.0.1
collected 38 items

wodles/aws/tests/test_aws.py ......................................                                                                                                                                           [100%]

================================================================================================ 38 passed in 0.25s =================================================================================================
```

### Manual

Having the `region` configured in `~/.aws/config`, I ran the next test cases:

```
[dev]
region = us-east-1
```

**Execute the module with `-r` option** :green_circle: https://github.com/wazuh/wazuh/pull/14993#issuecomment-1255625582
**Execute the module without specify the `-r` option** :green_circle: https://github.com/wazuh/wazuh/pull/14993#issuecomment-1255626011
**Execute the module with none of the above** :green_circle: https://github.com/wazuh/wazuh/pull/14993#issuecomment-1255626543
**Execute the module specifying a different profile** :green_circle: https://github.com/wazuh/wazuh/pull/14993#issuecomment-1255626956