### PR TITLE
Fix vulnerability detector configuration section obtained from `GET /manager/configuration` API endpoint

### DIFF
--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -95,7 +95,7 @@ CONF_SECTIONS = MappingProxyType({
     },
     'vulnerability-detector': {
         'type': 'merge',
-        'list_options': ['feed']
+        'list_options': ['feed', 'provider']
     },
     'osquery': {
         'type': 'merge',
@@ -251,7 +251,14 @@ def _read_option(section_name: str, opt: str) -> tuple:
             if list(opt):
                 for child in opt:
                     child_section, child_config = _read_option(child.tag.lower(), child)
-                    opt_value[child_section] = child_config
+                    if not (section_name, opt_name, child_section) == ('vulnerability-detector', 'provider', 'os'):
+                        opt_value[child_section] = child_config
+                    else:
+                        if opt_value.get(child_section):
+                            opt_value[child_section].append(child_config)
+                        else:
+                            opt_value[child_section] = [child_config]
+
             else:
                 opt_value['item'] = opt.text
         else:

--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -251,12 +251,12 @@ def _read_option(section_name: str, opt: str) -> tuple:
             if list(opt):
                 for child in opt:
                     child_section, child_config = _read_option(child.tag.lower(), child)
-                    if not (section_name, opt_name, child_section) == ('vulnerability-detector', 'provider', 'os'):
+                    if (section_name, opt_name, child_section) != ('vulnerability-detector', 'provider', 'os'):
                         opt_value[child_section] = child_config
                     else:
-                        if opt_value.get(child_section):
+                        try:
                             opt_value[child_section].append(child_config)
-                        else:
+                        except KeyError:
                             opt_value[child_section] = [child_config]
 
             else:

--- a/framework/wazuh/core/tests/data/configuration/default/vulnerability_detector.conf
+++ b/framework/wazuh/core/tests/data/configuration/default/vulnerability_detector.conf
@@ -1,0 +1,15 @@
+<vulnerability-detector>
+    <enabled>no</enabled>
+    <interval>5m</interval>
+
+    <provider name="canonical">
+        <enabled>no</enabled>
+        <os>trusty</os>
+        <os>xenial</os>
+        <os>bionic</os>
+        <os>focal</os>
+        <os>jammy</os>
+        <update_interval>1h</update_interval>
+    </provider>
+
+</vulnerability-detector>

--- a/framework/wazuh/core/tests/test_configuration.py
+++ b/framework/wazuh/core/tests/test_configuration.py
@@ -74,21 +74,21 @@ def test_insert_section(json_dst, section_name, section_data):
 
 def test_read_option():
     """Checks insert_section function."""
-    # with open(os.path.join(parent_directory, tmp_path, 'configuration/default/options.conf')) as f:
-    #     data = fromstring(f.read())
-    #     assert configuration._read_option('open-scap', data)[0] == 'directories'
-    #     assert configuration._read_option('syscheck', data)[0] == 'directories'
-    #     assert configuration._read_option('labels', data)[0] == 'directories'
-    #
-    # with open(os.path.join(parent_directory, tmp_path, 'configuration/default/options1.conf')) as f:
-    #     data = fromstring(f.read())
-    #     assert configuration._read_option('labels', data)[0] == 'label'
-    #     assert configuration._read_option('test', data) == ('label', {'name': 'first', 'item': 'test'})
-    #
-    # with open(os.path.join(parent_directory, tmp_path, 'configuration/default/synchronization.conf')) as f:
-    #     data = fromstring(f.read())
-    #     assert configuration._read_option('open-scap', data)[0] == 'synchronization'
-    #     assert configuration._read_option('syscheck', data)[0] == 'synchronization'
+    with open(os.path.join(parent_directory, tmp_path, 'configuration/default/options.conf')) as f:
+        data = fromstring(f.read())
+        assert configuration._read_option('open-scap', data)[0] == 'directories'
+        assert configuration._read_option('syscheck', data)[0] == 'directories'
+        assert configuration._read_option('labels', data)[0] == 'directories'
+
+    with open(os.path.join(parent_directory, tmp_path, 'configuration/default/options1.conf')) as f:
+        data = fromstring(f.read())
+        assert configuration._read_option('labels', data)[0] == 'label'
+        assert configuration._read_option('test', data) == ('label', {'name': 'first', 'item': 'test'})
+
+    with open(os.path.join(parent_directory, tmp_path, 'configuration/default/synchronization.conf')) as f:
+        data = fromstring(f.read())
+        assert configuration._read_option('open-scap', data)[0] == 'synchronization'
+        assert configuration._read_option('syscheck', data)[0] == 'synchronization'
 
     with open(os.path.join(parent_directory, tmp_path, 'configuration/default/vulnerability_detector.conf')) as f:
         data = fromstring(f.read())


### PR DESCRIPTION
|Related issue|
|---|
| #14294  |



## Description

This PR closes https://github.com/wazuh/wazuh/issues/14294

In this pull request, I have updated the core functions in charge of getting the ossec.conf configuration for the GET /manager/configuration API endpoint.

After the changes:

`GET /manager/configuration?section=vulnerability-detector`

```json
{
  "data": {
    "affected_items": [
      {
        "vulnerability-detector": {
          "enabled": "no",
          "interval": "5m",
          "min_full_scan_interval": "6h",
          "run_on_start": "yes",
          "provider": [
            {
              "name": "canonical",
              "enabled": "no",
              "os": [
                "trusty",
                "xenial",
                "bionic",
                "focal",
                "jammy"
              ],
              "update_interval": "1h"
            },
            {
              "name": "debian",
              "enabled": "no",
              "os": [
                "buster",
                "bullseye"
              ],
              "update_interval": "1h"
            },
            {
              "name": "redhat",
              "enabled": "no",
              "os": [
                "5",
                "6",
                "7",
                "8",
                "9"
              ],
              "update_interval": "1h"
            },
            {
              "name": "alas",
              "enabled": "no",
              "os": [
                "amazon-linux",
                "amazon-linux-2",
                "amazon-linux-2022"
              ],
              "update_interval": "1h"
            },
            {
              "name": "suse",
              "enabled": "no",
              "os": [
                "11-server",
                "11-desktop",
                "12-server",
                "12-desktop",
                "15-server",
                "15-desktop"
              ],
              "update_interval": "1h"
            },
            {
              "name": "arch",
              "enabled": "no",
              "update_interval": "1h"
            },
            {
              "name": "msu",
              "enabled": "yes",
              "update_interval": "1h"
            },
            {
              "name": "nvd",
              "enabled": "yes",
              "update_from_year": "2010",
              "update_interval": "1h"
            }
          ]
        }
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Configuration was successfully read in specified node",
  "error": 0
}
```

I have also updated the framework core unit tests.