### PR TITLE
Improve command to change user and group from version 4.2.x to 4.x.x

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -143,7 +143,7 @@ Install()
 
     # If update, start Wazuh
     if [ "X${update_only}" = "Xyes" ]; then
-        WazuhUpgrade
+        WazuhUpgrade $INSTYPE
         # Update versions previous to Wazuh 1.2
         UpdateOldVersions
         echo "Starting Wazuh..."

--- a/src/init/wazuh/wazuh.sh
+++ b/src/init/wazuh/wazuh.sh
@@ -209,8 +209,13 @@ WazuhUpgrade()
     # Replace and delete ossec group along with ossec users
     OSSEC_GROUP=ossec
     if (grep "^ossec:" /etc/group > /dev/null 2>&1) || (dscl . -read /Groups/ossec > /dev/null 2>&1)  ; then
-        find $PREINSTALLEDDIR -group $OSSEC_GROUP -user root -print0 | xargs -0 root:wazuh
-        find $PREINSTALLEDDIR -group $OSSEC_GROUP -print0 | xargs -0 wazuh:wazuh
+        if [ "X$1" = "Xserver" ]; then
+            find $PREINSTALLEDDIR -group $OSSEC_GROUP -user root -print0 | xargs -0 chown root:wazuh
+            find $PREINSTALLEDDIR -group $OSSEC_GROUP -print0 | xargs -0 chown wazuh:wazuh
+        else
+            find $PREINSTALLEDDIR -group $OSSEC_GROUP -user root -exec chown root:wazuh {} \;
+            find $PREINSTALLEDDIR -group $OSSEC_GROUP -exec chown wazuh:wazuh {} \;
+        fi
     fi
     ./src/init/delete-oldusers.sh $OSSEC_GROUP
 

--- a/src/init/wazuh/wazuh.sh
+++ b/src/init/wazuh/wazuh.sh
@@ -209,8 +209,8 @@ WazuhUpgrade()
     # Replace and delete ossec group along with ossec users
     OSSEC_GROUP=ossec
     if (grep "^ossec:" /etc/group > /dev/null 2>&1) || (dscl . -read /Groups/ossec > /dev/null 2>&1)  ; then
-        find $PREINSTALLEDDIR -group $OSSEC_GROUP -user root -exec chown root:wazuh {} \;
-        find $PREINSTALLEDDIR -group $OSSEC_GROUP -exec chown wazuh:wazuh {} \;
+        find $PREINSTALLEDDIR -group $OSSEC_GROUP -user root -print0 | xargs -0 root:wazuh
+        find $PREINSTALLEDDIR -group $OSSEC_GROUP -print0 | xargs -0 wazuh:wazuh
     fi
     ./src/init/delete-oldusers.sh $OSSEC_GROUP
 


### PR DESCRIPTION
|Related issue|
|---|
| #14175  |

# Solution report

## Goal
This report has for goal to make a summary of the implemented solution.

## Tests description
To solve this problem, two VMs with 2 cores and 1Gb of RAM, both from CentOS, were used, one locally and one being an AWS instance. First installed a manager version 4.2.7 in both VMs and take the time neccesary to update using the old version of installer, i.e that one with the command `find ./folder -user u -group g -exec chown nu:ng {} \;` and using the new version, i.e, with the command `find ./folder -user u -group g -print0 | xargs -0 chown nu:ng`.

In both VMs a half million of files was created on the folder `/var/ossec/quque/rids`

## Results
For the local VM, the following results were got:

| update w/ | time[s]   |
|--------------|---------|
| old version | 566.92 |
| new version | 38.87 |
_(Table 1: Local VM with 2 core and 1Gb of memory. Update from 4.2.7 to 4.x.x)_

Also, we can see the following proof that te command take almost the 90% of the update process.

| update w/ | time[s]   |
|--------------|---------|
| old version | 965.01 |
| new version | 14.57 |
_(Table 2: AWS VM with 2 core and 1Gb of memory. Update from 4.2.7 to 4.x.x)_

![long_command_proof](https://user-images.githubusercontent.com/27935340/192624132-5c7f21a4-dbb2-41b6-8549-f5c049bbedf8.png)
_(Figure 1: Proof command long execution time on local VM)_

![command_aws](https://user-images.githubusercontent.com/27935340/192624338-574d0d69-ce54-4cb8-b3b3-df405c046941.png)
_(Figure 2: Proof command long execution time on AWS VM)_

![split_command_chown](https://user-images.githubusercontent.com/27935340/192624705-d52bfd5b-dd7c-4838-adea-e6f613498af0.png)
_(Figure 3: Proof aplit the new chown command in `find` and `xargs`)_

## Conclutions
The improvement show an increment of speed of 4000% in average, proving that the use of `xargs` it's the best option to solve the issue.


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [ ] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors