### PR TITLE
Fix agent upgrade module settings parser to set a default CA file

### DIFF
--- a/src/config/wmodules-agent-upgrade.c
+++ b/src/config/wmodules-agent-upgrade.c
@@ -66,11 +66,7 @@ int wm_agent_upgrade_read(__attribute__((unused)) const OS_XML *xml, xml_node **
     }
     #endif
 
-    if (!nodes) {
-        return 0;
-    }
-
-    for(int i = 0; nodes[i]; i++)
+    for (int i = 0; nodes && nodes[i]; i++)
     {
         if(!nodes[i]->element) {
             merror(XML_ELEMNULL);


### PR DESCRIPTION
|Related issue|
|---|
|Fixes #14970|

This PR applies the fix proposed at #14970: let the agent upgrade module set a default CA file when:
- There is no modern `<agent-upgrade>` block in the configuration.
- CA verification is enabled.
- No CA file path is explicitly defined.

## Tests

### Legacy settings

<details><summary>🟢 Verification enabled and CA defined (default)</summary>

```xml
<active-response>
  <disabled>no</disabled>
  <ca_store>etc/wpk_root.pem</ca_store>
  <ca_verification>yes</ca_verification>
</active-response>
```

```json
{
  "enabled": "yes",
  "ca_verification": "yes",
  "ca_store": [
    "etc/wpk_root.pem"
  ]
}
```

</details>

<details><summary>🟣 Verification enabled but no CA defined</summary>

```xml
<active-response>
  <disabled>no</disabled>
  <!--ca_store>etc/wpk_root.pem</ca_store-->
  <ca_verification>yes</ca_verification>
</active-response>
```

```json
{
  "enabled": "yes",
  "ca_verification": "yes",
  "ca_store": [
    "etc/wpk_root.pem"
  ]
}
```

</details>

<details><summary>🟣 Verification disabled but CA defined</summary>

```xml
<active-response>
  <disabled>no</disabled>
  <ca_store>etc/wpk_root.pem</ca_store>
  <ca_verification>no</ca_verification>
</active-response>
```

```json
{
  "enabled": "yes",
  "ca_verification": "no"
}
```

</details>

<details><summary>🟢 No <code>&lt;active-response&gt;</code> block</summary>

```xml
<!--active-response>
  <disabled>no</disabled>
  <ca_store>etc/wpk_root.pem</ca_store>
  <ca_verification>yes</ca_verification>
</active-response-->
```

```json
{
  "enabled": "yes",
  "ca_verification": "yes",
  "ca_store": [
    "etc/wpk_root.pem"
  ]
}
```

</details>

### Modern settings

<details><summary>🟢 Verification disabled but CA defined</summary>

```xml
<agent-upgrade>
  <enabled>yes</enabled>
  <ca_verification>
    <enabled>no</enabled>
    <ca_store>etc/wpk_root.pem</ca_store>
  </ca_verification>
</agent-upgrade>
```

```json

{
  "enabled": "yes",
  "ca_verification": "no"
}
```

Now, the stored settings are coherent with the legacy configuration. The agent accepts any WPK with this configuration:

```
2022/09/28 10:44:12 wazuh-modulesd: WARNING: No root CA defined to verify file 'var/incoming/wazuh_agent_v4.3.8_linux_x86_64.wpk'.
```

</details>

#### Legend

🟢 The test passed before and after this fix.
🟣 The test failed before the fix and it works now.

### Memory tests

<details><summary>🟢 Run wazuh-modulesd on Valgrind</summary>

```
==14576== LEAK SUMMARY:
==14576==    definitely lost: 0 bytes in 0 blocks
==14576==    indirectly lost: 0 bytes in 0 blocks
==14576==      possibly lost: 1,152 bytes in 4 blocks
==14576==    still reachable: 80,120 bytes in 16 blocks
==14576==         suppressed: 0 bytes in 0 blocks
```

</details>