### PR TITLE
Disables Restart Manager and closes GUI in Wazuh Agent MSI installation and upgrade

### DIFF
--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -111,7 +111,7 @@
         </UI>
         <InstallExecuteSequence>
             <!-- Close the GUI -->
-            <Custom Action="CloseGUI" Before="InstallInitialize"></Custom>
+            <Custom Action="CloseGUI" After="InstallInitialize"></Custom>
             <!-- Set deployment values -->
             <Custom Action="SetWazuhManager" Before="SetCustomActionDataValue">ADDRESS &lt;&gt; "" AND WAZUH_MANAGER = ""</Custom>
             <Custom Action="SetWazuhManagerPort" Before="SetCustomActionDataValue">SERVER_PORT &lt;&gt; "" AND WAZUH_MANAGER_PORT = ""</Custom>

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -100,7 +100,8 @@
         <CustomAction Id="StopOssecService" Directory="APPLICATIONFOLDER" ExeCommand="NET STOP OssecSvc" Execute="deferred" Impersonate="no" Return="ignore" />
         <CustomAction Id="DeleteOssecService" Directory="APPLICATIONFOLDER" ExeCommand="SC DELETE OssecSvc" Execute="deferred" Impersonate="no" Return="ignore" />
 
-        <!-- Close the Wazuh Agent GUI -->
+        <!-- Close the Wazuh agent GUI -->
+
         <CustomAction Id="CloseGUI" Directory="APPLICATIONFOLDER" ExeCommand="TASKKILL /F /IM win32ui.exe" Execute="deferred" Impersonate="no" Return="ignore" />
         <UI>
             <UIRef Id="WixUI_Advanced" />

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -3,6 +3,9 @@
     <Product Id="*" Name="Wazuh Agent" Language="1033" Version="4.4.0" Manufacturer="Wazuh, Inc." UpgradeCode="F495AC57-7BDE-4C4B-92D8-DBE40A9AA5A0">
         <Package Description="Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring" Comments="wazuh-agent" InstallerVersion="200" Compressed="yes" />
         <Media Id="1" Cabinet="simple.cab" EmbedCab="yes" CompressionLevel="high" />
+
+        <!-- Disable Restart Manager -->
+        <Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable"/>
         <!-- Default configuration values -->
         <Property Id="WAZUH_MANAGER" Secure="yes"/>
         <Property Id="WAZUH_MANAGER_PORT" Secure="yes"/>
@@ -97,6 +100,8 @@
         <CustomAction Id="StopOssecService" Directory="APPLICATIONFOLDER" ExeCommand="NET STOP OssecSvc" Execute="deferred" Impersonate="no" Return="ignore" />
         <CustomAction Id="DeleteOssecService" Directory="APPLICATIONFOLDER" ExeCommand="SC DELETE OssecSvc" Execute="deferred" Impersonate="no" Return="ignore" />
 
+        <!-- Close the Wazuh Agent GUI -->
+        <CustomAction Id="CloseGUI" Directory="APPLICATIONFOLDER" ExeCommand="TASKKILL /F /IM win32ui.exe" Execute="deferred" Impersonate="no" Return="ignore" />
         <UI>
             <UIRef Id="WixUI_Advanced" />
             <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4"><![CDATA[WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1"]]></Publish>
@@ -104,6 +109,8 @@
             <Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="LaunchUI">WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 and NOT Installed</Publish>
         </UI>
         <InstallExecuteSequence>
+            <!-- Close the GUI -->
+            <Custom Action="CloseGUI" Before="InstallInitialize"></Custom>
             <!-- Set deployment values -->
             <Custom Action="SetWazuhManager" Before="SetCustomActionDataValue">ADDRESS &lt;&gt; "" AND WAZUH_MANAGER = ""</Custom>
             <Custom Action="SetWazuhManagerPort" Before="SetCustomActionDataValue">SERVER_PORT &lt;&gt; "" AND WAZUH_MANAGER_PORT = ""</Custom>


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/1485|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR modifies the MSI Installer creator `wazuh-installer.wsx`. It disables the use of the Restart Manager when open applications are in conflict with the installation and it closes the Wazuh Agent GUI if the message urging the user to close it is ignored, solving the problem explained in issue https://github.com/wazuh/wazuh-packages/issues/1485.



## Logs/Alerts example

<!--
Paste here related logs and alerts
-->
Logs can be found in the issue.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->
All tests can be found in the issue.