### PR TITLE
Fix `GET /agents/{agent_id}/daemons/stats` error when cluster is disabled

### DIFF
--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -759,15 +759,13 @@ async def get_daemon_stats(request, agent_id: str, pretty: bool = False, wait_fo
     f_kwargs = {'agent_list': [agent_id],
                 'daemons_list': daemons_list}
 
-    nodes = raise_if_exc(await get_system_nodes())
     dapi = DistributedAPI(f=stats.get_daemons_stats_agents,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies'],
-                          nodes=nodes)
+                          rbac_permissions=request['token_info']['rbac_policies'])
     data = raise_if_exc(await dapi.distribute_function())
 
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)

--- a/api/api/controllers/test/test_agent_controller.py
+++ b/api/api/controllers/test/test_agent_controller.py
@@ -235,7 +235,8 @@ async def test_restart_agents_by_node(mock_exc, mock_dapi, mock_remove, mock_dfu
 @patch('api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
 @patch('api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
 @patch('api.controllers.agent_controller.check_component_configuration_pair')
-async def test_get_agent_config(mock_check_pair, mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_exp, mock_request=MagicMock()):
+async def test_get_agent_config(mock_check_pair, mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_exp,
+                                mock_request=MagicMock()):
     """Verify 'get_agent_config' endpoint is working as expected."""
     kwargs_param = {'configuration': 'configuration_value'
                     }
@@ -526,26 +527,23 @@ async def test_put_upgrade_custom_agents(mock_exc, mock_dapi, mock_remove, mock_
 async def test_get_daemon_stats(mock_exc, mock_dapi, mock_remove, mock_dfunc):
     """Verify 'get_daemon_stats' function is working as expected."""
     mock_request = MagicMock()
-    with patch('api.controllers.agent_controller.get_system_nodes', return_value=AsyncMock()) as mock_snodes:
-        result = await get_daemon_stats(request=mock_request,
-                                        agent_id='001',
-                                        daemons_list=['daemon_1', 'daemon_2'])
+    result = await get_daemon_stats(request=mock_request,
+                                    agent_id='001',
+                                    daemons_list=['daemon_1', 'daemon_2'])
 
-        f_kwargs = {'agent_list': ['001'],
-                    'daemons_list': ['daemon_1', 'daemon_2']}
-        mock_dapi.assert_called_once_with(f=stats.get_daemons_stats_agents,
-                                          f_kwargs=mock_remove.return_value,
-                                          request_type='distributed_master',
-                                          is_async=False,
-                                          wait_for_complete=False,
-                                          logger=ANY,
-                                          rbac_permissions=mock_request['token_info']['rbac_policies'],
-                                          nodes=mock_exc.return_value)
-        mock_remove.assert_called_once_with(f_kwargs)
-        mock_exc.assert_has_calls([call(mock_snodes.return_value), call(mock_dfunc.return_value)])
-        assert mock_exc.call_count == 2
+    f_kwargs = {'agent_list': ['001'],
+                'daemons_list': ['daemon_1', 'daemon_2']}
+    mock_dapi.assert_called_once_with(f=stats.get_daemons_stats_agents,
+                                      f_kwargs=mock_remove.return_value,
+                                      request_type='distributed_master',
+                                      is_async=False,
+                                      wait_for_complete=False,
+                                      logger=ANY,
+                                      rbac_permissions=mock_request['token_info']['rbac_policies'])
+    mock_remove.assert_called_once_with(f_kwargs)
+    mock_exc.assert_called_once_with(mock_dfunc.return_value)
 
-        assert isinstance(result, web_response.Response)
+    assert isinstance(result, web_response.Response)
 
 
 @pytest.mark.asyncio

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -180,6 +180,7 @@ WAZUH_COMPONENT_CONFIGURATION_MAPPING = MappingProxyType(
         'monitor': {"global", "internal"},
         'request': {"global", "remote", "internal"},
         'syscheck': {"syscheck", "rootcheck", "internal"},
+        'wazuh-db': {"wdb", "internal"},
         'wmodules': {"wmodules"}
     }
 )

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -325,7 +325,8 @@ def process_spawn_sleep(child):
     time.sleep(0.1)
 
 
-async def forward_function(func: callable, f_kwargs: dict = None, request_type: str = 'local_master'):
+async def forward_function(func: callable, f_kwargs: dict = None, request_type: str = 'local_master',
+                           nodes: list = None, broadcasting: bool = False):
     """Distribute function to master node.
 
     Parameters
@@ -336,7 +337,10 @@ async def forward_function(func: callable, f_kwargs: dict = None, request_type: 
         Function kwargs.
     request_type : str
         Request type.
-
+    nodes : list
+        System cluster nodes.
+    broadcasting : bool
+        Whether the function will be broadcasted or not.
     Returns
     -------
     Return either a dict or `WazuhResult` instance in case the execution did not fail. Return an exception otherwise.
@@ -346,6 +350,7 @@ async def forward_function(func: callable, f_kwargs: dict = None, request_type: 
     from asyncio import run
     from wazuh.core.cluster.dapi.dapi import DistributedAPI
     dapi = DistributedAPI(f=func, f_kwargs=f_kwargs, request_type=request_type,
-                          is_async=False, wait_for_complete=True, logger=logger)
+                          is_async=False, wait_for_complete=True, logger=logger, nodes=nodes,
+                          broadcasting=broadcasting)
     pool = concurrent.futures.ThreadPoolExecutor()
     return pool.submit(run, dapi.distribute_function()).result()

--- a/framework/wazuh/stats.py
+++ b/framework/wazuh/stats.py
@@ -103,11 +103,13 @@ def get_daemons_stats_agents(daemons_list: list = None, agent_list: list = None)
     AffectedItemsWazuhResult
         Dictionary with daemon's statistical information of the specified agents.
     """
+    agent_list = agent_list or ["all"]
     daemon_socket_mapping = {'wazuh-remoted': common.REMOTED_SOCKET,
                              'wazuh-analysisd': common.ANALYSISD_SOCKET}
     result = AffectedItemsWazuhResult(all_msg='Statistical information for each daemon was successfully read',
                                       some_msg='Could not read statistical information for some daemons',
-                                      none_msg='Could not read statistical information for any daemon')
+                                      none_msg='Could not read statistical information for any daemon',
+                                      sort_casting=['str'])
 
     if agent_list:
         if 'all' not in agent_list:


### PR DESCRIPTION
|Related issue|
|---|
|#14990|

This PR closes https://github.com/wazuh/wazuh/issues/14990

In this pull request, I have updated the agents endpoints controller to fix the `Cluster is not running` error, which is not expected.

The validator.py has also been updated as there was an error in the development branch after the development done in https://github.com/wazuh/wazuh/pull/14766.

_Edit_: this pull request also contains changes to the stats.py file to make possible the development of a script to get the statistics from all agents. Ref.: https://github.com/wazuh/wazuh-tools/issues/194

### Test results

```
test_agent_GET_endpoints.tavern.yaml - Standalone environment 
	 92 passed, 1 deselected, 94 warnings

test_agent_GET_endpoints.tavern.yaml - Cluster environment 
	 93 passed, 94 warnings

test_rbac_black_agent_endpoints.tavern.yaml 
	 42 passed, 43 warnings

test_rbac_white_agent_endpoints.tavern.yaml 
	 42 passed, 43 warnings
```
