### PR TITLE
Fix client key example in agent insert endpoint

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -8870,7 +8870,7 @@ paths:
                 name: NewHost_2
                 ip: 10.0.10.11
                 id: "123"
-                key: 1abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghi64
+                key: 1abcdef1234567890abcdef1234567890abcdef1234567890abcdef123456789
                 force:
                   enabled: True
                   disconnected_time:


### PR DESCRIPTION
## Description
This fixes the example shown for the `POST /agents/insert` endpoint.
The current example shows all alphanumeric characters when the Wazuh agents only work with hexadecimal characters.

Using this endpoint allows to wrongly create the agent registration with the invalid characters, and configuring an agent to use it will result in failed connections.

## Tests
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities
