### PR TITLE
Add native Shuffle integration

### DIFF
--- a/integrations/shuffle
+++ b/integrations/shuffle
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+# Created by Shuffle, AS. <frikky@shuffler.io>.
+# Based on the Slack integration using Webhooks
+
+import json
+import sys
+import time
+import os
+
+try:
+    import requests
+    from requests.auth import HTTPBasicAuth
+except Exception as e:
+    print("No module 'requests' found. Install: pip install requests")
+    sys.exit(1)
+
+# ADD THIS TO ossec.conf configuration:
+#  <integration>
+#      <name>custom-shuffle</name>
+#      <hook_url>http://<IP>:3001/api/v1/hooks/<HOOK_ID></hook_url>
+#      <level>3</level>
+#      <alert_format>json</alert_format>
+#  </integration>
+
+# Global vars
+debug_enabled = False
+pwd = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+json_alert = {}
+now = time.strftime("%a %b %d %H:%M:%S %Z %Y")
+
+# Set paths
+log_file = '{0}/logs/integrations.log'.format(pwd)
+
+try:
+    with open("/tmp/shuffle_start.txt", "w+") as tmp:
+        tmp.write("Script started")
+except:
+    pass
+
+
+def main(args):
+    debug("# Starting")
+
+    # Read args
+    alert_file_location = args[1]
+    webhook = args[3]
+
+    debug("# Webhook")
+    debug(webhook)
+
+    debug("# File location")
+    debug(alert_file_location)
+
+    # Load alert. Parse JSON object.
+    try:
+        with open(alert_file_location) as alert_file:
+            json_alert = json.load(alert_file)
+    except:
+        debug("# Alert file %s doesn't exist" % alert_file_location)
+
+    debug("# Processing alert")
+    try:
+        debug(json_alert)
+    except Exception as e:
+        debug("Failed getting json_alert %s" % e)
+        sys.exit(1)
+
+    debug("# Generating message")
+    msg = generate_msg(json_alert)
+    if isinstance(msg, str):
+        if len(msg) == 0:
+            return
+    debug(msg)
+
+    debug("# Sending message")
+
+    try:
+        with open("/tmp/shuffle_end.txt", "w+") as tmp:
+            tmp.write("Script done pre-msg sending")
+    except:
+        pass
+
+
+    send_msg(msg, webhook)
+
+
+def debug(msg):
+    if debug_enabled:
+        msg = "{0}: {1}\n".format(now, msg)
+        print(msg)
+        f = open(log_file, "a")
+        f.write(msg)
+        f.close()
+
+# Skips container kills to stop self-recursion
+def filter_msg(alert):
+    # These are things that recursively happen because Shuffle starts Docker containers
+    skip = ["87924", "87900", "87901", "87902", "87903", "87904", "86001", "86002", "86003", "87932", "80710", "87929", "87928", "5710"]
+    if alert["rule"]["id"] in skip:
+        return False
+
+    #try:
+    #    if "docker" in alert["rule"]["description"].lower() and "
+    #msg['text'] = alert.get('full_log')
+    #except:
+    #    pass
+    #msg['title'] = alert['rule']['description'] if 'description' in alert['rule'] else "N/A"
+
+    return True
+
+def generate_msg(alert):
+    if not filter_msg(alert):
+        print("Skipping rule %s" % alert["rule"]["id"])
+        return ""
+
+    level = alert['rule']['level']
+
+    if (level <= 4):
+        severity = 1
+    elif (level >= 5 and level <= 7):
+        severity = 2
+    else:
+        severity = 3
+
+    msg = {}
+    msg['severity'] = severity
+    msg['pretext'] = "WAZUH Alert"
+    msg['title'] = alert['rule']['description'] if 'description' in alert['rule'] else "N/A"
+    msg['text'] = alert.get('full_log')
+    msg['rule_id'] = alert["rule"]["id"]
+    msg['timestamp'] = alert["timestamp"]
+    msg['id'] = alert['id']
+    msg["all_fields"] = alert
+
+    #msg['fields'] = []
+    #    msg['fields'].append({
+    #        "title": "Agent",
+    #        "value": "({0}) - {1}".format(
+    #            alert['agent']['id'],
+    #            alert['agent']['name']
+    #        ),
+    #    })
+    #if 'agentless' in alert:
+    #    msg['fields'].append({
+    #        "title": "Agentless Host",
+    #        "value": alert['agentless']['host'],
+    #    })
+
+    #msg['fields'].append({"title": "Location", "value": alert['location']})
+    #msg['fields'].append({
+    #    "title": "Rule ID",
+    #    "value": "{0} _(Level {1})_".format(alert['rule']['id'], level),
+    #})
+
+    #attach = {'attachments': [msg]}
+
+    return json.dumps(msg)
+
+
+def send_msg(msg, url):
+    debug("# In send msg")
+    headers = {'content-type': 'application/json', 'Accept-Charset': 'UTF-8'}
+    res = requests.post(url, data=msg, headers=headers, verify=False)
+    debug("# After send msg: %s" % res)
+
+
+if __name__ == "__main__":
+    try:
+        # Read arguments
+        bad_arguments = False
+        if len(sys.argv) >= 4:
+            msg = '{0} {1} {2} {3} {4}'.format(
+                now,
+                sys.argv[1],
+                sys.argv[2],
+                sys.argv[3],
+                sys.argv[4] if len(sys.argv) > 4 else '',
+            )
+            #debug_enabled = (len(sys.argv) > 4 and sys.argv[4] == 'debug')
+            debug_enabled = True
+        else:
+            msg = '{0} Wrong arguments'.format(now)
+            bad_arguments = True
+
+        # Logging the call
+        try:
+            f = open(log_file, 'a')
+        except:
+            f = open(log_file, 'w+')
+            f.write("")
+            f.close()
+
+        f = open(log_file, 'a')
+        f.write(msg + '\n')
+        f.close()
+
+        if bad_arguments:
+            debug("# Exiting: Bad arguments. Inputted: %s" % sys.argv)
+            sys.exit(1)
+
+        # Main function
+        main(sys.argv)
+
+    except Exception as e:
+        debug(str(e))
+        raise

--- a/integrations/shuffle
+++ b/integrations/shuffle
@@ -1,7 +1,13 @@
 #!/usr/bin/env python3
 # Created by Shuffle, AS. <frikky@shuffler.io>.
 # Based on the Slack integration using Webhooks
+#
+# This program is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
 
+import contextlib
 import json
 import sys
 import time
@@ -31,11 +37,9 @@ now = time.strftime("%a %b %d %H:%M:%S %Z %Y")
 # Set paths
 log_file = '{0}/logs/integrations.log'.format(pwd)
 
-try:
+with contextlib.suppress(Exception):
     with open("/tmp/shuffle_start.txt", "w+") as tmp:
         tmp.write("Script started")
-except:
-    pass
 
 
 def main(args):

--- a/integrations/shuffle
+++ b/integrations/shuffle
@@ -13,7 +13,6 @@ import sys
 import time
 import os
 import logging
-from datetime import datetime, timezone
 
 try:
     import requests
@@ -37,7 +36,7 @@ json_alert = {}
 now = time.strftime("%a %b %d %H:%M:%S %Z %Y")
 
 # Set paths
-log_file = '{0}/logs/integrations.log'.format(pwd)
+log_file = f'{pwd}/logs/integrations.log'
 log_shuffle = "/tmp/shuffle"
 
 logging_msg_format = '%(asctime)s shuffle: %(levelname)s: %(message)s'
@@ -58,7 +57,7 @@ def main(args):
 
     # Read args
     alert_file_location = args[1]
-    webhook = args[3]
+    webhook: str = args[3]
 
     debug("# Webhook")
     debug(webhook)
@@ -81,7 +80,7 @@ def main(args):
         sys.exit(1)
 
     debug("# Generating message")
-    msg = generate_msg(json_alert)
+    msg: str = generate_msg(json_alert)
     if isinstance(msg, str):
         if len(msg) == 0:
             return
@@ -104,7 +103,7 @@ def debug(msg):
 
 
 # Skips container kills to stop self-recursion
-def filter_msg(alert):
+def filter_msg(alert) -> bool:
     # These are things that recursively happen because Shuffle starts Docker containers
     skip = ["87924", "87900", "87901", "87902", "87903", "87904", "86001", "86002", "86003", "87932", "80710", "87929",
             "87928", "5710"]
@@ -121,7 +120,7 @@ def filter_msg(alert):
     return True
 
 
-def generate_msg(alert):
+def generate_msg(alert) -> str:
     if not filter_msg(alert):
         print("Skipping rule %s" % alert["rule"]["id"])
         return ""
@@ -145,7 +144,7 @@ def generate_msg(alert):
     return json.dumps(msg)
 
 
-def send_msg(msg, url):
+def send_msg(msg: str, url: str):
     debug("# In send msg")
     headers = {'content-type': 'application/json', 'Accept-Charset': 'UTF-8'}
     res = requests.post(url, data=msg, headers=headers, verify=False)
@@ -172,13 +171,6 @@ if __name__ == "__main__":
             bad_arguments = True
 
         # Logging the call
-        try:
-            f = open(log_file, 'a')
-        except:
-            f = open(log_file, 'w+')
-            f.write("")
-            f.close()
-
         f = open(log_file, 'a')
         f.write(msg + '\n')
         f.close()

--- a/integrations/shuffle
+++ b/integrations/shuffle
@@ -22,7 +22,7 @@ except Exception as e:
 
 # ADD THIS TO ossec.conf configuration:
 #  <integration>
-#      <name>custom-shuffle.py</name>
+#      <name>custom-shuffle</name>
 #      <hook_url>http://<IP>:3001/api/v1/hooks/<HOOK_ID></hook_url>
 #      <level>3</level>
 #      <alert_format>json</alert_format>
@@ -78,12 +78,9 @@ def main(args):
 
     debug("# Sending message")
 
-    try:
+    with contextlib.suppress(Exception):
         with open("/tmp/shuffle_end.txt", "w+") as tmp:
             tmp.write("Script done pre-msg sending")
-    except:
-        pass
-
 
     send_msg(msg, webhook)
 

--- a/integrations/shuffle
+++ b/integrations/shuffle
@@ -12,6 +12,8 @@ import json
 import sys
 import time
 import os
+import logging
+from datetime import datetime, timezone
 
 try:
     import requests
@@ -22,7 +24,7 @@ except Exception as e:
 
 # ADD THIS TO ossec.conf configuration:
 #  <integration>
-#      <name>custom-shuffle</name>
+#      <name>shuffle</name>
 #      <hook_url>http://<IP>:3001/api/v1/hooks/<HOOK_ID></hook_url>
 #      <level>3</level>
 #      <alert_format>json</alert_format>
@@ -36,13 +38,22 @@ now = time.strftime("%a %b %d %H:%M:%S %Z %Y")
 
 # Set paths
 log_file = '{0}/logs/integrations.log'.format(pwd)
+log_shuffle = "/tmp/shuffle"
 
-with contextlib.suppress(Exception):
-    with open("/tmp/shuffle_start.txt", "w+") as tmp:
-        tmp.write("Script started")
+logging_msg_format = '%(asctime)s shuffle: %(levelname)s: %(message)s'
+logging_date_format = '%Y/%m/%d %I:%M:%S'
+
+
+def set_logger():
+    """Set the logger configuration."""
+    logging.basicConfig(level=logging.INFO, format=logging_msg_format,
+                        datefmt=logging_date_format, filename=log_shuffle,filemode='a')
 
 
 def main(args):
+    set_logger()
+    logging.info("Script started")
+
     debug("# Starting")
 
     # Read args
@@ -78,9 +89,7 @@ def main(args):
 
     debug("# Sending message")
 
-    with contextlib.suppress(Exception):
-        with open("/tmp/shuffle_end.txt", "w+") as tmp:
-            tmp.write("Script done pre-msg sending")
+    logging.info("Script done pre-msg sending")
 
     send_msg(msg, webhook)
 
@@ -93,21 +102,24 @@ def debug(msg):
         f.write(msg)
         f.close()
 
+
 # Skips container kills to stop self-recursion
 def filter_msg(alert):
     # These are things that recursively happen because Shuffle starts Docker containers
-    skip = ["87924", "87900", "87901", "87902", "87903", "87904", "86001", "86002", "86003", "87932", "80710", "87929", "87928", "5710"]
+    skip = ["87924", "87900", "87901", "87902", "87903", "87904", "86001", "86002", "86003", "87932", "80710", "87929",
+            "87928", "5710"]
     if alert["rule"]["id"] in skip:
         return False
 
-    #try:
+    # try:
     #    if "docker" in alert["rule"]["description"].lower() and "
-    #msg['text'] = alert.get('full_log')
-    #except:
+    # msg['text'] = alert.get('full_log')
+    # except:
     #    pass
-    #msg['title'] = alert['rule']['description'] if 'description' in alert['rule'] else "N/A"
+    # msg['title'] = alert['rule']['description'] if 'description' in alert['rule'] else "N/A"
 
     return True
+
 
 def generate_msg(alert):
     if not filter_msg(alert):
@@ -123,37 +135,12 @@ def generate_msg(alert):
     else:
         severity = 3
 
-    msg = {}
-    msg['severity'] = severity
-    msg['pretext'] = "WAZUH Alert"
-    msg['title'] = alert['rule']['description'] if 'description' in alert['rule'] else "N/A"
-    msg['text'] = alert.get('full_log')
-    msg['rule_id'] = alert["rule"]["id"]
-    msg['timestamp'] = alert["timestamp"]
-    msg['id'] = alert['id']
-    msg["all_fields"] = alert
-
-    #msg['fields'] = []
-    #    msg['fields'].append({
-    #        "title": "Agent",
-    #        "value": "({0}) - {1}".format(
-    #            alert['agent']['id'],
-    #            alert['agent']['name']
-    #        ),
-    #    })
-    #if 'agentless' in alert:
-    #    msg['fields'].append({
-    #        "title": "Agentless Host",
-    #        "value": alert['agentless']['host'],
-    #    })
-
-    #msg['fields'].append({"title": "Location", "value": alert['location']})
-    #msg['fields'].append({
-    #    "title": "Rule ID",
-    #    "value": "{0} _(Level {1})_".format(alert['rule']['id'], level),
-    #})
-
-    #attach = {'attachments': [msg]}
+    msg = {'severity': severity, 'pretext': "WAZUH Alert",
+           'title': alert['rule']['description'] if 'description' in alert['rule'] else "N/A",
+           'text': alert.get('full_log'),
+           'rule_id': alert["rule"]["id"],
+           'timestamp': alert["timestamp"],
+           'id': alert['id'], "all_fields": alert}
 
     return json.dumps(msg)
 
@@ -166,6 +153,7 @@ def send_msg(msg, url):
 
 
 if __name__ == "__main__":
+
     try:
         # Read arguments
         bad_arguments = False
@@ -177,7 +165,7 @@ if __name__ == "__main__":
                 sys.argv[3],
                 sys.argv[4] if len(sys.argv) > 4 else '',
             )
-            #debug_enabled = (len(sys.argv) > 4 and sys.argv[4] == 'debug')
+            # debug_enabled = (len(sys.argv) > 4 and sys.argv[4] == 'debug')
             debug_enabled = True
         else:
             msg = '{0} Wrong arguments'.format(now)

--- a/integrations/shuffle.py
+++ b/integrations/shuffle.py
@@ -22,7 +22,7 @@ except Exception as e:
 
 # ADD THIS TO ossec.conf configuration:
 #  <integration>
-#      <name>custom-shuffle</name>
+#      <name>custom-shuffle.py</name>
 #      <hook_url>http://<IP>:3001/api/v1/hooks/<HOOK_ID></hook_url>
 #      <level>3</level>
 #      <alert_format>json</alert_format>

--- a/integrations/shuffle.py
+++ b/integrations/shuffle.py
@@ -7,7 +7,13 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
-import contextlib
+# Error Codes:
+#   1 - Module requests not found
+#   2 - Incorrect input arguments
+#   3 - Alert File does not exist
+#   4 - Error getting json_alert
+
+
 import json
 import sys
 import time
@@ -34,14 +40,13 @@ pwd = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 json_alert = {}
 now = time.strftime("%a %b %d %H:%M:%S %Z %Y")
 SKIP_RULE_IDS = ["87924", "87900", "87901", "87902", "87903", "87904", "86001", "86002", "86003", "87932",
-                            "80710", "87929", "87928", "5710"]
+                 "80710", "87929", "87928", "5710"]
 
 # Set paths
 LOG_FILE = f'{pwd}/logs/integrations.log'
 
 
 def main(args):
-
     debug("# Starting")
 
     # Read args
@@ -60,13 +65,14 @@ def main(args):
             json_alert = json.load(alert_file)
     except:
         debug("# Alert file %s doesn't exist" % alert_file_location)
+        sys.exit(3)
 
     debug("# Processing alert")
     try:
         debug(json_alert)
     except Exception as e:
         debug("Failed getting json_alert %s" % e)
-        sys.exit(1)
+        sys.exit(4)
 
     debug("# Generating message")
     msg: str = generate_msg(json_alert)
@@ -87,9 +93,8 @@ def debug(msg):
     if debug_enabled:
         msg = "{0}: {1}\n".format(now, msg)
         print(msg)
-        f = open(LOG_FILE, "a")
-        f.write(msg)
-        f.close()
+        with open(LOG_FILE, "a") as f:
+            f.write(msg)
 
 
 # Skips container kills to stop self-recursion
@@ -150,13 +155,12 @@ if __name__ == "__main__":
             bad_arguments = True
 
         # Logging the call
-        f = open(LOG_FILE, 'a')
-        f.write(msg + '\n')
-        f.close()
+        with open(LOG_FILE, "a") as f:
+            f.write(msg + '\n')
 
         if bad_arguments:
             debug("# Exiting: Bad arguments. Inputted: %s" % sys.argv)
-            sys.exit(1)
+            sys.exit(2)
 
         # Main function
         main(sys.argv)

--- a/integrations/shuffle.py
+++ b/integrations/shuffle.py
@@ -81,9 +81,12 @@ def main(args):
 
     debug("# Generating message")
     msg: str = generate_msg(json_alert)
+
+    # Check if alert is skipped
     if isinstance(msg, str):
-        if len(msg) == 0:
+        if not msg:
             return
+
     debug(msg)
 
     debug("# Sending message")

--- a/integrations/shuffle.py
+++ b/integrations/shuffle.py
@@ -37,7 +37,7 @@ now = time.strftime("%a %b %d %H:%M:%S %Z %Y")
 
 # Set paths
 log_file = f'{pwd}/logs/integrations.log'
-log_shuffle = "/tmp/shuffle.py"
+log_shuffle = "/tmp/shuffle.log"
 
 logging_msg_format = '%(asctime)s shuffle.py: %(levelname)s: %(message)s'
 logging_date_format = '%Y/%m/%d %I:%M:%S'

--- a/integrations/shuffle.py
+++ b/integrations/shuffle.py
@@ -47,6 +47,40 @@ LOG_FILE = f'{pwd}/logs/integrations.log'
 
 
 def main(args):
+    global debug_enabled
+    try:
+        # Read arguments
+        bad_arguments = False
+        if len(args) >= 4:
+            msg = '{0} {1} {2} {3} {4}'.format(
+                now,
+                args[1],
+                args[2],
+                args[3],
+                args[4] if len(args) > 4 else '',
+            )
+            debug_enabled = (len(args) > 4 and args[4] == 'debug')
+        else:
+            msg = '{0} Wrong arguments'.format(now)
+            bad_arguments = True
+
+        # Logging the call
+        with open(LOG_FILE, "a") as f:
+            f.write(msg + '\n')
+
+        if bad_arguments:
+            debug("# Exiting: Bad arguments. Inputted: %s" % args)
+            sys.exit(2)
+
+        # Main function
+        process_args(args)
+
+    except Exception as e:
+        debug(str(e))
+        raise
+
+
+def process_args(args):
     debug("# Starting")
 
     # Read args
@@ -135,35 +169,4 @@ def send_msg(msg: str, url: str):
 
 
 if __name__ == "__main__":
-
-    try:
-        # Read arguments
-        bad_arguments = False
-        if len(sys.argv) >= 4:
-            msg = '{0} {1} {2} {3} {4}'.format(
-                now,
-                sys.argv[1],
-                sys.argv[2],
-                sys.argv[3],
-                sys.argv[4] if len(sys.argv) > 4 else '',
-            )
-
-            debug_enabled = (len(sys.argv) > 4 and sys.argv[4] == 'debug')
-        else:
-            msg = '{0} Wrong arguments'.format(now)
-            bad_arguments = True
-
-        # Logging the call
-        with open(LOG_FILE, "a") as f:
-            f.write(msg + '\n')
-
-        if bad_arguments:
-            debug("# Exiting: Bad arguments. Inputted: %s" % sys.argv)
-            sys.exit(2)
-
-        # Main function
-        main(sys.argv)
-
-    except Exception as e:
-        debug(str(e))
-        raise
+    main(sys.argv)

--- a/integrations/shuffle.py
+++ b/integrations/shuffle.py
@@ -23,7 +23,7 @@ except Exception as e:
 
 # ADD THIS TO ossec.conf configuration:
 #  <integration>
-#      <name>shuffle</name>
+#      <name>shuffle.py</name>
 #      <hook_url>http://<IP>:3001/api/v1/hooks/<HOOK_ID></hook_url>
 #      <level>3</level>
 #      <alert_format>json</alert_format>
@@ -37,9 +37,9 @@ now = time.strftime("%a %b %d %H:%M:%S %Z %Y")
 
 # Set paths
 log_file = f'{pwd}/logs/integrations.log'
-log_shuffle = "/tmp/shuffle"
+log_shuffle = "/tmp/shuffle.py"
 
-logging_msg_format = '%(asctime)s shuffle: %(levelname)s: %(message)s'
+logging_msg_format = '%(asctime)s shuffle.py: %(levelname)s: %(message)s'
 logging_date_format = '%Y/%m/%d %I:%M:%S'
 
 

--- a/integrations/shuffle.py
+++ b/integrations/shuffle.py
@@ -16,7 +16,7 @@ import os
 try:
     import requests
     from requests.auth import HTTPBasicAuth
-except Exception as e:
+except ModuleNotFoundError as e:
     print("No module 'requests' found. Install: pip install requests")
     sys.exit(1)
 

--- a/integrations/shuffle.py
+++ b/integrations/shuffle.py
@@ -23,7 +23,7 @@ except Exception as e:
 
 # ADD THIS TO ossec.conf configuration:
 #  <integration>
-#      <name>shuffle.py</name>
+#      <name>shuffle</name>
 #      <hook_url>http://<IP>:3001/api/v1/hooks/<HOOK_ID></hook_url>
 #      <level>3</level>
 #      <alert_format>json</alert_format>
@@ -105,10 +105,9 @@ def debug(msg):
 # Skips container kills to stop self-recursion
 def filter_msg(alert) -> bool:
     # These are things that recursively happen because Shuffle starts Docker containers
-    skip = ["87924", "87900", "87901", "87902", "87903", "87904", "86001", "86002", "86003", "87932", "80710", "87929",
+    skip_rule_ids = ["87924", "87900", "87901", "87902", "87903", "87904", "86001", "86002", "86003", "87932", "80710", "87929",
             "87928", "5710"]
-    if alert["rule"]["id"] in skip:
-        return False
+    return not alert["rule"]["id"] in skip_rule_ids
 
     # try:
     #    if "docker" in alert["rule"]["description"].lower() and "
@@ -117,7 +116,6 @@ def filter_msg(alert) -> bool:
     #    pass
     # msg['title'] = alert['rule']['description'] if 'description' in alert['rule'] else "N/A"
 
-    return True
 
 
 def generate_msg(alert) -> str:

--- a/integrations/shuffle.py
+++ b/integrations/shuffle.py
@@ -33,6 +33,8 @@ debug_enabled = False
 pwd = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 json_alert = {}
 now = time.strftime("%a %b %d %H:%M:%S %Z %Y")
+SKIP_RULE_IDS = ["87924", "87900", "87901", "87902", "87903", "87904", "86001", "86002", "86003", "87932",
+                            "80710", "87929", "87928", "5710"]
 
 # Set paths
 log_file = f'{pwd}/logs/integrations.log'
@@ -92,18 +94,9 @@ def debug(msg):
 
 # Skips container kills to stop self-recursion
 def filter_msg(alert) -> bool:
-    # These are things that recursively happen because Shuffle starts Docker containers
-    skip_rule_ids = ["87924", "87900", "87901", "87902", "87903", "87904", "86001", "86002", "86003", "87932", "80710", "87929",
-            "87928", "5710"]
-    return not alert["rule"]["id"] in skip_rule_ids
+    # SKIP_RULE_IDS need to be filtered because Shuffle starts Docker containers, therefore those alerts are triggered
 
-    # try:
-    #    if "docker" in alert["rule"]["description"].lower() and "
-    # msg['text'] = alert.get('full_log')
-    # except:
-    #    pass
-    # msg['title'] = alert['rule']['description'] if 'description' in alert['rule'] else "N/A"
-
+    return not alert["rule"]["id"] in SKIP_RULE_IDS
 
 
 def generate_msg(alert) -> str:
@@ -150,8 +143,8 @@ if __name__ == "__main__":
                 sys.argv[3],
                 sys.argv[4] if len(sys.argv) > 4 else '',
             )
-            # debug_enabled = (len(sys.argv) > 4 and sys.argv[4] == 'debug')
-            debug_enabled = True
+
+            debug_enabled = (len(sys.argv) > 4 and sys.argv[4] == 'debug')
         else:
             msg = '{0} Wrong arguments'.format(now)
             bad_arguments = True

--- a/integrations/shuffle.py
+++ b/integrations/shuffle.py
@@ -12,7 +12,6 @@ import json
 import sys
 import time
 import os
-import logging
 
 try:
     import requests
@@ -37,21 +36,9 @@ now = time.strftime("%a %b %d %H:%M:%S %Z %Y")
 
 # Set paths
 log_file = f'{pwd}/logs/integrations.log'
-log_shuffle = "/tmp/shuffle.log"
-
-logging_msg_format = '%(asctime)s shuffle.py: %(levelname)s: %(message)s'
-logging_date_format = '%Y/%m/%d %I:%M:%S'
-
-
-def set_logger():
-    """Set the logger configuration."""
-    logging.basicConfig(level=logging.INFO, format=logging_msg_format,
-                        datefmt=logging_date_format, filename=log_shuffle,filemode='a')
 
 
 def main(args):
-    set_logger()
-    logging.info("Script started")
 
     debug("# Starting")
 
@@ -90,8 +77,6 @@ def main(args):
     debug(msg)
 
     debug("# Sending message")
-
-    logging.info("Script done pre-msg sending")
 
     send_msg(msg, webhook)
 

--- a/integrations/shuffle.py
+++ b/integrations/shuffle.py
@@ -37,7 +37,7 @@ SKIP_RULE_IDS = ["87924", "87900", "87901", "87902", "87903", "87904", "86001", 
                             "80710", "87929", "87928", "5710"]
 
 # Set paths
-log_file = f'{pwd}/logs/integrations.log'
+LOG_FILE = f'{pwd}/logs/integrations.log'
 
 
 def main(args):
@@ -87,7 +87,7 @@ def debug(msg):
     if debug_enabled:
         msg = "{0}: {1}\n".format(now, msg)
         print(msg)
-        f = open(log_file, "a")
+        f = open(LOG_FILE, "a")
         f.write(msg)
         f.close()
 
@@ -150,7 +150,7 @@ if __name__ == "__main__":
             bad_arguments = True
 
         # Logging the call
-        f = open(log_file, 'a')
+        f = open(LOG_FILE, 'a')
         f.write(msg + '\n')
         f.close()
 

--- a/integrations/shuffle.py
+++ b/integrations/shuffle.py
@@ -63,16 +63,15 @@ def main(args):
     try:
         with open(alert_file_location) as alert_file:
             json_alert = json.load(alert_file)
-    except:
+    except FileNotFoundError:
         debug("# Alert file %s doesn't exist" % alert_file_location)
         sys.exit(3)
-
-    debug("# Processing alert")
-    try:
-        debug(json_alert)
-    except Exception as e:
+    except json.decoder.JSONDecodeError as e:
         debug("Failed getting json_alert %s" % e)
         sys.exit(4)
+
+    debug("# Processing alert")
+    debug(json_alert)
 
     debug("# Generating message")
     msg: str = generate_msg(json_alert)

--- a/integrations/tests/test_shuffle.py
+++ b/integrations/tests/test_shuffle.py
@@ -9,7 +9,9 @@ import sys
 import os
 import json
 import pytest
+import requests
 import shuffle
+from unittest.mock import patch, mock_open
 
 sys.path.append(os.path.join(os.path.dirname(
     os.path.realpath(__file__)), '..', '..'))
@@ -24,9 +26,102 @@ alert_template = {'timestamp': 'year-month-dayThours:minuts:seconds+0000',
 
 msg_template = '{"severity": 1, "pretext": "WAZUH Alert", "title": "alert description", "text": "full log.", "rule_id": "rule-id", "timestamp": "year-month-dayThours:minuts:seconds+0000", "id": "alert_id", "all_fields": {"timestamp": "year-month-dayThours:minuts:seconds+0000", "rule": {"level": 0, "description": "alert description", "id": "rule-id", "firedtimes": 1}, "id": "alert_id", "full_log": "full log.", "decoder": {"name": "decoder-name"}, "location": "wazuh-X"}}'
 
+sys_args_template = ['/var/ossec/integrations/shuffle.py', '/tmp/shuffle-XXXXXX-XXXXXXX.alert', '',
+                     'http://<IP>:3001/api/v1/hooks/<HOOK_ID>', ' > /dev/null 2>&1']
+
+
+@pytest.mark.parametrize('args', [sys_args_template])
+def test_main_alert_file_exit(args):
+    """
+    Test that main function exits when alert file is not found
+
+    Parameters
+    ----------
+    args: list[str]
+       list of the arguments passed to the main function
+
+    -------
+
+    """
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        shuffle.main(args)
+    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.value.code == 3
+
+
+@pytest.mark.parametrize('args, alert', [(sys_args_template, alert_template)])
+def test_main(args, alert):
+    """
+    Test the correct execution of the main function
+
+    Parameters
+    ----------
+    args: list[str]
+       list of the arguments passed to the main function
+
+    alert: json
+       template alert read from the alert file
+
+
+    """
+    with patch("builtins.open", mock_open()), \
+            patch('json.load', return_value=alert), \
+            patch('requests.post', return_value=requests.Response):
+        shuffle.main(args)
+
+
+@pytest.mark.parametrize('args, alert', [(sys_args_template, alert_template)])
+def test_main_not_sending_message(args, alert):
+    """
+    Test that the send_msg function is not executed due to empty message after generate_msg
+
+    Parameters
+    ----------
+    args: list[str]
+       list of the arguments passed to the main function
+
+    alert: json
+       template alert read from the alert file
+    """
+    with patch("builtins.open", mock_open()), \
+            patch('json.load', return_value=alert), \
+            patch('shuffle.generate_msg', return_value=''):
+        shuffle.main(args)
+
+
+@pytest.mark.parametrize('debug_enabled, msg, expected_result', [
+    (True, msg_template, f"{shuffle.now}: {msg_template}\n")
+])
+def test_debug(tmpdir, debug_enabled, msg, expected_result):
+    """
+    Test the correct execution of the debug function, writing the expected log when debug mode enabled
+
+    Parameters
+    ----------
+    tmpdir: py.path.local
+        Path to a temporary directory generated for the test
+
+    debug_enabled: bool
+        determines if debug mode is enabled or not
+
+    msg: str
+        message to be logged by the debug function
+
+    expected_result: str
+        expected log to be obtained after the execution of the debug function
+
+
+    """
+    log_file = tmpdir.join('test.log')
+    with patch('shuffle.debug_enabled', return_value=debug_enabled), \
+            patch('shuffle.LOG_FILE', str(log_file)):
+        shuffle.debug(msg)
+
+    assert log_file.read() == expected_result
+
 
 @pytest.mark.parametrize('alert, expected_msg, rule_id', [
-(alert_template, "", shuffle.SKIP_RULE_IDS[0]),
+    (alert_template, "", shuffle.SKIP_RULE_IDS[0]),
     (alert_template, msg_template, 'rule-id')
 ])
 def test_generate_msg(alert, expected_msg, rule_id):
@@ -38,11 +133,12 @@ def test_generate_msg(alert, expected_msg, rule_id):
     alert : json
         json data that simulates the values that could have been obtained from alert_file_location.
 
-    msg : str
+    expected_msg : str
         message that should be returned by the generate_msg function
     """
     alert['rule']['id'] = rule_id
     assert shuffle.generate_msg(alert) == expected_msg
+
 
 @pytest.mark.parametrize('alert, rule_level, severity', [
     (alert_template, 3, 1),
@@ -50,6 +146,22 @@ def test_generate_msg(alert, expected_msg, rule_id):
     (alert_template, 8, 3)
 ])
 def test_generate_msg_severity(alert, rule_level, severity):
+    """
+    Test that the different rule levels generate different severities in the message delivered by generate_msg
+
+    Parameters
+    ----------
+    alert: json
+        json that that simulates the values that could have been obtained from alert_file_location
+
+    rule_level: int
+        integer that represents the rule level
+
+    severity: int
+        expected severity level for the corresponding rule level
+
+    """
+
     alert['rule']['level'] = rule_level
     assert json.loads(shuffle.generate_msg(alert))['severity'] == severity
 
@@ -63,6 +175,8 @@ def test_filtered_msg(alert, rule_ids):
     ----------
     alert : json
         json data that simulates the values that could have been obtained from alert_file_location.
+    rule_ids: str
+         rule ids that will get the alert to be filtered
 
     """
     for skip_id in rule_ids:
@@ -80,6 +194,28 @@ def test_not_filtered_msg(alert, rule_id):
     alert : json
         json data that simulates the values that could have been obtained from alert_file_location.
 
+    rule_id: str
+         rule id that will not get the alert to be filtered
     """
     alert['rule']['id'] = rule_id
     assert shuffle.filter_msg(alert)
+
+
+@pytest.mark.parametrize('msg, url', [(msg_template, 'http://webhook-url')])
+def test_send_msg_raise_exception(msg, url):
+    """
+    Test that the send_msg function will raise an exception when passed the wrong webhook url
+
+    Parameters
+    ----------
+    msg: str
+        message to be sent via integratord
+
+    url: str
+        webhook url of the integrated service
+
+    """
+    with patch('requests.post') as sendmock, \
+            pytest.raises(requests.exceptions.ConnectionError):
+        sendmock.side_effect = requests.exceptions.ConnectionError
+        shuffle.send_msg(msg, url)

--- a/integrations/tests/test_shuffle.py
+++ b/integrations/tests/test_shuffle.py
@@ -80,7 +80,7 @@ def test_process_args():
 
 
 def test_process_args_json_exit(tmpdir):
-    """Test the correct execution of the process_args function.
+    """Test that the process_args function exits when json exception is raised.
 
     Parameters
     ----------
@@ -91,7 +91,9 @@ def test_process_args_json_exit(tmpdir):
     with patch('shuffle.debug_enabled', return_value=True), \
             patch('shuffle.LOG_FILE', str(log_file)), \
             patch("builtins.open", mock_open()), \
+            patch('json.load') as json_load, \
             pytest.raises(SystemExit) as pytest_wrapped_e:
+        json_load.side_effect = json.decoder.JSONDecodeError("Expecting value", "", 0)
         shuffle.process_args(sys_args_template)
     assert pytest_wrapped_e.value.code == 4
 

--- a/integrations/tests/test_shuffle.py
+++ b/integrations/tests/test_shuffle.py
@@ -116,8 +116,10 @@ def test_debug():
         open_mock().write.assert_called_with(f"{shuffle.now}: {msg_template}\n")
 
 
-@pytest.mark.parametrize('expected_msg, rule_id',
-                         list(("", x) for x in shuffle.SKIP_RULE_IDS) + [(msg_template, 'rule-id')])
+@pytest.mark.parametrize('rule_id, expected_msg', [
+    (shuffle.SKIP_RULE_IDS[0], ""),
+    ('rule-id', msg_template)
+])
 def test_generate_msg(expected_msg, rule_id):
     """Test that the expected message is generated when json_alert received.
 
@@ -135,7 +137,8 @@ def test_generate_msg(expected_msg, rule_id):
 
 @pytest.mark.parametrize('rule_level, severity', [
     (3, 1),
-    (6, 2),
+    (5, 2),
+    (7, 2),
     (8, 3)
 ])
 def test_generate_msg_severity(rule_level, severity):
@@ -153,9 +156,10 @@ def test_generate_msg_severity(rule_level, severity):
     assert json.loads(shuffle.generate_msg(alert_template))['severity'] == severity
 
 
-@pytest.mark.parametrize('rule_id, result',
-                         list((x, False) for x in shuffle.SKIP_RULE_IDS) + [('rule-id', True)]
-                         )
+@pytest.mark.parametrize('rule_id, result', [
+    (shuffle.SKIP_RULE_IDS[0], False),
+    ('rule-id', True)
+])
 def test_filter_msg(rule_id, result):
     """Test the filter_msg function.
 

--- a/integrations/tests/test_shuffle.py
+++ b/integrations/tests/test_shuffle.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2015, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute
+# it and/or modify it under the terms of GPLv2
+
+"""Unit tests for shuffle.py integration."""
+
+import sys
+import os
+import pytest
+import shuffle
+from unittest.mock import patch
+
+sys.path.append(os.path.join(os.path.dirname(
+    os.path.realpath(__file__)), '..', '..'))
+
+@pytest.mark.parametrize('json_alert, msg', [( {'timestamp': 'year-month-dayThours:minuts:seconds+0000',
+                                                 'rule': {'level': 0, 'description': 'alert description',
+                                                          'id': 'rule-id',
+                                                          'firedtimes': 1},
+                                                'id': 'alert_id',
+                                                 'full_log': 'full log.', 'decoder': {'name': 'decoder-name'},
+                                                 'location': 'wazuh-X'},
+                                                '{"severity": 1, "pretext": "WAZUH Alert", "title": "alert description", "text": "full log.", "rule_id": "rule-id", "timestamp": "year-month-dayThours:minuts:seconds+0000", "id": "alert_id", "all_fields": {"timestamp": "year-month-dayThours:minuts:seconds+0000", "rule": {"level": 0, "description": "alert description", "id": "rule-id", "firedtimes": 1}, "id": "alert_id", "full_log": "full log.", "decoder": {"name": "decoder-name"}, "location": "wazuh-X"}}')])
+
+
+def test_generate_msg(json_alert, msg):
+    """
+        Test that the expected message is generated when json_alert received.
+
+        Parameters
+        ----------
+        json_alert : json
+            json data that simulates the values that could have
+            been obtained from alert_file_location.
+
+        msg : str
+            message that should be retourned by the generate_msg function
+        """
+    assert shuffle.generate_msg(json_alert) == msg
+    # assert shuffle.generate_msg(json_alert) == msg
+
+
+def test_filter_msg():
+    pass
+
+
+def test_send_msg():
+    pass

--- a/integrations/tests/test_shuffle.py
+++ b/integrations/tests/test_shuffle.py
@@ -14,6 +14,10 @@ import random
 sys.path.append(os.path.join(os.path.dirname(
     os.path.realpath(__file__)), '..', '..'))
 
+filter_values = ["87924", "87900", "87901", "87902", "87903", "87904", "86001",
+                 "86002", "86003", "87932", "80710", "87929", "87928",
+                 "5710"]
+
 
 @pytest.mark.parametrize('json_alert, msg', [({'timestamp': 'year-month-dayThours:minuts:seconds+0000',
                                                'rule': {'level': 0, 'description': 'alert description',
@@ -22,7 +26,15 @@ sys.path.append(os.path.join(os.path.dirname(
                                                'id': 'alert_id',
                                                'full_log': 'full log.', 'decoder': {'name': 'decoder-name'},
                                                'location': 'wazuh-X'},
-                                              '{"severity": 1, "pretext": "WAZUH Alert", "title": "alert description", "text": "full log.", "rule_id": "rule-id", "timestamp": "year-month-dayThours:minuts:seconds+0000", "id": "alert_id", "all_fields": {"timestamp": "year-month-dayThours:minuts:seconds+0000", "rule": {"level": 0, "description": "alert description", "id": "rule-id", "firedtimes": 1}, "id": "alert_id", "full_log": "full log.", "decoder": {"name": "decoder-name"}, "location": "wazuh-X"}}')])
+                                              '{"severity": 1, "pretext": "WAZUH Alert", "title": "alert description", "text": "full log.", "rule_id": "rule-id", "timestamp": "year-month-dayThours:minuts:seconds+0000", "id": "alert_id", "all_fields": {"timestamp": "year-month-dayThours:minuts:seconds+0000", "rule": {"level": 0, "description": "alert description", "id": "rule-id", "firedtimes": 1}, "id": "alert_id", "full_log": "full log.", "decoder": {"name": "decoder-name"}, "location": "wazuh-X"}}'),
+                                             ({'timestamp': 'year-month-dayThours:minuts:seconds+0000',
+                                               'rule': {'level': 0, 'description': 'alert description',
+                                                        'id': random.choice(filter_values),
+                                                        'firedtimes': 1},
+                                               'id': 'alert_id',
+                                               'full_log': 'full log.', 'decoder': {'name': 'decoder-name'},
+                                               'location': 'wazuh-X'},
+                                              '')])
 def test_generate_msg(json_alert, msg):
     """
     Test that the expected message is generated when json_alert received.
@@ -39,17 +51,14 @@ def test_generate_msg(json_alert, msg):
     assert shuffle.generate_msg(json_alert) == msg
 
 
-@pytest.mark.parametrize('json_alert, filter_values', [({'timestamp': 'year-month-dayThours:minuts:seconds+0000',
+@pytest.mark.parametrize('json_alert', [({'timestamp': 'year-month-dayThours:minuts:seconds+0000',
                                                          'rule': {'level': 0, 'description': 'alert description',
                                                                   'id': 'rule-id',
                                                                   'firedtimes': 1},
                                                          'id': 'alert_id',
                                                          'full_log': 'full log.', 'decoder': {'name': 'decoder-name'},
-                                                         'location': 'wazuh-X'},
-                                                        ["87924", "87900", "87901", "87902", "87903", "87904", "86001",
-                                                         "86002", "86003", "87932", "80710", "87929", "87928",
-                                                         "5710"])])
-def test_filtered_msg(json_alert, filter_values):
+                                                         'location': 'wazuh-X'})])
+def test_filtered_msg(json_alert):
     """
     Test that the alerts with certain rule ids are filtered.
 

--- a/integrations/tests/test_shuffle.py
+++ b/integrations/tests/test_shuffle.py
@@ -14,46 +14,44 @@ import random
 sys.path.append(os.path.join(os.path.dirname(
     os.path.realpath(__file__)), '..', '..'))
 
+alert_template = {'timestamp': 'year-month-dayThours:minuts:seconds+0000',
+                  'rule': {'level': 0, 'description': 'alert description',
+                           'id': 'rule-id',
+                           'firedtimes': 1},
+                  'id': 'alert_id',
+                  'full_log': 'full log.', 'decoder': {'name': 'decoder-name'},
+                  'location': 'wazuh-X'}
 
-@pytest.mark.parametrize('json_alert, msg', [({'timestamp': 'year-month-dayThours:minuts:seconds+0000',
-                                               'rule': {'level': 0, 'description': 'alert description',
-                                                        'id': 'rule-id',
-                                                        'firedtimes': 1},
-                                               'id': 'alert_id',
-                                               'full_log': 'full log.', 'decoder': {'name': 'decoder-name'},
-                                               'location': 'wazuh-X'},
-                                              '{"severity": 1, "pretext": "WAZUH Alert", "title": "alert description", "text": "full log.", "rule_id": "rule-id", "timestamp": "year-month-dayThours:minuts:seconds+0000", "id": "alert_id", "all_fields": {"timestamp": "year-month-dayThours:minuts:seconds+0000", "rule": {"level": 0, "description": "alert description", "id": "rule-id", "firedtimes": 1}, "id": "alert_id", "full_log": "full log.", "decoder": {"name": "decoder-name"}, "location": "wazuh-X"}}'),
-                                             ({'timestamp': 'year-month-dayThours:minuts:seconds+0000',
-                                               'rule': {'level': 0, 'description': 'alert description',
-                                                        'id': random.choice(shuffle.SKIP_RULE_IDS),
-                                                        'firedtimes': 1},
-                                               'id': 'alert_id',
-                                               'full_log': 'full log.', 'decoder': {'name': 'decoder-name'},
-                                               'location': 'wazuh-X'},
-                                              '')])
-def test_generate_msg(json_alert, msg):
+msg_template = '{"severity": 1, "pretext": "WAZUH Alert", "title": "alert description", "text": "full log.", "rule_id": "rule-id", "timestamp": "year-month-dayThours:minuts:seconds+0000", "id": "alert_id", "all_fields": {"timestamp": "year-month-dayThours:minuts:seconds+0000", "rule": {"level": 0, "description": "alert description", "id": "rule-id", "firedtimes": 1}, "id": "alert_id", "full_log": "full log.", "decoder": {"name": "decoder-name"}, "location": "wazuh-X"}}'
+
+
+@pytest.mark.parametrize('alert, expected_msg, rule_id', [
+    (alert_template, msg_template, 'rule-id'),
+    (alert_template, "", shuffle.SKIP_RULE_IDS[0])
+])
+def test_generate_msg(alert, expected_msg, rule_id):
     """
     Test that the expected message is generated when json_alert received.
 
     Parameters
     ----------
     json_alert : json
-        json data that simulates the values that could have
-        been obtained from alert_file_location.
+        json data that simulates the values that could have been obtained from alert_file_location.
 
     msg : str
         message that should be returned by the generate_msg function
     """
-    assert shuffle.generate_msg(json_alert) == msg
+    alert['rule']['id'] = rule_id
+    assert shuffle.generate_msg(alert) == expected_msg
 
 
 @pytest.mark.parametrize('json_alert', [({'timestamp': 'year-month-dayThours:minuts:seconds+0000',
-                                                         'rule': {'level': 0, 'description': 'alert description',
-                                                                  'id': 'rule-id',
-                                                                  'firedtimes': 1},
-                                                         'id': 'alert_id',
-                                                         'full_log': 'full log.', 'decoder': {'name': 'decoder-name'},
-                                                         'location': 'wazuh-X'})])
+                                          'rule': {'level': 0, 'description': 'alert description',
+                                                   'id': 'rule-id',
+                                                   'firedtimes': 1},
+                                          'id': 'alert_id',
+                                          'full_log': 'full log.', 'decoder': {'name': 'decoder-name'},
+                                          'location': 'wazuh-X'})])
 def test_filtered_msg(json_alert):
     """
     Test that the alerts with certain rule ids are filtered.
@@ -61,8 +59,7 @@ def test_filtered_msg(json_alert):
     Parameters
     ----------
     json_alert : json
-        json data that simulates the values that could have
-        been obtained from alert_file_location.
+        json data that simulates the values that could have been obtained from alert_file_location.
 
     """
     json_alert['rule']['id'] = random.choice(shuffle.SKIP_RULE_IDS)
@@ -84,8 +81,7 @@ def test_not_filtered_msg(json_alert):
     Parameters
     ----------
     json_alert : json
-        json data that simulates the values that could have
-        been obtained from alert_file_location.
+        json data that simulates the values that could have been obtained from alert_file_location.
 
     """
     assert shuffle.filter_msg(json_alert)

--- a/integrations/tests/test_shuffle.py
+++ b/integrations/tests/test_shuffle.py
@@ -61,7 +61,9 @@ def test_main_correct_execution():
 
 def test_process_args_alert_file_exit():
     """Test that process_args function exits when alert file is not found."""
-    with pytest.raises(SystemExit) as pytest_wrapped_e:
+    with patch("builtins.open") as open_mock, \
+            pytest.raises(SystemExit) as pytest_wrapped_e:
+        open_mock.side_effect = FileNotFoundError
         shuffle.process_args(sys_args_template)
     assert pytest_wrapped_e.value.code == 3
 

--- a/integrations/tests/test_shuffle.py
+++ b/integrations/tests/test_shuffle.py
@@ -9,41 +9,78 @@ import sys
 import os
 import pytest
 import shuffle
-from unittest.mock import patch
+import random
 
 sys.path.append(os.path.join(os.path.dirname(
     os.path.realpath(__file__)), '..', '..'))
 
-@pytest.mark.parametrize('json_alert, msg', [( {'timestamp': 'year-month-dayThours:minuts:seconds+0000',
-                                                 'rule': {'level': 0, 'description': 'alert description',
-                                                          'id': 'rule-id',
-                                                          'firedtimes': 1},
-                                                'id': 'alert_id',
-                                                 'full_log': 'full log.', 'decoder': {'name': 'decoder-name'},
-                                                 'location': 'wazuh-X'},
-                                                '{"severity": 1, "pretext": "WAZUH Alert", "title": "alert description", "text": "full log.", "rule_id": "rule-id", "timestamp": "year-month-dayThours:minuts:seconds+0000", "id": "alert_id", "all_fields": {"timestamp": "year-month-dayThours:minuts:seconds+0000", "rule": {"level": 0, "description": "alert description", "id": "rule-id", "firedtimes": 1}, "id": "alert_id", "full_log": "full log.", "decoder": {"name": "decoder-name"}, "location": "wazuh-X"}}')])
 
-
+@pytest.mark.parametrize('json_alert, msg', [({'timestamp': 'year-month-dayThours:minuts:seconds+0000',
+                                               'rule': {'level': 0, 'description': 'alert description',
+                                                        'id': 'rule-id',
+                                                        'firedtimes': 1},
+                                               'id': 'alert_id',
+                                               'full_log': 'full log.', 'decoder': {'name': 'decoder-name'},
+                                               'location': 'wazuh-X'},
+                                              '{"severity": 1, "pretext": "WAZUH Alert", "title": "alert description", "text": "full log.", "rule_id": "rule-id", "timestamp": "year-month-dayThours:minuts:seconds+0000", "id": "alert_id", "all_fields": {"timestamp": "year-month-dayThours:minuts:seconds+0000", "rule": {"level": 0, "description": "alert description", "id": "rule-id", "firedtimes": 1}, "id": "alert_id", "full_log": "full log.", "decoder": {"name": "decoder-name"}, "location": "wazuh-X"}}')])
 def test_generate_msg(json_alert, msg):
     """
-        Test that the expected message is generated when json_alert received.
+    Test that the expected message is generated when json_alert received.
 
-        Parameters
-        ----------
-        json_alert : json
-            json data that simulates the values that could have
-            been obtained from alert_file_location.
+    Parameters
+    ----------
+    json_alert : json
+        json data that simulates the values that could have
+        been obtained from alert_file_location.
 
-        msg : str
-            message that should be retourned by the generate_msg function
-        """
+    msg : str
+        message that should be retourned by the generate_msg function
+    """
     assert shuffle.generate_msg(json_alert) == msg
-    # assert shuffle.generate_msg(json_alert) == msg
 
 
-def test_filter_msg():
-    pass
+@pytest.mark.parametrize('json_alert, filter_values', [({'timestamp': 'year-month-dayThours:minuts:seconds+0000',
+                                                         'rule': {'level': 0, 'description': 'alert description',
+                                                                  'id': 'rule-id',
+                                                                  'firedtimes': 1},
+                                                         'id': 'alert_id',
+                                                         'full_log': 'full log.', 'decoder': {'name': 'decoder-name'},
+                                                         'location': 'wazuh-X'},
+                                                        ["87924", "87900", "87901", "87902", "87903", "87904", "86001",
+                                                         "86002", "86003", "87932", "80710", "87929", "87928",
+                                                         "5710"])])
+def test_filtered_msg(json_alert, filter_values):
+    """
+    Test that the alerts with certain rule ids are filtered.
+
+    Parameters
+    ----------
+    json_alert : json
+        json data that simulates the values that could have
+        been obtained from alert_file_location.
+
+    """
+    json_alert['rule']['id'] = random.choice(filter_values)
+
+    assert not shuffle.filter_msg(json_alert)
 
 
-def test_send_msg():
-    pass
+@pytest.mark.parametrize('json_alert', [({'timestamp': 'year-month-dayThours:minuts:seconds+0000',
+                                          'rule': {'level': 0, 'description': 'alert description',
+                                                   'id': 'rule-id',
+                                                   'firedtimes': 1},
+                                          'id': 'alert_id',
+                                          'full_log': 'full log.', 'decoder': {'name': 'decoder-name'},
+                                          'location': 'wazuh-X'})])
+def test_not_filtered_msg(json_alert):
+    """
+    Test that the alerts that not contain certain rule ids are not filtered.
+
+    Parameters
+    ----------
+    json_alert : json
+        json data that simulates the values that could have
+        been obtained from alert_file_location.
+
+    """
+    assert shuffle.filter_msg(json_alert)

--- a/integrations/tests/test_shuffle.py
+++ b/integrations/tests/test_shuffle.py
@@ -9,14 +9,13 @@ import sys
 import os
 import pytest
 import shuffle
-import random
 
 sys.path.append(os.path.join(os.path.dirname(
     os.path.realpath(__file__)), '..', '..'))
 
 alert_template = {'timestamp': 'year-month-dayThours:minuts:seconds+0000',
                   'rule': {'level': 0, 'description': 'alert description',
-                           'id': 'rule-id',
+                           'id': '',
                            'firedtimes': 1},
                   'id': 'alert_id',
                   'full_log': 'full log.', 'decoder': {'name': 'decoder-name'},
@@ -35,7 +34,7 @@ def test_generate_msg(alert, expected_msg, rule_id):
 
     Parameters
     ----------
-    json_alert : json
+    alert : json
         json data that simulates the values that could have been obtained from alert_file_location.
 
     msg : str
@@ -45,43 +44,32 @@ def test_generate_msg(alert, expected_msg, rule_id):
     assert shuffle.generate_msg(alert) == expected_msg
 
 
-@pytest.mark.parametrize('json_alert', [({'timestamp': 'year-month-dayThours:minuts:seconds+0000',
-                                          'rule': {'level': 0, 'description': 'alert description',
-                                                   'id': 'rule-id',
-                                                   'firedtimes': 1},
-                                          'id': 'alert_id',
-                                          'full_log': 'full log.', 'decoder': {'name': 'decoder-name'},
-                                          'location': 'wazuh-X'})])
-def test_filtered_msg(json_alert):
+@pytest.mark.parametrize('alert, rule_ids', [(alert_template, shuffle.SKIP_RULE_IDS)])
+def test_filtered_msg(alert, rule_ids):
     """
     Test that the alerts with certain rule ids are filtered.
 
     Parameters
     ----------
-    json_alert : json
+    alert : json
         json data that simulates the values that could have been obtained from alert_file_location.
 
     """
-    json_alert['rule']['id'] = random.choice(shuffle.SKIP_RULE_IDS)
+    for skip_id in rule_ids:
+        alert['rule']['id'] = skip_id
+        assert not shuffle.filter_msg(alert)
 
-    assert not shuffle.filter_msg(json_alert)
 
-
-@pytest.mark.parametrize('json_alert', [({'timestamp': 'year-month-dayThours:minuts:seconds+0000',
-                                          'rule': {'level': 0, 'description': 'alert description',
-                                                   'id': 'rule-id',
-                                                   'firedtimes': 1},
-                                          'id': 'alert_id',
-                                          'full_log': 'full log.', 'decoder': {'name': 'decoder-name'},
-                                          'location': 'wazuh-X'})])
-def test_not_filtered_msg(json_alert):
+@pytest.mark.parametrize('alert, rule_id', [(alert_template, 'rule-id')])
+def test_not_filtered_msg(alert, rule_id):
     """
     Test that the alerts that not contain certain rule ids are not filtered.
 
     Parameters
     ----------
-    json_alert : json
+    alert : json
         json data that simulates the values that could have been obtained from alert_file_location.
 
     """
-    assert shuffle.filter_msg(json_alert)
+    alert['rule']['id'] = rule_id
+    assert shuffle.filter_msg(alert)

--- a/integrations/tests/test_shuffle.py
+++ b/integrations/tests/test_shuffle.py
@@ -7,6 +7,7 @@
 
 import sys
 import os
+import json
 import pytest
 import shuffle
 
@@ -25,8 +26,8 @@ msg_template = '{"severity": 1, "pretext": "WAZUH Alert", "title": "alert descri
 
 
 @pytest.mark.parametrize('alert, expected_msg, rule_id', [
-    (alert_template, msg_template, 'rule-id'),
-    (alert_template, "", shuffle.SKIP_RULE_IDS[0])
+(alert_template, "", shuffle.SKIP_RULE_IDS[0]),
+    (alert_template, msg_template, 'rule-id')
 ])
 def test_generate_msg(alert, expected_msg, rule_id):
     """
@@ -42,6 +43,15 @@ def test_generate_msg(alert, expected_msg, rule_id):
     """
     alert['rule']['id'] = rule_id
     assert shuffle.generate_msg(alert) == expected_msg
+
+@pytest.mark.parametrize('alert, rule_level, severity', [
+    (alert_template, 3, 1),
+    (alert_template, 6, 2),
+    (alert_template, 8, 3)
+])
+def test_generate_msg_severity(alert, rule_level, severity):
+    alert['rule']['level'] = rule_level
+    assert json.loads(shuffle.generate_msg(alert))['severity'] == severity
 
 
 @pytest.mark.parametrize('alert, rule_ids', [(alert_template, shuffle.SKIP_RULE_IDS)])

--- a/integrations/tests/test_shuffle.py
+++ b/integrations/tests/test_shuffle.py
@@ -14,10 +14,6 @@ import random
 sys.path.append(os.path.join(os.path.dirname(
     os.path.realpath(__file__)), '..', '..'))
 
-filter_values = ["87924", "87900", "87901", "87902", "87903", "87904", "86001",
-                 "86002", "86003", "87932", "80710", "87929", "87928",
-                 "5710"]
-
 
 @pytest.mark.parametrize('json_alert, msg', [({'timestamp': 'year-month-dayThours:minuts:seconds+0000',
                                                'rule': {'level': 0, 'description': 'alert description',
@@ -29,7 +25,7 @@ filter_values = ["87924", "87900", "87901", "87902", "87903", "87904", "86001",
                                               '{"severity": 1, "pretext": "WAZUH Alert", "title": "alert description", "text": "full log.", "rule_id": "rule-id", "timestamp": "year-month-dayThours:minuts:seconds+0000", "id": "alert_id", "all_fields": {"timestamp": "year-month-dayThours:minuts:seconds+0000", "rule": {"level": 0, "description": "alert description", "id": "rule-id", "firedtimes": 1}, "id": "alert_id", "full_log": "full log.", "decoder": {"name": "decoder-name"}, "location": "wazuh-X"}}'),
                                              ({'timestamp': 'year-month-dayThours:minuts:seconds+0000',
                                                'rule': {'level': 0, 'description': 'alert description',
-                                                        'id': random.choice(filter_values),
+                                                        'id': random.choice(shuffle.SKIP_RULE_IDS),
                                                         'firedtimes': 1},
                                                'id': 'alert_id',
                                                'full_log': 'full log.', 'decoder': {'name': 'decoder-name'},
@@ -46,7 +42,7 @@ def test_generate_msg(json_alert, msg):
         been obtained from alert_file_location.
 
     msg : str
-        message that should be retourned by the generate_msg function
+        message that should be returned by the generate_msg function
     """
     assert shuffle.generate_msg(json_alert) == msg
 
@@ -69,7 +65,7 @@ def test_filtered_msg(json_alert):
         been obtained from alert_file_location.
 
     """
-    json_alert['rule']['id'] = random.choice(filter_values)
+    json_alert['rule']['id'] = random.choice(shuffle.SKIP_RULE_IDS)
 
     assert not shuffle.filter_msg(json_alert)
 

--- a/integrations/tests/test_shuffle.py
+++ b/integrations/tests/test_shuffle.py
@@ -69,6 +69,32 @@ def test_main(args, alert):
             patch('requests.post', return_value=requests.Response):
         shuffle.main(args)
 
+@pytest.mark.parametrize('debug_enabled,args', [(True, sys_args_template)])
+def test_main_json_exit(tmpdir, debug_enabled, args):
+    """
+    Test the correct execution of the main function
+
+    Parameters
+    ----------
+    tmpdir: py.path.local
+        Path to a temporary directory generated for the tests logs
+
+    debug_enabled: bool
+        determines if debug mode is enabled or not
+
+    args: list[str]
+       list of the arguments passed to the main function
+
+
+    """
+    log_file = tmpdir.join('test.log')
+    with patch('shuffle.debug_enabled', return_value=debug_enabled), \
+            patch('shuffle.LOG_FILE', str(log_file)), \
+            patch("builtins.open", mock_open()), \
+            pytest.raises(SystemExit) as pytest_wrapped_e:
+        shuffle.main(args)
+    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.value.code == 4
 
 @pytest.mark.parametrize('args, alert', [(sys_args_template, alert_template)])
 def test_main_not_sending_message(args, alert):
@@ -99,7 +125,7 @@ def test_debug(tmpdir, debug_enabled, msg, expected_result):
     Parameters
     ----------
     tmpdir: py.path.local
-        Path to a temporary directory generated for the test
+        Path to a temporary directory generated for the tests logs
 
     debug_enabled: bool
         determines if debug mode is enabled or not

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -995,7 +995,7 @@ InstallLocal()
     ${INSTALL} -m 750 -o root -g ${WAZUH_GROUP} ../integrations/pagerduty ${INSTALLDIR}/integrations/pagerduty
     ${INSTALL} -m 750 -o root -g ${WAZUH_GROUP} ../integrations/slack ${INSTALLDIR}/integrations/slack.py
     ${INSTALL} -m 750 -o root -g ${WAZUH_GROUP} ../integrations/virustotal ${INSTALLDIR}/integrations/virustotal.py
-    ${INSTALL} -m 750 -o root -g ${WAZUH_GROUP} ../integrations/shuffle ${INSTALLDIR}/integrations/shuffle.py
+    ${INSTALL} -m 750 -o root -g ${WAZUH_GROUP} ../integrations/shuffle.py ${INSTALLDIR}/integrations/shuffle.py
     touch ${INSTALLDIR}/logs/integrations.log
     chmod 640 ${INSTALLDIR}/logs/integrations.log
     chown ${WAZUH_USER}:${WAZUH_GROUP} ${INSTALLDIR}/logs/integrations.log

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -995,6 +995,7 @@ InstallLocal()
     ${INSTALL} -m 750 -o root -g ${WAZUH_GROUP} ../integrations/pagerduty ${INSTALLDIR}/integrations/pagerduty
     ${INSTALL} -m 750 -o root -g ${WAZUH_GROUP} ../integrations/slack ${INSTALLDIR}/integrations/slack.py
     ${INSTALL} -m 750 -o root -g ${WAZUH_GROUP} ../integrations/virustotal ${INSTALLDIR}/integrations/virustotal.py
+    ${INSTALL} -m 750 -o root -g ${WAZUH_GROUP} ../integrations/shuffle ${INSTALLDIR}/integrations/shuffle.py
     touch ${INSTALLDIR}/logs/integrations.log
     chmod 640 ${INSTALLDIR}/logs/integrations.log
     chown ${WAZUH_USER}:${WAZUH_GROUP} ${INSTALLDIR}/logs/integrations.log
@@ -1114,6 +1115,7 @@ InstallServer()
     # Add the wrappers for python script in active-response
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../framework/wrappers/generic_wrapper.sh ${INSTALLDIR}/integrations/slack
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../framework/wrappers/generic_wrapper.sh ${INSTALLDIR}/integrations/virustotal
+    ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../framework/wrappers/generic_wrapper.sh ${INSTALLDIR}/integrations/shuffle
 
 }
 

--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -79,7 +79,16 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
                 continue;
             }
         }
-
+        else if(strcmp(integrator_config[s]->name, "shuffle") == 0)
+        {
+            if(!integrator_config[s]->hookurl)
+            {
+                integrator_config[s]->enabled = 0;
+                merror("Unable to enable integration for: '%s'. Missing hook URL.", integrator_config[s]->name);
+                s++;
+                continue;
+            }
+        }
         else if(strcmp(integrator_config[s]->name, "pagerduty") == 0)
         {
             if(!integrator_config[s]->apikey)


### PR DESCRIPTION
|Related issue|
|---|
|#15034|

## Description

This PR closes #15034. It adds the Shuffle integration script as Wazuh native. Related installation files have been modified in order to only need the `ossec.conf` when in need to integrate with Shuffle. Also, unit tests have been carried out to check the behavior of the script.

## Configuration options
Inside `ossec.conf`, the following configuration is required to enable the integration
```
 <integration>
     <name>shuffle</name>
     <hook_url>http://<IP>:3001/api/v1/hooks/<HOOK_ID></hook_url>
     <level>3</level>
     <alert_format>json</alert_format>
 </integration>
```
## Unit Tests
```
============================= test session starts ==============================
platform linux -- Python 3.9.5, pytest-6.0.1, py-1.11.0, pluggy-0.13.1 -- /home/test_user/venv/unittest-env/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.14.0-1052-oem-x86_64-with-glibc2.31', 'Packages': {'pytest': '6.0.1', 'py': '1.11.0', 'pluggy': '0.13.1'}, 'Plugins': {'cov': '3.0.0', 'trio': '0.7.0', 'metadata': '2.0.2', 'asyncio': '0.15.1', 'aiohttp': '0.3.0', 'html': '2.1.1'}}
rootdir: /home/test_user/git/wazuh
plugins: cov-3.0.0, trio-0.7.0, metadata-2.0.2, asyncio-0.15.1, aiohttp-0.3.0, html-2.1.1
collecting ... collected 18 items

integrations/tests/test_shuffle.py::test_main_bad_arguments_exit PASSED  [  5%]
integrations/tests/test_shuffle.py::test_main_exception PASSED           [ 11%]
integrations/tests/test_shuffle.py::test_main PASSED                     [ 16%]
integrations/tests/test_shuffle.py::test_process_args_exit[FileNotFoundError-3] PASSED [ 22%]
integrations/tests/test_shuffle.py::test_process_args_exit[side_effect1-4] PASSED [ 27%]
integrations/tests/test_shuffle.py::test_process_args PASSED             [ 33%]
integrations/tests/test_shuffle.py::test_process_args_not_sending_message PASSED [ 38%]
integrations/tests/test_shuffle.py::test_debug PASSED                    [ 44%]
integrations/tests/test_shuffle.py::test_generate_msg[87924-] PASSED     [ 50%]
integrations/tests/test_shuffle.py::test_generate_msg[rule-id-{"severity": 1, "pretext": "WAZUH Alert", "title": "alert description", "text": "full log.", "rule_id": "rule-id", "timestamp": "year-month-dayThours:minuts:seconds+0000", "id": "alert_id", "all_fields": {"timestamp": "year-month-dayThours:minuts:seconds+0000", "rule": {"level": 0, "description": "alert description", "id": "rule-id", "firedtimes": 1}, "id": "alert_id", "full_log": "full log.", "decoder": {"name": "decoder-name"}, "location": "wazuh-X"}}] PASSED [ 55%]
integrations/tests/test_shuffle.py::test_generate_msg_severity[3-1] PASSED [ 61%]
integrations/tests/test_shuffle.py::test_generate_msg_severity[5-2] PASSED [ 66%]
integrations/tests/test_shuffle.py::test_generate_msg_severity[7-2] PASSED [ 72%]
integrations/tests/test_shuffle.py::test_generate_msg_severity[8-3] PASSED [ 77%]
integrations/tests/test_shuffle.py::test_filter_msg[87924-False] PASSED  [ 83%]
integrations/tests/test_shuffle.py::test_filter_msg[rule-id-True] PASSED [ 88%]
integrations/tests/test_shuffle.py::test_send_msg_raise_exception PASSED [ 94%]
integrations/tests/test_shuffle.py::test_send_msg PASSED                 [100%]

============================== 18 passed in 0.08s ==============================
```
