### PR TITLE
Fix on deleted event missing permissions

### DIFF
--- a/src/ci/build_tools.py
+++ b/src/ci/build_tools.py
@@ -353,11 +353,14 @@ def makeTarget(targetName, tests, debug):
     """
     utils.printSubHeader(moduleName=targetName,
                          headerKey="makeAll")
-    makeTargetCommand = "make TARGET={} -j4".format(targetName)
+    makeTargetCommand = "make TARGET={}".format(targetName)
+    if targetName == "server":
+        makeTargetCommand += " INSTALLDIR=/path"
     if tests:
         makeTargetCommand += " TEST=1"
     if debug:
         makeTargetCommand += " DEBUG=1"
+    makeTargetCommand += " -j4"
     out = subprocess.run(makeTargetCommand,
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,

--- a/src/ci/run_check.py
+++ b/src/ci/run_check.py
@@ -377,21 +377,25 @@ def runScanBuild(targetName):
                       headerKey="scanbuild")
     build_tools.cleanAll()
     build_tools.cleanExternals()
+    build_tools.makeDeps(targetName=targetName,
+                         srcOnly=True)
+    build_tools.makeTarget(targetName=targetName,
+                           tests=False,
+                           debug=True)
+    build_tools.cleanInternals()
     if targetName == "winagent":
-        build_tools.makeDeps(targetName, True)
-        build_tools.makeTarget(targetName="winagent",
-                               tests=False,
-                               debug=True)
-        build_tools.cleanInternals()
         scanBuildCommand = "scan-build --status-bugs \
                             --use-cc=/usr/bin/i686-w64-mingw32-gcc \
                             --use-c++=/usr/bin/i686-w64-mingw32-g++-posix \
                             --analyzer-target=i686-w64-mingw32 \
                             --force-analyze-debug-code \
                             make TARGET=winagent DEBUG=1 -j4"
+    elif targetName == "server":
+        scanBuildCommand = "scan-build --status-bugs \
+                            --force-analyze-debug-code \
+                            --exclude external/ make TARGET={} INSTALLDIR=/path \
+                            DEBUG=1 -j4".format(targetName)
     else:
-        build_tools.makeDeps(targetName=targetName,
-                             srcOnly=False)
         scanBuildCommand = "scan-build --status-bugs \
                             --force-analyze-debug-code \
                             --exclude external/ make TARGET={} \

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -268,9 +268,7 @@ typedef struct registry_ignore_regex {
 typedef struct fim_file_data {
     // Checksum attributes
     unsigned int size;
-#ifdef WIN32
     cJSON * perm_json;
-#endif
     char * perm;
     char * attributes;
     char * uid;

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -1318,9 +1318,7 @@ fim_file_data *fim_get_data(const char *file, const directory_t *configuration, 
 void init_fim_data_entry(fim_file_data *data) {
     data->size = 0;
     data->perm = NULL;
-#ifdef WIN32
     data->perm_json = NULL;
-#endif
     data->attributes = NULL;
     data->uid = NULL;
     data->gid = NULL;

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -220,6 +220,7 @@ static void dbsync_attributes_json(const cJSON *dbsync_event, const directory_t 
 
     if (configuration->options & CHECK_PERM) {
         if (aux = cJSON_GetObjectItem(dbsync_event, "perm"), aux != NULL) {
+            printf("%s\n", cJSON_Print(aux));
 #ifndef WIN32
             cJSON_AddStringToObject(attributes, "perm", cJSON_GetStringValue(aux));
 #else

--- a/src/syscheckd/src/db/src/dbFileItem.cpp
+++ b/src/syscheckd/src/db/src/dbFileItem.cpp
@@ -30,6 +30,11 @@ void FileItem::createFimEntry()
             data->attributes = const_cast<char*>(m_attributes.c_str());
             data->uid = static_cast<char*>(std::calloc(uid_size + 1, sizeof(char)));
 
+            if (!m_permJSON.empty())
+            {
+                data->perm_json = cJSON_Parse(m_permJSON.dump().c_str());
+            }
+
             if (data->uid)
             {
                 std::strncpy(data->uid, std::to_string(m_uid).c_str(), uid_size);
@@ -105,7 +110,16 @@ void FileItem::createJSON()
     data["dev"] = m_dev;
     data["inode"] = m_inode;
     data["size"] = m_size;
-    data["perm"] = m_perm;
+
+    if (m_permJSON.empty())
+    {
+        data["perm"] = m_perm;
+    }
+    else
+    {
+        data["perm"] = m_permJSON;
+    }
+
     data["attributes"] = m_attributes;
     data["uid"] = m_uid;
     data["gid"] = m_gid;

--- a/src/syscheckd/src/db/src/dbFileItem.hpp
+++ b/src/syscheckd/src/db/src/dbFileItem.hpp
@@ -34,6 +34,11 @@ struct FimFileDataDeleter
                     std::free(fimFile->file_entry.data->uid);
                 }
 
+                if (fimFile->file_entry.data->perm_json)
+                {
+                    cJSON_Delete(fimFile->file_entry.data->perm_json);
+                }
+
                 std::free(fimFile->file_entry.data);
             }
 
@@ -64,6 +69,15 @@ class FileItem final : public DBItem
             m_groupname = fim->file_entry.data->group_name == NULL ? "" : fim->file_entry.data->group_name;
             m_perm = fim->file_entry.data->perm == NULL ? "" : fim->file_entry.data->perm;
 
+            if (!fim->file_entry.data->perm_json)
+            {
+                m_permJSON = nlohmann::json(nullptr);
+            }
+            else
+            {
+                m_permJSON = nlohmann::json::parse(cJSON_Print(fim->file_entry.data->perm_json));
+            }
+
             FIMDBCreator<OS_TYPE>::encodeString(m_attributes);
             FIMDBCreator<OS_TYPE>::encodeString(m_username);
             FIMDBCreator<OS_TYPE>::encodeString(m_groupname);
@@ -90,11 +104,21 @@ class FileItem final : public DBItem
             m_gid = fim.at("gid");
             m_groupname = fim.at("group_name");
             m_md5 = fim.at("hash_md5");
-            m_perm = fim.at("perm");
             m_sha1 = fim.at("hash_sha1");
             m_sha256 = fim.at("hash_sha256");
             m_uid = fim.at("uid");
             m_username = fim.at("user_name");
+
+            if (fim["perm"].is_object())
+            {
+                m_permJSON = fim["perm"];
+                m_perm = "";
+            }
+            else
+            {
+                m_permJSON = nlohmann::json(nullptr);
+                m_perm = fim.at("perm");
+            }
 
             createFimEntry();
             m_statementConf = std::make_unique<nlohmann::json>(fim);
@@ -126,6 +150,7 @@ class FileItem final : public DBItem
         std::string                                     m_sha1;
         std::string                                     m_sha256;
         std::string                                     m_username;
+        nlohmann::json                                  m_permJSON;
         std::unique_ptr<fim_entry, FimFileDataDeleter>  m_fimEntry;
         std::unique_ptr<nlohmann::json>                 m_statementConf;
 

--- a/src/syscheckd/src/db/tests/db/dbItem/FileItem/CMakeLists.txt
+++ b/src/syscheckd/src/db/tests/db/dbItem/FileItem/CMakeLists.txt
@@ -4,8 +4,11 @@ project(fileitem_unit_test)
 
 set(CMAKE_CXX_FLAGS_DEBUG "-g --coverage")
 
-file(GLOB fileitem_UNIT_TEST_SRC
-    "*.cpp")
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    file(GLOB fileitem_UNIT_TEST_SRC "dbFileItemTestWindows.cpp")
+else()
+    file(GLOB fileitem_UNIT_TEST_SRC "dbFileItemTest.cpp")
+endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 
 include_directories(${SRC_FOLDER}/shared_modules/dbsync/include/)
 include_directories(${SRC_FOLDER}/shared_modules/rsync/include/)

--- a/src/syscheckd/src/db/tests/db/dbItem/FileItem/dbFileItemTest.h
+++ b/src/syscheckd/src/db/tests/db/dbItem/FileItem/dbFileItemTest.h
@@ -21,7 +21,8 @@ class FileItemTest : public testing::Test {
 
         void SetUp() override;
         void TearDown() override;
-        fim_entry* fimEntryTest;
+        fim_entry * fimEntryTest;
+        nlohmann::json json;
 };
 
 #endif //_FILEITEM_TEST_H

--- a/src/syscheckd/src/db/tests/db/dbItem/FileItem/dbFileItemTestWindows.cpp
+++ b/src/syscheckd/src/db/tests/db/dbItem/FileItem/dbFileItemTestWindows.cpp
@@ -16,7 +16,7 @@
 void FileItemTest::SetUp()
 {
     fimEntryTest = reinterpret_cast<fim_entry*>(std::calloc(1, sizeof(fim_entry)));
-    fim_file_data* data = reinterpret_cast<fim_file_data*>(std::calloc(1, sizeof(fim_file_data)));
+    fim_file_data * data = reinterpret_cast<fim_file_data*>(std::calloc(1, sizeof(fim_file_data)));
 
     fimEntryTest->type = FIM_TYPE_FILE;
     fimEntryTest->file_entry.path = const_cast<char*>("/etc/wgetrc");
@@ -33,13 +33,85 @@ void FileItemTest::SetUp()
     data->mode = FIM_SCHEDULED;
     data->mtime = 1578075431;
     data->options = 131583;
-    data->perm = const_cast<char*>("-rw-rw-r--");
-    data->perm_json = NULL;
+    data->perm_json = cJSON_CreateObject();
+    cJSON * permission = cJSON_CreateObject();
+    cJSON * permission1 = cJSON_CreateObject();
+    cJSON * allowed = cJSON_CreateArray();
+    cJSON_AddItemToArray(allowed, cJSON_CreateString("delete"));
+    cJSON_AddItemToArray(allowed, cJSON_CreateString("read_control"));
+    cJSON_AddItemToArray(allowed, cJSON_CreateString("write_dac"));
+    cJSON_AddItemToArray(allowed, cJSON_CreateString("write_owner"));
+    cJSON_AddItemToArray(allowed, cJSON_CreateString("synchronize"));
+    cJSON_AddItemToArray(allowed, cJSON_CreateString("read_data"));
+    cJSON_AddItemToObject(permission, "allowed", allowed);
+    cJSON_AddItemToObject(permission, "name", cJSON_CreateString("Administradores"));
+    cJSON_AddItemToObject(data->perm_json, "S-1-5-32-544", permission);
+    cJSON * allowed1 = cJSON_CreateArray();
+    cJSON_AddItemToArray(allowed1, cJSON_CreateString("delete"));
+    cJSON_AddItemToArray(allowed1, cJSON_CreateString("read_control"));
+    cJSON_AddItemToArray(allowed1, cJSON_CreateString("write_dac"));
+    cJSON_AddItemToArray(allowed1, cJSON_CreateString("write_owner"));
+    cJSON_AddItemToArray(allowed1, cJSON_CreateString("synchronize"));
+    cJSON_AddItemToArray(allowed1, cJSON_CreateString("read_data"));
+    cJSON_AddItemToObject(permission1, "allowed", allowed1);
+    cJSON_AddItemToObject(permission1, "name", cJSON_CreateString("System"));
+    cJSON_AddItemToObject(data->perm_json, "S-1-5-32-545", permission1);
     data->scanned = 1;
     data->size = 4925;
     data->uid = const_cast<char*>("0");
     data->user_name = const_cast<char*>("fakeUser");
     fimEntryTest->file_entry.data = data;
+    const auto permissions = R"(
+        {
+            "S-1-5-32-544":
+            {
+                "name": "Administradores",
+                "allowed":
+                    [
+                        "delete",
+                        "read_control",
+                        "write_dac",
+                        "write_owner",
+                        "synchronize",
+                        "read_data"
+                    ]
+            },
+            "S-1-5-32-545":
+            {
+                "name": "System",
+                "allowed":
+                [
+                    "delete",
+                    "read_control",
+                    "write_dac",
+                    "write_owner",
+                    "synchronize",
+                    "read_data"
+                ]
+            }
+        }
+    )"_json;
+    json = {
+            {"attributes", "10"},
+            {"checksum", "a2fbef8f81af27155dcee5e3927ff6243593b91a"},
+            {"dev", 2051},
+            {"gid", 0},
+            {"group_name", "root"},
+            {"hash_md5", "4b531524aa13c8a54614100b570b3dc7"},
+            {"hash_sha1", "7902feb66d0bcbe4eb88e1bfacf28befc38bd58b"},
+            {"hash_sha256", "e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a"},
+            {"inode", 1152921500312810880},
+            {"last_event", 1596489275},
+            {"mode", 0},
+            {"mtime", 1578075431},
+            {"options", 131583},
+            {"path", "/etc/wgetrc"},
+            {"perm", permissions},
+            {"scanned", 1},
+            {"size", 4925},
+            {"uid", 0},
+            {"user_name", "fakeUser"}
+    };
 }
 
 void FileItemTest::TearDown()
@@ -52,10 +124,9 @@ TEST_F(FileItemTest, fileItemConstructorFromFIM)
 {
     EXPECT_NO_THROW(
     {
-        auto file = new FileItem(fimEntryTest);
+        auto file = std::make_unique<FileItem>(fimEntryTest);
         auto scanned = file->state();
         EXPECT_TRUE(scanned);
-        delete file;
     });
 }
 
@@ -84,13 +155,13 @@ TEST_F(FileItemTest, fileItemConstructorFromFIMWithNullParameters)
     data->size = 0;
     data->uid = NULL;
     data->user_name = NULL;
+    data->perm_json = NULL;
     fimEntryTestNull->file_entry.data = data;
     EXPECT_NO_THROW(
     {
-        auto file = new FileItem(fimEntryTestNull);
+        auto file = std::make_unique<FileItem>(fimEntryTestNull);
         auto scanned = file->state();
         EXPECT_TRUE(scanned);
-        delete file;
     });
     os_free(data);
     os_free(fimEntryTestNull);
@@ -98,27 +169,17 @@ TEST_F(FileItemTest, fileItemConstructorFromFIMWithNullParameters)
 
 TEST_F(FileItemTest, fileItemConstructorFromJSON)
 {
-    const auto insertJSON = R"(
-        {
-            "attributes":"10", "checksum":"a2fbef8f81af27155dcee5e3927ff6243593b91a", "dev":2051, "gid":0, "group_name":"root",
-            "hash_md5":"4b531524aa13c8a54614100b570b3dc7", "hash_sha1":"7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
-            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":1152921500312810880, "last_event":1596489275,
-            "mode":0, "mtime":1578075431, "options":131583, "path":"/etc/wgetrc", "perm":"-rw-rw-r--", "scanned":1, "size":4925,
-            "uid":0, "user_name":"fakeUser"
-        }
-    )"_json;
     EXPECT_NO_THROW(
     {
-        auto fileTest = new FileItem(insertJSON);
+        auto fileTest = std::make_unique<FileItem>(json);
         auto scanned = fileTest->state();
         EXPECT_TRUE(scanned);
-        delete fileTest;
     });
 }
 
 TEST_F(FileItemTest, getFIMEntryWithFimCtr)
 {
-    auto file = new FileItem(fimEntryTest);
+    auto file = std::make_unique<FileItem>(fimEntryTest);
     auto fileEntry = file->toFimEntry();
     ASSERT_EQ(std::strcmp(fileEntry->file_entry.path, fimEntryTest->file_entry.path), 0);
     ASSERT_EQ(std::strcmp(fileEntry->file_entry.data->attributes, fimEntryTest->file_entry.data->attributes), 0);
@@ -134,27 +195,16 @@ TEST_F(FileItemTest, getFIMEntryWithFimCtr)
     ASSERT_EQ(fileEntry->file_entry.data->mode, fimEntryTest->file_entry.data->mode);
     ASSERT_EQ(fileEntry->file_entry.data->mtime, fimEntryTest->file_entry.data->mtime);
     ASSERT_EQ(fileEntry->file_entry.data->options, fimEntryTest->file_entry.data->options);
-    ASSERT_EQ(std::strcmp(fileEntry->file_entry.data->perm, fimEntryTest->file_entry.data->perm), 0);
+    ASSERT_EQ(std::strcmp(cJSON_Print(fileEntry->file_entry.data->perm_json), cJSON_Print(fimEntryTest->file_entry.data->perm_json)), 0);
     ASSERT_EQ(fileEntry->file_entry.data->scanned, fimEntryTest->file_entry.data->scanned);
     ASSERT_EQ(fileEntry->file_entry.data->size, fimEntryTest->file_entry.data->size);
     ASSERT_EQ(std::strcmp(fileEntry->file_entry.data->uid, fimEntryTest->file_entry.data->uid), 0);
-    ASSERT_EQ(std::strcmp(fileEntry->file_entry.data->user_name, fimEntryTest->file_entry.data->user_name), 0);
-
-    delete file;
+    ASSERT_EQ(std::strcmp(fileEntry->file_entry.data->user_name, fimEntryTest->file_entry.data->user_name), 0);//*/
 }
 
 TEST_F(FileItemTest, getFIMEntryWithJSONCtr)
 {
-    const auto insertJSON = R"(
-        {
-            "attributes":"10", "checksum":"a2fbef8f81af27155dcee5e3927ff6243593b91a", "dev":2051, "gid":0, "group_name":"root",
-            "hash_md5":"4b531524aa13c8a54614100b570b3dc7", "hash_sha1":"7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
-            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":1152921500312810880, "last_event":1596489275,
-            "mode":0, "mtime":1578075431, "options":131583, "path":"/etc/wgetrc", "perm":"-rw-rw-r--", "scanned":1, "size":4925,
-            "uid":0, "user_name":"fakeUser"
-        }
-    )"_json;
-    auto file = new FileItem(insertJSON);
+    auto file = std::make_unique<FileItem>(json);
     auto fileEntry = file->toFimEntry();
     ASSERT_EQ(std::strcmp(fileEntry->file_entry.path, fimEntryTest->file_entry.path), 0);
     ASSERT_EQ(std::strcmp(fileEntry->file_entry.data->attributes, fimEntryTest->file_entry.data->attributes), 0);
@@ -170,62 +220,31 @@ TEST_F(FileItemTest, getFIMEntryWithJSONCtr)
     ASSERT_EQ(fileEntry->file_entry.data->mode, fimEntryTest->file_entry.data->mode);
     ASSERT_EQ(fileEntry->file_entry.data->mtime, fimEntryTest->file_entry.data->mtime);
     ASSERT_EQ(fileEntry->file_entry.data->options, fimEntryTest->file_entry.data->options);
-    ASSERT_EQ(std::strcmp(fileEntry->file_entry.data->perm, fimEntryTest->file_entry.data->perm), 0);
+    ASSERT_EQ(std::strcmp(cJSON_Print(fileEntry->file_entry.data->perm_json), cJSON_Print(fimEntryTest->file_entry.data->perm_json)), 0);
     ASSERT_EQ(fileEntry->file_entry.data->scanned, fimEntryTest->file_entry.data->scanned);
     ASSERT_EQ(fileEntry->file_entry.data->size, fimEntryTest->file_entry.data->size);
     ASSERT_EQ(std::strcmp(fileEntry->file_entry.data->uid, fimEntryTest->file_entry.data->uid), 0);
     ASSERT_EQ(std::strcmp(fileEntry->file_entry.data->user_name, fimEntryTest->file_entry.data->user_name), 0);
-
-    delete file;
 }
 
 TEST_F(FileItemTest, getJSONWithFimCtr)
 {
-    auto file = new FileItem(fimEntryTest);
-    const auto expectedValue = R"(
-        {
-            "table": "file_entry",
-            "data":[{"attributes":"10", "checksum":"a2fbef8f81af27155dcee5e3927ff6243593b91a", "dev":2051, "gid":0, "group_name":"root",
-            "hash_md5":"4b531524aa13c8a54614100b570b3dc7", "hash_sha1":"7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
-            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":1152921500312810880, "last_event":1596489275,
-            "mode":0, "mtime":1578075431, "options":131583, "path":"/etc/wgetrc", "perm":"-rw-rw-r--", "scanned":1, "size":4925,
-            "uid":0, "user_name":"fakeUser"}]
-        }
-    )"_json;
-    ASSERT_TRUE(*file->toJSON() == expectedValue);
-    delete file;
+    auto file = std::make_unique<FileItem>(fimEntryTest);
+    const auto returnValue = *file->toJSON();
+    ASSERT_TRUE(returnValue["data"][0] == json);
 }
 
 TEST_F(FileItemTest, getJSONWithJSONCtr)
 {
-    auto file = new FileItem(fimEntryTest);
-    const auto expectedValue = R"(
-        {
-            "table": "file_entry",
-            "data":[{"attributes":"10", "checksum":"a2fbef8f81af27155dcee5e3927ff6243593b91a", "dev":2051, "gid":0, "group_name":"root",
-            "hash_md5":"4b531524aa13c8a54614100b570b3dc7", "hash_sha1":"7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
-            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":1152921500312810880, "last_event":1596489275,
-            "mode":0, "mtime":1578075431, "options":131583, "path":"/etc/wgetrc", "perm":"-rw-rw-r--", "scanned":1, "size":4925,
-            "uid":0, "user_name":"fakeUser"}]
-        }
-    )"_json;
-    ASSERT_TRUE(*file->toJSON() == expectedValue);
-    delete file;
+    auto file = std::make_unique<FileItem>(fimEntryTest);
+    const auto returnValue = *file->toJSON();
+    ASSERT_TRUE(returnValue["data"][0] == json);
 }
 
 TEST_F(FileItemTest, fileItemReportOldData)
 {
-    auto file = new FileItem(fimEntryTest, true);
-    const auto expectedValue = R"(
-        {
-            "table": "file_entry",
-            "data":[{"attributes":"10", "checksum":"a2fbef8f81af27155dcee5e3927ff6243593b91a", "dev":2051, "gid":0, "group_name":"root",
-            "hash_md5":"4b531524aa13c8a54614100b570b3dc7", "hash_sha1":"7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
-            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":1152921500312810880, "last_event":1596489275,
-            "mode":0, "mtime":1578075431, "options":131583, "path":"/etc/wgetrc", "perm":"-rw-rw-r--", "scanned":1, "size":4925,
-            "uid":0, "user_name":"fakeUser"}],"options":{"return_old_data": true, "ignore":["last_event"]}
-        }
-    )"_json;
-    ASSERT_TRUE(*file->toJSON() == expectedValue);
-    delete file;
+    auto file = std::make_unique<FileItem>(fimEntryTest, true);
+    const auto returnValue = *file->toJSON();
+    const auto expectedValue = R"({"return_old_data": true, "ignore":["last_event"]})"_json;
+    ASSERT_TRUE(returnValue["options"] == expectedValue);
 }

--- a/src/unit_tests/os_execd/CMakeLists.txt
+++ b/src/unit_tests/os_execd/CMakeLists.txt
@@ -34,7 +34,8 @@ if(${TARGET} STREQUAL "winagent")
                              ${DEBUG_OP_WRAPPERS}")
 
     list(APPEND execd_names "test_get_command_by_name")
-    list(APPEND execd_flags "${DEBUG_OP_WRAPPERS}")
+    list(APPEND execd_flags "-Wl,--wrap=syscom_dispatch -Wl,--wrap=Start_win32_Syscheck -Wl,--wrap=is_fim_shutdown \
+                             -Wl,--wrap=_imp__dbsync_initialize -Wl,--wrap=_imp__rsync_initialize -Wl,--wrap=fim_db_teardown \ ${DEBUG_OP_WRAPPERS}")
 else()
     list(APPEND execd_names "test_execd")
     list(APPEND execd_flags "-Wl,--wrap,time -Wl,--wrap,select -Wl,--wrap,OS_RecvUnix \


### PR DESCRIPTION
|EPIC|Component|
|---|---|
| https://github.com/wazuh/wazuh/issues/9103 | FIM |

|Related issue|
|---|
|Closes #14957 |
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors