### PR TITLE
Fix framework and API scripts install

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -37,7 +37,7 @@ install:
 	$(INSTALL_FILE) scripts/wazuh-apid.py ${INSTALLDIR}/api/scripts
 
     # Install scripts/%.py on $(INSTALLDIR)/bin/%
-	$(foreach script,$(wildcard scripts/*.py)),$(INSTALL_EXEC) wrappers/generic_wrapper.sh $(patsubst scripts/%.py,$(INSTALLDIR)/bin/%,$(script));)
+	$(foreach script,$(wildcard scripts/*.py),$(INSTALL_EXEC) wrappers/generic_wrapper.sh $(patsubst scripts/%.py,$(INSTALLDIR)/bin/%,$(script));)
 
 restore:
     # Restore old API config

--- a/api/Makefile
+++ b/api/Makefile
@@ -37,7 +37,7 @@ install:
 	$(INSTALL_FILE) scripts/wazuh-apid.py ${INSTALLDIR}/api/scripts
 
     # Install scripts/%.py on $(INSTALLDIR)/bin/%
-	$(foreach script,$(wildcard scripts/*),$(INSTALL_EXEC) wrappers/generic_wrapper.sh $(patsubst scripts/%.py,$(INSTALLDIR)/bin/%,$(script));)
+	$(foreach script,$(wildcard scripts/*.py)),$(INSTALL_EXEC) wrappers/generic_wrapper.sh $(patsubst scripts/%.py,$(INSTALLDIR)/bin/%,$(script));)
 
 restore:
     # Restore old API config

--- a/framework/Makefile
+++ b/framework/Makefile
@@ -44,7 +44,7 @@ install:
 #	Remove update_ruleset script when upgrading to >=4.2.0 (deprecated)
 	[ ! -e ${INSTALLDIR}/bin/update_ruleset ] || $(RM_FILE) ${INSTALLDIR}/bin/update_ruleset
 #	Install scripts/%.py on $(INSTALLDIR)/bin/%
-	$(foreach script,$(wildcard scripts/*),$(INSTALL_EXEC) wrappers/generic_wrapper.sh $(patsubst scripts/%.py,$(INSTALLDIR)/bin/%,$(script));)
+	$(foreach script,$(wildcard scripts/*.py),$(INSTALL_EXEC) wrappers/generic_wrapper.sh $(patsubst scripts/%.py,$(INSTALLDIR)/bin/%,$(script));)
 #   Provisional name change for wazuh-logtest and wazuh-clusterd
 	$(MV_FILE) $(INSTALLDIR)/bin/wazuh_logtest $(INSTALLDIR)/bin/wazuh-logtest
 	$(MV_FILE) $(INSTALLDIR)/bin/wazuh_clusterd $(INSTALLDIR)/bin/wazuh-clusterd


### PR DESCRIPTION
This PR fixes an issue with the installation of the framework scripts folder after merging https://github.com/wazuh/wazuh/pull/13424.

There was an issue were the generic_wrapper.sh file was copied inside the repository folder:

![image](https://user-images.githubusercontent.com/48716145/198012638-60af88da-4fef-4aad-a98e-2bd8877dc4d5.png)

After the fix, it does not happen and the binaries are properly created:

![image](https://user-images.githubusercontent.com/48716145/198012777-f126ac7f-6718-4e3e-bc8c-aedfc576dda2.png)
