### PR TITLE
Fix to race condition in Remoted blocking agent connections

### DIFF
--- a/src/headers/sec.h
+++ b/src/headers/sec.h
@@ -16,6 +16,13 @@
 #include "shared.h"
 #include "os_crypto/sha1/sha1_op.h"
 
+/* Defines to switch according to different OS_AddSocket or, failing that, the case of using UDP protocol */
+#define OS_ADDSOCKET_ERROR          0   ///< OSHash_Set_ex returns 0 on error (* see OS_AddSocket and OSHash_Set_ex)
+#define OS_ADDSOCKET_KEY_UPDATED    1   ///< OSHash_Set_ex returns 1 when key existed, so it is update (*)
+#define OS_ADDSOCKET_KEY_ADDED      2   ///< OSHash_Set_ex returns 2 when key didn't existed, so it is added  (*)
+
+#define USING_UDP_NO_CLIENT_SOCKET  -1  ///< When using UDP, no valid client socket FD is set
+
 typedef enum _crypt_method {
     W_METH_BLOWFISH, W_METH_AES
 } crypt_method;

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -704,7 +704,9 @@ int OS_AddSocket(keystore * keys, unsigned int i, int sock) {
     snprintf(strsock, sizeof(strsock), "%d", sock);
 
     w_mutex_lock(&keys->keytree_sock_mutex);
-    int r = rbtree_insert(keys->keytree_sock, strsock, keys->keyentries[i]) ? 2 : rbtree_replace(keys->keytree_sock, strsock, keys->keyentries[i]) ? 1 : 0;
+    int r = rbtree_insert(keys->keytree_sock, strsock, keys->keyentries[i]) ? OS_ADDSOCKET_KEY_ADDED :
+            rbtree_replace(keys->keytree_sock, strsock, keys->keyentries[i]) ? OS_ADDSOCKET_KEY_UPDATED :
+            OS_ADDSOCKET_ERROR;
     w_mutex_unlock(&keys->keytree_sock_mutex);
 
     return r;

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -354,12 +354,6 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
         return;
     }
 
-    /* Reply to the agent */
-    snprintf(msg_ack, OS_FLSIZE, "%s%s", CONTROL_HEADER, HC_ACK);
-    if (send_msg(key->id, msg_ack, -1) >= 0) {
-        rem_inc_send_ack(key->id);
-    }
-
     /* Filter UTF-8 characters */
     char * clean = w_utf8_filter(r_msg, true);
     r_msg = clean;
@@ -400,6 +394,14 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
         }
 
         rem_inc_recv_ctrl_keepalive(key->id);
+    }
+
+    if (is_shutdown == 0) {
+        /* Reply to the agent except on shutdown message*/
+        snprintf(msg_ack, OS_FLSIZE, "%s%s", CONTROL_HEADER, HC_ACK);
+        if (send_msg(key->id, msg_ack, -1) >= 0) {
+            rem_inc_send_ack(key->id);
+        }
     }
 
     w_mutex_lock(&lastmsg_mutex);

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -72,14 +72,6 @@ static void _push_request(const char *request,const char *type);
 static int key_request_connect();
 static int key_request_reconnect();
 
-/* Defines to switch according to different OS_AddSocket or, failing that, the case of using UDP protocol */
-#define OS_ADDSOCKET_ERROR          0   ///< OSHash_Set_ex returns 0 on error (* see OS_AddSocket and OSHash_Set_ex)
-#define OS_ADDSOCKET_KEY_UPDATED    1   ///< OSHash_Set_ex returns 1 when key existed, so it is update (*)
-#define OS_ADDSOCKET_KEY_ADDED      2   ///< OSHash_Set_ex returns 2 when key didn't existed, so it is added  (*)
-#define REMOTED_USING_UDP           42  ///< When using UDP, OS_AddSocket isn't called, so an arbitrary value is used
-
-#define USING_UDP_NO_CLIENT_SOCKET  -1  ///< When using UDP, no valid client socket FD is set
-
 /* Handle secure connections */
 void HandleSecure()
 {

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -639,27 +639,26 @@ STATIC void HandleSecureMessage(const message_t *message, int *wdb_sock) {
         keyentry * key = OS_DupKeyEntry(keys.keyentries[agentid]);
 
         if (protocol == REMOTED_NET_PROTOCOL_TCP) {
-            if (strncmp(tmp_msg, HC_STARTUP, sizeof(HC_STARTUP)) == 0) {
+            if (message->counter > rem_getCounter(message->sock)) {
                 keys.keyentries[agentid]->sock = message->sock;
-                w_mutex_unlock(&keys.keyentries[agentid]->mutex);
+            }
 
-                r = OS_AddSocket(&keys, agentid, message->sock);
+            w_mutex_unlock(&keys.keyentries[agentid]->mutex);
 
-                switch (r) {
-                case OS_ADDSOCKET_ERROR:
-                    merror("Couldn't add TCP socket to keystore.");
-                    break;
-                case OS_ADDSOCKET_KEY_UPDATED:
-                    mdebug2("TCP socket %d already in keystore. Updating...", message->sock);
-                    break;
-                case OS_ADDSOCKET_KEY_ADDED:
-                    mdebug2("TCP socket %d added to keystore.", message->sock);
-                    break;
-                default:
-                    ;
-                }
-            } else {
-                w_mutex_unlock(&keys.keyentries[agentid]->mutex);
+            r = OS_AddSocket(&keys, agentid, message->sock);
+
+            switch (r) {
+            case OS_ADDSOCKET_ERROR:
+                merror("Couldn't add TCP socket to keystore.");
+                break;
+            case OS_ADDSOCKET_KEY_UPDATED:
+                mdebug2("TCP socket %d already in keystore. Updating...", message->sock);
+                break;
+            case OS_ADDSOCKET_KEY_ADDED:
+                mdebug2("TCP socket %d added to keystore.", message->sock);
+                break;
+            default:
+                ;
             }
         } else {
             keys.keyentries[agentid]->sock = USING_UDP_NO_CLIENT_SOCKET;
@@ -713,6 +712,8 @@ STATIC void HandleSecureMessage(const message_t *message, int *wdb_sock) {
 int _close_sock(keystore * keys, int sock) {
     int retval = 0;
 
+    rem_setCounter(sock, global_counter);
+
     key_lock_read();
     retval = OS_DeleteSocket(keys, sock);
     key_unlock();
@@ -723,7 +724,6 @@ int _close_sock(keystore * keys, int sock) {
         rem_dec_tcp();
     }
 
-    rem_setCounter(sock, global_counter);
     mdebug1("TCP peer disconnected [%d]", sock);
 
     return retval;

--- a/src/unit_tests/remoted/test_manager.c
+++ b/src/unit_tests/remoted/test_manager.c
@@ -3367,10 +3367,6 @@ void test_save_controlmsg_invalid_msg(void **state)
     size_t msg_length = sizeof(r_msg);
     int *wdb_sock = NULL;
 
-    expect_string(__wrap_send_msg, msg, "001");
-
-    expect_string(__wrap_rem_inc_send_ack, agent_id, "001");
-
     expect_string(__wrap__mwarn, formatted_msg, "Invalid message from agent: 'NEW_AGENT' (001)");
 
     save_controlmsg(&key, r_msg, msg_length, wdb_sock);
@@ -3752,10 +3748,6 @@ void test_save_controlmsg_shutdown(void **state)
     size_t msg_length = sizeof(r_msg);
     int *wdb_sock = NULL;
 
-    expect_string(__wrap_send_msg, msg, "001");
-
-    expect_string(__wrap_rem_inc_send_ack, agent_id, "001");
-
     expect_string(__wrap_rem_inc_recv_ctrl_shutdown, agent_id, "001");
 
     expect_any(__wrap_get_ipv4_string, address);
@@ -3821,10 +3813,6 @@ void test_save_controlmsg_shutdown_wdb_fail(void **state)
     key.peer_info.ss_family = AF_INET6;
     size_t msg_length = sizeof(r_msg);
     int *wdb_sock = NULL;
-
-    expect_string(__wrap_send_msg, msg, "001");
-
-    expect_string(__wrap_rem_inc_send_ack, agent_id, "001");
 
     expect_string(__wrap_rem_inc_recv_ctrl_shutdown, agent_id, "001");
 


### PR DESCRIPTION
|Related issue|Manual Testing|
|---|---|
|https://github.com/wazuh/wazuh/issues/12776|https://github.com/wazuh/wazuh-qa/issues/3382|

## Description

This PR fix the problem with agents conections. Before when any control message was processed the socket number was assigned. So when a shutdown message arrived the socket was closed by the thread that handles incomming tcp connections before that message was processed. This caused a wrong mapping of the socket number to the previous value. This behaviour is now fixed by assigning the number of socket only when a start up message arrives.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Working on cluster environments
- [x] Configuration on demand reports new parameters
- [x] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)
- [x] Stress test for affected components
