### PR TITLE
Fix `GET /agents/upgrade_result` endpoint internal error with code 1814 in large environments

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -23,6 +23,9 @@ from wazuh.rbac.decorators import expose_resources
 cluster_enabled = not read_cluster_config(from_import=True)['disabled']
 node_id = get_node().get('node') if cluster_enabled else None
 
+UPGRADE_CHUNK_SIZE = 500
+UPGRADE_RESULT_CHUNK_SIZE = 97
+
 # Error codes generated from upgrade socket error codes that should be excluded in upgrade functions
 # 1819 -> The WPK for this platform is not available
 # 1820 -> Upgrade procedure could not start. Agent already upgrading
@@ -1148,7 +1151,8 @@ def upgrade_agents(agent_list: list = None, wpk_repo: str = None, version: str =
         # Transform the format of the agent ids to the general format
         eligible_agents = [int(agent) for agent in eligible_agents]
 
-        agents_result_chunks = [eligible_agents[x:x + 500] for x in range(0, len(eligible_agents), 500)]
+        agents_result_chunks = [eligible_agents[x:x + UPGRADE_CHUNK_SIZE] for x in
+                                range(0, len(eligible_agents), UPGRADE_CHUNK_SIZE)]
 
         agent_results = list()
         for agents_chunk in agents_result_chunks:
@@ -1257,7 +1261,8 @@ def get_upgrade_result(agent_list: list = None, filters: dict = None, q: str = N
         # Transform the format of the agent ids to the general format
         eligible_agents = [int(agent) for agent in eligible_agents]
 
-        agents_result_chunks = [eligible_agents[x:x + 500] for x in range(0, len(eligible_agents), 500)]
+        agents_result_chunks = [eligible_agents[x:x + UPGRADE_RESULT_CHUNK_SIZE] for x in
+                                range(0, len(eligible_agents), UPGRADE_RESULT_CHUNK_SIZE)]
 
         task_results = list()
         for agents_chunk in agents_result_chunks:

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -1385,7 +1385,7 @@ def get_rbac_filters(system_resources: set = None, permitted_resources: list = N
     return {'filters': filters, 'rbac_negate': negate}
 
 
-def create_upgrade_tasks(eligible_agents: list, chunk_size: int, command: str, **kwargs: dict) -> list:
+def create_upgrade_tasks(eligible_agents: list, chunk_size: int, command: str, **kwargs) -> list:
     """Recursive function used to create the agents upgrade tasks.
 
     If a task manager communication error is in the response (error with code 4), the chunk size used is split in half.
@@ -1398,7 +1398,7 @@ def create_upgrade_tasks(eligible_agents: list, chunk_size: int, command: str, *
         Number of agents to be sent to the upgrade socket at the same time.
     command : str
         Upgrade command. Values: 'upgrade', 'upgrade_custom', 'upgrade_result'.
-    **kwargs : dict
+    **kwargs
         Upgrade procedure extra parameters.
 
     Returns

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -1406,7 +1406,7 @@ def create_upgrade_tasks(eligible_agents: list, chunk_size: int, command: str, *
     list
         Upgrade tasks results.
     """
-    result = list()
+    result = []
     agents_chunks = [eligible_agents[x:x + chunk_size] for x in range(0, len(eligible_agents), chunk_size)]
     for chunk in agents_chunks:
         response = core_upgrade_agents(command=command, agents_chunk=chunk, wpk_repo=kwargs.get('wpk_repo'),
@@ -1414,8 +1414,8 @@ def create_upgrade_tasks(eligible_agents: list, chunk_size: int, command: str, *
                                        use_http=kwargs.get('use_http'), file_path=kwargs.get('file_path'),
                                        installer=kwargs.get('installer'), get_result=kwargs.get('get_result'))
 
-        # In case of task manager communication error, try to create the upgrade tasks again with a shorter chunk size
-        # If the chunk size used is 1, return the response with the task manager communication error
+        # In case of task manager communication error, try to create the upgrade tasks again with a smaller chunk size
+        # If the used chunk size is 1, return the response with the task manager communication error
         if any(item['error'] == 4 for item in response['data']) and chunk_size != 1:
             return create_upgrade_tasks(eligible_agents, chunk_size // 2, command, **kwargs)
 

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -1137,7 +1137,7 @@ def test_agent_upgrade_agents(mock_socket, mock_wdb, mock_client_keys, agent_set
     raise_error : bool
         Boolean variable used to indicate that the
     """
-    with patch('wazuh.agent.core_upgrade_agents') as core_upgrade_agents_mock:
+    with patch('wazuh.core.agent.core_upgrade_agents') as core_upgrade_agents_mock:
         core_upgrade_agents_mock.return_value = result_from_socket
 
         if raise_error:
@@ -1250,7 +1250,7 @@ def test_agent_get_upgrade_result(mock_socket, mock_wdb, mock_client_keys, agent
     raise_error : bool
         Boolean variable used to indicate that the
     """
-    with patch('wazuh.agent.core_upgrade_agents') as core_upgrade_agents_mock:
+    with patch('wazuh.core.agent.core_upgrade_agents') as core_upgrade_agents_mock:
         core_upgrade_agents_mock.return_value = result_from_socket
 
         if raise_error:


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/14759|


## Description

This PR closes https://github.com/wazuh/wazuh/issues/14759.

In this pull request, I have reviewed the chunk size used by the framework function in charge of getting the agents' upgrade results. I have also added a function to change the chunk size dynamically when a task manager communication error is received from the socket.

In order to test this PR in a large Wazuh environment, I have used the simulate-agents QA tool.

Apart from using the simulate-agents tool, I have also updated the core responses so the socket always returns the worst response (talking about size).

Simulating 150 agents, with the framework changes (new chunk size, 97 agents).

#### Upgrade tasks creation (chunk=500)

<details>

<summary>PUT /agents/upgrade output</summary>

```json
{
  "data": {
    "affected_items": [
      {
        "agent": "004",
        "task_id": 107
      },
      {
        "agent": "005",
        "task_id": 112
      },
      {
        "agent": "006",
        "task_id": 116
      },
      {
        "agent": "007",
        "task_id": 120
      },
      {
        "agent": "008",
        "task_id": 127
      },
      {
        "agent": "009",
        "task_id": 131
      },
      {
        "agent": "010",
        "task_id": 78
      },
      {
        "agent": "011",
        "task_id": 86
      },
      {
        "agent": "012",
        "task_id": 89
      },
      {
        "agent": "013",
        "task_id": 94
      },
      {
        "agent": "014",
        "task_id": 102
      },
      {
        "agent": "015",
        "task_id": 106
      },
      {
        "agent": "016",
        "task_id": 115
      },
      {
        "agent": "017",
        "task_id": 117
      },
      {
        "agent": "018",
        "task_id": 121
      },
      {
        "agent": "019",
        "task_id": 126
      },
      {
        "agent": "020",
        "task_id": 153
      },
      {
        "agent": "021",
        "task_id": 161
      },
      {
        "agent": "022",
        "task_id": 7
      },
      {
        "agent": "023",
        "task_id": 9
      },
      {
        "agent": "024",
        "task_id": 19
      },
      {
        "agent": "025",
        "task_id": 22
      },
      {
        "agent": "026",
        "task_id": 27
      },
      {
        "agent": "027",
        "task_id": 32
      },
      {
        "agent": "028",
        "task_id": 36
      },
      {
        "agent": "029",
        "task_id": 37
      },
      {
        "agent": "030",
        "task_id": 66
      },
      {
        "agent": "031",
        "task_id": 71
      },
      {
        "agent": "032",
        "task_id": 75
      },
      {
        "agent": "033",
        "task_id": 80
      },
      {
        "agent": "034",
        "task_id": 84
      },
      {
        "agent": "035",
        "task_id": 91
      },
      {
        "agent": "036",
        "task_id": 93
      },
      {
        "agent": "037",
        "task_id": 100
      },
      {
        "agent": "038",
        "task_id": 104
      },
      {
        "agent": "039",
        "task_id": 114
      },
      {
        "agent": "040",
        "task_id": 143
      },
      {
        "agent": "041",
        "task_id": 147
      },
      {
        "agent": "042",
        "task_id": 149
      },
      {
        "agent": "043",
        "task_id": 157
      },
      {
        "agent": "044",
        "task_id": 163
      },
      {
        "agent": "045",
        "task_id": 6
      },
      {
        "agent": "046",
        "task_id": 10
      },
      {
        "agent": "047",
        "task_id": 18
      },
      {
        "agent": "048",
        "task_id": 21
      },
      {
        "agent": "049",
        "task_id": 28
      },
      {
        "agent": "050",
        "task_id": 54
      },
      {
        "agent": "051",
        "task_id": 55
      },
      {
        "agent": "052",
        "task_id": 62
      },
      {
        "agent": "053",
        "task_id": 65
      },
      {
        "agent": "054",
        "task_id": 70
      },
      {
        "agent": "055",
        "task_id": 73
      },
      {
        "agent": "056",
        "task_id": 77
      },
      {
        "agent": "057",
        "task_id": 87
      },
      {
        "agent": "058",
        "task_id": 88
      },
      {
        "agent": "059",
        "task_id": 95
      },
      {
        "agent": "060",
        "task_id": 133
      },
      {
        "agent": "061",
        "task_id": 138
      },
      {
        "agent": "062",
        "task_id": 139
      },
      {
        "agent": "063",
        "task_id": 144
      },
      {
        "agent": "064",
        "task_id": 148
      },
      {
        "agent": "065",
        "task_id": 151
      },
      {
        "agent": "066",
        "task_id": 154
      },
      {
        "agent": "067",
        "task_id": 162
      },
      {
        "agent": "068",
        "task_id": 4
      },
      {
        "agent": "069",
        "task_id": 13
      },
      {
        "agent": "070",
        "task_id": 44
      },
      {
        "agent": "071",
        "task_id": 46
      },
      {
        "agent": "072",
        "task_id": 49
      },
      {
        "agent": "073",
        "task_id": 52
      },
      {
        "agent": "074",
        "task_id": 57
      },
      {
        "agent": "075",
        "task_id": 61
      },
      {
        "agent": "076",
        "task_id": 68
      },
      {
        "agent": "077",
        "task_id": 69
      },
      {
        "agent": "078",
        "task_id": 74
      },
      {
        "agent": "079",
        "task_id": 82
      },
      {
        "agent": "080",
        "task_id": 124
      },
      {
        "agent": "081",
        "task_id": 128
      },
      {
        "agent": "082",
        "task_id": 132
      },
      {
        "agent": "083",
        "task_id": 135
      },
      {
        "agent": "084",
        "task_id": 136
      },
      {
        "agent": "085",
        "task_id": 140
      },
      {
        "agent": "086",
        "task_id": 142
      },
      {
        "agent": "087",
        "task_id": 146
      },
      {
        "agent": "088",
        "task_id": 150
      },
      {
        "agent": "089",
        "task_id": 158
      },
      {
        "agent": "090",
        "task_id": 35
      },
      {
        "agent": "091",
        "task_id": 38
      },
      {
        "agent": "092",
        "task_id": 42
      },
      {
        "agent": "093",
        "task_id": 45
      },
      {
        "agent": "094",
        "task_id": 48
      },
      {
        "agent": "095",
        "task_id": 50
      },
      {
        "agent": "096",
        "task_id": 53
      },
      {
        "agent": "097",
        "task_id": 58
      },
      {
        "agent": "098",
        "task_id": 60
      },
      {
        "agent": "099",
        "task_id": 67
      },
      {
        "agent": "100",
        "task_id": 98
      },
      {
        "agent": "101",
        "task_id": 99
      },
      {
        "agent": "102",
        "task_id": 108
      },
      {
        "agent": "103",
        "task_id": 113
      },
      {
        "agent": "104",
        "task_id": 118
      },
      {
        "agent": "105",
        "task_id": 122
      },
      {
        "agent": "106",
        "task_id": 129
      },
      {
        "agent": "107",
        "task_id": 130
      },
      {
        "agent": "108",
        "task_id": 134
      },
      {
        "agent": "109",
        "task_id": 137
      },
      {
        "agent": "110",
        "task_id": 14
      },
      {
        "agent": "111",
        "task_id": 16
      },
      {
        "agent": "112",
        "task_id": 24
      },
      {
        "agent": "113",
        "task_id": 26
      },
      {
        "agent": "114",
        "task_id": 30
      },
      {
        "agent": "115",
        "task_id": 34
      },
      {
        "agent": "116",
        "task_id": 39
      },
      {
        "agent": "117",
        "task_id": 41
      },
      {
        "agent": "118",
        "task_id": 43
      },
      {
        "agent": "119",
        "task_id": 47
      },
      {
        "agent": "120",
        "task_id": 81
      },
      {
        "agent": "121",
        "task_id": 83
      },
      {
        "agent": "122",
        "task_id": 92
      },
      {
        "agent": "123",
        "task_id": 97
      },
      {
        "agent": "124",
        "task_id": 103
      },
      {
        "agent": "125",
        "task_id": 109
      },
      {
        "agent": "126",
        "task_id": 111
      },
      {
        "agent": "127",
        "task_id": 119
      },
      {
        "agent": "128",
        "task_id": 123
      },
      {
        "agent": "129",
        "task_id": 125
      },
      {
        "agent": "130",
        "task_id": 155
      },
      {
        "agent": "131",
        "task_id": 160
      },
      {
        "agent": "132",
        "task_id": 5
      },
      {
        "agent": "133",
        "task_id": 12
      },
      {
        "agent": "134",
        "task_id": 17
      },
      {
        "agent": "135",
        "task_id": 23
      },
      {
        "agent": "136",
        "task_id": 25
      },
      {
        "agent": "137",
        "task_id": 31
      },
      {
        "agent": "138",
        "task_id": 33
      },
      {
        "agent": "139",
        "task_id": 40
      },
      {
        "agent": "140",
        "task_id": 64
      },
      {
        "agent": "141",
        "task_id": 72
      },
      {
        "agent": "142",
        "task_id": 76
      },
      {
        "agent": "143",
        "task_id": 79
      },
      {
        "agent": "144",
        "task_id": 85
      },
      {
        "agent": "145",
        "task_id": 90
      },
      {
        "agent": "146",
        "task_id": 96
      },
      {
        "agent": "147",
        "task_id": 101
      },
      {
        "agent": "148",
        "task_id": 105
      },
      {
        "agent": "149",
        "task_id": 110
      },
      {
        "agent": "150",
        "task_id": 141
      },
      {
        "agent": "151",
        "task_id": 145
      },
      {
        "agent": "152",
        "task_id": 152
      },
      {
        "agent": "153",
        "task_id": 156
      },
      {
        "agent": "154",
        "task_id": 159
      },
      {
        "agent": "155",
        "task_id": 8
      },
      {
        "agent": "156",
        "task_id": 11
      },
      {
        "agent": "157",
        "task_id": 15
      },
      {
        "agent": "158",
        "task_id": 20
      },
      {
        "agent": "159",
        "task_id": 29
      },
      {
        "agent": "160",
        "task_id": 51
      },
      {
        "agent": "161",
        "task_id": 56
      },
      {
        "agent": "162",
        "task_id": 59
      },
      {
        "agent": "163",
        "task_id": 63
      }
    ],
    "total_affected_items": 160,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All upgrade tasks were created",
  "error": 0
}
```

</details>


#### Getting upgrade tasks results (chunk=97)

No errors were found, and the upgrade tasks were returned properly. Note that the `error_msg` contains extra characters to simulate the worst case (biggest possible socket message).

[response.json.txt](https://github.com/wazuh/wazuh/files/9755291/response.json.txt)


#### Getting upgrade tasks results (chunk=110)

An error was found, code 1814 (expected as we are using a chunk higher than the one set (more information about the chunk size investigation in https://github.com/wazuh/wazuh/issues/14759))

<details>

<summary>Response</summary>

```json
{
  "title": "Wazuh Internal Error",
  "detail": "Task manager communication error",
  "dapi_errors": {
    "master-node": {
      "error": "Task manager communication error",
      "logfile": "WAZUH_HOME/logs/api.log"
    }
  },
  "error": 1814
}
```

</details>

<details>

<summary>api.log</summary>

```
2022/10/11 09:29:16 ERROR: Task manager communication error
concurrent.futures.process._RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.9/concurrent/futures/process.py", line 243, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.5.0-py3.9.egg/wazuh/core/cluster/dapi/dapi.py", line 244, in run_local
    data = f(**f_kwargs)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.5.0-py3.9.egg/wazuh/rbac/decorators.py", line 420, in wrapper
    result = func(*args, **kwargs) if not skip_execution else None
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.5.0-py3.9.egg/wazuh/agent.py", line 1098, in get_upgrade_result
    raise WazuhInternalError(error_code, cmd_error=True, extra_message=task_result['message'])
wazuh.core.exception.WazuhInternalError: Error 1814 - Task manager communication error
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.5.0-py3.9.egg/wazuh/core/cluster/dapi/dapi.py", line 289, in execute_local_request
    data = await asyncio.wait_for(task, timeout=timeout)
  File "/var/ossec/framework/python/lib/python3.9/asyncio/tasks.py", line 481, in wait_for
    return fut.result()
wazuh.core.exception.WazuhInternalError: Error 1814 - Task manager communication error
2022/10/11 09:29:16 INFO: wazuh 172.20.0.1 "GET /agents/upgrade_result" with parameters {} and body {} done in 0.113s: 500
```

</details>


As I said, I have also added a function to split the chunk size in half in case there is a task manager communication error (dynamic chunk size). This may not happen after the solution proposed and commented above, but in case the worst socket response is a different one in the future, this function will be useful and no task manager communication errors will be shown.

I have tested this new function with the same use case that raised the 1814 error above (chunk_size=`110`). **With the function, the error is handled and the chunk_size used is `55`.**
