### PR TITLE
Improve Wazuh limits configuration check when uploading new configurations with the API

### DIFF
--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -1878,23 +1878,17 @@ def test_get_utc_now():
     assert date == datetime.datetime(1970, 1, 1, 0, 1, tzinfo=datetime.timezone.utc)
 
 
+@pytest.mark.parametrize("configuration", [
+    "<root><global><limits><eps><whatever>yes</whatever></eps></limits></global></root>",
+    "<root><global><logall>no</logall></global><global><limits><eps><whatever>yes</whatever></eps></limits>"
+    "</global></root>"
+])
 @pytest.mark.parametrize("limits_conf, expect_exc", [
     ({'eps': {'allow': True}}, False),
     ({'eps': {'allow': False}}, True)
 ])
-def test_check_disabled_limits_in_conf(limits_conf, expect_exc):
+def test_check_disabled_limits_in_conf(configuration, limits_conf, expect_exc):
     """Test if forbidden limits in the API settings are blocked."""
-    configuration = """
-    <root>
-      <global>
-        <limits>
-          <eps>
-            <whatever>yes</whatever>
-          </eps>
-        </limits>
-      </global>
-    </root>"""
-
     new_conf = utils.configuration.api_conf
     new_conf['upload_configuration']['limits'].update(limits_conf)
 

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -794,12 +794,14 @@ def check_disabled_limits_in_conf(data):
     blocked_configurations = configuration.api_conf['upload_configuration']
 
     xml_file = fromstring(data)
-    limits_section = xml_file.find("global").find("limits")
-    if limits_section is None:
+    found_limits = []
+    for global_section in xml_file.findall("global"):
+        found_limits += [limit_section for limit_section in global_section.findall("limits") or []]
+    if len(found_limits) == 0:
         return
 
     for disabled_limit in [conf for conf, allowed in blocked_configurations['limits'].items() if not allowed['allow']]:
-        if limits_section.find(disabled_limit):
+        if any([conf_limit.find(disabled_limit) for conf_limit in found_limits]):
             raise WazuhError(1127, extra_message=f"global > limits > {disabled_limit}")
 
 


### PR DESCRIPTION
|Related issue|
|---|
|closes #15047 |

## Description

This PR improves the Wazuh limits configuration detection when using the API, taking into account that there could be multiple configuration tags with the same name.

## Tests performed

### Unit tests

- Adding a new test case with the reported behavior (no changes to the code)

```
================================================ test session starts ================================================
platform linux -- Python 3.9.9, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: testinfra-5.0.0, metadata-1.11.0, cov-2.12.0, asyncio-0.18.3, aiohttp-0.3.0, html-3.1.1
asyncio: mode=legacy
collected 4 items                                                                                                   

framework/wazuh/core/tests/test_utils.py ...F                                                                 [100%]

===================================================== FAILURES ======================================================
_ test_check_disabled_limits_in_conf[limits_conf1-True-<root><global><logall>no</logall></global><global><limits><eps><whatever>yes</whatever></eps></limits></global></root>] _

configuration = '<root><global><logall>no</logall></global><global><limits><eps><whatever>yes</whatever></eps></limits></global></root>'
limits_conf = {'eps': {'allow': False}}, expect_exc = True

    @pytest.mark.parametrize("configuration", [
        "<root><global><limits><eps><whatever>yes</whatever></eps></limits></global></root>",
        "<root><global><logall>no</logall></global><global><limits><eps><whatever>yes</whatever></eps></limits>"
        "</global></root>"
    ])
    @pytest.mark.parametrize("limits_conf, expect_exc", [
        ({'eps': {'allow': True}}, False),
        ({'eps': {'allow': False}}, True)
    ])
    def test_check_disabled_limits_in_conf(configuration, limits_conf, expect_exc):
        """Test if forbidden limits in the API settings are blocked."""
        new_conf = utils.configuration.api_conf
        new_conf['upload_configuration']['limits'].update(limits_conf)
    
        with patch('wazuh.core.utils.configuration.api_conf', new=new_conf):
            if expect_exc:
                with pytest.raises(exception.WazuhError, match=".* 1127 .*"):
>                   utils.check_disabled_limits_in_conf(configuration)
E                   Failed: DID NOT RAISE <class 'wazuh.core.exception.WazuhError'>

framework/wazuh/core/tests/test_utils.py:1898: Failed
============================================== short test summary info ==============================================
FAILED framework/wazuh/core/tests/test_utils.py::test_check_disabled_limits_in_conf[limits_conf1-True-<root><global><logall>no</logall></global><global><limits><eps><whatever>yes</whatever></eps></limits></global></root>]

```

- After adding the fix

```
================================================ test session starts ================================================
platform linux -- Python 3.9.9, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: testinfra-5.0.0, metadata-1.11.0, cov-2.12.0, asyncio-0.18.3, aiohttp-0.3.0, html-3.1.1
asyncio: mode=legacy
collected 4 items                                                                                                   

framework/wazuh/core/tests/test_utils.py ....                                                                 [100%]

=========================================== 4 passed, 4 warnings in 0.21s ===========================================

```

### Manual API test

With an API configuration like the following:

```yaml
# Uploadable Wazuh configuration sections
upload_configuration:
#   remote_commands:
#     localfile:
#       allow: yes
#       exceptions: []
#     wodle_command:
#       allow: yes
#       exceptions: []
  limits:
    eps:
      allow: no
```

And a Wazuh configuration like the following (truncated):

```xml
<ossec_config>
  <global>
    <jsonout_output>yes</jsonout_output>
    <alerts_log>yes</alerts_log>
    <logall>no</logall>
    <logall_json>no</logall_json>
    <email_notification>no</email_notification>
    <smtp_server>smtp.example.wazuh.com</smtp_server>
    <email_from>wazuh@example.wazuh.com</email_from>
    <email_to>recipient@example.wazuh.com</email_to>
    <email_maxperhour>12</email_maxperhour>
    <email_log_source>alerts.log</email_log_source>
    <agents_disconnection_time>10m</agents_disconnection_time>
    <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
  </global>
  <global>
    <limits>
      <eps>
        <maximum>101</maximum>
      </eps>
    </limits>
  </global>
  <alerts>

(...)
```

The API will correctly prevent the previous configuration from being uploaded:

```json
{
  "data": {
    "affected_items": [],
    "total_affected_items": 0,
    "total_failed_items": 1,
    "failed_items": [
      {
        "error": {
          "code": 1127,
          "message": "Forbidden section detected: global > limits > eps",
          "remediation": "To solve this issue, please enable the section in the API settings: https://documentation.wazuh.com/4.5/user-manual/api/configuration.html"
        },
        "id": [
          "master-node"
        ]
      }
    ]
  },
  "message": "Could not update configuration in specified node",
  "error": 1
}
```

Regards,
Víctor