### PR TITLE
CustomBucket and ServerAccess debug message level modification

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -1029,7 +1029,7 @@ class AWSBucket(WazuhIntegration):
                         match_start = date_match.span()[0] if date_match else None
 
                         if not self._same_prefix(match_start, aws_account_id, aws_region):
-                            debug(f"++ Skipping file with another prefix: {bucket_file['Key']}", 2)
+                            debug(f"++ Skipping file with another prefix: {bucket_file['Key']}", 3)
                             continue
 
                     if self.already_processed(bucket_file['Key'], aws_account_id, aws_region):
@@ -2503,7 +2503,7 @@ class AWSServerAccess(AWSCustomBucket):
                             sys.exit(17)
 
                     if not self._same_prefix(match_start, aws_account_id, aws_region):
-                        debug(f"++ Skipping file with another prefix: {bucket_file['Key']}", 2)
+                        debug(f"++ Skipping file with another prefix: {bucket_file['Key']}", 3)
                         continue
 
                     if self.already_processed(bucket_file['Key'], aws_account_id, aws_region):


### PR DESCRIPTION
|Related issue|
|---|
|11148|

This PR closes #11148. It modifies the debug level required to display the message `Skipping file with another prefix...` that may appear when executing the AWS module to get `Custom Buckets` or `Server Access` logs.

## Manual Debug level tests
### Debug level 2
```
    /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-kms -t custom -s 2022-JAN-01 -p dev -d2
    DEBUG: +++ Debug mode on - Level: 2
    DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
    DEBUG: +++ Table does not exist; create
    DEBUG: +++ Marker: 2022/01/01
    DEBUG: ++ Found new log: 2022/01/15/12/firehose_kms-1-2022-01-15-12-27-26-756d81b8-7031-4a07-a50c-db292e6db64b
    DEBUG: ++ Found new log: 2022/01/16/12/firehose_kms-1-2022-01-16-12-27-26-756d81b8-7031-4a07-a50c-db292e6db64b
    DEBUG: ++ Found new log: 2022/01/17/12/firehose_kms-1-2022-01-17-12-27-26-756d81b8-7031-4a07-a50c-db292e6db64b
    DEBUG: +++ DB Maintenance
```

### Debug level 3

```
    /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-kms -t custom -s 2022-JAN-01 -p dev -d3
    DEBUG: +++ Debug mode on - Level: 3
    DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
    DEBUG: +++ Table does not exist; create
    DEBUG: +++ Marker: 2022/01/01
    DEBUG: ++ Found new log: 2022/01/15/12/firehose_kms-1-2022-01-15-12-27-26-756d81b8-7031-4a07-a50c-db292e6db64b
    DEBUG: ++ Reformat message
    DEBUG: {"integration": "aws", "aws": {"log_info": {"aws_account_alias": "", "log_file": "2022/01/15/12/firehose_kms-1-2022-01-15-12-27-26-756d81b8-7031-4a07-a50c-db292e6db64b", "s3bucket": "wazuh-aws-wodle-kms"}, "eventVersion": "1.05", "userIdentity": {"type": "IAMUser", "principalId": "principalId", "arn": "arn:aws:iam::accountID:user/username", "accountId": "accountID", "accessKeyId": "accessKeyId", "userName": "username", "sessionContext": {"attributes": {"mfaAuthenticated": "false", "creationDate": "2018-11-07T07:53:47Z"}}, "invokedBy": "secretsmanager.amazonaws.com"}, "eventTime": "2018-11-07T17:27:01Z", "eventSource": "kms.amazonaws.com", "eventName": "GenerateDataKey", "awsRegion": "us-east-1", "sourceIPAddress": "secretsmanager.amazonaws.com", "userAgent": "secretsmanager.amazonaws.com", "requestParameters": {"keySpec": "XXXXXX", "encryptionContext": {"SecretARN": "arn:aws:secretsmanager:us-east-1:accountID:secret:XXXXXXXXX", "SecretVersionId": "XXXXXXXXXXXXXX"}, "keyId": "alias/aws/secretsmanager"}, "requestID": "requestID", "eventID": "eventID", "readOnly": true, "resources": {"ARN": "arn:aws:kms:us-east-1:accountID:key/cfc9617a-1a82-4534-86f5-19aef567a45d", "accountId": "accountID", "type": "AWS::KMS::Key"}, "eventType": "AwsApiCall", "vpcEndpointId": "vpcEndpointId", "source": "kms"}}
    DEBUG: ++ Found new log: 2022/01/16/12/firehose_kms-1-2022-01-16-12-27-26-756d81b8-7031-4a07-a50c-db292e6db64b
    DEBUG: ++ Reformat message
    DEBUG: {"integration": "aws", "aws": {"log_info": {"aws_account_alias": "", "log_file": "2022/01/16/12/firehose_kms-1-2022-01-16-12-27-26-756d81b8-7031-4a07-a50c-db292e6db64b", "s3bucket": "wazuh-aws-wodle-kms"}, "eventVersion": "1.05", "userIdentity": {"type": "IAMUser", "principalId": "principalId", "arn": "arn:aws:iam::accountID:user/username", "accountId": "accountID", "accessKeyId": "accessKeyId", "userName": "username", "sessionContext": {"attributes": {"mfaAuthenticated": "false", "creationDate": "2018-11-07T07:53:47Z"}}, "invokedBy": "secretsmanager.amazonaws.com"}, "eventTime": "2018-11-07T17:27:01Z", "eventSource": "kms.amazonaws.com", "eventName": "GenerateDataKey", "awsRegion": "us-east-1", "sourceIPAddress": "secretsmanager.amazonaws.com", "userAgent": "secretsmanager.amazonaws.com", "requestParameters": {"keySpec": "XXXXXX", "encryptionContext": {"SecretARN": "arn:aws:secretsmanager:us-east-1:accountID:secret:XXXXXXXXX", "SecretVersionId": "XXXXXXXXXXXXXX"}, "keyId": "alias/aws/secretsmanager"}, "requestID": "requestID", "eventID": "eventID", "readOnly": true, "resources": {"ARN": "arn:aws:kms:us-east-1:accountID:key/cfc9617a-1a82-4534-86f5-19aef567a45d", "accountId": "accountID", "type": "AWS::KMS::Key"}, "eventType": "AwsApiCall", "vpcEndpointId": "vpcEndpointId", "source": "kms"}}
    DEBUG: ++ Found new log: 2022/01/17/12/firehose_kms-1-2022-01-17-12-27-26-756d81b8-7031-4a07-a50c-db292e6db64b
    DEBUG: ++ Reformat message
    DEBUG: {"integration": "aws", "aws": {"log_info": {"aws_account_alias": "", "log_file": "2022/01/17/12/firehose_kms-1-2022-01-17-12-27-26-756d81b8-7031-4a07-a50c-db292e6db64b", "s3bucket": "wazuh-aws-wodle-kms"}, "eventVersion": "1.05", "userIdentity": {"type": "IAMUser", "principalId": "principalId", "arn": "arn:aws:iam::accountID:user/username", "accountId": "accountID", "accessKeyId": "accessKeyId", "userName": "username", "sessionContext": {"attributes": {"mfaAuthenticated": "false", "creationDate": "2018-11-07T07:53:47Z"}}, "invokedBy": "secretsmanager.amazonaws.com"}, "eventTime": "2018-11-07T17:27:01Z", "eventSource": "kms.amazonaws.com", "eventName": "GenerateDataKey", "awsRegion": "us-east-1", "sourceIPAddress": "secretsmanager.amazonaws.com", "userAgent": "secretsmanager.amazonaws.com", "requestParameters": {"keySpec": "XXXXXX", "encryptionContext": {"SecretARN": "arn:aws:secretsmanager:us-east-1:accountID:secret:XXXXXXXXX", "SecretVersionId": "XXXXXXXXXXXXXX"}, "keyId": "alias/aws/secretsmanager"}, "requestID": "requestID", "eventID": "eventID", "readOnly": true, "resources": {"ARN": "arn:aws:kms:us-east-1:accountID:key/cfc9617a-1a82-4534-86f5-19aef567a45d", "accountId": "accountID", "type": "AWS::KMS::Key"}, "eventType": "AwsApiCall", "vpcEndpointId": "vpcEndpointId", "source": "kms"}}
    DEBUG: ++ Skipping file with another prefix: kms/2018/11/07/17/firehose_kms-1-2018-11-07-17-27-26-756d81b8-7031-4a07-a50c-db292e6db64b
    DEBUG: ++ Skipping file with another prefix: kms_compress_encrypted/2018/11/12/08/firehose_kms-1-2018-11-12-08-16-58-975f1ad7-14e4-41ce-a805-3310fdf07f61.zip
    ...
    DEBUG: ++ Skipping file with another prefix: test_prefix/kms_compress_encrypted/2018/12/03/14/firehose_kms-1-2018-12-03-14-09-26-b7d50739-5b81-44a5-9a1a-aca2ff8ade40.zip
    DEBUG: ++ Skipping file with another prefix: test_prefix/kms_compress_encrypted/2018/12/03/14/firehose_kms-1-2018-12-03-14-14-57-a65fd90f-66f7-4ded-8ad2-28caa7e17ef4.zip
    DEBUG: ++ Skipping file with another prefix: test_prefix/kms_compress_encrypted/2018/12/03/14/firehose_kms-1-2018-12-03-14-20-22-fdc84279-3a2b-4d2f-aee2-6adf295b076c.zip
    DEBUG: ++ Skipping file with another prefix: test_prefix/kms_compress_encrypted/2018/12/03/14/firehose_kms-1-2018-12-03-14-25-53-d2b1a5b4-8456-474e-a434-972f34ec4e9c.zip
    DEBUG: ++ Skipping file with another prefix: test_prefix/kms_compress_encrypted/2018/12/03/14/firehose_kms-1-2018-12-03-14-31-03-6722571b-2cc6-4d86-8bef-7ba4937f5231.zip
    DEBUG: ++ Skipping file with another prefix: test_prefix/kms_compress_encrypted/2018/12/03/14/firehose_kms-1-2018-12-03-14-36-06-c9ded56a-daee-42fb-a45e-63bee4330927.zip
    DEBUG: +++ DB Maintenance
```
