### PR TITLE
Cloudwatch message debug level modification

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -3125,21 +3125,23 @@ class AWSCloudWatchLogs(AWSService):
             parameters['nextToken'] = token
 
             # Send events to Analysisd
-            for event in response['events']:
+            if response['events']:
                 debug('+++ Sending events to Analysisd...', 1)
-                debug('The message is "{}"'.format(event['message']), 2)
-                debug('The message\'s timestamp is {}'.format(event["timestamp"]), 3)
-                self.send_msg(event['message'], dump_json=False)
+                for event in response['events']:
+                    debug('The message is "{}"'.format(event['message']), 3)
+                    debug('The message\'s timestamp is {}'.format(event["timestamp"]), 3)
+                    self.send_msg(event['message'], dump_json=False)
 
-                if min_start_time is None:
-                    min_start_time = event['timestamp']
-                elif event['timestamp'] < min_start_time:
-                    min_start_time = event['timestamp']
+                    if min_start_time is None:
+                        min_start_time = event['timestamp']
+                    elif event['timestamp'] < min_start_time:
+                        min_start_time = event['timestamp']
 
-                if max_end_time is None:
-                    max_end_time = event['timestamp']
-                elif event['timestamp'] > max_end_time:
-                    max_end_time = event['timestamp']
+                    if max_end_time is None:
+                        max_end_time = event['timestamp']
+                    elif event['timestamp'] > max_end_time:
+                        max_end_time = event['timestamp']
+                debug(f"+++ Sent {len(response['events'])} events to Analysisd", 1)
 
         return {'token': token, 'start_time': min_start_time, 'end_time': max_end_time}
 


### PR DESCRIPTION
|Related issue|
|---|
|#11160|

## Description

This PR closes #11160. It modifies the debug level required to display certain messages by the AWS module, specifically when retrieving CloudWatch event messages.

## Manual Debug level tests
### Debug level 2
```
/var/ossec/wodles/aws/aws-s3 -sr cloudwatchlogs -g 4_5_test -d 2 -s 2022-JUL-29 -p dev -r us-east-1
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Getting alerts from "us-east-1" region.
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: only logs: 1659052800000
DEBUG: +++ Table does not exist; create
DEBUG: Getting log streams for "4_5_test" log group
DEBUG: Found "test_stream" log stream in 4_5_test
DEBUG: Getting data from DB for log stream "test_stream" in log group "4_5_test"
DEBUG: Token: "None", start_time: "None", end_time: "None"
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "4_5_test" using token "None", start_time "1659052800000" and end_time "None"
DEBUG: +++ Sending events to Analysisd...
DEBUG: +++ Sent 16 events to Analysisd
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "4_5_test" using token "f/37022632589172071573263438858639281121463877139200933888/s", start_time "1659052800000" and end_time "None"
DEBUG: Saving data for log group "4_5_test" and log stream "test_stream".
DEBUG: The saved values are "{'token': 'f/37022632589205522689054233858347788404597368857223462911/s', 'start_time': 1659052800000, 'end_time': 1660152262159}"
DEBUG: Purging the BD
DEBUG: Getting log streams for "4_5_test" log group
DEBUG: Found "test_stream" log stream in 4_5_test
DEBUG: committing changes and closing the DB
```

### Debug level 3
```
/var/ossec/wodles/aws/aws-s3 -sr cloudwatchlogs -g 4_5_test -d 3 -s 2022-JUL-29 -p dev -r us-east-1
DEBUG: +++ Debug mode on - Level: 3
DEBUG: +++ Getting alerts from "us-east-1" region.
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: only logs: 1659052800000
DEBUG: +++ Table does not exist; create
DEBUG: Getting log streams for "4_5_test" log group
DEBUG: Found "test_stream" log stream in 4_5_test
DEBUG: Getting data from DB for log stream "test_stream" in log group "4_5_test"
DEBUG: Token: "None", start_time: "None", end_time: "None"
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "4_5_test" using token "None", start_time "1659052800000" and end_time "None"
DEBUG: +++ Sending events to Analysisd...
DEBUG: The message is "Test log 0 - 2022-7-29"
DEBUG: The message's timestamp is 1659100462660
DEBUG: "Test log 0 - 2022-7-29"
DEBUG: The message is "Test log 1 - 2022-7-29"
DEBUG: The message's timestamp is 1659100472502
DEBUG: "Test log 1 - 2022-7-29"
DEBUG: The message is "Test log 2 - 2022-7-29"
DEBUG: The message's timestamp is 1659100483581
DEBUG: "Test log 2 - 2022-7-29"
DEBUG: The message is "Test log 3 - 2022-7-29"
DEBUG: The message's timestamp is 1659100492369
DEBUG: "Test log 3 - 2022-7-29"
DEBUG: The message is "Test log 4 - 2022-7-29"
DEBUG: The message's timestamp is 1659100502933
DEBUG: "Test log 4 - 2022-7-29"
DEBUG: The message is "Test log 5 - 2022-7-29"
DEBUG: The message's timestamp is 1659100512690
DEBUG: "Test log 5 - 2022-7-29"
DEBUG: The message is "Test log 6 - 2022-7-29"
DEBUG: The message's timestamp is 1659100522240
DEBUG: "Test log 6 - 2022-7-29"
DEBUG: The message is "Test log 7 - 2022-7-29"
DEBUG: The message's timestamp is 1659100531170
DEBUG: "Test log 7 - 2022-7-29"
DEBUG: The message is "Test log 8 - 2022-7-29"
DEBUG: The message's timestamp is 1659100540310
DEBUG: "Test log 8 - 2022-7-29"
DEBUG: The message is "Test log 9 - 2022-7-29"
DEBUG: The message's timestamp is 1659100550044
DEBUG: "Test log 9 - 2022-7-29"
DEBUG: The message is "Test log 10 - 2022-7-29"
DEBUG: The message's timestamp is 1659100556663
DEBUG: "Test log 10 - 2022-7-29"
DEBUG: The message is "Test log 11 - 2022-7-29"
DEBUG: The message's timestamp is 1659100566406
DEBUG: "Test log 11 - 2022-7-29"
DEBUG: The message is "Test log 12 - 2022-7-29"
DEBUG: The message's timestamp is 1659100574840
DEBUG: "Test log 12 - 2022-7-29"
DEBUG: The message is "Test log 13 - 2022-8-1      1659355579"
DEBUG: The message's timestamp is 1659355591835
DEBUG: "Test log 13 - 2022-8-1      1659355579"
DEBUG: The message is "Test log 14 - 2022-8-5   1659625348516"
DEBUG: The message's timestamp is 1659625354421
DEBUG: "Test log 14 - 2022-8-5   1659625348516"
DEBUG: The message is "Test log 15 - 2022-8-10    1660152255717"
DEBUG: The message's timestamp is 1660152262159
DEBUG: "Test log 15 - 2022-8-10    1660152255717"
DEBUG: +++ Sent 16 events to Analysisd
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "4_5_test" using token "f/37022632589172071573263438858639281121463877139200933888/s", start_time "1659052800000" and end_time "None"
DEBUG: Saving data for log group "4_5_test" and log stream "test_stream".
DEBUG: The saved values are "{'token': 'f/37022632589205522689054233858347788404597368857223462911/s', 'start_time': 1659052800000, 'end_time': 1660152262159}"
DEBUG: Purging the BD
DEBUG: Getting log streams for "4_5_test" log group
DEBUG: Found "test_stream" log stream in 4_5_test
DEBUG: committing changes and closing the DB
```