### PR TITLE
Fix the handling of DB accesses in Vulnerability Detector

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -1165,8 +1165,6 @@ void test_wm_vuldet_linux_rm_nvd_not_affected_packages_vuln_count_failed_prepare
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5573): Couldn't verify if the vulnerability 'CVE-000-000' of the package 'test-wazuh' is already patched.");
 
-    will_return(__wrap_sqlite3_close_v2, 0);
-
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
 
@@ -1500,8 +1498,6 @@ void test_wm_vuldet_linux_rm_oval_not_affected_packages_source_failed_prepare_nv
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5584): Couldn't verify if the vulnerability 'CVE-000-000' is reported in the NVD feed.");
 
-    will_return(__wrap_sqlite3_close_v2, 0);
-
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
 
@@ -1579,8 +1575,6 @@ void test_wm_vuldet_linux_rm_oval_not_affected_packages_source_failed_prepare_ma
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5573): Couldn't verify if the vulnerability 'CVE-000-000' of the package 'test-wazuh' is already patched.");
-
-    will_return(__wrap_sqlite3_close_v2, 0);
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
@@ -1896,8 +1890,6 @@ void test_wm_vuldet_linux_rm_false_positives_error_removing_nvd_not_affected(voi
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5573): Couldn't verify if the vulnerability 'CVE-2016-6489' of the package 'libhogweed4' is already patched.");
 
-    will_return(__wrap_sqlite3_close_v2, 0);
-
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
 
@@ -1945,8 +1937,6 @@ void test_wm_vuldet_linux_rm_false_positives_error_removing_oval_not_affected(vo
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5584): Couldn't verify if the vulnerability 'CVE-2016-6489' is reported in the NVD feed.");
-
-    will_return(__wrap_sqlite3_close_v2, 0);
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
@@ -2431,8 +2421,6 @@ void test_wm_vuldet_generate_os_and_kernel_package_os_package_error(void **state
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
 
-    will_return(__wrap_sqlite3_close_v2, 0);
-
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "(5449): It was not possible to insert 'enterprise_linux' in the agent software table.");
 
@@ -2458,8 +2446,6 @@ void test_wm_vuldet_generate_os_and_kernel_package_kernel_package_error(void **s
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-
-    will_return(__wrap_sqlite3_close_v2, 0);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "(5449): It was not possible to insert 'linux_kernel' in the agent software table.");
@@ -2855,8 +2841,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_prepare_nvd_configured_year
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
 
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
-
     int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
     assert_int_equal(OS_INVALID, ret);
@@ -2917,8 +2901,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_prepare(void **state)
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
 
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
-
     int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
     assert_int_equal(OS_INVALID, ret);
@@ -2955,8 +2937,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_prepare_rh(void **state)
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
     int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
@@ -2995,8 +2975,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_prepare_deb(void **state)
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
 
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
-
     int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
     assert_int_equal(OS_INVALID, ret);
@@ -3033,8 +3011,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_prepare_amazon(void **state
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
     int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
@@ -3080,8 +3056,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_step(void **state)
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
     int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
@@ -4136,7 +4110,6 @@ void test_wm_vuldet_linux_oval_duplicated_cve_false_positive_os_invalid(void **s
     will_return(__wrap_sqlite3_errmsg, "error");
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
     int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
@@ -4330,7 +4303,6 @@ void test_wm_vuldet_oval_discard_mismatching_cve_entries_non_valid(void **state)
     will_return(__wrap_sqlite3_errmsg, "error");
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
     int ret = wm_vuldet_oval_discard_mismatching_cve_entries(db, agents_it, cve_id, pkg_version, pkg_name, vertype);
     assert_int_equal(ret, OS_INVALID);
@@ -4362,7 +4334,6 @@ void test_wm_vuldet_oval_discard_mismatching_cve_entries_set_error(void **state)
     will_return(__wrap_sqlite3_errmsg, "error");
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
     int ret = wm_vuldet_oval_discard_mismatching_cve_entries(db, agents_it, cve_id, pkg_version, pkg_name, vertype);
     assert_int_equal(ret, OS_INVALID);
@@ -5518,7 +5489,6 @@ void test_wm_vuldet_process_agent_vulnerabilities_fill_report_nvd_cve_info_error
     will_return(__wrap_sqlite3_errmsg, "error");
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
     int ret = wm_vuldet_process_agent_vulnerabilities(db, cve_table, agent, &scan_ctx);
 
@@ -5580,7 +5550,6 @@ void test_wm_vuldet_process_agent_vulnerabilities_fill_report_nvd_references_err
     will_return(__wrap_sqlite3_errmsg, "error");
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
     int ret = wm_vuldet_process_agent_vulnerabilities(db, cve_table, agent, &scan_ctx);
 
@@ -5654,7 +5623,6 @@ void test_wm_vuldet_process_agent_vulnerabilities_fill_report_nvd_scoring_error(
     will_return(__wrap_sqlite3_errmsg, "error");
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
     int ret = wm_vuldet_process_agent_vulnerabilities(db, cve_table, agent, &scan_ctx);
 
@@ -5697,7 +5665,6 @@ void test_wm_vuldet_process_agent_vulnerabilities_fill_report_oval_error(void **
     will_return(__wrap_sqlite3_errmsg, "error");
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
     int ret = wm_vuldet_process_agent_vulnerabilities(db, cve_table, agent, &scan_ctx);
 
@@ -6414,7 +6381,6 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_adding_data_fr
     will_return(__wrap_sqlite3_errmsg, "error");
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
     int ret = wm_vuldet_process_agent_vulnerabilities(db, cve_table, agent, &scan_ctx);
 
@@ -9728,8 +9694,6 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_oval_vulnerabilities_
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
 
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
-
     will_return(__wrap_OSHash_Clean, 0);
 
     int ret = wm_vuldet_find_agent_vulnerabilities(db, agent, NULL, &scan_ctx);
@@ -9930,8 +9894,6 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_rm_false_positives_er
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5573): Couldn't verify if the vulnerability 'CVE-2016-6489' of the package 'libhogweed4' is already patched.");
 
-    will_return(__wrap_sqlite3_close_v2, 0);
-
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
 
@@ -10095,7 +10057,6 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_process_agent_vulnerabiliti
     will_return(__wrap_sqlite3_errmsg, "error");
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
     will_return(__wrap_OSHash_Clean, 0);
 
@@ -10819,6 +10780,12 @@ void test_wm_vuldet_check_timestamp_open_error()
     will_return(__wrap_sqlite3_open_v2, NULL); // sqlite db
     will_return(__wrap_sqlite3_open_v2, SQLITE_ERROR);
 
+    // wm_vuldet_sql_error
+    will_return(__wrap_sqlite3_errmsg, "error");
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
+    will_return(__wrap_sqlite3_close_v2, 1);
+
     int ret = wm_vuldet_check_timestamp(NULL, NULL, NULL);
     assert_int_equal(ret, VU_TIMESTAMP_FAIL);
 }
@@ -10831,6 +10798,11 @@ void test_wm_vuldet_check_timestamp_prepare_error()
     will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_ERROR);
+
+    // wm_vuldet_sql_error
+    will_return(__wrap_sqlite3_errmsg, "error");
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
     will_return(__wrap_sqlite3_close_v2, 1);
 
     int ret = wm_vuldet_check_timestamp(NULL, NULL, NULL);
@@ -11163,7 +11135,10 @@ void test_wm_vuldet_fetch_oval_ubuntu_failed()
     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
     will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_ERROR);
-
+    // wm_vuldet_sql_error
+    will_return(__wrap_sqlite3_errmsg, "error");
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
     will_return(__wrap_sqlite3_close_v2, 1);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
@@ -15720,8 +15695,6 @@ void test_wm_vuldet_index_debian_prepare_error(void **state)
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
 
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
-
     int ret = wm_vuldet_index_debian(db, target, update);
 
     assert_int_equal(ret, -1);
@@ -15829,8 +15802,6 @@ void test_wm_vuldet_index_debian_step_error(void **state)
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-
-    will_return(__wrap_sqlite3_close_v2, SQLITE_ERROR);
 
     int ret = wm_vuldet_index_debian(db, target, update);
 
@@ -17801,7 +17772,6 @@ void test_wm_vuldet_get_arch_id_prepare_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "error");
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-    will_return(__wrap_sqlite3_close_v2, 1);
 
     int ret = wm_vuldet_get_arch_id(db, CVE_id, target, name, version, &id);
     assert_int_equal(ret, OS_INVALID);
@@ -17839,7 +17809,6 @@ void test_wm_vuldet_insert_ALAS_cve_prepare_error(void **state) {
     will_return(__wrap_sqlite3_errmsg, "error");
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-    will_return(__wrap_sqlite3_close_v2, 1);
 
     ret = wm_vuldet_insert_ALAS(db, alas_it, target);
     assert_int_equal(ret, OS_INVALID);
@@ -17890,11 +17859,9 @@ void test_wm_vuldet_insert_ALAS_cve_step_error(void **state) {
     expect_value(__wrap_sqlite3_bind_int, value, 1);    // arch_id
     expect_sqlite3_step_call(SQLITE_ERROR);
 
-    // wm_vuldet_sql_error
     will_return(__wrap_sqlite3_errmsg, "error");
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-    will_return(__wrap_sqlite3_close_v2, 1);
 
     ret = wm_vuldet_insert_ALAS(db, alas_it, target);
     assert_int_equal(ret, OS_INVALID);
@@ -17929,11 +17896,9 @@ void test_wm_vuldet_insert_ALAS_arch_prepare_error(void **state) {
     // wm_vuldet_insert_ALAS (insert architectures)
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_ERROR);
 
-    // wm_vuldet_sql_error
     will_return(__wrap_sqlite3_errmsg, "error");
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-    will_return(__wrap_sqlite3_close_v2, 1);
 
     ret = wm_vuldet_insert_ALAS(db, alas_it, target);
     assert_int_equal(ret, OS_INVALID);
@@ -17977,11 +17942,9 @@ void test_wm_vuldet_insert_ALAS_arch_step_error(void **state) {
     expect_string(__wrap_sqlite3_bind_text, buffer, architecture);
     expect_sqlite3_step_call(SQLITE_ERROR);
 
-    // wm_vuldet_sql_error
     will_return(__wrap_sqlite3_errmsg, "error");
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-    will_return(__wrap_sqlite3_close_v2, 1);
 
     ret = wm_vuldet_insert_ALAS(db, alas_it, target);
     assert_int_equal(ret, OS_INVALID);
@@ -18028,11 +17991,9 @@ void test_wm_vuldet_insert_ALAS_ref_prepare_error(void **state) {
     // wm_vuldet_insert_ALAS (insert references)
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_ERROR);
 
-    // wm_vuldet_sql_error
     will_return(__wrap_sqlite3_errmsg, "error");
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-    will_return(__wrap_sqlite3_close_v2, 1);
 
     ret = wm_vuldet_insert_ALAS(db, alas_it, target);
     assert_int_equal(ret, OS_INVALID);
@@ -18087,11 +18048,9 @@ void test_wm_vuldet_insert_ALAS_ref_step_error(void **state) {
     expect_string(__wrap_sqlite3_bind_text, buffer, reference);
     expect_sqlite3_step_call(SQLITE_ERROR);
 
-    // wm_vuldet_sql_error
     will_return(__wrap_sqlite3_errmsg, "error");
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-    will_return(__wrap_sqlite3_close_v2, 1);
 
     ret = wm_vuldet_insert_ALAS(db, alas_it, target);
     assert_int_equal(ret, OS_INVALID);
@@ -18980,6 +18939,11 @@ void test_wm_vuldet_check_feed_metadata_valid_MSU_metadata(void **state)
     expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
     will_return(__wrap_sqlite3_open_v2, NULL);
     will_return(__wrap_sqlite3_open_v2, SQLITE_ERROR);
+    // wm_vuldet_sql_error
+    will_return(__wrap_sqlite3_errmsg, "error");
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
+    will_return(__wrap_sqlite3_close_v2, 1);
 
     // Insert
     feed_metadata msu = {0};
@@ -19135,6 +19099,11 @@ void test_wm_vuldet_check_feed_metadata_valid_ALAS_metadata(void **state)
     expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
     will_return(__wrap_sqlite3_open_v2, NULL);
     will_return(__wrap_sqlite3_open_v2, SQLITE_ERROR);
+    // wm_vuldet_sql_error
+    will_return(__wrap_sqlite3_errmsg, "error");
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
+    will_return(__wrap_sqlite3_close_v2, 1);
 
     // Insert
     feed_metadata alas = {0};

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector_nvd.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector_nvd.c
@@ -219,8 +219,6 @@ void test_wm_vuldet_get_children_prepare_error(void **state)
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
 
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
-
     int ret = wm_vuldet_get_children(db, configuration_id, package_id, children);
     assert_int_equal(ret, -1);
 }
@@ -292,8 +290,6 @@ void test_wm_vuldet_get_siblings_prepare_error(void **state)
     expect_string(__wrap__mterror, formatted_msg, "(5571): Couldn't get from the NVD the 'siblings' dependencies of the package with ID '0'");
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
     int ret = wm_vuldet_get_siblings(db, configuration_id, parent, siblings);
     assert_int_equal(ret, -1);
@@ -515,8 +511,6 @@ void test_wm_vuldet_check_generic_package_prepare_error(void **state)
     expect_string(__wrap__mterror, formatted_msg, "(5570): Couldn't get from the NVD the 'generic' vulnerabilities of the package 'test'");
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
     int ret = wm_vuldet_check_generic_package(db,
                                               FEED_DEBIAN,
@@ -1729,8 +1723,6 @@ void test_wm_vuldet_check_generic_package_children_invalid(void **state)
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
 
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
-
     int ret = wm_vuldet_check_generic_package(db,
                                               FEED_DEBIAN,
                                               pkg_name,
@@ -1899,8 +1891,6 @@ void test_wm_vuldet_check_generic_package_siblings_invalid(void **state)
     expect_string(__wrap__mterror, formatted_msg, "(5571): Couldn't get from the NVD the 'siblings' dependencies of the package with ID '0'");
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
     int ret = wm_vuldet_check_generic_package(db,
                                               FEED_DEBIAN,
@@ -3484,8 +3474,6 @@ void test_wm_vuldet_check_specific_package_prepare_error(void **state)
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
 
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
-
     int ret = wm_vuldet_check_specific_package(db,
                                                FEED_DEBIAN,
                                                pkg_name,
@@ -3871,8 +3859,6 @@ void test_wm_vuldet_check_specific_package_children_invalid(void **state)
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
 
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
-
     int ret = wm_vuldet_check_specific_package(db,
                                                FEED_DEBIAN,
                                                pkg_name,
@@ -4031,8 +4017,6 @@ void test_wm_vuldet_check_specific_package_siblings_invalid(void **state)
     expect_string(__wrap__mterror, formatted_msg, "(5571): Couldn't get from the NVD the 'siblings' dependencies of the package with ID '0'");
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
     int ret = wm_vuldet_check_specific_package(db,
                                                FEED_DEBIAN,
@@ -5560,8 +5544,6 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_prepare_error(void **state)
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
 
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
-
     int ret = wm_vuldet_linux_nvd_vulnerabilities(db, agent, cve_table);
     assert_int_equal(ret, -1);
 }
@@ -5687,8 +5669,6 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_source_generic_invalid(void **stat
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
 
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
-
     int ret = wm_vuldet_linux_nvd_vulnerabilities(db, agent, cve_table);
     assert_int_equal(ret, -1);
 }
@@ -5797,8 +5777,6 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_source_specific_invalid(void **sta
     expect_string(__wrap__mterror, formatted_msg, "(5570): Couldn't get from the NVD the 'specific' vulnerabilities of the package 'source'");
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
     int ret = wm_vuldet_linux_nvd_vulnerabilities(db, agent, cve_table);
     assert_int_equal(ret, -1);
@@ -6124,8 +6102,6 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_name_generic_invalid(void **state)
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
 
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
-
     int ret = wm_vuldet_linux_nvd_vulnerabilities(db, agent, cve_table);
     assert_int_equal(ret, -1);
 }
@@ -6234,8 +6210,6 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_name_specific_invalid(void **state
     expect_string(__wrap__mterror, formatted_msg, "(5570): Couldn't get from the NVD the 'specific' vulnerabilities of the package 'name'");
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
-
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
     int ret = wm_vuldet_linux_nvd_vulnerabilities(db, agent, cve_table);
     assert_int_equal(ret, -1);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -101,10 +101,9 @@ STATIC int wm_vuldet_check_db();
  * @brief Insert the CVEs information, fetched from the feeds, into VULNERABILITIES_INFO table.
  * @param parsed_oval The feed's information.
  * @param db SQLite3 Database pointer.
- * @param stmt SQL query statement pointer.
  * @return 0 if success.
  */
-STATIC int wm_vuldet_insert_cve_info(wm_vuldet_db *parsed_oval, sqlite3 *db, sqlite3_stmt *stmt);
+STATIC int wm_vuldet_insert_cve_info(wm_vuldet_db *parsed_oval, sqlite3 *db);
 
 STATIC int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update);
 STATIC int wm_vuldet_remove_target_table(sqlite3 *db, char *TABLE, const char *target);
@@ -680,7 +679,7 @@ int wm_vuldet_create_file(const char *path, const char *source) {
     const char *ROOT = "root";
     const char *sql;
     const char *tail;
-    sqlite3 *db;
+    sqlite3 *db = NULL;
     sqlite3_stmt *stmt = NULL;
     int result;
     uid_t uid;
@@ -1567,7 +1566,9 @@ int wm_vuldet_process_agent_vulnerabilities(sqlite3 *db, OSHash *cve_table, scan
 error:
 
     wm_vuldet_free_report(report);
-    return wm_vuldet_sql_error(db, stmt);
+    mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+    wdb_finalize(stmt);
+    return OS_INVALID;
 }
 
 int wm_vuldet_send_cve_report(vu_report *report) {
@@ -1886,7 +1887,9 @@ int wm_vuldet_linux_rm_nvd_not_affected_packages(sqlite3 *db, scan_agent *agent,
             if (!pkg->discard) {
                 if (wm_vuldet_prepare(db, vu_queries[VU_GET_VULN_COUNT], -1, &stmt, NULL) != SQLITE_OK) {
                     mterror(WM_VULNDETECTOR_LOGTAG, VU_FILTER_VULN_ERROR, cve, pkg->bin_name);
-                    return wm_vuldet_sql_error(db, stmt);
+                    mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                    wdb_finalize(stmt);
+                    return OS_INVALID;
                 }
 
                 sqlite3_bind_text(stmt, 1, cve, -1, NULL);
@@ -2011,7 +2014,9 @@ int wm_vuldet_linux_rm_oval_not_affected_packages(sqlite3 *db, const char *cve, 
 
             if (wm_vuldet_prepare(db, vu_queries[VU_GET_NVD_CVE_COUNT], -1, &stmt, NULL) != SQLITE_OK) {
                 mterror(WM_VULNDETECTOR_LOGTAG, VU_FILTER_VULN_NVD_ERROR, cve);
-                return wm_vuldet_sql_error(db, stmt);
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                wdb_finalize(stmt);
+                return OS_INVALID;
             }
 
             sqlite3_bind_text(stmt, 1, cve, -1, NULL);
@@ -2024,7 +2029,9 @@ int wm_vuldet_linux_rm_oval_not_affected_packages(sqlite3 *db, const char *cve, 
 
                 if (wm_vuldet_prepare(db, vu_queries[VU_GET_NVD_MATCHES_COUNT], -1, &stmt, NULL) != SQLITE_OK) {
                     mterror(WM_VULNDETECTOR_LOGTAG, VU_FILTER_VULN_ERROR, cve, pkg->bin_name);
-                    return wm_vuldet_sql_error(db, stmt);
+                    mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                    wdb_finalize(stmt);
+                    return OS_INVALID;
                 }
 
                 sqlite3_bind_text(stmt, 1, cve, -1, NULL);
@@ -2160,7 +2167,9 @@ int wm_vuldet_oval_discard_mismatching_cve_entries(sqlite3 *db, scan_agent *agen
     }
 
     if (wm_vuldet_prepare(db, query, -1, &stmt, NULL) != SQLITE_OK) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     sqlite3_bind_text(stmt, 1, vu_feed_tag[agents_it->dist_ver], -1, NULL);
@@ -2177,7 +2186,9 @@ int wm_vuldet_oval_discard_mismatching_cve_entries(sqlite3 *db, scan_agent *agen
     }
 
     if (result != SQLITE_DONE && result != SQLITE_ROW) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     wdb_finalize(stmt);
@@ -2201,7 +2212,9 @@ int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, scan_agent *agents_it, OSH
     // Getting the configured NVD year
     if (wm_vuldet_prepare(db, vu_queries[VU_GET_NVD_CONFIGURED_YEAR], -1, &stmt, NULL) != SQLITE_OK) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_GET_NVD_YEAR_ERROR);
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     if (SQLITE_ROW != wm_vuldet_step(stmt)) {
@@ -2241,7 +2254,9 @@ int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, scan_agent *agents_it, OSH
 
     if (wm_vuldet_prepare(db, query, -1, &stmt, NULL) != SQLITE_OK) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_GET_PACKAGES_ERROR, scan_ctx->agent_id);
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     sqlite3_bind_text(stmt, 1, vu_feed_tag[agents_it->dist_ver], -1, NULL);
@@ -2258,7 +2273,9 @@ int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, scan_agent *agents_it, OSH
         wdb_finalize(stmt);
         return 0;
     default:
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     do {
@@ -2500,7 +2517,7 @@ int wm_vuldet_find_obsolete_vulnerabilities(scan_ctx_t* scan_ctx) {
 
 int wm_vuldet_check_agent_vulnerabilities(wm_vuldet_t *vuldet) {
     scan_agent *agents_it;
-    sqlite3 *db;
+    sqlite3 *db = NULL;
     sqlite3_stmt *stmt = NULL;
     bool retry_agents = false;
     bool abort_scan = false;
@@ -2636,19 +2653,23 @@ int wm_vuldet_remove_target_table(sqlite3 *db, char *TABLE, const char *target) 
     size_t size;
 
     if (size = snprintf(sql, MAX_QUERY_SIZE, vu_queries[VU_REMOVE_OS], TABLE), sql[size - 1] != ';') {
-        sqlite3_close_v2(db);
         return OS_INVALID;
     }
 
     if (wm_vuldet_prepare(db, sql, -1, &stmt, NULL) != SQLITE_OK) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     sqlite3_bind_text(stmt, 1, target, -1, NULL);
 
     if (wm_vuldet_step(stmt) != SQLITE_DONE) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
+
     wdb_finalize(stmt);
 
     return 0;
@@ -2798,7 +2819,9 @@ int wm_vuldet_index_debian(sqlite3 *db, const char *target, update_node *update)
             if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_CVE], -1, &stmt, NULL) != SQLITE_OK) {
                 os_free(target_lower);
                 cJSON_Delete(deb_json);
-                return wm_vuldet_sql_error(db, stmt);
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                wdb_finalize(stmt);
+                return OS_INVALID;
             }
 
             sqlite3_bind_text(stmt, 1, cve, -1, NULL);
@@ -2813,7 +2836,9 @@ int wm_vuldet_index_debian(sqlite3 *db, const char *target, update_node *update)
             if (wm_vuldet_step(stmt) != SQLITE_DONE) {
                 os_free(target_lower);
                 cJSON_Delete(deb_json);
-                return wm_vuldet_sql_error(db, stmt);
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                wdb_finalize(stmt);
+                return OS_INVALID;
             }
 
             wdb_finalize(stmt);
@@ -2827,13 +2852,16 @@ int wm_vuldet_index_debian(sqlite3 *db, const char *target, update_node *update)
     return 0;
 }
 
-int wm_vuldet_insert_cve_info(wm_vuldet_db *parsed_oval, sqlite3 *db, sqlite3_stmt *stmt) {
+int wm_vuldet_insert_cve_info(wm_vuldet_db *parsed_oval, sqlite3 *db) {
     info_cve *info_it = parsed_oval->info_cves;
+    sqlite3_stmt *stmt = NULL;
     int result;
 
     while (info_it) {
         if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_CVE_INFO], -1, &stmt, NULL) != SQLITE_OK) {
-            return wm_vuldet_sql_error(db, stmt);
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+            wdb_finalize(stmt);
+            return OS_INVALID;
         }
 
         sqlite3_bind_text(stmt, 1, info_it->cveid, -1, NULL);
@@ -2850,7 +2878,9 @@ int wm_vuldet_insert_cve_info(wm_vuldet_db *parsed_oval, sqlite3 *db, sqlite3_st
         sqlite3_bind_text(stmt, 12, info_it->cwe, -1, NULL);
 
         if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
-            return wm_vuldet_sql_error(db, stmt);
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+            wdb_finalize(stmt);
+            return OS_INVALID;
         }
         wdb_finalize(stmt);
 
@@ -2858,13 +2888,17 @@ int wm_vuldet_insert_cve_info(wm_vuldet_db *parsed_oval, sqlite3 *db, sqlite3_st
         int j;
         for (j = 0; info_it->refs && (j < info_it->refs->elements) && info_it->refs->values[j]; j++) {
             if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_REF_INFO], -1, &stmt, NULL) != SQLITE_OK) {
-                return wm_vuldet_sql_error(db, stmt);
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                wdb_finalize(stmt);
+                return OS_INVALID;
             }
             sqlite3_bind_text(stmt, 1, info_it->cveid, -1, NULL);
             sqlite3_bind_text(stmt, 2, parsed_oval->OS, -1, NULL);
             sqlite3_bind_text(stmt, 3, info_it->refs->values[j], -1, NULL);
             if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
-                return wm_vuldet_sql_error(db, stmt);
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                wdb_finalize(stmt);
+                return OS_INVALID;
             }
             wdb_finalize(stmt);
         }
@@ -2872,13 +2906,17 @@ int wm_vuldet_insert_cve_info(wm_vuldet_db *parsed_oval, sqlite3 *db, sqlite3_st
         // Saving the bugzilla references corresponding to the current CVE
         for (j = 0; info_it->bugzilla_references && (j < info_it->bugzilla_references->elements) && info_it->bugzilla_references->values[j]; j++) {
             if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_BUG_REF_INFO], -1, &stmt, NULL) != SQLITE_OK) {
-                return wm_vuldet_sql_error(db, stmt);
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                wdb_finalize(stmt);
+                return OS_INVALID;
             }
             sqlite3_bind_text(stmt, 1, info_it->cveid, -1, NULL);
             sqlite3_bind_text(stmt, 2, parsed_oval->OS, -1, NULL);
             sqlite3_bind_text(stmt, 3, info_it->bugzilla_references->values[j], -1, NULL);
             if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
-                return wm_vuldet_sql_error(db, stmt);
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                wdb_finalize(stmt);
+                return OS_INVALID;
             }
             wdb_finalize(stmt);
         }
@@ -2887,13 +2925,17 @@ int wm_vuldet_insert_cve_info(wm_vuldet_db *parsed_oval, sqlite3 *db, sqlite3_st
         // Saving the advisories corresponding to the current CVE
         for (j = 0; info_it->advisories && (j < info_it->advisories->elements) && info_it->advisories->values[j]; j++) {
             if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_ADVISORY_INFO], -1, &stmt, NULL) != SQLITE_OK) {
-                return wm_vuldet_sql_error(db, stmt);
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                wdb_finalize(stmt);
+                return OS_INVALID;
             }
             sqlite3_bind_text(stmt, 1, info_it->cveid, -1, NULL);
             sqlite3_bind_text(stmt, 2, parsed_oval->OS, -1, NULL);
             sqlite3_bind_text(stmt, 3, info_it->advisories->values[j], -1, NULL);
             if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
-                return wm_vuldet_sql_error(db, stmt);
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                wdb_finalize(stmt);
+                return OS_INVALID;
             }
             wdb_finalize(stmt);
         }
@@ -2905,7 +2947,7 @@ int wm_vuldet_insert_cve_info(wm_vuldet_db *parsed_oval, sqlite3 *db, sqlite3_st
 }
 
 int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
-    sqlite3 *db;
+    sqlite3 *db = NULL;
     sqlite3_stmt *stmt = NULL;
     int result;
     const char *query;
@@ -2930,34 +2972,39 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
     switch (update->dist_ref) {
         case FEED_REDHAT:
             if (wm_vuldet_remove_target_table(db, ARCHITECTURES_TABLE, parsed_oval->OS) ||
-                wm_vuldet_remove_target_table(db, CVE_TABLE, parsed_oval->OS)) {
+                    wm_vuldet_remove_target_table(db, CVE_TABLE, parsed_oval->OS)) {
+                sqlite3_close_v2(db);
                 return OS_INVALID;
             }
             break;
         case FEED_UBUNTU:
         case FEED_DEBIAN:
             if (wm_vuldet_remove_target_table(db, CVE_TABLE, parsed_oval->OS)      ||
-                wm_vuldet_remove_target_table(db, METADATA_TABLE, parsed_oval->OS) ||
-                wm_vuldet_remove_target_table(db, CVE_INFO_TABLE, parsed_oval->OS) ||
-                wm_vuldet_remove_target_table(db, VARIABLES_TABLE, parsed_oval->OS)) {
+                    wm_vuldet_remove_target_table(db, METADATA_TABLE, parsed_oval->OS) ||
+                    wm_vuldet_remove_target_table(db, CVE_INFO_TABLE, parsed_oval->OS) ||
+                    wm_vuldet_remove_target_table(db, VARIABLES_TABLE, parsed_oval->OS)) {
+                sqlite3_close_v2(db);
                 return OS_INVALID;
             }
         break;
         case FEED_CPEW:
             if (wm_vuldet_clean_wcpe(db)) {
+                sqlite3_close_v2(db);
                 return OS_INVALID;
             }
         break;
         case FEED_ARCH:
             if (wm_vuldet_remove_target_table(db, CVE_TABLE, parsed_oval->OS) ||
-                wm_vuldet_remove_target_table(db, CVE_INFO_TABLE, parsed_oval->OS)) {
+                    wm_vuldet_remove_target_table(db, CVE_INFO_TABLE, parsed_oval->OS)) {
+                sqlite3_close_v2(db);
                 return OS_INVALID;
             }
             break;
         case FEED_ALAS:
             if (wm_vuldet_remove_target_table(db, CVE_TABLE, parsed_oval->OS) ||
-                wm_vuldet_remove_target_table(db, ARCHITECTURES_TABLE, parsed_oval->OS) ||
-                wm_vuldet_remove_target_table(db, CVE_REF_TABLE, parsed_oval->OS)) {
+                    wm_vuldet_remove_target_table(db, ARCHITECTURES_TABLE, parsed_oval->OS) ||
+                    wm_vuldet_remove_target_table(db, CVE_REF_TABLE, parsed_oval->OS)) {
+                sqlite3_close_v2(db);
                 return OS_INVALID;
             }
         break;
@@ -2989,6 +3036,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
 
         if (wm_vuldet_insert_cpe_dic(db, w_cpes_it)){
             mterror(WM_VULNDETECTOR_LOGTAG, VU_CPES_INSERT_ERROR);
+            sqlite3_close_v2(db);
             return OS_INVALID;
         }
         free(w_cpes_it);
@@ -2998,6 +3046,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_INS_MSU);
 
         if (wm_vuldet_insert_MSU(db, msu_it)){
+            sqlite3_close_v2(db);
             return OS_INVALID;
         }
     }
@@ -3006,6 +3055,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_INS_VUL_SEC, "ALAS");
 
         if (wm_vuldet_insert_ALAS(db, alas_it, vu_feed_tag[update->dist_tag_ref])){
+            sqlite3_close_v2(db);
             return OS_INVALID;
         }
     }
@@ -3013,8 +3063,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
     if (nvd_it) {
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_INS_VUL_SEC, "NVD");
         if (wm_vuldet_index_nvd(db, update, nvd_it)) {
-            wm_vuldet_sql_error(db, stmt);
-            return OS_INVALID;
+            return wm_vuldet_sql_error(db, stmt);
         }
         parsed_oval->nvd_vulnerabilities = NULL;
     }
@@ -3273,7 +3322,8 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
     // Discard the CVE info from the RHEL OVALs
     if (parsed_oval->info_cves && (update->dist_ref != FEED_REDHAT)) {
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_UPDATE_VU_INFO, update->dist_ext);
-        if (result = wm_vuldet_insert_cve_info(parsed_oval, db, stmt), result) {
+        if (result = wm_vuldet_insert_cve_info(parsed_oval, db), result) {
+            sqlite3_close_v2(db);
             return result;
         }
     }
@@ -3310,6 +3360,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
 
     sqlite3_exec(db, vu_queries[END_T], NULL, NULL, NULL);
     sqlite3_close_v2(db);
+
     return 0;
 }
 
@@ -4421,12 +4472,15 @@ int wm_vuldet_check_timestamp(const char *target, char *timst, char *ret_timst) 
     sqlite3 *db = NULL;
 
     if (sqlite3_open_v2(CVE_DB, &db, SQLITE_OPEN_READWRITE, NULL) != SQLITE_OK) {
-        goto end;
+        wm_vuldet_sql_error(db, stmt);
+        return retval;
     } else {
         if (wm_vuldet_prepare(db, vu_queries[TIMESTAMP_QUERY], -1, &stmt, NULL) != SQLITE_OK) {
-            goto end;
+            wm_vuldet_sql_error(db, stmt);
+            return retval;
         }
         sqlite3_bind_text(stmt, 1, target, -1, NULL);
+        retval = VU_TIMESTAMP_OUTDATED;
         if (wm_vuldet_step(stmt) == SQLITE_ROW) {
             if (stored_timestamp = (const char *) sqlite3_column_text(stmt, 0), stored_timestamp) {
                 if (!strcmp(stored_timestamp, timst)) {
@@ -4434,17 +4488,14 @@ int wm_vuldet_check_timestamp(const char *target, char *timst, char *ret_timst) 
                     if (ret_timst) {
                         snprintf(ret_timst, OS_SIZE_256, "%s", stored_timestamp);
                     }
-                    goto end;
                 }
             }
         }
-        retval = VU_TIMESTAMP_OUTDATED;
     }
-end:
-    if (db) {
-        sqlite3_close_v2(db);
-    }
+
+    sqlite3_close_v2(db);
     wdb_finalize(stmt);
+
     return retval;
 }
 
@@ -4487,12 +4538,13 @@ int wm_vuldet_fetch_feed(update_node *update, int8_t *need_update) {
 
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_METADATA_CLEAN, vu_feed_tag[update->dist_tag_ref]);
 
-        sqlite3 *db;
+        sqlite3 *db = NULL;
         if (sqlite3_open_v2(CVE_DB, &db, SQLITE_OPEN_READWRITE, NULL) != SQLITE_OK) {
             return wm_vuldet_sql_error(db, NULL);
         }
 
         if (wm_vuldet_remove_target_table(db, METADATA_TABLE, vu_feed_tag[update->dist_tag_ref])) {
+            sqlite3_close_v2(db);
             return OS_INVALID;
         }
 
@@ -5739,7 +5791,9 @@ int wm_vuldet_db_empty(sqlite3 *db, vu_feed version) {
     int result = 0;
 
     if (wm_vuldet_prepare(db, vu_queries[VU_CHECK_DB_CONTENT], -1, &stmt, NULL) != SQLITE_OK) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     sqlite3_bind_text(stmt, 1, vu_feed_tag[version], -1, NULL);
@@ -5757,7 +5811,7 @@ int wm_vuldet_db_empty(sqlite3 *db, vu_feed version) {
 }
 
 int wm_vuldet_nvd_empty() {
-    sqlite3 *db;
+    sqlite3 *db = NULL;
     sqlite3_stmt *stmt = NULL;
     int result;
 
@@ -6217,7 +6271,7 @@ int wm_vuldet_insert_agent_data(sqlite3 *db,
     }
 
     if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_AGENTS], -1, &stmt, NULL) != SQLITE_OK) {
-        wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
         goto end;
     }
 
@@ -6265,7 +6319,7 @@ int wm_vuldet_insert_agent_data(sqlite3 *db,
     }
 
     if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
-        wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
         goto end;
     }
 
@@ -6928,7 +6982,7 @@ int wm_vuldet_insert_cpe_dic(sqlite3 *db, vu_cpe_dic *w_cpes) {
     int i;
     int entry_id;
     vu_cpe_dic_node *node_it;
-    sqlite3_stmt *stmt;
+    sqlite3_stmt *stmt = NULL;
 
     sqlite3_exec(db, vu_queries[VU_REMOVE_CPE_DIC], NULL, NULL, NULL);
 
@@ -6936,13 +6990,17 @@ int wm_vuldet_insert_cpe_dic(sqlite3 *db, vu_cpe_dic *w_cpes) {
         for (node_it = w_cpes->targets[i]; node_it; node_it = wm_vuldet_free_dic_node(node_it), entry_id++) {
 
             if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_CPE_HELPER], -1, &stmt, NULL) != SQLITE_OK) {
-                return wm_vuldet_sql_error(db, stmt);
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                wdb_finalize(stmt);
+                return OS_INVALID;
             }
             sqlite3_bind_int(stmt, 1, entry_id);
             sqlite3_bind_text(stmt, 2, w_cpes->targets_name[i], -1, NULL);
             sqlite3_bind_int(stmt, 3, node_it->action);
             if (wm_vuldet_step(stmt) != SQLITE_DONE) {
-                return wm_vuldet_sql_error(db, stmt);
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                wdb_finalize(stmt);
+                return OS_INVALID;
             }
             wdb_finalize(stmt);
 
@@ -6959,7 +7017,9 @@ int wm_vuldet_insert_cpe_dic(sqlite3 *db, vu_cpe_dic *w_cpes) {
     os_free(w_cpes->targets);
 
     if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_METADATA], -1, &stmt, NULL) != SQLITE_OK) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     sqlite3_bind_text(stmt, 1, vu_feed_tag[FEED_CPEW], -1, NULL);
@@ -6972,7 +7032,9 @@ int wm_vuldet_insert_cpe_dic(sqlite3 *db, vu_cpe_dic *w_cpes) {
     sqlite3_bind_int(stmt, 8, 0);
 
     if (wm_vuldet_step(stmt) != SQLITE_DONE) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
     wdb_finalize(stmt);
 
@@ -6984,7 +7046,7 @@ int wm_vuldet_insert_cpe_dic(sqlite3 *db, vu_cpe_dic *w_cpes) {
 }
 
 int wm_vuldet_insert_cpe_dic_array(sqlite3 *db, vu_query query, int id, vu_cpe_dic_section *section) {
-    sqlite3_stmt *stmt;
+    sqlite3_stmt *stmt = NULL;
     int type_value;
     int pattern_it, subpattern_it;
     char ***section_it;
@@ -7026,7 +7088,9 @@ int wm_vuldet_insert_cpe_dic_array(sqlite3 *db, vu_query query, int id, vu_cpe_d
                 char *condition = NULL;
 
                 if (wm_vuldet_prepare(db, vu_queries[query], -1, &stmt, NULL) != SQLITE_OK) {
-                    return wm_vuldet_sql_error(db, stmt);
+                    mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                    wdb_finalize(stmt);
+                    return OS_INVALID;
                 }
 
                 cterm = !*section_it[pattern_it][subpattern_it] &&
@@ -7057,7 +7121,9 @@ int wm_vuldet_insert_cpe_dic_array(sqlite3 *db, vu_query query, int id, vu_cpe_d
                     free(term);
                     free(comp_field);
                     free(condition);
-                    return wm_vuldet_sql_error(db, stmt);
+                    mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                    wdb_finalize(stmt);
+                    return OS_INVALID;
                 }
 
                 wdb_finalize(stmt);
@@ -7334,13 +7400,17 @@ int wm_vuldet_remove_sequence(sqlite3 *db, char *table) {
     sqlite3_stmt *stmt = NULL;
 
     if (wm_vuldet_prepare(db, vu_queries[VU_REMOVE_SQUENCE], -1, &stmt, NULL) != SQLITE_OK) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     sqlite3_bind_text(stmt, 1, table, -1, NULL);
 
     if (wm_vuldet_step(stmt) != SQLITE_DONE) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
     wdb_finalize(stmt);
 
@@ -7353,13 +7423,17 @@ int wm_vuldet_remove_table(sqlite3 *db, char *table) {
 
     snprintf(query, OS_SIZE_128, vu_queries[DELETE_QUERY], table);
     if (wm_vuldet_prepare(db, query, -1, &stmt, NULL) != SQLITE_OK) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     sqlite3_bind_text(stmt, 1, table, -1, NULL);
 
     if (wm_vuldet_step(stmt) != SQLITE_DONE) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
     wdb_finalize(stmt);
 
@@ -7413,12 +7487,14 @@ int wm_vuldet_clean_rh(sqlite3 *db) {
         if (sqlite3_open_v2(CVE_DB, &db, SQLITE_OPEN_READWRITE, NULL) != SQLITE_OK) {
             return wm_vuldet_sql_error(db, NULL);
         }
-
         open_db = 1;
     }
 
     if (wm_vuldet_remove_target_table(db, METADATA_TABLE, vu_feed_tag[FEED_REDHAT])  ||
-        wm_vuldet_remove_target_table(db, CVE_INFO_TABLE, vu_feed_tag[FEED_REDHAT])) {
+            wm_vuldet_remove_target_table(db, CVE_INFO_TABLE, vu_feed_tag[FEED_REDHAT])) {
+        if (open_db) {
+            sqlite3_close_v2(db);
+        }
         return OS_INVALID;
     }
     if (open_db) {
@@ -7434,14 +7510,16 @@ int wm_vuldet_clean_wcpe(sqlite3 *db) {
         if (sqlite3_open_v2(CVE_DB, &db, SQLITE_OPEN_READWRITE, NULL) != SQLITE_OK) {
             return wm_vuldet_sql_error(db, NULL);
         }
-
         open_db = 1;
     }
 
     if (wm_vuldet_remove_target_table(db, METADATA_TABLE, vu_feed_tag[FEED_CPEW])        ||
-        wm_vuldet_remove_table(db, CPEH_SOURCE_TABLE) ||
-        wm_vuldet_remove_table(db, CPET_TRANSL_TABLE) ||
-        wm_vuldet_remove_table(db, CPE_HELPER_TABLE)) {
+            wm_vuldet_remove_table(db, CPEH_SOURCE_TABLE) ||
+            wm_vuldet_remove_table(db, CPET_TRANSL_TABLE) ||
+            wm_vuldet_remove_table(db, CPE_HELPER_TABLE)) {
+        if (open_db) {
+            sqlite3_close_v2(db);
+        }
         return OS_INVALID;
     }
     if (open_db) {
@@ -8129,7 +8207,9 @@ int wm_vulndet_insert_msu_vul_entry(sqlite3 *db, vu_msu_vul_entry *vul) {
 
     for (; vul; vul = wm_vuldet_free_msu_vul_node(vul)) {
         if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_MSU], -1, &stmt, NULL) != SQLITE_OK) {
-            return wm_vuldet_sql_error(db, stmt);
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+            wdb_finalize(stmt);
+            return OS_INVALID;
         }
 
         sqlite3_bind_text(stmt, 1, vul->cveid, -1, NULL);
@@ -8144,7 +8224,9 @@ int wm_vulndet_insert_msu_vul_entry(sqlite3 *db, vu_msu_vul_entry *vul) {
         sqlite3_bind_text(stmt, 8, vul->check_type, -1, NULL);
 
         if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
-            return wm_vuldet_sql_error(db, stmt);
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+            wdb_finalize(stmt);
+            return OS_INVALID;
         }
         wdb_finalize(stmt);
     }
@@ -8162,7 +8244,9 @@ int wm_vulndet_insert_msu_dep_entry(sqlite3 *db, vu_msu_dep_entry *dep) {
         int i;
         for (i = 0; dep->supers[i]; i++) {
             if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_MSU_SUPER], -1, &stmt, NULL) != SQLITE_OK) {
-                return wm_vuldet_sql_error(db, stmt);
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                wdb_finalize(stmt);
+                return OS_INVALID;
             }
             if (dep->patch) {
                 sqlite3_bind_text(stmt, 1, strncmp(dep->patch, "KB", 2) ? dep->patch : dep->patch + 2, -1, NULL);
@@ -8176,7 +8260,9 @@ int wm_vulndet_insert_msu_dep_entry(sqlite3 *db, vu_msu_dep_entry *dep) {
             }
 
             if (result = wm_vuldet_step(stmt), result != SQLITE_DONE) {
-                return wm_vuldet_sql_error(db, stmt);
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                wdb_finalize(stmt);
+                return OS_INVALID;
             }
             wdb_finalize(stmt);
         }
@@ -8419,7 +8505,8 @@ int wm_vuldet_insert_ALAS(sqlite3 *db, vu_alas_vuln *vul_it, const char *target)
                 for (int i = 0; vul_it->vulnerabilities && vul_it->vulnerabilities[i]; i++) {
 
                     if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_CVE], -1, &stmt, NULL) != SQLITE_OK) {
-                        retval = wm_vuldet_sql_error(db, stmt);
+                        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                        retval = OS_INVALID;
                         goto end;
                     }
 
@@ -8434,7 +8521,8 @@ int wm_vuldet_insert_ALAS(sqlite3 *db, vu_alas_vuln *vul_it, const char *target)
                     sqlite3_bind_int(stmt, 9, arch_id);
 
                     if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
-                        retval = wm_vuldet_sql_error(db, stmt);
+                        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                        retval = OS_INVALID;
                         goto end;
                     }
 
@@ -8451,7 +8539,8 @@ int wm_vuldet_insert_ALAS(sqlite3 *db, vu_alas_vuln *vul_it, const char *target)
             // Insert architecture values
             if (arch_id && vul_it->alas_pkg[k]->pkg_arch) {
                 if (wm_vuldet_prepare(db, vu_queries[VU_UPDATE_ARCH], -1, &stmt, NULL) != SQLITE_OK) {
-                    retval = wm_vuldet_sql_error(db, stmt);
+                    mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                    retval = OS_INVALID;
                     goto end;
                 }
 
@@ -8460,7 +8549,8 @@ int wm_vuldet_insert_ALAS(sqlite3 *db, vu_alas_vuln *vul_it, const char *target)
                 sqlite3_bind_text(stmt, 3, vul_it->alas_pkg[k]->pkg_arch, -1, NULL);
 
                 if (result = wm_vuldet_step(stmt), result != SQLITE_DONE) {
-                    retval = wm_vuldet_sql_error(db, stmt);
+                    mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                    retval = OS_INVALID;
                     goto end;
                 }
                 wdb_finalize(stmt);
@@ -8471,23 +8561,25 @@ int wm_vuldet_insert_ALAS(sqlite3 *db, vu_alas_vuln *vul_it, const char *target)
         for (int i = 0; vul_it->vulnerabilities && vul_it->vulnerabilities[i]; i++) {
             for (int j = 0; vul_it->references && vul_it->references[j]; j++) {
                 if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_REF_INFO], -1, &stmt, NULL) != SQLITE_OK) {
-                    retval = wm_vuldet_sql_error(db, stmt);
+                    mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                    retval = OS_INVALID;
                     goto end;
                 }
                 sqlite3_bind_text(stmt, 1, vul_it->vulnerabilities[i], -1, NULL);
                 sqlite3_bind_text(stmt, 2, target, -1, NULL);
                 sqlite3_bind_text(stmt, 3, vul_it->references[j], -1, NULL);
                 if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
-                    retval = wm_vuldet_sql_error(db, stmt);
+                    mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                    retval = OS_INVALID;
                     goto end;
                 }
-                wdb_finalize(stmt);
             }
         }
     }
 
 end:
     wm_vuldet_free_alas(alas_list);
+    wdb_finalize(stmt);
     return retval;
 }
 
@@ -8496,7 +8588,9 @@ int wm_vuldet_get_arch_id(sqlite3 * db, const char *cveid, const char *target, c
     int result;
 
     if (wm_vuldet_prepare(db, vu_queries[VU_GET_ARCH_ID], -1, &stmt, NULL) != SQLITE_OK) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     sqlite3_bind_text(stmt, 1, cveid, -1, NULL);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -326,8 +326,7 @@ STATIC int wm_vuldet_request_hotfixes(sqlite3 *db, const char *agent_id);
 STATIC void wm_vuldet_reset_tables(sqlite3 *db);
 STATIC int wm_vuldet_index_json(wm_vuldet_db *parsed_vulnerabilities, update_node *update, char *path, char multi_path);
 STATIC int wm_vuldet_index_nvd(sqlite3 *db, update_node *upd, nvd_vulnerability *nvd_it);
-STATIC int wm_vuldet_clean_rh(sqlite3 *db);
-STATIC int wm_vuldet_clean_wcpe(sqlite3 *db);
+STATIC int wm_vuldet_clean_rh();
 STATIC void wm_vuldet_get_package_os(const char *version, const char **os_major, char **os_minor);
 STATIC void wm_vuldet_set_subversion(char *version, char **os_minor);
 STATIC cJSON *wm_vuldet_json_fread(char *json_file);
@@ -2701,7 +2700,7 @@ int wm_vuldet_update_feed(update_node *upd, int8_t *updated) {
 
         // If it is a Red Hat update, we need to clean the database before we start
         if (upd->dist_ref == FEED_JREDHAT) {
-            wm_vuldet_clean_rh(NULL);
+            wm_vuldet_clean_rh();
         }
 
         for (upd->update_it = start; upd->update_it <= end; (upd->update_it)++) {
@@ -2711,7 +2710,7 @@ int wm_vuldet_update_feed(update_node *upd, int8_t *updated) {
                 if (upd->dist_ref == FEED_NVD) {
                     wm_vuldet_clean_nvd_year(NULL, upd->update_it);
                 } else if (upd->dist_ref == FEED_JREDHAT) {
-                    wm_vuldet_clean_rh(NULL);
+                    wm_vuldet_clean_rh();
                 }
                 return OS_INVALID;
             } else {
@@ -2722,13 +2721,13 @@ int wm_vuldet_update_feed(update_node *upd, int8_t *updated) {
                         case VU_TRY_NEXT_PAGE: // The maximum number of possible attempts for a page has been exhausted, the following page will be attempted
                             if (pages_fail == RED_HAT_REPO_MAX_FAIL_ITS) { // The allowed number of failed pages has been exhausted. The feed will not be updated.
                                 mterror(WM_VULNDETECTOR_LOGTAG, VU_RH_REQ_FAIL_MAX, RED_HAT_REPO_MAX_FAIL_ITS);
-                                wm_vuldet_clean_rh(NULL);
+                                wm_vuldet_clean_rh();
                                 return OS_INVALID;
                             }
                             pages_fail++;
                         break;
                         case VU_INV_FEED:
-                            wm_vuldet_clean_rh(NULL);
+                            wm_vuldet_clean_rh();
                             return OS_INVALID;
                         default:
                             mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_DOWNLOAD_PAGE_SUC, upd->update_it);
@@ -2979,7 +2978,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
             break;
         case FEED_UBUNTU:
         case FEED_DEBIAN:
-            if (wm_vuldet_remove_target_table(db, CVE_TABLE, parsed_oval->OS)      ||
+            if (wm_vuldet_remove_target_table(db, CVE_TABLE, parsed_oval->OS) ||
                     wm_vuldet_remove_target_table(db, METADATA_TABLE, parsed_oval->OS) ||
                     wm_vuldet_remove_target_table(db, CVE_INFO_TABLE, parsed_oval->OS) ||
                     wm_vuldet_remove_target_table(db, VARIABLES_TABLE, parsed_oval->OS)) {
@@ -2988,7 +2987,10 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
             }
         break;
         case FEED_CPEW:
-            if (wm_vuldet_clean_wcpe(db)) {
+            if (wm_vuldet_remove_target_table(db, METADATA_TABLE, vu_feed_tag[FEED_CPEW]) ||
+                    wm_vuldet_remove_table(db, CPEH_SOURCE_TABLE) ||
+                    wm_vuldet_remove_table(db, CPET_TRANSL_TABLE) ||
+                    wm_vuldet_remove_table(db, CPE_HELPER_TABLE)) {
                 sqlite3_close_v2(db);
                 return OS_INVALID;
             }
@@ -7450,7 +7452,9 @@ int wm_vuldet_index_nvd(sqlite3 *db, update_node *upd, nvd_vulnerability *nvd_it
     // update, we just need to clean the NVD for the year being indexed.
     if (result = wm_vuldet_has_offline_update(db), result == OS_INVALID) {
         goto error;
-    } else if (result == 1 && upd->multi_path && wm_vuldet_clean_nvd(db)) {
+    }
+
+    if (result == 1 && upd->multi_path && wm_vuldet_clean_nvd(db)) {
         goto error;
     } else if (!upd->multi_path && wm_vuldet_clean_nvd_year(db, upd->update_it)) {
         goto error;
@@ -7480,51 +7484,20 @@ error:
     return OS_INVALID;
 }
 
-int wm_vuldet_clean_rh(sqlite3 *db) {
-    char open_db = 0;
+int wm_vuldet_clean_rh() {
+    sqlite3 *db = NULL;
 
-    if (!db) {
-        if (sqlite3_open_v2(CVE_DB, &db, SQLITE_OPEN_READWRITE, NULL) != SQLITE_OK) {
-            return wm_vuldet_sql_error(db, NULL);
-        }
-        open_db = 1;
+    if (sqlite3_open_v2(CVE_DB, &db, SQLITE_OPEN_READWRITE, NULL) != SQLITE_OK) {
+        return wm_vuldet_sql_error(db, NULL);
     }
 
     if (wm_vuldet_remove_target_table(db, METADATA_TABLE, vu_feed_tag[FEED_REDHAT])  ||
             wm_vuldet_remove_target_table(db, CVE_INFO_TABLE, vu_feed_tag[FEED_REDHAT])) {
-        if (open_db) {
-            sqlite3_close_v2(db);
-        }
+        sqlite3_close_v2(db);
         return OS_INVALID;
     }
-    if (open_db) {
-        sqlite3_close_v2(db);
-    }
-    return 0;
-}
 
-int wm_vuldet_clean_wcpe(sqlite3 *db) {
-    char open_db = 0;
-
-    if (!db) {
-        if (sqlite3_open_v2(CVE_DB, &db, SQLITE_OPEN_READWRITE, NULL) != SQLITE_OK) {
-            return wm_vuldet_sql_error(db, NULL);
-        }
-        open_db = 1;
-    }
-
-    if (wm_vuldet_remove_target_table(db, METADATA_TABLE, vu_feed_tag[FEED_CPEW])        ||
-            wm_vuldet_remove_table(db, CPEH_SOURCE_TABLE) ||
-            wm_vuldet_remove_table(db, CPET_TRANSL_TABLE) ||
-            wm_vuldet_remove_table(db, CPE_HELPER_TABLE)) {
-        if (open_db) {
-            sqlite3_close_v2(db);
-        }
-        return OS_INVALID;
-    }
-    if (open_db) {
-        sqlite3_close_v2(db);
-    }
+    sqlite3_close_v2(db);
     return 0;
 }
 
@@ -8573,6 +8546,7 @@ int wm_vuldet_insert_ALAS(sqlite3 *db, vu_alas_vuln *vul_it, const char *target)
                     retval = OS_INVALID;
                     goto end;
                 }
+                wdb_finalize(stmt);
             }
         }
     }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -474,15 +474,6 @@ void wm_vuldet_free_multi_cpe(cpe *node) {
 int wm_vuldet_get_min_cpe_index(sqlite3 *db, int *min_index) {
     sqlite3_stmt *stmt = NULL;
     int success = 0;
-    char close_db = 0;
-
-    if (!db) {
-        if (sqlite3_open_v2(CVE_DB, &db, SQLITE_OPEN_READONLY, NULL) != SQLITE_OK) {
-            wm_vuldet_sql_error(db, stmt);
-            return OS_INVALID;
-        }
-        close_db = 1;
-    }
 
     if (wm_vuldet_prepare(db, vu_queries[VU_MIN_CPEINDEX], -1, &stmt, NULL) != SQLITE_OK) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
@@ -502,9 +493,6 @@ int wm_vuldet_get_min_cpe_index(sqlite3 *db, int *min_index) {
     success = 1;
 end:
     wdb_finalize(stmt);
-    if (close_db) {
-        sqlite3_close_v2(db);
-    }
     return !success;
 }
 
@@ -3775,27 +3763,17 @@ end:
 }
 
 int wm_vuldet_clean_nvd(sqlite3 *db) {
-    char open_db = 0;
-
-    if (!db) {
-        if (sqlite3_open_v2(CVE_DB, &db, SQLITE_OPEN_READWRITE, NULL) != SQLITE_OK) {
-            return wm_vuldet_sql_error(db, NULL);
-        }
-        open_db = 1;
-    }
 
     if (wm_vuldet_remove_table(db, "NVD_METADATA") ||
-        wm_vuldet_remove_table(db, "NVD_CVE") ||
-        wm_vuldet_remove_table(db, "NVD_METRIC_CVSS") ||
-        wm_vuldet_remove_table(db, "NVD_REFERENCE") ||
-        wm_vuldet_remove_table(db, "NVD_CVE_CONFIGURATION") ||
-        wm_vuldet_remove_table(db, "NVD_CVE_MATCH") ||
-        wm_vuldet_remove_table(db, "NVD_CPE")) {
+            wm_vuldet_remove_table(db, "NVD_CVE") ||
+            wm_vuldet_remove_table(db, "NVD_METRIC_CVSS") ||
+            wm_vuldet_remove_table(db, "NVD_REFERENCE") ||
+            wm_vuldet_remove_table(db, "NVD_CVE_CONFIGURATION") ||
+            wm_vuldet_remove_table(db, "NVD_CVE_MATCH") ||
+            wm_vuldet_remove_table(db, "NVD_CPE")) {
         return OS_INVALID;
     }
-    if (open_db) {
-        sqlite3_close_v2(db);
-    }
+
     return 0;
 }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -485,7 +485,8 @@ int wm_vuldet_get_min_cpe_index(sqlite3 *db, int *min_index) {
     }
 
     if (wm_vuldet_prepare(db, vu_queries[VU_MIN_CPEINDEX], -1, &stmt, NULL) != SQLITE_OK) {
-        wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
         return OS_INVALID;
     }
     if (wm_vuldet_step(stmt) == SQLITE_ROW) {
@@ -519,7 +520,9 @@ int wm_vuldet_extract_agent_cpes(scan_agent *agent, sqlite3 *db) {
     cpe_list *node_list = NULL;
 
     if (wm_vuldet_prepare(db, vu_queries[VU_GET_PACK_WITHOUT_CPE], -1, &stmt, NULL) != SQLITE_OK) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     sqlite3_bind_text(stmt, 1, agent->agent_id, -1, NULL);
@@ -552,7 +555,9 @@ int wm_vuldet_extract_agent_cpes(scan_agent *agent, sqlite3 *db) {
             char *part = NULL;
             for (p_index = 0; pkg_terms->product_terms[p_index]; p_index++) {
                 if (wm_vuldet_prepare(db, vu_queries[VU_SEARCH_AGENT_CPE], -1, &stmt, NULL) != SQLITE_OK) {
-                    return wm_vuldet_sql_error(db, stmt);
+                    mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                    wdb_finalize(stmt);
+                    return OS_INVALID;
                 }
 
                 sqlite3_bind_text(stmt, 1, pkg_terms->vendor_terms[v_index], -1, NULL);
@@ -610,9 +615,7 @@ int wm_vuldet_extract_agent_cpes(scan_agent *agent, sqlite3 *db) {
             sqlite3_bind_text(stmt, 6, pkg_terms->o_arch, -1, NULL);
 
             if (wm_vuldet_step(stmt) != SQLITE_DONE) {
-                wm_vuldet_sql_error(db, stmt);
-                db = NULL;
-                stmt = NULL;
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
                 goto end;
             }
             wdb_finalize(stmt);
@@ -664,11 +667,10 @@ end:
 int wm_vuldet_update_agent_cpes(scan_agent *agent, sqlite3 *db) {
     char buffer[OS_SIZE_6144] = "";
     sqlite3_stmt *stmt = NULL;
-    int success = 0;
+    int result = -1;
 
     if (wm_vuldet_prepare(db, vu_queries[VU_GET_AGENT_CPES], -1, &stmt, NULL) != SQLITE_OK) {
-        wm_vuldet_sql_error(db, stmt);
-        db = NULL;
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
         goto end;
     }
 
@@ -710,17 +712,10 @@ int wm_vuldet_update_agent_cpes(scan_agent *agent, sqlite3 *db) {
         }
     }
 
-    success = 1;
+    result = 0;
 end:
     wdb_finalize(stmt);
-
-    if (!success) {
-        if (db) {
-            sqlite3_close_v2(db);
-        }
-        return OS_INVALID;
-    }
-    return 0;
+    return result;
 }
 
 int wm_vuldet_generate_agent_cpes_with_terms(sqlite3 *db, scan_agent *agent) {
@@ -927,9 +922,9 @@ int wm_vuldet_fetch_nvd_cve(update_node *update) {
         }
 
         if (sqlite3_open_v2(CVE_DB, &db, SQLITE_OPEN_READWRITE, NULL)) {
-            wm_vuldet_sql_error(db, stmt);
-            db = NULL;
-            return VU_INV_FEED;
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+            retval = VU_INV_FEED;
+            goto end;
         }
 
         while (fgets(buffer, OS_MAXSTR, fp)) {
@@ -937,9 +932,10 @@ int wm_vuldet_fetch_nvd_cve(update_node *update) {
                 timestamp = found + strlen(feed_timestamp);
 
                 if (wm_vuldet_prepare(db, vu_queries[VU_GET_NVD_TIMESTAMP], -1, &stmt, NULL) != SQLITE_OK) {
-                    wm_vuldet_sql_error(db, stmt);
-                    db = NULL;
-                    return VU_INV_FEED;
+                    mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                    wdb_finalize(stmt);
+                    retval = VU_INV_FEED;
+                    goto end;
                 }
                 sqlite3_bind_int(stmt, 1, update->update_it);
 
@@ -1006,10 +1002,12 @@ end:
 }
 
 int wm_vuldet_insert_nvd_metadata(sqlite3 *db, int year, char *size, char *zip_size, char *g_size, char *sha256, char *last_mod, int cve_count, char alternative) {
-    sqlite3_stmt *stmt;
+    sqlite3_stmt *stmt = NULL;
 
     if (wm_vuldet_prepare(db, vu_queries[VU_REP_NVD_METADATA], -1, &stmt, NULL) != SQLITE_OK) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     sqlite3_bind_int(stmt, 1, year);
@@ -1022,7 +1020,9 @@ int wm_vuldet_insert_nvd_metadata(sqlite3 *db, int year, char *size, char *zip_s
     sqlite3_bind_int(stmt, 8, alternative);
 
     if (wm_vuldet_step(stmt) != SQLITE_DONE) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
     wdb_finalize(stmt);
 
@@ -1033,13 +1033,17 @@ int wm_vuldet_clean_nvd_metadata(sqlite3 *db, int year) {
     sqlite3_stmt *stmt = NULL;
 
     if (wm_vuldet_prepare(db, vu_queries[VU_REMOVE_NVD_METADATA], -1, &stmt, NULL) != SQLITE_OK) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     sqlite3_bind_int(stmt, 1, year);
 
     if (wm_vuldet_step(stmt) != SQLITE_DONE) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
     wdb_finalize(stmt);
 
@@ -1341,7 +1345,9 @@ int wm_vuldet_insert_nvd_cve(sqlite3 *db, nvd_vulnerability *nvd_data, int year)
     int id_nvd_cve = 0;
 
     if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_NVD_CVE], -1, &stmt, NULL) != SQLITE_OK) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     sqlite3_bind_int(stmt, 1, year);
@@ -1354,16 +1360,22 @@ int wm_vuldet_insert_nvd_cve(sqlite3 *db, nvd_vulnerability *nvd_data, int year)
     sqlite3_bind_text(stmt, 8, nvd_data->last_modified, -1, NULL);
 
     if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
     wdb_finalize(stmt);
 
     if (wm_vuldet_prepare(db, vu_queries[VU_GET_MAX_NVD_CVE_ID], -1, &stmt, NULL) != SQLITE_OK) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     if (result = wm_vuldet_step(stmt), result != SQLITE_ROW) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     id_nvd_cve = sqlite3_column_int(stmt, 0);
@@ -1390,7 +1402,6 @@ int wm_vuldet_insert_nvd_cve(sqlite3 *db, nvd_vulnerability *nvd_data, int year)
         }
     } else {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_NVD_ROW_GET_ERROR, "NVD_CVE");
-        sqlite3_close_v2(db);
         return OS_INVALID;
     }
 
@@ -1406,14 +1417,18 @@ int wm_vuldet_insert_nvd_cve_references(sqlite3 *db, nvd_references *nvd_data, c
     node = nvd_data;
     while(node && node->url) {
         if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_NVD_REFERENCE], -1, &stmt, NULL) != SQLITE_OK) {
-            return wm_vuldet_sql_error(db, stmt);
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+            wdb_finalize(stmt);
+            return OS_INVALID;
         }
         sqlite3_bind_int(stmt, 1, node_id);
         sqlite3_bind_text(stmt, 2, node->url, -1, NULL);
         sqlite3_bind_text(stmt, 3, node->refsource, -1, NULL);
 
         if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
-            return wm_vuldet_sql_error(db, stmt);
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+            wdb_finalize(stmt);
+            return OS_INVALID;
         }
 
         // Check if there is included a link to the official NVD website
@@ -1433,7 +1448,9 @@ int wm_vuldet_insert_nvd_cve_references(sqlite3 *db, nvd_references *nvd_data, c
 
         if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_NVD_REFERENCE], -1, &stmt, NULL) != SQLITE_OK) {
             os_free(nvd_cve_ref);
-            return wm_vuldet_sql_error(db, stmt);
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+            wdb_finalize(stmt);
+            return OS_INVALID;
         }
         sqlite3_bind_int(stmt, 1, node_id);
         sqlite3_bind_text(stmt, 2, nvd_cve_ref, -1, NULL);
@@ -1441,7 +1458,9 @@ int wm_vuldet_insert_nvd_cve_references(sqlite3 *db, nvd_references *nvd_data, c
 
         if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
             os_free(nvd_cve_ref);
-            return wm_vuldet_sql_error(db, stmt);
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+            wdb_finalize(stmt);
+            return OS_INVALID;
         }
 
         os_free(nvd_cve_ref);
@@ -1456,7 +1475,9 @@ int wm_vuldet_insert_nvd_cve_metric_cvss(sqlite3 *db, cv_scoring_system *nvd_dat
     int result;
 
     if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_NVD_METRIC_CVSS], -1, &stmt, NULL) != SQLITE_OK) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     sqlite3_bind_int(stmt, 1, node_id);
@@ -1467,7 +1488,9 @@ int wm_vuldet_insert_nvd_cve_metric_cvss(sqlite3 *db, cv_scoring_system *nvd_dat
     sqlite3_bind_double(stmt, 6, nvd_data->impact_score);
 
     if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
     wdb_finalize(stmt);
 
@@ -1483,23 +1506,31 @@ int wm_vuldet_insert_nvd_cve_configuration(sqlite3 *db, nvd_configuration *nvd_d
     node = nvd_data;
     while(node) {
         if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_NVD_CVE_CONFIGURATION], -1, &stmt, NULL) != SQLITE_OK) {
-            return wm_vuldet_sql_error(db, stmt);
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+            wdb_finalize(stmt);
+            return OS_INVALID;
         }
         sqlite3_bind_int(stmt, 1, cve_node_id);
         sqlite3_bind_int(stmt, 2, parent);
         sqlite3_bind_text(stmt, 3, node->operator, -1, NULL);
 
         if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
-            return wm_vuldet_sql_error(db, stmt);
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+            wdb_finalize(stmt);
+            return OS_INVALID;
         }
         wdb_finalize(stmt);
 
         if (wm_vuldet_prepare(db, vu_queries[VU_GET_MAX_CONFIGURATION_ID], -1, &stmt, NULL) != SQLITE_OK) {
-            return wm_vuldet_sql_error(db, stmt);
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+            wdb_finalize(stmt);
+            return OS_INVALID;
         }
 
         if (result = wm_vuldet_step(stmt), result != SQLITE_ROW) {
-            return wm_vuldet_sql_error(db, stmt);
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+            wdb_finalize(stmt);
+            return OS_INVALID;
         }
 
         conf_id = sqlite3_column_int(stmt, 0);
@@ -1518,7 +1549,6 @@ int wm_vuldet_insert_nvd_cve_configuration(sqlite3 *db, nvd_configuration *nvd_d
             }
         } else {
             mterror(WM_VULNDETECTOR_LOGTAG, VU_NVD_ROW_GET_ERROR, "NVD_CVE_CONFIGURATION");
-            sqlite3_close_v2(db);
             return OS_INVALID;
         }
         node = node->next;
@@ -1541,7 +1571,9 @@ int wm_vuldet_insert_nvd_cve_match(sqlite3 *db, nvd_conf_cpe_match *nvd_data, in
             }
 
             if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_NVD_CVE_MATCHES], -1, &stmt, NULL) != SQLITE_OK) {
-                return wm_vuldet_sql_error(db, stmt);
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                wdb_finalize(stmt);
+                return OS_INVALID;
             }
             sqlite3_bind_int(stmt, 1, conf_id);
             sqlite3_bind_int(stmt, 2, cpe_id);
@@ -1553,7 +1585,9 @@ int wm_vuldet_insert_nvd_cve_match(sqlite3 *db, nvd_conf_cpe_match *nvd_data, in
             sqlite3_bind_text(stmt, 8, node->version_end_excluding, -1, NULL);
 
             if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
-                return wm_vuldet_sql_error(db, stmt);
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                wdb_finalize(stmt);
+                return OS_INVALID;
             }
             wdb_finalize(stmt);
         }
@@ -1574,7 +1608,9 @@ int wm_vuldet_insert_nvd_cve_cpe(sqlite3 *db, cpe *cpe_data) {
 
 
     if (wm_vuldet_prepare(db, vu_queries[VU_GET_MAX_NVD_CPE_ID], -1, &stmt, NULL) != SQLITE_OK) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
     result = wm_vuldet_step(stmt);
 
@@ -1587,12 +1623,16 @@ int wm_vuldet_insert_nvd_cve_cpe(sqlite3 *db, cpe *cpe_data) {
     } else if (result == SQLITE_DONE) {
         cpe_id = 1;
     } else {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
     wdb_finalize(stmt);
 
     if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_NVD_CPE], -1, &stmt, NULL) != SQLITE_OK) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
     sqlite3_bind_int(stmt, 1, cpe_id);
     sqlite3_bind_text(stmt, 2, cpe_data->part, -1, NULL);
@@ -1608,13 +1648,17 @@ int wm_vuldet_insert_nvd_cve_cpe(sqlite3 *db, cpe *cpe_data) {
     sqlite3_bind_text(stmt, 12, cpe_data->other, -1, NULL);
 
     if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
     wdb_finalize(stmt);
 
     if(result == SQLITE_CONSTRAINT) {
         if (wm_vuldet_prepare(db, vu_queries[VU_GET_AN_CPE_ID], -1, &stmt, NULL) != SQLITE_OK) {
-            return wm_vuldet_sql_error(db, stmt);
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+            wdb_finalize(stmt);
+            return OS_INVALID;
         }
         sqlite3_bind_text(stmt, 1, cpe_data->part, -1, NULL);
         sqlite3_bind_text(stmt, 2, cpe_data->vendor, -1, NULL);
@@ -1629,7 +1673,9 @@ int wm_vuldet_insert_nvd_cve_cpe(sqlite3 *db, cpe *cpe_data) {
         sqlite3_bind_text(stmt, 11, cpe_data->other, -1, NULL);
 
         if (result = wm_vuldet_step(stmt), result != SQLITE_ROW) {
-            return wm_vuldet_sql_error(db, stmt);
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+            wdb_finalize(stmt);
+            return OS_INVALID;
         }
         cpe_id = sqlite3_column_int(stmt, 0);
         wdb_finalize(stmt);
@@ -1734,7 +1780,9 @@ int wm_vuldet_linux_nvd_vulnerabilities(sqlite3 *db, scan_agent *agent, OSHash *
     //Collect packages and versions from agents (data previously taken from sys_programs)
     if (wm_vuldet_prepare(db, vu_queries[VU_AGENT_PACKAGE_VERSION], -1, &stmt, NULL) != SQLITE_OK) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_GET_PACKAGES_ERROR, atoi(agent->agent_id));
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     sqlite3_bind_text(stmt, 1, agent->agent_id, -1, NULL);
@@ -1859,7 +1907,9 @@ int wm_vuldet_find_nvd_vulnerabilities(sqlite3 *db, scan_agent *agent, wm_vuldet
     cpe *stored_cpe;
 
     if (wm_vuldet_prepare(db, vu_queries[VU_GET_DICT_CPE], -1, &stmt, NULL) != SQLITE_OK) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
     sqlite3_bind_text(stmt, 1, agent->agent_id, -1, NULL);
 
@@ -1895,7 +1945,9 @@ int wm_vuldet_find_nvd_vulnerabilities(sqlite3 *db, scan_agent *agent, wm_vuldet
             wm_vuldet_free_cpe(&stored_cpe);
             break;
         default:
-            return wm_vuldet_sql_error(db, stmt);
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+            wdb_finalize(stmt);
+            return OS_INVALID;
         }
     }
 
@@ -1936,7 +1988,9 @@ int wm_vuldet_get_vuln_nvd_cpe(sqlite3 *db,
     int retval = OS_INVALID;
 
     if (wm_vuldet_prepare(db, vu_queries[VU_GET_NVD_CPE], -1, &stmt, NULL) != SQLITE_OK) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
     sqlite3_bind_text(stmt, 1, agent_cpe->part, -1, NULL);
     sqlite3_bind_text(stmt, 2, agent_cpe->vendor, -1, NULL);
@@ -2054,7 +2108,7 @@ int wm_vuldet_get_vuln_nvd_cpe(sqlite3 *db,
     retval = 0;
 end:
     if (retval) {
-        wm_vuldet_sql_error(db, NULL);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
     }
 
     wdb_finalize(stmt);
@@ -2349,7 +2403,11 @@ int wm_vuldet_process_agent_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd
     retval = 0;
 error:
     wm_vuldet_free_report(report);
-    return retval ? wm_vuldet_sql_error(db, stmt) : 0;
+    if (retval) {
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+    }
+    return retval;
 }
 
 char *wm_vuldet_clean_version(const char *version) {
@@ -2462,7 +2520,9 @@ int wm_vuldet_check_generic_package(sqlite3 *dbCVE,
 
     if (wm_vuldet_prepare(dbCVE, query, -1, &stmt, NULL) != SQLITE_OK) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_GET_PACKAGES_VULN_ERROR, "generic", temp_name);
-        return wm_vuldet_sql_error(dbCVE, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(dbCVE));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     sqlite3_bind_text(stmt, 1, temp_name, -1, NULL);
@@ -2713,7 +2773,9 @@ int wm_vuldet_check_specific_package(sqlite3 *dbCVE,
     if (wm_vuldet_prepare(dbCVE, query, -1, &stmt, NULL) != SQLITE_OK) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_GET_PACKAGES_VULN_ERROR, "specific", temp_name);
         os_free(sql_version);
-        return wm_vuldet_sql_error(dbCVE, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(dbCVE));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     sqlite3_bind_text(stmt, 1, temp_name, -1, NULL);
@@ -2845,7 +2907,9 @@ int wm_vuldet_get_children(sqlite3 * dbCVE, int configuration_id, int package_id
 
     if (wm_vuldet_prepare(dbCVE, vu_queries[VU_GET_CHILDREN], -1, &stmt, NULL) != SQLITE_OK) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_GET_PACKAGES_DEP_ERROR, "children", package_id);
-        return wm_vuldet_sql_error(dbCVE, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(dbCVE));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     sqlite3_bind_int(stmt, 1, configuration_id);
@@ -2866,7 +2930,9 @@ int wm_vuldet_get_siblings(sqlite3 * dbCVE, int parent, int configuration_id, in
 
     if (wm_vuldet_prepare(dbCVE, vu_queries[VU_GET_SIBLINGS], -1, &stmt, NULL) != SQLITE_OK) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_GET_PACKAGES_DEP_ERROR, "siblings", configuration_id);
-        return wm_vuldet_sql_error(dbCVE, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(dbCVE));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     sqlite3_bind_int(stmt, 1, parent);
@@ -2988,7 +3054,9 @@ int wm_vuldet_check_nvd_logical(sqlite3 *db, char *agent_id, vu_nvd_report *rp, 
     rp->vulnerable = 0;
 
     if (wm_vuldet_prepare(db, vu_queries[VU_GET_CONF_AND], -1, &stmt_conf, NULL) != SQLITE_OK) {
-        return wm_vuldet_sql_error(db, stmt_conf);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt_conf);
+        return OS_INVALID;
     }
     sqlite3_bind_int(stmt_conf, 1, parent);
     sqlite3_bind_int(stmt_conf, 2, conf_id);
@@ -3000,7 +3068,9 @@ int wm_vuldet_check_nvd_logical(sqlite3 *db, char *agent_id, vu_nvd_report *rp, 
 
             if (wm_vuldet_prepare(db, vu_queries[VU_GET_MATCHES_AND], -1, &stmt_match, NULL) != SQLITE_OK) {
                 wdb_finalize(stmt_conf);
-                return wm_vuldet_sql_error(db, stmt_match);
+                wdb_finalize(stmt_match);
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                return OS_INVALID;
             }
             sqlite3_bind_int(stmt_match, 1, and_conf);
 
@@ -3012,7 +3082,9 @@ int wm_vuldet_check_nvd_logical(sqlite3 *db, char *agent_id, vu_nvd_report *rp, 
                     if (wm_vuldet_prepare(db, vu_queries[VU_GET_CPE_AND], -1, &stmt_cpe, NULL) != SQLITE_OK) {
                         wdb_finalize(stmt_conf);
                         wdb_finalize(stmt_match);
-                        return wm_vuldet_sql_error(db, stmt_cpe);
+                        wdb_finalize(stmt_cpe);
+                        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                        return OS_INVALID;
                     }
                     sqlite3_bind_int(stmt_match, 1, and_mach);
 
@@ -3026,7 +3098,9 @@ int wm_vuldet_check_nvd_logical(sqlite3 *db, char *agent_id, vu_nvd_report *rp, 
                                 wdb_finalize(stmt_conf);
                                 wdb_finalize(stmt_match);
                                 wdb_finalize(stmt_cpe);
-                                return wm_vuldet_sql_error(db, stmt_agentcpe);
+                                wdb_finalize(stmt_agentcpe);
+                                mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                                return OS_INVALID;
                             }
                             sqlite3_bind_text(stmt_agentcpe, 1, vendor, -1, NULL);
                             sqlite3_bind_text(stmt_agentcpe, 2, product, -1, NULL);
@@ -3043,7 +3117,9 @@ int wm_vuldet_check_nvd_logical(sqlite3 *db, char *agent_id, vu_nvd_report *rp, 
                                     wdb_finalize(stmt_conf);
                                     wdb_finalize(stmt_match);
                                     wdb_finalize(stmt_cpe);
-                                    return wm_vuldet_sql_error(db, stmt_agentcpe);
+                                    wdb_finalize(stmt_agentcpe);
+                                    mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                                    return OS_INVALID;
                                 }
                             }
                             wdb_finalize(stmt_agentcpe);
@@ -3052,7 +3128,9 @@ int wm_vuldet_check_nvd_logical(sqlite3 *db, char *agent_id, vu_nvd_report *rp, 
                         default:
                             wdb_finalize(stmt_conf);
                             wdb_finalize(stmt_match);
-                            return wm_vuldet_sql_error(db, stmt_cpe);
+                            wdb_finalize(stmt_cpe);
+                            mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                            return OS_INVALID;
                         }
                     }
                     wdb_finalize(stmt_cpe);
@@ -3060,14 +3138,18 @@ int wm_vuldet_check_nvd_logical(sqlite3 *db, char *agent_id, vu_nvd_report *rp, 
 
                 default:
                     wdb_finalize(stmt_conf);
-                    return wm_vuldet_sql_error(db, stmt_match);
+                    wdb_finalize(stmt_match);
+                    mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                    return OS_INVALID;
                 }
             }
             wdb_finalize(stmt_match);
             break;
 
         default:
-            return wm_vuldet_sql_error(db, stmt_conf);
+            wdb_finalize(stmt_conf);
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+            return OS_INVALID;
         }
     }
 
@@ -3137,16 +3219,14 @@ int wm_vuldet_get_dic_matches(sqlite3 *db, char *agent_id, sqlite3_stmt **stmt) 
     wdb_finalize(*stmt);
 
     if (wm_vuldet_prepare(db, vu_queries[VU_GET_DIC_MATCHES], -1, stmt, NULL) != SQLITE_OK) {
-        goto error;
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(*stmt);
+        return OS_INVALID;
     }
 
     sqlite3_bind_text(*stmt, 1, agent_id, -1, NULL);
 
     return 0;
-error:
-    wm_vuldet_sql_error(db, *stmt);
-    *stmt = NULL;
-    return OS_INVALID;
 }
 
 
@@ -3157,7 +3237,9 @@ int wm_vuldet_add_dic_cpe(sqlite3 *db, int *cpe_index, cpe_list **node_list, cpe
     int pos;
 
     if (wm_vuldet_prepare(db, vu_queries[VU_UPDATE_AGENT_CPE], -1, &stmt, NULL) != SQLITE_OK) {
-        wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     sqlite3_bind_int(stmt, 1, *cpe_index);
@@ -3168,7 +3250,9 @@ int wm_vuldet_add_dic_cpe(sqlite3 *db, int *cpe_index, cpe_list **node_list, cpe
     sqlite3_bind_text(stmt, 6, o_app->target_hw, -1, NULL);
 
     if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
     wdb_finalize(stmt);
 
@@ -3237,7 +3321,7 @@ int wm_vuldet_get_correlation_id(sqlite3 *db, int cpeh_id, const char *type, cha
     int retval = -1;
 
     if (wm_vuldet_prepare(db, vu_queries[VU_GET_EXACT_TERM], -1, &stmt, NULL) != SQLITE_OK) {
-        wm_vuldet_sql_error(db, NULL);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
         goto end;
     }
     sqlite3_bind_int(stmt, 1, cpeh_id);
@@ -3263,7 +3347,7 @@ int wm_vuldet_get_correlation_id(sqlite3 *db, int cpeh_id, const char *type, cha
             goto end;
         break;
         default:
-            wm_vuldet_sql_error(db, NULL);
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
             goto end;
     }
 
@@ -3278,9 +3362,6 @@ int wm_vuldet_dic_check_rep_vendor(sqlite3 *db, scan_agent *agent, int *min_cpe_
     cpe o_app;
     cpe *g_app = NULL;
     sqlite3_stmt *stmt_vendor = NULL;
-    sqlite3_stmt *stmt_product = NULL;
-    sqlite3_stmt *stmt_version = NULL;
-    sqlite3_stmt *stmt_translation = NULL;
 
     // Create the Regex callback
     sqlite3_create_function_v2(db, "REGEXP", 2, SQLITE_ANY, 0, &w_sql_regex, 0, 0, 0);
@@ -3427,7 +3508,7 @@ int wm_vuldet_dic_check_rep_vendor(sqlite3 *db, scan_agent *agent, int *min_cpe_
         }
 
         if (result != SQLITE_DONE) {
-            wm_vuldet_sql_error(db, NULL);
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
             goto end;
         }
     }
@@ -3439,15 +3520,12 @@ end:
     }
 
     wdb_finalize(stmt_vendor);
-    wdb_finalize(stmt_product);
-    wdb_finalize(stmt_version);
-    wdb_finalize(stmt_translation);
 
     return retval;
 }
 
 int wm_vuldet_get_translate_term(sqlite3 *db, int cpeh_id, cpe_tags type, int pos, cpe *g_app) {
-    sqlite3_stmt *stmt;
+    sqlite3_stmt *stmt = NULL;
     int result;
     int i = 0;
     char **term = NULL;
@@ -3475,7 +3553,9 @@ int wm_vuldet_get_translate_term(sqlite3 *db, int cpeh_id, cpe_tags type, int po
     }
 
     if (wm_vuldet_prepare(db, vu_queries[VU_GET_TRANSLATION_TERM], -1, &stmt, NULL) != SQLITE_OK) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     sqlite3_bind_int(stmt, 1, cpeh_id);
@@ -3512,7 +3592,9 @@ int wm_vuldet_get_translate_term(sqlite3 *db, int cpeh_id, cpe_tags type, int po
     }
 
     if (result != SQLITE_DONE) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
 
     wdb_finalize(stmt);
@@ -3640,7 +3722,6 @@ int wm_vuldet_index_nvd_metadata(sqlite3 *db, int year, int cve_count, char alte
 
     if (!alternative) {
         if (fp = fopen(VU_TEMP_METADATA_FILE, "r"), !fp) {
-            sqlite3_close_v2(db);
             goto end;
         }
 
@@ -3680,11 +3761,11 @@ int wm_vuldet_index_nvd_metadata(sqlite3 *db, int year, int cve_count, char alte
 
     retval = 0;
 end:
-    free(size);
-    free(zip_size);
-    free(g_size);
-    free(sha256);
-    free(last_mod);
+    os_free(size);
+    os_free(zip_size);
+    os_free(g_size);
+    os_free(sha256);
+    os_free(last_mod);
 
     w_fclose(fp);
     if (remove(VU_TEMP_METADATA_FILE) < 0 && errno != ENOENT) {
@@ -3700,7 +3781,6 @@ int wm_vuldet_clean_nvd(sqlite3 *db) {
         if (sqlite3_open_v2(CVE_DB, &db, SQLITE_OPEN_READWRITE, NULL) != SQLITE_OK) {
             return wm_vuldet_sql_error(db, NULL);
         }
-
         open_db = 1;
     }
 
@@ -3724,8 +3804,11 @@ int wm_vuldet_has_offline_update(sqlite3 *db) {
     int retval = 0;
 
     if (wm_vuldet_prepare(db, vu_queries[VU_GET_OFFLINE_UPDATE], -1, &stmt, NULL) != SQLITE_OK) {
-        return wm_vuldet_sql_error(db, stmt);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+        wdb_finalize(stmt);
+        return OS_INVALID;
     }
+
     if (wm_vuldet_step(stmt) == SQLITE_ROW) {
         retval = 1;
     }
@@ -3739,24 +3822,24 @@ int wm_vuldet_clean_nvd_year(sqlite3 *db, int year) {
     sqlite3_stmt *stmt = NULL;
     sqlite3_stmt *stmt2 = NULL;
     char year_str[11];
+    int result = -1;
 
     snprintf(year_str, 10, "%d", year);
 
     if (!db) {
-        if (sqlite3_open_v2(CVE_DB, &db, SQLITE_OPEN_READWRITE, NULL) != SQLITE_OK) {
-            return wm_vuldet_sql_error(db, NULL);
-        }
-
         open_db = 1;
+        if (sqlite3_open_v2(CVE_DB, &db, SQLITE_OPEN_READWRITE, NULL) != SQLITE_OK) {
+            goto end;
+        }
     }
 
     // Clean metadata
     if (wm_vuldet_clean_nvd_metadata(db, year)) {
-        return OS_INVALID;
+        goto end;
     }
 
     if (wm_vuldet_prepare(db, vu_queries[VU_GET_NVD_CVE_YEAR], -1, &stmt, NULL) != SQLITE_OK) {
-        return wm_vuldet_sql_error(db, stmt);
+        goto end;
     }
 
     sqlite3_bind_int(stmt, 1, year);
@@ -3768,8 +3851,7 @@ int wm_vuldet_clean_nvd_year(sqlite3 *db, int year) {
 
         // Clean matches
         if (wm_vuldet_prepare(db, vu_queries[VU_GET_NVD_CONFIG], -1, &stmt2, NULL) != SQLITE_OK) {
-            wdb_finalize(stmt);
-            return wm_vuldet_sql_error(db, stmt2);
+            goto end;
         }
 
         sqlite3_bind_int(stmt2, 1, id);
@@ -3779,17 +3861,15 @@ int wm_vuldet_clean_nvd_year(sqlite3 *db, int year) {
             int id_config = sqlite3_column_int(stmt2, 0);
 
             if (wm_vuldet_prepare(db, vu_queries[VU_REMOVE_CVE_MATCHES], -1, &stmt3, NULL) != SQLITE_OK) {
-                wdb_finalize(stmt);
-                wdb_finalize(stmt2);
-                return wm_vuldet_sql_error(db, stmt3);
+                wdb_finalize(stmt3);
+                goto end;
             }
 
             sqlite3_bind_int(stmt3, 1, id_config);
 
             if (wm_vuldet_step(stmt3) != SQLITE_DONE) {
-                wdb_finalize(stmt);
-                wdb_finalize(stmt2);
-                return wm_vuldet_sql_error(db, stmt3);
+                wdb_finalize(stmt3);
+                goto end;
             }
             wdb_finalize(stmt3);
         }
@@ -3798,14 +3878,12 @@ int wm_vuldet_clean_nvd_year(sqlite3 *db, int year) {
         // Clean configuration, references and metrics
         for (sql = vu_queries[VU_REMOVE_CVE_TABLE_REFS]; sql && *sql; sql = tail) {
             if (wm_vuldet_prepare(db, sql, -1, &stmt2, &tail) != SQLITE_OK) {
-                wdb_finalize(stmt);
-                return wm_vuldet_sql_error(db, stmt2);
+                goto end;
             }
             sqlite3_bind_int(stmt2, 1, id);
 
             if (wm_vuldet_step(stmt2) != SQLITE_DONE) {
-                wdb_finalize(stmt);
-                return wm_vuldet_sql_error(db, stmt2);
+                goto end;
             }
             wdb_finalize(stmt2);
         }
@@ -3813,22 +3891,30 @@ int wm_vuldet_clean_nvd_year(sqlite3 *db, int year) {
     wdb_finalize(stmt);
 
     if (wm_vuldet_prepare(db, vu_queries[VU_REMOVE_NVD_CVE], -1, &stmt, NULL) != SQLITE_OK) {
-        return wm_vuldet_sql_error(db, stmt);
+        goto end;
     }
 
     sqlite3_bind_text(stmt, 1, year_str, -1, NULL);
 
     if (wm_vuldet_step(stmt) != SQLITE_DONE) {
-        return wm_vuldet_sql_error(db, stmt);
+        goto end;
     }
-    wdb_finalize(stmt);
 
     sqlite3_exec(db, vu_queries[VU_REMOVE_NVD_CPE], NULL, NULL, NULL);
 
+    result = 0;
+
+end:
+    if (result) {
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+    }
     if (open_db) {
         sqlite3_close_v2(db);
     }
-    return 0;
+    wdb_finalize(stmt);
+    wdb_finalize(stmt2);
+
+    return result;
 }
 
 void wm_vuldet_expand_msu_variables(cpe *g_app) {


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/15060|

## Description

The main goal of this pull request is to avoid the vulnerability database handlers being closed more than once when any error appears. This aims to fix a crash in `wazuh-modulesd` found in the SQLite library when accessing the database after it is closed, leading to unexpected behaviors.

## Rationale

Conclusions about the research made to determine that the crashes found in issue #15060 and also some cloud environments can be consulted in [this comment](https://github.com/wazuh/wazuh/issues/15060#issuecomment-1277972533).

We didn't manage to reproduce the crash in our local environments. However, forcing the same situation to arise that we assume caused the crash in those cases, we have obtained a valgrind report that confirms that there is an `Invalid read` when a DB handler has been closed and subsequently used to print an error message.

```
==9743== Invalid read of size 4
==9743==    at 0x55B4940: sqlite3SafetyCheckSickOrOk (in /var/ossec/lib/libwazuhext.so)
==9743==    by 0x55DC4BB: sqlite3Close (in /var/ossec/lib/libwazuhext.so)
==9743==    by 0x49C13E: wm_vuldet_check_timestamp (wm_vuln_detector.c:4470)
==9743==    by 0x49B9C0: wm_vuldet_fetch_oval (wm_vuln_detector.c:4354)
==9743==    by 0x49CA63: wm_vuldet_fetch_feed (wm_vuln_detector.c:4621)
==9743==    by 0x48A03A: wm_vuldet_sync_feed (wm_vuln_detector.c:676)
==9743==    by 0x49310A: wm_vuldet_update_feed (wm_vuln_detector.c:2736)
==9743==    by 0x49CBA2: wm_vuldet_check_feed (wm_vuln_detector.c:4645)
==9743==    by 0x49D0A3: wm_vuldet_run_update (wm_vuln_detector.c:4745)
==9743==    by 0x49FC0D: wm_vuldet_main (wm_vuln_detector.c:5274)
==9743==    by 0x606DEA4: start_thread (in /usr/lib64/libpthread-2.17.so)
==9743==    by 0x6380B0C: clone (in /usr/lib64/libc-2.17.so)
```

This trace is very similar to the one found in the coredump generated in one of the crashes.
```
(gdb) bt
#0  0x00007fa4c48b7940 in sqlite3SafetyCheckSickOrOk () from /var/ossec/bin/../lib/libwazuhext.so
#1  0x00007fa4c48c2a6b in sqlite3_errmsg () from /var/ossec/bin/../lib/libwazuhext.so
#2  0x0000000000480b92 in wm_vuldet_sql_error (db=0x7fa4912ee3c8, stmt=0x0)
    at wazuh_modules/vulnerability_detector/wm_vuln_detector.c:2627
```

So it proves that the `Invalid read` situation may lead to a segmentation fault depending on the memory that is being accessed.

Having reviewed the Vulnerability Detector code, we found plenty of possible flows where the database handler may be accessed after it is closed.

## Proposed fix

- The whole Vulnerability Detector module has been reviewed to ensure the scope of every handler is managed in the same function, avoiding closing the handler at a different point from where it was opened. This makes it easier to keep a trace of the handler's scope.
- Most of these closing points were because of the calling of `wm_vuldet_sql_error()` to raise an error, which implies the closing of the database handler.
- In order to avoid introducing new errors, this fix tries to modify as less logic as possible, just keeping calls to `wm_vuldet_sql_error()` in functions where the database should be closed before returning. Otherwise, we avoid closing the database.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Added unit tests (for new features)

<!-- Ruleset required checks, rules/decoder -->
- Manual tests
  - [x] Run Vulnerability Detector fetching every available feed
  - [x] Run Vulnerability Detector scan for Linux and Windows agents
  - [x] Force errors while the database is opened to check errors are propagated as expected