### PR TITLE
Removed create_table and init_db methods and reused inherited ones

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -631,23 +631,6 @@ class AWSBucket(WazuhIntegration):
             except Exception as e:
                 debug("+++ Error marking log {} as completed: {}".format(log_file['Key'], e), 2)
 
-    def create_table(self):
-        try:
-            debug('+++ Table does not exist; create', 1)
-            self.db_connector.execute(self.sql_create_table.format(table_name=self.db_table_name))
-        except Exception as e:
-            print("ERROR: Unable to create SQLite DB: {}".format(e))
-            sys.exit(6)
-
-    def init_db(self):
-        try:
-            tables = set(map(operator.itemgetter(0), self.db_connector.execute(self.sql_find_table_names)))
-        except Exception as e:
-            print("ERROR: Unexpected error accessing SQLite DB: {}".format(e))
-            sys.exit(5)
-        # DB does exist yet
-        if self.db_table_name not in tables:
-            self.create_table()
 
     def db_count_region(self, aws_account_id, aws_region):
         """Counts the number of rows in DB for a region
@@ -955,7 +938,7 @@ class AWSBucket(WazuhIntegration):
             exception_handler("Unkown error reading/parsing file {}: {}".format(log_key, e), 1)
 
     def iter_bucket(self, account_id, regions):
-        self.init_db()
+        self.init_db(self.sql_create_table.format(table_name=self.db_table_name))
         self.iter_regions_and_accounts(account_id, regions)
         self.db_connector.commit()
         self.db_connector.execute(self.sql_db_optimize)


### PR DESCRIPTION
|Related issue|
|---|
|#14851|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR closes #14851. Removes the methods `create_table` and `init_db` from `AWSBucket`, and reuse the same methods inherited from `WazuhIntegration`.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

### Unittests

```bash
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.9.9, pytest-5.4.3, py-1.11.0, pluggy-0.13.1
rootdir: /home/nstefani/git/wazuh
plugins: tavern-1.2.2, aiohttp-0.3.0, trio-0.7.0, cov-3.0.0, html-2.1.1, asyncio-0.15.1, metadata-2.0.1
collected 38 items

wodles/aws/tests/test_aws.py ......................................                                                                                                                                           [100%]

================================================================================================ 38 passed in 0.24s =================================================================================================
```

### Manual

After doing the change as we can see the module is working correctly.

```bash
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -s 2022-Feb-01 -p dev -d2
```

```bash
root@a03c3caf165f:/# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -s 2022-Feb-01 -d2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: Found configuration for connection retries in /root/.aws/config
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXX/CloudTrail/us-west-1/2022/02/01
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXX/CloudTrail/us-west-1/2022/02/11/XXXXXXXXX_CloudTrail_us-west-1_20220211T0000Z_HASDOtJxgfdNInHa.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXX/CloudTrail/us-west-1/2022/03/30/XXXXXXXXX_CloudTrail_us-west-1_20220330T0000Z_HASDoKlxgfdNInHa.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXX/CloudTrail/us-west-1/2022/03/30/XXXXXXXXX_CloudTrail_us-west-1_20220330T0000Z_HASDoKlxgfdNInHa.json.zip
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXX/CloudTrail/us-west-1/2022/03/30/XXXXXXXXX_CloudTrail_us-west-1_20220330T0000Z_HASDoKlxgfdkdIOa.json.txt
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on 166157449999 - us-west-1
DEBUG: +++ Marker: AWSLogs/166157449999/CloudTrail/us-west-1/2022/02/01
DEBUG: +++ No logs to process in bucket: 166157449999/us-west-1
DEBUG: +++ DB Maintenance
```

The DB table for the bucket type was created

```bash
root@a03c3caf165f:/# sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db "SELECT name FROM sqlite_master WHERE type='table';"
metadata
cloudtrail
sqlite_stat1
```