### PR TITLE
Obtaining the 'aarch64' architecture in the manager and thus fixing the WPK upgrade. 

### DIFF
--- a/src/shared/remoted_op.c
+++ b/src/shared/remoted_op.c
@@ -22,7 +22,7 @@
  * @retval A string pointer to the architecture. NULL if not found.
  */
 char * get_os_arch(char * os_header) {
-    const char * ARCHS[] = { "x86_64", "i386", "i686", "sparc", "amd64", "i86pc", "ia64", "AIX", "armv6", "armv7", NULL };
+    const char * ARCHS[] = { "x86_64", "i386", "i686", "sparc", "amd64", "i86pc", "ia64", "AIX", "armv6", "armv7", "aarch64", NULL };
     char * os_arch = NULL;
     int i;
 


### PR DESCRIPTION
|Related issue|
|---|
|#14982|

## Description

The problem, found in issue #14982, was due to the fact that the manager could not correctly obtain the `aarch64` architecture that the agent had, so the upgrade failed because it appeared with a `NULL` value.

This bug can be reproduced using a manager with any version that does not have this fix, and also the architecture of the agent that you want to upgrade is `aarch64`. 

With the change made in this PR, the manager now correctly detects the architecture (_aarch64_) of the agent, and this allows the WPK upgrade to be performed correctly.

> The change simply adds the “new” architecture to the array so that it matches and sets the variable correctly.

## Configuration options

The steps to set up the correct configuration for testing can be found in the description of issue #14982.

## Logs/Alerts example

With the fix, we can see how the manager saves the value of _`aarch64`_ in the variable `arch`, inside the `global.db`:
```
# sqlite3 /var/ossec/queue/db/global.db "SELECT OS_NAME, OS_MAJOR, OS_MINOR, OS_ARCH FROM AGENT WHERE ID = 2" -table
+--------------+----------+----------+---------+
|   os_name    | os_major | os_minor | os_arch |
+--------------+----------+----------+---------+
| Amazon Linux | 2022     |          | aarch64 |
+--------------+----------+----------+---------+
```

Then we see how after getting the value of `arch` and applying the same steps as in the issue to create the WPK for _arm64_, the agent is upgraded correctly:
```
# /var/ossec/bin/agent_upgrade -a 002 -f /tmp/myagent.wpk -x ./upgrade.sh

Upgrading...

Upgraded agents:
	Agent 002 upgraded: Wazuh v4.4.0 -> Wazuh v4.4.0
```

In addition, I attach the _upgrade.log_ file after the successful upgrade:
[upgrade.log](https://github.com/wazuh/wazuh/files/9754639/upgrade.log)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
