### PR TITLE
Bug fix for rule 91801 - 0915-win-powershell_rules.xml

### DIFF
--- a/ruleset/rules/0915-win-powershell_rules.xml
+++ b/ruleset/rules/0915-win-powershell_rules.xml
@@ -10,7 +10,7 @@
 
 <!-- Powershell Operational grouping -->
   <rule id="91801" level="0">
-    <if_sid>60000</if_sid>
+    <if_sid>60000,60009,60010,60011</if_sid>
     <field name="win.system.channel">^Microsoft-Windows-PowerShell/Operational$</field>
     <options>no_full_log</options>
     <description>Group of Windows rules for the Powershell/Operational channel.</description>


### PR DESCRIPTION
Updated the if_sid in the Grouping rule 91801 to include the correct parent rule IDs.

Reason for the Change:  
Depending on the severity level of the PowerShell EventLog, rules 60009, 60010 and 60011 will trigger after 60000. 
 --- The above 3 rules and are all tried before 91801. As such rule 91801 will never be matched unless the additional 3 if_sids are included.  




Excerpt of a logtest before the if_sid change (rule 91801 is never tried). 
    Trying rule: 60000 - Group of windows rules.
       *Rule 60000 matched.
       *Trying child rules.
    Trying rule: 60001 - Group of Windows rules for the security channel.
    Trying rule: 60002 - Group of Windows rules for the system channel.
    Trying rule: 60003 - Group of Windows rules for the application channel.
    Trying rule: 60004 - Group of Windows rules for the sysmon channel.
    Trying rule: 60005 - Group of Windows rules for the system channel.
    Trying rule: 60016 - Group of Microsoft Windows Diagnosis Scripted rules
    Trying rule: 60018 - Group of Microsoft Windows Management Instrumentation (WMI) rules.
    Trying rule: 60009 - Windows informational or verbose event
       *Rule 60009 matched.
       *Trying child rules.
    Trying rule: 64100 - Group of Windows rules for Remote Access
    Trying rule: 64104 - Group of Windows rules for Terminal Services








Example of testing Post change: (the rule is tried and matches). 
    Trying rule: 60000 - Group of windows rules.
       *Rule 60000 matched.
       *Trying child rules.
    Trying rule: 60001 - Group of Windows rules for the security channel.
    Trying rule: 60002 - Group of Windows rules for the system channel.
    Trying rule: 60003 - Group of Windows rules for the application channel.
    Trying rule: 60004 - Group of Windows rules for the sysmon channel.
    Trying rule: 60005 - Group of Windows rules for the system channel.
    Trying rule: 60016 - Group of Microsoft Windows Diagnosis Scripted rules
    Trying rule: 60018 - Group of Microsoft Windows Management Instrumentation (WMI) rules.
    Trying rule: 60009 - Windows informational or verbose event
       *Rule 60009 matched.
       *Trying child rules.
    Trying rule: 64100 - Group of Windows rules for Remote Access
    Trying rule: 64104 - Group of Windows rules for Terminal Services
    Trying rule: 91801 - Group of Windows rules for the Powershell/Operational channel.
       *Rule 91801 matched.
       *Trying child rules.
    Trying rule: 91802 - Group of Windows rules for the Powershell/Operational channel.
       *Rule 91802 matched.

|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] Dr. Memory
  - [x] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report
  - [x] Coverity
  - [x] Dr. Memory
- Memory tests for macOS
  - [x] Scan-build report
  - [x] Leaks
  - [x] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Working on cluster environments
- [x] Configuration on demand reports new parameters
- [x] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)
- [x] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [x] Added unit testing files ".ini"
  - [x] runtests.py executed without errors