### PR TITLE
Engine - API - Callback registration and protocol handler

### DIFF
--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -137,6 +137,7 @@ target_include_directories(main
     ${CLI11_SOURCE_DIR}/include
 )
 
+add_subdirectory(${ENGINE_SOURCE_DIR}/API)
 add_subdirectory(${ENGINE_SOURCE_DIR}/base)
 add_subdirectory(${ENGINE_SOURCE_DIR}/builder)
 add_subdirectory(${ENGINE_SOURCE_DIR}/catalog)
@@ -150,7 +151,7 @@ add_subdirectory(${ENGINE_SOURCE_DIR}/wdb)
 add_subdirectory(${ENGINE_SOURCE_DIR}/cmds)
 
 #TODO isolate rxcpp
-target_link_libraries(main base cmds)
+target_link_libraries(main base cmds api)
 
 # Build test
 if(ENGINE_BUILD_TEST)

--- a/src/engine/source/API/CMakeLists.txt
+++ b/src/engine/source/API/CMakeLists.txt
@@ -7,7 +7,6 @@ set(ENGINE_API_INCLUDE_DIR ${ENGINE_SOURCE_DIR}/API/include)
 add_library(api STATIC
     ${ENGINE_API_SOURCE_DIR}/registry.cpp
     ${ENGINE_API_SOURCE_DIR}/wazuhRequest.cpp
-    ${ENGINE_API_SOURCE_DIR}/wazuhResponse.cpp
 )
 
 
@@ -16,7 +15,6 @@ target_link_libraries(api PRIVATE base)
 target_include_directories(api
     PUBLIC
     ${ENGINE_API_INCLUDE_DIR}
-
     PRIVATE
     ${ENGINE_API_SOURCE_DIR}
     ${ENGINE_SOURCE_DIR}/json

--- a/src/engine/source/API/CMakeLists.txt
+++ b/src/engine/source/API/CMakeLists.txt
@@ -1,0 +1,23 @@
+set(ENGINE_API_SOURCE_DIR ${ENGINE_SOURCE_DIR}/API/src)
+set(ENGINE_API_INCLUDE_DIR ${ENGINE_SOURCE_DIR}/API/include)
+
+####################################################################################################
+# Sources - Includes
+####################################################################################################
+add_library(api STATIC
+    ${ENGINE_API_SOURCE_DIR}/registry.cpp
+    ${ENGINE_API_SOURCE_DIR}/wazuhRequest.cpp
+    ${ENGINE_API_SOURCE_DIR}/wazuhResponse.cpp
+)
+
+
+target_link_libraries(api PRIVATE base)
+
+target_include_directories(api
+    PUBLIC
+    ${ENGINE_API_INCLUDE_DIR}
+
+    PRIVATE
+    ${ENGINE_API_SOURCE_DIR}
+    ${ENGINE_SOURCE_DIR}/json
+)

--- a/src/engine/source/API/include/API/registry.hpp
+++ b/src/engine/source/API/include/API/registry.hpp
@@ -34,7 +34,8 @@ class Registry
 {
 
     std::map<std::string, CommandFn> m_commands; ///< Map of commands and callbacks
-    std::shared_mutex m_mutex; ///< A mutex for thread safety (read/write, protect m_commands)
+    std::shared_mutex
+        m_mutex; ///< A mutex for thread safety (read/write, protect m_commands)
 
 public:
     // Constructors
@@ -44,7 +45,7 @@ public:
     ~Registry()
     {
         // Lock mutex for write access and unlock on destruction
-        std::unique_lock<std::shared_mutex> lock { m_mutex };
+        std::unique_lock<std::shared_mutex> lock {m_mutex};
         m_commands.clear();
     };
 
@@ -57,10 +58,11 @@ public:
     /**
      * @brief Register a command in the registry
      *
-     * @param command The command name
+     * @param command The command name, can't be empty
      * @param callback The callback function
      * @return true If the command was registered
-     * @return false If the command was not registered (already exists)
+     * @return false If the command was not registered (already exists, the command is
+     * empty or the callback is null)
      */
     bool registerCommand(const std::string& command, const CommandFn callback);
 

--- a/src/engine/source/API/include/API/registry.hpp
+++ b/src/engine/source/API/include/API/registry.hpp
@@ -1,0 +1,79 @@
+#ifndef _API_REGISTRY_HPP
+#define _API_REGISTRY_HPP
+
+#include <functional>
+#include <map>
+#include <shared_mutex>
+#include <string>
+
+#include <json/json.hpp>
+
+#include "wazuhResponse.hpp"
+
+namespace api
+{
+
+// TODO: Implement a way to unregister commands
+// TODO: Add a command to list all available commands (And their description)
+// TODO: Add a command to get info about engine (version, etc) and API (version, etc)
+
+/**
+ * @brief Represent a command function, which receives a json::Json with the params and
+ * returns a WazuhResponse.
+ */
+using CommandFn = std::function<WazuhResponse(const json::Json&)>;
+
+/**
+ * @brief A registry for API commands
+ *
+ * This class is used as registry of API wazuh internal commands.
+ * It allows to register API commands with a callback function.
+ *
+ */
+class Registry
+{
+
+    std::map<std::string, CommandFn> m_commands; ///< Map of commands and callbacks
+    std::shared_mutex m_mutex; ///< A mutex for thread safety (read/write, protect m_commands)
+
+public:
+    // Constructors
+    Registry()
+        : m_commands()
+        , m_mutex() {};
+    ~Registry()
+    {
+        // Lock mutex for write access and unlock on destruction
+        std::unique_lock<std::shared_mutex> lock { m_mutex };
+        m_commands.clear();
+    };
+
+    // A unique instance of the same registry, remove copy and move constructors
+    Registry(const Registry&) = delete;
+    Registry(Registry&&) = delete;
+    Registry& operator=(const Registry&) = delete;
+    Registry& operator=(Registry&&) = delete;
+
+    /**
+     * @brief Register a command in the registry
+     *
+     * @param command The command name
+     * @param callback The callback function
+     * @return true If the command was registered
+     * @return false If the command was not registered (already exists)
+     */
+    bool registerCommand(const std::string& command, const CommandFn callback);
+
+    /**
+     * @brief Get the callback function for a command
+     *
+     * @param command The command name
+     * @return The callback function
+     * @return commandNotFound function If the command was not found
+     */
+    CommandFn getCallback(const std::string& command);
+};
+
+} // namespace api
+
+#endif // _API_REGISTRY_HPP

--- a/src/engine/source/API/include/API/wazuhRequest.hpp
+++ b/src/engine/source/API/include/API/wazuhRequest.hpp
@@ -29,6 +29,7 @@ public:
     explicit WazuhRequest(const json::Json& json)
         : m_jrequest(json)
     {
+        m_version = -1;
         m_error = validate();
     }
 
@@ -37,26 +38,6 @@ public:
      */
     ~WazuhRequest() = default;
 
-    // Rule of five
-    WazuhRequest(const WazuhRequest& other)
-        : m_jrequest(other.m_jrequest)
-    {
-    }
-    WazuhRequest(WazuhRequest&& other)
-        : m_jrequest(std::move(other.m_jrequest))
-    {
-    }
-    WazuhRequest& operator=(const WazuhRequest& other)
-    {
-        m_jrequest = other.m_jrequest;
-        return *this;
-    }
-    WazuhRequest& operator=(WazuhRequest&& other)
-    {
-        m_jrequest = std::move(other.m_jrequest);
-        return *this;
-    }
-
     /**
      * @brief Get command from the request
      *
@@ -64,7 +45,7 @@ public:
      * @return empty if the request is not valid
      */
     std::optional<std::string> getCommand() const {
-        return m_jrequest.getString("/command");
+        return  isValid() ? m_jrequest.getString("/command") : std::nullopt;
     };
 
     /**
@@ -75,7 +56,7 @@ public:
      */
     std::optional<json::Json> getParameters() const
     {
-        return m_jrequest.getJson("/parameters");
+        return  isValid() ? m_jrequest.getJson("/parameters") : std::nullopt;
     }
 
     /**
@@ -100,6 +81,9 @@ public:
      * @param command Command name
      * @param parameters Parameters
      * @return WazuhRequest
+     *
+     * @throw std::runtime_error if the command is empty or the parameters are not a JSON
+     * object
      */
     static WazuhRequest create(std::string_view command, const json::Json& parameters);
 

--- a/src/engine/source/API/include/API/wazuhRequest.hpp
+++ b/src/engine/source/API/include/API/wazuhRequest.hpp
@@ -1,0 +1,117 @@
+#ifndef _API_WAZUH_REQUEST_HPP
+#define _API_WAZUH_REQUEST_HPP
+
+#include <json/json.hpp>
+
+namespace api
+{
+
+/**
+ * @brief A standard protocol for internal communication between Wazuh components
+ *
+ * https://github.com/wazuh/wazuh/issues/5934
+ */
+class WazuhRequest
+{
+    static constexpr auto VERSION_SUPPORTED {1};
+
+    int m_version;
+    json::Json m_jrequest;
+    std::optional<std::string> m_error;
+
+public:
+    // TODO Delete explicit when json constructor does not throw exceptions
+    /**
+     * @brief Construct a new Wazuh Request object
+     *
+     * @param json
+     */
+    explicit WazuhRequest(const json::Json& json)
+        : m_jrequest(json)
+    {
+        m_error = validate();
+    }
+
+    /**
+     * @brief Destroy the Wazuh Request object
+     */
+    ~WazuhRequest() = default;
+
+    // Rule of five
+    WazuhRequest(const WazuhRequest& other)
+        : m_jrequest(other.m_jrequest)
+    {
+    }
+    WazuhRequest(WazuhRequest&& other)
+        : m_jrequest(std::move(other.m_jrequest))
+    {
+    }
+    WazuhRequest& operator=(const WazuhRequest& other)
+    {
+        m_jrequest = other.m_jrequest;
+        return *this;
+    }
+    WazuhRequest& operator=(WazuhRequest&& other)
+    {
+        m_jrequest = std::move(other.m_jrequest);
+        return *this;
+    }
+
+    /**
+     * @brief Get command from the request
+     *
+     * @return std::string command
+     * @return empty if the request is not valid
+     */
+    std::optional<std::string> getCommand() const {
+        return m_jrequest.getString("/command");
+    };
+
+    /**
+     * @brief Get parameters from the request
+     *
+     * @return json::Json parameters
+     * @return empty if the request is not valid
+     */
+    std::optional<json::Json> getParameters() const
+    {
+        return m_jrequest.getJson("/parameters");
+    }
+
+    /**
+     * @brief Check if the request is valid
+     *
+     * @return true if the request is valid
+     * @return false if the request is not valid
+     */
+    bool isValid() const { return !m_error.has_value(); }
+
+    /**
+     * @brief Get the error message
+     *
+     * @return empty if the request is valid
+     * @return std::optional<std::string> error message
+     */
+    std::optional<std::string> error() const { return m_error; }
+
+    /**
+     * @brief Create a Wazuh Request object from a command and parameters
+     *
+     * @param command Command name
+     * @param parameters Parameters
+     * @return WazuhRequest
+     */
+    static WazuhRequest create(std::string_view command, const json::Json& parameters);
+
+private:
+    /**
+     * @brief Validate the wazuh request protocol
+     *
+     * @return std::optional<std::string> Error message if the request is not valid
+     * @return nullopt if the request is valid
+     */
+    std::optional<std::string> validate() const;
+};
+
+#endif // _API_WAZUH_REQUEST_HPP
+}

--- a/src/engine/source/API/include/API/wazuhResponse.hpp
+++ b/src/engine/source/API/include/API/wazuhResponse.hpp
@@ -1,0 +1,109 @@
+#ifndef _API_WAZUH_RESPONSE_HPP
+#define _API_WAZUH_RESPONSE_HPP
+
+#include <json/json.hpp>
+#include <logging/logging.hpp>
+
+namespace api
+{
+
+/**
+ * @brief A standard protocol for internal communication between Wazuh components
+ *
+ * https://github.com/wazuh/wazuh/issues/5934
+ */
+class WazuhResponse
+{
+private:
+    // Mandatory fields for all responses
+    int m_error;                          ///< Error code
+    json::Json m_data;                    ///< Data
+    std::optional<std::string> m_message; ///< Optional message
+
+public:
+    // TODO Delete explicit when json constructor does not throw exceptions
+    /**
+     * @brief  Construct a new Wazuh Response object
+     *
+     * @param data Data to be sent, it can be a json object or a string
+     * @param error Error code (0 if no error)
+     * @param message Optional message
+     */
+    explicit WazuhResponse(const json::Json& data,
+                           int error,
+                           std::string_view message = "") noexcept
+        : m_data(data)
+        , m_error(error)
+    {
+        m_message = message.empty() ? std::nullopt : std::make_optional(message);
+    }
+
+    // Rule of five
+    WazuhResponse(const WazuhResponse& other)
+        : m_data(other.m_data)
+        , m_error(other.m_error)
+        , m_message(other.m_message)
+    {
+    }
+    WazuhResponse(WazuhResponse&& other)
+        : m_data(std::move(other.m_data))
+        , m_error(std::move(other.m_error))
+        , m_message(std::move(other.m_message))
+    {
+    }
+    WazuhResponse& operator=(const WazuhResponse& other)
+    {
+        m_data = other.m_data;
+        m_error = other.m_error;
+        m_message = other.m_message;
+        return *this;
+    }
+    WazuhResponse& operator=(WazuhResponse&& other)
+    {
+        m_data = std::move(other.m_data);
+        m_error = std::move(other.m_error);
+        m_message = std::move(other.m_message);
+        return *this;
+    }
+    ~WazuhResponse() = default;
+
+    // Getters
+    const json::Json& data() const { return m_data; }
+    int error() const { return m_error; }
+    const std::optional<std::string>& message() const { return m_message; }
+
+    // Setters
+    void data(const json::Json& data) { m_data = data; }
+    void error(int error) { m_error = error; }
+    void message(const std::string& message) { m_message = message; }
+
+    /**
+     * @brief Conver the response to a string according to the protocol
+     *
+     * @return response as a string
+     */
+    std::string toString() const
+    {
+        if (m_message.has_value())
+        {
+            return fmt::format("{{\"data\":{},\"error\":{},\"message\":\"{}\"}}",
+                               m_data.str(),
+                               m_error,
+                               m_message.value());
+        }
+        return fmt::format("{{\"data\":{},\"error\":{}}}", m_data.str(), m_error);
+    }
+
+    /**
+     * @brief Validate the response
+     *
+     * A response is valid if the data is a json object or a array
+     * @return true
+     * @return false
+     */
+    bool isValid() const { return !(!m_data.isObject() && !m_data.isArray()); }
+};
+
+} // namespace api
+
+#endif // _API_WAZUH_RESPONSE_HPP

--- a/src/engine/source/API/include/API/wazuhResponse.hpp
+++ b/src/engine/source/API/include/API/wazuhResponse.hpp
@@ -35,37 +35,8 @@ public:
         : m_data(data)
         , m_error(error)
     {
-        m_message = message.empty() ? std::nullopt : std::make_optional(message);
+        m_message = message.empty() ? std::nullopt : std::optional<std::string> {message};
     }
-
-    // Rule of five
-    WazuhResponse(const WazuhResponse& other)
-        : m_data(other.m_data)
-        , m_error(other.m_error)
-        , m_message(other.m_message)
-    {
-    }
-    WazuhResponse(WazuhResponse&& other)
-        : m_data(std::move(other.m_data))
-        , m_error(std::move(other.m_error))
-        , m_message(std::move(other.m_message))
-    {
-    }
-    WazuhResponse& operator=(const WazuhResponse& other)
-    {
-        m_data = other.m_data;
-        m_error = other.m_error;
-        m_message = other.m_message;
-        return *this;
-    }
-    WazuhResponse& operator=(WazuhResponse&& other)
-    {
-        m_data = std::move(other.m_data);
-        m_error = std::move(other.m_error);
-        m_message = std::move(other.m_message);
-        return *this;
-    }
-    ~WazuhResponse() = default;
 
     // Getters
     const json::Json& data() const { return m_data; }

--- a/src/engine/source/API/include/API/wazuhResponse.hpp
+++ b/src/engine/source/API/include/API/wazuhResponse.hpp
@@ -38,14 +38,46 @@ public:
         m_message = message.empty() ? std::nullopt : std::optional<std::string> {message};
     }
 
-    // Getters
+    /**
+     * @brief Return data object of the response
+     *
+     * @return data object
+     */
     const json::Json& data() const { return m_data; }
+
+    /**
+     * @brief Return error code of the response
+     *
+     * @return error code
+     */
     int error() const { return m_error; }
+
+    /**
+     * @brief Return message of the response if exists
+     *
+     * @return message of the response if exists
+     */
     const std::optional<std::string>& message() const { return m_message; }
 
-    // Setters
+    /**
+     * @brief Set data object of the response, overwriting the previous one
+     *
+     * @param data object
+     */
     void data(const json::Json& data) { m_data = data; }
+
+    /**
+     * @brief Set error code of the response, overwriting the previous one
+     *
+     * @param error code
+     */
     void error(int error) { m_error = error; }
+
+    /**
+     * @brief Set message of the response, overwriting the previous one if exists
+     *
+     * @param message of the response
+     */
     void message(const std::string& message) { m_message = message; }
 
     /**

--- a/src/engine/source/API/src/registry.cpp
+++ b/src/engine/source/API/src/registry.cpp
@@ -1,0 +1,32 @@
+#include "API/registry.hpp"
+
+
+namespace api
+{
+
+bool Registry::registerCommand(const std::string& command, const CommandFn callback)
+{
+    std::unique_lock<std::shared_mutex> lock(m_mutex);
+    if (m_commands.find(command) != m_commands.end())
+    {
+        return false;
+    }
+    m_commands[command] = callback;
+
+    return true;
+};
+
+CommandFn Registry::getCallback(const std::string& command)
+{
+    std::shared_lock<std::shared_mutex> lock(m_mutex);
+    if (m_commands.find(command) != m_commands.end())
+    {
+        return m_commands[command];
+    }
+    return [](const json::Json&)
+    {
+        return WazuhResponse {json::Json {}, -1, "Command not found"};
+    };
+};
+
+} // namespace api

--- a/src/engine/source/API/src/registry.cpp
+++ b/src/engine/source/API/src/registry.cpp
@@ -1,11 +1,15 @@
 #include "API/registry.hpp"
 
-
 namespace api
 {
 
 bool Registry::registerCommand(const std::string& command, const CommandFn callback)
 {
+    if (command.empty() || callback == nullptr)
+    {
+        return false;
+    }
+
     std::unique_lock<std::shared_mutex> lock(m_mutex);
     if (m_commands.find(command) != m_commands.end())
     {

--- a/src/engine/source/API/src/wazuhRequest.cpp
+++ b/src/engine/source/API/src/wazuhRequest.cpp
@@ -31,15 +31,15 @@ std::optional<std::string> WazuhRequest::validate() const
     }
     if (!m_jrequest.exists("/origin") || !m_jrequest.isObject("/origin"))
     {
-        return "The request must have a origin field with a JSON object value";
+        return "The request must have an origin field with a JSON object value";
     }
     if (!m_jrequest.exists("/origin/name") || !m_jrequest.isString("/origin/name"))
     {
-        return "The request must have a origin/name field with a string value";
+        return "The request must have an origin/name field with a string value";
     }
     if (!m_jrequest.exists("/origin/module") || !m_jrequest.isString("/origin/module"))
     {
-        return "The request must have a origin/module field with a string value";
+        return "The request must have an origin/module field with a string value";
     }
 
     return std::nullopt;
@@ -47,6 +47,16 @@ std::optional<std::string> WazuhRequest::validate() const
 
 WazuhRequest WazuhRequest::create(std::string_view command, const json::Json& parameters)
 {
+
+    if (command.empty())
+    {
+        throw std::runtime_error("The command cannot be empty");
+    }
+    if (!parameters.isObject())
+    {
+        throw std::runtime_error("The parameters must be a JSON type object");
+    }
+
     json::Json jrequest;
     jrequest.setInt(VERSION_SUPPORTED, "/version");
     jrequest.setString(command, "/command");

--- a/src/engine/source/API/src/wazuhRequest.cpp
+++ b/src/engine/source/API/src/wazuhRequest.cpp
@@ -1,0 +1,60 @@
+#include <API/wazuhRequest.hpp>
+
+namespace api
+{
+/*
+ * https://github.com/wazuh/wazuh/issues/5934
+ */
+std::optional<std::string> WazuhRequest::validate() const
+{
+    if (!m_jrequest.isObject())
+    {
+        return "The request must be a JSON type object";
+    }
+    if (!m_jrequest.exists("/version") || !m_jrequest.isInt("/version"))
+    {
+        return "The request must have a version field with an integer value";
+    }
+    // Check if the version is supported
+    if (m_jrequest.getInt("/version").value() != VERSION_SUPPORTED)
+    {
+        return "The request version is not supported";
+    }
+
+    if (!m_jrequest.exists("/command") || !m_jrequest.isString("/command"))
+    {
+        return "The request must have a command field with a string value";
+    }
+    if (!m_jrequest.exists("/parameters") || !m_jrequest.isObject("/parameters"))
+    {
+        return "The request must have a parameters field with a JSON object value";
+    }
+    if (!m_jrequest.exists("/origin") || !m_jrequest.isObject("/origin"))
+    {
+        return "The request must have a origin field with a JSON object value";
+    }
+    if (!m_jrequest.exists("/origin/name") || !m_jrequest.isString("/origin/name"))
+    {
+        return "The request must have a origin/name field with a string value";
+    }
+    if (!m_jrequest.exists("/origin/module") || !m_jrequest.isString("/origin/module"))
+    {
+        return "The request must have a origin/module field with a string value";
+    }
+
+    return std::nullopt;
+}
+
+WazuhRequest WazuhRequest::create(std::string_view command, const json::Json& parameters)
+{
+    json::Json jrequest;
+    jrequest.setInt(VERSION_SUPPORTED, "/version");
+    jrequest.setString(command, "/command");
+    jrequest.set("/parameters", parameters);
+    jrequest.setString("Wazuh-Engine", "/origin/module");
+    jrequest.setString("api", "/origin/name");
+
+    return WazuhRequest(jrequest);
+}
+
+} // namespace api

--- a/src/engine/source/API/src/wazuhRequest.cpp
+++ b/src/engine/source/API/src/wazuhRequest.cpp
@@ -20,7 +20,6 @@ std::optional<std::string> WazuhRequest::validate() const
     {
         return "The request version is not supported";
     }
-
     if (!m_jrequest.exists("/command") || !m_jrequest.isString("/command"))
     {
         return "The request must have a command field with a string value";

--- a/src/engine/source/API/src/wazuhResponse.cpp
+++ b/src/engine/source/API/src/wazuhResponse.cpp
@@ -1,6 +1,0 @@
-#include <API/wazuhResponse.hpp>
-
-namespace api
-{
-
-} // namespace api

--- a/src/engine/source/API/src/wazuhResponse.cpp
+++ b/src/engine/source/API/src/wazuhResponse.cpp
@@ -1,0 +1,6 @@
+#include <API/wazuhResponse.hpp>
+
+namespace api
+{
+
+} // namespace api

--- a/src/engine/source/json/include/json/json.hpp
+++ b/src/engine/source/json/include/json/json.hpp
@@ -331,6 +331,15 @@ public:
      */
     std::optional<std::string> str(std::string_view path) const;
 
+     /**
+     * @brief Get a copy of the Json object or nothing if the path not found.c++ diagram
+     *
+     * @param path The path to the object, default value is root object ("").
+     * @return std::optional<Json> The Json object if it exists, std::nullopt otherwise.
+     * @throw std::runtime_error If path is invalid.
+     */
+    std::optional<Json> getJson(std::string_view path = "") const;
+
     friend std::ostream& operator<<(std::ostream& os, const Json& json);
 
     /************************************************************************************/

--- a/src/engine/source/json/src/json.cpp
+++ b/src/engine/source/json/src/json.cpp
@@ -172,6 +172,7 @@ bool Json::equals(std::string_view basePointerPath,
     }
 }
 
+// TODO Invert parameters to be consistent with other methods.
 void Json::set(std::string_view pointerPath, const Json& value)
 {
     auto fieldPtr = rapidjson::Pointer(pointerPath.data());
@@ -1060,4 +1061,29 @@ void Json::merge(std::string_view source, std::string_view path)
                                              source));
     }
 }
+
+std::optional<Json> Json::getJson(std::string_view path) const
+{
+    auto pp = rapidjson::Pointer(path.data());
+
+    if (pp.IsValid())
+    {
+        auto* val = pp.Get(m_document);
+        if (val)
+        {
+            return Json(*val);
+        }
+        else
+        {
+            return std::nullopt;
+        }
+    }
+    else
+    {
+        throw std::runtime_error(fmt::format("[Json::getJson(basePointerPath)] "
+                                             "Invalid json path: [{}]",
+                                             path));
+    }
+}
+
 } // namespace json

--- a/src/engine/source/server/CMakeLists.txt
+++ b/src/engine/source/server/CMakeLists.txt
@@ -43,9 +43,11 @@ add_library(server STATIC
 #TODO do this better
 target_link_libraries(server base uv_a)
 
-target_include_directories(server PUBLIC
-    ${CameronQueue_SOURCE_DIR}
+target_include_directories(server
+    PUBLIC
     ${ENGINE_SERVER_SOURCE_DIR}
+    PRIVATE
+    ${CameronQueue_SOURCE_DIR}
     ${ENGINE_SOURCE_DIR}/json
     ${uvw_SOURCE_DIR}/src/
     ${uvw_SOURCE_DIR}/src/uvw/

--- a/src/engine/source/wdb/CMakeLists.txt
+++ b/src/engine/source/wdb/CMakeLists.txt
@@ -14,7 +14,6 @@ target_link_libraries(wdb PRIVATE base)
 target_include_directories(wdb
     PRIVATE
     ${ENGINE_WDB_SOURCE_DIR}
-    # TODO Fix this (json/json)
     ${ENGINE_SOURCE_DIR}/json
     # TODO Remove this whens isolate rxcpp from base types
     ${RxCpp_SOURCE_DIR}/Rx/v2/src

--- a/src/engine/test/CMakeLists.txt
+++ b/src/engine/test/CMakeLists.txt
@@ -31,12 +31,14 @@ target_link_libraries(engine_test_main
     base
     kvdb
     wdb
+    api
     )
 
 include(GoogleTest)
 
 #TODO: Fix server tests
 #add_subdirectory(${TEST_SOURCE_DIR}/server)
+add_subdirectory(${TEST_SOURCE_DIR}/API)
 add_subdirectory(${TEST_SOURCE_DIR}/base)
 add_subdirectory(${TEST_SOURCE_DIR}/builder)
 add_subdirectory(${TEST_SOURCE_DIR}/catalog)

--- a/src/engine/test/source/API/CMakeLists.txt
+++ b/src/engine/test/source/API/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(API_test
     registry_test.cpp
     wazuhRequest_test.cpp
+    wazuhResponse_test.cpp
 )
 
 target_include_directories(API_test

--- a/src/engine/test/source/API/CMakeLists.txt
+++ b/src/engine/test/source/API/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(API_test
+    wazuhRequest_test.cpp
+)
+
+target_include_directories(API_test
+    PRIVATE
+    ${ENGINE_SOURCE_DIR}/API/src
+)
+
+target_link_libraries(API_test gtest_main base api)
+gtest_discover_tests(API_test)

--- a/src/engine/test/source/API/CMakeLists.txt
+++ b/src/engine/test/source/API/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(API_test
+    registry_test.cpp
     wazuhRequest_test.cpp
 )
 

--- a/src/engine/test/source/API/registry_test.cpp
+++ b/src/engine/test/source/API/registry_test.cpp
@@ -1,0 +1,194 @@
+
+#include <gtest/gtest.h>
+
+#include <API/registry.hpp>
+#include <json/json.hpp>
+
+TEST(Registry, empty)
+{
+
+    // Registry
+    api::Registry registry;
+
+    // Get callback in registry
+    auto cmdTest = registry.getCallback("test");
+
+    // Execute 2 times the callback fn
+    auto response = cmdTest(json::Json {R"({"testArgKey": "testArgValue"})"});
+    ASSERT_EQ(response.toString(),
+              R"({"data":null,"error":-1,"message":"Command not found"})");
+
+    auto response2 = cmdTest(json::Json {R"({"testArgKey": "testArgValue"})"});
+    ASSERT_EQ(response.toString(), response2.toString());
+
+    auto cmdTestEmpty = registry.getCallback("");
+    auto response3 = cmdTestEmpty(json::Json {R"({"testArgKey": "testArgValue"})"});
+    ASSERT_EQ(response3.toString(),
+              R"({"data":null,"error":-1,"message":"Command not found"})");
+}
+
+TEST(Registry, addComand)
+{
+
+    // Registry
+    api::Registry registry;
+    std::string command {"test"};
+
+    // Get callback in registry
+    auto cmdTest = registry.getCallback(command);
+    auto response = cmdTest(json::Json {R"({"testArgKey": "testArgValue"})"});
+    auto cmdNotFound = response.toString();
+    ASSERT_EQ(response.toString(),
+              R"({"data":null,"error":-1,"message":"Command not found"})");
+
+    // Add command
+    registry.registerCommand(command,
+                             [](const json::Json& json) -> api::WazuhResponse {
+                                 return api::WazuhResponse {json, 0, "OK"};
+                             });
+
+    // Get callback in registry
+    cmdTest = registry.getCallback(command);
+    response = cmdTest(json::Json {R"({"testArgKey": "testArgValue"})"});
+    ASSERT_EQ(response.toString(),
+              R"({"data":{"testArgKey":"testArgValue"},"error":0,"message":"OK"})");
+
+    // Check the new command against the old one
+    ASSERT_NE(cmdNotFound, response.toString());
+}
+
+TEST(Registry, addComandEmpty)
+{
+
+    // Registry
+    api::Registry registry;
+    std::string command {""};
+
+    // Get callback in registry (Not )
+    auto cmdTest = registry.getCallback(command);
+    auto response = cmdTest(json::Json {R"({"testArgKey": "testArgValue"})"});
+    auto cmdNotFound = response.toString();
+    ASSERT_EQ(response.toString(),
+              R"({"data":null,"error":-1,"message":"Command not found"})");
+
+    // Attempt to add command
+    bool res = registry.registerCommand(command,
+                                        [](const json::Json& json) -> api::WazuhResponse {
+                                            return api::WazuhResponse {json, 0, "OK"};
+                                        });
+
+    ASSERT_FALSE(res); // Fail
+
+    // Get callback in registry (Not found)
+    cmdTest = registry.getCallback(command);
+    response = cmdTest(json::Json {R"({"testArgKey": "testArgValue"})"});
+    // Check the new command against the old one
+    ASSERT_EQ(cmdNotFound, response.toString());
+}
+
+TEST(Registry, addNullCommand)
+{
+
+    // Registry
+    api::Registry registry;
+    std::string command {"test"};
+
+    // Get callback in registry
+    auto cmdTest = registry.getCallback(command);
+    auto response = cmdTest(json::Json {R"({"testArgKey": "testArgValue"})"});
+    auto cmdNotFound = response.toString();
+    ASSERT_EQ(response.toString(),
+              R"({"data":null,"error":-1,"message":"Command not found"})");
+
+    // Add command
+    bool res = registry.registerCommand(command, nullptr);
+    ASSERT_FALSE(res); // Fail
+
+    // Get callback in registry
+    cmdTest = registry.getCallback(command);
+    response = cmdTest(json::Json {R"({"testArgKey": "testArgValue"})"});
+    // Check the new command against the old one
+    ASSERT_EQ(cmdNotFound, response.toString());
+}
+
+TEST(Registry, AddduplicateCommand)
+{
+
+    // Registry
+    api::Registry registry;
+    std::string command {"test"};
+
+    // Get callback in registry
+    auto cmdTest = registry.getCallback(command);
+    auto response = cmdTest(json::Json {R"({"testArgKey": "testArgValue"})"});
+    ASSERT_EQ(response.toString(),
+              R"({"data":null,"error":-1,"message":"Command not found"})");
+
+    // Add command for the first time
+    bool res =
+        registry.registerCommand(command,
+                                 [](const json::Json& json) -> api::WazuhResponse {
+                                     return api::WazuhResponse {json, 1, "OK cmd1"};
+                                 });
+    ASSERT_TRUE(res); // OK
+    // Get callback in registry
+    cmdTest = registry.getCallback(command);
+    response = cmdTest(json::Json {R"({"testArgKey": "testArgValue"})"});
+    ASSERT_EQ(response.toString(),
+              R"({"data":{"testArgKey":"testArgValue"},"error":1,"message":"OK cmd1"})");
+
+    // Add command
+    res = registry.registerCommand(command,
+                                   [](const json::Json& json) -> api::WazuhResponse {
+                                       return api::WazuhResponse {json, 2, "OK cmd2"};
+                                   });
+    ASSERT_FALSE(res); // Fail
+
+    // Get callback in registry
+    cmdTest = registry.getCallback(command);
+    response = cmdTest(json::Json {R"({"testArgKey": "testArgValue"})"});
+    ASSERT_EQ(response.toString(),
+              R"({"data":{"testArgKey":"testArgValue"},"error":1,"message":"OK cmd1"})");
+}
+
+TEST(Registry, AddMultipleCommands)
+{
+
+    // Registry
+    api::Registry registry;
+    std::string command {"test"};
+    std::string command2 {"test2"};
+
+    // Get callback in registry
+    auto cmdTest = registry.getCallback(command);
+    auto response = cmdTest(json::Json {R"({"testArgKey": "testArgValue"})"});
+    ASSERT_EQ(response.toString(),
+              R"({"data":null,"error":-1,"message":"Command not found"})");
+
+    // Add command for the first time
+    bool res =
+        registry.registerCommand(command,
+                                 [](const json::Json& json) -> api::WazuhResponse {
+                                     return api::WazuhResponse {json, 1, "OK cmd1"};
+                                 });
+    ASSERT_TRUE(res); // OK
+
+    // Add command for the first time
+    res = registry.registerCommand(command2,
+                                   [](const json::Json& json) -> api::WazuhResponse {
+                                       return api::WazuhResponse {json, 2, "OK cmd2"};
+                                   });
+    ASSERT_TRUE(res); // OK
+
+    // Get callback in registry
+    cmdTest = registry.getCallback(command);
+    response = cmdTest(json::Json {R"({"testArgKey": "testArgValue"})"});
+    ASSERT_EQ(response.toString(),
+              R"({"data":{"testArgKey":"testArgValue"},"error":1,"message":"OK cmd1"})");
+
+    // Get callback in registry
+    cmdTest = registry.getCallback(command2);
+    response = cmdTest(json::Json {R"({"testArgKey": "testArgValue"})"});
+    ASSERT_EQ(response.toString(),
+              R"({"data":{"testArgKey":"testArgValue"},"error":2,"message":"OK cmd2"})");
+}

--- a/src/engine/test/source/API/wazuhRequest_test.cpp
+++ b/src/engine/test/source/API/wazuhRequest_test.cpp
@@ -1,4 +1,3 @@
-
 #include <gtest/gtest.h>
 
 #include <API/wazuhRequest.hpp>

--- a/src/engine/test/source/API/wazuhRequest_test.cpp
+++ b/src/engine/test/source/API/wazuhRequest_test.cpp
@@ -1,0 +1,60 @@
+
+#include <gtest/gtest.h>
+
+#include <API/wazuhRequest.hpp>
+#include <API/wazuhResponse.hpp>
+#include <API/registry.hpp>
+#include <json/json.hpp>
+
+
+TEST(WazuhRequest, test_231)
+{
+
+    // Registry
+    api::Registry registry;
+
+    registry.registerCommand("loop", [](const json::Json &json) -> api::WazuhResponse {
+        return api::WazuhResponse { json, 0, "OK" };
+    });
+
+    registry.registerCommand("ping", [](const json::Json &json) -> api::WazuhResponse {
+        json::Json data { "\"pong\"" };
+        return api::WazuhResponse { data, 0, "OK" };
+    });
+
+
+    // WazuhRequest
+    api::WazuhRequest wazuhRequest_1 { api::WazuhRequest::create("loop", json::Json(R"({"test_123": "test_456"})")) };
+    api::WazuhRequest wazuhRequest_2 { api::WazuhRequest::create("ping", json::Json("{}")) };
+
+    // Validate
+    std::string error_1 = wazuhRequest_1.getParameters().value_or(json::Json("\"hola\"")).str();
+
+    ASSERT_TRUE(wazuhRequest_1.isValid());
+    ASSERT_TRUE(wazuhRequest_2.isValid());
+    ASSERT_EQ(wazuhRequest_1.getCommand().value(), "loop");
+    ASSERT_EQ(wazuhRequest_2.getCommand().value(), "ping");
+    ASSERT_EQ(wazuhRequest_1.getParameters().value(), json::Json(R"({"test_123": "test_456"})"));
+    ASSERT_EQ(wazuhRequest_2.getParameters().value(), json::Json("{}"));
+
+    // Get callback in registry
+    auto cmd = registry.getCallback(wazuhRequest_1.getCommand().value());
+
+    // Execute callback
+    auto response = cmd(wazuhRequest_1.getParameters().value());
+    auto resStr = response.toString();
+    ASSERT_EQ(response.toString(), R"({"data":{"test_123":"test_456"},"error":0,"message":"OK"})");
+
+    cmd = registry.getCallback(wazuhRequest_2.getCommand().value());
+    response = cmd(wazuhRequest_2.getParameters().value());
+    ASSERT_EQ(response.toString(), R"({"data":"pong","error":0,"message":"OK"})");
+
+    // Command not found
+    api::WazuhRequest wazuhRequest_3 { api::WazuhRequest::create("not_found", json::Json("{}")) };
+    ASSERT_TRUE(wazuhRequest_3.isValid());
+    ASSERT_EQ(wazuhRequest_3.getCommand().value(), "not_found");
+
+    cmd = registry.getCallback(wazuhRequest_3.getCommand().value());
+    response = cmd(wazuhRequest_3.getParameters().value());
+    ASSERT_EQ(response.toString(), R"({"data":null,"error":-1,"message":"Command not found"})");
+}

--- a/src/engine/test/source/API/wazuhResponse_test.cpp
+++ b/src/engine/test/source/API/wazuhResponse_test.cpp
@@ -1,0 +1,156 @@
+#include <gtest/gtest.h>
+
+#include <API/wazuhResponse.hpp>
+
+TEST(WazuhResponse, constructor)
+{
+    const json::Json jdata {R"({"test": "data"})"};
+    const int error {0};
+    const std::string message {"test message"};
+    const api::WazuhResponse wresponse {jdata, error, message};
+    EXPECT_EQ(wresponse.data(), jdata);
+    EXPECT_EQ(wresponse.error(), error);
+    EXPECT_EQ(wresponse.message(), message);
+}
+
+TEST(WazuhResponse, toString)
+{
+    const json::Json jdata {R"({"test": "data"})"};
+    const int error {0};
+    const std::string message {"test message"};
+    const api::WazuhResponse wresponse {jdata, error, message};
+    EXPECT_EQ(wresponse.toString(), R"({"data":{"test":"data"},"error":0,"message":"test message"})");
+}
+
+TEST(WazuhResponse, toStringNoMessage)
+{
+    const json::Json jdata {R"({"test": "data"})"};
+    const int error {0};
+    const api::WazuhResponse wresponse {jdata, error};
+    EXPECT_EQ(wresponse.toString(), R"({"data":{"test":"data"},"error":0})");
+}
+
+TEST(WazuhResponse, toStringEmptyMessage)
+{
+    const json::Json jdata {R"({"test": "data"})"};
+    const int error {0};
+    const std::string message {""};
+    const api::WazuhResponse wresponse {jdata, error, message};
+    EXPECT_EQ(wresponse.toString(), R"({"data":{"test":"data"},"error":0})");
+}
+
+TEST(WazuhResponse, toStringEmptyData)
+{
+    const json::Json jdata {R"({})"};
+    const int error {0};
+    const std::string message {"test message"};
+    const api::WazuhResponse wresponse {jdata, error, message};
+    EXPECT_EQ(wresponse.toString(), R"({"data":{},"error":0,"message":"test message"})");
+}
+
+TEST(WazuhResponse, toStringArrayData)
+{
+    const json::Json jdata {R"([{"test": "data"}])"};
+    const int error {0};
+    const std::string message {"test message"};
+    const api::WazuhResponse wresponse {jdata, error, message};
+    EXPECT_EQ(wresponse.toString(), R"({"data":[{"test":"data"}],"error":0,"message":"test message"})");
+}
+
+TEST(WazuhResponse, toStringEmptyDataEmptyMessage)
+{
+    const json::Json jdata {R"({})"};
+    const int error {0};
+    const std::string message {""};
+    const api::WazuhResponse wresponse {jdata, error, message};
+    EXPECT_EQ(wresponse.toString(), R"({"data":{},"error":0})");
+}
+
+TEST(WazuhResponse, validateOkObject) {
+    const json::Json jdata {R"({"test": "data"})"};
+    const int error {0};
+    const std::string message {"test message"};
+    const api::WazuhResponse wresponse {jdata, error, message};
+    EXPECT_TRUE(wresponse.isValid());
+}
+
+TEST(WazuhResponse, validateOkArray) {
+    const json::Json jdata {R"([{"test": "data"}])"};
+    const int error {0};
+    const std::string message {"test message"};
+    const api::WazuhResponse wresponse {jdata, error, message};
+    EXPECT_TRUE(wresponse.isValid());
+}
+
+TEST(WazuhResponse, validateOkEmptyObject) {
+    const json::Json jdata {R"({})"};
+    const int error {0};
+    const std::string message {"test message"};
+    const api::WazuhResponse wresponse {jdata, error, message};
+    EXPECT_TRUE(wresponse.isValid());
+}
+
+TEST(WazuhResponse, validateOkEmptyArray) {
+    const json::Json jdata {R"([])"};
+    const int error {0};
+    const std::string message {"test message"};
+    const api::WazuhResponse wresponse {jdata, error, message};
+    EXPECT_TRUE(wresponse.isValid());
+}
+
+TEST(WazuhResponse, validateOkEmptyMessage) {
+    const json::Json jdata {R"({"test": "data"})"};
+    const int error {0};
+    const std::string message {""};
+    const api::WazuhResponse wresponse {jdata, error, message};
+    EXPECT_TRUE(wresponse.isValid());
+}
+
+TEST(WazuhResponse, validateOkEmptyData) {
+    const json::Json jdata {R"({})"};
+    const int error {0};
+    const std::string message {"test message"};
+    const api::WazuhResponse wresponse {jdata, error, message};
+    EXPECT_TRUE(wresponse.isValid());
+}
+
+TEST(WazuhResponse, validateOkEmptyDataEmptyMessage) {
+    const json::Json jdata {R"({})"};
+    const int error {0};
+    const std::string message {""};
+    const api::WazuhResponse wresponse {jdata, error, message};
+    EXPECT_TRUE(wresponse.isValid());
+}
+
+TEST(WazuhResponse, validateErrorInvalidDataStr) {
+    const json::Json jdata {R"("test")"};
+    const int error {0};
+    const std::string message {"test message"};
+    const api::WazuhResponse wresponse {jdata, error, message};
+    EXPECT_FALSE(wresponse.isValid());
+}
+
+
+TEST(WazuhResponse, validateErrorInvalidDataInt) {
+    const json::Json jdata {R"(1)"};
+    const int error {0};
+    const std::string message {"test message"};
+    const api::WazuhResponse wresponse {jdata, error, message};
+    EXPECT_FALSE(wresponse.isValid());
+}
+
+TEST(WazuhResponse, validateErrorInvalidDataBool) {
+    const json::Json jdata {R"(true)"};
+    const int error {0};
+    const std::string message {"test message"};
+    const api::WazuhResponse wresponse {jdata, error, message};
+    EXPECT_FALSE(wresponse.isValid());
+}
+
+TEST(WazuhResponse, validateErrorInvalidDataNull) {
+    const json::Json jdata {R"(null)"};
+    const int error {0};
+    const std::string message {"test message"};
+    const api::WazuhResponse wresponse {jdata, error, message};
+    EXPECT_FALSE(wresponse.isValid());
+}

--- a/src/engine/test/source/json/json_test.cpp
+++ b/src/engine/test/source/json/json_test.cpp
@@ -1719,3 +1719,111 @@ TEST(JsonSettersTest, MergeRefFailCases)
     // Merging into a non-object non-array
     ASSERT_THROW(jObjDst.merge("/to_merge_obj", "/key1"), std::runtime_error);
 }
+
+// json getJson test
+TEST(getJsonTest, getObjectOk) {
+    Json j {R"({
+        "key1": "value1",
+        "key2": "value2",
+        "key3": {
+            "key4": "value4"
+        }
+    })"};
+
+    Json jExpected {R"({
+        "key4": "value4"
+    })"};
+
+    ASSERT_EQ(j.getJson("/key3"), jExpected);
+}
+
+TEST(getJsonTest, getArrayOk) {
+    Json j {R"({
+        "key1": "value1",
+        "key2": "value2",
+        "key3": [1, 2, 3]
+    })"};
+
+    Json jExpected {R"(
+        [1, 2, 3]
+    )"};
+
+    ASSERT_EQ(j.getJson("/key3"), jExpected);
+}
+
+TEST(getJsonTest, getIntOk) {
+    Json j {R"({
+        "key1": "value1",
+        "key2": "value2",
+        "key3": 100
+    })"};
+
+    Json jExpected {R"(
+        100
+    )"};
+
+    ASSERT_EQ(j.getJson("/key3"), jExpected);
+}
+
+TEST(getJsonTest, getStringOk) {
+    Json j {R"({
+        "key1": "value1",
+        "key2": "value2",
+        "key3": "test value 3"
+    })"};
+
+    Json jExpected {R"(
+        "test value 3"
+    )"};
+
+    ASSERT_EQ(j.getJson("/key3"), jExpected);
+}
+
+TEST(getJsonTest, getBoolOk) {
+    Json j {R"({
+        "key1": "value1",
+        "key2": "value2",
+        "key3": true
+    })"};
+
+    Json jExpected {R"(
+        true
+    )"};
+
+    ASSERT_EQ(j.getJson("/key3"), jExpected);
+}
+
+TEST(getJsonTest, getNullOk) {
+    Json j {R"({
+        "key1": "value1",
+        "key2": "value2",
+        "key3": null
+    })"};
+
+    Json jExpected {R"(
+        null
+    )"};
+
+    ASSERT_EQ(j.getJson("/key3"), jExpected);
+}
+
+TEST(getJsonTest, pathNotFound) {
+    Json j {R"({
+        "key1": "value1",
+        "key2": "value2",
+        "key3": null
+    })"};
+
+    ASSERT_EQ(j.getJson("/key4"), std::optional<Json>());
+}
+
+TEST(getJsonTest, invalidPath) {
+    Json j {R"({
+        "key1": "value1",
+        "key2": "value2",
+        "key3": null
+    })"};
+
+    ASSERT_THROW(j.getJson("key3~"), std::runtime_error);
+}
+

--- a/src/engine/test/source/json/json_test.cpp
+++ b/src/engine/test/source/json/json_test.cpp
@@ -1194,6 +1194,8 @@ TEST(JsonSettersTest, SetString)
     ASSERT_EQ("newValue", jEmpty.getString().value());
     ASSERT_NO_THROW(jObjEmpty.setString("newValue", "/nested"));
     ASSERT_EQ("newValue", jObjEmpty.getString("/nested").value());
+    ASSERT_NO_THROW(jObjString.setString("newValue", ""));
+    ASSERT_EQ("newValue", jObjString.getString().value());
 
     // Invalid pointer
     ASSERT_THROW(jObjString.setString("newValue", "object/key"), std::runtime_error);


### PR DESCRIPTION
|Related issue|
|---|
| #15036  |

According to isue #15036, this PR implements:

- [x] A callback registry should be provided, where modules can register the commands they accept and a function callback to process them.
- [x] Validate a string or a json (to be obtained by a request to the API) against the protocol specified in the issue https://github.com/wazuh/wazuh/issues/5934
- [x]  Provide an interface so that modules can create their callback function and always be compliant with the response protocol specified in the issue #5934

In addition, this contemplates:
- [x] Tests
- [x] Thread-Safe implementation
