### PR TITLE
[4.3.9] Update protobuf to 3.19.6

### DIFF
--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -56,7 +56,7 @@ mypy-extensions==0.4.3
 openapi-spec-validator==0.2.6
 packaging==20.9
 pathlib==1.0.1
-protobuf==4.21.6
+protobuf==3.19.6
 proto-plus==1.19.0
 psutil==5.7.0
 pyasn1==0.4.8


### PR DESCRIPTION
|Related issue|
|---|
|#15005|

Due to the vulnerability detected in the `protobuf` library in versions lower than `3.18.3`, we have decided to update this library to 3.19.6.