### PR TITLE
Add `distinct` and `select` parameters to `GET /sca/{agent_id}` and `GET /sca/{agent_id}/checks/{policy_id}` endpoints

### DIFF
--- a/api/api/controllers/sca_controller.py
+++ b/api/api/controllers/sca_controller.py
@@ -16,43 +16,48 @@ from wazuh.core.common import DATABASE_LIMIT
 logger = logging.getLogger('wazuh-api')
 
 
-async def get_sca_agent(request, agent_id=None, pretty=False, wait_for_complete=False, name=None, description=None,
-                        references=None, offset=0, limit=DATABASE_LIMIT, sort=None, search=None, select=None, q=None,
-                        distinct=False):
+async def get_sca_agent(request, agent_id: str = None, pretty: bool = False, wait_for_complete: bool = False,
+                        name: str = None, description: str = None, references: str = None, offset: int = 0,
+                        limit: int = DATABASE_LIMIT, sort: str = None, search: str = None, select: str = None,
+                        q: str = None, distinct: bool = False) -> web.Response:
     """Get security configuration assessment (SCA) database of an agent.
 
     Parameters
     ----------
+    request : connexion.request
     agent_id : str
         Agent ID. All possible values since 000 onwards.
     pretty : bool
-        Show results in human-readable format
+        Show results in human-readable format.
     wait_for_complete : bool
-        Disable timeout response
+        Disable timeout response.
     name : str
-        Filters by policy name
+        Filters by policy name.
     description : str
-        Filters by policy description
+        Filters by policy description.
     references : str
-        Filters by references
+        Filters by references.
     offset : int
-        First element to return in the collection
+        First element to return in the collection.
     limit : int
-        Maximum number of elements to return
+        Maximum number of elements to return.
     sort : str
-        Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order
+        Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending
+        or descending order.
     search : str
         Looks for elements with the specified string.
     select : str
         Select which fields to return (separated by comma).
     q : str
-        Query to filter results by. This is specially useful to filter by total checks passed, failed or total score (fields pass, fail, score)
+        Query to filter results by. This is specially useful to filter by total checks passed, failed or total score
+        (fields pass, fail, score).
     distinct : bool
         Look for distinct values.
 
     Returns
     -------
-    AllItemsResponseSCADatabase
+    web.Response
+        API response.
     """
     filters = {'name': name,
                'description': description,
@@ -80,69 +85,75 @@ async def get_sca_agent(request, agent_id=None, pretty=False, wait_for_complete=
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-async def get_sca_checks(request, agent_id=None, pretty=False, wait_for_complete=False, policy_id=None, title=None,
-                         description=None, rationale=None, remediation=None, command=None, status=None, reason=None,
-                         file=None, process=None, directory=None, registry=None, references=None, result=None,
-                         condition=None, offset=0, limit=DATABASE_LIMIT, sort=None, search=None, select=None, q=None,
-                         distinct=False):
-    """Get policy monitoring alerts for a given policy
+async def get_sca_checks(request, agent_id: str = None, pretty: bool = False, wait_for_complete: bool = False,
+                         policy_id: str = None, title: str = None, description: str = None, rationale: str = None,
+                         remediation: str = None, command: str = None, status: str = None, reason: str = None,
+                         file: str = None, process: str = None, directory: str = None, registry: str = None,
+                         references: str = None, result: str = None, condition: str = None, offset: int = 0,
+                         limit: int = DATABASE_LIMIT, sort: str = None, search: str = None, select: str = None,
+                         q: str = None, distinct: bool = False) -> web.Response:
+    """Get policy monitoring alerts for a given policy.
 
     Parameters
     ----------
+    request : connexion.request
     agent_id : str
-        Agent ID. All possible values since 000 onwards
+        Agent ID. All possible values since 000 onwards.
     pretty : bool
-        Show results in human-readable format
+        Show results in human-readable format.
     wait_for_complete : bool
-        Disable timeout response
+        Disable timeout response.
     policy_id : str
-        Filters by policy id
+        Filters by policy id.
     title : str
-        Filters by title
+        Filters by title.
     description : str
-        Filters by policy description
+        Filters by policy description.
     rationale : str
-        Filters by rationale
+        Filters by rationale.
     remediation : str
-        Filters by remediation
+        Filters by remediation.
     command : str
-        Filters by command
+        Filters by command.
     status : str
-        Filters by status
+        Filters by status.
     reason : str
-        Filters by reason
+        Filters by reason.
     file : str
-        Filters by file
+        Filters by file.
     process : str
-        Filters by process
+        Filters by process.
     directory : str
-        Filters by directory
+        Filters by directory.
     registry : str
-        Filters by registry
+        Filters by registry.
     references : str
-        Filters by references
+        Filters by references.
     result : str
-        Filters by result
+        Filters by result.
     condition : str
-        Filters by condition
+        Filters by condition.
     offset : int
-        First element to return in the collection
+        First element to return in the collection.
     limit : int
-        Maximum number of elements to return
+        Maximum number of elements to return.
     sort : str
-        Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order
+        Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending
+        or descending order.
     search : str
         Looks for elements with the specified string.
     select : str
         Select which fields to return (separated by comma).
     q : str
-        Query to filter results by. This is specially useful to filter by total checks passed, failed or total score (fields pass, fail, score)
+        Query to filter results by. This is specially useful to filter by total checks passed, failed or total score
+        (fields pass, fail, score).
     distinct : bool
         Look for distinct values.
 
     Returns
     -------
-    AllItemsResponseSCADatabase
+    web.Response
+        API response.
     """
     filters = {'title': title,
                'description': description,

--- a/api/api/controllers/sca_controller.py
+++ b/api/api/controllers/sca_controller.py
@@ -79,7 +79,8 @@ async def get_sca_agent(request, agent_id=None, pretty=False, wait_for_complete=
 async def get_sca_checks(request, agent_id=None, pretty=False, wait_for_complete=False, policy_id=None, title=None,
                          description=None, rationale=None, remediation=None, command=None, status=None, reason=None,
                          file=None, process=None, directory=None, registry=None, references=None, result=None,
-                         condition=None, offset=0, limit=DATABASE_LIMIT, sort=None, search=None, select=None, q=None):
+                         condition=None, offset=0, limit=DATABASE_LIMIT, sort=None, search=None, select=None, q=None,
+                         distinct=False):
     """Get policy monitoring alerts for a given policy
 
     Parameters
@@ -132,6 +133,8 @@ async def get_sca_checks(request, agent_id=None, pretty=False, wait_for_complete
         Select which fields to return (separated by comma).
     q : str
         Query to filter results by. This is specially useful to filter by total checks passed, failed or total score (fields pass, fail, score)
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -160,6 +163,7 @@ async def get_sca_checks(request, agent_id=None, pretty=False, wait_for_complete
                 'search': parse_api_param(search, 'search'),
                 'select': select,
                 'q': q,
+                'distinct': distinct,
                 'filters': filters}
 
     dapi = DistributedAPI(f=sca.get_sca_checks,

--- a/api/api/controllers/sca_controller.py
+++ b/api/api/controllers/sca_controller.py
@@ -17,7 +17,8 @@ logger = logging.getLogger('wazuh-api')
 
 
 async def get_sca_agent(request, agent_id=None, pretty=False, wait_for_complete=False, name=None, description=None,
-                        references=None, offset=0, limit=DATABASE_LIMIT, sort=None, search=None, select=None, q=None):
+                        references=None, offset=0, limit=DATABASE_LIMIT, sort=None, search=None, select=None, q=None,
+                        distinct=False):
     """Get security configuration assessment (SCA) database of an agent.
 
     Parameters
@@ -46,6 +47,8 @@ async def get_sca_agent(request, agent_id=None, pretty=False, wait_for_complete=
         Select which fields to return (separated by comma).
     q : str
         Query to filter results by. This is specially useful to filter by total checks passed, failed or total score (fields pass, fail, score)
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -62,6 +65,7 @@ async def get_sca_agent(request, agent_id=None, pretty=False, wait_for_complete=
                 'search': parse_api_param(search, 'search'),
                 'select': select,
                 'q': q,
+                'distinct': distinct,
                 'filters': filters}
     dapi = DistributedAPI(f=sca.get_sca_list,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/controllers/sca_controller.py
+++ b/api/api/controllers/sca_controller.py
@@ -17,8 +17,8 @@ logger = logging.getLogger('wazuh-api')
 
 
 async def get_sca_agent(request, agent_id=None, pretty=False, wait_for_complete=False, name=None, description=None,
-                        references=None, offset=0, limit=DATABASE_LIMIT, sort=None, search=None, q=None):
-    """Get security configuration assessment (SCA) database of an agent
+                        references=None, offset=0, limit=DATABASE_LIMIT, sort=None, search=None, select=None, q=None):
+    """Get security configuration assessment (SCA) database of an agent.
 
     Parameters
     ----------
@@ -41,7 +41,9 @@ async def get_sca_agent(request, agent_id=None, pretty=False, wait_for_complete=
     sort : str
         Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order
     search : str
-        Looks for elements with the specified string
+        Looks for elements with the specified string.
+    select : str
+        Select which fields to return (separated by comma).
     q : str
         Query to filter results by. This is specially useful to filter by total checks passed, failed or total score (fields pass, fail, score)
 
@@ -58,6 +60,7 @@ async def get_sca_agent(request, agent_id=None, pretty=False, wait_for_complete=
                 'limit': limit,
                 'sort': parse_api_param(sort, 'sort'),
                 'search': parse_api_param(search, 'search'),
+                'select': select,
                 'q': q,
                 'filters': filters}
     dapi = DistributedAPI(f=sca.get_sca_list,

--- a/api/api/controllers/sca_controller.py
+++ b/api/api/controllers/sca_controller.py
@@ -79,7 +79,7 @@ async def get_sca_agent(request, agent_id=None, pretty=False, wait_for_complete=
 async def get_sca_checks(request, agent_id=None, pretty=False, wait_for_complete=False, policy_id=None, title=None,
                          description=None, rationale=None, remediation=None, command=None, status=None, reason=None,
                          file=None, process=None, directory=None, registry=None, references=None, result=None,
-                         condition=None, offset=0, limit=DATABASE_LIMIT, sort=None, search=None, q=None):
+                         condition=None, offset=0, limit=DATABASE_LIMIT, sort=None, search=None, select=None, q=None):
     """Get policy monitoring alerts for a given policy
 
     Parameters
@@ -127,7 +127,9 @@ async def get_sca_checks(request, agent_id=None, pretty=False, wait_for_complete
     sort : str
         Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order
     search : str
-        Looks for elements with the specified string
+        Looks for elements with the specified string.
+    select : str
+        Select which fields to return (separated by comma).
     q : str
         Query to filter results by. This is specially useful to filter by total checks passed, failed or total score (fields pass, fail, score)
 
@@ -156,6 +158,7 @@ async def get_sca_checks(request, agent_id=None, pretty=False, wait_for_complete
                 'limit': limit,
                 'sort': parse_api_param(sort, 'sort'),
                 'search': parse_api_param(search, 'search'),
+                'select': select,
                 'q': q,
                 'filters': filters}
 

--- a/api/api/controllers/test/test_sca_controller.py
+++ b/api/api/controllers/test/test_sca_controller.py
@@ -35,7 +35,9 @@ async def test_get_sca_agent(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_
                 'limit': DATABASE_LIMIT,
                 'sort': None,
                 'search': None,
+                'select': None,
                 'q': None,
+                'distinct': False,
                 'filters': filters
                 }
     mock_dapi.assert_called_once_with(f=sca.get_sca_list,
@@ -80,7 +82,9 @@ async def test_get_sca_checks(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock
                 'limit': DATABASE_LIMIT,
                 'sort': None,
                 'search': None,
+                'select': None,
                 'q': None,
+                'distinct': False,
                 'filters': filters
                 }
     mock_dapi.assert_called_once_with(f=sca.get_sca_checks,

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -12342,6 +12342,7 @@ paths:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/select'
         - $ref: '#/components/parameters/query'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "List of SCA Checks for a given policy ID"

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -12262,6 +12262,7 @@ paths:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/select'
         - $ref: '#/components/parameters/query'
       responses:
         '200':

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -12340,6 +12340,7 @@ paths:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/select'
         - $ref: '#/components/parameters/query'
       responses:
         '200':

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -12264,6 +12264,7 @@ paths:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/select'
         - $ref: '#/components/parameters/query'
+        - $ref: '#/components/parameters/distinct'
       responses:
         '200':
           description: "SCA database elements"

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -45,7 +45,7 @@ def test_token_raw_format(response):
     assert type(response.text) is str
 
 
-def test_select_key_affected_items(response, select_key):
+def test_select_key_affected_items(response, select_key, flag_nested_key_list=False):
     """Check that all items in response have no other keys than those specified in 'select_key'.
 
     Absence of 'select_key' in response does not raise any error. However, extra keys in response (not specified
@@ -54,9 +54,14 @@ def test_select_key_affected_items(response, select_key):
     Some keys like 'id', 'agent_id', etc. are accepted even if not specified in 'select_key' since
     they ignore the 'select' param in API.
 
-    :param response: Request response
-    :param select_key: Keys requested in select parameter.
-        Lists and nested fields accepted e.g: id,cpu.mhz,json
+    Parameters
+    ----------
+    response : Request response
+    select_key : str
+        Keys requested in select parameter. Lists and nested fields accepted e.g: id,cpu.mhz,json
+    flag_nested_key_list : bool
+        Flag used to indicate that the nested key contains a list. Used to test endpoints like
+        GET /sca/{agent_id}/checks/{policy_id}.
     """
     main_keys = set()
     nested_keys = dict()
@@ -79,15 +84,50 @@ def test_select_key_affected_items(response, select_key):
 
         # Check if there are keys in response that were not specified in 'select_keys', apart from those which can be
         # mandatory (id, agent_id, etc).
-        assert (set1 == set() or set1 == set1.intersection({'id', 'agent_id', 'file', 'task_id'} | main_keys)), \
-            f'Select keys are {main_keys}, but the response contains these keys: {set1}'
+        assert (set1 == set() or set1 == set1.intersection(
+            {'id', 'agent_id', 'file', 'task_id',
+             'policy_id'} | main_keys)), f'Select keys are {main_keys}, but the response contains these keys: {set1}'
 
         for nested_key in nested_keys.items():
+            # nested_key = compliance, value
             try:
-                set2 = nested_key[1].symmetric_difference(set(item[nested_key[0]].keys()))
+                if not flag_nested_key_list:
+                    set2 = nested_key[1].symmetric_difference(set(item[nested_key[0]].keys()))
+
+                # If we are using select in endpoints like GET /sca/{agent_id}/checks/{policy_id},
+                # the nested field contains a list
+                else:
+                    set2 = nested_key[1].symmetric_difference(set(item[nested_key[0]][0].keys()))
+
                 assert set2 == set(), f'Nested select keys are {nested_key[1]}, but this one is different {set2}'
             except KeyError:
                 assert nested_key[0] in main_keys
+
+
+def test_select_distinct_nested_sca_checks(response, select_key):
+    """Check that all items in response have no other keys than those specified in 'select_key'.
+
+    This function is specifically used for the SCA checks endpoint, when distinct=True and select contains a nested
+    field.
+
+    This function does not take into account min select fields.
+
+    Absence of 'select_key' in response does not raise any error. However, extra keys in response (not specified
+    in 'select_key') will raise assertion error.
+
+    Parameters
+    ----------
+    response : Request response
+    select_key : str
+        Keys requested in select parameter. Lists and nested fields accepted e.g: id,cpu.mhz,json
+    """
+    main_keys = set(select_key.split(','))
+
+    for item in response.json()['data']['affected_items']:
+        # Check that there are no keys in the item that are not specified in 'select_keys'
+        set1 = main_keys.symmetric_difference(set(item.keys()))
+        assert set1 == set() or set1 == set1.intersection(main_keys),\
+            f'Select keys are {main_keys}, but an item contains the keys: {set(item.keys())}'
 
 
 def test_select_key_affected_items_with_agent_id(response, select_key):

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -415,7 +415,88 @@ stages:
         error: 2007
 
 ---
-test_name: GET /sca/001/checks/{policy}
+test_name: GET /sca/{agent_id} using select (parametrized)
+
+marks:
+  - parametrize:
+      key: field
+      vals:
+        - policy_id
+        - name
+        - description
+        - references
+        - pass
+        - fail
+        - score
+        - invalid
+        - total_checks
+        - hash_file
+        - end_scan
+        - start_scan
+
+stages:
+
+  - name: Get agent SCA data using select
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        select: "{field}"
+    response:
+      status_code: 200
+      verify_response_with:
+        # Check response item keys are the selected keys
+        - function: tavern_utils:test_select_key_affected_items
+          extra_kwargs:
+            select_key: "{field:s}"
+
+---
+test_name: GET /sca/{agent_id} using select (parametrized) and distinct
+
+marks:
+  - parametrize:
+      key: field
+      vals:
+        - policy_id
+        - name
+        - description
+        - references
+        - pass
+        - fail
+        - score
+        - invalid
+        - total_checks
+        - hash_file
+        - end_scan
+        - start_scan
+
+stages:
+
+  - name: Get agent SCA data using select and distinct
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        select: "{field}"
+        distinct: True
+    response:
+      status_code: 200
+      verify_response_with:
+        # Check response item keys are the selected keys
+        - function: tavern_utils:test_select_key_affected_items
+          extra_kwargs:
+            select_key: "{field:s}"
+        # Check distinct is applied properly
+        - function: tavern_utils:test_distinct_key
+
+---
+test_name: GET /sca/{agent_id}/checks/{policy_id}
 
 stages:
   - name: Get policy ID
@@ -921,3 +1002,106 @@ stages:
           total_affected_items: !anyint
           failed_items: [ ]
           total_failed_items: 0
+
+  # select tests
+
+  - name: Get SCA checks filtering by rationale
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        rationale: "{expected_rationale_command:s}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *sca_check_result_001_command
+          total_affected_items: !anyint
+          failed_items: [ ]
+          total_failed_items: 0
+
+---
+test_name: GET /sca/{agent_id}/checks/{policy_id} using select and select + distinct (parametrized)
+
+marks:
+  - parametrize:
+      key: field
+      vals:
+        - policy_id
+        - remediation
+        - condition
+        - rules.rule
+        - rationale
+        - id
+        - command
+        - title
+        - reason
+        - description
+        - registry
+        - process
+        - rules.type
+        - file
+        - status
+        - compliance.value
+        - directory
+        - result
+        - compliance.key
+        - references
+
+stages:
+
+  - name: Get policy ID
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      save:
+        json:
+          sca_policy_id: data.affected_items[0].policy_id
+
+  - name: Get agent SCA data using select
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        select: "{field}"
+    response:
+      status_code: 200
+      verify_response_with:
+        # Check response item keys are the selected keys
+        - function: tavern_utils:test_select_key_affected_items
+          extra_kwargs:
+            select_key: "{field:s}"
+            flag_nested_key_list: True
+
+  - name: Get agent SCA data using select and distinct
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        select: "{field}"
+        distinct: True
+    response:
+      status_code: 200
+      verify_response_with:
+        # Check response item keys are the selected keys
+        - function: tavern_utils:test_select_distinct_nested_sca_checks
+          extra_kwargs:
+            select_key: "{field:s}"
+        # Check distinct is applied properly
+        - function: tavern_utils:test_distinct_key

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -643,16 +643,6 @@ stages:
         - function: tavern_utils:test_count_elements
           extra_kwargs:
             n_expected_items: 2
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *sca_check_result_001
-            - <<: *sca_check_result_001
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Get SCA checks using sort=-title
     request:

--- a/framework/wazuh/core/sca.py
+++ b/framework/wazuh/core/sca.py
@@ -128,8 +128,8 @@ class WazuhDBQuerySCACheck(WazuhDBQuerySCA):
         min_select_fields = {'id'}
         select = min_select_fields if select == [] else select
 
-        WazuhDBQuerySCA.__init__(self, agent_id=agent_id, offset=0, limit=None, sort=sort, filters={},
-                                 search=None, count=False, get_data=True, min_select_fields=min_select_fields,
+        WazuhDBQuerySCA.__init__(self, agent_id=agent_id, offset=0, limit=None, sort=sort, filters={}, search=None,
+                                 count=False, get_data=True, min_select_fields=min_select_fields,
                                  select=select or list(SCA_CHECK_DB_FIELDS.keys()), default_query=default_query,
                                  fields=SCA_CHECK_DB_FIELDS, default_sort_field='id', default_sort_order='ASC',
                                  query='')
@@ -254,9 +254,9 @@ class WazuhDBQueryDistinctSCACheck(WazuhDBQuerySCA):
         policy_id : str
             Filter by SCA policy ID.
         sort : dict
-            Sorts the items. Format: {"fields":["field1","field2"],"order":"asc|desc"}.
+            Sorts the items. Format: {"fields":["field1","field2"],"order":"asc|desc"}
         select : list
-            Select fields to return. Format: ["field1","field2"].
+            Select fields to return. Format: ["field1","field2"]
         """
         policy_query_filter = f"policy_id={policy_id}"
         default_sort_field, default_sort_order = 'id', 'ASC'
@@ -274,9 +274,8 @@ class WazuhDBQueryDistinctSCACheck(WazuhDBQuerySCA):
             inner_query.query = inner_query.backend._substitute_params(inner_query.query, inner_query.request)
 
         # The main object is built using the inner query and `select`, `limit`, `offset`, and `sort` parameters
-        WazuhDBQuerySCA.__init__(self, agent_id=agent_id, offset=offset, limit=limit, sort=sort, filters={},
-                                 search={}, count=True, get_data=True, select=select or list(fields.keys()),
-                                 default_query=f"{self.DEFAULT_QUERY} ({inner_query.query})",
-                                 fields=fields, default_sort_field=default_sort_field,
-                                 default_sort_order=default_sort_order, min_select_fields=set(),
-                                 query='')
+        WazuhDBQuerySCA.__init__(self, agent_id=agent_id, offset=offset, limit=limit, sort=sort, filters={}, search={},
+                                 count=True, get_data=True, select=select or list(fields.keys()),
+                                 default_query=f"{self.DEFAULT_QUERY} ({inner_query.query})", fields=fields,
+                                 default_sort_field=default_sort_field, default_sort_order=default_sort_order,
+                                 min_select_fields=set(), query='')

--- a/framework/wazuh/core/tests/test_sca.py
+++ b/framework/wazuh/core/tests/test_sca.py
@@ -4,23 +4,28 @@
 
 from datetime import datetime, timezone
 from types import MappingProxyType
-from unittest.mock import patch, ANY
+from unittest.mock import call, patch, ANY
 
 import pytest
 
 with patch('wazuh.core.common.wazuh_uid'):
     with patch('wazuh.core.common.wazuh_gid'):
         from wazuh.core import sca as core_sca
+        from wazuh.core.exception import WazuhError
 
 
 @pytest.mark.parametrize('agent_id, offset, limit, sort, search, select, query, count, get_data', [
     ('001', 0, 10, {'order': 'asc'}, {'value': 'test', 'negation': True}, {'id'}, None, False, True),
+    ('001', 0, 10, {'order': 'asc'}, {'value': 'test', 'negation': True}, {'id'}, None, False, True),
+])
+@pytest.mark.parametrize('distinct', [
+    True, False
 ])
 @patch('wazuh.core.agent.Agent.get_basic_information')
 @patch('wazuh.core.utils.WazuhDBBackend.__init__', return_value=None)
 @patch('wazuh.core.utils.WazuhDBQuery.__init__')
-def test_WazuhDBQuerySCA__init__(mock_wdbq, mock_backend, mock_get_basic_info, agent_id, offset, limit, sort, search,
-                                 select, query, count, get_data):
+def test_WazuhDBQuerySCA__init__(mock_wdbq, mock_backend, mock_get_basic_info, distinct, agent_id, offset, limit, sort,
+                                 search, query, count, get_data, select):
     """Test if method __init__ of WazuhDBQuerySCA works properly.
 
     Parameters
@@ -43,50 +48,24 @@ def test_WazuhDBQuerySCA__init__(mock_wdbq, mock_backend, mock_get_basic_info, a
         Whether to compute the total of items or not.
     get_data: bool
         Whether to return data or not.
+    distinct: bool
+        Look for distinct values.
     """
-    core_sca.WazuhDBQuerySCA(agent_id=agent_id, offset=offset, limit=limit, sort=sort, search=search, select=select,
-                             query=query, count=count, get_data=get_data)
+    wdbq_sca = core_sca.WazuhDBQuerySCA(agent_id=agent_id, offset=offset, limit=limit, sort=sort, search=search,
+                                        select=select, query=query, count=count, get_data=get_data, distinct=distinct)
+    wdbq_sca.agent_id = agent_id
+    wdbq_sca.default_query = 'SELECT {0} FROM sca_policy sca INNER JOIN sca_scan_info si ON sca.id=si.policy_id' \
+        if not distinct else 'SELECT DISTINCT {0} FROM sca_policy sca INNER JOIN sca_scan_info si ' \
+                             'ON sca.id=si.policy_id'
+
     mock_get_basic_info.assert_called_once()
     mock_wdbq.assert_called_once_with(ANY, offset=offset, limit=limit, table='sca_policy', sort=sort, search=search,
                                       select=select, fields=core_sca.WazuhDBQuerySCA.DB_FIELDS,
                                       default_sort_field='policy_id', default_sort_order='DESC', filters={},
                                       query=query, count=count, get_data=get_data,
-                                      date_fields={'end_scan', 'start_scan'}, backend=ANY)
+                                      date_fields={'end_scan', 'start_scan'}, min_select_fields={'policy_id'},
+                                      backend=ANY)
     mock_backend.assert_called_once_with(agent_id)
-
-
-@pytest.mark.parametrize('agent_id, offset, limit, sort, search, select, query, count, get_data', [
-    ('001', 0, 10, {'order': 'asc'}, {'value': 'test', 'negation': True}, {'id'}, None, False, True),
-])
-def test_WazuhDBQuerySCA__default_count_query(agent_id, offset, limit, sort, search, select, query, count, get_data):
-    """Check if WazuhDBQueryTask's method _default_count_query works properly.
-
-    Parameters
-    ----------
-    agent_id: str
-        Agent ID to fetch information about.
-    offset: int
-        First item to return.
-    limit: int
-        Maximum number of items to return.
-    sort: dict
-        Criteria used to sort the resulting items.
-    search: dict
-        Values used to filter the query.
-    select: list
-        Fields to return.
-    query: str
-        Query to filter in database.
-    count: bool
-        Whether to compute the total of items or not.
-    get_data: bool
-        Whether to return data or not.
-    """
-    with patch('wazuh.core.utils.WazuhDBBackend.__init__', return_value=None), \
-            patch('wazuh.core.agent.Agent.get_basic_information'):
-        wdbq_sca = core_sca.WazuhDBQuerySCA(agent_id=agent_id, offset=offset, limit=limit, sort=sort, search=search,
-                                            select=select, query=query, count=count, get_data=get_data)
-        assert wdbq_sca._default_count_query() == f"SELECT COUNT(DISTINCT policy_id)" + " FROM ({0})"
 
 
 @pytest.mark.parametrize('agent_id, offset, limit, sort, search, select, query, count, get_data', [
@@ -95,7 +74,7 @@ def test_WazuhDBQuerySCA__default_count_query(agent_id, offset, limit, sort, sea
 ])
 def test_WazuhDBQuerySCA__format_data_into_dictionary(agent_id, offset, limit, sort, search, select, query, count,
                                                       get_data):
-    """Check if WazuhDBQueryTask's method _format_data_into_dictionary works properly.
+    """Check if WazuhDBQuerySCA's method _format_data_into_dictionary works properly.
 
     Parameters
     ----------
@@ -143,25 +122,49 @@ def test_WazuhDBQuerySCA__format_data_into_dictionary(agent_id, offset, limit, s
     ([1, 2, 3, 4], "SELECT {0} FROM sca_check WHERE id IN (1, 2, 3, 4)"),
     ([], "SELECT {0} FROM sca_check")
 ])
+@pytest.mark.parametrize('select', [
+    ['test'], [], None
+])
 @patch('wazuh.core.sca.WazuhDBQuerySCA.__init__')
-def test_WazuhDBQuerySCACheck__init__(mock_wdbqsca, sca_checks_test_list, expected_default_query):
+def test_WazuhDBQuerySCACheck__init__(mock_wdbqsca, select, sca_checks_test_list, expected_default_query):
     """Test if method __init__ of WazuhDBQuerySCACheck works properly.
 
     Parameters
     ----------
+    select : list or None
+        Fields to return.
     sca_checks_test_list : list
         List of SCA checks IDs.
     expected_default_query : str
         Expected default query.
     """
-    core_sca.WazuhDBQuerySCACheck(agent_id='000', sort='test', sca_checks_ids=sca_checks_test_list)
+    core_sca.WazuhDBQuerySCACheck(agent_id='000', select=select, sort={'fields': ['title'], 'order': 'asc'},
+                                  sca_checks_ids=sca_checks_test_list)
+    select = {'id'} if select == [] else select
 
-    mock_wdbqsca.assert_called_once_with(ANY, agent_id='000', offset=0, limit=None, sort='test', filters={},
-                                         search=None, count=False, get_data=True,
-                                         select=list(core_sca.SCA_CHECK_DB_FIELDS.keys()),
-                                         default_query=expected_default_query,
-                                         fields=core_sca.SCA_CHECK_DB_FIELDS, count_field='id',
+    mock_wdbqsca.assert_called_once_with(ANY, agent_id='000', offset=0, limit=None,
+                                         sort={'fields': ['title'], 'order': 'asc'}, filters={}, search=None,
+                                         count=False,
+                                         get_data=True, min_select_fields={'id'},
+                                         select=select or list(core_sca.SCA_CHECK_DB_FIELDS.keys()),
+                                         default_query=expected_default_query, fields=core_sca.SCA_CHECK_DB_FIELDS,
                                          default_sort_field='id', default_sort_order='ASC', query='')
+
+
+@patch('wazuh.core.utils.WazuhDBBackend.__init__', return_value=None)
+@patch('wazuh.core.agent.Agent.get_basic_information')
+@patch('os.path.exists', return_value=True)
+def test_WazuhDBQuerySCACheck_parse_select_filter(mock_exists, mock_get_basic_info, mock_backend):
+    """Test if method _parse_select_filter of WazuhDBQuerySCACheck works properly."""
+    wdbq_sca_check = core_sca.WazuhDBQuerySCACheck(agent_id='000', sort={'value': 'test'},
+                                                   select=['test'], sca_checks_ids=[])
+    try:
+        wdbq_sca_check._parse_select_filter(['test'])
+    except WazuhError as e:
+        assert e.code == 1724
+        assert ", ".join(
+            set(wdbq_sca_check.fields.keys()).union(core_sca.SCA_CHECK_COMPLIANCE_DB_FIELDS.keys()).union(
+                core_sca.SCA_CHECK_RULES_DB_FIELDS.keys()) - {'id_check'}) in e.message
 
 
 @pytest.mark.parametrize('query', [
@@ -180,16 +183,16 @@ def test_WazuhDBQuerySCACheckIDs__init__(mock_wdbqsca, query):
                       core_sca.SCA_CHECK_RULES_DB_FIELDS
     expected_fields.pop('id_check')
 
-    core_sca.WazuhDBQuerySCACheckIDs(agent_id='000', offset=10, limit=20, filters={'test': 'value'}, search='test',
-                                     query=query, policy_id='test_policy_id')
+    core_sca.WazuhDBQuerySCACheckIDs(agent_id='000', offset=10, limit=20, filters={'test': 'value'},
+                                     search={'value': 'test'},
+                                     query=query, policy_id='test_policy_id', sort={})
 
-    mock_wdbqsca.assert_called_once_with(ANY, agent_id='000', offset=10, limit=20, sort=None, filters={'test': 'value'},
-                                         search='test', count=True, get_data=True, select=[],
+    mock_wdbqsca.assert_called_once_with(ANY, agent_id='000', offset=10, limit=20, sort={}, filters={'test': 'value'},
+                                         search={'value': 'test'}, count=True, get_data=True, select=[],
                                          default_query="SELECT DISTINCT(id) FROM sca_check a "
                                                        "LEFT JOIN sca_check_compliance b ON a.id=b.id_check "
                                                        "LEFT JOIN sca_check_rules c ON a.id=c.id_check",
-                                         fields=expected_fields, count_field='id', default_sort_field='id',
-                                         default_sort_order='ASC',
+                                         fields=expected_fields, default_sort_field='id', default_sort_order='ASC',
                                          query=f"policy_id=test_policy_id;{query}" if query
                                          else "policy_id=test_policy_id")
 
@@ -200,19 +203,25 @@ def test_WazuhDBQuerySCACheckIDs__init__(mock_wdbqsca, query):
 @pytest.mark.parametrize('table', [
     'sca_check_compliance', 'sca_check_rules'
 ])
+@pytest.mark.parametrize('select', [
+    None, ['test']
+])
 @patch('wazuh.core.sca.WazuhDBQuerySCA.__init__')
-def test_WazuhDBQuerySCACheckRelational__init__(mock_wdbqsca, table, sca_checks_test_list):
+def test_WazuhDBQuerySCACheckRelational__init__(mock_wdbqsca, select, table, sca_checks_test_list):
     """Test if method __init__ of WazuhDBQuerySCACheckRelational works properly.
 
     Parameters
     ----------
+    select : list or None
+        Fields to select.
     table : str
         Table used to initialize the WazuhDBQuerySCACheckRelational object.
     sca_checks_test_list : list
         List of SCA checks IDs.
     """
     query_sca_check_relational = core_sca.WazuhDBQuerySCACheckRelational(agent_id='000', table=table,
-                                                                         id_check_list=sca_checks_test_list)
+                                                                         id_check_list=sca_checks_test_list,
+                                                                         select=select)
     expected_fields = MappingProxyType({'sca_check_rules': core_sca.SCA_CHECK_RULES_DB_FIELDS,
                                         'sca_check_compliance': core_sca.SCA_CHECK_COMPLIANCE_DB_FIELDS})
     expected_default_query = "SELECT {0} FROM " + table
@@ -222,6 +231,36 @@ def test_WazuhDBQuerySCACheckRelational__init__(mock_wdbqsca, table, sca_checks_
     assert query_sca_check_relational.sca_check_table == table
     mock_wdbqsca.assert_called_once_with(ANY, agent_id='000', default_query=expected_default_query,
                                          fields=expected_fields[table], offset=0, limit=None, sort=None,
-                                         select=list(expected_fields[table].keys()), count=False, get_data=True,
-                                         default_sort_field='id_check', default_sort_order='ASC', query=None,
-                                         search=None)
+                                         select=select or list(expected_fields[table].keys()), count=False,
+                                         get_data=True, default_sort_field='id_check', default_sort_order='ASC',
+                                         query=None, search=None, min_select_fields=set())
+
+
+@pytest.mark.parametrize('select', [
+    ['test'], None
+])
+@patch('wazuh.core.sca.WazuhDBQuerySCA.__enter__')
+@patch('wazuh.core.sca.WazuhDBQuerySCA.__init__', return_value=None)
+@patch('wazuh.core.sca.WazuhDBQuery.__exit__')
+def test_WazuhDBQueryDistinctSCACheck__init__(mock_exit, mock_wdbqsca, mock_enter, select):
+    """Test if method __init__ of WazuhDBQueryDistinctSCACheck works properly."""
+    mock_enter.return_value.query = "SELECT * FROM sca_check a LEFT JOIN sca_check_compliance b ON a.id=b.id_check LEFT JOIN " \
+                                    "sca_check_rules c ON a.id=c.id_check"
+    fields = core_sca.SCA_CHECK_DB_FIELDS | core_sca.SCA_CHECK_COMPLIANCE_DB_FIELDS | core_sca.SCA_CHECK_RULES_DB_FIELDS
+    fields.pop('id_check')
+
+    core_sca.WazuhDBQueryDistinctSCACheck(agent_id='000', offset=10, limit=20, filters={'test': 'value'},
+                                          search={'value': 'test'}, query='test~a', policy_id='test_policy_id',
+                                          sort={'fields': ['title'], 'order': 'asc'}, select=select)
+
+    # Assertions
+    mock_wdbqsca.assert_has_calls(
+        [call(agent_id='000', offset=0, limit=None, sort={'fields': ['title'], 'order': 'asc'},
+              query='policy_id=test_policy_id;test~a', count=False, get_data=False, select=[], default_sort_field='id',
+              default_sort_order='ASC', filters={'test': 'value'}, fields=fields,
+              default_query=core_sca.WazuhDBQueryDistinctSCACheck.INNER_QUERY_PATTERN, search={'value': 'test'}),
+         call(ANY, agent_id='000', offset=10, limit=20, sort={'fields': ['title'], 'order': 'asc'}, filters={},
+              search={}, count=True, get_data=True, select=select or list(fields.keys()),
+              default_query="SELECT DISTINCT {0} FROM " + f"({mock_enter.return_value.query})", fields=fields,
+              default_sort_field='id', default_sort_order='ASC', min_select_fields=set(), query='')],
+        any_order=False)

--- a/framework/wazuh/sca.py
+++ b/framework/wazuh/sca.py
@@ -8,9 +8,9 @@ from wazuh.core import common
 from wazuh.core.agent import get_agents_info
 from wazuh.core.exception import WazuhResourceNotFound
 from wazuh.core.results import AffectedItemsWazuhResult
-from wazuh.core.sca import (WazuhDBQueryDistinctSCACheck, WazuhDBQuerySCA, WazuhDBQuerySCACheck,
-                            WazuhDBQuerySCACheckIDs, WazuhDBQuerySCACheckRelational,
-                            SCA_CHECK_COMPLIANCE_DB_FIELDS, SCA_CHECK_RULES_DB_FIELDS, SCA_CHECK_DB_FIELDS)
+from wazuh.core.sca import (
+    WazuhDBQueryDistinctSCACheck, WazuhDBQuerySCA, WazuhDBQuerySCACheck, WazuhDBQuerySCACheckIDs,
+    WazuhDBQuerySCACheckRelational, SCA_CHECK_COMPLIANCE_DB_FIELDS, SCA_CHECK_RULES_DB_FIELDS, SCA_CHECK_DB_FIELDS)
 from wazuh.rbac.decorators import expose_resources
 
 
@@ -78,7 +78,7 @@ def get_sca_checks(policy_id: str = None, agent_list: list = None, q: str = "", 
     policy_id : str
         Policy id to get the checks from.
     agent_list : list
-        Agent id to get the policies from
+        Agent id to get the policies from.
     q : str
         Defines query to filter in DB.
     offset : int
@@ -179,8 +179,8 @@ def get_sca_checks(policy_id: str = None, agent_list: list = None, q: str = "", 
             else:
                 # Get SCA checks fields distinct
                 with WazuhDBQueryDistinctSCACheck(agent_id=agent_list[0], offset=offset, limit=limit, filters=filters,
-                                                  search=search, query=q, policy_id=policy_id,
-                                                  sort=sort, select=select) as sca_check_query:
+                                                  search=search, query=q, policy_id=policy_id, sort=sort,
+                                                  select=select) as sca_check_query:
                     sca_check_data = sca_check_query.run()
 
                 result.total_affected_items = sca_check_data['totalItems']

--- a/framework/wazuh/sca.py
+++ b/framework/wazuh/sca.py
@@ -8,9 +8,9 @@ from wazuh.core import common
 from wazuh.core.agent import get_agents_info
 from wazuh.core.exception import WazuhResourceNotFound
 from wazuh.core.results import AffectedItemsWazuhResult
-from wazuh.core.sca import (WazuhDBQuerySCA, WazuhDBQuerySCACheck, WazuhDBQuerySCACheckIDs,
-                            WazuhDBQuerySCACheckRelational, SCA_CHECK_COMPLIANCE_DB_FIELDS, SCA_CHECK_RULES_DB_FIELDS,
-                            SCA_CHECK_DB_FIELDS)
+from wazuh.core.sca import (WazuhDBQueryDistinctSCACheck, WazuhDBQuerySCA, WazuhDBQuerySCACheck,
+                            WazuhDBQuerySCACheckIDs, WazuhDBQuerySCACheckRelational,
+                            SCA_CHECK_COMPLIANCE_DB_FIELDS, SCA_CHECK_RULES_DB_FIELDS, SCA_CHECK_DB_FIELDS)
 from wazuh.rbac.decorators import expose_resources
 
 
@@ -67,7 +67,7 @@ def get_sca_list(agent_list: list = None, q: str = "", offset: int = 0, limit: i
 @expose_resources(actions=["sca:read"], resources=['agent:id:{agent_list}'])
 def get_sca_checks(policy_id: str = None, agent_list: list = None, q: str = "", offset: int = 0,
                    limit: int = common.DATABASE_LIMIT, sort: dict = None, search: dict = None, select: list = None,
-                   filters: dict = None) -> AffectedItemsWazuhResult:
+                   filters: dict = None, distinct: bool = False) -> AffectedItemsWazuhResult:
     """Get a list of checks analyzed for a policy.
 
     Parameters
@@ -90,6 +90,8 @@ def get_sca_checks(policy_id: str = None, agent_list: list = None, q: str = "", 
         Select which fields to return.
     filters : dict
         Define field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}
+    distinct : bool
+        Look for distinct values.
 
     Returns
     -------
@@ -103,69 +105,83 @@ def get_sca_checks(policy_id: str = None, agent_list: list = None, q: str = "", 
     if len(agent_list) != 0:
         if agent_list[0] in get_agents_info():
 
-            # Get SCA checks IDs from the checks, rules and compliance tables
-            # The query includes the `filters`, `q`, `search`, `limit`, `offset` and `sort` parameters
-            with WazuhDBQuerySCACheckIDs(agent_id=agent_list[0], offset=offset, limit=limit, filters=filters,
-                                         search=search, query=q, policy_id=policy_id, sort=sort) as sca_check_query:
-                sca_check_data = sca_check_query.run()
-                result.total_affected_items = sca_check_data['totalItems']
+            # Workaround for distinct=False
+            if not distinct:
+                # Get SCA checks IDs from the checks, rules and compliance tables
+                # The query includes the `filters`, `q`, `search`, `limit`, `offset` and `sort` parameters
+                with WazuhDBQuerySCACheckIDs(agent_id=agent_list[0], offset=offset, limit=limit, filters=filters,
+                                             search=search, query=q, policy_id=policy_id, sort=sort) as sca_check_query:
+                    sca_check_data = sca_check_query.run()
+                    result.total_affected_items = sca_check_data['totalItems']
 
-            # Create SCA checks IDs list from the query response
-            id_check_list = [check['id'] for check in sca_check_data['items']]
+                # Create SCA checks IDs list from the query response
+                id_check_list = [check['id'] for check in sca_check_data['items']]
 
-            if id_check_list:
-                # Get SCA checks items from the checks table with the SCA checks IDs list
-                # The query includes the `sort` and `select` parameters
-                with WazuhDBQuerySCACheck(
-                        agent_id=agent_list[0],
-                        select=select if not select else list(
-                            set(select) - SCA_CHECK_RULES_DB_FIELDS.keys() - SCA_CHECK_COMPLIANCE_DB_FIELDS.keys()),
-                        sort=sort, sca_checks_ids=id_check_list) as sca_check_query:
+                if id_check_list:
+                    # Get SCA checks items from the checks table with the SCA checks IDs list
+                    # The query includes the `sort` and `select` parameters
+                    with WazuhDBQuerySCACheck(
+                            agent_id=agent_list[0],
+                            select=select if not select else list(
+                                set(select) - SCA_CHECK_RULES_DB_FIELDS.keys() - SCA_CHECK_COMPLIANCE_DB_FIELDS.keys()),
+                            sort=sort, sca_checks_ids=id_check_list) as sca_check_query:
+                        sca_check_data = sca_check_query.run()
+
+                    # Get compliance if all fields selected (not select), or if a compliance field is in select
+                    sca_check_compliance_items = []
+                    select_compliance = set(select) - SCA_CHECK_RULES_DB_FIELDS.keys() - \
+                                        SCA_CHECK_DB_FIELDS.keys() if select else None
+                    if not select or select_compliance:
+                        with WazuhDBQuerySCACheckRelational(
+                                agent_id=agent_list[0], table="sca_check_compliance", id_check_list=id_check_list,
+                                select=select if not select
+                                else list(select_compliance) + ['id_check']) as sca_check_compliance_query:
+                            sca_check_compliance_items = sca_check_compliance_query.run()['items']
+
+                    # Get rules if all fields selected (not select), or if a rules field is in select
+                    sca_check_rules_items = []
+                    select_rules = set(select) - SCA_CHECK_COMPLIANCE_DB_FIELDS.keys() - \
+                                   SCA_CHECK_DB_FIELDS.keys() if select else None
+                    if not select or select_rules:
+                        with WazuhDBQuerySCACheckRelational(
+                                agent_id=agent_list[0], table="sca_check_rules", id_check_list=id_check_list,
+                                select=select if not select
+                                else list(select_rules) + ['id_check']) as sca_check_rules_query:
+                            sca_check_rules_items = sca_check_rules_query.run()['items']
+
+                    # Add compliance and rules to SCA checks data
+                    id_check_rules_compliance = {id_check: {'compliance': [], 'rules': []} for id_check in
+                                                 id_check_list}
+                    for compliance in sca_check_compliance_items:
+                        id_check_rules_compliance[compliance['id_check']]['compliance'].append(
+                            {k.split('.')[1]: v for k, v in compliance.items() if k != 'id_check'})
+                    for rule in sca_check_rules_items:
+                        id_check_rules_compliance[rule['id_check']]['rules'].append(
+                            {k.split('.')[1]: v for k, v in rule.items() if k != 'id_check'})
+
+                    if sca_check_rules_items and sca_check_compliance_items:
+                        for sca_check in sca_check_data['items']:
+                            sca_check['compliance'] = id_check_rules_compliance[sca_check['id']]['compliance']
+                            sca_check['rules'] = id_check_rules_compliance[sca_check['id']]['rules']
+                    elif sca_check_rules_items:
+                        for sca_check in sca_check_data['items']:
+                            sca_check['rules'] = id_check_rules_compliance[sca_check['id']]['rules']
+                    elif sca_check_compliance_items:
+                        for sca_check in sca_check_data['items']:
+                            sca_check['compliance'] = id_check_rules_compliance[sca_check['id']]['compliance']
+
+                result.affected_items.extend(sca_check_data['items'])
+
+            # Workaround for distinct=True
+            else:
+                # Get SCA checks fields distinct
+                with WazuhDBQueryDistinctSCACheck(agent_id=agent_list[0], offset=offset, limit=limit, filters=filters,
+                                                  search=search, query=q, policy_id=policy_id,
+                                                  sort=sort, select=select) as sca_check_query:
                     sca_check_data = sca_check_query.run()
 
-                # Get compliance if all fields selected (not select), or if a compliance field is in select
-                sca_check_compliance_items = []
-                select_compliance = set(select) - SCA_CHECK_RULES_DB_FIELDS.keys() - \
-                                    SCA_CHECK_DB_FIELDS.keys() if select else None
-                if not select or select_compliance:
-                    with WazuhDBQuerySCACheckRelational(
-                            agent_id=agent_list[0], table="sca_check_compliance", id_check_list=id_check_list,
-                            select=select if not select
-                            else list(select_compliance) + ['id_check']) as sca_check_compliance_query:
-                        sca_check_compliance_items = sca_check_compliance_query.run()['items']
-
-                # Get rules if all fields selected (not select), or if a rules field is in select
-                sca_check_rules_items = []
-                select_rules = set(select) - SCA_CHECK_COMPLIANCE_DB_FIELDS.keys() - \
-                               SCA_CHECK_DB_FIELDS.keys() if select else None
-                if not select or select_rules:
-                    with WazuhDBQuerySCACheckRelational(
-                            agent_id=agent_list[0], table="sca_check_rules", id_check_list=id_check_list,
-                            select=select if not select
-                            else list(select_rules) + ['id_check']) as sca_check_rules_query:
-                        sca_check_rules_items = sca_check_rules_query.run()['items']
-
-                # Add compliance and rules to SCA checks data
-                id_check_rules_compliance = {id_check: {'compliance': [], 'rules': []} for id_check in id_check_list}
-                for compliance in sca_check_compliance_items:
-                    id_check_rules_compliance[compliance['id_check']]['compliance'].append(
-                        {k.split('.')[1]: v for k, v in compliance.items() if k != 'id_check'})
-                for rule in sca_check_rules_items:
-                    id_check_rules_compliance[rule['id_check']]['rules'].append(
-                        {k.split('.')[1]: v for k, v in rule.items() if k != 'id_check'})
-
-                if sca_check_rules_items and sca_check_compliance_items:
-                    for sca_check in sca_check_data['items']:
-                        sca_check['compliance'] = id_check_rules_compliance[sca_check['id']]['compliance']
-                        sca_check['rules'] = id_check_rules_compliance[sca_check['id']]['rules']
-                elif sca_check_rules_items:
-                    for sca_check in sca_check_data['items']:
-                        sca_check['rules'] = id_check_rules_compliance[sca_check['id']]['rules']
-                elif sca_check_compliance_items:
-                    for sca_check in sca_check_data['items']:
-                        sca_check['compliance'] = id_check_rules_compliance[sca_check['id']]['compliance']
-
-            result.affected_items.extend(sca_check_data['items'])
+                result.total_affected_items = sca_check_data['totalItems']
+                result.affected_items.extend(sca_check_data['items'])
 
         else:
             result.add_failed_item(id_=agent_list[0], error=WazuhResourceNotFound(1701))

--- a/framework/wazuh/sca.py
+++ b/framework/wazuh/sca.py
@@ -118,13 +118,15 @@ def get_sca_checks(policy_id: str = None, agent_list: list = None, q: str = "", 
                 # The query includes the `sort` and `select` parameters
                 with WazuhDBQuerySCACheck(
                         agent_id=agent_list[0],
-                        select=select if not select else list(set(select).intersection(SCA_CHECK_DB_FIELDS.keys())),
+                        select=select if not select else list(
+                            set(select) - SCA_CHECK_RULES_DB_FIELDS.keys() - SCA_CHECK_COMPLIANCE_DB_FIELDS.keys()),
                         sort=sort, sca_checks_ids=id_check_list) as sca_check_query:
                     sca_check_data = sca_check_query.run()
 
                 # Get compliance if all fields selected (not select), or if a compliance field is in select
                 sca_check_compliance_items = []
-                select_compliance = set(select).intersection(SCA_CHECK_COMPLIANCE_DB_FIELDS.keys()) if select else None
+                select_compliance = set(select) - SCA_CHECK_RULES_DB_FIELDS.keys() - \
+                                    SCA_CHECK_DB_FIELDS.keys() if select else None
                 if not select or select_compliance:
                     with WazuhDBQuerySCACheckRelational(
                             agent_id=agent_list[0], table="sca_check_compliance", id_check_list=id_check_list,
@@ -134,7 +136,8 @@ def get_sca_checks(policy_id: str = None, agent_list: list = None, q: str = "", 
 
                 # Get rules if all fields selected (not select), or if a rules field is in select
                 sca_check_rules_items = []
-                select_rules = set(select).intersection(SCA_CHECK_RULES_DB_FIELDS.keys()) if select else None
+                select_rules = set(select) - SCA_CHECK_COMPLIANCE_DB_FIELDS.keys() - \
+                               SCA_CHECK_DB_FIELDS.keys() if select else None
                 if not select or select_rules:
                     with WazuhDBQuerySCACheckRelational(
                             agent_id=agent_list[0], table="sca_check_rules", id_check_list=id_check_list,

--- a/framework/wazuh/sca.py
+++ b/framework/wazuh/sca.py
@@ -16,7 +16,7 @@ from wazuh.rbac.decorators import expose_resources
 
 @expose_resources(actions=["sca:read"], resources=['agent:id:{agent_list}'])
 def get_sca_list(agent_list: list = None, q: str = "", offset: int = 0, limit: int = common.DATABASE_LIMIT,
-                 sort: dict = None, search: dict = None, select: list = None,
+                 sort: dict = None, search: dict = None, select: list = None, distinct: bool = False,
                  filters: dict = None) -> AffectedItemsWazuhResult:
     """Get a list of policies analyzed in the configuration assessment for a given agent.
 
@@ -36,6 +36,8 @@ def get_sca_list(agent_list: list = None, q: str = "", offset: int = 0, limit: i
         Looks for items with the specified string. Format: {"fields": ["field1","field2"]}
     select : list
         Select fields to return. Format: ["field1","field2"].
+    distinct : bool
+        Look for distinct values.
     filters : dict
         Define field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}
 
@@ -53,7 +55,8 @@ def get_sca_list(agent_list: list = None, q: str = "", offset: int = 0, limit: i
         if agent_list[0] in get_agents_info():
 
             with WazuhDBQuerySCA(agent_id=agent_list[0], offset=offset, limit=limit, sort=sort, search=search,
-                                 select=select, count=True, get_data=True, query=q, filters=filters) as db_query:
+                                 select=select, count=True, get_data=True, query=q, filters=filters,
+                                 distinct=distinct) as db_query:
                 data = db_query.run()
 
             result.affected_items.extend(data['items'])

--- a/framework/wazuh/sca.py
+++ b/framework/wazuh/sca.py
@@ -125,31 +125,32 @@ def get_sca_checks(policy_id: str = None, agent_list: list = None, q: str = "", 
                     # The query includes the `sort` and `select` parameters
                     with WazuhDBQuerySCACheck(
                             agent_id=agent_list[0],
-                            select=select if not select else list(
-                                set(select) - SCA_CHECK_RULES_DB_FIELDS.keys() - SCA_CHECK_COMPLIANCE_DB_FIELDS.keys()),
+                            select=select if not select else [s for s in select if
+                                                              s not in SCA_CHECK_RULES_DB_FIELDS.keys() and s not in
+                                                              SCA_CHECK_COMPLIANCE_DB_FIELDS.keys()],
                             sort=sort, sca_checks_ids=id_check_list) as sca_check_query:
                         sca_check_data = sca_check_query.run()
 
                     # Get compliance if all fields selected (not select), or if a compliance field is in select
                     sca_check_compliance_items = []
-                    select_compliance = set(select) - SCA_CHECK_RULES_DB_FIELDS.keys() - \
-                                        SCA_CHECK_DB_FIELDS.keys() if select else None
+                    select_compliance = [s for s in select if s not in SCA_CHECK_RULES_DB_FIELDS.keys() and s not in
+                                         SCA_CHECK_DB_FIELDS.keys()] if select else None
                     if not select or select_compliance:
                         with WazuhDBQuerySCACheckRelational(
                                 agent_id=agent_list[0], table="sca_check_compliance", id_check_list=id_check_list,
                                 select=select if not select
-                                else list(select_compliance) + ['id_check']) as sca_check_compliance_query:
+                                else select_compliance + ['id_check']) as sca_check_compliance_query:
                             sca_check_compliance_items = sca_check_compliance_query.run()['items']
 
                     # Get rules if all fields selected (not select), or if a rules field is in select
                     sca_check_rules_items = []
-                    select_rules = set(select) - SCA_CHECK_COMPLIANCE_DB_FIELDS.keys() - \
-                                   SCA_CHECK_DB_FIELDS.keys() if select else None
+                    select_rules = [s for s in select if s not in SCA_CHECK_COMPLIANCE_DB_FIELDS.keys() and s not in
+                                    SCA_CHECK_DB_FIELDS.keys()] if select else None
                     if not select or select_rules:
                         with WazuhDBQuerySCACheckRelational(
                                 agent_id=agent_list[0], table="sca_check_rules", id_check_list=id_check_list,
                                 select=select if not select
-                                else list(select_rules) + ['id_check']) as sca_check_rules_query:
+                                else select_rules + ['id_check']) as sca_check_rules_query:
                             sca_check_rules_items = sca_check_rules_query.run()['items']
 
                     # Add compliance and rules to SCA checks data


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/14407|



## Description

This PR closes https://github.com/wazuh/wazuh/issues/14407.

In this pull request, I have added the `distinct` and `select` parameters to the SCA endpoints.

The related API integration tests and unit tests have also been updated.

