### PR TITLE
Fix compilation on GCC 4.2.3 for HP-UX

### DIFF
--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -99,6 +99,11 @@
 #ifdef __cplusplus
 #include <atomic>
 #define _Atomic(T) std::atomic<T>
+#else
+#ifdef hpux
+// TODO: remove this line after upgrading GCC on HP-UX
+#define _Atomic(T) T
+#endif
 #endif
 
 #include <time.h>

--- a/src/os_crypto/shared/msgs.c
+++ b/src/os_crypto/shared/msgs.c
@@ -27,14 +27,14 @@ static void ReloadCounter(const keystore *keys, unsigned int id, const char * ci
 static char *CheckSum(char *msg, size_t length) __attribute((nonnull));
 
 /* Sending counts */
-static _Atomic unsigned int global_count = 0;
-static _Atomic unsigned int local_count  = 0;
+static _Atomic (unsigned int) global_count = 0;
+static _Atomic (unsigned int) local_count  = 0;
 
 /* Average compression rates */
-static _Atomic unsigned int evt_count = 0;
-static _Atomic unsigned int rcv_count = 0;
-static _Atomic size_t c_orig_size = 0;
-static _Atomic size_t c_comp_size = 0;
+static _Atomic (unsigned int) evt_count = 0;
+static _Atomic (unsigned int) rcv_count = 0;
+static _Atomic (size_t) c_orig_size = 0;
+static _Atomic (size_t) c_comp_size = 0;
 
 /* Global variables (read from define file) */
 unsigned int _s_comp_print = 0;


### PR DESCRIPTION
|Related issue|
|---|
|Fixes #15182|

## Description

PR #14981 fixed multiple race conditions found in wazuh-remoted. Some of them were fixed by adding the `_Atomic` modifier to data variables shared among threads. However, some of this code is shared between wazuh-remoted and wazuh-agentd.

`_Atomic` is supported by GCC 5 or above. However, we're building the agent on HP-UX using GCC 4.2.3. This makes the compilation fail on HP-UX.

This fix aims to let the agent be built on HP-UX by removing the `_Atomic` modifier. As the related race conditions affect wazuh-remoted only, we expect that this does not affect the agent.

Anyway, we will be able to revert this change after merging #9103, because that will make us upgrade GCC on HP-UX, which will support `_Atomic`.

## Tests

- [x] Manual compilation on HP-UX.