### PR TITLE
Wazuh api extract hash

### DIFF
--- a/ruleset/decoders/0007-wazuh-api_decoders.xml
+++ b/ruleset/decoders/0007-wazuh-api_decoders.xml
@@ -5,6 +5,7 @@
 <!-- Sample log
 2021/04/20 16:00:35 INFO: wazuh 127.0.0.1 "PUT /agents/group" with parameters {"group_id": "group1", "agents_list": "629,650,654,682"} and body {} done in 0.075s: 200
 2021/10/05 10:30:21 INFO: Generated private key file in WAZUH_PATH/api/configuration/ssl/server.key
+2022/02/03 10:37:36 INFO: wazuh (d8466023fdec3f1310679989d8827eee) 172.20.0.1 "GET /rules" with parameters {"filename": "0010-rules_config.xml"} and body {} done in 0.073s: 200
 -->
 
 <decoder name="wazuh-api">

--- a/ruleset/decoders/0007-wazuh-api_decoders.xml
+++ b/ruleset/decoders/0007-wazuh-api_decoders.xml
@@ -11,8 +11,18 @@
    <prematch type="pcre2">\s\d+:\d+:\d+\s\w+:\s\S+\s\d+.\d+.\d+.\d+</prematch>
 </decoder>
 
+<decoder name="wazuh-api">
+   <prematch type="pcre2">\s\d+:\d+:\d+\s\w+:\s\S+\s\(\S+\)\s+\d+.\d+.\d+.\d+</prematch>
+</decoder>
+
 <decoder name="wazuh-api-info">
   <prematch type="pcre2">^\d+\/\d+\/\d+\s\d+:\d+:\d+\sINFO:\s\w+\s\w+|^\d+\/\d+\/\d+\s\d+:\d+:\d+\sWARNING:\s\w+\s\w+|^\d+\/\d+\/\d+\s\d+:\d+:\d+\sERROR:\s\w+\s\w+|^\d+\/\d+\/\d+\s\d+:\d+:\d+\sCRITICAL:\s\w+\s\w+</prematch>
+</decoder>
+
+<decoder name="wazuh-api-fields">
+  <parent>wazuh-api</parent>
+  <regex type="pcre2">\S+\s\((\S+)\)\s\d+\.\d+\.\d+\.\d+\s</regex>
+  <order>hash</order>
 </decoder>
 
 <decoder name="wazuh-api-fields">
@@ -35,7 +45,7 @@
 
 <decoder name="wazuh-api-fields">
   <parent>wazuh-api</parent>
-  <regex type="pcre2">:\s\S+\s(\d+\.\d+\.\d+\.\d+)\s</regex>
+  <regex type="pcre2">:\s\S+(?:\s\(\S+\))?\s(\d+\.\d+\.\d+\.\d+)\s</regex>
   <order>srcip</order>
 </decoder>
 

--- a/ruleset/decoders/0007-wazuh-api_decoders.xml
+++ b/ruleset/decoders/0007-wazuh-api_decoders.xml
@@ -23,7 +23,7 @@
 <decoder name="wazuh-api-fields">
   <parent>wazuh-api</parent>
   <regex type="pcre2">\S+\s\((\S+)\)\s\d+\.\d+\.\d+\.\d+\s</regex>
-  <order>hash</order>
+  <order>auth_context_hash</order>
 </decoder>
 
 <decoder name="wazuh-api-fields">

--- a/ruleset/testing/tests/api.ini
+++ b/ruleset/testing/tests/api.ini
@@ -118,6 +118,13 @@ rule = 426
 alert = 4
 decoder = wazuh-api
 
+[API authentication success with HASH]
+log 1 pass = 2022/02/03 10:37:36 INFO: wazuh (d8466023fdec3f1310679989d8827eee) 172.20.0.1 "POST /security/user/authenticate/run_as" with parameters {"raw": "true"} and body {"user_name": "test", "is_reserved": false, "is_hidden": false, "is_internal_user": true, "user_requested_tenant": "__user__", "backend_roles": [""], "custom_attribute_names": [], "tenants": {"test": true, "global_tenant": true, "admin_tenant": true}, "roles": ["own_index", "all_access"]} done in 0.309s: 200
+rule = 426
+alert = 4
+decoder = wazuh-api
+
+
 [API authentication failure]
 log 1 pass = 2021/10/05 10:33:15 INFO: testing 172.21.0.1 "POST /security/user/authenticate" with parameters {} and body {} done in 0.354s: 400
 rule = 427


### PR DESCRIPTION
|Related issue|
|---|
|#12151|

## Description
Add decoding support for the new wazuh-api log format that includes a HASH field. 

### New log format:

```
<timestamp> <log_type> <user> (<hash>) <ip> "<method> <path>" <parameters> <body> <elapsed> <status>
```

### Sample log: 

```
2022/02/03 10:37:36 INFO: wazuh (d8466023fdec3f1310679989d8827eee) 172.20.0.1 "GET /rules" with parameters {"filename": "0010-rules_config.xml"} and body {} done in 0.073s: 200
```

## Decoder modification: 

- Added parent decoding to detect the HASH in new API logs:

```
<decoder name="wazuh-api">
   <prematch type="pcre2">\s\d+:\d+:\d+\s\w+:\s\S+\s\(\S+\)\s+\d+.\d+.\d+.\d+</prematch>
</decoder>
```
- Added field extractor decoder to extract HASH field: 

```
<decoder name="wazuh-api-fields">
  <parent>wazuh-api</parent>
  <regex type="pcre2">\S+\s\((\S+)\)\s\d+\.\d+\.\d+\.\d+\s</regex>
  <order>auth_context_hash</order>
</decoder>
```

- Modified srcip field extractor decoder for logs with or without HASH field:

```
<decoder name="wazuh-api-fields">
  <parent>wazuh-api</parent>
  <regex type="pcre2">:\s\S+(?:\s\(\S+\))?\s(\d+\.\d+\.\d+\.\d+)\s</regex>
  <order>srcip</order>
</decoder>
```

## Testing:
<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [x] Added unit testing files ".ini"
  - [x] runtests.py executed without errors