### PR TITLE
Fix `not JSON serializable` error in cluster

### DIFF
--- a/framework/wazuh/core/cluster/server.py
+++ b/framework/wazuh/core/cluster/server.py
@@ -141,7 +141,7 @@ class AbstractServerHandler(c_common.Handler):
         self.name = data.decode()
         if self.name in self.server.clients:
             self.name = ''
-            raise exception.WazuhClusterError(3028, extra_message=data)
+            raise exception.WazuhClusterError(3028, extra_message=data.decode())
         elif self.name == self.server.configuration['node_name']:
             raise exception.WazuhClusterError(3029)
         else:

--- a/framework/wazuh/core/cluster/tests/test_server.py
+++ b/framework/wazuh/core/cluster/tests/test_server.py
@@ -136,7 +136,7 @@ def test_AbstractServerHandler_hello(create_task_mock):
         abstract_server_handler.hello(b"elif_test")
 
     abstract_server_handler.server.clients["if_test"] = "testing"
-    with pytest.raises(WazuhClusterError, match=f".* 3028 .* b'if_test'"):
+    with pytest.raises(WazuhClusterError, match=f".* 3028 .* if_test"):
         abstract_server_handler.hello(b"if_test")
     assert abstract_server_handler.name == ""
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #14730 |

## Description

This PR fixes the bug reported in #14730. An unhandled exception was being generated on the master node when two workers tried to connect under the same name:
```2022/10/27 06:45:44 INFO: [Worker] [Main] Connection from ('172.19.0.5', 49008)
2022/10/27 06:45:44 ERROR: [Worker] [Main] Internal error processing request 'b'hello'': Error 3028 - Worker node ID already exists: b'worker1'
2022/10/27 06:45:44 ERROR: [Worker] [Main] Error during handshake with incoming connection: Object of type bytes is not JSON serializable. 
  File "/var/ossec/framework/python/lib/python3.9/asyncio/selector_events.py", line 870, in _read_ready__data_received
    self._protocol.data_received(data)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.5.0-py3.9.egg/wazuh/core/cluster/common.py", line 843, in data_received
    self.dispatch(command, counter, payload)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.5.0-py3.9.egg/wazuh/core/cluster/common.py", line 861, in dispatch
    command, payload = b'err', json.dumps(e, cls=WazuhJSONEncoder).encode()
  File "/var/ossec/framework/python/lib/python3.9/json/__init__.py", line 234, in dumps
    return cls(
  File "/var/ossec/framework/python/lib/python3.9/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/var/ossec/framework/python/lib/python3.9/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.5.0-py3.9.egg/wazuh/core/cluster/common.py", line 1762, in default
    return json.JSONEncoder.default(self, obj)
  File "/var/ossec/framework/python/lib/python3.9/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '

2022/10/27 06:45:44 INFO: [Worker] [Main] Cancelling pending tasks.
```

## Logs/Alerts example

Although the consequences were not serious, this prevented the worker from logging the reason for the rejection. Now the master logs are correct:
```
2022/10/27 06:52:48 INFO: [Worker] [Main] Connection from ('172.19.0.5', 43956)
2022/10/27 06:52:48 ERROR: [Worker] [Main] Internal error processing request 'b'hello'': Error 3028 - Worker node ID already exists: worker1
2022/10/27 06:52:48 ERROR: [Worker] [Main] Error during handshake with incoming connection.
2022/10/27 06:52:48 INFO: [Worker] [Main] Cancelling pending tasks.
```

And the worker logs show that the connection is being aborted for using a duplicate name:
```
2022/10/27 06:52:48 INFO: [Local Server] [Main] Serving on /var/ossec/queue/cluster/c-internal.sock
2022/10/27 06:52:48 ERROR: [Worker worker1] [Main] Could not connect to master: Error 3028 - Worker node ID already exists: worker1.
2022/10/27 06:52:48 INFO: [Worker worker1] [Main] The master closed the connection
```

## Tests

```
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.9.5, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/selu/Git/wazuh/framework
plugins: anyio-3.5.0, asyncio-0.18.1, aiohttp-1.0.4, cov-3.0.0
asyncio: mode=auto
collected 2025 items                                                                                                                                                                                        

framework/scripts/tests/test_agent_groups.py ..............                                                                                                                                           [  0%]
framework/scripts/tests/test_agent_upgrade.py ...............                                                                                                                                         [  1%]
framework/scripts/tests/test_cluster_control.py ......                                                                                                                                                [  1%]
framework/scripts/tests/test_wazuh_clusterd.py .......                                                                                                                                                [  2%]
framework/scripts/tests/test_wazuh_logtest.py ......................                                                                                                                                  [  3%]
framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................................                                                                                                                 [  4%]
framework/wazuh/core/cluster/tests/test_client.py ................                                                                                                                                    [  5%]
framework/wazuh/core/cluster/tests/test_cluster.py ...................................                                                                                                                [  7%]
framework/wazuh/core/cluster/tests/test_common.py ..................................................................................                                                                  [ 11%]
framework/wazuh/core/cluster/tests/test_control.py ......                                                                                                                                             [ 11%]
framework/wazuh/core/cluster/tests/test_local_client.py .............                                                                                                                                 [ 12%]
framework/wazuh/core/cluster/tests/test_local_server.py ........................                                                                                                                      [ 13%]
framework/wazuh/core/cluster/tests/test_master.py ....................................................                                                                                                [ 16%]
framework/wazuh/core/cluster/tests/test_server.py ..............................                                                                                                                      [ 17%]
framework/wazuh/core/cluster/tests/test_utils.py ...........                                                                                                                                          [ 18%]
framework/wazuh/core/cluster/tests/test_worker.py ...................................                                                                                                                 [ 19%]
framework/wazuh/core/tests/test_active_response.py ..............                                                                                                                                     [ 20%]
framework/wazuh/core/tests/test_agent.py ...................................................................................................................................................          [ 27%]
framework/wazuh/core/tests/test_cdb_list.py ......................................                                                                                                                    [ 29%]
framework/wazuh/core/tests/test_common.py .........                                                                                                                                                   [ 30%]
framework/wazuh/core/tests/test_configuration.py ....................................                                                                                                                 [ 31%]
framework/wazuh/core/tests/test_database.py .............                                                                                                                                             [ 32%]
framework/wazuh/core/tests/test_decoder.py ................                                                                                                                                           [ 33%]
framework/wazuh/core/tests/test_exception.py ...                                                                                                                                                      [ 33%]
framework/wazuh/core/tests/test_input_validator.py ...                                                                                                                                                [ 33%]
framework/wazuh/core/tests/test_logtest.py ..                                                                                                                                                         [ 33%]
framework/wazuh/core/tests/test_manager.py ...............                                                                                                                                            [ 34%]
framework/wazuh/core/tests/test_mitre.py .............                                                                                                                                                [ 35%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                                                                                                                                               [ 35%]
framework/wazuh/core/tests/test_results.py ........................................                                                                                                                   [ 37%]
framework/wazuh/core/tests/test_rootcheck.py .............                                                                                                                                            [ 37%]
framework/wazuh/core/tests/test_rule.py ......................                                                                                                                                        [ 38%]
framework/wazuh/core/tests/test_sca.py ........................                                                                                                                                       [ 40%]
framework/wazuh/core/tests/test_security.py ............                                                                                                                                              [ 40%]
framework/wazuh/core/tests/test_stats.py ............                                                                                                                                                 [ 41%]
framework/wazuh/core/tests/test_syscheck.py .......                                                                                                                                                   [ 41%]
framework/wazuh/core/tests/test_syscollector.py ...                                                                                                                                                   [ 41%]
framework/wazuh/core/tests/test_task.py ........                                                                                                                                                      [ 42%]
framework/wazuh/core/tests/test_utils.py ............................................................................................................................................................ [ 49%]
.........................................................................................                                                                                                             [ 54%]
framework/wazuh/core/tests/test_vulnerability.py ..                                                                                                                                                   [ 54%]
framework/wazuh/core/tests/test_wazuh_queue.py ....................                                                                                                                                   [ 55%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                                                  [ 56%]
framework/wazuh/core/tests/test_wdb.py ...............................                                                                                                                                [ 57%]
framework/wazuh/core/tests/test_wlogging.py .........                                                                                                                                                 [ 58%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                                                                                                                                    [ 58%]
framework/wazuh/rbac/tests/test_decorators.py .........................................................................................................                                               [ 63%]
framework/wazuh/rbac/tests/test_default_configuration.py .......................................................                                                                                      [ 66%]
framework/wazuh/rbac/tests/test_orm.py ......................................................                                                                                                         [ 69%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                           [ 69%]
framework/wazuh/tests/test_active_response.py ............                                                                                                                                            [ 70%]
framework/wazuh/tests/test_agent.py ......................................................................................................................                                            [ 76%]
framework/wazuh/tests/test_cdb_list.py .....................................................                                                                                                          [ 78%]
framework/wazuh/tests/test_ciscat.py .................................                                                                                                                                [ 80%]
framework/wazuh/tests/test_cluster.py ..........                                                                                                                                                      [ 80%]
framework/wazuh/tests/test_decoder.py ...................................                                                                                                                             [ 82%]
framework/wazuh/tests/test_group.py .......                                                                                                                                                           [ 82%]
framework/wazuh/tests/test_logtest.py ......                                                                                                                                                          [ 83%]
framework/wazuh/tests/test_manager.py ....................................                                                                                                                            [ 84%]
framework/wazuh/tests/test_mitre.py .......                                                                                                                                                           [ 85%]
framework/wazuh/tests/test_rootcheck.py ..................................................                                                                                                            [ 87%]
framework/wazuh/tests/test_rule.py ........................................................                                                                                                           [ 90%]
framework/wazuh/tests/test_sca.py ...........                                                                                                                                                         [ 91%]
framework/wazuh/tests/test_security.py .........................................................................                                                                                      [ 94%]
framework/wazuh/tests/test_stats.py .......                                                                                                                                                           [ 94%]
framework/wazuh/tests/test_syscheck.py ..........................                                                                                                                                     [ 96%]
framework/wazuh/tests/test_syscollector.py ............                                                                                                                                               [ 96%]
framework/wazuh/tests/test_task.py ............................                                                                                                                                       [ 98%]
framework/wazuh/tests/test_vulnerability.py ....................................                                                                                                                      [100%]

============================================================================== 2025 passed, 3778 warnings in 312.15s (0:05:12) ==============================================================================
```
