### PR TITLE
Add GuardDuty Native support to the AWS Wodle

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2302,7 +2302,7 @@ class AWSGuardDutyBucket(AWSCustomBucket):
         if log_key.endswith('jsonl.gz'):
             with self.decompress_file(log_key=log_key) as f:
                 json_list = list(f)
-                return [dict(json.loads(x), source=json.loads(x)['service']['serviceName']) for x in json_list]
+                return [dict(x, source=x['service']['serviceName']) for json_item in json_list if (x := json.loads(json_item))]
         else:
             return AWSCustomBucket.load_information_from_file(self, log_key)
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2299,10 +2299,14 @@ class AWSGuardDutyBucket(AWSCustomBucket):
             yield event
 
     def load_information_from_file(self, log_key):
-        if log_key.endswith('jsonl.gz'):
+        if log_key.endswith('.jsonl.gz'):
             with self.decompress_file(log_key=log_key) as f:
                 json_list = list(f)
-                return [dict(x, source=x['service']['serviceName']) for json_item in json_list if (x := json.loads(json_item))]
+                result = []
+                for json_item in json_list:
+                    x = json.loads(json_item)
+                    result.append(dict(x, source=x['service']['serviceName']))
+                return result
         else:
             return AWSCustomBucket.load_information_from_file(self, log_key)
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2299,7 +2299,7 @@ class AWSGuardDutyBucket(AWSCustomBucket):
             yield event
 
     def load_information_from_file(self, log_key):
-        if log_key.split('.', 1)[1] == 'jsonl.gz':
+        if log_key.endswith('jsonl.gz'):
             with self.decompress_file(log_key=log_key) as f:
                 json_list = list(f)
                 return [dict(json.loads(x), source=json.loads(x)['service']['serviceName']) for x in json_list]

--- a/wodles/aws/tests/test_aws.py
+++ b/wodles/aws/tests/test_aws.py
@@ -351,6 +351,7 @@ def test_config_format_created_date(date: str, expected_date: str, aws_config_bu
     ({'Key' : '836629801214/iplogs/2021-01-18/2021-01-18-00-00-zxsb.csv.gz'}, 20210118),
     ({'Key' : '2020/09/30/13/firehose_guardduty-1-2020-09-30-13-17-05-532e184c-1hfba.zip'}, 20200930),
     ({'Key' : '2020/10/15/03/firehose_guardduty-1-2020-10-15-03-22-01-ea728dd1-763a4.zip'}, 20201015),
+    ({'Key' : 'AWSLogs/567970947422/GuardDuty/us-east-1/2022/10/21/ec7b0b8c-5ec8-32ec-8e77-c738515b4f6f.jsonl.gz'}, 20221021),
     ({'Key' : '2021/03/18/aws-waf-logs-delivery-stream-1-2021-03-18-10-32-48-77baca34f-efad-4f14-45bd7871'}, 20210318),
     ({'Key' : '2021/09/06/aws-waf-logs-delivery-stream-1-2021-09-06-21-02-18-8ba031bbd-babf-4c6a-83ba282c'}, 20210906),
     ({'Key' : '2021-11-12-09-11-26-B9F9F891E8D0EB13'}, 20211112),


### PR DESCRIPTION
|Related issue|
|---|
|#4950|


## Description

This PR closes #4950. It adds the functionality of processing GuardDuty Native logs, maintaining the previous one for GuardDuty with Kinesis.


## Manual Tests
### GuardDuty Native Bucket

```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-guardduty-native -t guardduty -s 2021-Jun-22 -p dev -d2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on account-id - region
DEBUG: +++ Marker: AWSLogs/account-id/GuardDuty/region/2021/06/22
DEBUG: ++ Found new log: AWSLogs/account-id/GuardDuty/region/2022/09/20/09d41cb2-dc23-3ec6-a59d-b77625c6ddd8.jsonl.gz
DEBUG: ++ Found new log: AWSLogs/account-id/GuardDuty/region/2022/09/20/2642d6b9-c0c0-30e4-a7cb-ce1983c53e1b.jsonl.gz
DEBUG: ++ Found new log: AWSLogs/account-id/GuardDuty/region/2022/09/20/388203f4-4d6b-3be7-8790-843978860f98.jsonl.gz
DEBUG: ++ Found new log: AWSLogs/account-id/GuardDuty/region/2022/09/20/4b6c54fe-fb15-357a-b7d9-20099bea7999.jsonl.gz
DEBUG: ++ Found new log: AWSLogs/account-id/GuardDuty/region/2022/09/20/4bc69a8c-53b8-30bd-9f1d-11bf615b5cbd.jsonl.gz
DEBUG: ++ Found new log: AWSLogs/account-id/GuardDuty/region/2022/09/20/566c9fde-c2bf-34eb-b1f0-dc37f0665c6f.jsonl.gz
DEBUG: ++ Found new log: AWSLogs/account-id/GuardDuty/region/2022/09/20/a54d242d-0200-3fcc-a321-3ff67887047d.jsonl.gz
DEBUG: ++ Found new log: AWSLogs/account-id/GuardDuty/region/2022/09/20/ba106b79-a888-3dab-bc58-f929860d3776.jsonl.gz
DEBUG: ++ Found new log: AWSLogs/account-id/GuardDuty/region/2022/09/20/c65747f2-c625-3972-b9b6-222172434149.jsonl.gz
DEBUG: ++ Found new log: AWSLogs/account-id/GuardDuty/region/2022/09/20/d995abe7-81df-397d-8a0a-b1033a4058af.jsonl.gz
DEBUG: ++ Found new log: AWSLogs/account-id/GuardDuty/region/2022/10/21/4ca2d459-4b27-34f9-9f96-0689041ab45b.jsonl.gz
DEBUG: ++ Found new log: AWSLogs/account-id/GuardDuty/region/2022/10/21/b67b5cbd-cf37-3c91-97ad-2ab367d01eab.jsonl.gz
DEBUG: ++ Found new log: AWSLogs/account-id/GuardDuty/region/2022/10/21/ec7b0b8c-5ec8-32ec-8e77-c738515b4f6f.jsonl.gz
DEBUG: +++ DB Maintenance
```
### GuardDuty + Kinesis Bucket

```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-guardduty -t guardduty -s 2021-Jun-22 -p dev -d2 | grep -v 'Skipping file with'
DEBUG: +++ Debug mode on - Level: 2
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
The GuardDuty + Kinesis integration was deprecated in 4.5. GuardDuty native support should be used instead. Check https://documentation.wazuh.com/current/amazon/services/supported-services/guardduty.html#amazon-configuration for more information.
DEBUG: +++ Marker: 2021/06/22
DEBUG: ++ Found new log: 2021/06/22/16/firehose_guardduty-1-2021-06-22-16-15-05-872e154c-1fd8-4369-a151-947ec0438d8d.zip
DEBUG: ++ Found new log: 2021/07/08/03/firehose_guardduty-1-2021-07-08-03-46-07-12788dc1-723b-4e2b-9d12-07885e967524.zip
DEBUG: ++ Found new log: 2021/12/24/03/firehose_guardduty-1-2021-12-24-03-46-07-12788dc1-723b-4e2b-9d12-07885e967524.zip
DEBUG: +++ DB Maintenance
```


## Unit Tests
```
============================= test session starts ==============================
platform linux -- Python 3.9.5, pytest-6.0.1, py-1.11.0, pluggy-0.13.1 -- /home/test_user/venv/unittest-env/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.14.0-1054-oem-x86_64-with-glibc2.31', 'Packages': {'pytest': '6.0.1', 'py': '1.11.0', 'pluggy': '0.13.1'}, 'Plugins': {'cov': '3.0.0', 'trio': '0.7.0', 'metadata': '2.0.2', 'asyncio': '0.15.1', 'aiohttp': '0.3.0', 'html': '2.1.1'}}
rootdir: /home/test_user/git/wazuh
plugins: cov-3.0.0, trio-0.7.0, metadata-2.0.2, asyncio-0.15.1, aiohttp-0.3.0, html-2.1.1
collecting ... collected 39 items

wodles/aws/tests/test_aws.py::test_metadata_version_buckets[AWSCloudTrailBucket] PASSED [  2%]
wodles/aws/tests/test_aws.py::test_metadata_version_buckets[AWSConfigBucket] PASSED [  5%]
wodles/aws/tests/test_aws.py::test_metadata_version_buckets[AWSVPCFlowBucket] PASSED [  7%]
wodles/aws/tests/test_aws.py::test_metadata_version_buckets[AWSCustomBucket] PASSED [ 10%]
wodles/aws/tests/test_aws.py::test_metadata_version_buckets[AWSGuardDutyBucket] PASSED [ 12%]
wodles/aws/tests/test_aws.py::test_metadata_version_services[AWSInspector] PASSED [ 15%]
wodles/aws/tests/test_aws.py::test_db_maintenance[AWSCloudTrailBucket-schema_cloudtrail_test.sql-cloudtrail] PASSED [ 17%]
wodles/aws/tests/test_aws.py::test_db_maintenance[AWSConfigBucket-schema_config_test.sql-config] PASSED [ 20%]
wodles/aws/tests/test_aws.py::test_db_maintenance[AWSVPCFlowBucket-schema_vpcflow_test.sql-vpcflow] PASSED [ 23%]
wodles/aws/tests/test_aws.py::test_db_maintenance[AWSCustomBucket-schema_custom_test.sql-custom] PASSED [ 25%]
wodles/aws/tests/test_aws.py::test_db_maintenance[AWSGuardDutyBucket-schema_guardduty_test.sql-guardduty] PASSED [ 28%]
wodles/aws/tests/test_aws.py::test_decompress_file_gz[aws_bucket0-test.gz-gzip.open] PASSED [ 30%]
wodles/aws/tests/test_aws.py::test_decompress_file_gz[aws_bucket0-test.zip-zipfile.ZipFile] PASSED [ 33%]
wodles/aws/tests/test_aws.py::test_decompress_file_snappy_skip[aws_bucket0-test.snappy] PASSED [ 35%]
wodles/aws/tests/test_aws.py::test_decompress_snappy_ko[aws_bucket0-test.snappy-False-SystemExit] PASSED [ 38%]
wodles/aws/tests/test_aws.py::test_decompress_file_ko[.gz-aws_bucket0] PASSED [ 41%]
wodles/aws/tests/test_aws.py::test_decompress_file_ko[.zip-aws_bucket0] PASSED [ 43%]
wodles/aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-False] PASSED [ 46%]
wodles/aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-True] PASSED [ 48%]
wodles/aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-invalid-json-True] PASSED [ 51%]
wodles/aws/tests/test_aws.py::test_aws_waf_load_information_from_file[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-wrong-structure-True] PASSED [ 53%]
wodles/aws/tests/test_aws.py::test_aws_waf_load_information_from_file_ko[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-invalid-json-False-SystemExit] PASSED [ 56%]
wodles/aws/tests/test_aws.py::test_aws_waf_load_information_from_file_ko[aws_waf_bucket0-/home/test_user/git/wazuh/wodles/aws/tests/data/log_files/WAF/aws-waf-wrong-structure-False-SystemExit] PASSED [ 58%]
wodles/aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2021/1/19-20210119] PASSED [ 61%]
wodles/aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2021/1/1-20210101] PASSED [ 64%]
wodles/aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2021/01/01-20210101] PASSED [ 66%]
wodles/aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2000/2/12-20000212] PASSED [ 69%]
wodles/aws/tests/test_aws.py::test_config_format_created_date[aws_config_bucket0-2022/02/1-20220201] PASSED [ 71%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file0-20211221] PASSED [ 74%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file1-20200103] PASSED [ 76%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file2-20200920] PASSED [ 79%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file3-20210118] PASSED [ 82%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file4-20200930] PASSED [ 84%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file5-20201015] PASSED [ 87%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file6-20221021] PASSED [ 89%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file7-20210318] PASSED [ 92%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file8-20210906] PASSED [ 94%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file9-20211112] PASSED [ 97%]
wodles/aws/tests/test_aws.py::test_custom_get_creation_date[aws_custom_bucket0-log_file10-20210123] PASSED [100%]

============================== 39 passed in 0.17s ==============================
```