### PR TITLE
Audit message without body is logged to debug instead of being an error

### DIFF
--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -116,9 +116,12 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
         // Extract header: "\.*type=\.* msg=audit(.*):"
         //                                        --
 
-        if (!((id = strstr(buffer, "type=")) && (id = strstr(id + 5, " msg=audit(")) && (p = strstr(id += 11, "): ")))) {
+        if (!((id = strstr(buffer, "type=")) && (id = strstr(id + 5, " msg=audit(")))) {
             merror("Discarding audit message because of invalid syntax.");
             break;
+        } else if (!(p = strstr(id += 11, "): "))) {
+            mdebug2("Read audit message in '%s' with empty payload. Dropping line.", lf->file);
+            continue;
         }
 
         z = p - id;


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/15195|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Currently an audit log entry like this:

type=UNKNOWN[1421] msg=audit(1666174999.201:7269):

will result in an error being logged in the Wazuh logs if it does not contain a space at the end, complaining of invalid syntax. I believe this is incorrect. The syntax is not wrong - it just doesn't have a message body to read. In this PR the checks in read_audit.c for the audit log syntax have been separated, allowing an invalid syntax to still error whilst a log entry with no body can emit a debug warning instead.

This will shrink the Wazuh error log considerably on my systems here. 

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

2022/10/19 11:47:26 wazuh-logcollector[9461] read_audit.c:120 at read_audit(): ERROR: Discarding audit message because of invalid syntax.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors