### PR TITLE
Fix remote policy detection in SCA

### DIFF
--- a/src/config/wmodules-sca.c
+++ b/src/config/wmodules-sca.c
@@ -311,7 +311,11 @@ int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module)
                         os_calloc(1,sizeof(wm_sca_policy_t), policy);
                         policy->enabled = enabled;
                         policy->policy_id = NULL;
+                        #ifdef WIN32
+                        policy->remote = strstr(realpath_buffer, "shared\\") != NULL;
+                        #else
                         policy->remote = strstr(realpath_buffer, "etc/shared/") != NULL;
+                        #endif
                         os_strdup(realpath_buffer, policy->policy_path);
                         sca->policies[policies_count] = policy;
                         sca->policies[policies_count + 1] = NULL;

--- a/src/config/wmodules-sca.c
+++ b/src/config/wmodules-sca.c
@@ -265,26 +265,16 @@ int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module)
                     snprintf(relative_path, PATH_MAX, "%s", children[j]->content);
 
                     #ifdef WIN32
-                    if (relative_path[1] && relative_path[2]) {
-                        if ((relative_path[1] == ':') || (relative_path[0] == '\\' && relative_path[1] == '\\')) {
-                            sprintf(realpath_buffer,"%s", relative_path);
-                        } else {
-                            const int path_length = GetFullPathName(relative_path, PATH_MAX, realpath_buffer, NULL);
-                            if (!path_length) {
-                                mwarn("File '%s' not found.", relative_path);
-                                continue;
-                            }
-                        }
+                    const int path_length = GetFullPathName(relative_path, PATH_MAX, realpath_buffer, NULL);
+                    if (!path_length) {
+                        mwarn("File '%s' not found.", relative_path);
+                        continue;
                     }
                     #else
-                    if(relative_path[0] == '/') {
-                        sprintf(realpath_buffer,"%s", relative_path);
-                    } else {
-                        const char * const realpath_buffer_ref = realpath(relative_path, realpath_buffer);
-                        if (!realpath_buffer_ref) {
-                            mwarn("File '%s' not found.", relative_path);
-                            continue;
-                        }
+                    const char * const realpath_buffer_ref = realpath(relative_path, realpath_buffer);
+                    if (!realpath_buffer_ref) {
+                        mwarn("File '%s' not found.", relative_path);
+                        continue;
                     }
                     #endif
 

--- a/src/unit_tests/wazuh_modules/sca/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/sca/CMakeLists.txt
@@ -9,7 +9,7 @@
 list(APPEND tests_names "test_wm_sca")
 list(APPEND tests_flags "-Wl,--wrap=time,--wrap=w_time_delay,--wrap=w_sleep_until,--wrap=_mwarn,--wrap=_minfo,--wrap=_merror \
                          -Wl,--wrap=_mtwarn,--wrap=_mtinfo,--wrap=_mterror,--wrap=FOREVER,--wrap=IsFile,--wrap=getDefine_Int \
-                         -Wl,--wrap=StartMQ,--wrap=CreateThread,--wrap=wm_exec,--wrap=wm_sendmsg,--wrap=opendir")
+                         -Wl,--wrap=StartMQ,--wrap=CreateThread,--wrap=wm_exec,--wrap=wm_sendmsg,--wrap=opendir,--wrap=realpath,--wrap=atexit")
 list(APPEND use_shared_libs 1)
 
 list(APPEND shared_libs "../scheduling/wmodules_scheduling_helpers.h")

--- a/src/unit_tests/wazuh_modules/sca/test_wm_sca.c
+++ b/src/unit_tests/wazuh_modules/sca/test_wm_sca.c
@@ -82,6 +82,8 @@ static int setup_module() {
     will_return(__wrap_opendir, 0);
     expect_string(__wrap__mtinfo, tag, "sca");
     expect_any(__wrap__mtinfo, formatted_msg);
+    expect_string(__wrap_realpath, path, "/var/ossec/etc/shared/your_policy_file.yml");
+    will_return(__wrap_realpath, "/var/ossec/etc/shared/your_policy_file.yml");
     expect_string(__wrap_IsFile, file, "/var/ossec/etc/shared/your_policy_file.yml");
     will_return(__wrap_IsFile, 0);
 
@@ -182,6 +184,8 @@ void test_fake_tag(void **state) {
     will_return(__wrap_opendir, 0);
     expect_string(__wrap__mtinfo, tag, "sca");
     expect_any(__wrap__mtinfo, formatted_msg);
+    expect_string(__wrap_realpath, path, "/var/ossec/etc/shared/your_policy_file.yml");
+    will_return(__wrap_realpath, "/var/ossec/etc/shared/your_policy_file.yml");
     expect_string(__wrap_IsFile, file, "/var/ossec/etc/shared/your_policy_file.yml");
     will_return(__wrap_IsFile, 0);
 
@@ -203,6 +207,8 @@ void test_read_scheduling_monthday_configuration(void **state) {
     will_return(__wrap_opendir, 0);
     expect_string(__wrap__mtinfo, tag, "sca");
     expect_any(__wrap__mtinfo, formatted_msg);
+    expect_string(__wrap_realpath, path, "/var/ossec/etc/shared/your_policy_file.yml");
+    will_return(__wrap_realpath, "/var/ossec/etc/shared/your_policy_file.yml");
     expect_string(__wrap_IsFile, file, "/var/ossec/etc/shared/your_policy_file.yml");
     will_return(__wrap_IsFile, 0);
 
@@ -231,6 +237,8 @@ void test_read_scheduling_weekday_configuration(void **state) {
     will_return(__wrap_opendir, 0);
     expect_string(__wrap__mtinfo, tag, "sca");
     expect_any(__wrap__mtinfo, formatted_msg);
+    expect_string(__wrap_realpath, path, "/var/ossec/etc/shared/your_policy_file.yml");
+    will_return(__wrap_realpath, "/var/ossec/etc/shared/your_policy_file.yml");
     expect_string(__wrap_IsFile, file, "/var/ossec/etc/shared/your_policy_file.yml");
     will_return(__wrap_IsFile, 0);
 
@@ -257,6 +265,8 @@ void test_read_scheduling_daytime_configuration(void **state) {
     will_return(__wrap_opendir, 0);
     expect_string(__wrap__mtinfo, tag, "sca");
     expect_any(__wrap__mtinfo, formatted_msg);
+    expect_string(__wrap_realpath, path, "/var/ossec/etc/shared/your_policy_file.yml");
+    will_return(__wrap_realpath, "/var/ossec/etc/shared/your_policy_file.yml");
     expect_string(__wrap_IsFile, file, "/var/ossec/etc/shared/your_policy_file.yml");
     will_return(__wrap_IsFile, 0);
 
@@ -283,6 +293,8 @@ void test_read_scheduling_interval_configuration(void **state) {
     will_return(__wrap_opendir, 0);
     expect_string(__wrap__mtinfo, tag, "sca");
     expect_any(__wrap__mtinfo, formatted_msg);
+    expect_string(__wrap_realpath, path, "/var/ossec/etc/shared/your_policy_file.yml");
+    will_return(__wrap_realpath, "/var/ossec/etc/shared/your_policy_file.yml");
     expect_string(__wrap_IsFile, file, "/var/ossec/etc/shared/your_policy_file.yml");
     will_return(__wrap_IsFile, 0);
 


### PR DESCRIPTION
|Version|Module|Component|Platform|
|---|---|---|---|
|3.9.0|SCA|Agent|UNIX & Windows|

This PR aims to fix the SCA configuration parser to skip commands in policy files transmitted from the manager via remote configuration.

## Rationale

SCA provides an internal option to enable or disable remote command execution:

```
sca.remote_commands=0
```

The agent must ignore commands (defined with `c: ...`) from policy files stored in the shared folder:
|Platform|Shared folder path|
|---|---|
|UNIX|_etc/shared/*_|
|Windows|_shared\\*_|

However, the agent always compares the full path of the policy file with `etc/shared/`. This makes the agent fail to detect policy files in shared folders, preventing it from skipping remote commands. In addition, the agent won't detect as remote the folder path `/var/ossec/etc/./shared` as it does not normalize absolute paths.

## Proposed fix

1. Find the shared folder name in each policy file path depending on the agent's platform, according to the table above.
2. Normalize every path to policy files, including absolute paths.

## Tests

- [x] The Windows agent rejects command execution in a shared folder defined with slashes (`/`).
```
2022/09/26 16:13:59 sca: WARNING: Ignoring check for policy 'Testing file 1'. The internal option 'sca.remote_commands' is disabled.
```
- [x] The Windows agent rejects command execution in a shared folder defined with backslashes (`\`).
```
2022/09/26 16:14:02 sca: WARNING: Ignoring check for policy 'Testing file 2'. The internal option 'sca.remote_commands' is disabled.
```
- [x] The Windows agent rejects command execution in a shared folder defined with an absolute path:
```xml
<policy>C:\Program Files (x86)\ossec-agent\./shared/test_windows.yml</policy>
```
```
2022/09/27 10:58:30 sca: INFO: Starting evaluation of policy: 'C:\Program Files (x86)\ossec-agent\shared\test_windows.yml'
2022/09/27 10:58:30 sca: WARNING: Ignoring check for policy 'Testing file for Windows'. The internal option 'sca.remote_commands' is disabled.
```
- [x] The Linux agent rejects command execution in a shared folder defined with an absolute path, even if it does not follow the exact pattern:
```xml
<policy>/var/ossec/etc/./shared/test_unix.yml</policy>
```
```
2022/09/27 10:58:31 sca: INFO: Starting evaluation of policy: '/var/ossec/etc/shared/test_unix.yml'
2022/09/27 10:58:31 sca: WARNING: Ignoring check for policy 'Testing file for UNIX'. The internal option 'sca.remote_commands' is disabled.
```

### Configuration

```xml
<agent_config>
  <sca>
    <policies>
      <policy>C:\Program Files (x86)\ossec-agent\./shared/test_windows.yml</policy>
      <policy>/var/ossec/etc/./shared/test_unix.yml</policy>
    </policies>
  </sca>
</agent_config>
```

### Sample policy files

<details><summary>etc/shared/default/test_windows.yml</summary>

```yml
policy:
  id: "test_windows"
  file: "test_windows.yml"
  name: "Testing file for Windows"
  description: "Testing file."

requirements:
  title: "Check that the Windows platform is Windows 11"
  description: "Requirements for running under Windows 11"
  condition: all
  rules:
    - 'r:HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion -> ProductName -> r:^Windows 10 Pro'

checks:

  - id: 90000
    title: "Test 99000."
    description: "Test"
    condition: all
    rules:
      - 'c:net.exe accounts -> r:Minimum password'

```

</details>

<details><summary>etc/shared/default/test_unix.yml</summary>

```yml
policy:
  id: "test_unix"
  file: "test_unix.yml"
  name: "Testing file for UNIX"
  description: "Testing file."

requirements:
  title: "Check that the Windows platform is Ubuntu 22.04"
  description: "Requirements for running under Ubuntu 22.04"
  condition: all
  rules:
    - "f:/etc/os-release -> r:Ubuntu 22.04"
    - "f:/proc/sys/kernel/ostype -> Linux"

checks:

  - id: 99000
    title: "Test 99000."
    description: "Test"
    condition: all
    rules:
      - "c:modprobe -n -v cramfs -> r:^install /bin/true"
```

</details>