### PR TITLE
Engine - Active Responses

### DIFF
--- a/src/engine/source/builder/CMakeLists.txt
+++ b/src/engine/source/builder/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(builders OBJECT
   builders/opBuilderWdb.cpp
   builders/opBuilderARWrite.cpp
   builders/opBuilderSCAdecoder.cpp
+  builders/opBuilderHelperActiveResponse.cpp
   definitions.cpp
   asset.cpp
   environment.cpp

--- a/src/engine/source/builder/builders/opBuilderARWrite.hpp
+++ b/src/engine/source/builder/builders/opBuilderARWrite.hpp
@@ -15,6 +15,7 @@
 
 namespace builder::internals::builders
 {
+// TODO: move all the sockets to a shared utils directory
 constexpr const char* AR_QUEUE_PATH {"/var/ossec/queue/alerts/ar"};
 
 /**

--- a/src/engine/source/builder/builders/opBuilderHelperActiveResponse.cpp
+++ b/src/engine/source/builder/builders/opBuilderHelperActiveResponse.cpp
@@ -1,0 +1,228 @@
+/* Copyright (C) 2015-2022, Wazuh Inc.
+ * All rights reserved.
+ *
+ */
+
+#include "opBuilderHelperActiveResponse.hpp"
+
+#include <algorithm>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <variant>
+
+#include <baseHelper.hpp>
+#include <utils/socketInterface/unixDatagram.hpp>
+#include <opBuilderARWrite.hpp> //TODO -> check header position
+#include <utils/stringUtils.hpp>
+
+using base::utils::socketInterface::SendRetval;
+using base::utils::socketInterface::unixDatagram;
+
+namespace ar
+{
+// create a base JSON object
+json::Json baseJson(R"({
+    "version":0,
+    "origin":{
+        "name":"",
+        "module":""
+        },
+    "command":"",
+    "parameters":{
+        "extra_args":[],
+        "alert":""
+        }
+    })");
+
+// Paths
+constexpr auto AGENT_ID_PATH = "/agent/id";
+constexpr auto ORIGIN_NAME_PATH = "/origin/name";
+constexpr auto VERSION_PATH = "/version";
+constexpr auto ALERT_PATH = "/parameters/alert";
+constexpr auto EXTRA_ARGS_PATH = "/parameters/extra_args";
+constexpr auto EVENT_ORIGINAL = "/event/original";
+
+// values
+constexpr auto NODE_NAME = "node01";
+constexpr auto MODULE = "wazuh-analysisd";
+constexpr int VERSION = 1;
+constexpr int AGENT_NONE = -1;
+
+}
+
+namespace builder::internals::builders
+{
+
+// _ar_result: +ar/<command-name>/<location>/<timeout>/<$_args>
+base::Expression opBuilderHelperActiveResponse(const std::any& definition)
+{
+    //TODO: check if Active response is enabled first, if not throw runtime_error
+    //for this create ActiveResponse Object with init from main.cpp
+
+    // Extract parameters from definition
+    auto [targetField, name, raw_parameters] =
+        helper::base::extractDefinition(definition);
+
+    // Identify references and build JSON pointer paths
+    auto parameters {helper::base::processParameters(raw_parameters)};
+
+    // Assert expected number of parameters
+    helper::base::checkParametersMinSize(parameters, 2);
+
+    // Format name for the tracer
+    name = helper::base::formatHelperFilterName(name, targetField, parameters);
+
+    // Get command-name -> mandatory presence being value or reference
+    const helper::base::Parameter commandName {parameters[0]};
+
+    // Get Location -> mandatory value
+    // Not checking location value because nothing will be executed on manager
+    helper::base::checkParameterType(parameters[1], helper::base::Parameter::Type::VALUE);
+    const auto location {parameters[1].m_value};
+    if(location.empty())
+    {
+        throw std::runtime_error(fmt::format("[base::opBuilderHelperActiveResponse] -> "
+                                             "Failure: <location> shouldn't be empty"));
+    }
+    std::shared_ptr<unixDatagram> socketAR {nullptr};
+    socketAR = std::make_shared<unixDatagram>(AR_QUEUE_PATH);
+
+    // Get timeout first optional parameter
+    const auto parametersSize = parameters.size();
+    std::string timeoutField;
+    if(parametersSize > 2)
+    {
+        timeoutField = parameters[2].m_value;
+    }
+
+    // Get _args seccond optional parameter -> should be an array
+    std::string argsRef;
+    if(parametersSize > 3)
+    {
+        helper::base::checkParameterType(parameters[3], helper::base::Parameter::Type::REFERENCE);
+        argsRef = parameters[3].m_value;
+    }
+
+    // If it has more than 4 arguments then it's an error
+    if(parametersSize > 4)
+    {
+        throw std::runtime_error(fmt::format("[base::opBuilderHelperActiveResponse] -> "
+                                             "Failure: Too many arguments"));
+    }
+
+    // Tracing
+    const auto successTrace {fmt::format("[{}] -> Success", name)};
+    const auto failureTrace1 {fmt::format("[{}] -> Failure: [{}] not found", name, parameters[3].m_value)};
+    const auto failureTrace2 {fmt::format("[{}] -> Failure: query is empty", name)};
+    const auto failureTrace3 {fmt::format("[{}] -> Failure", name)};
+    const auto failureTrace4 {fmt::format("[{}] -> Failure: Unable to get agent ID", name)};
+
+    // Function that implements the helper
+    return base::Term<base::EngineOp>::create(
+        name,
+        [=,
+         targetField = std::move(targetField),
+         commandName = std::move(commandName),
+         location = std::move(location),
+         socketAR = std::move(socketAR),
+         timeoutField = std::move(timeoutField),
+         argsRef = std::move(argsRef),
+         name = std::move(name)](base::Event event) -> base::result::Result<base::Event> {
+            // TODO: module name and version are fixed values, should be changed?
+            ar::baseJson.setInt(ar::VERSION, ar::VERSION_PATH);
+
+            // TODO: get Node name from ossec.conf -> if not "undefined" -> if not ""
+            // harcoded for now
+            ar::baseJson.setString(ar::NODE_NAME, ar::ORIGIN_NAME_PATH);
+
+            int agentID {ar::AGENT_NONE};
+            // Check location
+            if (!location.compare("LOCAL"))
+            {
+                agentID = std::stoi(event->getString(ar::AGENT_ID_PATH).value());
+            }
+            else if (!location.compare("ALL"))
+            {
+                // TODO: rigt now not supported (won't be hadled in the Execd)
+                // but send a keyword either way
+            }
+            else
+            {
+                // Specific ID
+                agentID = std::stoi(location);
+            }
+
+            if(agentID == ar::AGENT_NONE)
+            {
+                return base::result::makeFailure(event, failureTrace4);
+            }
+
+            // Check existence and not emptyness of argsRef if used
+            if (!argsRef.empty())
+            {
+                const auto extraArgsArray = event->getArray(argsRef);
+                if (!extraArgsArray.has_value())
+                {
+                    return base::result::makeFailure(event, failureTrace1);
+                }
+                else
+                {
+                    for (const auto arrayElement : extraArgsArray.value())
+                    {
+                        // fill "alert" in json with this array
+                        ar::baseJson.appendString(
+                            std::string_view {arrayElement.getString().value()},
+                            std::string_view {ar::EXTRA_ARGS_PATH});
+                    }
+                }
+            }
+
+            // Set alert field from event
+            // TODO: create alert from event! -> Eventinfo_to_jsonstr(lf, false, NULL);
+            // rigth now we're setting the whole event as an alert
+            ar::baseJson.setString(std::string_view {event->getString(ar::EVENT_ORIGINAL).value()},
+                                   std::string_view {ar::ALERT_PATH});
+
+            // If version lower to 4.2.5 should escape exclamation, dollar, single quote
+            // and backquote
+
+            std::string query {ar::baseJson.prettyStr()};
+
+            // Append header message
+            const std::string completeMesage =
+                fmt::format("(local_source) [] N{}{} {} {}",
+                            !location.compare("LOCAL") ? 'R' : 'N',
+                            !location.compare("ALL") ? 'S' : 'N',
+                            agentID,
+                            query);
+
+            if (query.empty())
+            {
+                return base::result::makeFailure(event, failureTrace2);
+            }
+            else
+            {
+                try
+                {
+                    if (SendRetval::SUCCESS == socketAR->sendMsg(query))
+                    {
+                        event->setBool(true, targetField);
+                        return base::result::makeSuccess(event, successTrace);
+                    }
+                    else
+                    {
+                        return base::result::makeFailure(event, failureTrace3);
+                    }
+                }
+                catch (const std::exception& e)
+                {
+                    const auto failureTraceEx {
+                        fmt::format("[{}] -> Failure: [{}]", name, e.what())};
+                    return base::result::makeFailure(event, failureTraceEx);
+                }
+            }
+        });
+}
+
+} // namespace builder::internals::builders

--- a/src/engine/source/builder/builders/opBuilderHelperActiveResponse.hpp
+++ b/src/engine/source/builder/builders/opBuilderHelperActiveResponse.hpp
@@ -1,0 +1,28 @@
+/* Copyright (C) 2015-2021, Wazuh Inc.
+ * All rights reserved.
+ *
+ */
+
+#ifndef _OP_BUILDER_HELPER_ACTIVE_RESPONSE_H
+#define _OP_BUILDER_HELPER_ACTIVE_RESPONSE_H
+
+#include <any>
+
+#include <baseTypes.hpp>
+
+#include "expression.hpp"
+#include <utils/stringUtils.hpp>
+
+namespace builder::internals::builders
+{
+
+/**
+ * @brief Helper Function that 
+ * 
+ * @param definition 
+ * @return base::Expression 
+ */
+base::Expression opBuilderHelperActiveResponse(const std::any& definition);
+} // namespace builder::internals::builders
+
+#endif // _OP_BUILDER_HELPER_ACTIVE_RESPONSE_H

--- a/src/engine/source/builder/register.hpp
+++ b/src/engine/source/builder/register.hpp
@@ -3,6 +3,7 @@
 
 #include "builders/opBuilderARWrite.hpp"
 #include "builders/opBuilderFileOutput.hpp"
+#include "builders/opBuilderHelperActiveResponse.hpp"
 #include "builders/opBuilderHelperFilter.hpp"
 #include "builders/opBuilderHelperMap.hpp"
 #include "builders/opBuilderHelperNetInfoAddress.hpp"
@@ -131,6 +132,8 @@ static void registerBuilders()
     Registry::registerBuilder(builders::opBuilderHelperSaveNetInfoIPv6,
                               "helper.saveNetInfoIPv6");
 
+    // Active Response
+    Registry::registerBuilder(builders::opBuilderHelperActiveResponse, "helper.ar");
 }
 } // namespace builder::internals
 

--- a/src/engine/test/source/builder/CMakeLists.txt
+++ b/src/engine/test/source/builder/CMakeLists.txt
@@ -211,3 +211,9 @@ add_executable(opBuilderHelperNetInfoAddress_test
   ${TEST_SOURCE_DIR}/base/socketInterface/testAuxiliar/socketAuxiliarFunctions.cpp
 )
 gtest_discover_tests(opBuilderHelperNetInfoAddress_test)
+
+add_executable(opBuilderHelperActiveResponse_test
+  ${BUILDER_BUILDERS_TEST_SOURCE_DIR}/opBuilderHelperActiveResponse_test.cpp
+  ${TEST_SOURCE_DIR}/base/socketInterface/testAuxiliar/socketAuxiliarFunctions.cpp
+)
+gtest_discover_tests(opBuilderHelperActiveResponse_test)

--- a/src/engine/test/source/builder/builders/opBuilderHelperActiveResponse_test.cpp
+++ b/src/engine/test/source/builder/builders/opBuilderHelperActiveResponse_test.cpp
@@ -1,0 +1,67 @@
+/* Copyright (C) 2015-2022, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <any>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <baseTypes.hpp>
+#include <utils/socketInterface/unixDatagram.hpp>
+#include <utils/socketInterface/unixSecureStream.hpp>
+
+#include <logging/logging.hpp>
+#include <wdb/wdb.hpp>
+
+#include "opBuilderHelperActiveResponse.hpp"
+#include "socketAuxiliarFunctions.hpp"
+
+using namespace base;
+using namespace builder::internals::builders;
+
+using std::string;
+
+const string targetField {"/result"};
+const string helperFunctionName {"ar"};
+const std::vector<string> commonArguments {"command-name", "LOCAL", "100","$_argvs"};
+
+class opBuilderHelperActiveResponseTest : public ::testing::Test
+{
+protected:
+    const fmtlog::LogLevel logLevel {fmtlog::getLogLevel()};
+
+    void SetUp() override
+    {
+        // Disable error logs for these tests
+        fmtlog::setLogLevel(fmtlog::LogLevel(logging::LogLevel::Off));
+    }
+
+    void TearDown() override
+    {
+        // Restore original log level
+        fmtlog::setLogLevel(fmtlog::LogLevel(logLevel));
+    }
+};
+
+TEST_F(opBuilderHelperActiveResponseTest, BuildSimplest)
+{
+    const auto tuple {std::make_tuple(targetField, helperFunctionName, commonArguments)};
+
+    ASSERT_NO_THROW(opBuilderHelperActiveResponse(tuple));
+}
+
+TEST_F(opBuilderHelperActiveResponseTest, checkWrongQttyParams)
+{
+    const std::vector<string> arguments {"command-name"};
+
+    const auto tuple {std::make_tuple(targetField, helperFunctionName, arguments)};
+
+    ASSERT_THROW(opBuilderHelperActiveResponse(tuple), std::runtime_error);
+}


### PR DESCRIPTION
|Related issue|
|---|
|#14737|

### WIP

As requested on issue #14737, it is necessary to develop a way to integrate the active responses request system into the Wazuh Engine.

The behavior of the Active Responses on the Engine's predecessor, Analysisd, was studied, and some of the collected information was dumped on issue #15027.
<!--
## Configuration options

When proceeding, this section should include new configuration parameters.

## Logs/Alerts example

Paste here related logs and alerts
-->
