### PR TITLE
Add authorization context hash to API logs and update API ruleset

### DIFF
--- a/api/api/alogging.py
+++ b/api/api/alogging.py
@@ -2,6 +2,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 import binascii
+import hashlib
 import json
 import logging
 import re
@@ -9,15 +10,17 @@ from base64 import b64decode
 
 from aiohttp.abc import AbstractAccessLogger
 from pythonjsonlogger import jsonlogger
+
 from wazuh.core.wlogging import WazuhLogger
 
-from api.configuration import api_conf
-
-# compile regex when the module is imported so it's not necessary to compile it everytime log.info is called
+# Compile regex when the module is imported so it's not necessary to compile it everytime log.info is called
 request_pattern = re.compile(r'\[.+]|\s+\*\s+')
 
 # Variable used to specify an unknown user
 UNKNOWN_USER_STRING = "unknown_user"
+
+# Run_as login endpoint path
+RUN_AS_LOGIN_ENDPOINT = "/security/user/authenticate/run_as"
 
 
 class AccessLogger(AbstractAccessLogger):
@@ -30,7 +33,7 @@ class AccessLogger(AbstractAccessLogger):
             if not handler.stream or handler.stream.closed:
                 handler.stream = handler._open()
 
-    def custom_logging(self, user, remote, method, path, query, body, time, status):
+    def custom_logging(self, user, remote, method, path, query, body, time, status, hash_auth_context=''):
         """Provide the log entry structure depending on the logging format.
 
         Parameters
@@ -51,27 +54,35 @@ class AccessLogger(AbstractAccessLogger):
             Required time to compute the request.
         status : int
             Status code of the request.
+        hash_auth_context : str, optional
+            Hash representing the authorization context. Default: ''
         """
+        if not hash_auth_context:
+            log_info = f'{user} {remote} "{method} {path}" with parameters {json.dumps(query)} ' \
+                       f'and body {json.dumps(body)} done in {time:.3f}s: {status}'
+            json_info = {'user': user,
+                         'ip': remote,
+                         'http_method': method,
+                         'uri': f'{method} {path}',
+                         'parameters': query,
+                         'body': body,
+                         'time': f'{time:.3f}s',
+                         'status_code': status}
+        else:
+            log_info = f'{user} ({hash_auth_context}) {remote} "{method} {path}" with parameters {json.dumps(query)} ' \
+                       f'and body {json.dumps(body)} done in {time:.3f}s: {status}'
+            json_info = {'user': user,
+                         'hash_auth_context': hash_auth_context,
+                         'ip': remote,
+                         'http_method': method,
+                         'uri': f'{method} {path}',
+                         'parameters': query,
+                         'body': body,
+                         'time': f'{time:.3f}s',
+                         'status_code': status}
 
-        self.logger.info(f'{user} '
-                         f'{remote} '
-                         f'"{method} {path}" '
-                         f'with parameters {json.dumps(query)} and body {json.dumps(body)} '
-                         f'done in {time:.3f}s: {status}',
-                         extra={'log_type': 'log'}
-                         )
-
-        self.logger.info({'user': user,
-                          'ip': remote,
-                          'http_method': method,
-                          'uri': f'{method} {path}',
-                          'parameters': query,
-                          'body': body,
-                          'time': f'{time:.3f}s',
-                          'status_code': status
-                          },
-                         extra={'log_type': 'json'}
-                         )
+        self.logger.info(log_info, extra={'log_type': 'log'})
+        self.logger.info(json_info, extra={'log_type': 'json'})
 
     def log(self, request, response, time):
         self.check_stream()
@@ -83,6 +94,7 @@ class AccessLogger(AbstractAccessLogger):
             body['password'] = '****'
         if 'key' in body and '/agents' in request.path:
             body['key'] = '****'
+
         # With permanent redirect, not found responses or any response with no token information,
         # decode the JWT token to get the username
         user = request.get('user', '')
@@ -92,15 +104,17 @@ class AccessLogger(AbstractAccessLogger):
             except (KeyError, IndexError, binascii.Error):
                 user = UNKNOWN_USER_STRING
 
-        self.custom_logging(user,
-                            request.remote,
-                            request.method,
-                            request.path,
-                            query,
-                            body,
-                            time,
-                            response.status
-                            )
+        # Get or create authorization context hash
+        hash_auth_context = ''
+        # Get hash from token information
+        if 'token_info' in request:
+            hash_auth_context = request['token_info'].get('hash_auth_context', '')
+        # Create hash if run_as login
+        if not hash_auth_context and request.path == RUN_AS_LOGIN_ENDPOINT:
+            hash_auth_context = hashlib.blake2b(json.dumps(body).encode(), digest_size=16).hexdigest()
+
+        self.custom_logging(user, request.remote, request.method, request.path, query, body, time, response.status,
+                            hash_auth_context=hash_auth_context)
 
 
 class APILogger(WazuhLogger):
@@ -143,6 +157,7 @@ class WazuhJsonFormatter(jsonlogger.JsonFormatter):
     """
     Define the custom JSON log formatter used by wlogging.
     """
+
     def add_fields(self, log_record, record, message_dict):
         """Implement custom logic for adding fields in a log entry.
 
@@ -160,7 +175,7 @@ class WazuhJsonFormatter(jsonlogger.JsonFormatter):
             record.message = {
                 'type': 'request',
                 'payload': message_dict
-                }
+            }
         else:
             # Traceback handling
             traceback = message_dict.get('exc_info')
@@ -168,13 +183,13 @@ class WazuhJsonFormatter(jsonlogger.JsonFormatter):
                 record.message = {
                     'type': 'error',
                     'payload': f'{record.message}. {traceback}'
-                    }
+                }
             else:
                 # Plain text messages
                 record.message = {
                     'type': 'informative',
                     'payload': record.message
-                    }
+                }
         log_record['timestamp'] = self.formatTime(record, self.datefmt)
         log_record['levelname'] = record.levelname
         log_record['data'] = record.message

--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -3,6 +3,8 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import asyncio
+import hashlib
+import json
 import logging
 import os
 from concurrent.futures import ThreadPoolExecutor
@@ -135,17 +137,17 @@ def get_security_conf():
     return conf.security_conf
 
 
-def generate_token(user_id=None, data=None, run_as=False):
-    """Generate an encoded jwt token. This method should be called once a user is properly logged on.
+def generate_token(user_id=None, data=None, auth_context=None):
+    """Generate an encoded JWT token. This method should be called once a user is properly logged on.
 
     Parameters
     ----------
     user_id : str
-        Unique username
+        Unique username.
     data : dict
-        Roles permissions for the user
-    run_as : bool
-        Indicate if the user has logged in with run_as or not
+        Roles permissions for the user.
+    auth_context : dict
+        Authorization context used in the run as login request.
 
     Returns
     -------
@@ -161,15 +163,16 @@ def generate_token(user_id=None, data=None, run_as=False):
     timestamp = int(core_utils.get_utc_now().timestamp())
 
     payload = {
-        "iss": JWT_ISSUER,
-        "aud": "Wazuh API REST",
-        "nbf": timestamp,
-        "exp": timestamp + result['auth_token_exp_timeout'],
-        "sub": str(user_id),
-        "run_as": run_as,
-        "rbac_roles": data['roles'],
-        "rbac_mode": result['rbac_mode']
-    }
+                  "iss": JWT_ISSUER,
+                  "aud": "Wazuh API REST",
+                  "nbf": timestamp,
+                  "exp": timestamp + result['auth_token_exp_timeout'],
+                  "sub": str(user_id),
+                  "run_as": auth_context is not None,
+                  "rbac_roles": data['roles'],
+                  "rbac_mode": result['rbac_mode']
+              } | ({"hash_auth_context": hashlib.blake2b(json.dumps(auth_context).encode(), digest_size=16).hexdigest()}
+                   if auth_context is not None else {})
 
     return jwt.encode(payload, generate_keypair()[0], algorithm=JWT_ALGORITHM)
 

--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -120,7 +120,8 @@ async def run_as_login(request, user: str, raw: bool = False) -> web.Response:
     web.Response
         Raw or JSON response with the generated access token.
     """
-    f_kwargs = {'user_id': user, 'auth_context': await request.json()}
+    auth_context = await request.json()
+    f_kwargs = {'user_id': user, 'auth_context': auth_context}
 
     dapi = DistributedAPI(f=preprocessor.get_permissions,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -132,7 +133,7 @@ async def run_as_login(request, user: str, raw: bool = False) -> web.Response:
 
     token = None
     try:
-        token = generate_token(user_id=user, data=data.dikt, run_as=True)
+        token = generate_token(user_id=user, data=data.dikt, auth_context=auth_context)
     except WazuhException as e:
         raise_if_exc(e)
 

--- a/ruleset/decoders/0007-wazuh-api_decoders.xml
+++ b/ruleset/decoders/0007-wazuh-api_decoders.xml
@@ -5,14 +5,25 @@
 <!-- Sample log
 2021/04/20 16:00:35 INFO: wazuh 127.0.0.1 "PUT /agents/group" with parameters {"group_id": "group1", "agents_list": "629,650,654,682"} and body {} done in 0.075s: 200
 2021/10/05 10:30:21 INFO: Generated private key file in WAZUH_PATH/api/configuration/ssl/server.key
+2022/02/03 10:37:36 INFO: wazuh (d8466023fdec3f1310679989d8827eee) 172.20.0.1 "GET /rules" with parameters {"filename": "0010-rules_config.xml"} and body {} done in 0.073s: 200
 -->
 
 <decoder name="wazuh-api">
    <prematch type="pcre2">\s\d+:\d+:\d+\s\w+:\s\S+\s\d+.\d+.\d+.\d+</prematch>
 </decoder>
 
+<decoder name="wazuh-api">
+   <prematch type="pcre2">\s\d+:\d+:\d+\s\w+:\s\S+\s\(\S+\)\s+\d+.\d+.\d+.\d+</prematch>
+</decoder>
+
 <decoder name="wazuh-api-info">
   <prematch type="pcre2">^\d+\/\d+\/\d+\s\d+:\d+:\d+\sINFO:\s\w+\s\w+|^\d+\/\d+\/\d+\s\d+:\d+:\d+\sWARNING:\s\w+\s\w+|^\d+\/\d+\/\d+\s\d+:\d+:\d+\sERROR:\s\w+\s\w+|^\d+\/\d+\/\d+\s\d+:\d+:\d+\sCRITICAL:\s\w+\s\w+</prematch>
+</decoder>
+
+<decoder name="wazuh-api-fields">
+  <parent>wazuh-api</parent>
+  <regex type="pcre2">\S+\s\((\S+)\)\s\d+\.\d+\.\d+\.\d+\s</regex>
+  <order>auth_context_hash</order>
 </decoder>
 
 <decoder name="wazuh-api-fields">
@@ -35,7 +46,7 @@
 
 <decoder name="wazuh-api-fields">
   <parent>wazuh-api</parent>
-  <regex type="pcre2">:\s\S+\s(\d+\.\d+\.\d+\.\d+)\s</regex>
+  <regex type="pcre2">:\s\S+(?:\s\(\S+\))?\s(\d+\.\d+\.\d+\.\d+)\s</regex>
   <order>srcip</order>
 </decoder>
 

--- a/ruleset/testing/tests/api.ini
+++ b/ruleset/testing/tests/api.ini
@@ -118,6 +118,13 @@ rule = 426
 alert = 4
 decoder = wazuh-api
 
+[API authentication success with HASH]
+log 1 pass = 2022/02/03 10:37:36 INFO: wazuh (d8466023fdec3f1310679989d8827eee) 172.20.0.1 "POST /security/user/authenticate/run_as" with parameters {"raw": "true"} and body {"user_name": "test", "is_reserved": false, "is_hidden": false, "is_internal_user": true, "user_requested_tenant": "__user__", "backend_roles": [""], "custom_attribute_names": [], "tenants": {"test": true, "global_tenant": true, "admin_tenant": true}, "roles": ["own_index", "all_access"]} done in 0.309s: 200
+rule = 426
+alert = 4
+decoder = wazuh-api
+
+
 [API authentication failure]
 log 1 pass = 2021/10/05 10:33:15 INFO: testing 172.21.0.1 "POST /security/user/authenticate" with parameters {} and body {} done in 0.354s: 400
 rule = 427


### PR DESCRIPTION
|Related issue|
|---|
|closes https://github.com/wazuh/wazuh/issues/12149|


## Description

This PR closes the epic issue https://github.com/wazuh/wazuh/issues/12149.

The pull request merges the development branch into 4.4. This branch includes changes to the API ruleset and logs. Now the API requests made by users logged in with authorization context will log an extra field, containing the authorization context hash.

