### PR TITLE
Update Arch Linux feed URL for Vulnerability Detector

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -10538,7 +10538,7 @@ void test_wm_vuldet_fetch_arch_success()
     update->timeout     = 300;
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug1, formatted_msg, "(5404): Trying to download 'https://security.archlinux.org/all.json'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "(5404): Trying to download 'https://security.archlinux.org/issues/all.json'");
 
     // Attempting to download
     expect_string(__wrap_wurl_request_uncompress_bz2_gz, url, repo);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -63,7 +63,7 @@
 #define RED_HAT_REPO "https://www.redhat.com/security/data/oval/v2/RHEL%s/rhel-%s-including-unpatched.oval.xml.bz2"
 #define RED_HAT5_REPO "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL5.xml.bz2"
 #define ARCH_REPO_MAX_ATTEMPTS 3
-#define JSON_ARCH_REPO "https://security.archlinux.org/all.json"
+#define JSON_ARCH_REPO "https://security.archlinux.org/issues/all.json"
 #define NVD_CPE_REPO "https://nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.3.xml.gz"
 #define NVD_CVE_REPO_META "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-%d.meta"
 #define NVD_CVE_REPO "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-%d.json.gz"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/15180|

## Description

This pull request updates the default URL to download the vulnerability feed for Arch Linux OS.

They updated the URL where all the vulnerable packages are indexed.
- Old URL: https://security.archlinux.org/all.json
- New URL: https://security.archlinux.org/issues/all.json

## Configuration options

```xml
    <!-- Arch OS vulnerabilities -->
    <provider name="arch">
      <enabled>yes</enabled>
      <update_interval>1h</update_interval>
    </provider>
```

## Logs/Alerts example

The feed now is downloaded as expected with the default configuration:

```
2022/10/24 15:23:05 wazuh-modulesd:vulnerability-detector: INFO: (5430): The update of the 'Arch Linux' feed finished successfully.
```

The database is filled:
```
# sqlite3 /var/ossec/queue/vulnerabilities/cve.db 'select count(*) from VULNERABILITIES where TARGET="ARCH";'
8218
```

The Arch Linux agent is scanned and alerts are generated:
```
2022/10/24 16:25:50 wazuh-modulesd:vulnerability-detector: INFO: (5450): Analyzing agent '001' vulnerabilities.
2022/10/24 16:26:06 wazuh-modulesd:vulnerability-detector: INFO: (5471): Finished vulnerability assessment for agent '001'
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language
- [x] Unit tests are updated