### PR TITLE
Optimize multigroups and shared files generation

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -196,8 +196,8 @@ remoted.recv_timeout=1
 remoted.merge_shared=1
 
 # Store the temporary shared configuration file on disk
-# 0. Disable (in memory)
-# 1. Enable
+# 0. No, store in memory (default)
+# 1. Yes, store on disk
 remoted.disk_storage=0
 
 # Keys file reloading latency (seconds) [1..3600]

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -195,6 +195,11 @@ remoted.recv_timeout=1
 # 1. Enable (default)
 remoted.merge_shared=1
 
+# Store the temporary shared configuration file on disk
+# 0. Disable (in memory)
+# 1. Enable
+remoted.disk_storage=0
+
 # Keys file reloading latency (seconds) [1..3600]
 remoted.keyupdate_interval=10
 

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -207,7 +207,7 @@ void DeleteState();
  * @param path_offset Offset for recursion.
  * @return 1 if the merged file was created, 0 on error.
  */
-int MergeAppendFile(FILE *finalfp, const char *files, int path_offset) __attribute__((nonnull(1)));
+int MergeAppendFile(FILE *finalfp, const char *files, int path_offset) __attribute__((nonnull(1, 2)));
 
 
 /**

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -202,13 +202,12 @@ void DeleteState();
 /**
  * @brief Merge files recursively into one single file.
  *
- * @param finalpath Path of the generated file.
+ * @param finalfp Handler of the file.
  * @param files Files to be merged.
- * @param tag Tag to be added on the generated file.
  * @param path_offset Offset for recursion.
  * @return 1 if the merged file was created, 0 on error.
  */
-int MergeAppendFile(const char *finalpath, const char *files, const char *tag, int path_offset) __attribute__((nonnull(1)));
+int MergeAppendFile(FILE *finalfp, const char *files, int path_offset) __attribute__((nonnull(1)));
 
 
 /**

--- a/src/remoted/config.c
+++ b/src/remoted/config.c
@@ -148,6 +148,7 @@ cJSON *getRemoteInternalConfig(void) {
     cJSON_AddNumberToObject(remoted,"request_timeout",request_timeout);
     cJSON_AddNumberToObject(remoted,"response_timeout",response_timeout);
     cJSON_AddNumberToObject(remoted,"shared_reload",INTERVAL);
+    cJSON_AddNumberToObject(remoted,"disk_storage",disk_storage);
     cJSON_AddNumberToObject(remoted,"rlimit_nofile",nofile);
     cJSON_AddNumberToObject(remoted,"merge_shared",logr.nocmerged);
     cJSON_AddNumberToObject(remoted,"guess_agent_group",guess_agent_group);

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -619,7 +619,9 @@ STATIC void c_group(const char *group, OSHash **_f_time, os_md5 *_merged_sum, ch
                     return;
                 }
             } else {
-                OS_MD5_Str(finalbuf, finalsize, md5sum_tmp);
+                if (finalbuf) {
+                    OS_MD5_Str(finalbuf, finalsize, md5sum_tmp);
+                }
             }
 
             if ((OS_MD5_File(merged, md5sum, OS_TEXT) != 0) || (strcmp(md5sum_tmp, md5sum) != 0)) {

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -600,14 +600,14 @@ STATIC void c_group(const char *group, OSHash **_f_time, os_md5 *_merged_sum, ch
 
         if (create_merged) {
             fclose(finalfp);
-            OS_MD5_Str(finalbuf, finalsize, md5sum);
+            OS_MD5_Str(finalbuf, finalsize, md5sum_tmp);
             if ((OS_MD5_File(merged, md5sum, OS_TEXT) != 0) || (strcmp(md5sum_tmp, md5sum) != 0)) {
                 if (finalfp = fopen(merged, "w"), finalfp == NULL) {
                     merror("Unable to open file: '%s' due to [(%d)-(%s)].", merged, errno, strerror(errno));
                     os_free(finalbuf);
                     return;
                 }
-                fprintf(finalfp, "%s", finalbuf);
+                fwrite(finalbuf, finalsize, 1, finalfp);
                 fclose(finalfp);
             }
             os_free(finalbuf);

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -590,20 +590,21 @@ STATIC void c_group(const char *group, OSHash **_f_time, os_md5 *_merged_sum, ch
                 return;
             }
         }
-    }
 
-    if (OS_MD5_File(merged_tmp, md5sum_tmp, OS_TEXT) != 0) {
         if (create_merged) {
-            merror("Accessing file '%s'", merged_tmp);
-        }
-    } else {
-        if (OS_MD5_File(merged, md5sum, OS_TEXT) != 0) {
-            OS_MoveFile(merged_tmp, merged);
-        } else {
-            if (strcmp(md5sum_tmp, md5sum) != 0) {
-                OS_MoveFile(merged_tmp, merged);
+            if (OS_MD5_File(merged_tmp, md5sum_tmp, OS_TEXT) == 0) {
+                if (OS_MD5_File(merged, md5sum, OS_TEXT) == 0) {
+                    if (strcmp(md5sum_tmp, md5sum) != 0) {
+                        OS_MoveFile(merged_tmp, merged);
+                    } else {
+                        unlink(merged_tmp);
+                    }
+                } else {
+                    OS_MoveFile(merged_tmp, merged);
+                }
             } else {
-                unlink(merged_tmp);
+                merror("Accessing file '%s'", merged_tmp);
+                return;
             }
         }
     }
@@ -616,6 +617,8 @@ STATIC void c_group(const char *group, OSHash **_f_time, os_md5 *_merged_sum, ch
         } else {
             ftime_add(_f_time, SHAREDCFG_FILENAME, attrib.st_mtime);
         }
+    } else if (create_merged) {
+        merror("Accessing file '%s'", merged);
     }
 }
 

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -194,6 +194,7 @@ extern int request_pool;
 extern int request_timeout;
 extern int response_timeout;
 extern int INTERVAL;
+extern int disk_storage;
 extern rlim_t nofile;
 extern int guess_agent_group;
 extern unsigned receive_chunk;

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -146,7 +146,7 @@ LIST(APPEND analysisd_flags "-Wl,--wrap,wdbc_query_ex ${DEBUG_OP_WRAPPERS}")
 list(APPEND analysisd_names "test_analysis-state")
 list(APPEND analysisd_flags "-Wl,--wrap,time -Wl,--wrap,rem_get_qsize -Wl,--wrap,rem_get_tsize \
                             -Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_Add -Wl,--wrap,OSHash_Add_ex -Wl,--wrap,OSHash_Begin \
-                            -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap,OSHash_Delete -Wl,--wrap,OSHash_Get \
+                            -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap,OSHash_Delete -Wl,--wrap,OSHash_Get -Wl,--wrap,OSHash_Clean \
                             -Wl,--wrap,OSHash_Get_ex -Wl,--wrap,OSHash_Next -Wl,--wrap,OSHash_SetFreeDataPointer \
                             -Wl,--wrap,OSHash_Update_ex -Wl,--wrap,OSHash_Update -Wl,--wrap,OSHash_Get_Elem_ex \
                             -Wl,--wrap,wdb_get_agents_ids_of_current_node -Wl,--wrap,_merror -Wl,--wrap,limit_reached")

--- a/src/unit_tests/logcollector/test_state.c
+++ b/src/unit_tests/logcollector/test_state.c
@@ -446,8 +446,7 @@ void test__w_logcollector_generate_state_one_target_restart(void ** state) {
 void test__w_logcollector_state_update_file_new_data(void ** state) {
     w_lc_state_storage_t stat = {0};
     stat.states = *state;
-    __real_OSHash_SetFreeDataPointer(stat.states, (void (*)(void *))free_state_file);
-
+    __real_OSHash_SetFreeDataPointer(mock_hashmap, (void (*)(void *))free_state_file);
 
     expect_value(__wrap_OSHash_Get, self, stat.states);
     expect_string(__wrap_OSHash_Get, key, "/test_path");

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -25,7 +25,7 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 # Generate remoted tests
 list(APPEND remoted_names "test_manager")
 list(APPEND remoted_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,w_parser_get_agent \
-                            -Wl,--wrap,_merror \
+                            -Wl,--wrap,_merror -Wl,--wrap,_merror_exit \
                             -Wl,--wrap,MergeAppendFile -Wl,--wrap,OS_MoveFile -Wl,--wrap,w_parser_get_group \
                             -Wl,--wrap,wurl_request -Wl,--wrap,TestUnmergeFiles -Wl,--wrap,OS_MD5_File \
                             -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap,OSHash_Delete -Wl,--wrap,OSHash_Get \
@@ -33,7 +33,7 @@ list(APPEND remoted_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,w_
                             -Wl,--wrap,OSHash_Update_ex -Wl,--wrap,OSHash_Update -Wl,--wrap,OSHash_Get_Elem_ex \
                             -Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_Add -Wl,--wrap,OSHash_Add_ex \
                             -Wl,--wrap,checkBinaryFile -Wl,--wrap,OSHash_Set -Wl,--wrap,_minfo \
-                            -Wl,--wrap,opendir -Wl,--wrap,cldir_ex -Wl,--wrap,wreaddir -Wl,--wrap=_mwarn \
+                            -Wl,--wrap,opendir -Wl,--wrap,cldir_ex_ignore -Wl,--wrap,wreaddir -Wl,--wrap=_mwarn \
                             -Wl,--wrap,closedir -Wl,--wrap,OSHash_Clean -Wl,--wrap,rmdir_ex -Wl,--wrap,mkdir -Wl,--wrap,stat\
                             -Wl,--wrap,OS_SHA256_String -Wl,--wrap,readdir -Wl,--wrap,strerror \
                             -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose -Wl,--wrap,remove \

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -28,6 +28,7 @@ list(APPEND remoted_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,w_
                             -Wl,--wrap,_merror -Wl,--wrap,_merror_exit \
                             -Wl,--wrap,MergeAppendFile -Wl,--wrap,OS_MoveFile -Wl,--wrap,w_parser_get_group \
                             -Wl,--wrap,wurl_request -Wl,--wrap,TestUnmergeFiles -Wl,--wrap,OS_MD5_File \
+                            -Wl,--wrap,open_memstream -Wl,--wrap,OS_MD5_Str -Wl,--wrap,fprintf\
                             -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap,OSHash_Delete -Wl,--wrap,OSHash_Get \
                             -Wl,--wrap,OSHash_Get_ex -Wl,--wrap,OSHash_Next -Wl,--wrap,OSHash_SetFreeDataPointer \
                             -Wl,--wrap,OSHash_Update_ex -Wl,--wrap,OSHash_Update -Wl,--wrap,OSHash_Get_Elem_ex \

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -83,7 +83,7 @@ list(APPEND remoted_flags "-W")
 list(APPEND remoted_names "test_remote-state")
 list(APPEND remoted_flags "-Wl,--wrap,time -Wl,--wrap,rem_get_qsize -Wl,--wrap,rem_get_tsize \
                             -Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_Add -Wl,--wrap,OSHash_Add_ex -Wl,--wrap,OSHash_Begin \
-                            -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap,OSHash_Delete -Wl,--wrap,OSHash_Get \
+                            -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap,OSHash_Delete -Wl,--wrap,OSHash_Get -Wl,--wrap,OSHash_Clean \
                             -Wl,--wrap,OSHash_Get_ex -Wl,--wrap,OSHash_Next -Wl,--wrap,OSHash_SetFreeDataPointer \
                             -Wl,--wrap,OSHash_Update_ex -Wl,--wrap,OSHash_Update -Wl,--wrap,OSHash_Get_Elem_ex \
                             -Wl,--wrap,wdb_get_agents_ids_of_current_node -Wl,--wrap,_merror")

--- a/src/unit_tests/remoted/test_manager.c
+++ b/src/unit_tests/remoted/test_manager.c
@@ -51,6 +51,25 @@ void free_keyentry(keyentry *key) {
     os_free(key->raw_key);
 }
 
+static void free_group(void *data) {
+    if (data) {
+        group_t *group = (group_t *)data;
+        if (group->f_time) {
+            OSHash_Clean(group->f_time, free_file_time);
+        }
+        os_free(group->name);
+        os_free(group);
+    }
+}
+
+static void free_group_c_group(void *data) {
+    if (data) {
+        group_t *group = (group_t *)data;
+        os_free(group->name);
+        os_free(group);
+    }
+}
+
 int __wrap_send_msg(const char *msg, ssize_t msg_length) {
     check_expected(msg);
     return 0;
@@ -67,280 +86,419 @@ static int test_teardown_group(void ** state) {
 }
 
 static int test_c_group_setup(void ** state) {
-    os_calloc(1, (2) * sizeof(group_t *), groups);
-    os_calloc(1, sizeof(group_t), groups[0]);
-    groups[0]->name = strdup("test_default");
-    groups[1] = NULL;
+    group_t *group = NULL;
+
+    test_mode = 0;
+
+    groups = OSHash_Create();
+
+    os_calloc(1, sizeof(group_t), group);
+    group->name = strdup("test_default");
+    OSHash_Add_ex(groups, "test_default", group);
+
+    test_mode = 1;
+
+    state[0] = group;
 
     return 0;
 }
 
 static int test_find_group_setup(void ** state) {
-    os_calloc(1, (3) * sizeof(group_t *), groups);
-    os_calloc(1, sizeof(group_t), groups[0]);
-    groups[0]->name = strdup("test_default");
-    os_calloc(2, sizeof(file_sum *), groups[0]->f_sum);
-    os_calloc(1, sizeof(file_sum), groups[0]->f_sum[0]);
-    os_strdup("test_file", groups[0]->f_sum[0]->name);
-    strncpy(groups[0]->f_sum[0]->sum, "ABCDEF1234567890", 32);
-    os_calloc(1, sizeof(group_t), groups[1]);
-    groups[1]->name = strdup("test_test_default");
-    os_calloc(2, sizeof(file_sum *), groups[1]->f_sum);
-    os_calloc(1, sizeof(file_sum), groups[1]->f_sum[0]);
-    os_strdup("test_test_file", groups[1]->f_sum[0]->name);
-    strncpy(groups[1]->f_sum[0]->sum, "12345ABCDEF67890", 32);
-    groups[2] = NULL;
+    group_t *group1 = NULL;
+    group_t *group2 = NULL;
+
+    test_mode = 0;
+
+    groups = OSHash_Create();
+
+    os_calloc(1, sizeof(group_t), group1);
+    group1->name = strdup("test_default");
+    snprintf(group1->merged_sum, 17, "ABCDEF1234567890");
+    OSHash_Add_ex(groups, "test_default", group1);
+
+    os_calloc(1, sizeof(group_t), group2);
+    group2->name = strdup("test_test_default");
+    snprintf(group2->merged_sum, 17, "ABCDEF1234567809");
+    OSHash_Add_ex(groups, "test_test_default", group2);
+
+    test_mode = 1;
+
+    state[0] = group1;
+    state[1] = group2;
+
+    return 0;
+}
+
+static int test_process_deleted_groups_setup(void ** state) {
+    group_t *group1 = NULL;
+    group_t *group2 = NULL;
+
+    test_mode = 0;
+
+    os_calloc(1, sizeof(group_t), group1);
+    group1->name = strdup("test_default");
+
+    os_calloc(1, sizeof(group_t), group2);
+    group2->name = strdup("test_test_default");
+
+    test_mode = 1;
+
+    state[0] = group1;
+    state[1] = group2;
 
     return 0;
 }
 
 static int test_find_multi_group_setup(void ** state) {
-    os_calloc(1, (3) * sizeof(group_t *), multi_groups);
-    os_calloc(1, sizeof(group_t), multi_groups[0]);
-    multi_groups[0]->name = strdup("test_default2");
-    os_calloc(2, sizeof(file_sum *), multi_groups[0]->f_sum);
-    os_calloc(1, sizeof(file_sum), multi_groups[0]->f_sum[0]);
-    os_strdup("test_file2", multi_groups[0]->f_sum[0]->name);
-    strncpy(multi_groups[0]->f_sum[0]->sum, "1234567890ABCDEF", 32);
-    os_calloc(1, sizeof(group_t), multi_groups[1]);
-    multi_groups[1]->name = strdup("test_test_default2");
-    os_calloc(2, sizeof(file_sum *), multi_groups[1]->f_sum);
-    os_calloc(1, sizeof(file_sum), multi_groups[1]->f_sum[0]);
-    os_strdup("test_test_file2", multi_groups[1]->f_sum[0]->name);
-    strncpy(multi_groups[1]->f_sum[0]->sum, "67890ABCDEF12345", 32);
-    multi_groups[2] = NULL;
+    group_t *multigroup1 = NULL;
+    group_t *multigroup2 = NULL;
+
+    test_mode = 0;
+
+    multi_groups = OSHash_Create();
+
+    os_calloc(1, sizeof(group_t), multigroup1);
+    multigroup1->name = strdup("test_default2");
+    snprintf(multigroup1->merged_sum, 17, "1234567890ABCDEF");
+    OSHash_Add_ex(multi_groups, "test_default2", multigroup1);
+
+    os_calloc(1, sizeof(group_t), multigroup2);
+    multigroup2->name = strdup("test_test_default2");
+    snprintf(multigroup2->merged_sum, 17, "1234567890ABCDFE");
+    OSHash_Add_ex(multi_groups, "test_test_default2", multigroup2);
+
+    test_mode = 1;
+
+    state[0] = multigroup1;
+    state[1] = multigroup2;
 
     return 0;
 }
 
-static int test_fsum_changed_setup(void ** state) {
-    file_sum **f_sum1;
-    file_sum **f_sum2;
-    os_calloc(3, sizeof(file_sum *), f_sum1);
-    os_calloc(1, sizeof(file_sum), f_sum1[0]);
-    os_calloc(1, sizeof(file_sum), f_sum1[1]);
-    strncpy(f_sum1[0]->sum, "FEDCBA0987654321", 32);
-    os_strdup("file1", f_sum1[0]->name);
-    strncpy(f_sum1[1]->sum, "0987654321FEDCBA", 32);
-    os_strdup("file2", f_sum1[1]->name);
-    os_calloc(3, sizeof(file_sum *), f_sum2);
-    os_calloc(1, sizeof(file_sum), f_sum2[0]);
-    os_calloc(1, sizeof(file_sum), f_sum2[1]);
-    strncpy(f_sum2[0]->sum, "0987654321FEDCBA", 32);
-    os_strdup("file2", f_sum2[0]->name);
-    strncpy(f_sum2[1]->sum, "FEDCBA0987654321", 32);
-    os_strdup("file1", f_sum2[1]->name);
+static int test_process_deleted_multi_groups_setup(void ** state) {
+    group_t *multigroup1 = NULL;
+    group_t *multigroup2 = NULL;
 
-    state[0] = f_sum1;
-    state[1] = f_sum2;
+    test_mode = 0;
+
+    os_calloc(1, sizeof(group_t), multigroup1);
+    multigroup1->name = strdup("test_default2");
+
+    os_calloc(1, sizeof(group_t), multigroup2);
+    multigroup2->name = strdup("test_test_default2");
+
+    test_mode = 1;
+
+    state[0] = multigroup1;
+    state[1] = multigroup2;
+
+    return 0;
+}
+
+static int test_ftime_changed_setup(void ** state) {
+    file_time *file1 = NULL;
+    file_time *file2 = NULL;
+    file_time *file3 = NULL;
+    file_time *file4 = NULL;
+
+    test_mode = 0;
+
+    os_calloc(1, sizeof(file_time), file1);
+    file1->name = strdup("file1");
+    file1->m_time = 123456789;
+
+    os_calloc(1, sizeof(file_time), file2);
+    file2->name = strdup("file2");
+    file2->m_time = 123456798;
+
+    test_mode = 1;
+
+    state[0] = file1;
+    state[1] = file2;
 
     return 0;
 }
 
 static int test_process_group_setup(void ** state) {
-    os_calloc(1, (2) * sizeof(group_t *), groups);
-    os_calloc(1, sizeof(group_t), groups[0]);
-    groups[0]->name = strdup("test_default");
-    os_calloc(2, sizeof(file_sum *), groups[0]->f_sum);
-    os_calloc(1, sizeof(file_sum), groups[0]->f_sum[0]);
-    strncpy(groups[0]->f_sum[0]->sum, "AAAAAAAAAAAAAAAA", 32);
-    os_strdup("merged.mg", groups[0]->f_sum[0]->name);
-    groups[1] = NULL;
+    group_t *group = NULL;
+    file_time *file = NULL;
+
+    test_mode = 0;
+
+    groups = OSHash_Create();
+
+    os_calloc(1, sizeof(group_t), group);
+    group->name = strdup("test_default");
+    group->f_time = OSHash_Create();
+    os_calloc(1, sizeof(file_time), file);
+    file->name = strdup("merged.mg");
+    file->m_time = 123456789;
+    OSHash_Add_ex(group->f_time, "merged.mg", file);
+    strncpy(group->merged_sum, "AAAAAAAAAAAAAAAA", 32);
+    OSHash_Add_ex(groups, "test_default", group);
+
+    if (setup_hashmap(state) != 0) {
+        return 1;
+    }
+
+    test_mode = 1;
+
+    state[0] = group->f_time;
+    state[1] = group;
 
     return 0;
 }
 
 static int test_process_multi_groups_setup(void ** state) {
-    os_calloc(1, (2) * sizeof(group_t *), multi_groups);
-    os_calloc(1, sizeof(group_t), multi_groups[0]);
-    multi_groups[0]->name = strdup("groupA,groupB");
-    os_calloc(2, sizeof(file_sum *), multi_groups[0]->f_sum);
-    os_calloc(1, sizeof(file_sum), multi_groups[0]->f_sum[0]);
-    os_strdup("test_file2", multi_groups[0]->f_sum[0]->name);
-    strncpy(multi_groups[0]->f_sum[0]->sum, "1234567890ABCDEF", 32);
-    multi_groups[1] = NULL;
+    group_t *multigroup = NULL;
+    file_time *file = NULL;
+
+    test_mode = 0;
+
+    multi_groups = OSHash_Create();
+
+    os_calloc(1, sizeof(group_t), multigroup);
+    multigroup->name = strdup("groupA,groupB");
+    multigroup->f_time = OSHash_Create();
+    os_calloc(1, sizeof(file_time), file);
+    file->name = strdup("test_file2");
+    file->m_time = 123456789;
+    OSHash_Add_ex(multigroup->f_time, "test_file2", file);
+    OSHash_Add_ex(multi_groups, "groupA,groupB", multigroup);
+
+    if (setup_hashmap(state) != 0) {
+        return 1;
+    }
+
+    test_mode = 1;
 
     return 0;
 }
 
-static int test_process_multi_groups_group_changed_setup(void ** state) {
-    os_calloc(1, (2) * sizeof(group_t *), multi_groups);
-    os_calloc(1, sizeof(group_t), multi_groups[0]);
-    multi_groups[0]->name = strdup("group1,group2");
-    os_calloc(2, sizeof(file_sum *), multi_groups[0]->f_sum);
-    os_calloc(1, sizeof(file_sum), multi_groups[0]->f_sum[0]);
-    os_strdup("test_file2", multi_groups[0]->f_sum[0]->name);
-    strncpy(multi_groups[0]->f_sum[0]->sum, "1234567890ABCDEF", 32);
-    multi_groups[1] = NULL;
+static int test_process_multi_groups_groups_setup(void ** state) {
+    group_t *group1 = NULL;
+    group_t *group2 = NULL;
+    group_t *multigroup = NULL;
+    file_time *file = NULL;
 
-    os_calloc(1, (3) * sizeof(group_t *), groups);
-    os_calloc(1, sizeof(group_t), groups[0]);
-    groups[0]->name = strdup("group1");
-    groups[0]->has_changed = true;
-    groups[0]->exists = true;
-    os_calloc(1, sizeof(group_t), groups[1]);
-    groups[1]->name = strdup("group2");
-    groups[1]->has_changed = false;
-    groups[1]->exists = true;
-    groups[2] = NULL;
+    test_mode = 0;
 
-    return 0;
-}
+    multi_groups = OSHash_Create();
 
-static int test_process_multi_groups_group_not_changed_setup(void ** state) {
+    os_calloc(1, sizeof(group_t), multigroup);
+    multigroup->name = strdup("group1,group2");
+    multigroup->f_time = OSHash_Create();
+    os_calloc(1, sizeof(file_time), file);
+    file->name = strdup("test_file2");
+    file->m_time = 123456789;
+    OSHash_Add_ex(multigroup->f_time, "test_file2", file);
+    OSHash_Add_ex(multi_groups, "group1,group2", multigroup);
 
-    os_calloc(1, (2) * sizeof(group_t *), multi_groups);
-    os_calloc(1, sizeof(group_t), multi_groups[0]);
-    multi_groups[0]->name = strdup("group1,group2");
-    os_calloc(2, sizeof(file_sum *), multi_groups[0]->f_sum);
-    os_calloc(1, sizeof(file_sum), multi_groups[0]->f_sum[0]);
-    os_strdup("test_file2", multi_groups[0]->f_sum[0]->name);
-    strncpy(multi_groups[0]->f_sum[0]->sum, "1234567890ABCDEF", 32);
-    multi_groups[1] = NULL;
+    groups = OSHash_Create();
 
-    os_calloc(1, (3) * sizeof(group_t *), groups);
-    os_calloc(1, sizeof(group_t), groups[0]);
-    groups[0]->name = strdup("group1");
-    groups[0]->has_changed = false;
-    groups[0]->exists = true;
-    os_calloc(1, sizeof(group_t), groups[1]);
-    groups[1]->name = strdup("group2");
-    groups[1]->has_changed = false;
-    groups[1]->exists = true;
-    groups[2] = NULL;
+    os_calloc(1, sizeof(group_t), group1);
+    group1->name = strdup("group1");
+    group1->has_changed = true;
+    group1->exists = true;
+    OSHash_Add_ex(groups, "group1", group1);
+
+    os_calloc(1, sizeof(group_t), group2);
+    group2->name = strdup("group2");
+    group2->has_changed = false;
+    group2->exists = true;
+    OSHash_Add_ex(groups, "group2", group2);
+
+    if (setup_hashmap(state) != 0) {
+        return 1;
+    }
+
+    test_mode = 1;
+
+    state[0] = group1;
+    state[1] = multigroup;
 
     return 0;
 }
 
 static int test_c_files_setup(void ** state) {
-    os_calloc(1, (3) * sizeof(group_t *), groups);
-    os_calloc(1, sizeof(group_t), groups[0]);
-    groups[0]->name = strdup("test_default");
-    os_calloc(2, sizeof(file_sum *), groups[0]->f_sum);
-    os_calloc(1, sizeof(file_sum), groups[0]->f_sum[0]);
-    os_strdup("test_file", groups[0]->f_sum[0]->name);
-    strncpy(groups[0]->f_sum[0]->sum, "ABCDEF1234567890", 32);
-    os_calloc(1, sizeof(group_t), groups[1]);
-    groups[1]->name = strdup("test_test_default");
-    os_calloc(2, sizeof(file_sum *), groups[1]->f_sum);
-    os_calloc(1, sizeof(file_sum), groups[1]->f_sum[0]);
-    os_strdup("test_test_file", groups[1]->f_sum[0]->name);
-    strncpy(groups[1]->f_sum[0]->sum, "12345ABCDEF67890", 32);
-    groups[2] = NULL;
+    group_t *group1 = NULL;
+    group_t *group2 = NULL;
+    group_t *multigroup1 = NULL;
+    group_t *multigroup2 = NULL;
+    file_time *file1 = NULL;
+    file_time *file2 = NULL;
+    file_time *file3 = NULL;
+    file_time *file4 = NULL;
 
-    os_calloc(1, (3) * sizeof(group_t *), multi_groups);
-    os_calloc(1, sizeof(group_t), multi_groups[0]);
-    multi_groups[0]->name = strdup("test_default2");
-    os_calloc(2, sizeof(file_sum *), multi_groups[0]->f_sum);
-    os_calloc(1, sizeof(file_sum), multi_groups[0]->f_sum[0]);
-    os_strdup("test_file2", multi_groups[0]->f_sum[0]->name);
-    strncpy(multi_groups[0]->f_sum[0]->sum, "1234567890ABCDEF", 32);
-    os_calloc(1, sizeof(group_t), multi_groups[1]);
-    multi_groups[1]->name = strdup("test_test_default2");
-    os_calloc(2, sizeof(file_sum *), multi_groups[1]->f_sum);
-    os_calloc(1, sizeof(file_sum), multi_groups[1]->f_sum[0]);
-    os_strdup("test_test_file2", multi_groups[1]->f_sum[0]->name);
-    strncpy(multi_groups[1]->f_sum[0]->sum, "67890ABCDEF12345", 32);
-    multi_groups[2] = NULL;
+    test_mode = 0;
+
+    groups = OSHash_Create();
+
+    os_calloc(1, sizeof(group_t), group1);
+    group1->name = strdup("test_default");
+    group1->f_time = OSHash_Create();
+    os_calloc(1, sizeof(file_time), file1);
+    file1->name = strdup("test_file");
+    file1->m_time = 123456789;
+    OSHash_Add_ex(group1->f_time, "test_file", file1);
+    OSHash_Add_ex(groups, "test_default", group1);
+
+    os_calloc(1, sizeof(group_t), group2);
+    group2->name = strdup("test_test_default");
+    group2->f_time = OSHash_Create();
+    os_calloc(1, sizeof(file_time), file2);
+    file2->name = strdup("test_test_file");
+    file2->m_time = 123456798;
+    OSHash_Add_ex(group2->f_time, "test_test_file", file2);
+    OSHash_Add_ex(groups, "test_test_default", group2);
+
+    multi_groups = OSHash_Create();
+
+    os_calloc(1, sizeof(group_t), multigroup1);
+    multigroup1->name = strdup("test_default2");
+    multigroup1->f_time = OSHash_Create();
+    os_calloc(1, sizeof(file_time), file3);
+    file3->name = strdup("test_file2");
+    file3->m_time = 123456789;
+    OSHash_Add_ex(multigroup1->f_time, "test_file2", file3);
+    OSHash_Add_ex(multi_groups, "test_default2", multigroup1);
+
+    os_calloc(1, sizeof(group_t), multigroup2);
+    multigroup2->name = strdup("test_test_default2");
+    multigroup2->f_time = OSHash_Create();
+    os_calloc(1, sizeof(file_time), file4);
+    file4->name = strdup("test_test_file2");
+    file4->m_time = 123456798;
+    OSHash_Add_ex(multigroup2->f_time, "test_test_file2", file4);
+    OSHash_Add_ex(multi_groups, "test_test_default2", multigroup2);
+
+    test_mode = 1;
 
     return 0;
 }
 
 static int test_c_group_teardown(void ** state) {
-    int i;
-    int j;
-    file_sum **f_sum = NULL;
+    test_mode = 0;
 
     if (groups) {
-        for (i = 0; groups[i]; i++) {
-            free_file_sum(groups[i]->f_sum);
-            os_free(groups[i]->name);
-            os_free(groups[i]);
-        }
-
-        os_free(groups);
+        OSHash_Clean(groups, free_group_c_group);
     }
+
+    test_mode = 1;
 
     return 0;
 }
 
 static int test_c_multi_group_teardown(void ** state) {
-    int i;
-    int j;
-    file_sum **f_sum = NULL;
+    test_mode = 0;
 
     if (multi_groups) {
-        for (i = 0; multi_groups[i]; i++) {
-            free_file_sum(multi_groups[i]->f_sum);
-            os_free(multi_groups[i]->name);
-            os_free(multi_groups[i]);
-        }
-
-        os_free(multi_groups);
+        OSHash_Clean(multi_groups, free_group);
     }
 
-    return 0;
-}
-
-static int test_fsum_changed_teardown(void ** state) {
-    file_sum **f_sum1 = (file_sum **)state[0];
-    file_sum **f_sum2 = (file_sum **)state[1];
-    free_file_sum(f_sum1);
-    free_file_sum(f_sum2);
+    test_mode = 1;
 
     return 0;
 }
 
-static int test_process_multi_group_check_group_changed_teardown(void ** state) {
-    int i;
-    int j;
+static int test_process_deleted_groups_teardown(void ** state) {
+    group_t *group = (group_t *)state[1];
+
+    test_mode = 0;
+
+    free_group_c_group(group);
+
+    test_mode = 1;
+
+    return 0;
+}
+
+static int test_ftime_changed_teardown(void ** state) {
+    file_time *file1 = (file_time *)state[0];
+    file_time *file2 = (file_time *)state[1];
+
+    test_mode = 0;
+
+    free_file_time(file1);
+    free_file_time(file2);
+
+    test_mode = 1;
+
+    return 0;
+}
+
+static int test_process_groups_teardown(void ** state) {
+    OSHash *f_time = (OSHash *)state[0];
+
+    test_mode = 0;
+
+    OSHash_Clean(f_time, free_file_time);
+
+    if (groups) {
+        OSHash_Clean(groups, free_group_c_group);
+    }
+
+    if (teardown_hashmap(NULL) != 0) {
+        return -1;
+    }
+
+    test_mode = 1;
+
+    return 0;
+}
+
+static int test_process_multi_groups_teardown(void ** state) {
+    test_mode = 0;
 
     if (multi_groups) {
-        for (i = 0; multi_groups[i]; i++) {
-            os_free(multi_groups[i]->name);
-            os_free(multi_groups[i]);
-        }
+        OSHash_Clean(multi_groups, free_group);
+    }
 
-        os_free(multi_groups);
+    if (teardown_hashmap(NULL) != 0) {
+        return -1;
+    }
+
+    test_mode = 1;
+
+    return 0;
+}
+
+static int test_process_multi_groups_groups_teardown(void ** state) {
+    OSHash *f_time = (OSHash *)state[0];
+
+    test_mode = 0;
+
+    OSHash_Clean(f_time, free_file_time);
+
+    if (multi_groups) {
+        OSHash_Clean(multi_groups, free_group_c_group);
     }
 
     if (groups) {
-        for (j = 0; groups[j]; j++) {
-            free_file_sum(groups[j]->f_sum);
-            os_free(groups[j]->name);
-            os_free(groups[j]);
-        }
-
-        os_free(groups);
+        OSHash_Clean(groups, free_group);
     }
+
+    if (teardown_hashmap(NULL) != 0) {
+        return -1;
+    }
+
+    test_mode = 1;
 
     return 0;
 }
 
 static int test_c_files_teardown(void ** state) {
-    int i;
-    int j;
-    file_sum **f_sum = NULL;
+    test_mode = 0;
 
     if (groups) {
-        for (i = 0; groups[i]; i++) {
-            free_file_sum(groups[i]->f_sum);
-            os_free(groups[i]->name);
-            os_free(groups[i]);
-        }
-
-        os_free(groups);
+        OSHash_Clean(groups, free_group);
     }
 
     if (multi_groups) {
-        for (i = 0; multi_groups[i]; i++) {
-            free_file_sum(multi_groups[i]->f_sum);
-            os_free(multi_groups[i]->name);
-            os_free(multi_groups[i]);
-        }
-
-        os_free(multi_groups);
+        OSHash_Clean(multi_groups, free_group);
     }
+
+    test_mode = 1;
 
     return 0;
 }
@@ -468,56 +626,191 @@ void test_lookfor_agent_group_message_without_second_enter()
     assert_null(r_group);
 }
 
-void test_c_group_fail(void **state)
+void test_c_group_no_changes(void **state)
 {
-    const char *group = "test_default";
+    group_t *group = (group_t *)state[0];
 
-    expect_string(__wrap_w_parser_get_group, name, groups[0]->name);
+    const char *group_name = "test_default";
+
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, (OSHash *)10);
+
+    expect_string(__wrap_w_parser_get_group, name, group->name);
     will_return(__wrap_w_parser_get_group, NULL);
 
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/ar.conf");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_test");
-    will_return(__wrap_OS_MD5_File, -1);
+    expect_string(__wrap_MergeAppendFile, finalpath, "etc/shared/test_default/merged.mg.tmp");
+    expect_string(__wrap_MergeAppendFile, tag, group_name);
+    expect_value(__wrap_MergeAppendFile, path_offset, -1);
+    will_return(__wrap_MergeAppendFile, 1);
+
+    expect_string(__wrap_stat, __file, "etc/shared/ar.conf");
+    will_return(__wrap_stat, 0);
+    will_return(__wrap_stat, -1);
 
     // Start validate_shared_files function
     expect_string(__wrap_wreaddir, name, "etc/shared/test_default");
     will_return(__wrap_wreaddir, NULL);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "At validate_shared_files(): Could not open directory 'etc/shared/test_default'");
+    expect_string(__wrap__mdebug1, formatted_msg, "Could not open directory 'etc/shared/test_default'");
     // End validate_shared_files function
+
+    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/merged.mg.tmp");
+    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
+    will_return(__wrap_OS_MD5_File, "md5_test");
+    will_return(__wrap_OS_MD5_File, 0);
+
+    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/merged.mg");
+    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
+    will_return(__wrap_OS_MD5_File, "md5_test");
+    will_return(__wrap_OS_MD5_File, 0);
+
+    expect_string(__wrap_unlink, file, "etc/shared/test_default/merged.mg.tmp");
+    will_return(__wrap_unlink, -1);
+
+    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/merged.mg");
+    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
+    will_return(__wrap_OS_MD5_File, "md5_test");
+    will_return(__wrap_OS_MD5_File, 0);
+
+    expect_string(__wrap_stat, __file, "etc/shared/test_default/merged.mg");
+    will_return(__wrap_stat, 0);
+    will_return(__wrap_stat, 0);
+
+    OSHash_Add_ex_check_data = 0;
+    expect_value(__wrap_OSHash_Add_ex, self, (OSHash *)10);
+    expect_string(__wrap_OSHash_Add_ex, key, "merged.mg");
+    will_return(__wrap_OSHash_Add_ex, 1);
+
+    expect_string(__wrap__merror, formatted_msg, "Couldn't add file 'merged.mg' to group hash table.");
+
+    c_group(group_name, &group->f_time, &group->merged_sum, SHAREDCFG_DIR, true);
+
+    assert_string_equal(group->name, "test_default");
+    assert_string_equal(group->merged_sum, "md5_test");
+    assert_non_null(group->f_time);
+}
+
+void test_c_group_changes(void **state)
+{
+    group_t *group = (group_t *)state[0];
+
+    const char *group_name = "test_default";
+
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, (OSHash *)10);
+
+    expect_string(__wrap_w_parser_get_group, name, group->name);
+    will_return(__wrap_w_parser_get_group, NULL);
+
+    expect_string(__wrap_MergeAppendFile, finalpath, "etc/shared/test_default/merged.mg.tmp");
+    expect_string(__wrap_MergeAppendFile, tag, group_name);
+    expect_value(__wrap_MergeAppendFile, path_offset, -1);
+    will_return(__wrap_MergeAppendFile, 1);
+
+    expect_string(__wrap_stat, __file, "etc/shared/ar.conf");
+    will_return(__wrap_stat, 0);
+    will_return(__wrap_stat, -1);
+
+    // Start validate_shared_files function
+    expect_string(__wrap_wreaddir, name, "etc/shared/test_default");
+    will_return(__wrap_wreaddir, NULL);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Could not open directory 'etc/shared/test_default'");
+    // End validate_shared_files function
+
+    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/merged.mg.tmp");
+    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
+    will_return(__wrap_OS_MD5_File, "md5_test");
+    will_return(__wrap_OS_MD5_File, 0);
+
+    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/merged.mg");
+    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
+    will_return(__wrap_OS_MD5_File, "md5_test2");
+    will_return(__wrap_OS_MD5_File, 0);
+
+    expect_string(__wrap_OS_MoveFile, src, "etc/shared/test_default/merged.mg.tmp");
+    expect_string(__wrap_OS_MoveFile, dst, "etc/shared/test_default/merged.mg");
+    will_return(__wrap_OS_MoveFile, 0);
+
+    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/merged.mg");
+    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
+    will_return(__wrap_OS_MD5_File, "md5_test2");
+    will_return(__wrap_OS_MD5_File, 0);
+
+    expect_string(__wrap_stat, __file, "etc/shared/test_default/merged.mg");
+    will_return(__wrap_stat, 0);
+    will_return(__wrap_stat, -1);
+
+    expect_string(__wrap__merror, formatted_msg, "Unable to get entry attributes 'etc/shared/test_default/merged.mg'");
+
+    c_group(group_name, &group->f_time, &group->merged_sum, SHAREDCFG_DIR, true);
+
+    assert_string_equal(group->name, "test_default");
+    assert_string_equal(group->merged_sum, "md5_test2");
+    assert_non_null(group->f_time);
+}
+
+void test_c_group_fail(void **state)
+{
+    group_t *group = (group_t *)state[0];
+
+    const char *group_name = "test_default";
+
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, (OSHash *)10);
+
+    expect_string(__wrap_w_parser_get_group, name, group->name);
+    will_return(__wrap_w_parser_get_group, NULL);
+
+    expect_string(__wrap_MergeAppendFile, finalpath, "etc/shared/test_default/merged.mg.tmp");
+    expect_string(__wrap_MergeAppendFile, tag, group_name);
+    expect_value(__wrap_MergeAppendFile, path_offset, -1);
+    will_return(__wrap_MergeAppendFile, 1);
+
+    expect_string(__wrap_stat, __file, "etc/shared/ar.conf");
+    will_return(__wrap_stat, 0);
+    will_return(__wrap_stat, -1);
+
+    // Start validate_shared_files function
+    expect_string(__wrap_wreaddir, name, "etc/shared/test_default");
+    will_return(__wrap_wreaddir, NULL);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Could not open directory 'etc/shared/test_default'");
+    // End validate_shared_files function
+
+    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/merged.mg.tmp");
+    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
+    will_return(__wrap_OS_MD5_File, "md5_test");
+    will_return(__wrap_OS_MD5_File, 0);
 
     expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/merged.mg");
     expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
     will_return(__wrap_OS_MD5_File, "md5_test");
     will_return(__wrap_OS_MD5_File, -1);
 
-    expect_string(__wrap_MergeAppendFile, finalpath, "etc/shared/test_default/merged.mg.tmp");
-    expect_string(__wrap_MergeAppendFile, tag, "test_default");
-    expect_value(__wrap_MergeAppendFile, path_offset, -1);
-    will_return(__wrap_MergeAppendFile, 1);
-
     expect_string(__wrap_OS_MoveFile, src, "etc/shared/test_default/merged.mg.tmp");
     expect_string(__wrap_OS_MoveFile, dst, "etc/shared/test_default/merged.mg");
     will_return(__wrap_OS_MoveFile, 0);
 
+    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/merged.mg");
+    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
+    will_return(__wrap_OS_MD5_File, "md5_test");
+    will_return(__wrap_OS_MD5_File, -1);
+
     expect_string(__wrap__merror, formatted_msg, "Accessing file 'etc/shared/test_default/merged.mg'");
 
-    c_group(group, &groups[0]->f_sum, SHAREDCFG_DIR, true);
+    c_group(group_name, &group->f_time, &group->merged_sum, SHAREDCFG_DIR, true);
 
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_non_null(groups[0]->f_sum);
-    assert_non_null(groups[0]->f_sum[0]);
-    assert_string_equal(groups[0]->f_sum[0]->name, "merged.mg");
-    assert_null(groups[0]->f_sum[1]);
-    assert_null(groups[1]);
-
+    assert_string_equal(group->name, "test_default");
+    assert_string_equal(group->merged_sum, "");
+    assert_non_null(group->f_time);
 }
 
-void test_c_group_downloaded_file_is_corrupted(void **state)
+void test_c_group_downloaded_file(void **state)
 {
-    const char *group = "test_default";
+    group_t *group = (group_t *)state[0];
+
+    const char *group_name = "test_default";
 
     // Initialize r_group structure
     remote_files_group *r_group = NULL;
@@ -532,7 +825,105 @@ void test_c_group_downloaded_file_is_corrupted(void **state)
     r_group->merge_file_index = 0;
     r_group->merged_is_downloaded = 1;
 
-    expect_string(__wrap_w_parser_get_group, name, groups[0]->name);
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, (OSHash *)10);
+
+    expect_string(__wrap_w_parser_get_group, name, group->name);
+    will_return(__wrap_w_parser_get_group, r_group);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Downloading shared file 'etc/shared/test_default/merged.mg' from 'r_group->files_url'");
+
+    expect_string(__wrap_wurl_request, url, r_group->files->url);
+    expect_string(__wrap_wurl_request, dest, "var/download/merged.mg");
+    will_return(__wrap_wurl_request, 0);
+
+    expect_string(__wrap_TestUnmergeFiles, finalpath, "var/download/merged.mg");
+    will_return(__wrap_TestUnmergeFiles, 1);
+
+    expect_string(__wrap_OS_MoveFile, src, "var/download/merged.mg");
+    expect_string(__wrap_OS_MoveFile, dst, "etc/shared/test_default/merged.mg");
+    will_return(__wrap_OS_MoveFile, 0);
+
+    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/merged.mg");
+    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
+    will_return(__wrap_OS_MD5_File, "md5_test");
+    will_return(__wrap_OS_MD5_File, -1);
+
+    expect_string(__wrap__merror, formatted_msg, "Accessing file 'etc/shared/test_default/merged.mg'");
+
+    c_group(group_name, &group->f_time, &group->merged_sum, SHAREDCFG_DIR, true);
+
+    os_free(r_group->name)
+    os_free(r_group->files->name);
+    os_free(r_group->files->url);
+    os_free(r_group->files);
+    os_free(r_group);
+}
+
+void test_c_group_downloaded_file_no_poll(void **state)
+{
+    group_t *group = (group_t *)state[0];
+
+    const char *group_name = "test_default";
+
+    // Initialize r_group structure
+    remote_files_group *r_group = NULL;
+    os_malloc(sizeof(remote_files_group), r_group);
+    os_strdup("r_group_name", r_group->name);
+    os_malloc(sizeof(file), r_group->files);
+    os_strdup("r_group->files_name", r_group->files->name);
+    os_strdup("r_group->files_url", r_group->files->url);
+
+    r_group->poll = 0;
+    r_group->current_polling_time = 1;
+    r_group->merge_file_index = 0;
+    r_group->merged_is_downloaded = 1;
+
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, (OSHash *)10);
+
+    expect_string(__wrap_w_parser_get_group, name, group->name);
+    will_return(__wrap_w_parser_get_group, r_group);
+
+    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/merged.mg");
+    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
+    will_return(__wrap_OS_MD5_File, "md5_test");
+    will_return(__wrap_OS_MD5_File, -1);
+
+    expect_string(__wrap__merror, formatted_msg, "Accessing file 'etc/shared/test_default/merged.mg'");
+
+    c_group(group_name, &group->f_time, &group->merged_sum, SHAREDCFG_DIR, true);
+
+    os_free(r_group->name)
+    os_free(r_group->files->name);
+    os_free(r_group->files->url);
+    os_free(r_group->files);
+    os_free(r_group);
+}
+
+void test_c_group_downloaded_file_is_corrupted(void **state)
+{
+    group_t *group = (group_t *)state[0];
+
+    const char *group_name = "test_default";
+
+    // Initialize r_group structure
+    remote_files_group *r_group = NULL;
+    os_malloc(sizeof(remote_files_group), r_group);
+    os_strdup("r_group_name", r_group->name);
+    os_malloc(sizeof(file), r_group->files);
+    os_strdup("r_group->files_name", r_group->files->name);
+    os_strdup("r_group->files_url", r_group->files->url);
+
+    r_group->poll = 0;
+    r_group->current_polling_time = 0;
+    r_group->merge_file_index = 0;
+    r_group->merged_is_downloaded = 1;
+
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, (OSHash *)10);
+
+    expect_string(__wrap_w_parser_get_group, name, group->name);
     will_return(__wrap_w_parser_get_group, r_group);
 
     expect_string(__wrap__mdebug1, formatted_msg, "Downloading shared file 'etc/shared/test_default/merged.mg' from 'r_group->files_url'");
@@ -550,7 +941,7 @@ void test_c_group_downloaded_file_is_corrupted(void **state)
     expect_string(__wrap__merror, formatted_msg, "The downloaded file 'var/download/merged.mg' is corrupted.");
     expect_string(__wrap__merror, formatted_msg, "Failed to delete file 'var/download/merged.mg'");
 
-    c_group(group, &groups[0]->f_sum, SHAREDCFG_DIR, true);
+    c_group(group_name, &group->f_time, &group->merged_sum, SHAREDCFG_DIR, true);
 
     os_free(r_group->name)
     os_free(r_group->files->name);
@@ -561,7 +952,9 @@ void test_c_group_downloaded_file_is_corrupted(void **state)
 
 void test_c_group_download_all_files(void **state)
 {
-    const char *group = "test_default";
+    group_t *group = (group_t *)state[0];
+
+    const char *group_name = "test_default";
 
     // Initialize r_group structure
     remote_files_group *r_group = NULL;
@@ -579,7 +972,10 @@ void test_c_group_download_all_files(void **state)
     r_group->merge_file_index = -1;
     r_group->merged_is_downloaded = 1;
 
-    expect_string(__wrap_w_parser_get_group, name, groups[0]->name);
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, (OSHash *)10);
+
+    expect_string(__wrap_w_parser_get_group, name, group->name);
     will_return(__wrap_w_parser_get_group, r_group);
 
     expect_string(__wrap__mdebug1, formatted_msg, "Downloading shared file 'etc/shared/test_default/r_group->files_name' from 'r_group->files_url'");
@@ -599,7 +995,7 @@ void test_c_group_download_all_files(void **state)
 
     expect_string(__wrap__merror, formatted_msg, "Accessing file 'etc/shared/test_default/merged.mg'");
 
-    c_group(group, &groups[0]->f_sum, SHAREDCFG_DIR, true);
+    c_group(group_name, &group->f_time, &group->merged_sum, SHAREDCFG_DIR, true);
 
     os_free(r_group->name)
     os_free(r_group->files->name);
@@ -608,9 +1004,11 @@ void test_c_group_download_all_files(void **state)
     os_free(r_group);
 }
 
-void test_c_group_read_directory(void **state)
+void test_c_group_no_create_shared_file(void **state)
 {
-    const char *group = "test_default";
+    group_t *group = (group_t *)state[0];
+
+    const char *group_name = "test_default";
 
     // Initialize r_group structure
     remote_files_group *r_group = NULL;
@@ -625,16 +1023,18 @@ void test_c_group_read_directory(void **state)
     r_group->merge_file_index = 0;
     r_group->merged_is_downloaded = 0;
 
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/ar.conf");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_test");
-    will_return(__wrap_OS_MD5_File, -1);
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, (OSHash *)10);
+
+    expect_string(__wrap_stat, __file, "etc/shared/ar.conf");
+    will_return(__wrap_stat, 0);
+    will_return(__wrap_stat, -1);
 
     // Start validate_shared_files function
     expect_string(__wrap_wreaddir, name, "etc/shared/test_default");
     will_return(__wrap_wreaddir, NULL);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "At validate_shared_files(): Could not open directory 'etc/shared/test_default'");
+    expect_string(__wrap__mdebug1, formatted_msg, "Could not open directory 'etc/shared/test_default'");
     // End validate_shared_files function
 
     expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/merged.mg");
@@ -642,7 +1042,7 @@ void test_c_group_read_directory(void **state)
     will_return(__wrap_OS_MD5_File, "md5_test");
     will_return(__wrap_OS_MD5_File, -1);
 
-    c_group(group, &groups[0]->f_sum, SHAREDCFG_DIR, false);
+    c_group(group_name, &group->f_time, &group->merged_sum, SHAREDCFG_DIR, false);
 
     os_free(r_group->name)
     os_free(r_group->files->name);
@@ -650,18 +1050,16 @@ void test_c_group_read_directory(void **state)
     os_free(r_group->files);
     os_free(r_group);
 
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_non_null(groups[0]->f_sum);
-    assert_non_null(groups[0]->f_sum[0]);
-    assert_string_equal(groups[0]->f_sum[0]->name, "merged.mg");
-    assert_null(groups[0]->f_sum[1]);
-    assert_null(groups[1]);
+    assert_string_equal(group->name, "test_default");
+    assert_string_equal(group->merged_sum, "");
+    assert_non_null(group->f_time);
 }
 
 void test_c_group_invalid_share_file(void **state)
 {
-    const char *group = "test_default";
+    group_t *group = (group_t *)state[0];
+
+    const char *group_name = "test_default";
 
     // Initialize r_group structure
     remote_files_group *r_group = NULL;
@@ -676,7 +1074,10 @@ void test_c_group_invalid_share_file(void **state)
     r_group->merge_file_index = 0;
     r_group->merged_is_downloaded = 0;
 
-    expect_string(__wrap_w_parser_get_group, name, groups[0]->name);
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, (OSHash *)10);
+
+    expect_string(__wrap_w_parser_get_group, name, group->name);
     will_return(__wrap_w_parser_get_group, NULL);
 
     expect_string(__wrap_MergeAppendFile, finalpath, "etc/shared/test_default/merged.mg.tmp");
@@ -684,34 +1085,37 @@ void test_c_group_invalid_share_file(void **state)
     expect_value(__wrap_MergeAppendFile, path_offset, -1);
     will_return(__wrap_MergeAppendFile, 1);
 
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/ar.conf");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_test");
-    will_return(__wrap_OS_MD5_File, 0);
+    struct stat stat_buf = { .st_mtime = 123456788 };
+    expect_string(__wrap_stat, __file, "etc/shared/ar.conf");
+    will_return(__wrap_stat, &stat_buf);
+    will_return(__wrap_stat, 0);
 
     expect_string(__wrap_MergeAppendFile, finalpath, "etc/shared/test_default/merged.mg.tmp");
     expect_value(__wrap_MergeAppendFile, path_offset, -1);
     will_return(__wrap_MergeAppendFile, 1);
 
+    OSHash_Add_ex_check_data = 0;
+    expect_value(__wrap_OSHash_Add_ex, self, (OSHash *)10);
+    expect_string(__wrap_OSHash_Add_ex, key, "ar.conf");
+    will_return(__wrap_OSHash_Add_ex, 1);
+
+    expect_string(__wrap__merror, formatted_msg, "Couldn't add file 'ar.conf' to group hash table.");
+
     // Start validate_shared_files function
     expect_string(__wrap_wreaddir, name, "etc/shared/test_default");
     will_return(__wrap_wreaddir, NULL);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "At validate_shared_files(): Could not open directory 'etc/shared/test_default'");
+    expect_string(__wrap__mdebug1, formatted_msg, "Could not open directory 'etc/shared/test_default'");
     // End validate_shared_files function
 
-    expect_string(__wrap_OS_MoveFile, src, "etc/shared/test_default/merged.mg.tmp");
-    expect_string(__wrap_OS_MoveFile, dst, "etc/shared/test_default/merged.mg");
-    will_return(__wrap_OS_MoveFile, 0);
-
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/merged.mg");
+    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/merged.mg.tmp");
     expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
     will_return(__wrap_OS_MD5_File, "md5_test");
     will_return(__wrap_OS_MD5_File, -1);
 
-    expect_string(__wrap__merror, formatted_msg, "Accessing file 'etc/shared/test_default/merged.mg'");
+    expect_string(__wrap__merror, formatted_msg, "Accessing file 'etc/shared/test_default/merged.mg.tmp'");
 
-    c_group(group, &groups[0]->f_sum, SHAREDCFG_DIR, true);
+    c_group(group_name, &group->f_time, &group->merged_sum, SHAREDCFG_DIR, true);
 
     os_free(r_group->name)
     os_free(r_group->files->name);
@@ -722,7 +1126,9 @@ void test_c_group_invalid_share_file(void **state)
 
 void test_c_group_append_file_error(void **state)
 {
-    const char *group = "test_default";
+    group_t *group = (group_t *)state[0];
+
+    const char *group_name = "test_default";
 
     // Initialize r_group structure
     remote_files_group *r_group = NULL;
@@ -737,7 +1143,10 @@ void test_c_group_append_file_error(void **state)
     r_group->merge_file_index = 0;
     r_group->merged_is_downloaded = 0;
 
-    expect_string(__wrap_w_parser_get_group, name, groups[0]->name);
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, (OSHash *)10);
+
+    expect_string(__wrap_w_parser_get_group, name, group->name);
     will_return(__wrap_w_parser_get_group, NULL);
 
     expect_string(__wrap_MergeAppendFile, finalpath, "etc/shared/test_default/merged.mg.tmp");
@@ -745,14 +1154,21 @@ void test_c_group_append_file_error(void **state)
     expect_value(__wrap_MergeAppendFile, path_offset, -1);
     will_return(__wrap_MergeAppendFile, 1);
 
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/ar.conf");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_test");
-    will_return(__wrap_OS_MD5_File, 0);
+    struct stat stat_buf = { .st_mtime = 123456788 };
+    expect_string(__wrap_stat, __file, "etc/shared/ar.conf");
+    will_return(__wrap_stat, &stat_buf);
+    will_return(__wrap_stat, 0);
 
     expect_string(__wrap_MergeAppendFile, finalpath, "etc/shared/test_default/merged.mg.tmp");
     expect_value(__wrap_MergeAppendFile, path_offset, -1);
     will_return(__wrap_MergeAppendFile, 1);
+
+    OSHash_Add_ex_check_data = 0;
+    expect_value(__wrap_OSHash_Add_ex, self, (OSHash *)10);
+    expect_string(__wrap_OSHash_Add_ex, key, "ar.conf");
+    will_return(__wrap_OSHash_Add_ex, 0);
+
+    expect_string(__wrap__merror, formatted_msg, "Couldn't add file 'ar.conf' to group hash table.");
 
     // Start validate_shared_files function
     char ** files = NULL;
@@ -763,15 +1179,10 @@ void test_c_group_append_file_error(void **state)
     expect_string(__wrap_wreaddir, name, "etc/shared/test_default");
     will_return(__wrap_wreaddir, files);
 
-    struct stat stat_buf = { .st_mode = S_IFREG };
+    struct stat stat_buf2 = { .st_mode = S_IFREG };
     expect_string(__wrap_stat, __file, "etc/shared/test_default/test-file");
-    will_return(__wrap_stat, &stat_buf);
+    will_return(__wrap_stat, &stat_buf2);
     will_return(__wrap_stat, 0);
-
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/test-file");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_test");
-    will_return(__wrap_OS_MD5_File, 0);
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 10);
@@ -792,7 +1203,7 @@ void test_c_group_append_file_error(void **state)
     expect_string(__wrap_unlink, file, "etc/shared/test_default/merged.mg.tmp");
     will_return(__wrap_unlink, -1);
 
-    c_group(group, &groups[0]->f_sum, SHAREDCFG_DIR, true);
+    c_group(group_name, &group->f_time, &group->merged_sum, SHAREDCFG_DIR, true);
 
     os_free(r_group->name)
     os_free(r_group->files->name);
@@ -803,7 +1214,9 @@ void test_c_group_append_file_error(void **state)
 
 void test_c_group_append_ar_error(void **state)
 {
-    const char *group = "test_default";
+    group_t *group = (group_t *)state[0];
+
+    const char *group_name = "test_default";
 
     // Initialize r_group structure
     remote_files_group *r_group = NULL;
@@ -818,7 +1231,10 @@ void test_c_group_append_ar_error(void **state)
     r_group->merge_file_index = 0;
     r_group->merged_is_downloaded = 0;
 
-    expect_string(__wrap_w_parser_get_group, name, groups[0]->name);
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, (OSHash *)10);
+
+    expect_string(__wrap_w_parser_get_group, name, group->name);
     will_return(__wrap_w_parser_get_group, NULL);
 
     expect_string(__wrap_MergeAppendFile, finalpath, "etc/shared/test_default/merged.mg.tmp");
@@ -826,10 +1242,10 @@ void test_c_group_append_ar_error(void **state)
     expect_value(__wrap_MergeAppendFile, path_offset, -1);
     will_return(__wrap_MergeAppendFile, 1);
 
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/ar.conf");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_test");
-    will_return(__wrap_OS_MD5_File, 0);
+    struct stat stat_buf = { .st_mtime = 123456788 };
+    expect_string(__wrap_stat, __file, "etc/shared/ar.conf");
+    will_return(__wrap_stat, &stat_buf);
+    will_return(__wrap_stat, 0);
 
     expect_string(__wrap_MergeAppendFile, finalpath, "etc/shared/test_default/merged.mg.tmp");
     expect_value(__wrap_MergeAppendFile, path_offset, -1);
@@ -838,7 +1254,7 @@ void test_c_group_append_ar_error(void **state)
     expect_string(__wrap_unlink, file, "etc/shared/test_default/merged.mg.tmp");
     will_return(__wrap_unlink, -1);
 
-    c_group(group, &groups[0]->f_sum, SHAREDCFG_DIR, true);
+    c_group(group_name, &group->f_time, &group->merged_sum, SHAREDCFG_DIR, true);
 
     os_free(r_group->name)
     os_free(r_group->files->name);
@@ -849,7 +1265,9 @@ void test_c_group_append_ar_error(void **state)
 
 void test_c_group_truncate_error(void **state)
 {
-    const char *group = "test_default";
+    group_t *group = (group_t *)state[0];
+
+    const char *group_name = "test_default";
 
     // Initialize r_group structure
     remote_files_group *r_group = NULL;
@@ -864,7 +1282,10 @@ void test_c_group_truncate_error(void **state)
     r_group->merge_file_index = 0;
     r_group->merged_is_downloaded = 0;
 
-    expect_string(__wrap_w_parser_get_group, name, groups[0]->name);
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, (OSHash *)10);
+
+    expect_string(__wrap_w_parser_get_group, name, group->name);
     will_return(__wrap_w_parser_get_group, NULL);
 
     expect_string(__wrap_MergeAppendFile, finalpath, "etc/shared/test_default/merged.mg.tmp");
@@ -875,7 +1296,7 @@ void test_c_group_truncate_error(void **state)
     expect_string(__wrap_unlink, file, "etc/shared/test_default/merged.mg.tmp");
     will_return(__wrap_unlink, -1);
 
-    c_group(group, &groups[0]->f_sum, SHAREDCFG_DIR, true);
+    c_group(group_name, &group->f_time, &group->merged_sum, SHAREDCFG_DIR, true);
 
     os_free(r_group->name)
     os_free(r_group->files->name);
@@ -887,29 +1308,33 @@ void test_c_group_truncate_error(void **state)
 void test_c_multi_group_hash_multigroup_null(void **state)
 {
     char *multi_group = NULL;
-    file_sum ***_f_sum = NULL;
+    OSHash *_f_time = (OSHash *)10;
+    os_md5 sum;
     char *hash_multigroup = NULL;
 
-    c_multi_group(multi_group, _f_sum, hash_multigroup, true);
+    c_multi_group(multi_group, &_f_time, &sum, hash_multigroup, true);
 }
 
 void test_c_multi_group_open_directory_fail(void **state)
 {
     char *multi_group = NULL;
-    file_sum ***_f_sum = NULL;
+    OSHash *_f_time = (OSHash *)10;
+    os_md5 sum;
     char *hash_multigroup = NULL;
 
     os_strdup("multi_group_test", multi_group);
     os_strdup("multi_group_hash", hash_multigroup);
 
-    will_return(__wrap_cldir_ex, 0);
+    expect_string(__wrap_cldir_ex_ignore, name, "var/multigroups/multi_group_hash");
+    will_return(__wrap_cldir_ex_ignore, 0);
+
     will_return(__wrap_opendir, 0);
 
     will_return(__wrap_strerror, "No such file or directory");
 
     expect_string(__wrap__mdebug2, formatted_msg, "Opening directory: 'etc/shared': No such file or directory");
 
-    c_multi_group(multi_group, _f_sum, hash_multigroup, true);
+    c_multi_group(multi_group, &_f_time, &sum, hash_multigroup, true);
 
     os_free(hash_multigroup);
     os_free(multi_group);
@@ -918,14 +1343,16 @@ void test_c_multi_group_open_directory_fail(void **state)
 void test_c_multi_group_call_copy_directory(void **state)
 {
     char *multi_group = NULL;
+    OSHash *_f_time = (OSHash *)10;
+    os_md5 sum;
     char *hash_multigroup = NULL;
-    file_sum ***_f_sum = NULL;
-    os_malloc(sizeof(file_sum *), _f_sum);
 
     os_strdup("multi_group_test", multi_group);
     os_strdup("multi_group_hash", hash_multigroup);
 
-    will_return(__wrap_cldir_ex, 0);
+    expect_string(__wrap_cldir_ex_ignore, name, "var/multigroups/multi_group_hash");
+    will_return(__wrap_cldir_ex_ignore, 0);
+
     will_return(__wrap_opendir, 1);
 
     expect_string(__wrap_wreaddir, name, "etc/shared/multi_group_test");
@@ -936,14 +1363,13 @@ void test_c_multi_group_call_copy_directory(void **state)
     expect_string(__wrap_wdb_remove_group_db, name, "multi_group_test");
     will_return(__wrap_wdb_remove_group_db, OS_SUCCESS);
 
-    /* Open the multi-group files and generate merged */
+    // Open the multi-group files and generate merged
     will_return(__wrap_opendir, 0);
     will_return(__wrap_strerror, "No such file or directory");
     expect_string(__wrap__mdebug2, formatted_msg, "Opening directory: 'var/multigroups': No such file or directory");
 
-    c_multi_group(multi_group, _f_sum, hash_multigroup, true);
+    c_multi_group(multi_group, &_f_time, &sum, hash_multigroup, true);
 
-    os_free(_f_sum);
     os_free(hash_multigroup);
     os_free(multi_group);
 }
@@ -951,26 +1377,29 @@ void test_c_multi_group_call_copy_directory(void **state)
 void test_c_multi_group_read_dir_fail_no_entry(void **state)
 {
     char *multi_group = NULL;
-    file_sum ***_f_sum = NULL;
+    OSHash *_f_time = (OSHash *)10;
+    os_md5 sum;
     char *hash_multigroup = NULL;
 
     os_strdup("multi_group_test", multi_group);
     os_strdup("multi_group_hash", hash_multigroup);
 
-    will_return(__wrap_cldir_ex, 0);
+    expect_string(__wrap_cldir_ex_ignore, name, "var/multigroups/multi_group_hash");
+    will_return(__wrap_cldir_ex_ignore, 0);
+
     will_return(__wrap_opendir, 1);
 
     expect_string(__wrap_wreaddir, name, "etc/shared/multi_group_test");
     will_return(__wrap_wreaddir, NULL);
 
-    /* Open the multi-group files and generate merged */
+    // Open the multi-group files and generate merged //
     will_return(__wrap_opendir, 0);
     will_return(__wrap_strerror, "Not a directory");
     expect_string(__wrap__mdebug2, formatted_msg, "Opening directory: 'var/multigroups': Not a directory");
 
     errno = ENOTDIR;
 
-    c_multi_group(multi_group, _f_sum, hash_multigroup, true);
+    c_multi_group(multi_group, &_f_time, &sum, hash_multigroup, true);
 
     errno = 0;
 
@@ -981,13 +1410,16 @@ void test_c_multi_group_read_dir_fail_no_entry(void **state)
 void test_c_multi_group_Ignore_hidden_files(void **state)
 {
     char *multi_group = NULL;
-    file_sum ***_f_sum = NULL;
+    OSHash *_f_time = (OSHash *)10;
+    os_md5 sum;
     char *hash_multigroup = NULL;
 
     os_strdup("multi_group_test", multi_group);
     os_strdup("multi_group_hash", hash_multigroup);
 
-    will_return(__wrap_cldir_ex, 0);
+    expect_string(__wrap_cldir_ex_ignore, name, "var/multigroups/multi_group_hash");
+    will_return(__wrap_cldir_ex_ignore, 0);
+
     will_return(__wrap_opendir, 1);
 
     char** files = NULL;
@@ -1001,6 +1433,8 @@ void test_c_multi_group_Ignore_hidden_files(void **state)
     expect_string(__wrap_wreaddir, name, "etc/shared/multi_group_test");
     will_return(__wrap_wreaddir, files);
 
+    will_return(__wrap_opendir, 0);
+
     expect_any(__wrap_OSHash_Get, self);
     expect_string(__wrap_OSHash_Get, key, "etc/shared/multi_group_test/file_2");
     will_return(__wrap_OSHash_Get, NULL);
@@ -1011,6 +1445,7 @@ void test_c_multi_group_Ignore_hidden_files(void **state)
     expect_value(__wrap_w_copy_file, silent, 1);
     will_return(__wrap_w_copy_file, 0);
 
+    will_return(__wrap_opendir, 0);
 
     expect_any(__wrap_OSHash_Get, self);
     expect_string(__wrap_OSHash_Get, key, "etc/shared/multi_group_test/agent.conf");
@@ -1026,16 +1461,18 @@ void test_c_multi_group_Ignore_hidden_files(void **state)
     os_calloc(1, sizeof(time_t), last_modify);
     *last_modify = 10000;
 
+    will_return(__wrap_opendir, 0);
+
     expect_any(__wrap_OSHash_Get, self);
     expect_string(__wrap_OSHash_Get, key, "etc/shared/multi_group_test/ignore_file");
     will_return(__wrap_OSHash_Get, last_modify);
 
-    /* Open the multi-group files and generate merged */
+    // Open the multi-group files and generate merged //
     will_return(__wrap_opendir, 0);
     will_return(__wrap_strerror, "No such file or directory");
     expect_string(__wrap__mdebug2, formatted_msg, "Opening directory: 'var/multigroups': No such file or directory");
 
-    c_multi_group(multi_group, _f_sum, hash_multigroup, true);
+    c_multi_group(multi_group, &_f_time, &sum, hash_multigroup, true);
 
     os_free(last_modify);
     os_free(hash_multigroup);
@@ -1045,15 +1482,17 @@ void test_c_multi_group_Ignore_hidden_files(void **state)
 void test_c_multi_group_subdir_fail(void **state)
 {
     char *multi_group = NULL;
-    file_sum ***_f_sum = NULL;
+    OSHash *_f_time = (OSHash *)10;
+    os_md5 sum;
     char *hash_multigroup = NULL;
 
     os_strdup("multi_group_test", multi_group);
     os_strdup("hash_multi_group_test",hash_multigroup);
 
-    will_return(__wrap_cldir_ex, 0);
+    expect_string(__wrap_cldir_ex_ignore, name, "var/multigroups/hash_multi_group_test");
+    will_return(__wrap_cldir_ex_ignore, 0);
 
-    /* Open the multi-group files and generate merged */
+    // Open the multi-group files and generate merged //
     will_return(__wrap_opendir, 1);
 
     // Start copy_directory function
@@ -1063,16 +1502,18 @@ void test_c_multi_group_subdir_fail(void **state)
     errno = 1;
     expect_string(__wrap__mwarn, formatted_msg, "Could not open directory 'etc/shared/multi_group_test'. Group folder was deleted.");
 
+    expect_string(__wrap_wdb_remove_group_db, name, "multi_group_test");
+    will_return(__wrap_wdb_remove_group_db, OS_SUCCESS);
+
     // End copy_directory function
 
     will_return(__wrap_opendir, 0);
     will_return(__wrap_strerror, "ERROR");
     expect_string(__wrap__mdebug2, formatted_msg, "Opening directory: 'var/multigroups': ERROR");
 
-    c_multi_group(multi_group, _f_sum, hash_multigroup, true);
+    c_multi_group(multi_group, &_f_time, &sum, hash_multigroup, true);
 
     errno = 0;
-    os_free(_f_sum);
     os_free(hash_multigroup);
     os_free(multi_group);
 }
@@ -1080,17 +1521,17 @@ void test_c_multi_group_subdir_fail(void **state)
 void test_c_multi_group_call_c_group(void **state)
 {
     char *multi_group = NULL;
-    file_sum ***_f_sum = NULL;
-    os_malloc(sizeof(file_sum *), _f_sum);
-
+    OSHash *_f_time = (OSHash *)10;
+    os_md5 sum;
     char *hash_multigroup = NULL;
 
     os_strdup("multi_group_test", multi_group);
     os_strdup("hash_multi_group_test",hash_multigroup);
 
-    will_return(__wrap_cldir_ex, 0);
+    expect_string(__wrap_cldir_ex_ignore, name, "var/multigroups/hash_multi_group_test");
+    will_return(__wrap_cldir_ex_ignore, 0);
 
-    /* Open the multi-group files and generate merged */
+    // Open the multi-group files and generate merged //
     will_return(__wrap_opendir, 1);
 
     // Start copy_directory function
@@ -1108,304 +1549,475 @@ void test_c_multi_group_call_c_group(void **state)
     will_return(__wrap_opendir, 1);
 
     // Start c_group function
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, (OSHash *)10);
+
     expect_string(__wrap_w_parser_get_group, name, "hash_multi_group_test");
     will_return(__wrap_w_parser_get_group, NULL);
 
     expect_string(__wrap_MergeAppendFile, finalpath, "var/multigroups/hash_multi_group_test/merged.mg.tmp");
     expect_string(__wrap_MergeAppendFile, tag, "hash_multi_group_test");
     expect_value(__wrap_MergeAppendFile, path_offset, -1);
-    will_return(__wrap_MergeAppendFile, 1);
+    will_return(__wrap_MergeAppendFile, 0);
 
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/ar.conf");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_test");
-    will_return(__wrap_OS_MD5_File, -1);
-
-    // Start validate_shared_files function
-    expect_string(__wrap_wreaddir, name, "var/multigroups/hash_multi_group_test");
-    will_return(__wrap_wreaddir, NULL);
-
-    expect_string(__wrap__mdebug1, formatted_msg, "At validate_shared_files(): Could not open directory 'var/multigroups/hash_multi_group_test'");
-    // End validate_shared_files function
-
-    expect_string(__wrap_OS_MoveFile, src, "var/multigroups/hash_multi_group_test/merged.mg.tmp");
-    expect_string(__wrap_OS_MoveFile, dst, "var/multigroups/hash_multi_group_test/merged.mg");
-    will_return(__wrap_OS_MoveFile, 0);
-
-    expect_string(__wrap_OS_MD5_File, fname, "var/multigroups/hash_multi_group_test/merged.mg");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_test_mult");
-    will_return(__wrap_OS_MD5_File, 0);
+    expect_string(__wrap_unlink, file, "var/multigroups/hash_multi_group_test/merged.mg.tmp");
+    will_return(__wrap_unlink, -1);
     // End c_group function
 
-    c_multi_group(multi_group, _f_sum, hash_multigroup, true);
-
-    assert_non_null(_f_sum);
-    assert_non_null(_f_sum[0][0]);
-    assert_non_null(_f_sum[0][0]);
-    assert_string_equal(_f_sum[0][0]->name, "merged.mg");
-    assert_string_equal((char *)_f_sum[0][0]->sum, "md5_test_mult");
-    assert_null(_f_sum[0][1]);
+    c_multi_group(multi_group, &_f_time, &sum, hash_multigroup, true);
 
     errno = 0;
-    os_free(_f_sum[0][0]->name);
-    os_free(_f_sum[0][0]);
-    os_free(_f_sum[0]);
-    os_free(_f_sum);
+
     os_free(hash_multigroup);
     os_free(multi_group);
-}
-
-void test_find_group_found(void **state)
-{
-    group_t *group = find_group("test_default");
-
-    assert_non_null(group);
-    assert_string_equal(group->name, "test_default");
-    assert_non_null(group->f_sum);
-    assert_non_null(group->f_sum[0]);
-    assert_string_equal(group->f_sum[0]->name, "test_file");
-    assert_string_equal(group->f_sum[0]->sum, "ABCDEF1234567890");
-    assert_null(group->f_sum[1]);
-}
-
-void test_find_group_not_found(void **state)
-{
-    group_t *group = find_group("invalid_group");
-
-    assert_null(group);
-}
-
-void test_find_multi_group_found(void **state)
-{
-    group_t *multi_group = find_multi_group("test_default2");
-
-    assert_non_null(multi_group);
-    assert_string_equal(multi_group->name, "test_default2");
-    assert_non_null(multi_group->f_sum);
-    assert_non_null(multi_group->f_sum[0]);
-    assert_string_equal(multi_group->f_sum[0]->name, "test_file2");
-    assert_string_equal(multi_group->f_sum[0]->sum, "1234567890ABCDEF");
-    assert_null(multi_group->f_sum[1]);
-}
-
-void test_find_multi_group_not_found(void **state)
-{
-    group_t *multi_group = find_multi_group("invalid_multi_group");
-
-    assert_null(multi_group);
 }
 
 void test_find_group_from_file_found(void **state)
 {
     char group_name[OS_SIZE_65536] = {0};
-    group_t *group = find_group_from_file("test_file", "ABCDEF1234567890", group_name);
+
+    OSHashNode* node = NULL;
+    os_calloc(1, sizeof(OSHashNode), node);
+    node->data = state[0];
+
+    expect_value(__wrap_OSHash_Begin, self, groups);
+    will_return(__wrap_OSHash_Begin, node);
+
+    group_t *group = find_group_from_sum("ABCDEF1234567890", group_name);
 
     assert_string_equal(group_name, "test_default");
     assert_non_null(group);
     assert_string_equal(group->name, "test_default");
-    assert_non_null(group->f_sum);
-    assert_non_null(group->f_sum[0]);
-    assert_string_equal(group->f_sum[0]->name, "test_file");
-    assert_string_equal(group->f_sum[0]->sum, "ABCDEF1234567890");
-    assert_null(group->f_sum[1]);
+
+    os_free(node);
 }
 
 void test_find_group_from_file_not_found(void **state)
 {
     char group_name[OS_SIZE_65536] = {0};
-    group_t *group = find_group_from_file("invalid_file", "", group_name);
+
+    OSHashNode* node1 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node1);
+    node1->data = state[0];
+
+    OSHashNode* node2 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node2);
+    node2->data = state[1];
+
+    expect_value(__wrap_OSHash_Begin, self, groups);
+    will_return(__wrap_OSHash_Begin, node1);
+
+    expect_value(__wrap_OSHash_Next, self, groups);
+    will_return(__wrap_OSHash_Next, node2);
+
+    expect_value(__wrap_OSHash_Next, self, groups);
+    will_return(__wrap_OSHash_Next, NULL);
+
+    group_t *group = find_group_from_sum("2121212121", group_name);
 
     assert_string_equal(group_name, "\0");
     assert_null(group);
+
+    os_free(node1);
+    os_free(node2);
 }
 
 void test_find_multi_group_from_file_found(void **state)
 {
     char multi_group_name[OS_SIZE_65536] = {0};
-    group_t *multi_group = find_multi_group_from_file("test_file2", "1234567890ABCDEF", multi_group_name);
 
-    assert_string_equal(multi_group_name, "test_default2");
+    OSHashNode* node1 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node1);
+    node1->data = state[0];
+
+    OSHashNode* node2 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node2);
+    node2->data = state[1];
+
+    expect_value(__wrap_OSHash_Begin, self, multi_groups);
+    will_return(__wrap_OSHash_Begin, node1);
+
+    expect_value(__wrap_OSHash_Next, self, multi_groups);
+    will_return(__wrap_OSHash_Next, node2);
+
+    group_t *multi_group = find_multi_group_from_sum("1234567890ABCDFE", multi_group_name);
+
+    assert_string_equal(multi_group_name, "test_test_default2");
     assert_non_null(multi_group);
-    assert_string_equal(multi_group->name, "test_default2");
-    assert_non_null(multi_group->f_sum);
-    assert_non_null(multi_group->f_sum[0]);
-    assert_string_equal(multi_group->f_sum[0]->name, "test_file2");
-    assert_string_equal(multi_group->f_sum[0]->sum, "1234567890ABCDEF");
-    assert_null(multi_group->f_sum[1]);
+    assert_string_equal(multi_group->name, "test_test_default2");
+
+    os_free(node1);
+    os_free(node2);
 }
 
 void test_find_multi_group_from_file_not_found(void **state)
 {
     char multi_group_name[OS_SIZE_65536] = {0};
-    group_t *multi_group = find_multi_group_from_file("invalid_file", "", multi_group_name);
+
+    OSHashNode* node1 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node1);
+    node1->data = state[0];
+
+    OSHashNode* node2 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node2);
+    node2->data = state[1];
+
+    expect_value(__wrap_OSHash_Begin, self, multi_groups);
+    will_return(__wrap_OSHash_Begin, node1);
+
+    expect_value(__wrap_OSHash_Next, self, multi_groups);
+    will_return(__wrap_OSHash_Next, node2);
+
+    expect_value(__wrap_OSHash_Next, self, multi_groups);
+    will_return(__wrap_OSHash_Next, NULL);
+
+    group_t *multi_group = find_multi_group_from_sum("4545454545", multi_group_name);
 
     assert_string_equal(multi_group_name, "\0");
     assert_null(multi_group);
+
+    os_free(node1);
+    os_free(node2);
 }
 
-void test_fsum_changed_same_fsum(void **state)
+void test_ftime_changed_same_fsum(void **state)
 {
-    file_sum **f_sum1 = (file_sum **)state[0];
-    file_sum **f_sum2 = (file_sum **)state[1];
+    file_time *file1 = (file_time *)state[0];
 
-    assert_false(fsum_changed(f_sum1, f_sum2));
+    OSHashNode* node1 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node1);
+    node1->data = file1;
+
+    OSHash *hash1 = (OSHash *)10;
+    OSHash *hash2 = (OSHash *)11;
+
+    expect_value(__wrap_OSHash_Get_Elem_ex, self, hash1);
+    will_return(__wrap_OSHash_Get_Elem_ex, 2);
+
+    expect_value(__wrap_OSHash_Get_Elem_ex, self, hash2);
+    will_return(__wrap_OSHash_Get_Elem_ex, 2);
+
+    expect_value(__wrap_OSHash_Begin, self, hash1);
+    will_return(__wrap_OSHash_Begin, node1);
+
+    expect_value(__wrap_OSHash_Get_ex, self, hash2);
+    expect_string(__wrap_OSHash_Get_ex, key, "file1");
+    will_return(__wrap_OSHash_Get_ex, file1);
+
+    expect_value(__wrap_OSHash_Next, self, hash1);
+    will_return(__wrap_OSHash_Next, NULL);
+
+    assert_false(ftime_changed(hash1, hash2));
+
+    os_free(node1);
 }
 
-void test_fsum_changed_different_fsum_sum(void **state)
+void test_ftime_changed_different_fsum_sum(void **state)
 {
-    file_sum **f_sum1 = (file_sum **)state[0];
-    file_sum **f_sum2 = (file_sum **)state[1];
+    file_time *file1 = (file_time *)state[0];
+    file_time *file2 = (file_time *)state[1];
 
-    strncpy(f_sum2[1]->sum, "0987654321FEDCAB", 32);
+    OSHashNode* node1 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node1);
+    node1->data = file1;
 
-    assert_true(fsum_changed(f_sum1, f_sum2));
+    OSHash *hash1 = (OSHash *)10;
+    OSHash *hash2 = (OSHash *)11;
+
+    expect_value(__wrap_OSHash_Get_Elem_ex, self, hash1);
+    will_return(__wrap_OSHash_Get_Elem_ex, 2);
+
+    expect_value(__wrap_OSHash_Get_Elem_ex, self, hash2);
+    will_return(__wrap_OSHash_Get_Elem_ex, 2);
+
+    expect_value(__wrap_OSHash_Begin, self, hash1);
+    will_return(__wrap_OSHash_Begin, node1);
+
+    expect_value(__wrap_OSHash_Get_ex, self, hash2);
+    expect_string(__wrap_OSHash_Get_ex, key, "file1");
+    will_return(__wrap_OSHash_Get_ex, file2);
+
+    assert_true(ftime_changed(hash1, hash2));
+
+    os_free(node1);
 }
 
-void test_fsum_changed_different_fsum_name(void **state)
+void test_ftime_changed_different_fsum_name(void **state)
 {
-    file_sum **f_sum1 = (file_sum **)state[0];
-    file_sum **f_sum2 = (file_sum **)state[1];
+    file_time *file1 = (file_time *)state[0];
 
-    os_free(f_sum2[0]->name);
-    os_strdup("file3", f_sum2[0]->name);
+    OSHashNode* node1 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node1);
+    node1->data = file1;
 
-    assert_true(fsum_changed(f_sum1, f_sum2));
+    OSHash *hash1 = (OSHash *)10;
+    OSHash *hash2 = (OSHash *)11;
+
+    expect_value(__wrap_OSHash_Get_Elem_ex, self, hash1);
+    will_return(__wrap_OSHash_Get_Elem_ex, 2);
+
+    expect_value(__wrap_OSHash_Get_Elem_ex, self, hash2);
+    will_return(__wrap_OSHash_Get_Elem_ex, 2);
+
+    expect_value(__wrap_OSHash_Begin, self, hash1);
+    will_return(__wrap_OSHash_Begin, node1);
+
+    expect_value(__wrap_OSHash_Get_ex, self, hash2);
+    expect_string(__wrap_OSHash_Get_ex, key, "file1");
+    will_return(__wrap_OSHash_Get_ex, NULL);
+
+    assert_true(ftime_changed(hash1, hash2));
+
+    os_free(node1);
 }
 
-void test_fsum_changed_different_size(void **state)
+void test_ftime_changed_different_size(void **state)
 {
-    file_sum **f_sum1 = (file_sum **)state[0];
-    file_sum **f_sum2 = NULL;
+    OSHash *hash1 = (OSHash *)10;
+    OSHash *hash2 = (OSHash *)11;
 
-    os_calloc(2, sizeof(file_sum *), f_sum2);
-    os_calloc(1, sizeof(file_sum), f_sum2[0]);
-    strncpy(f_sum2[0]->sum, "0987654321FEDCBA", 32);
-    os_strdup("file2", f_sum2[0]->name);
+    expect_value(__wrap_OSHash_Get_Elem_ex, self, hash1);
+    will_return(__wrap_OSHash_Get_Elem_ex, 2);
 
-    assert_true(fsum_changed(f_sum1, f_sum2));
+    expect_value(__wrap_OSHash_Get_Elem_ex, self, hash2);
+    will_return(__wrap_OSHash_Get_Elem_ex, 1);
 
-    free_file_sum(f_sum2);
+    assert_true(ftime_changed(hash1, hash2));
 }
 
-void test_fsum_changed_one_null(void **state)
+void test_ftime_changed_one_null(void **state)
 {
-    file_sum **f_sum1 = (file_sum **)state[0];
-    file_sum **f_sum2 = NULL;
+    OSHash *hash1 = (OSHash *)10;
+    OSHash *hash2 = NULL;
 
-    assert_true(fsum_changed(f_sum1, f_sum2));
+    assert_true(ftime_changed(hash1, hash2));
 }
 
-void test_fsum_changed_both_null(void **state)
+void test_ftime_changed_both_null(void **state)
 {
-    file_sum **f_sum1 = NULL;
-    file_sum **f_sum2 = NULL;
+    OSHash *hash1 = NULL;
+    OSHash *hash2 = NULL;
 
-    assert_false(fsum_changed(f_sum1, f_sum2));
+    assert_false(ftime_changed(hash1, hash2));
 }
 
 void test_group_changed_not_changed(void **state)
 {
-    groups[0]->exists = true;
-    groups[0]->has_changed = false;
-    groups[1]->exists = true;
-    groups[1]->has_changed = false;
+    group_t *group1 = (group_t *)state[0];
+    group_t *group2 = (group_t *)state[1];
+
+    group1->exists = true;
+    group1->has_changed = false;
+    group2->exists = true;
+    group2->has_changed = false;
+
+    expect_value(__wrap_OSHash_Get_ex, self, groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "test_default");
+    will_return(__wrap_OSHash_Get_ex, group1);
+
+    expect_value(__wrap_OSHash_Get_ex, self, groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "test_test_default");
+    will_return(__wrap_OSHash_Get_ex, group2);
 
     assert_false(group_changed("test_default,test_test_default"));
 }
 
 void test_group_changed_has_changed(void **state)
 {
-    groups[0]->exists = true;
-    groups[0]->has_changed = false;
-    groups[1]->exists = true;
-    groups[1]->has_changed = true;
+    group_t *group1 = (group_t *)state[0];
+    group_t *group2 = (group_t *)state[1];
+
+    group1->exists = true;
+    group1->has_changed = false;
+    group2->exists = true;
+    group2->has_changed = true;
+
+    expect_value(__wrap_OSHash_Get_ex, self, groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "test_default");
+    will_return(__wrap_OSHash_Get_ex, group1);
+
+    expect_value(__wrap_OSHash_Get_ex, self, groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "test_test_default");
+    will_return(__wrap_OSHash_Get_ex, group2);
 
     assert_true(group_changed("test_default,test_test_default"));
 }
 
 void test_group_changed_not_exists(void **state)
 {
-    groups[0]->exists = true;
-    groups[0]->has_changed = false;
-    groups[1]->exists = false;
-    groups[1]->has_changed = false;
+    group_t *group1 = (group_t *)state[0];
+    group_t *group2 = (group_t *)state[1];
+
+    group1->exists = true;
+    group1->has_changed = false;
+    group2->exists = false;
+    group2->has_changed = false;
+
+    expect_value(__wrap_OSHash_Get_ex, self, groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "test_default");
+    will_return(__wrap_OSHash_Get_ex, group1);
+
+    expect_value(__wrap_OSHash_Get_ex, self, groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "test_test_default");
+    will_return(__wrap_OSHash_Get_ex, group2);
 
     assert_true(group_changed("test_default,test_test_default"));
 }
 
 void test_group_changed_invalid_group(void **state)
 {
-    groups[0]->exists = true;
-    groups[0]->has_changed = false;
-    groups[1]->exists = true;
-    groups[1]->has_changed = false;
+    group_t *group1 = (group_t *)state[0];
+    group_t *group2 = (group_t *)state[1];
+
+    group1->exists = true;
+    group1->has_changed = false;
+    group2->exists = true;
+    group2->has_changed = false;
+
+    expect_value(__wrap_OSHash_Get_ex, self, groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "test_default");
+    will_return(__wrap_OSHash_Get_ex, group1);
+
+    expect_value(__wrap_OSHash_Get_ex, self, groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "test_test_default");
+    will_return(__wrap_OSHash_Get_ex, group2);
+
+    expect_value(__wrap_OSHash_Get_ex, self, groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "invalid_group");
+    will_return(__wrap_OSHash_Get_ex, NULL);
 
     assert_true(group_changed("test_default,test_test_default,invalid_group"));
 }
 
 void test_process_deleted_groups_delete(void **state)
 {
-    groups[0]->exists = false;
-    groups[0]->has_changed = false;
-    groups[1]->exists = true;
-    groups[1]->has_changed = false;
+    group_t *group1 = (group_t *)state[0];
+    group_t *group2 = (group_t *)state[1];
+
+    group1->exists = false;
+    group1->has_changed = false;
+    group2->exists = true;
+    group2->has_changed = false;
+
+    OSHashNode* node1 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node1);
+    node1->key = "test_default";
+    node1->data = group1;
+
+    OSHashNode* node2 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node2);
+    node2->key = "test_test_default";
+    node2->data = group2;
+
+    expect_value(__wrap_OSHash_Begin, self, groups);
+    will_return(__wrap_OSHash_Begin, node1);
+
+    expect_value(__wrap_OSHash_Next, self, groups);
+    will_return(__wrap_OSHash_Next, node2);
+
+    expect_value(__wrap_OSHash_Delete_ex, self, groups);
+    expect_string(__wrap_OSHash_Delete_ex, key, "test_default");
+    will_return(__wrap_OSHash_Delete_ex, NULL);
+
+    will_return(__wrap_OSHash_Clean, 0);
+
+    expect_value(__wrap_OSHash_Next, self, groups);
+    will_return(__wrap_OSHash_Next, NULL);
 
     process_deleted_groups();
 
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_test_default");
-    assert_non_null(groups[0]->f_sum);
-    assert_non_null(groups[0]->f_sum[0]);
-    assert_string_equal(groups[0]->f_sum[0]->name, "test_test_file");
-    assert_string_equal(groups[0]->f_sum[0]->sum, "12345ABCDEF67890");
-    assert_null(groups[0]->f_sum[1]);
-    assert_false(groups[0]->has_changed);
-    assert_false(groups[0]->exists);
-    assert_null(groups[1]);
+    assert_non_null(group2);
+    assert_string_equal(group2->name, "test_test_default");
+    assert_false(group2->has_changed);
+    assert_false(group2->exists);
+
+    os_free(node1);
+    os_free(node2);
 }
 
 void test_process_deleted_groups_no_changes(void **state)
 {
-    groups[0]->exists = true;
-    groups[0]->has_changed = false;
-    groups[1]->exists = true;
-    groups[1]->has_changed = false;
+    group_t *group1 = (group_t *)state[0];
+    group_t *group2 = (group_t *)state[1];
+
+    group1->exists = true;
+    group1->has_changed = false;
+    group2->exists = true;
+    group2->has_changed = false;
+
+    OSHashNode* node1 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node1);
+    node1->key = "test_default";
+    node1->data = group1;
+
+    OSHashNode* node2 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node2);
+    node2->key = "test_test_default";
+    node2->data = group2;
+
+    expect_value(__wrap_OSHash_Begin, self, groups);
+    will_return(__wrap_OSHash_Begin, node1);
+
+    expect_value(__wrap_OSHash_Next, self, groups);
+    will_return(__wrap_OSHash_Next, node2);
+
+    expect_value(__wrap_OSHash_Next, self, groups);
+    will_return(__wrap_OSHash_Next, NULL);
 
     process_deleted_groups();
 
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_non_null(groups[0]->f_sum);
-    assert_non_null(groups[0]->f_sum[0]);
-    assert_string_equal(groups[0]->f_sum[0]->name, "test_file");
-    assert_string_equal(groups[0]->f_sum[0]->sum, "ABCDEF1234567890");
-    assert_null(groups[0]->f_sum[1]);
-    assert_false(groups[0]->has_changed);
-    assert_false(groups[0]->exists);
-    assert_non_null(groups[1]);
-    assert_string_equal(groups[1]->name, "test_test_default");
-    assert_non_null(groups[1]->f_sum);
-    assert_non_null(groups[1]->f_sum[0]);
-    assert_string_equal(groups[1]->f_sum[0]->name, "test_test_file");
-    assert_string_equal(groups[1]->f_sum[0]->sum, "12345ABCDEF67890");
-    assert_null(groups[1]->f_sum[1]);
-    assert_false(groups[1]->has_changed);
-    assert_false(groups[1]->exists);
-    assert_null(groups[2]);
+    assert_non_null(group1);
+    assert_string_equal(group1->name, "test_default");
+    assert_false(group1->has_changed);
+    assert_false(group1->exists);
+    assert_non_null(group2);
+    assert_string_equal(group2->name, "test_test_default");
+    assert_false(group2->has_changed);
+    assert_false(group2->exists);
+
+    os_free(node1);
+    os_free(node2);
 }
 
 void test_process_deleted_multi_groups_delete(void **state)
 {
-    multi_groups[0]->exists = false;
-    multi_groups[0]->has_changed = false;
-    multi_groups[1]->exists = true;
-    multi_groups[1]->has_changed = false;
+    group_t *multigroup1 = (group_t *)state[0];
+    group_t *multigroup2 = (group_t *)state[1];
+
+    multigroup1->exists = false;
+    multigroup1->has_changed = false;
+    multigroup2->exists = true;
+    multigroup2->has_changed = false;
+
+    OSHashNode* node1 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node1);
+    node1->key = "test_default2";
+    node1->data = multigroup1;
+
+    OSHashNode* node2 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node2);
+    node2->key = "test_test_default2";
+    node2->data = multigroup2;
 
     will_return(__wrap_OSHash_Clean, 0);
 
     expect_function_call(__wrap_OSHash_Create);
-    will_return(__wrap_OSHash_Create, NULL);
+    will_return(__wrap_OSHash_Create, (OSHash *)10);
+
+    expect_value(__wrap_OSHash_Begin, self, multi_groups);
+    will_return(__wrap_OSHash_Begin, node1);
+
+    expect_value(__wrap_OSHash_Next, self, multi_groups);
+    will_return(__wrap_OSHash_Next, node2);
+
+    expect_value(__wrap_OSHash_Delete_ex, self, multi_groups);
+    expect_string(__wrap_OSHash_Delete_ex, key, "test_default2");
+    will_return(__wrap_OSHash_Delete_ex, NULL);
+
+    will_return(__wrap_OSHash_Clean, 0);
+
+    expect_value(__wrap_OSHash_Next, self, multi_groups);
+    will_return(__wrap_OSHash_Next, NULL);
 
     expect_any(__wrap_OS_SHA256_String, str);
     will_return(__wrap_OS_SHA256_String, "6e3a107738e7d0fc85241f04ed9686d37738e7d08086fb46e3a100fc85241f04");
@@ -1413,53 +2025,128 @@ void test_process_deleted_multi_groups_delete(void **state)
     expect_string(__wrap_rmdir_ex, name, "var/multigroups/6e3a1077");
     will_return(__wrap_rmdir_ex, 0);
 
-    process_deleted_multi_groups();
+    process_deleted_multi_groups(false);
 
-    assert_non_null(multi_groups[0]);
-    assert_string_equal(multi_groups[0]->name, "test_test_default2");
-    assert_non_null(multi_groups[0]->f_sum);
-    assert_non_null(multi_groups[0]->f_sum[0]);
-    assert_string_equal(multi_groups[0]->f_sum[0]->name, "test_test_file2");
-    assert_string_equal(multi_groups[0]->f_sum[0]->sum, "67890ABCDEF12345");
-    assert_null(multi_groups[0]->f_sum[1]);
-    assert_false(multi_groups[0]->has_changed);
-    assert_false(multi_groups[0]->exists);
-    assert_null(multi_groups[1]);
+    assert_non_null(multigroup2);
+    assert_string_equal(multigroup2->name, "test_test_default2");
+    assert_false(multigroup2->has_changed);
+    assert_false(multigroup2->exists);
+
+    os_free(node1);
+    os_free(node2);
 }
 
 void test_process_deleted_multi_groups_no_changes(void **state)
 {
-    multi_groups[0]->exists = true;
-    multi_groups[0]->has_changed = false;
-    multi_groups[1]->exists = true;
-    multi_groups[1]->has_changed = false;
+    group_t *multigroup1 = (group_t *)state[0];
+    group_t *multigroup2 = (group_t *)state[1];
+
+    multigroup1->exists = true;
+    multigroup1->has_changed = false;
+    multigroup2->exists = true;
+    multigroup2->has_changed = false;
+
+    OSHashNode* node1 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node1);
+    node1->key = "test_default2";
+    node1->data = multigroup1;
+
+    OSHashNode* node2 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node2);
+    node2->key = "test_test_default2";
+    node2->data = multigroup2;
 
     will_return(__wrap_OSHash_Clean, 0);
 
     expect_function_call(__wrap_OSHash_Create);
-    will_return(__wrap_OSHash_Create, NULL);
+    will_return(__wrap_OSHash_Create, (OSHash *)10);
 
-    process_deleted_multi_groups();
+    expect_value(__wrap_OSHash_Begin, self, multi_groups);
+    will_return(__wrap_OSHash_Begin, node1);
 
-    assert_non_null(multi_groups[0]);
-    assert_string_equal(multi_groups[0]->name, "test_default2");
-    assert_non_null(multi_groups[0]->f_sum);
-    assert_non_null(multi_groups[0]->f_sum[0]);
-    assert_string_equal(multi_groups[0]->f_sum[0]->name, "test_file2");
-    assert_string_equal(multi_groups[0]->f_sum[0]->sum, "1234567890ABCDEF");
-    assert_null(multi_groups[0]->f_sum[1]);
-    assert_false(multi_groups[0]->has_changed);
-    assert_false(multi_groups[0]->exists);
-    assert_non_null(multi_groups[1]);
-    assert_string_equal(multi_groups[1]->name, "test_test_default2");
-    assert_non_null(multi_groups[1]->f_sum);
-    assert_non_null(multi_groups[1]->f_sum[0]);
-    assert_string_equal(multi_groups[1]->f_sum[0]->name, "test_test_file2");
-    assert_string_equal(multi_groups[1]->f_sum[0]->sum, "67890ABCDEF12345");
-    assert_null(multi_groups[1]->f_sum[1]);
-    assert_false(multi_groups[1]->has_changed);
-    assert_false(multi_groups[1]->exists);
-    assert_null(multi_groups[2]);
+    expect_value(__wrap_OSHash_Next, self, multi_groups);
+    will_return(__wrap_OSHash_Next, node2);
+
+    expect_value(__wrap_OSHash_Next, self, multi_groups);
+    will_return(__wrap_OSHash_Next, NULL);
+
+    process_deleted_multi_groups(false);
+
+    assert_non_null(multigroup1);
+    assert_string_equal(multigroup1->name, "test_default2");
+    assert_false(multigroup1->has_changed);
+    assert_false(multigroup1->exists);
+    assert_non_null(multigroup2);
+    assert_string_equal(multigroup2->name, "test_test_default2");
+    assert_false(multigroup2->has_changed);
+    assert_false(multigroup2->exists);
+
+    os_free(node1);
+    os_free(node2);
+}
+
+void test_process_deleted_multi_groups_no_changes_initial_scan(void **state)
+{
+    group_t *multigroup1 = (group_t *)state[0];
+    group_t *multigroup2 = (group_t *)state[1];
+
+    multigroup1->exists = true;
+    multigroup1->has_changed = false;
+    multigroup2->exists = true;
+    multigroup2->has_changed = false;
+
+    OSHashNode* node1 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node1);
+    node1->key = "test_default2";
+    node1->data = multigroup1;
+
+    OSHashNode* node2 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node2);
+    node2->key = "test_test_default2";
+    node2->data = multigroup2;
+
+    OSHashNode* node3 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node3);
+    node3->key = "ignore";
+    node3->data = "ignore_hash";
+
+    expect_value(__wrap_OSHash_Begin, self, m_hash);
+    will_return(__wrap_OSHash_Begin, node3);
+
+    expect_value(__wrap_OSHash_Next, self, m_hash);
+    will_return(__wrap_OSHash_Next, NULL);
+
+    expect_string(__wrap_cldir_ex_ignore, name, "var/multigroups");
+    will_return(__wrap_cldir_ex_ignore, 0);
+
+    will_return(__wrap_OSHash_Clean, 0);
+
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, (OSHash *)10);
+
+    expect_value(__wrap_OSHash_Begin, self, multi_groups);
+    will_return(__wrap_OSHash_Begin, node1);
+
+    expect_value(__wrap_OSHash_Next, self, multi_groups);
+    will_return(__wrap_OSHash_Next, node2);
+
+    expect_value(__wrap_OSHash_Next, self, multi_groups);
+    will_return(__wrap_OSHash_Next, NULL);
+
+    process_deleted_multi_groups(true);
+
+    assert_non_null(multigroup1);
+    assert_string_equal(multigroup1->name, "test_default2");
+    assert_false(multigroup1->has_changed);
+    assert_false(multigroup1->exists);
+    assert_non_null(multigroup2);
+    assert_string_equal(multigroup2->name, "test_test_default2");
+    assert_false(multigroup2->has_changed);
+    assert_false(multigroup2->exists);
+
+    os_free(node1);
+    os_free(node2);
+    os_free(node3);
 }
 
 void test_process_groups_open_directory_fail(void **state)
@@ -1494,7 +2181,7 @@ void test_process_groups_subdir_null(void **state)
     expect_string(__wrap_wreaddir, name, "etc/shared/test");
     will_return(__wrap_wreaddir, NULL);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "At process_groups(): Could not open directory 'etc/shared/test'");
+    expect_string(__wrap__mdebug1, formatted_msg, "Could not open directory 'etc/shared/test'");
 
     will_return(__wrap_readdir, NULL);
 
@@ -1548,6 +2235,8 @@ void test_process_groups_find_group_null(void **state)
     os_strdup("file_1", subdir[0]);
     subdir[1] = NULL;
 
+    __real_OSHash_SetFreeDataPointer(mock_hashmap, (void (*)(void *))free_group_c_group);
+
     will_return(__wrap_opendir, 1);
 
     will_return(__wrap_readdir, entry);
@@ -1555,7 +2244,19 @@ void test_process_groups_find_group_null(void **state)
     expect_string(__wrap_wreaddir, name, "etc/shared/test");
     will_return(__wrap_wreaddir, subdir);
 
+    expect_value(__wrap_OSHash_Get_ex, self, groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "test");
+    will_return(__wrap_OSHash_Get_ex, NULL);
+
+    OSHash_Add_ex_check_data = 0;
+    expect_value(__wrap_OSHash_Add_ex, self, groups);
+    expect_string(__wrap_OSHash_Add_ex, key, "test");
+    will_return(__wrap_OSHash_Add_ex, 2);
+
     // Start c_group function
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, (OSHash *)10);
+
     expect_string(__wrap_w_parser_get_group, name, "test");
     will_return(__wrap_w_parser_get_group, NULL);
 
@@ -1564,46 +2265,36 @@ void test_process_groups_find_group_null(void **state)
     expect_value(__wrap_MergeAppendFile, path_offset, -1);
     will_return(__wrap_MergeAppendFile, 1);
 
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/ar.conf");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_test");
-    will_return(__wrap_OS_MD5_File, -1);
+    expect_string(__wrap_stat, __file, "etc/shared/ar.conf");
+    will_return(__wrap_stat, 0);
+    will_return(__wrap_stat, -1);
 
     // Start validate_shared_files function
     expect_string(__wrap_wreaddir, name, "etc/shared/test");
     will_return(__wrap_wreaddir, NULL);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "At validate_shared_files(): Could not open directory 'etc/shared/test'");
+    expect_string(__wrap__mdebug1, formatted_msg, "Could not open directory 'etc/shared/test'");
     // End validate_shared_files function
-    // End c_group function
 
-    expect_string(__wrap_OS_MoveFile, src, "etc/shared/test/merged.mg.tmp");
-    expect_string(__wrap_OS_MoveFile, dst, "etc/shared/test/merged.mg");
-    will_return(__wrap_OS_MoveFile, 0);
-
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test/merged.mg");
+    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test/merged.mg.tmp");
     expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_merged");
-    will_return(__wrap_OS_MD5_File, 0);
+    will_return(__wrap_OS_MD5_File, "md5_test");
+    will_return(__wrap_OS_MD5_File, -1);
+
+    expect_string(__wrap__merror, formatted_msg, "Accessing file 'etc/shared/test/merged.mg.tmp'");
+    // End c_group function
 
     will_return(__wrap_readdir, NULL);
 
     process_groups();
-
-    assert_non_null(groups[1]);
-    assert_string_equal(groups[1]->name, "test");
-    assert_non_null(groups[1]->f_sum);
-    assert_non_null(groups[1]->f_sum[0]);
-    assert_string_equal(groups[1]->f_sum[0]->name, "merged.mg");
-    assert_true(groups[1]->has_changed);
-    assert_true(groups[1]->exists);
-    assert_null(groups[2]);
 
     os_free(entry);
 }
 
 void test_process_groups_find_group_changed(void **state)
 {
+    group_t *group = (group_t *)state[1];
+
     struct dirent *entry;
     os_calloc(1, sizeof(struct dirent), entry);
     strcpy(entry->d_name, "test_default");
@@ -1620,25 +2311,45 @@ void test_process_groups_find_group_changed(void **state)
     expect_string(__wrap_wreaddir, name, "etc/shared/test_default");
     will_return(__wrap_wreaddir, subdir);
 
+    expect_value(__wrap_OSHash_Get_ex, self, groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "test_default");
+    will_return(__wrap_OSHash_Get_ex, group);
+
     // Start c_group function
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/ar.conf");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "new_md5_test");
-    will_return(__wrap_OS_MD5_File, -1);
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, (OSHash *)10);
+
+    expect_string(__wrap_stat, __file, "etc/shared/ar.conf");
+    will_return(__wrap_stat, 0);
+    will_return(__wrap_stat, -1);
 
     // Start validate_shared_files function
     expect_string(__wrap_wreaddir, name, "etc/shared/test_default");
     will_return(__wrap_wreaddir, NULL);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "At validate_shared_files(): Could not open directory 'etc/shared/test_default'");
+    expect_string(__wrap__mdebug1, formatted_msg, "Could not open directory 'etc/shared/test_default'");
     // End validate_shared_files function
+
     expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/merged.mg");
     expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
     will_return(__wrap_OS_MD5_File, "1212121212121");
-    will_return(__wrap_OS_MD5_File, 0);
+    will_return(__wrap_OS_MD5_File, -1);
     // End c_group function
 
+    // Start ftime_changed
+    expect_value(__wrap_OSHash_Get_Elem_ex, self, group->f_time);
+    will_return(__wrap_OSHash_Get_Elem_ex, 2);
+
+    expect_value(__wrap_OSHash_Get_Elem_ex, self, (OSHash *)10);
+    will_return(__wrap_OSHash_Get_Elem_ex, 1);
+    // End ftime_changed
+
+    will_return(__wrap_OSHash_Clean, NULL);
+
     // Start c_group function
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, (OSHash *)11);
+
     expect_string(__wrap_w_parser_get_group, name, "test_default");
     will_return(__wrap_w_parser_get_group, NULL);
 
@@ -1647,49 +2358,40 @@ void test_process_groups_find_group_changed(void **state)
     expect_value(__wrap_MergeAppendFile, path_offset, -1);
     will_return(__wrap_MergeAppendFile, 1);
 
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/ar.conf");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "new_md5_test_2");
-    will_return(__wrap_OS_MD5_File, -1);
+    expect_string(__wrap_stat, __file, "etc/shared/ar.conf");
+    will_return(__wrap_stat, 0);
+    will_return(__wrap_stat, -1);
 
     // Start validate_shared_files function
     expect_string(__wrap_wreaddir, name, "etc/shared/test_default");
     will_return(__wrap_wreaddir, NULL);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "At validate_shared_files(): Could not open directory 'etc/shared/test_default'");
+    expect_string(__wrap__mdebug1, formatted_msg, "Could not open directory 'etc/shared/test_default'");
     // End validate_shared_files function
-    expect_string(__wrap_OS_MoveFile, src, "etc/shared/test_default/merged.mg.tmp");
-    expect_string(__wrap_OS_MoveFile, dst, "etc/shared/test_default/merged.mg");
-    will_return(__wrap_OS_MoveFile, 0);
 
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/merged.mg");
+    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/merged.mg.tmp");
     expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "3434343434343");
-    will_return(__wrap_OS_MD5_File, 0);
+    will_return(__wrap_OS_MD5_File, "md5_test");
+    will_return(__wrap_OS_MD5_File, -1);
+
+    expect_string(__wrap__merror, formatted_msg, "Accessing file 'etc/shared/test_default/merged.mg.tmp'");
     // End c_group function
 
     expect_string(__wrap__mdebug2, formatted_msg, "Group 'test_default' has changed.");
 
+    will_return(__wrap_OSHash_Clean, NULL);
+
     will_return(__wrap_readdir, NULL);
 
     process_groups();
-
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_non_null(groups[0]->f_sum);
-    assert_non_null(groups[0]->f_sum[0]);
-    assert_string_equal(groups[0]->f_sum[0]->name, "merged.mg");
-    assert_string_equal((char *)groups[0]->f_sum[0]->sum, "3434343434343");
-    assert_null(groups[0]->f_sum[1]);
-    assert_true(groups[0]->has_changed);
-    assert_true(groups[0]->exists);
-    assert_null(groups[1]);
 
     os_free(entry);
 }
 
 void test_process_groups_find_group_not_changed(void **state)
 {
+    group_t *group = (group_t *)state[1];
+
     struct dirent *entry;
     os_calloc(1, sizeof(struct dirent), entry);
     strcpy(entry->d_name, "test_default");
@@ -1701,6 +2403,10 @@ void test_process_groups_find_group_not_changed(void **state)
     os_strdup("agent.conf", subdir[2]);
     subdir[3] = NULL;
 
+    OSHashNode* node1 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node1);
+    node1->data = group->f_time;
+
     will_return(__wrap_opendir, 1);
 
     will_return(__wrap_readdir, entry);
@@ -1708,39 +2414,57 @@ void test_process_groups_find_group_not_changed(void **state)
     expect_string(__wrap_wreaddir, name, "etc/shared/test_default");
     will_return(__wrap_wreaddir, subdir);
 
+    expect_value(__wrap_OSHash_Get_ex, self, groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "test_default");
+    will_return(__wrap_OSHash_Get_ex, group);
+
     // Start c_group function
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/ar.conf");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "new_md5_test");
-    will_return(__wrap_OS_MD5_File, -1);
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, (OSHash *)10);
+
+    expect_string(__wrap_stat, __file, "etc/shared/ar.conf");
+    will_return(__wrap_stat, 0);
+    will_return(__wrap_stat, -1);
 
     // Start validate_shared_files function
     expect_string(__wrap_wreaddir, name, "etc/shared/test_default");
     will_return(__wrap_wreaddir, NULL);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "At validate_shared_files(): Could not open directory 'etc/shared/test_default'");
+    expect_string(__wrap__mdebug1, formatted_msg, "Could not open directory 'etc/shared/test_default'");
     // End validate_shared_files function
+
     expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/merged.mg");
     expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "AAAAAAAAAAAAAAAA");
-    will_return(__wrap_OS_MD5_File, 0);
+    will_return(__wrap_OS_MD5_File, "1212121212121");
+    will_return(__wrap_OS_MD5_File, -1);
     // End c_group function
+
+    // Start ftime_changed
+    expect_value(__wrap_OSHash_Get_Elem_ex, self, group->f_time);
+    will_return(__wrap_OSHash_Get_Elem_ex, 2);
+
+    expect_value(__wrap_OSHash_Get_Elem_ex, self, (OSHash *)10);
+    will_return(__wrap_OSHash_Get_Elem_ex, 2);
+
+    expect_value(__wrap_OSHash_Begin, self, group->f_time);
+    will_return(__wrap_OSHash_Begin, node1);
+
+    expect_value(__wrap_OSHash_Get_ex, self, (OSHash *)10);
+    expect_any(__wrap_OSHash_Get_ex, key);
+    will_return(__wrap_OSHash_Get_ex, group->f_time);
+
+    expect_value(__wrap_OSHash_Next, self, group->f_time);
+    will_return(__wrap_OSHash_Next, NULL);
+    // End ftime_changed
+
+    will_return(__wrap_OSHash_Clean, NULL);
 
     will_return(__wrap_readdir, NULL);
 
     process_groups();
 
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_non_null(groups[0]->f_sum);
-    assert_non_null(groups[0]->f_sum[0]);
-    assert_string_equal(groups[0]->f_sum[0]->name, "merged.mg");
-    assert_null(groups[0]->f_sum[1]);
-    assert_false(groups[0]->has_changed);
-    assert_true(groups[0]->exists);
-    assert_null(groups[1]);
-
     os_free(entry);
+    os_free(node1);
 }
 
 void test_process_multi_groups_no_agents(void **state)
@@ -1748,7 +2472,7 @@ void test_process_multi_groups_no_agents(void **state)
     expect_value(__wrap_wdb_get_all_agents, include_manager, false);
     will_return(__wrap_wdb_get_all_agents, NULL);
 
-    expect_value(__wrap_OSHash_Begin, self, NULL);
+    expect_value(__wrap_OSHash_Begin, self, m_hash);
     will_return(__wrap_OSHash_Begin, NULL);
 
     process_multi_groups();
@@ -1769,7 +2493,7 @@ void test_process_multi_groups_single_group(void **state)
     expect_value(__wrap_wdb_get_agent_info, id, 1);
     will_return(__wrap_wdb_get_agent_info, j_agent_info);
 
-    expect_value(__wrap_OSHash_Begin, self, NULL);
+    expect_value(__wrap_OSHash_Begin, self, m_hash);
     will_return(__wrap_OSHash_Begin, NULL);
 
     process_multi_groups();
@@ -1790,11 +2514,9 @@ void test_process_multi_groups_OSHash_Add_fail(void **state)
     expect_value(__wrap_wdb_get_agent_info, id, 1);
     will_return(__wrap_wdb_get_agent_info, j_agent_info);
 
-    m_hash = __real_OSHash_Create();
-
+    OSHash_Add_ex_check_data = 0;
     expect_value(__wrap_OSHash_Add_ex, self, m_hash);
     expect_string(__wrap_OSHash_Add_ex, key, "group1,group2");
-    expect_string(__wrap_OSHash_Add_ex, data, "ef48b4cd");
     will_return(__wrap_OSHash_Add_ex, 0);
 
     expect_string(__wrap__mdebug2, formatted_msg, "Couldn't add multigroup 'group1,group2' to hash table 'm_hash'");
@@ -1803,13 +2525,10 @@ void test_process_multi_groups_OSHash_Add_fail(void **state)
     will_return(__wrap_OSHash_Begin, NULL);
 
     process_multi_groups();
-
-    __real_OSHash_Clean(m_hash, cleaner);
 }
 
 void test_process_multi_groups_open_fail(void **state)
 {
-    test_mode = 0;
     int *agents_array = NULL;
     os_calloc(2, sizeof(int), agents_array);
     agents_array[0] = 1;
@@ -1817,13 +2536,18 @@ void test_process_multi_groups_open_fail(void **state)
 
     cJSON* j_agent_info = cJSON_Parse("[{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]");
 
+    __real_OSHash_SetFreeDataPointer(mock_hashmap, (void (*)(void *))cleaner);
+
     expect_value(__wrap_wdb_get_all_agents, include_manager, false);
     will_return(__wrap_wdb_get_all_agents, agents_array);
 
     expect_value(__wrap_wdb_get_agent_info, id, 1);
     will_return(__wrap_wdb_get_agent_info, j_agent_info);
 
-    m_hash = __real_OSHash_Create();
+    OSHash_Add_ex_check_data = 0;
+    expect_value(__wrap_OSHash_Add_ex, self, m_hash);
+    expect_string(__wrap_OSHash_Add_ex, key, "group1,group2");
+    will_return(__wrap_OSHash_Add_ex, 2);
 
     OSHashNode * hash_node;
     os_calloc(1, sizeof(OSHashNode), hash_node);
@@ -1848,13 +2572,10 @@ void test_process_multi_groups_open_fail(void **state)
 
     os_free(hash_node->key);
     os_free(hash_node);
-    __real_OSHash_Clean(m_hash, cleaner);
-    test_mode = 1;
 }
 
 void test_process_multi_groups_find_multi_group_null(void **state)
 {
-    test_mode = 0;
     int *agents_array = NULL;
     os_calloc(2, sizeof(int), agents_array);
     agents_array[0] = 1;
@@ -1862,13 +2583,20 @@ void test_process_multi_groups_find_multi_group_null(void **state)
 
     cJSON* j_agent_info = cJSON_Parse("[{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]");
 
+    __real_OSHash_SetFreeDataPointer(mock_hashmap, (void (*)(void *))free_group_c_group);
+
     expect_value(__wrap_wdb_get_all_agents, include_manager, false);
     will_return(__wrap_wdb_get_all_agents, agents_array);
 
     expect_value(__wrap_wdb_get_agent_info, id, 1);
     will_return(__wrap_wdb_get_agent_info, j_agent_info);
 
-    m_hash = __real_OSHash_Create();
+    OSHash_Add_ex_check_data = 0;
+    expect_value(__wrap_OSHash_Add_ex, self, m_hash);
+    expect_string(__wrap_OSHash_Add_ex, key, "group1,group2");
+    will_return(__wrap_OSHash_Add_ex, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Couldn't add multigroup 'group1,group2' to hash table 'm_hash'");
 
     OSHashNode * hash_node;
     os_calloc(1, sizeof(OSHashNode), hash_node);
@@ -1886,9 +2614,19 @@ void test_process_multi_groups_find_multi_group_null(void **state)
     expect_string(__wrap_wreaddir, name, "var/multigroups/ef48b4cd");
     will_return(__wrap_wreaddir, subdir);
 
+    expect_value(__wrap_OSHash_Get_ex, self, multi_groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "group1,group2");
+    will_return(__wrap_OSHash_Get_ex, NULL);
+
+    OSHash_Add_ex_check_data = 0;
+    expect_value(__wrap_OSHash_Add_ex, self, multi_groups);
+    expect_string(__wrap_OSHash_Add_ex, key, "group1,group2");
+    will_return(__wrap_OSHash_Add_ex, 2);
+
     // Start c_multi_group
     // Open the multi-group files and generate merged
-    will_return(__wrap_cldir_ex, 0);
+    expect_string(__wrap_cldir_ex_ignore, name, "var/multigroups/ef48b4cd");
+    will_return(__wrap_cldir_ex_ignore, 0);
 
     will_return(__wrap_opendir, 0);
     will_return(__wrap_strerror, "No such file or directory");
@@ -1899,20 +2637,17 @@ void test_process_multi_groups_find_multi_group_null(void **state)
 
     process_multi_groups();
 
-    assert_non_null(multi_groups[1]);
-    assert_string_equal(multi_groups[1]->name, "group1,group2");
-    assert_true(multi_groups[1]->exists);
-    assert_null(multi_groups[2]);
-
     os_free(hash_node->key);
     os_free(hash_node);
-    __real_OSHash_Clean(m_hash, cleaner);
-    test_mode = 1;
 }
 
 void test_process_multi_groups_group_changed(void **state)
 {
-    test_mode = 0;
+    group_t *group = (group_t *)state[0];
+    group_t *multigroup = (group_t *)state[1];
+
+    state[0] = multigroup->f_time;
+
     int *agents_array = NULL;
     os_calloc(2, sizeof(int), agents_array);
     agents_array[0] = 1;
@@ -1920,13 +2655,18 @@ void test_process_multi_groups_group_changed(void **state)
 
     cJSON* j_agent_info = cJSON_Parse("[{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]");
 
+    __real_OSHash_SetFreeDataPointer(mock_hashmap, (void (*)(void *))cleaner);
+
     expect_value(__wrap_wdb_get_all_agents, include_manager, false);
     will_return(__wrap_wdb_get_all_agents, agents_array);
 
     expect_value(__wrap_wdb_get_agent_info, id, 1);
     will_return(__wrap_wdb_get_agent_info, j_agent_info);
 
-    m_hash = __real_OSHash_Create();
+    OSHash_Add_ex_check_data = 0;
+    expect_value(__wrap_OSHash_Add_ex, self, m_hash);
+    expect_string(__wrap_OSHash_Add_ex, key, "group1,group2");
+    will_return(__wrap_OSHash_Add_ex, 2);
 
     OSHashNode * hash_node;
     os_calloc(1, sizeof(OSHashNode), hash_node);
@@ -1944,9 +2684,22 @@ void test_process_multi_groups_group_changed(void **state)
     expect_string(__wrap_wreaddir, name, "var/multigroups/ef48b4cd");
     will_return(__wrap_wreaddir, subdir);
 
+    expect_value(__wrap_OSHash_Get_ex, self, multi_groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "group1,group2");
+    will_return(__wrap_OSHash_Get_ex, multigroup);
+
+    // Start group_changed
+    expect_value(__wrap_OSHash_Get_ex, self, groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "group1");
+    will_return(__wrap_OSHash_Get_ex, group);
+    // End group_changed
+
+    will_return(__wrap_OSHash_Clean, NULL);
+
     // Start c_multi_group
     // Open the multi-group files and generate merged
-    will_return(__wrap_cldir_ex, 0);
+    expect_string(__wrap_cldir_ex_ignore, name, "var/multigroups/ef48b4cd");
+    will_return(__wrap_cldir_ex_ignore, 0);
 
     will_return(__wrap_opendir, 0);
     will_return(__wrap_strerror, "No such file or directory");
@@ -1959,19 +2712,19 @@ void test_process_multi_groups_group_changed(void **state)
 
     process_multi_groups();
 
-    assert_non_null(multi_groups[0]);
-    assert_string_equal(multi_groups[0]->name, "group1,group2");
-    assert_null(multi_groups[1]);
-
     os_free(hash_node->key);
     os_free(hash_node);
-    __real_OSHash_Clean(m_hash, cleaner);
-    test_mode = 1;
 }
 
 void test_process_multi_groups_changed_outside(void **state)
 {
-    test_mode = 0;
+    group_t *group = (group_t *)state[0];
+    group_t *multigroup = (group_t *)state[1];
+
+    group->has_changed = false;
+
+    state[0] = multigroup->f_time;
+
     int *agents_array = NULL;
     os_calloc(2, sizeof(int), agents_array);
     agents_array[0] = 1;
@@ -1979,13 +2732,18 @@ void test_process_multi_groups_changed_outside(void **state)
 
     cJSON* j_agent_info = cJSON_Parse("[{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]");
 
+    __real_OSHash_SetFreeDataPointer(mock_hashmap, (void (*)(void *))cleaner);
+
     expect_value(__wrap_wdb_get_all_agents, include_manager, false);
     will_return(__wrap_wdb_get_all_agents, agents_array);
 
     expect_value(__wrap_wdb_get_agent_info, id, 1);
     will_return(__wrap_wdb_get_agent_info, j_agent_info);
 
-    m_hash = __real_OSHash_Create();
+    OSHash_Add_ex_check_data = 0;
+    expect_value(__wrap_OSHash_Add_ex, self, m_hash);
+    expect_string(__wrap_OSHash_Add_ex, key, "group1,group2");
+    will_return(__wrap_OSHash_Add_ex, 2);
 
     OSHashNode * hash_node;
     os_calloc(1, sizeof(OSHashNode), hash_node);
@@ -2003,6 +2761,21 @@ void test_process_multi_groups_changed_outside(void **state)
     expect_string(__wrap_wreaddir, name, "var/multigroups/ef48b4cd");
     will_return(__wrap_wreaddir, subdir);
 
+    expect_value(__wrap_OSHash_Get_ex, self, multi_groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "group1,group2");
+    will_return(__wrap_OSHash_Get_ex, multigroup);
+
+    // Start group_changed
+    expect_value(__wrap_OSHash_Get_ex, self, groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "group1");
+    will_return(__wrap_OSHash_Get_ex, group);
+    expect_value(__wrap_OSHash_Get_ex, self, groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "group2");
+    will_return(__wrap_OSHash_Get_ex, group);
+    // End group_changed
+
+    will_return(__wrap_OSHash_Clean, NULL);
+
     // Start c_multi_group
     // Open the multi-group files, no generate merged
     will_return(__wrap_opendir, 0);
@@ -2010,7 +2783,8 @@ void test_process_multi_groups_changed_outside(void **state)
     expect_string(__wrap__mdebug2, formatted_msg, "Opening directory: 'var/multigroups': No such file or directory");
 
     // Open the multi-group files and generate merged
-    will_return(__wrap_cldir_ex, 0);
+    expect_string(__wrap_cldir_ex_ignore, name, "var/multigroups/ef48b4cd");
+    will_return(__wrap_cldir_ex_ignore, 0);
 
     will_return(__wrap_opendir, 0);
     will_return(__wrap_strerror, "No such file or directory");
@@ -2021,21 +2795,23 @@ void test_process_multi_groups_changed_outside(void **state)
     expect_value(__wrap_OSHash_Next, self, m_hash);
     will_return(__wrap_OSHash_Next, NULL);
 
-    process_multi_groups();
+    will_return(__wrap_OSHash_Clean, NULL);
 
-    assert_non_null(multi_groups[0]);
-    assert_string_equal(multi_groups[0]->name, "group1,group2");
-    assert_null(multi_groups[1]);
+    process_multi_groups();
 
     os_free(hash_node->key);
     os_free(hash_node);
-    __real_OSHash_Clean(m_hash, cleaner);
-    test_mode = 1;
 }
 
 void test_process_multi_groups_changed_outside_nocmerged(void **state)
 {
-    test_mode = 0;
+    group_t *group = (group_t *)state[0];
+    group_t *multigroup = (group_t *)state[1];
+
+    group->has_changed = false;
+
+    state[0] = multigroup->f_time;
+
     int *agents_array = NULL;
     os_calloc(2, sizeof(int), agents_array);
     agents_array[0] = 1;
@@ -2043,13 +2819,18 @@ void test_process_multi_groups_changed_outside_nocmerged(void **state)
 
     cJSON* j_agent_info = cJSON_Parse("[{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]");
 
+    __real_OSHash_SetFreeDataPointer(mock_hashmap, (void (*)(void *))cleaner);
+
     expect_value(__wrap_wdb_get_all_agents, include_manager, false);
     will_return(__wrap_wdb_get_all_agents, agents_array);
 
     expect_value(__wrap_wdb_get_agent_info, id, 1);
     will_return(__wrap_wdb_get_agent_info, j_agent_info);
 
-    m_hash = __real_OSHash_Create();
+    OSHash_Add_ex_check_data = 0;
+    expect_value(__wrap_OSHash_Add_ex, self, m_hash);
+    expect_string(__wrap_OSHash_Add_ex, key, "group1,group2");
+    will_return(__wrap_OSHash_Add_ex, 2);
 
     OSHashNode * hash_node;
     os_calloc(1, sizeof(OSHashNode), hash_node);
@@ -2066,6 +2847,21 @@ void test_process_multi_groups_changed_outside_nocmerged(void **state)
 
     expect_string(__wrap_wreaddir, name, "var/multigroups/ef48b4cd");
     will_return(__wrap_wreaddir, subdir);
+
+    expect_value(__wrap_OSHash_Get_ex, self, multi_groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "group1,group2");
+    will_return(__wrap_OSHash_Get_ex, multigroup);
+
+    // Start group_changed
+    expect_value(__wrap_OSHash_Get_ex, self, groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "group1");
+    will_return(__wrap_OSHash_Get_ex, group);
+    expect_value(__wrap_OSHash_Get_ex, self, groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "group2");
+    will_return(__wrap_OSHash_Get_ex, group);
+    // End group_changed
+
+    will_return(__wrap_OSHash_Clean, NULL);
 
     // Start c_multi_group
     // Open the multi-group files, no generate merged
@@ -2082,38 +2878,17 @@ void test_process_multi_groups_changed_outside_nocmerged(void **state)
 
     logr.nocmerged = 0;
 
-    assert_non_null(multi_groups[0]);
-    assert_string_equal(multi_groups[0]->name, "group1,group2");
-    assert_null(multi_groups[1]);
-
     os_free(hash_node->key);
     os_free(hash_node);
-    __real_OSHash_Clean(m_hash, cleaner);
-    test_mode = 1;
 }
 
 void test_c_files(void **state)
 {
-    expect_string(__wrap__mdebug2, formatted_msg, "Updating shared files sums.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Updating shared files.");
 
     will_return(__wrap_opendir, 0);
     will_return(__wrap_strerror, "No such file or directory");
     expect_string(__wrap__mdebug1, formatted_msg, "Opening directory: 'etc/shared': No such file or directory");
-
-    groups[0]->exists = true;
-    groups[0]->has_changed = false;
-    groups[1]->exists = true;
-    groups[1]->has_changed = false;
-
-    multi_groups[0]->exists = true;
-    multi_groups[0]->has_changed = false;
-    multi_groups[1]->exists = true;
-    multi_groups[1]->has_changed = false;
-
-    will_return(__wrap_OSHash_Clean, 0);
-
-    expect_function_call(__wrap_OSHash_Create);
-    will_return(__wrap_OSHash_Create, NULL);
 
     expect_value(__wrap_wdb_get_all_agents, include_manager, false);
     will_return(__wrap_wdb_get_all_agents, NULL);
@@ -2122,75 +2897,37 @@ void test_c_files(void **state)
     expect_value(__wrap_OSHash_Begin, self, m_hash);
     will_return(__wrap_OSHash_Begin, NULL);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "End updating shared files sums.");
+    expect_value(__wrap_OSHash_Begin, self, groups);
+    will_return(__wrap_OSHash_Begin, NULL);
 
-    c_files();
+    will_return(__wrap_OSHash_Clean, 0);
 
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_non_null(groups[0]->f_sum);
-    assert_non_null(groups[0]->f_sum[0]);
-    assert_string_equal(groups[0]->f_sum[0]->name, "test_file");
-    assert_string_equal(groups[0]->f_sum[0]->sum, "ABCDEF1234567890");
-    assert_null(groups[0]->f_sum[1]);
-    assert_false(groups[0]->has_changed);
-    assert_false(groups[0]->exists);
-    assert_non_null(groups[1]);
-    assert_string_equal(groups[1]->name, "test_test_default");
-    assert_non_null(groups[1]->f_sum);
-    assert_non_null(groups[1]->f_sum[0]);
-    assert_string_equal(groups[1]->f_sum[0]->name, "test_test_file");
-    assert_string_equal(groups[1]->f_sum[0]->sum, "12345ABCDEF67890");
-    assert_null(groups[1]->f_sum[1]);
-    assert_false(groups[1]->has_changed);
-    assert_false(groups[1]->exists);
-    assert_null(groups[2]);
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, (OSHash *)10);
 
-    assert_non_null(multi_groups[0]);
-    assert_string_equal(multi_groups[0]->name, "test_default2");
-    assert_non_null(multi_groups[0]->f_sum);
-    assert_non_null(multi_groups[0]->f_sum[0]);
-    assert_string_equal(multi_groups[0]->f_sum[0]->name, "test_file2");
-    assert_string_equal(multi_groups[0]->f_sum[0]->sum, "1234567890ABCDEF");
-    assert_null(multi_groups[0]->f_sum[1]);
-    assert_false(multi_groups[0]->has_changed);
-    assert_false(multi_groups[0]->exists);
-    assert_non_null(multi_groups[1]);
-    assert_string_equal(multi_groups[1]->name, "test_test_default2");
-    assert_non_null(multi_groups[1]->f_sum);
-    assert_non_null(multi_groups[1]->f_sum[0]);
-    assert_string_equal(multi_groups[1]->f_sum[0]->name, "test_test_file2");
-    assert_string_equal(multi_groups[1]->f_sum[0]->sum, "67890ABCDEF12345");
-    assert_null(multi_groups[1]->f_sum[1]);
-    assert_false(multi_groups[1]->has_changed);
-    assert_false(multi_groups[1]->exists);
-    assert_null(multi_groups[2]);
+    expect_value(__wrap_OSHash_Begin, self, multi_groups);
+    will_return(__wrap_OSHash_Begin, NULL);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "End updating shared files.");
+
+    c_files(false);
 }
 
 void test_validate_shared_files_files_null(void **state)
 {
-    file_sum **f_sum = NULL;
-    unsigned int f_size = 0;
+    OSHash *_f_time = (OSHash *)10;
 
     expect_string(__wrap_wreaddir, name, "etc/shared/test_default");
     will_return(__wrap_wreaddir, NULL);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "At validate_shared_files(): Could not open directory 'etc/shared/test_default'");
+    expect_string(__wrap__mdebug1, formatted_msg, "Could not open directory 'etc/shared/test_default'");
 
-    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &f_sum, &f_size, false, -1);
-
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_null(groups[1]);
-    assert_null(f_sum);
-    assert_int_equal(f_size, 0);
+    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &_f_time, false, -1);
 }
 
 void test_validate_shared_files_hidden_file(void **state)
 {
-    file_sum **f_sum = NULL;
-    unsigned int f_size = 0;
-    os_calloc(2, sizeof(file_sum *), f_sum);
+    OSHash *_f_time = (OSHash *)10;
 
     // Initialize files structure
     char ** files = NULL;
@@ -2201,22 +2938,12 @@ void test_validate_shared_files_hidden_file(void **state)
     expect_string(__wrap_wreaddir, name, "etc/shared/test_default");
     will_return(__wrap_wreaddir, files);
 
-    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &f_sum, &f_size, false, -1);
-
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_null(groups[1]);
-    assert_null(f_sum[0]);
-    assert_int_equal(f_size, 0);
-
-    free_file_sum(f_sum);
+    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &_f_time, false, -1);
 }
 
 void test_validate_shared_files_merged_file(void **state)
 {
-    file_sum **f_sum = NULL;
-    unsigned int f_size = 0;
-    os_calloc(2, sizeof(file_sum *), f_sum);
+    OSHash *_f_time = (OSHash *)10;
 
     // Initialize files structure
     char ** files = NULL;
@@ -2227,25 +2954,15 @@ void test_validate_shared_files_merged_file(void **state)
     expect_string(__wrap_wreaddir, name, "etc/shared/test_default");
     will_return(__wrap_wreaddir, files);
 
-    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &f_sum, &f_size, false, -1);
-
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_null(groups[1]);
-    assert_null(f_sum[0]);
-    assert_int_equal(f_size, 0);
-
-    free_file_sum(f_sum);
+    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &_f_time, false, -1);
 }
 
 void test_validate_shared_files_max_path_size_warning(void **state)
 {
-    file_sum **f_sum = NULL;
-    unsigned int f_size = 0;
-    os_calloc(2, sizeof(file_sum *), f_sum);
+    OSHash *_f_time = (OSHash *)10;
     char log_str[PATH_MAX + 1] = {0};
 
-    snprintf(log_str, PATH_MAX, "At validate_shared_files(): path too long '%s/test-file'", LONG_PATH);
+    snprintf(log_str, PATH_MAX, "Path too long '%s/test-file'", LONG_PATH);
 
     // Initialize files structure
     char ** files = NULL;
@@ -2260,25 +2977,15 @@ void test_validate_shared_files_max_path_size_warning(void **state)
 
     reported_path_size_exceeded = 0;
 
-    validate_shared_files(LONG_PATH, "test_default", "merged_tmp", &f_sum, &f_size, false, -1);
-
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_null(groups[1]);
-    assert_null(f_sum[0]);
-    assert_int_equal(f_size, 0);
-
-    free_file_sum(f_sum);
+    validate_shared_files(LONG_PATH, "test_default", "merged_tmp", &_f_time, false, -1);
 }
 
 void test_validate_shared_files_max_path_size_debug(void **state)
 {
-    file_sum **f_sum = NULL;
-    unsigned int f_size = 0;
-    os_calloc(2, sizeof(file_sum *), f_sum);
+    OSHash *_f_time = (OSHash *)10;
     char log_str[PATH_MAX + 1] = {0};
 
-    snprintf(log_str, PATH_MAX, "At validate_shared_files(): path too long '%s/test-file'", LONG_PATH);
+    snprintf(log_str, PATH_MAX, "Path too long '%s/test-file'", LONG_PATH);
 
     // Initialize files structure
     char ** files = NULL;
@@ -2293,23 +3000,14 @@ void test_validate_shared_files_max_path_size_debug(void **state)
 
     reported_path_size_exceeded = 1;
 
-    validate_shared_files(LONG_PATH, "test_default", "merged_tmp", &f_sum, &f_size, false, -1);
+    validate_shared_files(LONG_PATH, "test_default", "merged_tmp", &_f_time, false, -1);
 
     reported_path_size_exceeded = 0;
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_null(groups[1]);
-    assert_null(f_sum[0]);
-    assert_int_equal(f_size, 0);
-
-    free_file_sum(f_sum);
 }
 
 void test_validate_shared_files_valid_file_limite_size(void **state)
 {
-    file_sum **f_sum = NULL;
-    unsigned int f_size = 0;
-    os_calloc(2, sizeof(file_sum *), f_sum);
+    OSHash *_f_time = (OSHash *)10;
     char file_str[PATH_MAX + 1] = {0};
     snprintf(file_str, PATH_MAX, "%s/test-file", LONG_PATH);
 
@@ -2327,11 +3025,6 @@ void test_validate_shared_files_valid_file_limite_size(void **state)
     will_return(__wrap_stat, &stat_buf);
     will_return(__wrap_stat, 0);
 
-    expect_string(__wrap_OS_MD5_File, fname, file_str);
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_test");
-    will_return(__wrap_OS_MD5_File, 0);
-
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 10);
     invalid_files = OSHash_Create();
@@ -2343,62 +3036,19 @@ void test_validate_shared_files_valid_file_limite_size(void **state)
     expect_string(__wrap_checkBinaryFile, f_name, file_str);
     will_return(__wrap_checkBinaryFile, 0);
 
-    validate_shared_files(LONG_PATH, "test_default", "merged_tmp", &f_sum, &f_size, false, -1);
-    groups[0]->f_sum = f_sum;
+    OSHash_Add_ex_check_data = 0;
+    expect_value(__wrap_OSHash_Add_ex, self, (OSHash *)10);
+    expect_string(__wrap_OSHash_Add_ex, key, file_str);
+    will_return(__wrap_OSHash_Add_ex, 1);
 
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_non_null(groups[0]->f_sum);
-    assert_non_null(groups[0]->f_sum[0]);
-    assert_string_equal(groups[0]->f_sum[0]->name, file_str);
-    assert_string_equal((char *)groups[0]->f_sum[0]->sum, "md5_test");
-    assert_null(groups[0]->f_sum[1]);
-    assert_null(groups[1]);
-    assert_int_equal(f_size, 1);
-}
+    expect_any(__wrap__merror, formatted_msg);
 
-void test_validate_shared_files_md5_fail(void **state)
-{
-    file_sum **f_sum = NULL;
-    unsigned int f_size = 0;
-    os_calloc(2, sizeof(file_sum *), f_sum);
-
-    // Initialize files structure
-    char ** files = NULL;
-    os_malloc((2) * sizeof(char *), files);
-    files[0] = strdup("test-file");
-    files[1] = NULL;
-
-    expect_string(__wrap_wreaddir, name, "etc/shared/test_default");
-    will_return(__wrap_wreaddir, files);
-
-    struct stat stat_buf = { .st_mode = S_IFREG };
-    expect_string(__wrap_stat, __file, "etc/shared/test_default/test-file");
-    will_return(__wrap_stat, &stat_buf);
-    will_return(__wrap_stat, 0);
-
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/test-file");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_test");
-    will_return(__wrap_OS_MD5_File, -1);
-
-    expect_string(__wrap__merror, formatted_msg, "Accessing file 'etc/shared/test_default/test-file'");
-
-    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &f_sum, &f_size, false, -1);
-    groups[0]->f_sum = f_sum;
-
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_null(groups[1]);
-    assert_null(f_sum[0]);
-    assert_int_equal(f_size, 0);
+    validate_shared_files(LONG_PATH, "test_default", "merged_tmp", &_f_time, false, -1);
 }
 
 void test_validate_shared_files_still_invalid(void **state)
 {
-    file_sum **f_sum = NULL;
-    unsigned int f_size = 0;
-    os_calloc(2, sizeof(file_sum *), f_sum);
+    OSHash *_f_time = (OSHash *)10;
 
     // Initialize files structure
     char ** files = NULL;
@@ -2413,11 +3063,6 @@ void test_validate_shared_files_still_invalid(void **state)
     expect_string(__wrap_stat, __file, "etc/shared/test_default/test-file");
     will_return(__wrap_stat, &stat_buf);
     will_return(__wrap_stat, 0);
-
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/test-file");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_test");
-    will_return(__wrap_OS_MD5_File, 0);
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 10);
@@ -2441,23 +3086,14 @@ void test_validate_shared_files_still_invalid(void **state)
 
     expect_string(__wrap__mdebug1, formatted_msg, "File 'etc/shared/test_default/test-file' in group 'test_default' modified but still invalid.");
 
-    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &f_sum, &f_size, false, -1);
-    groups[0]->f_sum = f_sum;
-
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_null(groups[1]);
-    assert_null(f_sum[0]);
-    assert_int_equal(f_size, 0);
+    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &_f_time, false, -1);
 
     os_free(last_modify);
 }
 
 void test_validate_shared_files_valid_now(void **state)
 {
-    file_sum **f_sum = NULL;
-    unsigned int f_size = 0;
-    os_calloc(2, sizeof(file_sum *), f_sum);
+    OSHash *_f_time = (OSHash *)10;
 
     // Initialize files structure
     char ** files = NULL;
@@ -2472,11 +3108,6 @@ void test_validate_shared_files_valid_now(void **state)
     expect_string(__wrap_stat, __file, "etc/shared/test_default/test-file");
     will_return(__wrap_stat, &stat_buf);
     will_return(__wrap_stat, 0);
-
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/test-file");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_test");
-    will_return(__wrap_OS_MD5_File, 0);
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 10);
@@ -2499,24 +3130,19 @@ void test_validate_shared_files_valid_now(void **state)
 
     expect_string(__wrap__minfo, formatted_msg, "File 'etc/shared/test_default/test-file' in group 'test_default' is valid after last modification.");
 
-    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &f_sum, &f_size, false, -1);
-    groups[0]->f_sum = f_sum;
+    OSHash_Add_ex_check_data = 0;
+    expect_value(__wrap_OSHash_Add_ex, self, (OSHash *)10);
+    expect_string(__wrap_OSHash_Add_ex, key, "etc/shared/test_default/test-file");
+    will_return(__wrap_OSHash_Add_ex, 1);
 
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_non_null(groups[0]->f_sum);
-    assert_non_null(groups[0]->f_sum[0]);
-    assert_string_equal(groups[0]->f_sum[0]->name, "etc/shared/test_default/test-file");
-    assert_null(groups[0]->f_sum[1]);
-    assert_null(groups[1]);
-    assert_int_equal(f_size, 1);
+    expect_any(__wrap__merror, formatted_msg);
+
+    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &_f_time, false, -1);
 }
 
 void test_validate_shared_files_valid_file(void **state)
 {
-    file_sum **f_sum = NULL;
-    unsigned int f_size = 0;
-    os_calloc(2, sizeof(file_sum *), f_sum);
+    OSHash *_f_time = (OSHash *)10;
 
     // Initialize files structure
     char ** files = NULL;
@@ -2532,11 +3158,6 @@ void test_validate_shared_files_valid_file(void **state)
     will_return(__wrap_stat, &stat_buf);
     will_return(__wrap_stat, 0);
 
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/test-file");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_test");
-    will_return(__wrap_OS_MD5_File, 0);
-
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 10);
     invalid_files = OSHash_Create();
@@ -2548,25 +3169,19 @@ void test_validate_shared_files_valid_file(void **state)
     expect_string(__wrap_checkBinaryFile, f_name, "etc/shared/test_default/test-file");
     will_return(__wrap_checkBinaryFile, 0);
 
-    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &f_sum, &f_size, false, -1);
-    groups[0]->f_sum = f_sum;
+    OSHash_Add_ex_check_data = 0;
+    expect_value(__wrap_OSHash_Add_ex, self, (OSHash *)10);
+    expect_string(__wrap_OSHash_Add_ex, key, "etc/shared/test_default/test-file");
+    will_return(__wrap_OSHash_Add_ex, 1);
 
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_non_null(groups[0]->f_sum);
-    assert_non_null(groups[0]->f_sum[0]);
-    assert_string_equal(groups[0]->f_sum[0]->name, "etc/shared/test_default/test-file");
-    assert_string_equal((char *)groups[0]->f_sum[0]->sum, "md5_test");
-    assert_null(groups[0]->f_sum[1]);
-    assert_null(groups[1]);
-    assert_int_equal(f_size, 1);
+    expect_any(__wrap__merror, formatted_msg);
+
+    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &_f_time, false, -1);
 }
 
 void test_validate_shared_files_stat_error(void **state)
 {
-    file_sum **f_sum = NULL;
-    unsigned int f_size = 0;
-    os_calloc(2, sizeof(file_sum *), f_sum);
+    OSHash *_f_time = (OSHash *)10;
 
     // Initialize files structure
     char ** files = NULL;
@@ -2583,17 +3198,12 @@ void test_validate_shared_files_stat_error(void **state)
     will_return(__wrap_stat, &stat_buf_err);
     will_return(__wrap_stat, -1);
 
-    expect_string(__wrap__merror, formatted_msg, "At validate_shared_files(): Unable to get entry attributes 'etc/shared/test_default/stat-error-file'");
+    expect_string(__wrap__merror, formatted_msg, "Unable to get entry attributes 'etc/shared/test_default/stat-error-file'");
 
     struct stat stat_buf = { .st_mode = S_IFREG };
     expect_string(__wrap_stat, __file, "etc/shared/test_default/test-file");
     will_return(__wrap_stat, &stat_buf);
     will_return(__wrap_stat, 0);
-
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/test-file");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_test");
-    will_return(__wrap_OS_MD5_File, 0);
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 10);
@@ -2606,25 +3216,19 @@ void test_validate_shared_files_stat_error(void **state)
     expect_string(__wrap_checkBinaryFile, f_name, "etc/shared/test_default/test-file");
     will_return(__wrap_checkBinaryFile, 0);
 
-    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &f_sum, &f_size, false, -1);
-    groups[0]->f_sum = f_sum;
+    OSHash_Add_ex_check_data = 0;
+    expect_value(__wrap_OSHash_Add_ex, self, (OSHash *)10);
+    expect_string(__wrap_OSHash_Add_ex, key, "etc/shared/test_default/test-file");
+    will_return(__wrap_OSHash_Add_ex, 1);
 
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_non_null(groups[0]->f_sum);
-    assert_non_null(groups[0]->f_sum[0]);
-    assert_string_equal(groups[0]->f_sum[0]->name, "etc/shared/test_default/test-file");
-    assert_string_equal((char *)groups[0]->f_sum[0]->sum, "md5_test");
-    assert_null(groups[0]->f_sum[1]);
-    assert_null(groups[1]);
-    assert_int_equal(f_size, 1);
+    expect_any(__wrap__merror, formatted_msg);
+
+    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &_f_time, false, -1);
 }
 
 void test_validate_shared_files_merge_file(void **state)
 {
-    file_sum **f_sum = NULL;
-    unsigned int f_size = 0;
-    os_calloc(2, sizeof(file_sum *), f_sum);
+    OSHash *_f_time = (OSHash *)10;
 
     // Initialize files structure
     char ** files = NULL;
@@ -2639,11 +3243,6 @@ void test_validate_shared_files_merge_file(void **state)
     expect_string(__wrap_stat, __file, "etc/shared/test_default/test-file");
     will_return(__wrap_stat, &stat_buf);
     will_return(__wrap_stat, 0);
-
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/test-file");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_test");
-    will_return(__wrap_OS_MD5_File, 0);
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 10);
@@ -2660,25 +3259,19 @@ void test_validate_shared_files_merge_file(void **state)
     expect_value(__wrap_MergeAppendFile, path_offset, 0x18);
     will_return(__wrap_MergeAppendFile, 1);
 
-    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &f_sum, &f_size, true, -1);
-    groups[0]->f_sum = f_sum;
+    OSHash_Add_ex_check_data = 0;
+    expect_value(__wrap_OSHash_Add_ex, self, (OSHash *)10);
+    expect_string(__wrap_OSHash_Add_ex, key, "etc/shared/test_default/test-file");
+    will_return(__wrap_OSHash_Add_ex, 1);
 
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_non_null(groups[0]->f_sum);
-    assert_non_null(groups[0]->f_sum[0]);
-    assert_string_equal(groups[0]->f_sum[0]->name, "etc/shared/test_default/test-file");
-    assert_string_equal((char *)groups[0]->f_sum[0]->sum, "md5_test");
-    assert_null(groups[0]->f_sum[1]);
-    assert_null(groups[1]);
-    assert_int_equal(f_size, 1);
+    expect_any(__wrap__merror, formatted_msg);
+
+    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &_f_time, true, -1);
 }
 
 void test_validate_shared_files_merge_file_append_fail(void **state)
 {
-    file_sum **f_sum = NULL;
-    unsigned int f_size = 0;
-    os_calloc(2, sizeof(file_sum *), f_sum);
+    OSHash *_f_time = (OSHash *)10;
 
     // Initialize files structure
     char ** files = NULL;
@@ -2693,11 +3286,6 @@ void test_validate_shared_files_merge_file_append_fail(void **state)
     expect_string(__wrap_stat, __file, "etc/shared/test_default/test-file");
     will_return(__wrap_stat, &stat_buf);
     will_return(__wrap_stat, 0);
-
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/test-file");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_test");
-    will_return(__wrap_OS_MD5_File, 0);
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 10);
@@ -2714,22 +3302,12 @@ void test_validate_shared_files_merge_file_append_fail(void **state)
     expect_value(__wrap_MergeAppendFile, path_offset, 0x18);
     will_return(__wrap_MergeAppendFile, 0);
 
-    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &f_sum, &f_size, true, -1);
-    groups[0]->f_sum = f_sum;
-
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_non_null(groups[0]->f_sum);
-    assert_null(groups[0]->f_sum[0]);
-    assert_null(groups[1]);
-    assert_int_equal(f_size, 0);
+    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &_f_time, true, -1);
 }
 
 void test_validate_shared_files_fail_add(void **state)
 {
-    file_sum **f_sum = NULL;
-    unsigned int f_size = 0;
-    os_calloc(2, sizeof(file_sum *), f_sum);
+    OSHash *_f_time = (OSHash *)10;
 
     // Initialize files structure
     char ** files = NULL;
@@ -2744,11 +3322,6 @@ void test_validate_shared_files_fail_add(void **state)
     expect_string(__wrap_stat, __file, "etc/shared/test_default/test-file");
     will_return(__wrap_stat, &stat_buf);
     will_return(__wrap_stat, 0);
-
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/test-file");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_test");
-    will_return(__wrap_OS_MD5_File, 0);
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 10);
@@ -2766,22 +3339,12 @@ void test_validate_shared_files_fail_add(void **state)
 
     expect_string(__wrap__merror, formatted_msg, "Unable to add file 'etc/shared/test_default/test-file' to hash table of invalid files.");
 
-
-    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &f_sum, &f_size, false, -1);
-    groups[0]->f_sum = f_sum;
-
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_null(groups[1]);
-    assert_null(f_sum[0]);
-    assert_int_equal(f_size, 0);
+    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &_f_time, false, -1);
 }
 
 void test_validate_shared_files_subfolder_empty(void **state)
 {
-    file_sum **f_sum = NULL;
-    unsigned int f_size = 0;
-    os_calloc(2, sizeof(file_sum *), f_sum);
+    OSHash *_f_time = (OSHash *)10;
 
     // Initialize files structure
     char ** files = NULL;
@@ -2800,24 +3363,14 @@ void test_validate_shared_files_subfolder_empty(void **state)
     expect_string(__wrap_wreaddir, name, "etc/shared/test_default/test-subfolder");
     will_return(__wrap_wreaddir, NULL);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "At validate_shared_files(): Could not open directory 'etc/shared/test_default/test-subfolder'");
+    expect_string(__wrap__mdebug1, formatted_msg, "Could not open directory 'etc/shared/test_default/test-subfolder'");
 
-
-    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &f_sum, &f_size, false, -1);
-    groups[0]->f_sum = f_sum;
-
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_null(groups[1]);
-    assert_null(f_sum[0]);
-    assert_int_equal(f_size, 0);
+    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &_f_time, false, -1);
 }
 
 void test_validate_shared_files_subfolder_append_fail(void **state)
 {
-    file_sum **f_sum = NULL;
-    unsigned int f_size = 0;
-    os_calloc(2, sizeof(file_sum *), f_sum);
+    OSHash *_f_time = (OSHash *)10;
 
     // Initialize files structure
     char ** files = NULL;
@@ -2845,11 +3398,6 @@ void test_validate_shared_files_subfolder_append_fail(void **state)
     will_return(__wrap_stat, &stat_buf2);
     will_return(__wrap_stat, 0);
 
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/test-subfolder/test-file");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_test");
-    will_return(__wrap_OS_MD5_File, 0);
-
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 10);
     invalid_files = OSHash_Create();
@@ -2865,21 +3413,12 @@ void test_validate_shared_files_subfolder_append_fail(void **state)
     expect_value(__wrap_MergeAppendFile, path_offset, 0x18);
     will_return(__wrap_MergeAppendFile, 0);
 
-    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &f_sum, &f_size, true, -1);
-    groups[0]->f_sum = f_sum;
-
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_null(groups[1]);
-    assert_null(f_sum[0]);
-    assert_int_equal(f_size, 0);
+    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &_f_time, true, -1);
 }
 
 void test_validate_shared_files_valid_file_subfolder_empty(void **state)
 {
-    file_sum **f_sum = NULL;
-    unsigned int f_size = 0;
-    os_calloc(2, sizeof(file_sum *), f_sum);
+    OSHash *_f_time = (OSHash *)10;
 
     // Initialize files structure
     char ** files = NULL;
@@ -2896,11 +3435,6 @@ void test_validate_shared_files_valid_file_subfolder_empty(void **state)
     will_return(__wrap_stat, &stat_buf);
     will_return(__wrap_stat, 0);
 
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/test-file");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_test");
-    will_return(__wrap_OS_MD5_File, 0);
-
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 10);
     invalid_files = OSHash_Create();
@@ -2912,6 +3446,13 @@ void test_validate_shared_files_valid_file_subfolder_empty(void **state)
     expect_string(__wrap_checkBinaryFile, f_name, "etc/shared/test_default/test-file");
     will_return(__wrap_checkBinaryFile, 0);
 
+    OSHash_Add_ex_check_data = 0;
+    expect_value(__wrap_OSHash_Add_ex, self, (OSHash *)10);
+    expect_string(__wrap_OSHash_Add_ex, key, "etc/shared/test_default/test-file");
+    will_return(__wrap_OSHash_Add_ex, 1);
+
+    expect_any(__wrap__merror, formatted_msg);
+
     struct stat stat_buf_2 = { .st_mode = S_IFDIR };
     expect_string(__wrap_stat, __file, "etc/shared/test_default/test-subfolder");
     will_return(__wrap_stat, &stat_buf_2);
@@ -2920,28 +3461,14 @@ void test_validate_shared_files_valid_file_subfolder_empty(void **state)
     expect_string(__wrap_wreaddir, name, "etc/shared/test_default/test-subfolder");
     will_return(__wrap_wreaddir, NULL);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "At validate_shared_files(): Could not open directory 'etc/shared/test_default/test-subfolder'");
+    expect_string(__wrap__mdebug1, formatted_msg, "Could not open directory 'etc/shared/test_default/test-subfolder'");
 
-
-    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &f_sum, &f_size, false, -1);
-    groups[0]->f_sum = f_sum;
-
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_non_null(groups[0]->f_sum);
-    assert_non_null(groups[0]->f_sum[0]);
-    assert_string_equal(groups[0]->f_sum[0]->name, "etc/shared/test_default/test-file");
-    assert_string_equal((char *)groups[0]->f_sum[0]->sum, "md5_test");
-    assert_null(groups[0]->f_sum[1]);
-    assert_null(groups[1]);
-    assert_int_equal(f_size, 1);
+    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &_f_time, false, -1);
 }
 
 void test_validate_shared_files_subfolder_valid_file(void **state)
 {
-    file_sum **f_sum = NULL;
-    unsigned int f_size = 0;
-    os_calloc(2, sizeof(file_sum *), f_sum);
+    OSHash *_f_time = (OSHash *)10;
 
     // Initialize files structure
     char ** files = NULL;
@@ -2971,11 +3498,6 @@ void test_validate_shared_files_subfolder_valid_file(void **state)
     will_return(__wrap_stat, &stat_buf_2);
     will_return(__wrap_stat, 0);
 
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/test-subfolder/test-file");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_test");
-    will_return(__wrap_OS_MD5_File, 0);
-
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 10);
     invalid_files = OSHash_Create();
@@ -2987,25 +3509,19 @@ void test_validate_shared_files_subfolder_valid_file(void **state)
     expect_string(__wrap_checkBinaryFile, f_name, "etc/shared/test_default/test-subfolder/test-file");
     will_return(__wrap_checkBinaryFile, 0);
 
-    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &f_sum, &f_size, false, -1);
-    groups[0]->f_sum = f_sum;
+    OSHash_Add_ex_check_data = 0;
+    expect_value(__wrap_OSHash_Add_ex, self, (OSHash *)10);
+    expect_string(__wrap_OSHash_Add_ex, key, "etc/shared/test_default/test-subfolder/test-file");
+    will_return(__wrap_OSHash_Add_ex, 1);
 
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_non_null(groups[0]->f_sum);
-    assert_non_null(groups[0]->f_sum[0]);
-    assert_string_equal(groups[0]->f_sum[0]->name, "etc/shared/test_default/test-subfolder/test-file");
-    assert_string_equal((char *)groups[0]->f_sum[0]->sum, "md5_test");
-    assert_null(groups[0]->f_sum[1]);
-    assert_null(groups[1]);
-    assert_int_equal(f_size, 1);
+    expect_any(__wrap__merror, formatted_msg);
+
+    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &_f_time, false, -1);
 }
 
 void test_validate_shared_files_valid_file_subfolder_valid_file(void **state)
 {
-    file_sum **f_sum = NULL;
-    unsigned int f_size = 0;
-    os_calloc(2, sizeof(file_sum *), f_sum);
+    OSHash *_f_time = (OSHash *)10;
 
     // Initialize files structure
     char ** files = NULL;
@@ -3036,11 +3552,6 @@ void test_validate_shared_files_valid_file_subfolder_valid_file(void **state)
     will_return(__wrap_stat, &stat_buf_2);
     will_return(__wrap_stat, 0);
 
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/test-subfolder/test-file");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_test");
-    will_return(__wrap_OS_MD5_File, 0);
-
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 10);
     invalid_files = OSHash_Create();
@@ -3052,15 +3563,17 @@ void test_validate_shared_files_valid_file_subfolder_valid_file(void **state)
     expect_string(__wrap_checkBinaryFile, f_name, "etc/shared/test_default/test-subfolder/test-file");
     will_return(__wrap_checkBinaryFile, 0);
 
+    OSHash_Add_ex_check_data = 0;
+    expect_value(__wrap_OSHash_Add_ex, self, (OSHash *)10);
+    expect_string(__wrap_OSHash_Add_ex, key, "etc/shared/test_default/test-subfolder/test-file");
+    will_return(__wrap_OSHash_Add_ex, 1);
+
+    expect_any(__wrap__merror, formatted_msg);
+
     struct stat stat_buf_3 = { .st_mode = S_IFREG };
     expect_string(__wrap_stat, __file, "etc/shared/test_default/test-file-main-folder");
     will_return(__wrap_stat, &stat_buf_3);
     will_return(__wrap_stat, 0);
-
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/test-file-main-folder");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_file_main");
-    will_return(__wrap_OS_MD5_File, 0);
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 10);
@@ -3073,27 +3586,19 @@ void test_validate_shared_files_valid_file_subfolder_valid_file(void **state)
     expect_string(__wrap_checkBinaryFile, f_name, "etc/shared/test_default/test-file-main-folder");
     will_return(__wrap_checkBinaryFile, 0);
 
-    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &f_sum, &f_size, false, -1);
-    groups[0]->f_sum = f_sum;
+    OSHash_Add_ex_check_data = 0;
+    expect_value(__wrap_OSHash_Add_ex, self, (OSHash *)10);
+    expect_string(__wrap_OSHash_Add_ex, key, "etc/shared/test_default/test-file-main-folder");
+    will_return(__wrap_OSHash_Add_ex, 1);
 
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_non_null(groups[0]->f_sum);
-    assert_non_null(groups[0]->f_sum[0]);
-    assert_string_equal(groups[0]->f_sum[0]->name, "etc/shared/test_default/test-subfolder/test-file");
-    assert_string_equal((char *)groups[0]->f_sum[0]->sum, "md5_test");
-    assert_string_equal(groups[0]->f_sum[1]->name, "etc/shared/test_default/test-file-main-folder");
-    assert_string_equal((char *)groups[0]->f_sum[1]->sum, "md5_file_main");
-    assert_null(groups[0]->f_sum[2]);
-    assert_null(groups[1]);
-    assert_int_equal(f_size, 2);
+    expect_any(__wrap__merror, formatted_msg);
+
+    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &_f_time, false, -1);
 }
 
 void test_validate_shared_files_sub_subfolder_valid_file(void **state)
 {
-    file_sum **f_sum = NULL;
-    unsigned int f_size = 0;
-    os_calloc(2, sizeof(file_sum *), f_sum);
+    OSHash *_f_time = (OSHash *)10;
 
     // Initialize files structure
     char ** files = NULL;
@@ -3137,11 +3642,6 @@ void test_validate_shared_files_sub_subfolder_valid_file(void **state)
     will_return(__wrap_stat, &stat_buf_3);
     will_return(__wrap_stat, 0);
 
-    expect_string(__wrap_OS_MD5_File, fname, "etc/shared/test_default/test-subfolder/test-subfolder2/test-file");
-    expect_value(__wrap_OS_MD5_File, mode, OS_TEXT);
-    will_return(__wrap_OS_MD5_File, "md5_test");
-    will_return(__wrap_OS_MD5_File, 0);
-
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 10);
     invalid_files = OSHash_Create();
@@ -3153,18 +3653,14 @@ void test_validate_shared_files_sub_subfolder_valid_file(void **state)
     expect_string(__wrap_checkBinaryFile, f_name, "etc/shared/test_default/test-subfolder/test-subfolder2/test-file");
     will_return(__wrap_checkBinaryFile, 0);
 
-    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &f_sum, &f_size, false, -1);
-    groups[0]->f_sum = f_sum;
+    OSHash_Add_ex_check_data = 0;
+    expect_value(__wrap_OSHash_Add_ex, self, (OSHash *)10);
+    expect_string(__wrap_OSHash_Add_ex, key, "etc/shared/test_default/test-subfolder/test-subfolder2/test-file");
+    will_return(__wrap_OSHash_Add_ex, 1);
 
-    assert_non_null(groups[0]);
-    assert_string_equal(groups[0]->name, "test_default");
-    assert_non_null(groups[0]->f_sum);
-    assert_non_null(groups[0]->f_sum[0]);
-    assert_string_equal(groups[0]->f_sum[0]->name, "etc/shared/test_default/test-subfolder/test-subfolder2/test-file");
-    assert_string_equal((char *)groups[0]->f_sum[0]->sum, "md5_test");
-    assert_null(groups[0]->f_sum[1]);
-    assert_null(groups[1]);
-    assert_int_equal(f_size, 1);
+    expect_any(__wrap__merror, formatted_msg);
+
+    validate_shared_files("etc/shared/test_default", "test_default", "merged_tmp", &_f_time, false, -1);
 }
 
 void test_copy_directory_files_null_initial(void **state)
@@ -3226,7 +3722,7 @@ void test_copy_directory_merged_file(void **state)
 void test_copy_directory_source_path_too_long_warning(void **state)
 {
     char log_str[PATH_MAX + 1] = {0};
-    snprintf(log_str, PATH_MAX, "At copy_directory(): source path too long '%s/test-file'", LONG_PATH);
+    snprintf(log_str, PATH_MAX, "Source path too long '%s/test-file'", LONG_PATH);
 
     // Initialize files structure
     char ** files = NULL;
@@ -3247,7 +3743,7 @@ void test_copy_directory_source_path_too_long_warning(void **state)
 void test_copy_directory_source_path_too_long_debug(void **state)
 {
     char log_str[PATH_MAX + 1] = {0};
-    snprintf(log_str, PATH_MAX, "At copy_directory(): source path too long '%s/test-file'", LONG_PATH);
+    snprintf(log_str, PATH_MAX, "Source path too long '%s/test-file'", LONG_PATH);
 
     // Initialize files structure
     char ** files = NULL;
@@ -3270,7 +3766,7 @@ void test_copy_directory_source_path_too_long_debug(void **state)
 void test_copy_directory_destination_path_too_long_warning(void **state)
 {
     char log_str[PATH_MAX + 1] = {0};
-    snprintf(log_str, PATH_MAX, "At copy_directory(): destination path too long '%s/test-file'", LONG_PATH);
+    snprintf(log_str, PATH_MAX, "Destination path too long '%s/test-file'", LONG_PATH);
 
     // Initialize files structure
     char ** files = NULL;
@@ -3291,7 +3787,7 @@ void test_copy_directory_destination_path_too_long_warning(void **state)
 void test_copy_directory_destination_path_too_long_debug(void **state)
 {
     char log_str[PATH_MAX + 1] = {0};
-    snprintf(log_str, PATH_MAX, "At copy_directory(): destination path too long '%s/test-file'", LONG_PATH);
+    snprintf(log_str, PATH_MAX, "Destination path too long '%s/test-file'", LONG_PATH);
 
     // Initialize files structure
     char ** files = NULL;
@@ -3657,8 +4153,6 @@ void test_save_controlmsg_invalid_msg(void **state)
 
 void test_save_controlmsg_could_not_add_pending_data(void **state)
 {
-    test_mode = true;
-
     char r_msg[OS_SIZE_128] = {0};
     strcpy(r_msg, "Invalid message \n with enter");
 
@@ -3694,8 +4188,6 @@ void test_save_controlmsg_could_not_add_pending_data(void **state)
 
 void test_save_controlmsg_unable_to_save_last_keepalive(void **state)
 {
-    test_mode = true;
-
     char r_msg[OS_SIZE_128] = {0};
     strcpy(r_msg, "Invalid message \n with enter");
 
@@ -3738,8 +4230,6 @@ void test_save_controlmsg_unable_to_save_last_keepalive(void **state)
 
 void test_save_controlmsg_update_msg_error_parsing(void **state)
 {
-    test_mode = true;
-
     char r_msg[OS_SIZE_128] = {0};
     strcpy(r_msg, "valid message \n with enter");
 
@@ -3771,9 +4261,8 @@ void test_save_controlmsg_update_msg_error_parsing(void **state)
 
     expect_string(__wrap__mdebug2, formatted_msg, "save_controlmsg(): inserting 'valid message \n'");
 
-    static group_t *test_groups = NULL;
-    groups = &test_groups;
-    multi_groups = &test_groups;
+    groups = (OSHash *)10;
+    multi_groups = (OSHash *)10;
 
     char* group = NULL;
     w_strdup("test_group", group);
@@ -3781,6 +4270,14 @@ void test_save_controlmsg_update_msg_error_parsing(void **state)
     will_return(__wrap_wdb_get_agent_group, group);
 
     expect_string(__wrap__mdebug2, formatted_msg, "Agent '001' group is 'test_group'");
+
+    expect_value(__wrap_OSHash_Get_ex, self, groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "test_group");
+    will_return(__wrap_OSHash_Get_ex, NULL);
+
+    expect_value(__wrap_OSHash_Get_ex, self, multi_groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "test_group");
+    will_return(__wrap_OSHash_Get_ex, NULL);
 
     expect_string(__wrap__mdebug1, formatted_msg, "No such group 'test_group' for agent '001'");
 
@@ -3806,8 +4303,6 @@ void test_save_controlmsg_update_msg_error_parsing(void **state)
 
 void test_save_controlmsg_update_msg_unable_to_update_information(void **state)
 {
-    test_mode = true;
-
     char r_msg[OS_SIZE_128] = {0};
     strcpy(r_msg, "valid message \n with enter");
 
@@ -3839,32 +4334,25 @@ void test_save_controlmsg_update_msg_unable_to_update_information(void **state)
 
     expect_string(__wrap__mdebug2, formatted_msg, "save_controlmsg(): inserting 'valid message \n'");
 
-    os_calloc(1, (2) * sizeof(group_t *), groups);
-    os_calloc(1, sizeof(group_t), groups[0]);
-    groups[0]->name = strdup("test_group");
-    groups[0]->has_changed = false;
-    groups[0]->exists = true;
-    groups[1] = NULL;
+    groups = (OSHash *)10;
+    multi_groups = (OSHash *)10;
 
-    os_calloc(2, sizeof(file_sum *), groups[0]->f_sum);
-    os_calloc(1, sizeof(file_sum), groups[0]->f_sum[0]);
-    os_strdup("test_group", groups[0]->f_sum[0]->name);
-    strncpy(groups[0]->f_sum[0]->sum, "ABCDEF1234567890", 32);
-    groups[0]->f_sum[1] = NULL;
+    group_t *group = NULL;
+    os_calloc(1, sizeof(group_t), group);
+    group->name = strdup("test_group");
+    memset(&group->merged_sum, 0, sizeof(os_md5));
+    snprintf(group->merged_sum, 7, "112359");
 
-    os_calloc(1, (2) * sizeof(group_t *), multi_groups);
-    os_calloc(1, sizeof(group_t), multi_groups[0]);
-    multi_groups[0]->name = strdup("test_group");
-    multi_groups[0]->has_changed = false;
-    multi_groups[0]->exists = true;
-    multi_groups[1] = NULL;
-
-    char* group = NULL;
-    w_strdup("test_group", group);
+    char* group_name = NULL;
+    w_strdup("test_group", group_name);
     expect_value(__wrap_wdb_get_agent_group, id, 1);
-    will_return(__wrap_wdb_get_agent_group, group);
+    will_return(__wrap_wdb_get_agent_group, group_name);
 
     expect_string(__wrap__mdebug2, formatted_msg, "Agent '001' group is 'test_group'");
+
+    expect_value(__wrap_OSHash_Get_ex, self, groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "test_group");
+    will_return(__wrap_OSHash_Get_ex, group);
 
     agent_info_data *agent_data;
     os_calloc(1, sizeof(agent_info_data), agent_data);
@@ -3892,6 +4380,9 @@ void test_save_controlmsg_update_msg_unable_to_update_information(void **state)
 
     save_controlmsg(&key, r_msg, msg_length, wdb_sock);
 
+    os_free(group->name);
+    os_free(group);
+
     os_free(agent_data->manager_host);
     os_free(agent_data);
 
@@ -3905,8 +4396,6 @@ void test_save_controlmsg_update_msg_unable_to_update_information(void **state)
 
 void test_save_controlmsg_update_msg_lookfor_agent_group_fail(void **state)
 {
-    test_mode = true;
-
     char r_msg[OS_SIZE_128] = {0};
     strcpy(r_msg, "valid message \n with enter");
 
@@ -3973,7 +4462,6 @@ void test_save_controlmsg_update_msg_lookfor_agent_group_fail(void **state)
 
 void test_save_controlmsg_startup(void **state)
 {
-    test_mode = true;
     char r_msg[OS_SIZE_128] = {0};
     strcpy(r_msg, HC_STARTUP);
     keyentry key;
@@ -4018,7 +4506,6 @@ void test_save_controlmsg_startup(void **state)
 
 void test_save_controlmsg_shutdown(void **state)
 {
-    test_mode = true;
     char r_msg[OS_SIZE_128] = {0};
     strcpy(r_msg, HC_SHUTDOWN);
     keyentry key;
@@ -4085,7 +4572,6 @@ void test_save_controlmsg_shutdown(void **state)
 
 void test_save_controlmsg_shutdown_wdb_fail(void **state)
 {
-    test_mode = true;
     char r_msg[OS_SIZE_128] = {0};
     strcpy(r_msg, HC_SHUTDOWN);
     keyentry key;
@@ -4139,10 +4625,14 @@ int main(void)
         cmocka_unit_test(test_lookfor_agent_group_bad_message),
         cmocka_unit_test(test_lookfor_agent_group_message_without_second_enter),
         // Tests c_group
+        cmocka_unit_test_setup_teardown(test_c_group_no_changes, test_c_group_setup, test_c_group_teardown),
+        cmocka_unit_test_setup_teardown(test_c_group_changes, test_c_group_setup, test_c_group_teardown),
         cmocka_unit_test_setup_teardown(test_c_group_fail, test_c_group_setup, test_c_group_teardown),
+        cmocka_unit_test_setup_teardown(test_c_group_downloaded_file, test_c_group_setup, test_c_group_teardown),
+        cmocka_unit_test_setup_teardown(test_c_group_downloaded_file_no_poll, test_c_group_setup, test_c_group_teardown),
         cmocka_unit_test_setup_teardown(test_c_group_downloaded_file_is_corrupted, test_c_group_setup, test_c_group_teardown),
         cmocka_unit_test_setup_teardown(test_c_group_download_all_files, test_c_group_setup, test_c_group_teardown),
-        cmocka_unit_test_setup_teardown(test_c_group_read_directory, test_c_group_setup, test_c_group_teardown),
+        cmocka_unit_test_setup_teardown(test_c_group_no_create_shared_file, test_c_group_setup, test_c_group_teardown),
         cmocka_unit_test_setup_teardown(test_c_group_invalid_share_file, test_c_group_setup, test_c_group_teardown),
         cmocka_unit_test_setup_teardown(test_c_group_append_file_error, test_c_group_setup, test_c_group_teardown),
         cmocka_unit_test_setup_teardown(test_c_group_append_ar_error, test_c_group_setup, test_c_group_teardown),
@@ -4151,55 +4641,53 @@ int main(void)
         cmocka_unit_test(test_c_multi_group_hash_multigroup_null),
         cmocka_unit_test(test_c_multi_group_open_directory_fail),
         cmocka_unit_test(test_c_multi_group_call_copy_directory),
+        cmocka_unit_test(test_c_multi_group_read_dir_fail_no_entry),
+        cmocka_unit_test(test_c_multi_group_Ignore_hidden_files),
+        cmocka_unit_test(test_c_multi_group_subdir_fail),
         cmocka_unit_test(test_c_multi_group_call_c_group),
-        // Test find_group
-        cmocka_unit_test_setup_teardown(test_find_group_found, test_find_group_setup, test_c_group_teardown),
-        cmocka_unit_test_setup_teardown(test_find_group_not_found, test_find_group_setup, test_c_group_teardown),
-        // Test find_multi_group
-        cmocka_unit_test_setup_teardown(test_find_multi_group_found, test_find_multi_group_setup, test_c_multi_group_teardown),
-        cmocka_unit_test_setup_teardown(test_find_multi_group_not_found, test_find_multi_group_setup, test_c_multi_group_teardown),
-        // Test find_group_from_file
+        // Test find_group_from_sum
         cmocka_unit_test_setup_teardown(test_find_group_from_file_found, test_find_group_setup, test_c_group_teardown),
         cmocka_unit_test_setup_teardown(test_find_group_from_file_not_found, test_find_group_setup, test_c_group_teardown),
-        // Test find_multi_group_from_file
+        // Test find_multi_group_from_sum
         cmocka_unit_test_setup_teardown(test_find_multi_group_from_file_found, test_find_multi_group_setup, test_c_multi_group_teardown),
         cmocka_unit_test_setup_teardown(test_find_multi_group_from_file_not_found, test_find_multi_group_setup, test_c_multi_group_teardown),
-        // Test fsum_changed
-        cmocka_unit_test_setup_teardown(test_fsum_changed_same_fsum, test_fsum_changed_setup, test_fsum_changed_teardown),
-        cmocka_unit_test_setup_teardown(test_fsum_changed_different_fsum_sum, test_fsum_changed_setup, test_fsum_changed_teardown),
-        cmocka_unit_test_setup_teardown(test_fsum_changed_different_fsum_name, test_fsum_changed_setup, test_fsum_changed_teardown),
-        cmocka_unit_test_setup_teardown(test_fsum_changed_different_size, test_fsum_changed_setup, test_fsum_changed_teardown),
-        cmocka_unit_test_setup_teardown(test_fsum_changed_one_null, test_fsum_changed_setup, test_fsum_changed_teardown),
-        cmocka_unit_test(test_fsum_changed_both_null),
+        // Test ftime_changed
+        cmocka_unit_test_setup_teardown(test_ftime_changed_same_fsum, test_ftime_changed_setup, test_ftime_changed_teardown),
+        cmocka_unit_test_setup_teardown(test_ftime_changed_different_fsum_sum, test_ftime_changed_setup, test_ftime_changed_teardown),
+        cmocka_unit_test_setup_teardown(test_ftime_changed_different_fsum_name, test_ftime_changed_setup, test_ftime_changed_teardown),
+        cmocka_unit_test_setup_teardown(test_ftime_changed_different_size, test_ftime_changed_setup, test_ftime_changed_teardown),
+        cmocka_unit_test_setup_teardown(test_ftime_changed_one_null, test_ftime_changed_setup, test_ftime_changed_teardown),
+        cmocka_unit_test(test_ftime_changed_both_null),
         // Test group_changed
         cmocka_unit_test_setup_teardown(test_group_changed_not_changed, test_find_group_setup, test_c_group_teardown),
         cmocka_unit_test_setup_teardown(test_group_changed_has_changed, test_find_group_setup, test_c_group_teardown),
         cmocka_unit_test_setup_teardown(test_group_changed_not_exists, test_find_group_setup, test_c_group_teardown),
         cmocka_unit_test_setup_teardown(test_group_changed_invalid_group, test_find_group_setup, test_c_group_teardown),
         // Test process_deleted_groups
-        cmocka_unit_test_setup_teardown(test_process_deleted_groups_delete, test_find_group_setup, test_c_group_teardown),
+        cmocka_unit_test_setup_teardown(test_process_deleted_groups_delete, test_process_deleted_groups_setup, test_process_deleted_groups_teardown),
         cmocka_unit_test_setup_teardown(test_process_deleted_groups_no_changes, test_find_group_setup, test_c_group_teardown),
         // Test process_deleted_multi_groups
-        cmocka_unit_test_setup_teardown(test_process_deleted_multi_groups_delete, test_find_multi_group_setup, test_c_multi_group_teardown),
+        cmocka_unit_test_setup_teardown(test_process_deleted_multi_groups_delete, test_process_deleted_multi_groups_setup, test_process_deleted_groups_teardown),
         cmocka_unit_test_setup_teardown(test_process_deleted_multi_groups_no_changes, test_find_multi_group_setup, test_c_multi_group_teardown),
+        cmocka_unit_test_setup_teardown(test_process_deleted_multi_groups_no_changes_initial_scan, test_find_multi_group_setup, test_c_multi_group_teardown),
         // Test process_groups
         cmocka_unit_test(test_process_groups_open_directory_fail),
         cmocka_unit_test(test_process_groups_readdir_fail),
         cmocka_unit_test(test_process_groups_subdir_null),
         cmocka_unit_test(test_process_groups_skip),
         cmocka_unit_test(test_process_groups_skip_2),
-        cmocka_unit_test_setup_teardown(test_process_groups_find_group_null, test_process_group_setup, test_c_group_teardown),
-        cmocka_unit_test_setup_teardown(test_process_groups_find_group_changed, test_process_group_setup, test_c_group_teardown),
-        cmocka_unit_test_setup_teardown(test_process_groups_find_group_not_changed, test_process_group_setup, test_c_group_teardown),
+        cmocka_unit_test_setup_teardown(test_process_groups_find_group_null, test_process_group_setup, test_process_groups_teardown),
+        cmocka_unit_test_setup_teardown(test_process_groups_find_group_changed, test_process_group_setup, test_process_groups_teardown),
+        cmocka_unit_test_setup_teardown(test_process_groups_find_group_not_changed, test_process_group_setup, test_process_groups_teardown),
         // Test process_multi_groups
         cmocka_unit_test(test_process_multi_groups_no_agents),
         cmocka_unit_test(test_process_multi_groups_single_group),
         cmocka_unit_test(test_process_multi_groups_OSHash_Add_fail),
-        cmocka_unit_test(test_process_multi_groups_open_fail),
-        cmocka_unit_test_setup_teardown(test_process_multi_groups_find_multi_group_null, test_process_multi_groups_setup, test_c_multi_group_teardown),
-        cmocka_unit_test_setup_teardown(test_process_multi_groups_group_changed, test_process_multi_groups_group_changed_setup, test_process_multi_group_check_group_changed_teardown),
-        cmocka_unit_test_setup_teardown(test_process_multi_groups_changed_outside, test_process_multi_groups_group_not_changed_setup, test_process_multi_group_check_group_changed_teardown),
-        cmocka_unit_test_setup_teardown(test_process_multi_groups_changed_outside_nocmerged, test_process_multi_groups_group_not_changed_setup, test_process_multi_group_check_group_changed_teardown),
+        cmocka_unit_test_setup_teardown(test_process_multi_groups_open_fail, test_process_multi_groups_setup, test_process_multi_groups_teardown),
+        cmocka_unit_test_setup_teardown(test_process_multi_groups_find_multi_group_null, test_process_multi_groups_setup, test_process_multi_groups_teardown),
+        cmocka_unit_test_setup_teardown(test_process_multi_groups_group_changed, test_process_multi_groups_groups_setup, test_process_multi_groups_groups_teardown),
+        cmocka_unit_test_setup_teardown(test_process_multi_groups_changed_outside, test_process_multi_groups_groups_setup, test_process_multi_groups_groups_teardown),
+        cmocka_unit_test_setup_teardown(test_process_multi_groups_changed_outside_nocmerged, test_process_multi_groups_groups_setup, test_process_multi_groups_groups_teardown),
         // Test c_files
         cmocka_unit_test_setup_teardown(test_c_files, test_c_files_setup, test_c_files_teardown),
         // Test validate_shared_files
@@ -4209,7 +4697,6 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_validate_shared_files_max_path_size_warning, test_c_group_setup, test_c_group_teardown),
         cmocka_unit_test_setup_teardown(test_validate_shared_files_max_path_size_debug, test_c_group_setup, test_c_group_teardown),
         cmocka_unit_test_setup_teardown(test_validate_shared_files_valid_file_limite_size, test_c_group_setup, test_c_group_teardown),
-        cmocka_unit_test_setup_teardown(test_validate_shared_files_md5_fail, test_c_group_setup, test_c_group_teardown),
         cmocka_unit_test_setup_teardown(test_validate_shared_files_still_invalid, test_c_group_setup, test_c_group_teardown),
         cmocka_unit_test_setup_teardown(test_validate_shared_files_valid_now, test_c_group_setup, test_c_group_teardown),
         cmocka_unit_test_setup_teardown(test_validate_shared_files_valid_file, test_c_group_setup, test_c_group_teardown),

--- a/src/unit_tests/shared/test_file_op.c
+++ b/src/unit_tests/shared/test_file_op.c
@@ -25,7 +25,6 @@
 #include "../wrappers/wazuh/shared/file_op_wrappers.h"
 #include "../wrappers/externals/zlib/zlib_wrappers.h"
 
-
 /* setups/teardowns */
 static int setup_group(void **state) {
     test_mode = 1;
@@ -162,7 +161,6 @@ void test_DeletePID_success(void **state)
     assert_int_equal(0, ret);
 }
 
-
 void test_DeletePID_failure(void **state)
 {
     (void) state;
@@ -273,111 +271,14 @@ void test_w_uncompress_bz2_gz_file_bz2(void **state) {
 
     ret = w_uncompress_bz2_gz_file(path, dest);
     assert_int_equal(ret, 0);
-
 }
-
-void test_MergeAppendFile_filepath_null_fopen_fail(void **state) {
-
-    char * finalpath = "/test/shared/default/merged.mg";
-    char * file = NULL;
-    char * tag = "New TAG";
-    int path_offset = -1;
-    int ret;
-
-    expect_string(__wrap_fopen, path, finalpath);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, NULL);
-
-    expect_string(__wrap__merror, formatted_msg, "Unable to create merged file: '/test/shared/default/merged.mg' due to [(0)-(Success)].");
-
-    ret = MergeAppendFile(finalpath, file, tag, path_offset);
-    assert_int_equal(ret, 0);
-}
-
-void test_MergeAppendFile_filepath_null_chmod_fail(void **state) {
-
-    char * finalpath = "/test/shared/default/merged.mg";
-    char * file = NULL;
-    char * tag = "New TAG";
-    int path_offset = -1;
-    int ret;
-
-    expect_string(__wrap_fopen, path, finalpath);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 2);
-
-    expect_value(__wrap_fprintf, __stream, 2);
-    expect_string(__wrap_fprintf, formatted_msg, "#New TAG\n");
-    will_return(__wrap_fprintf, 0);
-
-    expect_value(__wrap_fclose, _File, 2);
-    will_return(__wrap_fclose, 1);
-
-    expect_string(__wrap_chmod, path, finalpath);
-    will_return(__wrap_chmod, -1);
-
-    expect_string(__wrap__merror, formatted_msg, "(1127): Could not chmod object '/test/shared/default/merged.mg' due to [(0)-(Success)].");
-
-    ret = MergeAppendFile(finalpath, file, tag, path_offset);
-    assert_int_equal(ret, 0);
-}
-
-void test_MergeAppendFile_filepath_null_success(void **state) {
-
-    char * finalpath = "/test/shared/default/merged.mg";
-    char * file = NULL;
-    char * tag = "New TAG";
-    int path_offset = -1;
-    int ret;
-
-    expect_string(__wrap_fopen, path, finalpath);
-    expect_string(__wrap_fopen, mode, "w");
-    will_return(__wrap_fopen, 2);
-
-    expect_value(__wrap_fprintf, __stream, 2);
-    expect_string(__wrap_fprintf, formatted_msg, "#New TAG\n");
-    will_return(__wrap_fprintf, 0);
-
-    expect_value(__wrap_fclose, _File, 2);
-    will_return(__wrap_fclose, 1);
-
-    expect_string(__wrap_chmod, path, finalpath);
-    will_return(__wrap_chmod, 0);
-
-    ret = MergeAppendFile(finalpath, file, tag, path_offset);
-    assert_int_equal(ret, 1);
-}
-
-void test_MergeAppendFile_finalpath_open_fail(void **state) {
-
-    char * finalpath = "/test/shared/default/merged.mg";
-    char * file = "test.txt";
-    char * tag = NULL;
-    int path_offset = -1;
-    int ret;
-
-    expect_string(__wrap_fopen, path, finalpath);
-    expect_string(__wrap_fopen, mode, "a");
-    will_return(__wrap_fopen, NULL);
-
-    expect_string(__wrap__merror, formatted_msg, "Unable to open file: '/test/shared/default/merged.mg' due to [(0)-(Success)].");
-
-    ret = MergeAppendFile(finalpath, file, tag, path_offset);
-    assert_int_equal(ret, 0);
-}
-
 
 void test_MergeAppendFile_open_fail(void **state) {
 
-    char * finalpath = "/test/shared/default/merged.mg";
+    FILE * finalfp = (FILE *)5;
     char * file = "test.txt";
-    char * tag = NULL;
     int path_offset = -1;
     int ret;
-
-    expect_string(__wrap_fopen, path, finalpath);
-    expect_string(__wrap_fopen, mode, "a");
-    will_return(__wrap_fopen, 5);
 
     expect_string(__wrap_fopen, path, file);
     expect_string(__wrap_fopen, mode, "r");
@@ -385,24 +286,16 @@ void test_MergeAppendFile_open_fail(void **state) {
 
     expect_string(__wrap__merror, formatted_msg, "Unable to open file: 'test.txt' due to [(0)-(Success)].");
 
-    expect_value(__wrap_fclose, _File, 5);
-    will_return(__wrap_fclose, 1);
-
-    ret = MergeAppendFile(finalpath, file, tag, path_offset);
+    ret = MergeAppendFile(finalfp, file, path_offset);
     assert_int_equal(ret, 0);
 }
 
 void test_MergeAppendFile_fseek_fail(void **state) {
 
-    char * finalpath = "/test/shared/default/merged.mg";
+    FILE * finalfp = (FILE *)5;
     char * file = "test.txt";
-    char * tag = NULL;
     int path_offset = -1;
     int ret;
-
-    expect_string(__wrap_fopen, path, finalpath);
-    expect_string(__wrap_fopen, mode, "a");
-    will_return(__wrap_fopen, 5);
 
     expect_string(__wrap_fopen, path, file);
     expect_string(__wrap_fopen, mode, "r");
@@ -412,27 +305,19 @@ void test_MergeAppendFile_fseek_fail(void **state) {
 
     expect_string(__wrap__merror, formatted_msg, "Unable to set EOF offset in file: 'test.txt', due to [(0)-(Success)].");
 
-    expect_value(__wrap_fclose, _File, 5);
-    will_return(__wrap_fclose, 1);
-
     expect_value(__wrap_fclose, _File, 6);
     will_return(__wrap_fclose, 1);
 
-    ret = MergeAppendFile(finalpath, file, tag, path_offset);
+    ret = MergeAppendFile(finalfp, file, path_offset);
     assert_int_equal(ret, 0);
 }
 
 void test_MergeAppendFile_fseek2_fail(void **state) {
 
-    char * finalpath = "/test/shared/default/merged.mg";
+    FILE * finalfp = (FILE *)5;
     char * file = "/test/shared/default/test.txt";
-    char * tag = "TAG_test";
     int path_offset = -1;
     int ret;
-
-    expect_string(__wrap_fopen, path, finalpath);
-    expect_string(__wrap_fopen, mode, "a");
-    will_return(__wrap_fopen, 5);
 
     expect_string(__wrap_fopen, path, file);
     expect_string(__wrap_fopen, mode, "r");
@@ -443,11 +328,7 @@ void test_MergeAppendFile_fseek2_fail(void **state) {
     will_return(__wrap_ftell, 0);
     expect_string(__wrap__mwarn, formatted_msg, "File '/test/shared/default/test.txt' is empty.");
 
-    expect_value(__wrap_fprintf, __stream, 5);
-    expect_string(__wrap_fprintf, formatted_msg, "#TAG_test\n");
-    will_return(__wrap_fprintf, 0);
-
-    expect_value(__wrap_fprintf, __stream, 5);
+    expect_value(__wrap_fprintf, __stream, finalfp);
     expect_string(__wrap_fprintf, formatted_msg, "!0 test.txt\n");
     will_return(__wrap_fprintf, 0);
 
@@ -455,27 +336,19 @@ void test_MergeAppendFile_fseek2_fail(void **state) {
 
     expect_string(__wrap__merror, formatted_msg, "Unable to set the offset in file: '/test/shared/default/test.txt', due to [(0)-(Success)].");
 
-    expect_value(__wrap_fclose, _File, 5);
-    will_return(__wrap_fclose, 1);
-
     expect_value(__wrap_fclose, _File, 6);
     will_return(__wrap_fclose, 1);
 
-    ret = MergeAppendFile(finalpath, file, tag, path_offset);
+    ret = MergeAppendFile(finalfp, file, path_offset);
     assert_int_equal(ret, 0);
 }
 
 void test_MergeAppendFile_diff_ftell(void **state) {
 
-    char * finalpath = "/test/shared/default/merged.mg";
+    FILE * finalfp = (FILE *)5;
     char * file = "/test/shared/default/test.txt";
-    char * tag = "TAG_test";
     int path_offset = 0;
     int ret;
-
-    expect_string(__wrap_fopen, path, finalpath);
-    expect_string(__wrap_fopen, mode, "a");
-    will_return(__wrap_fopen, 5);
 
     expect_string(__wrap_fopen, path, file);
     expect_string(__wrap_fopen, mode, "r");
@@ -485,11 +358,7 @@ void test_MergeAppendFile_diff_ftell(void **state) {
 
     will_return(__wrap_ftell, 25);
 
-    expect_value(__wrap_fprintf, __stream, 5);
-    expect_string(__wrap_fprintf, formatted_msg, "#TAG_test\n");
-    will_return(__wrap_fprintf, 0);
-
-    expect_value(__wrap_fprintf, __stream, 5);
+    expect_value(__wrap_fprintf, __stream, finalfp);
     expect_string(__wrap_fprintf, formatted_msg, "!25 /test/shared/default/test.txt\n");
     will_return(__wrap_fprintf, 0);
 
@@ -508,26 +377,18 @@ void test_MergeAppendFile_diff_ftell(void **state) {
     expect_value(__wrap_fclose, _File, 6);
     will_return(__wrap_fclose, 1);
 
-    expect_value(__wrap_fclose, _File, 5);
-    will_return(__wrap_fclose, 1);
-
     expect_string(__wrap__merror, formatted_msg, "File '/test/shared/default/test.txt' was modified after getting its size.");
 
-    ret = MergeAppendFile(finalpath, file, tag, path_offset);
+    ret = MergeAppendFile(finalfp, file, path_offset);
     assert_int_equal(ret, 0);
 }
 
 void test_MergeAppendFile_success(void **state) {
 
-    char * finalpath = "/test/shared/default/merged.mg";
+    FILE * finalfp = (FILE *)5;
     char * file = "/test/shared/default/test.txt";
-    char * tag = "TAG_test";
     int path_offset = 0;
     int ret;
-
-    expect_string(__wrap_fopen, path, finalpath);
-    expect_string(__wrap_fopen, mode, "a");
-    will_return(__wrap_fopen, 5);
 
     expect_string(__wrap_fopen, path, file);
     expect_string(__wrap_fopen, mode, "r");
@@ -537,11 +398,7 @@ void test_MergeAppendFile_success(void **state) {
 
     will_return(__wrap_ftell, 25);
 
-    expect_value(__wrap_fprintf, __stream, 5);
-    expect_string(__wrap_fprintf, formatted_msg, "#TAG_test\n");
-    will_return(__wrap_fprintf, 0);
-
-    expect_value(__wrap_fprintf, __stream, 5);
+    expect_value(__wrap_fprintf, __stream, finalfp);
     expect_string(__wrap_fprintf, formatted_msg, "!25 /test/shared/default/test.txt\n");
     will_return(__wrap_fprintf, 0);
 
@@ -560,10 +417,7 @@ void test_MergeAppendFile_success(void **state) {
     expect_value(__wrap_fclose, _File, 6);
     will_return(__wrap_fclose, 1);
 
-    expect_value(__wrap_fclose, _File, 5);
-    will_return(__wrap_fclose, 1);
-
-    ret = MergeAppendFile(finalpath, file, tag, path_offset);
+    ret = MergeAppendFile(finalfp, file, path_offset);
     assert_int_equal(ret, 1);
 }
 
@@ -585,7 +439,6 @@ void test_w_compress_gzfile_wfopen_fail(void **state){
 
     ret = w_compress_gzfile(srcfile, dstfile);
     assert_int_equal(ret, -1);
-
 }
 
 void test_w_compress_gzfile_gzopen_fail(void **state){
@@ -609,7 +462,6 @@ void test_w_compress_gzfile_gzopen_fail(void **state){
 
     ret = w_compress_gzfile(srcfile, dstfile);
     assert_int_equal(ret, -1);
-
 }
 
 void test_w_compress_gzfile_write_error(void **state){
@@ -646,7 +498,6 @@ void test_w_compress_gzfile_write_error(void **state){
 
     ret = w_compress_gzfile(srcfile, dstfile);
     assert_int_equal(ret, -1);
-
 }
 
 void test_w_compress_gzfile_success(void **state){
@@ -681,7 +532,6 @@ void test_w_compress_gzfile_success(void **state){
 
     ret = w_compress_gzfile(srcfile, dstfile);
     assert_int_equal(ret, 0);
-
 }
 
 // w_uncompress_gzfile
@@ -698,7 +548,6 @@ void test_w_uncompress_gzfile_lstat_fail(void **state) {
 
     ret = w_uncompress_gzfile(srcfile, dstfile);
     assert_int_equal(ret, -1);
-
 }
 
 void test_w_uncompress_gzfile_fopen_fail(void **state) {
@@ -719,7 +568,6 @@ void test_w_uncompress_gzfile_fopen_fail(void **state) {
 
     ret = w_uncompress_gzfile(srcfile, dstfile);
     assert_int_equal(ret, -1);
-
 }
 
 void test_w_uncompress_gzfile_gzopen_fail(void **state) {
@@ -747,7 +595,6 @@ void test_w_uncompress_gzfile_gzopen_fail(void **state) {
 
     ret = w_uncompress_gzfile(srcfile, dstfile);
     assert_int_equal(ret, -1);
-
 }
 
 void test_w_uncompress_gzfile_first_read_fail(void **state) {
@@ -790,7 +637,6 @@ void test_w_uncompress_gzfile_first_read_fail(void **state) {
 
     ret = w_uncompress_gzfile(srcfile, dstfile);
     assert_int_equal(ret, -1);
-
 }
 
 void test_w_uncompress_gzfile_first_read_success(void **state) {
@@ -841,7 +687,6 @@ void test_w_uncompress_gzfile_first_read_success(void **state) {
 
     ret = w_uncompress_gzfile(srcfile, dstfile);
     assert_int_equal(ret, -1);
-
 }
 
 void test_w_uncompress_gzfile_success(void **state) {
@@ -878,7 +723,6 @@ void test_w_uncompress_gzfile_success(void **state) {
 
     ret = w_uncompress_gzfile(srcfile, dstfile);
     assert_int_equal(ret, 0);
-
 }
 
 // w_homedir
@@ -1014,7 +858,6 @@ void test_w_homedir_stat_fail(void **state)
     expect_string(__wrap__merror_exit, formatted_msg, "(1108): Unable to find Wazuh install directory. Export it to WAZUH_HOME environment variable.");
 
     expect_assert_failure(w_homedir(argv0));
-
 }
 #endif
 
@@ -1157,14 +1000,12 @@ void test_expand_win32_wildcards_directories(void **state) {
     snprintf(vectors[0], OS_SIZE_128, "testdir_%d", 0);
     expect_find_first_file(path, vectors[0], FILE_ATTRIBUTE_DIRECTORY, (HANDLE) 1);
 
-
     for (int i = 1; i < N_PATHS; i++) {
         snprintf(vectors[i], OS_SIZE_128, "testdir_%d", i);
         expect_find_next_file((HANDLE) 1, vectors[i], FILE_ATTRIBUTE_DIRECTORY, (BOOL) 1);
     }
 
     expect_find_next_file((HANDLE) 1, NULL, (DWORD) 0, (BOOL) 0);
-
 
     result = expand_win32_wildcards(path);
     *state = result;
@@ -1211,7 +1052,6 @@ void test_expand_win32_wildcards_file_with_next_glob(void **state) {
     // Ending to expand the first wildcard
     expect_find_next_file((HANDLE) 1, NULL, 0, (BOOL) 0);
 
-
     // Beggining to expand the second wildcard
     snprintf(vectors[0], OS_SIZE_128, "test_%d", 0);
     expect_find_first_file("C:\\test_folder\\test?", vectors[0], FILE_ATTRIBUTE_NORMAL, (HANDLE) 1);
@@ -1247,10 +1087,6 @@ int main(void) {
 #ifdef TEST_SERVER
         cmocka_unit_test(test_w_uncompress_bz2_gz_file_bz2),
         // MergeAppendFile
-        cmocka_unit_test(test_MergeAppendFile_filepath_null_fopen_fail),
-        cmocka_unit_test(test_MergeAppendFile_filepath_null_chmod_fail),
-        cmocka_unit_test(test_MergeAppendFile_filepath_null_success),
-        cmocka_unit_test(test_MergeAppendFile_finalpath_open_fail),
         cmocka_unit_test(test_MergeAppendFile_open_fail),
         cmocka_unit_test(test_MergeAppendFile_fseek_fail),
         cmocka_unit_test(test_MergeAppendFile_fseek2_fail),

--- a/src/unit_tests/wrappers/libc/stdio_wrappers.c
+++ b/src/unit_tests/wrappers/libc/stdio_wrappers.c
@@ -216,3 +216,9 @@ int __wrap_fputc(char character, FILE *stream) {
     check_expected(stream);
     return mock();
 }
+
+FILE *__wrap_open_memstream(char **__bufloc, size_t *__sizeloc) {
+    *__bufloc = mock_type(char *);
+    *__sizeloc = mock_type(size_t);
+    return mock_ptr_type(FILE*);
+}

--- a/src/unit_tests/wrappers/libc/stdio_wrappers.h
+++ b/src/unit_tests/wrappers/libc/stdio_wrappers.h
@@ -59,4 +59,6 @@ int __wrap_pclose(FILE *stream);
 
 int __wrap_fputc(char character, FILE *stream);
 
+FILE *__wrap_open_memstream(char **__bufloc, size_t *__sizeloc);
+
 #endif

--- a/src/unit_tests/wrappers/wazuh/os_crypto/md5_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/os_crypto/md5_op_wrappers.c
@@ -23,6 +23,16 @@ int __wrap_OS_MD5_File(const char *fname, os_md5 output, int mode) {
     return mock();
 }
 
+int __wrap_OS_MD5_Str(const char *str, ssize_t length, os_md5 output) {
+    check_expected(str);
+    check_expected(length);
+
+    char *md5 = mock_type(char *);
+    strncpy(output, md5, sizeof(os_md5));
+
+    return mock();
+}
+
 void expect_OS_MD5_File_call(const char *fname, os_md5 output, int mode, int ret) {
     expect_string(__wrap_OS_MD5_File, fname, fname);
     expect_value(__wrap_OS_MD5_File, mode, mode);

--- a/src/unit_tests/wrappers/wazuh/os_crypto/md5_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/os_crypto/md5_op_wrappers.h
@@ -19,6 +19,7 @@ typedef char os_sha1[41];
 typedef char os_sha256[65];
 
 int __wrap_OS_MD5_File(const char *fname, os_md5 output, int mode);
+int __wrap_OS_MD5_Str(const char *str, ssize_t length, os_md5 output);
 void expect_OS_MD5_File_call(const char *fname, os_md5 output, int mode, int ret);
 
 int __wrap_OS_MD5_SHA1_SHA256_File(const char *fname, const char **prefilter_cmd, os_md5 md5output, os_sha1 sha1output,

--- a/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.c
@@ -180,6 +180,11 @@ int __wrap_cldir_ex(__attribute__((unused)) const char *name) {
     return mock();
 }
 
+int __wrap_cldir_ex_ignore(const char *name, __attribute__((unused)) const char ** ignore) {
+    check_expected(name);
+    return mock();
+}
+
 int __wrap_UnmergeFiles(const char *finalpath, const char *optdir, int mode) {
     check_expected(finalpath);
     check_expected(optdir);

--- a/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.c
@@ -210,11 +210,8 @@ int __wrap_w_fseek(FILE *x, int64_t pos, __attribute__((unused)) int mode) {
     return mock_type(int);
 }
 
-int __wrap_MergeAppendFile(const char *finalpath, __attribute__((unused)) const char *files, const char *tag, int path_offset) {
-    check_expected(finalpath);
-    if (tag) {
-        check_expected(tag);
-    }
+int __wrap_MergeAppendFile(FILE *finalfp, __attribute__((unused)) const char *files, int path_offset) {
+    check_expected(finalfp);
     check_expected(path_offset);
     return mock_type(int);
 }

--- a/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.h
@@ -72,6 +72,8 @@ int __wrap_w_ref_parent_folder(const char * path);
 
 int __wrap_cldir_ex(const char *name);
 
+int __wrap_cldir_ex_ignore(const char *name, const char ** ignore);
+
 int __wrap_UnmergeFiles(const char *finalpath, const char *optdir, int mode);
 
 #ifdef WIN32

--- a/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.h
@@ -89,7 +89,7 @@ int64_t __wrap_w_ftell (FILE *x);
 
 int __wrap_w_fseek(FILE *x, int64_t pos, int mode);
 
-int __wrap_MergeAppendFile(const char *finalpath, const char *files, const char *tag, int path_offset);
+int __wrap_MergeAppendFile(FILE *finalfp, const char *files, int path_offset);
 
 int __wrap_OS_MoveFile(const char *src, const char *dst);
 

--- a/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.c
@@ -39,7 +39,7 @@ int teardown_hashmap(__attribute__((unused)) void **state) {
 }
 
 int __real_OSHash_Add(OSHash *self, const char *key, void *data);
-int __wrap_OSHash_Add(OSHash *self, const char *key, void *data) {
+int __wrap_OSHash_Add(__attribute__((unused)) OSHash *self, const char *key, void *data) {
     int retval;
 
     if (key) check_expected(key);
@@ -47,7 +47,7 @@ int __wrap_OSHash_Add(OSHash *self, const char *key, void *data) {
     retval = mock();
 
     if (mock_hashmap != NULL && retval != 0) {
-        __real_OSHash_Add(self, key, data);
+        __real_OSHash_Add(mock_hashmap, key, data);
     }
 
     return retval;
@@ -66,7 +66,7 @@ int __wrap_OSHash_Add_ex(OSHash *self, const char *key, void *data) {
         retval =  mock();
 
         if (mock_hashmap != NULL && retval != 0) {
-            __real_OSHash_Add(self, key, data);
+            __real_OSHash_Add(mock_hashmap, key, data);
         }
 
         return retval;
@@ -83,6 +83,10 @@ void *__wrap_OSHash_Begin(const OSHash *self, __attribute__((unused)) unsigned i
 void *__real_OSHash_Clean(OSHash *self, void (*cleaner)(void*));
 void *__wrap_OSHash_Clean(__attribute__((unused)) OSHash *self,
                           __attribute__((unused)) void (*cleaner)(void*)) {
+    if (test_mode == 0) {
+        return __real_OSHash_Clean(self, cleaner);
+    }
+
     return mock_type(void *);
 }
 


### PR DESCRIPTION
|Related issue|Manual Testing|Integration Tests|Documentation|
|---|---|---|---|
|https://github.com/wazuh/wazuh/issues/14733|https://github.com/wazuh/wazuh-qa/issues/3370|https://github.com/wazuh/wazuh-qa/pull/3565|https://github.com/wazuh/wazuh-documentation/pull/5744|

## Description

This PR proposes many improvements in the multi-groups generation mechanism:

- Instead of using file hashes, the last modify time attribute is used to identify if a file has changed.
- Groups and multi-groups are now stored in a hash table to improve the search time of them.
- Only the MD5 of the `merged.mg` file is stored for each group, reducing memory usage.
- Now, multi-groups files are not deleted when restarting the manager. Instead, they are deleted only when something changed when the manager was down.
- Residual multi-group files are still deleted after a restart.
- Group files are deleted from multi-group folders after generating the shared file.
- Shared file is created in memory instead of disk.
- CPU usage has been largely improved for systems with thousands of groups and multi-groups.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Working on cluster environments
- [x] Added unit tests (for new features)