### PR TITLE
Fix enable service openSUSE

### DIFF
--- a/src/init/init.sh
+++ b/src/init/init.sh
@@ -95,7 +95,6 @@ runInit()
         then
             ln -sf ../${service} /etc/init.d/${service} > /dev/null 2>&1
             systemctl enable "wazuh-"$type
-
         fi
 
         return 0;

--- a/src/init/init.sh
+++ b/src/init/init.sh
@@ -93,7 +93,9 @@ runInit()
 
         if [ "X${update_only}" = "X" ]
         then
-            /sbin/chkconfig --add ${service} > /dev/null 2>&1
+            ln -sf ../${service} /etc/init.d/${service} > /dev/null 2>&1
+            systemctl enable "wazuh-"$type
+
         fi
 
         return 0;


### PR DESCRIPTION
|Related issue|
|---|
| #14924  |

# Solution report

## Goal
This report has for goal to make a summary of the implemented solution.

## Issue research
This issue is produced by a wrong symbolink in the openSUSE Leap 15.4 distribution.
The command

```bash
    /sbin/chkconfig --add ${service} > /dev/null 2>&1
```

The command `chckconfig`[^1] is  used  to  manipulate the runlevel links at boot time.  It can be thought of as a frontend to insserv. This command try to create this symbolic link

```bash
    ln -sf ../wazuh-$type /etc/init.d/rc2.d/S50wazuh-$type
```
Which crash because the path `/etc/init.d/rc2.d` it doesn't exist. This problem has been found in this [forum thread](https://forums.opensuse.org/showthread.php/569830-Can-systemctl-start-elasticsearch-but-not-systemctl-enable-it), where the explain of the reason it's because the package it's an original openSUSE package so it tries to use `/etc/init.d/rc2.d` which directory belongs to the old SystemV ways of doing but in openSUSE that directory is no longer in use and most probably not available anymore.


## Test description & results
To solve this problem we create a symbolic link to the correct path and then enable the service. 
To test this proposed solution, we attach some screen shots
![14924_fig1](https://user-images.githubusercontent.com/27935340/193261628-d63228ed-987f-449e-b1aa-a605d5e5710f.png)
(Figure 1: Error reproduction test and solution implementation) 

![14924_fig2](https://user-images.githubusercontent.com/27935340/193261678-912c57c7-9838-467d-a9d9-bd0a3028cdba.png)
(Figure 2: Solution success test)

## Conclutions
The proposed solution is similar to other symbolic links used in other operating systems. Also, it is important to remember that, the `ln` command does not care if the source file exists, so if there is an error in the path, it will not complain and it is relative to the parent directory of the symbolic link and not where `ln` is executed.

[^1]: [chkconfig(8) - Linux man page
](https://linux.die.net/man/8/chkconfig).

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [x] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors