### PR TITLE
Fix vulnerability API integration tests' healthcheck

### DIFF
--- a/api/test/integration/env/configurations/vulnerability/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/vulnerability/manager/healthcheck/healthcheck.py
@@ -30,8 +30,8 @@ def get_agents_node(status='active'):
         Dictionary like {agent_id: manager_name} if agents were obtained, else None.
     """
     try:
-        headers['Authorization'] = f'Bearer {get_response("POST", LOGIN_URL, headers)["data"]["token"]}'
-        response = get_response('GET', f'{BASE_URL}/agents?select=id,manager&status={status}',
+        headers['Authorization'] = f"Bearer {get_response('POST', LOGIN_URL, headers)['data']['token']}"
+        response = get_response("GET", f"{BASE_URL}/agents?select=id,manager&status={status}",
                                 headers)['data']['affected_items']
     except Exception:
         return


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/15192 |



## Description

This PR closes #15192 

In this pull request, I have updated the vulnerability API integration test health check.

Now the containers are healthy before the 20 minutes mentioned in the related issue as the health check is working properly.


```
CONTAINER ID   IMAGE                              COMMAND                  CREATED         STATUS                   PORTS                                           NAMES
bcb8efe2b962   integration_test_wazuh-agent_old   "/scripts/entrypoint…"   6 minutes ago   Up 6 minutes (healthy)                                                   env_wazuh-agent8_1
0d06cdfadc1f   integration_test_wazuh-agent_old   "/scripts/entrypoint…"   6 minutes ago   Up 6 minutes (healthy)                                                   env_wazuh-agent7_1
fcb231483c5c   integration_test_wazuh-agent_old   "/scripts/entrypoint…"   6 minutes ago   Up 6 minutes (healthy)                                                   env_wazuh-agent6_1
4151ac2f82d5   integration_test_wazuh-agent_old   "/scripts/entrypoint…"   6 minutes ago   Up 6 minutes (healthy)                                                   env_wazuh-agent5_1
20703837cab6   integration_test_wazuh-agent       "/scripts/entrypoint…"   6 minutes ago   Up 6 minutes (healthy)                                                   env_wazuh-agent4_1
7be80a974562   integration_test_wazuh-agent       "/scripts/entrypoint…"   6 minutes ago   Up 6 minutes (healthy)                                                   env_wazuh-agent3_1
942947d0abdf   integration_test_wazuh-agent       "/scripts/entrypoint…"   6 minutes ago   Up 6 minutes (healthy)                                                   env_wazuh-agent2_1
90a021531ea9   integration_test_wazuh-agent       "/scripts/entrypoint…"   6 minutes ago   Up 6 minutes (healthy)                                                   env_wazuh-agent1_1
1e02fec25841   integration_test_nginx-lb          "/scripts/entrypoint…"   6 minutes ago   Up 6 minutes             80/tcp                                          env_nginx-lb_1
7d734701ab8b   integration_test_wazuh-manager     "/scripts/entrypoint…"   6 minutes ago   Up 6 minutes (healthy)   0.0.0.0:55000->55000/tcp, :::55000->55000/tcp   env_wazuh-master_1
0a00cf468e47   integration_test_wazuh-manager     "/scripts/entrypoint…"   6 minutes ago   Up 6 minutes (healthy)                                                   env_wazuh-worker1_1
9223eac02a80   integration_test_wazuh-manager     "/scripts/entrypoint…"   6 minutes ago   Up 6 minutes (healthy)                                                   env_wazuh-worker2_1
```
                                                                                                       
                     
```                                                                                  
$ python3 run_tests.py -l test_vuln -m cluster
Collected tests [1]:
test_vulnerability_endpoints.tavern.yaml


test_vulnerability_endpoints.tavern.yaml - Cluster environment 
	 3 passed, 4 warnings
```
