### PR TITLE
Add Support for GCC & GCC High to the Office365 Module

### DIFF
--- a/src/config/wmodules-office365.c
+++ b/src/config/wmodules-office365.c
@@ -21,6 +21,7 @@ static const char *XML_TENANT_ID            = "tenant_id";
 static const char *XML_CLIENT_ID            = "client_id";
 static const char *XML_CLIENT_SECRET_PATH   = "client_secret_path";
 static const char *XML_CLIENT_SECRET        = "client_secret";
+static const char *XML_API_TYPE             = "api_type";
 
 static const char *XML_SUBSCRIPTIONS                = "subscriptions";
 static const char *XML_SUBSCRIPTION                 = "subscription";
@@ -136,6 +137,29 @@ int wm_office365_read(__attribute__((unused)) const OS_XML *xml, xml_node **node
                     }
                     os_free(office365_auth->client_secret);
                     os_strdup(children[j]->content, office365_auth->client_secret);
+                } else if (!strcmp(children[j]->element, XML_API_TYPE)) {
+                    if (strlen(children[j]->content) == 0){
+                        merror("Empty content for tag '%s' at module '%s'.", XML_API_TYPE, WM_OFFICE365_CONTEXT.name);
+                        OS_ClearNode(children);
+                        return OS_INVALID;
+                    }
+                    else if (!strcmp(children[j]->content, "commercial")){
+                        office365_auth->login_fqdn = "login.microsoftonline.com";
+                        office365_auth->management_fqdn = "manage.office.com";
+                    }
+                    else if (!strcmp(children[j]->content, "gcc")){
+                        office365_auth->login_fqdn = "login.microsoftonline.com";
+                        office365_auth->management_fqdn = "manage-gcc.office.com";
+                    }
+                    else if (!strcmp(children[j]->content, "gcc-high")){
+                        office365_auth->login_fqdn = "login.microsoftonline.us";
+                        office365_auth->management_fqdn = "manage.office365.us";
+                    }
+                    else {
+                        merror("Invalid content for tag '%s' at module '%s'.", XML_API_TYPE, WM_OFFICE365_CONTEXT.name);
+                        OS_ClearNode(children);
+                        return OS_INVALID;
+                    }
                 } else {
                     merror("No such tag '%s' at module '%s'.", children[j]->element, WM_OFFICE365_CONTEXT.name);
                     OS_ClearNode(children);

--- a/src/config/wmodules-office365.c
+++ b/src/config/wmodules-office365.c
@@ -41,11 +41,15 @@ int wm_office365_read(__attribute__((unused)) const OS_XML *xml, xml_node **node
         module->context = &WM_OFFICE365_CONTEXT;
         module->tag = strdup(module->context->name);
         os_calloc(1, sizeof(wm_office365), office365_config);
+        os_calloc(1, sizeof(wm_office365_auth), office365_auth);
+        office365_config->auth = office365_auth;
 
         office365_config->enabled =            WM_OFFICE365_DEFAULT_ENABLED;
         office365_config->only_future_events = WM_OFFICE365_DEFAULT_ONLY_FUTURE_EVENTS;
         office365_config->interval =           WM_OFFICE365_DEFAULT_INTERVAL;
         office365_config->curl_max_size =      WM_OFFICE365_DEFAULT_CURL_MAX_SIZE;
+        office365_auth->login_fqdn =           WM_OFFICE365_DEFAULT_API_LOGIN_FQDN;
+        office365_auth->management_fqdn =      WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN;
 
         module->data = office365_config;
     } else {
@@ -188,6 +192,12 @@ int wm_office365_read(__attribute__((unused)) const OS_XML *xml, xml_node **node
             } else if (!office365_auth->tenant_id) {
                 merror("'%s' is missing at module '%s'.", XML_TENANT_ID, WM_OFFICE365_CONTEXT.name);
                 return OS_INVALID;
+            }
+
+            // Keep backwards compatability with configs made prior to GCC(-High) support
+            if (!office365_auth->login_fqdn && !office365_auth->management_fqdn) {
+                office365_auth->login_fqdn = "login.microsoftonline.com";
+                office365_auth->management_fqdn = "manage-gcc.office.com";
             }
 
         } else if (!strcmp(nodes[i]->element, XML_SUBSCRIPTIONS)) {

--- a/src/config/wmodules-office365.c
+++ b/src/config/wmodules-office365.c
@@ -95,7 +95,7 @@ int wm_office365_read(__attribute__((unused)) const OS_XML *xml, xml_node **node
                 return OS_INVALID;
             }
         } else if (!strcmp(nodes[i]->element, XML_API_AUTH)) {
-            // Create new auth node if the current one is already configured (i.e., not the default)
+            // Only create a new auth node if the current one is already configured (i.e., not the default)
             if (office365_auth->tenant_id) {
                 os_calloc(1, sizeof(wm_office365_auth), office365_auth->next);
                 office365_auth = office365_auth->next;
@@ -138,20 +138,20 @@ int wm_office365_read(__attribute__((unused)) const OS_XML *xml, xml_node **node
                     os_free(office365_auth->client_secret);
                     os_strdup(children[j]->content, office365_auth->client_secret);
                 } else if (!strcmp(children[j]->element, XML_API_TYPE)) {
-                    if (strlen(children[j]->content) == 0){
+                    if (strlen(children[j]->content) == 0) {
                         merror("Empty content for tag '%s' at module '%s'.", XML_API_TYPE, WM_OFFICE365_CONTEXT.name);
                         OS_ClearNode(children);
                         return OS_INVALID;
                     }
-                    else if (!strcmp(children[j]->content, "commercial")){
+                    else if (!strcmp(children[j]->content, "commercial")) {
                         office365_auth->login_fqdn = "login.microsoftonline.com";
                         office365_auth->management_fqdn = "manage.office.com";
                     }
-                    else if (!strcmp(children[j]->content, "gcc")){
+                    else if (!strcmp(children[j]->content, "gcc")) {
                         office365_auth->login_fqdn = "login.microsoftonline.com";
                         office365_auth->management_fqdn = "manage-gcc.office.com";
                     }
-                    else if (!strcmp(children[j]->content, "gcc-high")){
+                    else if (!strcmp(children[j]->content, "gcc-high")) {
                         office365_auth->login_fqdn = "login.microsoftonline.us";
                         office365_auth->management_fqdn = "manage.office365.us";
                     }

--- a/src/config/wmodules-office365.c
+++ b/src/config/wmodules-office365.c
@@ -196,7 +196,7 @@ int wm_office365_read(__attribute__((unused)) const OS_XML *xml, xml_node **node
                 return OS_INVALID;
             }
 
-            // Keep backwards compatability with configs made prior to GCC(-High) support
+            // Keep retrocompatibility with configs made prior to GCC (High) support
             if (!office365_auth->login_fqdn && !office365_auth->management_fqdn) {
                 os_free(office365_auth->login_fqdn);
                 os_strdup("login.microsoftonline.com", office365_auth->login_fqdn);

--- a/src/config/wmodules-office365.c
+++ b/src/config/wmodules-office365.c
@@ -95,14 +95,10 @@ int wm_office365_read(__attribute__((unused)) const OS_XML *xml, xml_node **node
                 return OS_INVALID;
             }
         } else if (!strcmp(nodes[i]->element, XML_API_AUTH)) {
-            // Create auth node
-            if (office365_auth) {
+            // Create new auth node if the current one is already configured (i.e., not the default)
+            if (office365_auth->tenant_id) {
                 os_calloc(1, sizeof(wm_office365_auth), office365_auth->next);
                 office365_auth = office365_auth->next;
-            } else {
-                // First office365_auth
-                os_calloc(1, sizeof(wm_office365_auth), office365_auth);
-                office365_config->auth = office365_auth;
             }
 
             if (!(children = OS_GetElementsbyNode(xml, nodes[i]))) {

--- a/src/config/wmodules-office365.c
+++ b/src/config/wmodules-office365.c
@@ -48,8 +48,10 @@ int wm_office365_read(__attribute__((unused)) const OS_XML *xml, xml_node **node
         office365_config->only_future_events = WM_OFFICE365_DEFAULT_ONLY_FUTURE_EVENTS;
         office365_config->interval =           WM_OFFICE365_DEFAULT_INTERVAL;
         office365_config->curl_max_size =      WM_OFFICE365_DEFAULT_CURL_MAX_SIZE;
-        office365_auth->login_fqdn =           WM_OFFICE365_DEFAULT_API_LOGIN_FQDN;
-        office365_auth->management_fqdn =      WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN;
+        os_free(office365_auth->login_fqdn);
+        os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, office365_auth->login_fqdn);
+        os_free(office365_auth->management_fqdn);
+        os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, office365_auth->management_fqdn);
 
         module->data = office365_config;
     } else {
@@ -144,16 +146,22 @@ int wm_office365_read(__attribute__((unused)) const OS_XML *xml, xml_node **node
                         return OS_INVALID;
                     }
                     else if (!strcmp(children[j]->content, "commercial")) {
-                        office365_auth->login_fqdn = "login.microsoftonline.com";
-                        office365_auth->management_fqdn = "manage.office.com";
+                        os_free(office365_auth->login_fqdn);
+                        os_strdup("login.microsoftonline.com", office365_auth->login_fqdn);
+                        os_free(office365_auth->management_fqdn);
+                        os_strdup("manage.office.com", office365_auth->management_fqdn);
                     }
                     else if (!strcmp(children[j]->content, "gcc")) {
-                        office365_auth->login_fqdn = "login.microsoftonline.com";
-                        office365_auth->management_fqdn = "manage-gcc.office.com";
+                        os_free(office365_auth->login_fqdn);
+                        os_strdup("login.microsoftonline.com", office365_auth->login_fqdn);
+                        os_free(office365_auth->management_fqdn);
+                        os_strdup("manage-gcc.office.com", office365_auth->management_fqdn);
                     }
                     else if (!strcmp(children[j]->content, "gcc-high")) {
-                        office365_auth->login_fqdn = "login.microsoftonline.us";
-                        office365_auth->management_fqdn = "manage.office365.us";
+                        os_free(office365_auth->login_fqdn);
+                        os_strdup("login.microsoftonline.us", office365_auth->login_fqdn);
+                        os_free(office365_auth->management_fqdn);
+                        os_strdup("manage.office365.us", office365_auth->management_fqdn);
                     }
                     else {
                         merror("Invalid content for tag '%s' at module '%s'.", XML_API_TYPE, WM_OFFICE365_CONTEXT.name);
@@ -192,8 +200,10 @@ int wm_office365_read(__attribute__((unused)) const OS_XML *xml, xml_node **node
 
             // Keep backwards compatability with configs made prior to GCC(-High) support
             if (!office365_auth->login_fqdn && !office365_auth->management_fqdn) {
-                office365_auth->login_fqdn = "login.microsoftonline.com";
-                office365_auth->management_fqdn = "manage-gcc.office.com";
+                os_free(office365_auth->login_fqdn);
+                os_strdup("login.microsoftonline.com", office365_auth->login_fqdn);
+                os_free(office365_auth->management_fqdn);
+                os_strdup("manage.office.com", office365_auth->management_fqdn);
             }
 
         } else if (!strcmp(nodes[i]->element, XML_SUBSCRIPTIONS)) {

--- a/src/config/wmodules-office365.c
+++ b/src/config/wmodules-office365.c
@@ -145,21 +145,21 @@ int wm_office365_read(__attribute__((unused)) const OS_XML *xml, xml_node **node
                     }
                     else if (!strcmp(children[j]->content, "commercial")) {
                         os_free(office365_auth->login_fqdn);
-                        os_strdup("login.microsoftonline.com", office365_auth->login_fqdn);
+                        os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, office365_auth->login_fqdn);
                         os_free(office365_auth->management_fqdn);
-                        os_strdup("manage.office.com", office365_auth->management_fqdn);
+                        os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, office365_auth->management_fqdn);
                     }
                     else if (!strcmp(children[j]->content, "gcc")) {
                         os_free(office365_auth->login_fqdn);
-                        os_strdup("login.microsoftonline.com", office365_auth->login_fqdn);
+                        os_strdup(WM_OFFICE365_GCC_API_LOGIN_FQDN, office365_auth->login_fqdn);
                         os_free(office365_auth->management_fqdn);
-                        os_strdup("manage-gcc.office.com", office365_auth->management_fqdn);
+                        os_strdup(WM_OFFICE365_GCC_API_MANAGEMENT_FQDN, office365_auth->management_fqdn);
                     }
                     else if (!strcmp(children[j]->content, "gcc-high")) {
                         os_free(office365_auth->login_fqdn);
-                        os_strdup("login.microsoftonline.us", office365_auth->login_fqdn);
+                        os_strdup(WM_OFFICE365_GCC_HIGH_API_LOGIN_FQDN, office365_auth->login_fqdn);
                         os_free(office365_auth->management_fqdn);
-                        os_strdup("manage.office365.us", office365_auth->management_fqdn);
+                        os_strdup(WM_OFFICE365_GCC_HIGH_API_MANAGEMENT_FQDN, office365_auth->management_fqdn);
                     }
                     else {
                         merror("Invalid content for tag '%s' at module '%s'.", XML_API_TYPE, WM_OFFICE365_CONTEXT.name);
@@ -199,9 +199,9 @@ int wm_office365_read(__attribute__((unused)) const OS_XML *xml, xml_node **node
             // Keep retrocompatibility with configs made prior to GCC (High) support
             if (!office365_auth->login_fqdn && !office365_auth->management_fqdn) {
                 os_free(office365_auth->login_fqdn);
-                os_strdup("login.microsoftonline.com", office365_auth->login_fqdn);
+                os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, office365_auth->login_fqdn);
                 os_free(office365_auth->management_fqdn);
-                os_strdup("manage.office.com", office365_auth->management_fqdn);
+                os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, office365_auth->management_fqdn);
             }
 
         } else if (!strcmp(nodes[i]->element, XML_SUBSCRIPTIONS)) {

--- a/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
+++ b/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
@@ -1036,7 +1036,7 @@ void test_error_client_secret_path(void **state) {
     test_structure *test = *state;
     expect_string(__wrap_access, __name, "/path/to/secret");
     will_return(__wrap_access, -1);
-    expect_string(__wrap__merror, formatted_msg, "Invalid content for tag 'office365': The path cannot be opened.");
+    expect_string(__wrap__merror, formatted_msg, "Invalid content for tag 'client_secret_path' at module 'office365': The path cannot be opened.");
     test->nodes = string_to_xml_node(string, &(test->xml));
     assert_int_equal(wm_office365_read(&(test->xml), test->nodes, test->module),-1);
 }

--- a/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
+++ b/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
@@ -95,16 +95,22 @@ static int teardown_test_read(void **state) {
             os_free(((wm_office365*)test->module->data)->auth->client_id);
             os_free(((wm_office365*)test->module->data)->auth->client_secret_path);
             os_free(((wm_office365*)test->module->data)->auth->client_secret);
+            os_free(((wm_office365*)test->module->data)->auth->login_fqdn);
+            os_free(((wm_office365*)test->module->data)->auth->management_fqdn);
             if (((wm_office365*)test->module->data)->auth->next) {
                 os_free(((wm_office365*)test->module->data)->auth->next->tenant_id);
                 os_free(((wm_office365*)test->module->data)->auth->next->client_id);
                 os_free(((wm_office365*)test->module->data)->auth->next->client_secret_path);
                 os_free(((wm_office365*)test->module->data)->auth->next->client_secret);
+                os_free(((wm_office365*)test->module->data)->auth->next->login_fqdn);
+                os_free(((wm_office365*)test->module->data)->auth->next->management_fqdn);
                 if (((wm_office365*)test->module->data)->auth->next->next) {
                     os_free(((wm_office365*)test->module->data)->auth->next->next->tenant_id);
                     os_free(((wm_office365*)test->module->data)->auth->next->next->client_id);
                     os_free(((wm_office365*)test->module->data)->auth->next->next->client_secret_path);
                     os_free(((wm_office365*)test->module->data)->auth->next->next->client_secret);
+                    os_free(((wm_office365*)test->module->data)->auth->next->next->login_fqdn);
+                    os_free(((wm_office365*)test->module->data)->auth->next->next->management_fqdn);
                     os_free(((wm_office365*)test->module->data)->auth->next->next->next);
                 }
                 os_free(((wm_office365*)test->module->data)->auth->next->next);

--- a/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
+++ b/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
@@ -95,11 +95,15 @@ static int teardown_test_read(void **state) {
             os_free(((wm_office365*)test->module->data)->auth->client_id);
             os_free(((wm_office365*)test->module->data)->auth->client_secret_path);
             os_free(((wm_office365*)test->module->data)->auth->client_secret);
+            os_free(((wm_office365*)test->module->data)->auth->login_fqdn);
+            os_free(((wm_office365*)test->module->data)->auth->management_fqdn);
             if (((wm_office365*)test->module->data)->auth->next) {
                 os_free(((wm_office365*)test->module->data)->auth->next->tenant_id);
                 os_free(((wm_office365*)test->module->data)->auth->next->client_id);
                 os_free(((wm_office365*)test->module->data)->auth->next->client_secret_path);
                 os_free(((wm_office365*)test->module->data)->auth->next->client_secret);
+                os_free(((wm_office365*)test->module->data)->auth->login_fqdn);
+                os_free(((wm_office365*)test->module->data)->auth->management_fqdn);
                 os_free(((wm_office365*)test->module->data)->auth->next->next);
             }
             os_free(((wm_office365*)test->module->data)->auth->next);
@@ -163,6 +167,8 @@ void test_read_configuration(void **state) {
     assert_string_equal(module_data->auth->tenant_id, "your_tenant_id");
     assert_string_equal(module_data->auth->client_id, "your_client_id");
     assert_string_equal(module_data->auth->client_secret, "your_secret");
+    assert_string_equal(module_data->auth->login_fqdn, "login.microsoftonline.com"); // retrocompatability check
+    assert_string_equal(module_data->auth->management_fqdn, "manage.office.com"); // retrocompatability check
     assert_string_equal(module_data->subscription->subscription_name, "Audit.AzureActiveDirectory");
     assert_string_equal(module_data->subscription->next->subscription_name, "Audit.Exchange");
     assert_string_equal(module_data->subscription->next->next->subscription_name, "Audit.SharePoint");
@@ -180,11 +186,19 @@ void test_read_configuration_1(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<api_auth>"
             "<tenant_id>your_tenant_id_1</tenant_id>"
             "<client_id>your_client_id_1</client_id>"
+            "<client_secret>your_secret_1</client_secret>"
+            "<api_type>gcc</api_type>"
+        "</api_auth>"
+        "<api_auth>"
+            "<tenant_id>your_tenant_id_2</tenant_id>"
+            "<client_id>your_client_id_2</client_id>"
             "<client_secret_path>/path/to/secret</client_secret_path>"
+            "<api_type>gcc-high</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -207,9 +221,18 @@ void test_read_configuration_1(void **state) {
     assert_string_equal(module_data->auth->tenant_id, "your_tenant_id");
     assert_string_equal(module_data->auth->client_id, "your_client_id");
     assert_string_equal(module_data->auth->client_secret, "your_secret");
+    assert_string_equal(module_data->auth->login_fqdn, "login.microsoftonline.com");
+    assert_string_equal(module_data->auth->management_fqdn, "manage.office.com");
     assert_string_equal(module_data->auth->next->tenant_id, "your_tenant_id_1");
     assert_string_equal(module_data->auth->next->client_id, "your_client_id_1");
-    assert_string_equal(module_data->auth->next->client_secret_path, "/path/to/secret");
+    assert_string_equal(module_data->auth->next->client_secret, "your_secret_1");
+    assert_string_equal(module_data->auth->next->login_fqdn, "login.microsoftonline.com");
+    assert_string_equal(module_data->auth->next->management_fqdn, "manage-gcc.office.com");
+    assert_string_equal(module_data->auth->next->next->tenant_id, "your_tenant_id_2");
+    assert_string_equal(module_data->auth->next->next->client_id, "your_client_id_2");
+    assert_string_equal(module_data->auth->next->next->client_secret_path, "/path/to/secret");
+    assert_string_equal(module_data->auth->next->next->login_fqdn, "login.microsoftonline.us");
+    assert_string_equal(module_data->auth->next->next->management_fqdn, "manage.office365.us");
     assert_string_equal(module_data->subscription->subscription_name, "Audit.AzureActiveDirectory");
     assert_string_equal(module_data->subscription->next->subscription_name, "Audit.Exchange");
     assert_string_equal(module_data->subscription->next->next->subscription_name, "Audit.SharePoint");
@@ -223,6 +246,7 @@ void test_read_default_configuration(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
     ;
     test_structure *test = *state;
@@ -241,6 +265,7 @@ void test_read_interval(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -261,6 +286,8 @@ void test_read_interval(void **state) {
     assert_string_equal(module_data->auth->tenant_id, "your_tenant_id");
     assert_string_equal(module_data->auth->client_id, "your_client_id");
     assert_string_equal(module_data->auth->client_secret, "your_secret");
+    assert_string_equal(module_data->auth->login_fqdn, "login.microsoftonline.com");
+    assert_string_equal(module_data->auth->management_fqdn, "manage.office.com");
     assert_string_equal(module_data->subscription->subscription_name, "Audit.AzureActiveDirectory");
     assert_string_equal(module_data->subscription->next->subscription_name, "Audit.Exchange");
     assert_string_equal(module_data->subscription->next->next->subscription_name, "Audit.SharePoint");
@@ -278,6 +305,7 @@ void test_read_interval_s(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -304,6 +332,7 @@ void test_read_interval_s_fail(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -329,6 +358,7 @@ void test_read_interval_m(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -355,6 +385,7 @@ void test_read_interval_m_fail(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -380,6 +411,7 @@ void test_read_interval_h(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -406,6 +438,7 @@ void test_read_interval_h_fail(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -431,6 +464,7 @@ void test_read_interval_d(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -457,6 +491,7 @@ void test_read_interval_d_fail(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -482,6 +517,7 @@ void test_read_curl_max_size(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -502,6 +538,8 @@ void test_read_curl_max_size(void **state) {
     assert_string_equal(module_data->auth->tenant_id, "your_tenant_id");
     assert_string_equal(module_data->auth->client_id, "your_client_id");
     assert_string_equal(module_data->auth->client_secret, "your_secret");
+    assert_string_equal(module_data->auth->login_fqdn, "login.microsoftonline.com");
+    assert_string_equal(module_data->auth->management_fqdn, "manage.office.com");
     assert_string_equal(module_data->subscription->subscription_name, "Audit.AzureActiveDirectory");
     assert_string_equal(module_data->subscription->next->subscription_name, "Audit.Exchange");
     assert_string_equal(module_data->subscription->next->next->subscription_name, "Audit.SharePoint");
@@ -519,6 +557,7 @@ void test_read_curl_max_size_invalid_1(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -544,6 +583,7 @@ void test_read_curl_max_size_invalid_2(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -569,6 +609,7 @@ void test_read_curl_max_size_invalid_3(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -591,6 +632,7 @@ void test_secret_path_and_secret(void **state) {
             "<client_id>your_client_id</client_id>"
             "<client_secret_path>/path/to/secret</client_secret_path>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
     ;
     test_structure *test = *state;
@@ -609,6 +651,7 @@ void test_fake_tag(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -635,6 +678,7 @@ void test_fake_tag_1(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -661,6 +705,7 @@ void test_invalid_content_1(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription></subscription>"
@@ -686,6 +731,7 @@ void test_invalid_content_2(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -711,6 +757,7 @@ void test_invalid_content_3(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -736,6 +783,7 @@ void test_invalid_content_4(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -759,6 +807,7 @@ void test_invalid_interval(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -800,6 +849,7 @@ void test_error_api_auth_1(void **state) {
             "<invalid>your_tenant_id</invalid>"
             "<invalid>your_client_id</invalid>"
             "<invalid>your_secret</invalid>"
+            "<invalid>commercial</invalid>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -823,6 +873,7 @@ void test_error_tenant_id(void **state) {
             "<tenant_id></tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -845,6 +896,7 @@ void test_error_tenant_id_1(void **state) {
         "<api_auth>"
             "<client_id>your_client_id</client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -868,6 +920,7 @@ void test_error_client_id(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id></client_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -890,6 +943,7 @@ void test_error_client_id_1(void **state) {
         "<api_auth>"
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_secret>your_secret</client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -913,6 +967,7 @@ void test_error_client_secret(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret></client_secret>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -935,6 +990,7 @@ void test_error_client_secret_1(void **state) {
         "<api_auth>"
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -950,7 +1006,7 @@ void test_error_client_secret_1(void **state) {
     assert_int_equal(wm_office365_read(&(test->xml), test->nodes, test->module),-1);
 }
 
-void test_error_client_secret_path (void **state) {
+void test_error_client_secret_path(void **state) {
     const char *string =
         "<enabled>yes</enabled>\n"
         "<interval>10</interval>"
@@ -958,6 +1014,7 @@ void test_error_client_secret_path (void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret_path>/path/to/secret</client_secret_path>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -970,7 +1027,7 @@ void test_error_client_secret_path (void **state) {
     test_structure *test = *state;
     expect_string(__wrap_access, __name, "/path/to/secret");
     will_return(__wrap_access, -1);
-    expect_string(__wrap__merror, formatted_msg, "At module 'office365': The path cannot be opened.");
+    expect_string(__wrap__merror, formatted_msg, "Invalid content for tag 'office365': The path cannot be opened.");
     test->nodes = string_to_xml_node(string, &(test->xml));
     assert_int_equal(wm_office365_read(&(test->xml), test->nodes, test->module),-1);
 }
@@ -983,6 +1040,7 @@ void test_error_client_secret_path_1(void **state) {
             "<tenant_id>your_tenant_id</tenant_id>"
             "<client_id>your_client_id</client_id>"
             "<client_secret_path></client_secret_path>"
+            "<api_type>commercial</api_type>"
         "</api_auth>"
         "<subscriptions>"
             "<subscription>Audit.AzureActiveDirectory</subscription>"
@@ -1043,11 +1101,13 @@ void test_wm_office365_dump_yes_options(void **state) {
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret_path", data->office365_config->auth->client_secret_path);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
+    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
 
-    char *test = "{\"office365\":{\"enabled\":\"yes\",\"only_future_events\":\"yes\",\"interval\":10,\"api_auth\":[{\"tenant_id\":\"test_tenant_id\",\"client_id\":\"test_client_id\",\"client_secret_path\":\"test_client_secret_path\",\"client_secret\":\"test_client_secret\"}],\"subscriptions\":[\"test_subscription_name\"]}}";
+    char *test = "{\"office365\":{\"enabled\":\"yes\",\"only_future_events\":\"yes\",\"interval\":10,\"api_auth\":[{\"tenant_id\":\"test_tenant_id\",\"client_id\":\"test_client_id\",\"client_secret_path\":\"test_client_secret_path\",\"client_secret\":\"test_client_secret\",\"api_type\":\"commercial\"}],\"subscriptions\":[\"test_subscription_name\"]}}";
 
     cJSON *root = wm_office365_dump(data->office365_config);
     data->root_c = cJSON_PrintUnformatted(root);
@@ -1092,6 +1152,8 @@ void test_wm_office365_main_enable(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
+    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
     data->office365_config->only_future_events = 1;
@@ -1150,6 +1212,8 @@ void test_wm_office365_get_access_token_with_auth_secret(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
+    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -1185,6 +1249,8 @@ void test_wm_office365_get_access_token_with_auth_secret_path(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret_path", data->office365_config->auth->client_secret_path);
+    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
+    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -1217,6 +1283,8 @@ void test_wm_office365_get_access_token_with_auth_secret_response_400(void **sta
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
+    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(curl_response), data->response);
     data->response->status_code = 400;
@@ -1259,6 +1327,8 @@ void test_wm_office365_get_access_token_with_auth_secret_response_null(void **st
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
+    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(curl_response), data->response);
     data->response->status_code = 400;
@@ -1298,6 +1368,8 @@ void test_wm_office365_get_access_token_with_auth_secret_response_max_size_reach
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
+    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(curl_response), data->response);
     data->response->status_code = 400;
@@ -1340,6 +1412,8 @@ void test_wm_office365_get_access_token_with_auth_secret_error_json_response(voi
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
+    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(curl_response), data->response);
     data->response->status_code = 400;
@@ -1381,6 +1455,8 @@ void test_wm_office365_get_access_token_with_auth_secret_response_200(void **sta
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
+    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(curl_response), data->response);
     data->response->status_code = 200;
@@ -1425,6 +1501,8 @@ void test_wm_office365_manage_subscription_start_response_null(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
+    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
@@ -1476,6 +1554,8 @@ void test_wm_office365_manage_subscription_start_code_200(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
+    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
@@ -1527,6 +1607,8 @@ void test_wm_office365_manage_subscription_stop_error_json_response(void **state
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
+    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
@@ -1580,6 +1662,8 @@ void test_wm_office365_manage_subscription_stop_error_max_size_reached(void **st
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
+    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
@@ -1634,6 +1718,8 @@ void test_wm_office365_manage_subscription_stop_code_400_error_AF20024(void **st
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
+    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
@@ -1685,6 +1771,8 @@ void test_wm_office365_manage_subscription_stop_code_400_error_different_AF20024
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
+    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
@@ -2404,6 +2492,8 @@ void test_wm_office365_execute_scan_all(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
+    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
     data->office365_config->auth->next = NULL;
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
@@ -2556,6 +2646,8 @@ void test_wm_office365_execute_scan_initial_scan_only_future_events(void **state
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
+    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
     data->office365_config->only_future_events = 1;
@@ -2598,6 +2690,8 @@ void test_wm_office365_execute_scan_access_token_null(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
+    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
     data->office365_config->only_future_events = 1;
@@ -2643,6 +2737,8 @@ void test_wm_office365_execute_scan_manage_subscription_error(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
+    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
     data->office365_config->only_future_events = 0;
@@ -2708,6 +2804,8 @@ void test_wm_office365_execute_scan_saving_running_state_error(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
+    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
@@ -2767,6 +2865,8 @@ void test_wm_office365_execute_scan_content_blobs_fail(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
+    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
     data->office365_config->only_future_events = 0;
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
@@ -2868,6 +2968,8 @@ void test_wm_office365_execute_scan_get_logs_from_blob_response_null(void **stat
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
+    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
     data->office365_config->only_future_events = 0;

--- a/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
+++ b/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
@@ -1543,6 +1543,7 @@ void test_wm_office365_manage_subscription_start_response_null(void **state) {
 
     char *token = "test_token";
     char* client_id = "test_client_id";
+    char* management_fqdn = "manage.office.com";
     int start = 1;
 
     os_calloc(1, sizeof(wm_office365_auth), data->office365_config->auth);
@@ -1578,7 +1579,7 @@ void test_wm_office365_manage_subscription_start_response_null(void **state) {
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:office365");
     expect_string(__wrap__mtdebug1, formatted_msg, "Unknown error while managing subscription.");
 
-    value = wm_office365_manage_subscription(data->office365_config->subscription, client_id, token, start, max_size, &error_msg);
+    value = wm_office365_manage_subscription(data->office365_config->subscription, management_fqdn, client_id, token, start, max_size, &error_msg);
 
     assert_int_equal(value, OS_INVALID);
     assert_null(error_msg);
@@ -1596,6 +1597,7 @@ void test_wm_office365_manage_subscription_start_code_200(void **state) {
 
     char *token = "test_token";
     char* client_id = "test_client_id";
+    char* management_fqdn = "manage.office.com";
     int start = 1;
 
     os_calloc(1, sizeof(wm_office365_auth), data->office365_config->auth);
@@ -1631,7 +1633,7 @@ void test_wm_office365_manage_subscription_start_code_200(void **state) {
 
     expect_value(__wrap_wurl_free_response, response, data->response);
 
-    value = wm_office365_manage_subscription(data->office365_config->subscription, client_id, token, start, max_size, &error_msg);
+    value = wm_office365_manage_subscription(data->office365_config->subscription, management_fqdn, client_id, token, start, max_size, &error_msg);
 
     assert_int_equal(value, OS_SUCCESS);
     assert_null(error_msg);
@@ -1649,6 +1651,7 @@ void test_wm_office365_manage_subscription_stop_error_json_response(void **state
 
     char *token = "test_token";
     char* client_id = "test_client_id";
+    char* management_fqdn = "manage.office.com";
     int start = 0;
 
     os_calloc(1, sizeof(wm_office365_auth), data->office365_config->auth);
@@ -1686,7 +1689,7 @@ void test_wm_office365_manage_subscription_stop_error_json_response(void **state
 
     expect_value(__wrap_wurl_free_response, response, data->response);
 
-    value = wm_office365_manage_subscription(data->office365_config->subscription, client_id, token, start, max_size, &error_msg);
+    value = wm_office365_manage_subscription(data->office365_config->subscription, management_fqdn, client_id, token, start, max_size, &error_msg);
 
     assert_int_equal(value, OS_INVALID);
     assert_null(error_msg);
@@ -1704,6 +1707,7 @@ void test_wm_office365_manage_subscription_stop_error_max_size_reached(void **st
 
     char *token = "test_token";
     char* client_id = "test_client_id";
+    char* management_fqdn = "manage.office.com";
     int start = 0;
 
     os_calloc(1, sizeof(wm_office365_auth), data->office365_config->auth);
@@ -1742,7 +1746,7 @@ void test_wm_office365_manage_subscription_stop_error_max_size_reached(void **st
 
     expect_value(__wrap_wurl_free_response, response, data->response);
 
-    value = wm_office365_manage_subscription(data->office365_config->subscription, client_id, token, start, max_size, &error_msg);
+    value = wm_office365_manage_subscription(data->office365_config->subscription, management_fqdn, client_id, token, start, max_size, &error_msg);
 
     assert_int_equal(value, OS_INVALID);
     assert_null(error_msg);
@@ -1760,6 +1764,7 @@ void test_wm_office365_manage_subscription_stop_code_400_error_AF20024(void **st
 
     char *token = "test_token";
     char* client_id = "test_client_id";
+    char* management_fqdn = "manage.office.com";
     int start = 0;
 
     os_calloc(1, sizeof(wm_office365_auth), data->office365_config->auth);
@@ -1795,7 +1800,7 @@ void test_wm_office365_manage_subscription_stop_code_400_error_AF20024(void **st
 
     expect_value(__wrap_wurl_free_response, response, data->response);
 
-    value = wm_office365_manage_subscription(data->office365_config->subscription, client_id, token, start, max_size, &error_msg);
+    value = wm_office365_manage_subscription(data->office365_config->subscription, management_fqdn, client_id, token, start, max_size, &error_msg);
 
     assert_int_equal(value, OS_SUCCESS);
     assert_null(error_msg);
@@ -1813,6 +1818,7 @@ void test_wm_office365_manage_subscription_stop_code_400_error_different_AF20024
 
     char *token = "test_token";
     char* client_id = "test_client_id";
+    char* management_fqdn = "manage.office.com";
     int start = 0;
 
     os_calloc(1, sizeof(wm_office365_auth), data->office365_config->auth);
@@ -1850,7 +1856,7 @@ void test_wm_office365_manage_subscription_stop_code_400_error_different_AF20024
 
     expect_value(__wrap_wurl_free_response, response, data->response);
 
-    value = wm_office365_manage_subscription(data->office365_config->subscription, client_id, token, start, max_size, &error_msg);
+    value = wm_office365_manage_subscription(data->office365_config->subscription, management_fqdn, client_id, token, start, max_size, &error_msg);
 
     assert_int_equal(value, OS_INVALID);
     assert_string_equal(error_msg, data->response->body);

--- a/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
+++ b/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
@@ -102,8 +102,17 @@ static int teardown_test_read(void **state) {
                 os_free(((wm_office365*)test->module->data)->auth->next->client_id);
                 os_free(((wm_office365*)test->module->data)->auth->next->client_secret_path);
                 os_free(((wm_office365*)test->module->data)->auth->next->client_secret);
-                os_free(((wm_office365*)test->module->data)->auth->login_fqdn);
-                os_free(((wm_office365*)test->module->data)->auth->management_fqdn);
+                os_free(((wm_office365*)test->module->data)->auth->next->login_fqdn);
+                os_free(((wm_office365*)test->module->data)->auth->next->management_fqdn);
+                os_free(((wm_office365*)test->module->data)->auth->next->next);
+            }
+            if (((wm_office365*)test->module->data)->auth->next->next) {
+                os_free(((wm_office365*)test->module->data)->auth->next->next->tenant_id);
+                os_free(((wm_office365*)test->module->data)->auth->next->next->client_id);
+                os_free(((wm_office365*)test->module->data)->auth->next->next->client_secret_path);
+                os_free(((wm_office365*)test->module->data)->auth->next->next->client_secret);
+                os_free(((wm_office365*)test->module->data)->auth->next->next->login_fqdn);
+                os_free(((wm_office365*)test->module->data)->auth->next->next->management_fqdn);
                 os_free(((wm_office365*)test->module->data)->auth->next->next);
             }
             os_free(((wm_office365*)test->module->data)->auth->next);

--- a/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
+++ b/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
@@ -95,24 +95,18 @@ static int teardown_test_read(void **state) {
             os_free(((wm_office365*)test->module->data)->auth->client_id);
             os_free(((wm_office365*)test->module->data)->auth->client_secret_path);
             os_free(((wm_office365*)test->module->data)->auth->client_secret);
-            os_free(((wm_office365*)test->module->data)->auth->login_fqdn);
-            os_free(((wm_office365*)test->module->data)->auth->management_fqdn);
             if (((wm_office365*)test->module->data)->auth->next) {
                 os_free(((wm_office365*)test->module->data)->auth->next->tenant_id);
                 os_free(((wm_office365*)test->module->data)->auth->next->client_id);
                 os_free(((wm_office365*)test->module->data)->auth->next->client_secret_path);
                 os_free(((wm_office365*)test->module->data)->auth->next->client_secret);
-                os_free(((wm_office365*)test->module->data)->auth->next->login_fqdn);
-                os_free(((wm_office365*)test->module->data)->auth->next->management_fqdn);
-                os_free(((wm_office365*)test->module->data)->auth->next->next);
-            }
-            if (((wm_office365*)test->module->data)->auth->next->next) {
-                os_free(((wm_office365*)test->module->data)->auth->next->next->tenant_id);
-                os_free(((wm_office365*)test->module->data)->auth->next->next->client_id);
-                os_free(((wm_office365*)test->module->data)->auth->next->next->client_secret_path);
-                os_free(((wm_office365*)test->module->data)->auth->next->next->client_secret);
-                os_free(((wm_office365*)test->module->data)->auth->next->next->login_fqdn);
-                os_free(((wm_office365*)test->module->data)->auth->next->next->management_fqdn);
+                if (((wm_office365*)test->module->data)->auth->next->next) {
+                    os_free(((wm_office365*)test->module->data)->auth->next->next->tenant_id);
+                    os_free(((wm_office365*)test->module->data)->auth->next->next->client_id);
+                    os_free(((wm_office365*)test->module->data)->auth->next->next->client_secret_path);
+                    os_free(((wm_office365*)test->module->data)->auth->next->next->client_secret);
+                    os_free(((wm_office365*)test->module->data)->auth->next->next->next);
+                }
                 os_free(((wm_office365*)test->module->data)->auth->next->next);
             }
             os_free(((wm_office365*)test->module->data)->auth->next);
@@ -176,8 +170,8 @@ void test_read_configuration(void **state) {
     assert_string_equal(module_data->auth->tenant_id, "your_tenant_id");
     assert_string_equal(module_data->auth->client_id, "your_client_id");
     assert_string_equal(module_data->auth->client_secret, "your_secret");
-    assert_string_equal(module_data->auth->login_fqdn, "login.microsoftonline.com"); // retrocompatability check
-    assert_string_equal(module_data->auth->management_fqdn, "manage.office.com"); // retrocompatability check
+    assert_string_equal(module_data->auth->login_fqdn, "login.microsoftonline.com"); // retrocompatability test
+    assert_string_equal(module_data->auth->management_fqdn, "manage.office.com"); // retrocompatability test
     assert_string_equal(module_data->subscription->subscription_name, "Audit.AzureActiveDirectory");
     assert_string_equal(module_data->subscription->next->subscription_name, "Audit.Exchange");
     assert_string_equal(module_data->subscription->next->next->subscription_name, "Audit.SharePoint");

--- a/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
+++ b/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
@@ -1056,6 +1056,54 @@ void test_error_client_secret_path_1(void **state) {
     assert_int_equal(wm_office365_read(&(test->xml), test->nodes, test->module),-1);
 }
 
+void test_error_api_type(void **state) {
+    const char *string =
+        "<enabled>yes</enabled>\n"
+        "<interval>10</interval>"
+        "<api_auth>"
+            "<tenant_id>your_tenant_id</tenant_id>"
+            "<client_id>your_client_id</client_id>"
+            "<client_secret>your_secret</client_secret>"
+            "<api_type>invalid</api_type>"
+        "</api_auth>"
+        "<subscriptions>"
+            "<subscription>Audit.AzureActiveDirectory</subscription>"
+            "<subscription>Audit.Exchange</subscription>"
+            "<subscription>Audit.SharePoint</subscription>"
+            "<subscription>Audit.General</subscription>"
+            "<subscription>DLP.All</subscription>"
+        "</subscriptions>"
+    ;
+    test_structure *test = *state;
+    expect_string(__wrap__merror, formatted_msg, "Invalid content for tag 'api_type' at module 'office365'.");
+    test->nodes = string_to_xml_node(string, &(test->xml));
+    assert_int_equal(wm_office365_read(&(test->xml), test->nodes, test->module),-1);
+}
+
+void test_error_api_type_1(void **state) {
+    const char *string =
+        "<enabled>yes</enabled>\n"
+        "<interval>10</interval>"
+        "<api_auth>"
+            "<tenant_id>your_tenant_id</tenant_id>"
+            "<client_id>your_client_id</client_id>"
+            "<client_secret>your_secret</client_secret>"
+            "<api_type></api_type>"
+        "</api_auth>"
+        "<subscriptions>"
+            "<subscription>Audit.AzureActiveDirectory</subscription>"
+            "<subscription>Audit.Exchange</subscription>"
+            "<subscription>Audit.SharePoint</subscription>"
+            "<subscription>Audit.General</subscription>"
+            "<subscription>DLP.All</subscription>"
+        "</subscriptions>"
+    ;
+    test_structure *test = *state;
+    expect_string(__wrap__merror, formatted_msg, "Empty content for tag 'api_type' at module 'office365'.");
+    test->nodes = string_to_xml_node(string, &(test->xml));
+    assert_int_equal(wm_office365_read(&(test->xml), test->nodes, test->module),-1);
+}
+
 void test_wm_office365_dump_no_options(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     char *test = "{\"office365\":{\"enabled\":\"no\",\"only_future_events\":\"no\"}}";
@@ -3129,6 +3177,8 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_error_client_secret_1, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_error_client_secret_path, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_error_client_secret_path_1, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_error_api_type, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_error_api_type_1, setup_test_read, teardown_test_read),
     };
     const struct CMUnitTest tests_functionality[] = {
         cmocka_unit_test_setup_teardown(test_wm_office365_main_disabled, setup_conf, teardown_conf),

--- a/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
+++ b/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
@@ -176,8 +176,8 @@ void test_read_configuration(void **state) {
     assert_string_equal(module_data->auth->tenant_id, "your_tenant_id");
     assert_string_equal(module_data->auth->client_id, "your_client_id");
     assert_string_equal(module_data->auth->client_secret, "your_secret");
-    assert_string_equal(module_data->auth->login_fqdn, "login.microsoftonline.com"); // retrocompatability test
-    assert_string_equal(module_data->auth->management_fqdn, "manage.office.com"); // retrocompatability test
+    assert_string_equal(module_data->auth->login_fqdn, WM_OFFICE365_DEFAULT_API_LOGIN_FQDN); // retrocompatability test
+    assert_string_equal(module_data->auth->management_fqdn, WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN); // retrocompatability test
     assert_string_equal(module_data->subscription->subscription_name, "Audit.AzureActiveDirectory");
     assert_string_equal(module_data->subscription->next->subscription_name, "Audit.Exchange");
     assert_string_equal(module_data->subscription->next->next->subscription_name, "Audit.SharePoint");
@@ -230,18 +230,18 @@ void test_read_configuration_1(void **state) {
     assert_string_equal(module_data->auth->tenant_id, "your_tenant_id");
     assert_string_equal(module_data->auth->client_id, "your_client_id");
     assert_string_equal(module_data->auth->client_secret, "your_secret");
-    assert_string_equal(module_data->auth->login_fqdn, "login.microsoftonline.com");
-    assert_string_equal(module_data->auth->management_fqdn, "manage.office.com");
+    assert_string_equal(module_data->auth->login_fqdn, WM_OFFICE365_DEFAULT_API_LOGIN_FQDN);
+    assert_string_equal(module_data->auth->management_fqdn, WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN);
     assert_string_equal(module_data->auth->next->tenant_id, "your_tenant_id_1");
     assert_string_equal(module_data->auth->next->client_id, "your_client_id_1");
     assert_string_equal(module_data->auth->next->client_secret, "your_secret_1");
-    assert_string_equal(module_data->auth->next->login_fqdn, "login.microsoftonline.com");
-    assert_string_equal(module_data->auth->next->management_fqdn, "manage-gcc.office.com");
+    assert_string_equal(module_data->auth->next->login_fqdn, WM_OFFICE365_GCC_API_LOGIN_FQDN);
+    assert_string_equal(module_data->auth->next->management_fqdn, WM_OFFICE365_GCC_API_MANAGEMENT_FQDN);
     assert_string_equal(module_data->auth->next->next->tenant_id, "your_tenant_id_2");
     assert_string_equal(module_data->auth->next->next->client_id, "your_client_id_2");
     assert_string_equal(module_data->auth->next->next->client_secret_path, "/path/to/secret");
-    assert_string_equal(module_data->auth->next->next->login_fqdn, "login.microsoftonline.us");
-    assert_string_equal(module_data->auth->next->next->management_fqdn, "manage.office365.us");
+    assert_string_equal(module_data->auth->next->next->login_fqdn, WM_OFFICE365_GCC_HIGH_API_LOGIN_FQDN);
+    assert_string_equal(module_data->auth->next->next->management_fqdn, WM_OFFICE365_GCC_HIGH_API_MANAGEMENT_FQDN);
     assert_string_equal(module_data->subscription->subscription_name, "Audit.AzureActiveDirectory");
     assert_string_equal(module_data->subscription->next->subscription_name, "Audit.Exchange");
     assert_string_equal(module_data->subscription->next->next->subscription_name, "Audit.SharePoint");
@@ -295,8 +295,8 @@ void test_read_interval(void **state) {
     assert_string_equal(module_data->auth->tenant_id, "your_tenant_id");
     assert_string_equal(module_data->auth->client_id, "your_client_id");
     assert_string_equal(module_data->auth->client_secret, "your_secret");
-    assert_string_equal(module_data->auth->login_fqdn, "login.microsoftonline.com");
-    assert_string_equal(module_data->auth->management_fqdn, "manage.office.com");
+    assert_string_equal(module_data->auth->login_fqdn, WM_OFFICE365_DEFAULT_API_LOGIN_FQDN);
+    assert_string_equal(module_data->auth->management_fqdn, WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN);
     assert_string_equal(module_data->subscription->subscription_name, "Audit.AzureActiveDirectory");
     assert_string_equal(module_data->subscription->next->subscription_name, "Audit.Exchange");
     assert_string_equal(module_data->subscription->next->next->subscription_name, "Audit.SharePoint");
@@ -547,8 +547,8 @@ void test_read_curl_max_size(void **state) {
     assert_string_equal(module_data->auth->tenant_id, "your_tenant_id");
     assert_string_equal(module_data->auth->client_id, "your_client_id");
     assert_string_equal(module_data->auth->client_secret, "your_secret");
-    assert_string_equal(module_data->auth->login_fqdn, "login.microsoftonline.com");
-    assert_string_equal(module_data->auth->management_fqdn, "manage.office.com");
+    assert_string_equal(module_data->auth->login_fqdn, WM_OFFICE365_DEFAULT_API_LOGIN_FQDN);
+    assert_string_equal(module_data->auth->management_fqdn, WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN);
     assert_string_equal(module_data->subscription->subscription_name, "Audit.AzureActiveDirectory");
     assert_string_equal(module_data->subscription->next->subscription_name, "Audit.Exchange");
     assert_string_equal(module_data->subscription->next->next->subscription_name, "Audit.SharePoint");
@@ -1158,8 +1158,8 @@ void test_wm_office365_dump_yes_options(void **state) {
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret_path", data->office365_config->auth->client_secret_path);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
-    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
-    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
@@ -1209,8 +1209,8 @@ void test_wm_office365_main_enable(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
-    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
-    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
     data->office365_config->only_future_events = 1;
@@ -1269,8 +1269,8 @@ void test_wm_office365_get_access_token_with_auth_secret(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
-    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
-    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -1306,8 +1306,8 @@ void test_wm_office365_get_access_token_with_auth_secret_path(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret_path", data->office365_config->auth->client_secret_path);
-    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
-    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -1340,8 +1340,8 @@ void test_wm_office365_get_access_token_with_auth_secret_response_400(void **sta
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
-    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
-    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(curl_response), data->response);
     data->response->status_code = 400;
@@ -1384,8 +1384,8 @@ void test_wm_office365_get_access_token_with_auth_secret_response_null(void **st
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
-    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
-    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(curl_response), data->response);
     data->response->status_code = 400;
@@ -1425,8 +1425,8 @@ void test_wm_office365_get_access_token_with_auth_secret_response_max_size_reach
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
-    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
-    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(curl_response), data->response);
     data->response->status_code = 400;
@@ -1469,8 +1469,8 @@ void test_wm_office365_get_access_token_with_auth_secret_error_json_response(voi
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
-    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
-    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(curl_response), data->response);
     data->response->status_code = 400;
@@ -1512,8 +1512,8 @@ void test_wm_office365_get_access_token_with_auth_secret_response_200(void **sta
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
-    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
-    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(curl_response), data->response);
     data->response->status_code = 200;
@@ -1552,15 +1552,15 @@ void test_wm_office365_manage_subscription_start_response_null(void **state) {
 
     char *token = "test_token";
     char* client_id = "test_client_id";
-    char* management_fqdn = "manage.office.com";
+    char* management_fqdn = WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN;
     int start = 1;
 
     os_calloc(1, sizeof(wm_office365_auth), data->office365_config->auth);
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
-    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
-    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
@@ -1606,15 +1606,15 @@ void test_wm_office365_manage_subscription_start_code_200(void **state) {
 
     char *token = "test_token";
     char* client_id = "test_client_id";
-    char* management_fqdn = "manage.office.com";
+    char* management_fqdn = WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN;
     int start = 1;
 
     os_calloc(1, sizeof(wm_office365_auth), data->office365_config->auth);
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
-    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
-    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
@@ -1660,15 +1660,15 @@ void test_wm_office365_manage_subscription_stop_error_json_response(void **state
 
     char *token = "test_token";
     char* client_id = "test_client_id";
-    char* management_fqdn = "manage.office.com";
+    char* management_fqdn = WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN;
     int start = 0;
 
     os_calloc(1, sizeof(wm_office365_auth), data->office365_config->auth);
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
-    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
-    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
@@ -1716,15 +1716,15 @@ void test_wm_office365_manage_subscription_stop_error_max_size_reached(void **st
 
     char *token = "test_token";
     char* client_id = "test_client_id";
-    char* management_fqdn = "manage.office.com";
+    char* management_fqdn = WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN;
     int start = 0;
 
     os_calloc(1, sizeof(wm_office365_auth), data->office365_config->auth);
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
-    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
-    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
@@ -1773,15 +1773,15 @@ void test_wm_office365_manage_subscription_stop_code_400_error_AF20024(void **st
 
     char *token = "test_token";
     char* client_id = "test_client_id";
-    char* management_fqdn = "manage.office.com";
+    char* management_fqdn = WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN;
     int start = 0;
 
     os_calloc(1, sizeof(wm_office365_auth), data->office365_config->auth);
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
-    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
-    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
@@ -1827,15 +1827,15 @@ void test_wm_office365_manage_subscription_stop_code_400_error_different_AF20024
 
     char *token = "test_token";
     char* client_id = "test_client_id";
-    char* management_fqdn = "manage.office.com";
+    char* management_fqdn = WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN;
     int start = 0;
 
     os_calloc(1, sizeof(wm_office365_auth), data->office365_config->auth);
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
-    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
-    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
@@ -2555,8 +2555,8 @@ void test_wm_office365_execute_scan_all(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
-    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
-    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
     data->office365_config->auth->next = NULL;
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
@@ -2595,7 +2595,8 @@ void test_wm_office365_execute_scan_all(void **state) {
     will_return(__wrap_wurl_http_request, data->response);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:office365");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Office 365 API access token URL: 'https://login.microsoftonline.com/test_tenant_id/oauth2/v2.0/token'");
+    const char expected_token_url[] = "Office 365 API access token URL: 'https://" WM_OFFICE365_DEFAULT_API_LOGIN_FQDN "/test_tenant_id/oauth2/v2.0/token'";
+    expect_string(__wrap__mtdebug1, formatted_msg, expected_token_url);
 
     expect_value(__wrap_wurl_free_response, response, data->response);
 
@@ -2620,7 +2621,8 @@ void test_wm_office365_execute_scan_all(void **state) {
     will_return(__wrap_wurl_http_request, data->response);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:office365");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Office 365 API subscription URL: 'https://manage.office.com/api/v1.0/test_client_id/activity/feed/subscriptions/start?contentType=test_subscription_name'");
+    const char expected_subscription_url[] = "Office 365 API subscription URL: 'https://" WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN "/api/v1.0/test_client_id/activity/feed/subscriptions/start?contentType=test_subscription_name'";
+    expect_string(__wrap__mtdebug1, formatted_msg, expected_subscription_url);
 
     #ifndef WIN32
         will_return(__wrap_gmtime_r, 1);
@@ -2649,7 +2651,8 @@ void test_wm_office365_execute_scan_all(void **state) {
     expect_any(__wrap__mdebug1, formatted_msg);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:office365");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Office 365 API content blobs URL: 'https://manage.office.com/api/v1.0/test_client_id/activity/feed/subscriptions/content?contentType=test_subscription_name&startTime=2021-05-07 12:24:56&endTime=2021-05-07 12:24:56'");
+    const char expected_blob_url[] = "Office 365 API content blobs URL: 'https://" WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN "/api/v1.0/test_client_id/activity/feed/subscriptions/content?contentType=test_subscription_name&startTime=2021-05-07 12:24:56&endTime=2021-05-07 12:24:56'";
+    expect_string(__wrap__mtdebug1, formatted_msg, expected_blob_url);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:office365");
     expect_string(__wrap__mtdebug1, formatted_msg, "Office 365 API content URI: 'https://contentUri1.com'");
@@ -2709,8 +2712,8 @@ void test_wm_office365_execute_scan_initial_scan_only_future_events(void **state
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
-    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
-    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
     data->office365_config->only_future_events = 1;
@@ -2753,8 +2756,8 @@ void test_wm_office365_execute_scan_access_token_null(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
-    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
-    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
     data->office365_config->only_future_events = 1;
@@ -2800,8 +2803,8 @@ void test_wm_office365_execute_scan_manage_subscription_error(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
-    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
-    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
     data->office365_config->only_future_events = 0;
@@ -2867,8 +2870,8 @@ void test_wm_office365_execute_scan_saving_running_state_error(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
-    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
-    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
@@ -2928,8 +2931,8 @@ void test_wm_office365_execute_scan_content_blobs_fail(void **state) {
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
-    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
-    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
     data->office365_config->only_future_events = 0;
 
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
@@ -3031,8 +3034,8 @@ void test_wm_office365_execute_scan_get_logs_from_blob_response_null(void **stat
     os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
     os_strdup("test_client_id", data->office365_config->auth->client_id);
     os_strdup("test_client_secret", data->office365_config->auth->client_secret);
-    os_strdup("login.microsoftonline.com", data->office365_config->auth->login_fqdn);
-    os_strdup("manage.office.com", data->office365_config->auth->management_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
     os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
     os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
     data->office365_config->only_future_events = 0;

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -178,8 +178,6 @@ void wm_office365_auth_destroy(wm_office365_auth* office365_auth) {
         os_free(current->client_id);
         os_free(current->client_secret_path);
         os_free(current->client_secret);
-        os_free(current->login_fqdn);
-        os_free(current->management_fqdn);
         os_free(current);
         current = next;
     }

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -251,13 +251,16 @@ cJSON *wm_office365_dump(const wm_office365* office365_config) {
                 cJSON_AddStringToObject(api_auth, "client_secret", iter->client_secret);
             }
             // The management API FQDN is unique between API types, so the login FQDN can be safely ignored
-            if(iter->management_fqdn){
-                if(!strncmp(iter->management_fqdn, "manage.office.com", 17))
+            if (iter->management_fqdn) {
+                if (!strncmp(iter->management_fqdn, "manage.office.com", 17)) {
                     cJSON_AddStringToObject(api_auth, "api_type", "commercial");
-                if(!strncmp(iter->management_fqdn, "manage-gcc.office.com", 21))
+                }
+                if (!strncmp(iter->management_fqdn, "manage-gcc.office.com", 21)) {
                     cJSON_AddStringToObject(api_auth, "api_type", "gcc");
-                if(!strncmp(iter->management_fqdn, "manage.office365.us", 19))
+                }
+                if (!strncmp(iter->management_fqdn, "manage.office365.us", 19)) {
                     cJSON_AddStringToObject(api_auth, "api_type", "gcc-high");
+                }
             }
             cJSON_AddItemToArray(arr_auth, api_auth);
         }

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -541,7 +541,7 @@ STATIC char* wm_office365_get_access_token(wm_office365_auth* auth, size_t max_s
     }
 
     memset(auth_payload, '\0', OS_SIZE_8192);
-    snprintf(auth_payload, OS_SIZE_8192 -1, WM_OFFICE365_API_ACCESS_TOKEN_PAYLOAD, auth->client_id, current_auth->management_fqdn, auth_secret);
+    snprintf(auth_payload, OS_SIZE_8192 -1, WM_OFFICE365_API_ACCESS_TOKEN_PAYLOAD, auth->client_id, auth->management_fqdn, auth_secret);
 
     memset(url, '\0', OS_SIZE_8192);
     snprintf(url, OS_SIZE_8192 -1, WM_OFFICE365_API_ACCESS_TOKEN_URL, auth->login_fqdn, auth->tenant_id);

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -178,6 +178,8 @@ void wm_office365_auth_destroy(wm_office365_auth* office365_auth) {
         os_free(current->client_id);
         os_free(current->client_secret_path);
         os_free(current->client_secret);
+        os_free(current->login_fqdn);
+        os_free(current->management_fqdn);
         os_free(current);
         current = next;
     }

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -250,6 +250,15 @@ cJSON *wm_office365_dump(const wm_office365* office365_config) {
             if (iter->client_secret) {
                 cJSON_AddStringToObject(api_auth, "client_secret", iter->client_secret);
             }
+            // The management API FQDN is unique between API types, so the login FQDN can be safely ignored
+            if(iter->management_fqdn){
+                if(!strncmp(iter->management_fqdn, "manage.office.com", 17))
+                    cJSON_AddStringToObject(api_auth, "api_type", "commercial");
+                if(!strncmp(iter->management_fqdn, "manage-gcc.office.com", 21))
+                    cJSON_AddStringToObject(api_auth, "api_type", "gcc");
+                if(!strncmp(iter->management_fqdn, "manage.office365.us", 19))
+                    cJSON_AddStringToObject(api_auth, "api_type", "gcc-high");
+            }
             cJSON_AddItemToArray(arr_auth, api_auth);
         }
         if (cJSON_GetArraySize(arr_auth) > 0) {

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -60,6 +60,7 @@ STATIC char* wm_office365_get_access_token(wm_office365_auth* auth, size_t max_s
 /**
  * @brief Start/stop a subscription through Office365 API
  * @param subscription Office365 subscription node
+ * @param management_fqdn Office365 management API endpoint domain
  * @param client_id Client ID
  * @param token Authentication token
  * @param start Whether to start/end a subscription

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -252,13 +252,13 @@ cJSON *wm_office365_dump(const wm_office365* office365_config) {
             }
             // The management API FQDN is unique between API types, so the login FQDN can be safely ignored
             if (iter->management_fqdn) {
-                if (!strncmp(iter->management_fqdn, "manage.office.com", 17)) {
+                if (!strncmp(iter->management_fqdn, WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, 17)) {
                     cJSON_AddStringToObject(api_auth, "api_type", "commercial");
                 }
-                if (!strncmp(iter->management_fqdn, "manage-gcc.office.com", 21)) {
+                if (!strncmp(iter->management_fqdn, WM_OFFICE365_GCC_API_MANAGEMENT_FQDN, 21)) {
                     cJSON_AddStringToObject(api_auth, "api_type", "gcc");
                 }
-                if (!strncmp(iter->management_fqdn, "manage.office365.us", 19)) {
+                if (!strncmp(iter->management_fqdn, WM_OFFICE365_GCC_HIGH_API_MANAGEMENT_FQDN, 19)) {
                     cJSON_AddStringToObject(api_auth, "api_type", "gcc-high");
                 }
             }

--- a/src/wazuh_modules/wm_office365.h
+++ b/src/wazuh_modules/wm_office365.h
@@ -19,6 +19,8 @@
 #define WM_OFFICE365_DEFAULT_INTERVAL 60
 #define WM_OFFICE365_DEFAULT_CURL_MAX_SIZE 1048576L
 #define WM_OFFICE365_DEFAULT_CURL_REQUEST_TIMEOUT 60L
+#define WM_OFFICE365_DEFAULT_API_LOGIN_FQDN "login.microsoftonline.com"
+#define WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN "manage.office.com"
 
 #define WM_OFFICE365_MSG_DELAY 1000000 / wm_max_eps
 #define WM_OFFICE365_RETRIES_TO_SEND_ERROR 3
@@ -38,6 +40,8 @@ typedef struct wm_office365_auth {
     char *client_id;
     char *client_secret_path;
     char *client_secret;
+    char *login_fqdn;
+    char *management_fqdn;
     struct wm_office365_auth *next;
 } wm_office365_auth;
 

--- a/src/wazuh_modules/wm_office365.h
+++ b/src/wazuh_modules/wm_office365.h
@@ -26,11 +26,11 @@
 #define WM_OFFICE365_RETRIES_TO_SEND_ERROR 3
 #define WM_OFFICE365_NEXT_PAGE_REGEX "NextPageUri:\\s*(\\S+)"
 
-#define WM_OFFICE365_API_ACCESS_TOKEN_URL "https://login.microsoftonline.com/%s/oauth2/v2.0/token"
-#define WM_OFFICE365_API_SUBSCRIPTION_URL "https://manage.office.com/api/v1.0/%s/activity/feed/subscriptions/%s?contentType=%s"
-#define WM_OFFICE365_API_CONTENT_BLOB_URL "https://manage.office.com/api/v1.0/%s/activity/feed/subscriptions/content?contentType=%s&startTime=%s&endTime=%s"
+#define WM_OFFICE365_API_ACCESS_TOKEN_URL "https://%s/%s/oauth2/v2.0/token"
+#define WM_OFFICE365_API_SUBSCRIPTION_URL "https://%s/api/v1.0/%s/activity/feed/subscriptions/%s?contentType=%s"
+#define WM_OFFICE365_API_CONTENT_BLOB_URL "https://%s/api/v1.0/%s/activity/feed/subscriptions/content?contentType=%s&startTime=%s&endTime=%s"
 
-#define WM_OFFICE365_API_ACCESS_TOKEN_PAYLOAD "client_id=%s&scope=https://manage.office.com/.default&grant_type=client_credentials&client_secret=%s"
+#define WM_OFFICE365_API_ACCESS_TOKEN_PAYLOAD "client_id=%s&scope=https://%s/.default&grant_type=client_credentials&client_secret=%s"
 
 #define WM_OFFICE365_API_SUBSCRIPTION_START "start"
 #define WM_OFFICE365_API_SUBSCRIPTION_STOP "stop"

--- a/src/wazuh_modules/wm_office365.h
+++ b/src/wazuh_modules/wm_office365.h
@@ -22,6 +22,12 @@
 #define WM_OFFICE365_DEFAULT_API_LOGIN_FQDN "login.microsoftonline.com"
 #define WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN "manage.office.com"
 
+#define WM_OFFICE365_GCC_API_LOGIN_FQDN "login.microsoftonline.com"
+#define WM_OFFICE365_GCC_API_MANAGEMENT_FQDN "manage-gcc.office.com"
+
+#define WM_OFFICE365_GGC_HIGH_API_LOGIN_FQDN "login.microsoftonline.us"
+#define WM_OFFICE365_GCC_HIGH_API_MANAGEMENT_FQDN "manage.office365.us"
+
 #define WM_OFFICE365_MSG_DELAY 1000000 / wm_max_eps
 #define WM_OFFICE365_RETRIES_TO_SEND_ERROR 3
 #define WM_OFFICE365_NEXT_PAGE_REGEX "NextPageUri:\\s*(\\S+)"


### PR DESCRIPTION
|Related issue|Manual testing|
|---|---|
|Resolves #14029||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->
To provide additional context on the related issue, the Office365 module has several hard-coded API endpoints that are used to communicate with Microsoft 365/Azure tenants:
https://github.com/wazuh/wazuh/blob/6d972907c90cdfe709fa021d384519c02dd0b24a/src/wazuh_modules/wm_office365.h#L27-L31
However, these endpoints change depending on the MS 365 tenant's type/plan, e.g., commercial, government community cloud (GCC), or government community cloud high (GCC High). This makes it difficult for users to receive logs from GCC or GCC High tenants, as these endpoints cannot be changed without modifying the corresponding header file and rebuilding the Wazuh server from source. References on how these endpoints change between subscription plans can be found [here for the API endpoints](https://learn.microsoft.com/en-us/office/office-365-management-api/office-365-management-activity-api-reference) and [here for the authentication endpoint](https://learn.microsoft.com/en-us/azure/active-directory/develop/authentication-national-cloud).


## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR extends the Office365 module's functionality by providing a new configuration option, `api_type`, within the existing `api_auth` block. This new `api_type` parameter allows users to specify what kind of tenant they are using, from which the server can automatically select the appropriate endpoint FQDNs on a per-tenant basis. In the case that the `api_type` parameter is not provided in a tenant's `api_auth` block, the default value `commercial` is used, as its endpoints are the same as the current hard-coded ones, providing retrocompatibility.

Forks of the [wazuh-documentation](https://github.com/S-Bryce/wazuh-documentation/tree/dev-office365-gcc-support) and [wazuh-qa](https://github.com/S-Bryce/wazuh-qa/tree/dev-office365-gcc-support) repositories that update them vis-à-vis the new parameter have also been created. If this PR ends up being to everyone's liking, I would be happy to make additional PRs for those as well.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->
|Parameter|Allowed Values|
|---|---|
|api_auth\api_type|commercial, gcc, gcc-high|

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->
The examples below used an `api_type` of `gcc-high` and were connected to a GCC High tenant for testing:
```
# tail /var/ossec/logs/ossec.log | grep office365
2022/09/27 08:57:15 wazuh-modulesd:office365[2788] wm_office365.c:498 at wm_office365_execute_scan(): DEBUG: Bookmark updated to '2022-09-27T13:57:15Z' for tenant 'xxxx-xxxx-xxxx-xxxx-xxxx' and subscription 'Audit.AzureActiveDirectory', waiting '60' seconds to run next scan.
2022/09/27 08:57:15 wazuh-modulesd:office365[2788] wm_office365.c:604 at wm_office365_manage_subscription(): DEBUG: Office 365 API subscription URL: 'https://manage.office365.us/api/v1.0/xxxx-xxxx-xxxx-xxxx-xxxx/activity/feed/subscriptions/start?contentType=Audit.Exchange'
2022/09/27 08:57:15 wazuh-modulesd:office365[2788] wm_office365.c:654 at wm_office365_get_content_blobs(): DEBUG: Office 365 API content blobs URL: 'https://manage.office365.us/api/v1.0/xxxx-xxxx-xxxx-xxxx-xxxx/activity/feed/subscriptions/content?contentType=Audit.Exchange&startTime=2022-09-27T13:56:13Z&endTime=2022-09-27T13:57:15Z'
```

```
{
  "_index": "wazuh-alerts-4.x-2022.09.20",
  "_type": "_doc",
  "_id": "NzQtXIMBGHI76S58Hc6p",
  "_version": 1,
  "_score": null,
  "_source": {
    "input": {
      "type": "log"
    },
    "agent": {
      "name": "IDUSLABGCC",
      "id": "000"
    },
    "manager": {
      "name": "IDUSLABGCC"
    },
    "data": {
      "integration": "office365",
      "office365": {
        "AzureActiveDirectoryEventType": "1",
        "UserKey": "xxxx-xxxx-xxxx-xxxx-xxxx",
        "ActorIpAddress": "xxx.xxx.xxx.xxx",
        "Operation": "UserLoggedIn",
        "OrganizationId": "xxxx-xxxx-xxxx-xxxx-xxxx",
        "ExtendedProperties": [
          {
            "Value": "Success",
            "Name": "ResultStatusDetail"
          },
          {
            "Value": "true",
            "Name": "KeepMeSignedIn"
          },
          {
            "Value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36",
            "Name": "UserAgent"
          },
          {
            "Value": "SAS:ProcessAuth",
            "Name": "RequestType"
          }
        ],
        "IntraSystemId": "xxxx-xxxx-xxxx-xxxx-xxxx",
        "Target": [
          {
            "Type": 0,
            "ID": "xxxx-xxxx-xxxx-xxxx-xxxx"
          }
        ],
        "RecordType": "15",
        "Version": "1",
        "ModifiedProperties": [],
        "Actor": [
          {
            "Type": 0,
            "ID": "xxxx-xxxx-xxxx-xxxx-xxxx"
          },
          {
            "Type": 5,
            "ID": "xxxx@xxxx.xxxx"
          }
        ],
        "DeviceProperties": [
          {
            "Value": "Windows 10",
            "Name": "OS"
          },
          {
            "Value": "Chrome",
            "Name": "BrowserType"
          },
          {
            "Value": "False",
            "Name": "IsCompliantAndManaged"
          },
          {
            "Value": "xxxx-xxxx-xxxx-xxxx-xxxx",
            "Name": "SessionId"
          }
        ],
        "Subscription": "Audit.AzureActiveDirectory",
        "ActorContextId": "xxxx-xxxx-xxxx-xxxx-xxxx",
        "ResultStatus": "Success",
        "ObjectId": "xxxx-xxxx-xxxx-xxxx-xxxx",
        "ErrorNumber": "50140",
        "ClientIP": "xxx.xxx.xxx.xxxx",
        "Workload": "AzureActiveDirectory",
        "UserId": "xxxx@xxxx.xxxx",
        "TargetContextId": "xxxx-xxxx-xxxx-xxxx-xxxx",
        "CreationTime": "2022-09-20T18:28:46",
        "Id": "xxxx-xxxx-xxxx-xxxx-xxxx",
        "InterSystemsId": "xxxx-xxxx-xxxx-xxxx-xxxx",
        "ApplicationId": "xxxx-xxxx-xxxx-xxxx-xxxx",
        "UserType": "0"
      }
    },
    "rule": {
      "firedtimes": 1,
      "mail": false,
      "level": 3,
      "hipaa": [
        "164.312.a.2.I",
        "164.312.b",
        "164.312.d",
        "164.312.e.2.II"
      ],
      "pci_dss": [
        "8.3",
        "10.6.1"
      ],
      "description": "Office 365: Secure Token Service (STS) logon events in Azure Active Directory.",
      "groups": [
        "office365",
        "AzureActiveDirectoryStsLogon"
      ],
      "id": "91545"
    },
    "location": "office365",
    "decoder": {
      "name": "json"
    },
    "id": "1663698801.564178",
    "GeoLocation": {
      "city_name": "xxxx",
      "country_name": "xxxx",
      "region_name": "xxxx",
      "location": {
        "lon": xxxx,
        "lat": xxxx
      }
    },
    "timestamp": "2022-09-20T13:33:21.447-0500"
  },
  "fields": {
    "timestamp": [
      "2022-09-20T18:33:21.447Z"
    ]
  },
  "highlight": {
    "data.office365.Operation": [
      "@opensearch-dashboards-highlighted-field@UserLoggedIn@/opensearch-dashboards-highlighted-field@"
    ],
    "data.integration": [
      "@opensearch-dashboards-highlighted-field@office365@/opensearch-dashboards-highlighted-field@"
    ]
  },
  "sort": [
    1663698801447
  ]
}
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Configuration on demand reports new parameters
- [x] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)

## Test Validation
### Unit Testing
![image](https://user-images.githubusercontent.com/89558443/221645933-f49670d2-9178-4f10-b2f9-686b0373fc97.png)
![image](https://user-images.githubusercontent.com/89558443/221645973-41b269fb-32c4-4f5a-a381-edf99a397c86.png)
![image](https://user-images.githubusercontent.com/89558443/221645996-3a6484ad-8c43-4234-9428-bbc8e89b59d9.png)
![image](https://user-images.githubusercontent.com/89558443/221646010-c8a1c898-d460-4611-8559-71f2ff6f333a.png)

### Valgrind (memory leak testing)
![image](https://user-images.githubusercontent.com/89558443/221646063-71aa22cf-ec55-4c3b-a570-10ad92a942b7.png)

### Coverage Report
![image](https://user-images.githubusercontent.com/89558443/221646119-20963686-839c-44f2-859b-a56c81cf25b3.png)
