### PR TITLE
Fix memory leaks wazuh-authd

### DIFF
--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -163,11 +163,11 @@ int main(int argc, char **argv)
         const char *ca_cert = NULL;
         const char *server_cert = NULL;
         const char *server_key = NULL;
-        char cert_val[OS_SIZE_1024] = "\0";
-        char cert_key_bits[OS_SIZE_1024] = "\0";
-        char cert_key_path[PATH_MAX] = "\0";
-        char cert_path[PATH_MAX] = "\0";
-        char cert_subj[OS_MAXSTR] = "\0";
+        char cert_val[OS_SIZE_32 + 1] = "\0";
+        char cert_key_bits[OS_SIZE_32 + 1] = "\0";
+        char cert_key_path[PATH_MAX + 1] = "\0";
+        char cert_path[PATH_MAX + 1] = "\0";
+        char cert_subj[OS_MAXSTR + 1] = "\0";
         bool generate_certificate = false;
         unsigned short port = 0;
         unsigned long days_val = 0;
@@ -282,7 +282,9 @@ int main(int argc, char **argv)
                     }
 
                     generate_certificate = true;
-                    snprintf(cert_val, OS_SIZE_1024, "%s", optarg);
+                    if (snprintf(cert_val, OS_SIZE_32 + 1, "%s", optarg) > OS_SIZE_32) {
+                        mwarn("-%c argument exceeds %d bytes. Certificate validity info truncated", c, OS_SIZE_32);
+                    }
                     break;
 
                 case 'B':
@@ -291,7 +293,9 @@ int main(int argc, char **argv)
                     }
 
                     generate_certificate = true;
-                    snprintf(cert_key_bits, OS_SIZE_1024, "%s", optarg);
+                    if (snprintf(cert_key_bits, OS_SIZE_32 + 1, "%s", optarg) > OS_SIZE_32) {
+                        mwarn("-%c argument exceeds %d bytes. Certificate key size info truncated", c, OS_SIZE_32);
+                    }
                     break;
 
                 case 'K':
@@ -300,7 +304,9 @@ int main(int argc, char **argv)
                     }
 
                     generate_certificate = true;
-                    snprintf(cert_key_path, PATH_MAX, "%s", optarg);
+                    if (snprintf(cert_key_path, PATH_MAX + 1, "%s", optarg) > PATH_MAX) {
+                        mwarn("-%c argument exceeds %d bytes. Certificate key path info truncated", c, PATH_MAX);
+                    }
                     break;
 
                 case 'X':
@@ -309,7 +315,9 @@ int main(int argc, char **argv)
                     }
 
                     generate_certificate = true;
-                    snprintf(cert_path, PATH_MAX, "%s", optarg);
+                    if (snprintf(cert_path, PATH_MAX + 1, "%s", optarg) > PATH_MAX) {
+                        mwarn("-%c argument exceeds %d bytes. Certificate path info truncated", c, PATH_MAX);
+                    }
                     break;
 
                 case 'S':
@@ -318,7 +326,9 @@ int main(int argc, char **argv)
                     }
 
                     generate_certificate = true;
-                    snprintf(cert_subj, OS_MAXSTR, "%s", optarg);
+                    if (snprintf(cert_subj, OS_MAXSTR + 1, "%s", optarg) > OS_MAXSTR) {
+                        mwarn("-%c argument exceeds %d bytes. Certificate subject info truncated", c, OS_MAXSTR);
+                    }
                     break;
 
                 default:
@@ -329,23 +339,23 @@ int main(int argc, char **argv)
 
         if (generate_certificate) {
             // Sanitize parameters
-            if (cert_val == NULL) {
+            if (strlen(cert_val) == 0) {
                 merror_exit("Certificate expiration time not defined.");
             }
 
-            if (cert_key_bits == NULL) {
+            if (strlen(cert_key_bits) == 0) {
                 merror_exit("Certificate key size not defined.");
             }
 
-            if (cert_key_path == NULL) {
-                merror_exit("Key path not not defined.");
+            if (strlen(cert_key_path) == 0) {
+                merror_exit("Key path not defined.");
             }
 
-            if (cert_path == NULL) {
+            if (strlen(cert_path) == 0) {
                 merror_exit("Certificate path not defined.");
             }
 
-            if (cert_subj == NULL) {
+            if (strlen(cert_subj) == 0) {
                 merror_exit("Certificate subject not defined.");
             }
 

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -163,12 +163,12 @@ int main(int argc, char **argv)
         const char *ca_cert = NULL;
         const char *server_cert = NULL;
         const char *server_key = NULL;
-        const char *cert_val = NULL;
-        const char *cert_key_bits = NULL;
-        const char *cert_key_path = NULL;
-        const char *cert_path = NULL;
-        const char *cert_subj = NULL;
-        bool generate_certifacate = false;
+        char cert_val[OS_SIZE_1024] = "\0";
+        char cert_key_bits[OS_SIZE_1024] = "\0";
+        char cert_key_path[PATH_MAX] = "\0";
+        char cert_path[PATH_MAX] = "\0";
+        char cert_subj[OS_MAXSTR] = "\0";
+        bool generate_certificate = false;
         unsigned short port = 0;
         unsigned long days_val = 0;
         unsigned long key_bits = 0;
@@ -277,57 +277,57 @@ int main(int argc, char **argv)
                     break;
 
                 case 'C':
-                    generate_certifacate = true;
-
                     if (!optarg) {
                         merror_exit("-%c needs an argument", c);
                     }
-                    os_strdup(optarg, cert_val);
+
+                    generate_certificate = true;
+                    snprintf(cert_val, OS_SIZE_1024, "%s", optarg);
                     break;
 
                 case 'B':
-                    generate_certifacate = true;
-
                     if (!optarg) {
                         merror_exit("-%c needs an argument", c);
                     }
-                    os_strdup(optarg, cert_key_bits);
+
+                    generate_certificate = true;
+                    snprintf(cert_key_bits, OS_SIZE_1024, "%s", optarg);
                     break;
 
                 case 'K':
-                    generate_certifacate = true;
-
                     if (!optarg) {
                         merror_exit("-%c needs an argument", c);
                     }
-                    os_strdup(optarg, cert_key_path);
+
+                    generate_certificate = true;
+                    snprintf(cert_key_path, PATH_MAX, "%s", optarg);
                     break;
 
                 case 'X':
-                    generate_certifacate = true;
-
                     if (!optarg) {
                         merror_exit("-%c needs an argument", c);
                     }
-                    os_strdup(optarg, cert_path);
+
+                    generate_certificate = true;
+                    snprintf(cert_path, PATH_MAX, "%s", optarg);
                     break;
 
                 case 'S':
-                    generate_certifacate = true;
-
                     if (!optarg) {
                         merror_exit("-%c needs an argument", c);
                     }
-                    os_strdup(optarg, cert_subj);
+
+                    generate_certificate = true;
+                    snprintf(cert_subj, OS_MAXSTR, "%s", optarg);
                     break;
+
                 default:
                     help_authd(home_path);
                     break;
             }
         }
 
-        if (generate_certifacate) {
-
+        if (generate_certificate) {
             // Sanitize parameters
             if (cert_val == NULL) {
                 merror_exit("Certificate expiration time not defined.");


### PR DESCRIPTION
|Related issue|
|---|
|#15158|

## Description

This PR aims to fix some memory leaks in wazuh-authd 

## Scan-Build report

![image](https://user-images.githubusercontent.com/13010397/195891124-7aa32c73-1531-46b7-8c4d-8f2c5cae2a52.png)

## Logs/Alerts example

![image](https://user-images.githubusercontent.com/13010397/195890257-67693688-b0ba-4f4c-bc21-31a5aa378d5d.png)
![image](https://user-images.githubusercontent.com/13010397/195892862-87793cce-931a-44e2-8600-aae3f8112af0.png)

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report