### PR TITLE
Add on-demand scan query to Vulnerability Detector

### DIFF
--- a/src/unit_tests/wazuh_modules/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/CMakeLists.txt
@@ -21,6 +21,7 @@ if(${TARGET} STREQUAL "server")
   add_subdirectory(vulnerability_detector)
   add_subdirectory(task_manager)
   add_subdirectory(agent_upgrade)
+  add_subdirectory(wmodules)
 endif()
 
 add_subdirectory(github)

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
@@ -69,6 +69,9 @@ list(APPEND vulndetector_flags "-Wl,--wrap,_merror -Wl,--wrap,_mterror -Wl,--wra
                                 -Wl,--wrap,OSRegex_Compile -Wl,--wrap,OSRegex_Execute,--wrap,fflush -Wl,--wrap,fprintf -Wl,--wrap,fread -Wl,--wrap,fseek \
                                 -Wl,--wrap,remove -Wl,--wrap,getpid -Wl,--wrap,OSMatch_Execute -Wl,--wrap,OSRegex_Execute_ex -Wl,--wrap,fgetpos")
 
+list(APPEND vulndetector_names "test_wm_vuln_detector_run_now")
+list(APPEND vulndetector_flags " ")
+
 # Compilig tests
 list(LENGTH vulndetector_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector_run_now.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector_run_now.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+
+#include "../../wazuh_modules/wmodules.h"
+#include "wazuh_modules/vulnerability_detector/wm_vuln_detector.h"
+
+static int setup_run_now(void ** state) {
+    *state = calloc(1, sizeof(wm_vuldet_t));
+    return 0;
+}
+
+static int teardown_run_now(void ** state) {
+    free(*state);
+    return 0;
+}
+
+void test_wm_vuldet_set_run_now(void ** state) {
+    wm_vuldet_t * vuldet = *(wm_vuldet_t **)state;
+    wm_vuldet_set_run_now(vuldet);
+
+    assert_true(wm_vuldet_check_run_now(vuldet));
+}
+
+void test_wm_vuldet_clear_run_now(void ** state) {
+    wm_vuldet_t * vuldet = *(wm_vuldet_t **)state;
+    wm_vuldet_set_run_now(vuldet);
+    wm_vuldet_clear_run_now(vuldet);
+
+    assert_false(wm_vuldet_check_run_now(vuldet));
+}
+
+void test_wm_vuldet_query_run_now(void ** state) {
+    wm_vuldet_t * vuldet = *(wm_vuldet_t **)state;
+    char input[] = "run_now";
+    char * output = NULL;
+
+    size_t n = wm_vuldet_query(vuldet, input, &output);
+
+    assert_string_equal(output, "ok {\"data\": \"ack\"}");
+    assert_int_equal(n, 18);
+    assert_true(wm_vuldet_check_run_now(vuldet));
+
+    free(output);
+}
+
+void test_wm_vuldet_query_run_now_again(void ** state) {
+    wm_vuldet_t * vuldet = *(wm_vuldet_t **)state;
+    char input[] = "run_now";
+    char * output = NULL;
+
+    wm_vuldet_set_run_now(vuldet);
+    size_t n = wm_vuldet_query(vuldet, input, &output);
+
+    assert_string_equal(output, "ok {\"data\": \"already requested\"}");
+    assert_int_equal(n, 32);
+    assert_true(wm_vuldet_check_run_now(vuldet));
+
+    free(output);
+}
+
+void test_wm_vuldet_query_unknown(void ** state) {
+    wm_vuldet_t * vuldet = *(wm_vuldet_t **)state;
+    char input[] = "none";
+    char * output = NULL;
+
+    size_t n = wm_vuldet_query(vuldet, input, &output);
+
+    assert_string_equal(output, "err {\"message\": \"unknown command\"}");
+    assert_int_equal(n, 34);
+    assert_false(wm_vuldet_check_run_now(vuldet));
+
+    free(output);
+}
+
+int main() {
+    const struct CMUnitTest tests[] = {
+        // Test wm_vuldet_*_run_now
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_set_run_now, setup_run_now, teardown_run_now),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_clear_run_now, setup_run_now, teardown_run_now),
+
+        // Test wm_vuldet_query
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_query_run_now, setup_run_now, teardown_run_now),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_query_run_now_again, setup_run_now, teardown_run_now),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_query_unknown, setup_run_now, teardown_run_now),
+
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/wazuh_modules/wmodules/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/wmodules/CMakeLists.txt
@@ -1,0 +1,61 @@
+# Copyright (C) 2015, Wazuh Inc.
+#
+# This program is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
+
+# Generate wmodules library
+file(GLOB wmodules_files
+    ${SRC_FOLDER}/wazuh_modules/*.o)
+list(REMOVE_ITEM wmodules_files ${SRC_FOLDER}/wazuh_modules/main.o)
+
+add_library(WMODULES_O STATIC ${wmodules_files})
+
+set_source_files_properties(
+    ${wmodules_files}
+    PROPERTIES
+    EXTERNAL_OBJECT true
+    GENERATED true
+)
+
+set_target_properties(
+    WMODULES_O
+    PROPERTIES
+    LINKER_LANGUAGE C
+)
+
+target_link_libraries(WMODULES_O ${WAZUHLIB} ${WAZUHEXT} -lpthread)
+
+#include wrappers
+include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
+
+# Generate wmodules tests
+list(APPEND wmodules_names "test_wmodules")
+list(APPEND wmodules_flags " ")
+
+# Compilig tests
+list(LENGTH wmodules_names count)
+math(EXPR count "${count} - 1")
+foreach(counter RANGE ${count})
+    list(GET wmodules_names ${counter} test_name)
+    list(GET wmodules_flags ${counter} test_flags)
+
+    add_executable(${test_name} ${test_name}.c)
+
+    target_link_libraries(
+        ${test_name}
+        ${WAZUHLIB}
+        ${WAZUHEXT}
+        WMODULES_O
+        ${TEST_DEPS}
+    )
+
+    if(NOT test_flags STREQUAL " ")
+        target_link_libraries(
+            ${test_name}
+            ${test_flags}
+        )
+    endif()
+    add_test(NAME ${test_name} COMMAND ${test_name})
+endforeach()

--- a/src/unit_tests/wazuh_modules/wmodules/test_wmodules.c
+++ b/src/unit_tests/wazuh_modules/wmodules/test_wmodules.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ *
+ * Test corresponding to the wazuh-modulesd shared functions
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <time.h>
+
+#include "../../../wazuh_modules/wmodules.h"
+
+static size_t echo(void * module, char * query, char ** output) {
+    (void)module;
+    *output = strdup(query);
+    return strlen(query);
+}
+
+static int setup_modules(void ** state) {
+    static wm_context CONTEXTS[] = {
+        { .name = "A", .query = echo },
+        { .name = "B", .query = NULL },
+    };
+
+    wmodules = calloc(1, sizeof(wmodule));
+    wmodules->context = &CONTEXTS[0];
+    wmodules->next = calloc(1, sizeof(wmodule));
+    wmodules->next->context = &CONTEXTS[1];
+
+    *state = NULL;
+    return 0;
+}
+
+static int teardown_modules(void ** state) {
+    free(*state);
+    free(wmodules->next);
+    free(wmodules);
+
+    return 0;
+}
+
+static void test_find_module_found(void ** state) {
+    (void)state;
+
+    wmodule * m = wm_find_module("A");
+
+    assert_non_null(m);
+    assert_string_equal(m->context->name, "A");
+
+    m = wm_find_module("B");
+
+    assert_non_null(m);
+    assert_string_equal(m->context->name, "B");
+}
+
+static void test_find_module_not_found(void ** state) {
+    (void)state;
+
+    wmodule * m = wm_find_module("C");
+
+    assert_null(m);
+}
+
+static void test_module_query_no_args(void ** state) {
+    char input[] = "none";
+
+    size_t n = wm_module_query(input, (char **)state);
+
+    assert_string_equal(*state, "err {\"message\": \"module query needs arguments\"}");
+    assert_int_equal(n, 47);
+}
+
+static void test_module_query_no_module(void ** state) {
+    char input[] = "C some-command";
+
+    size_t n = wm_module_query(input, (char **)state);
+
+    assert_string_equal(*state, "err {\"message\": \"running module not found\"}");
+    assert_int_equal(n, 43);
+}
+
+static void test_module_query_no_queries(void ** state) {
+    char input[] = "B some-command";
+
+    size_t n = wm_module_query(input, (char **)state);
+
+    assert_string_equal(*state, "err {\"message\": \"module does not support queries\"}");
+    assert_int_equal(n, 50);
+}
+
+static void test_module_query_echo(void ** state) {
+    char input[] = "A echo";
+
+    size_t n = wm_module_query(input, (char **)state);
+
+    assert_string_equal(*state, "echo");
+    assert_int_equal(n, 4);
+}
+
+int main() {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_find_module_found, setup_modules, teardown_modules),
+        cmocka_unit_test_setup_teardown(test_find_module_not_found, setup_modules, teardown_modules),
+        cmocka_unit_test_setup_teardown(test_module_query_no_args, setup_modules, teardown_modules),
+        cmocka_unit_test_setup_teardown(test_module_query_no_module, setup_modules, teardown_modules),
+        cmocka_unit_test_setup_teardown(test_module_query_no_queries, setup_modules, teardown_modules),
+        cmocka_unit_test_setup_teardown(test_module_query_echo, setup_modules, teardown_modules),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.c
+++ b/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.c
@@ -38,12 +38,12 @@ STATIC cJSON *wm_agent_upgrade_dump(const wm_agent_upgrade* upgrade_config);
 
 /* Context definition */
 const wm_context WM_AGENT_UPGRADE_CONTEXT = {
-    AGENT_UPGRADE_WM_NAME,
-    (wm_routine)wm_agent_upgrade_main,
-    (void(*)(void *))wm_agent_upgrade_destroy,
-    (cJSON * (*)(const void *))wm_agent_upgrade_dump,
-    NULL,
-    NULL
+    .name = AGENT_UPGRADE_WM_NAME,
+    .start = (wm_routine)wm_agent_upgrade_main,
+    .destroy = (void(*)(void *))wm_agent_upgrade_destroy,
+    .dump = (cJSON * (*)(const void *))wm_agent_upgrade_dump,
+    .sync = NULL,
+    .stop = NULL,
 };
 
 #ifdef WIN32

--- a/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.c
+++ b/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.c
@@ -44,6 +44,7 @@ const wm_context WM_AGENT_UPGRADE_CONTEXT = {
     .dump = (cJSON * (*)(const void *))wm_agent_upgrade_dump,
     .sync = NULL,
     .stop = NULL,
+    .query = NULL,
 };
 
 #ifdef WIN32

--- a/src/wazuh_modules/task_manager/wm_task_manager.c
+++ b/src/wazuh_modules/task_manager/wm_task_manager.c
@@ -41,12 +41,12 @@ STATIC cJSON* wm_task_manager_dump(const wm_task_manager* task_config);
 
 /* Context definition */
 const wm_context WM_TASK_MANAGER_CONTEXT = {
-    TASK_MANAGER_WM_NAME,
-    (wm_routine)wm_task_manager_main,
-    (void (*)(void *))wm_task_manager_destroy,
-    (cJSON * (*)(const void *))wm_task_manager_dump,
-    NULL,
-    NULL
+    .name = TASK_MANAGER_WM_NAME,
+    .start = (wm_routine)wm_task_manager_main,
+    .destroy = (void (*)(void *))wm_task_manager_destroy,
+    .dump = (cJSON * (*)(const void *))wm_task_manager_dump,
+    .sync = NULL,
+    .stop = NULL,
 };
 
 size_t wm_task_manager_dispatch(const char *msg, char **response) {

--- a/src/wazuh_modules/task_manager/wm_task_manager.c
+++ b/src/wazuh_modules/task_manager/wm_task_manager.c
@@ -47,6 +47,7 @@ const wm_context WM_TASK_MANAGER_CONTEXT = {
     .dump = (cJSON * (*)(const void *))wm_task_manager_dump,
     .sync = NULL,
     .stop = NULL,
+    .query = NULL,
 };
 
 size_t wm_task_manager_dispatch(const char *msg, char **response) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -444,12 +444,12 @@ int usec;
 int deps_id = 0;
 
 const wm_context WM_VULNDETECTOR_CONTEXT = {
-    "vulnerability-detector",
-    (wm_routine)wm_vuldet_main,
-    (void (*)(void *))wm_vuldet_destroy,
-    (cJSON * (*)(const void *))wm_vuldet_dump,
-    NULL,
-    NULL
+    .name = "vulnerability-detector",
+    .start = (wm_routine)wm_vuldet_main,
+    .destroy = (void (*)(void *))wm_vuldet_destroy,
+    .dump = (cJSON * (*)(const void *))wm_vuldet_dump,
+    .sync = NULL,
+    .stop = NULL,
 };
 
 const char *version_null = "0:0";

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -450,6 +450,7 @@ const wm_context WM_VULNDETECTOR_CONTEXT = {
     .dump = (cJSON * (*)(const void *))wm_vuldet_dump,
     .sync = NULL,
     .stop = NULL,
+    .query = NULL,
 };
 
 const char *version_null = "0:0";

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -450,7 +450,7 @@ const wm_context WM_VULNDETECTOR_CONTEXT = {
     .dump = (cJSON * (*)(const void *))wm_vuldet_dump,
     .sync = NULL,
     .stop = NULL,
-    .query = NULL,
+    .query = (size_t (*)(void *, char *, char **)) wm_vuldet_query,
 };
 
 const char *version_null = "0:0";
@@ -5587,7 +5587,8 @@ void *wm_vuldet_main(wm_vuldet_t * vuldet) {
             mterror(WM_VULNDETECTOR_LOGTAG, VU_OVAL_UPDATE_ERROR);
         }
 
-        if ((curr_time - vuldet->last_scan >= vuldet->scan_interval)) {
+        if ((curr_time - vuldet->last_scan >= vuldet->scan_interval) || wm_vuldet_check_run_now(vuldet)) {
+            wm_vuldet_clear_run_now(vuldet);
             wm_vuldet_run_scan(vuldet);
         }
 
@@ -8253,7 +8254,10 @@ void wm_vuldet_run_sleep(wm_vuldet_t * vuldet) {
     }
 
     mtdebug2(WM_VULNDETECTOR_LOGTAG, "Sleeping for %lu seconds...", time_sleep);
-    sleep(time_sleep);
+
+    for (i = 0; i < time_sleep && !wm_vuldet_check_run_now(vuldet); i++) {
+        sleep(1);
+    }
 }
 
 void wm_vuldet_init(wm_vuldet_t * vuldet) {
@@ -9163,6 +9167,39 @@ void wm_vuldet_give_report_format(vu_report *report) {
     const char* severity = wm_vuldet_get_unified_severity(report->severity);
     os_free(report->severity);
     w_strdup(severity, report->severity);
+}
+
+// Set the run-now flag
+
+void wm_vuldet_set_run_now(wm_vuldet_t * vuldet) {
+    vuldet->flags.run_now = 1;
+}
+
+// Check the run-now flag
+
+bool wm_vuldet_check_run_now(const wm_vuldet_t * vuldet) {
+    return vuldet->flags.run_now;
+}
+
+// Clear the run-now flag
+
+void wm_vuldet_clear_run_now(wm_vuldet_t * vuldet) {
+    vuldet->flags.run_now = 0;
+}
+
+// Run a query
+
+size_t wm_vuldet_query(wm_vuldet_t * vuldet, char * query, char ** output) {
+    if (strcmp(query, "run_now") == 0) {
+        bool run_now = wm_vuldet_check_run_now(vuldet);
+        wm_vuldet_set_run_now(vuldet);
+        mdebug2("Scan requested.");
+        os_strdup(run_now ? "ok {\"data\": \"already requested\"}" : "ok {\"data\": \"ack\"}", *output);
+    } else {
+        os_strdup("err {\"message\": \"unknown command\"}", *output);
+    }
+
+    return strlen(*output);
 }
 
 #endif

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -396,6 +396,7 @@ typedef struct wm_vuldet_flags {
     unsigned int update:1;
     unsigned int patch_scan:1;
     unsigned int permissive_patch_scan:1;
+    unsigned int run_now:1;
 } wm_vuldet_flags;
 
 typedef struct wm_vuldet_state {
@@ -1185,6 +1186,39 @@ char* wm_vuldet_normalize_architecture_nvd(char* architecture);
  * @param report The report structure.
  */
 void wm_vuldet_give_report_format(vu_report *report);
+
+/**
+ * @brief Set the run-now flag
+ *
+ * @param vuldet Pointer to a Vulnerability Detector structure.
+ */
+void wm_vuldet_set_run_now(wm_vuldet_t * vuldet);
+
+/**
+ * @brief Check the run-now flag
+ *
+ * @param vuldet Pointer to a Vulnerability Detector structure.
+ * @return true When the run-now flag is enabled.
+ * @return false When the run-now flag is disabled.
+ */
+bool wm_vuldet_check_run_now(const wm_vuldet_t * vuldet);
+
+/**
+ * @brief Clear the run-now flag
+ *
+ * @param vuldet Pointer to a Vulnerability Detector structure.
+ */
+void wm_vuldet_clear_run_now(wm_vuldet_t * vuldet);
+
+/**
+ * @brief Run a query
+ *
+ * @param vuldet Pointer to Vulnerability Detector structure.
+ * @param query Query payload
+ * @param output Output payload
+ * @return size_t Size of the output
+ */
+size_t wm_vuldet_query(wm_vuldet_t * vuldet, char * query, char ** output);
 
 #endif
 #endif

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -40,6 +40,7 @@ const wm_context WM_AWS_CONTEXT = {
     .dump = (cJSON * (*)(const void *))wm_aws_dump,
     .sync = NULL,
     .stop = NULL,
+    .query = NULL,
 };
 
 // Module module main function. It won't return.

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -34,12 +34,12 @@ cJSON *wm_aws_dump(const wm_aws *aws_config);
 // Command module context definition
 
 const wm_context WM_AWS_CONTEXT = {
-    "aws-s3",
-    (wm_routine)wm_aws_main,
-    (void(*)(void *))wm_aws_destroy,
-    (cJSON * (*)(const void *))wm_aws_dump,
-    NULL,
-    NULL
+    .name = "aws-s3",
+    .start = (wm_routine)wm_aws_main,
+    .destroy = (void(*)(void *))wm_aws_destroy,
+    .dump = (cJSON * (*)(const void *))wm_aws_dump,
+    .sync = NULL,
+    .stop = NULL,
 };
 
 // Module module main function. It won't return.

--- a/src/wazuh_modules/wm_azure.c
+++ b/src/wazuh_modules/wm_azure.c
@@ -32,12 +32,12 @@ cJSON *wm_azure_dump(const wm_azure_t *azure);                          // Dump 
 //  Azure module context definition
 
 const wm_context WM_AZURE_CONTEXT = {
-    AZ_WM_NAME,
-    (wm_routine)wm_azure_main,
-    (void(*)(void *))wm_azure_destroy,
-    (cJSON * (*)(const void *))wm_azure_dump,
-    NULL,
-    NULL
+    .name = AZ_WM_NAME,
+    .start = (wm_routine)wm_azure_main,
+    .destroy = (void(*)(void *))wm_azure_destroy,
+    .dump = (cJSON * (*)(const void *))wm_azure_dump,
+    .sync = NULL,
+    .stop = NULL,
 };
 
 // Module main function. It won't return.

--- a/src/wazuh_modules/wm_azure.c
+++ b/src/wazuh_modules/wm_azure.c
@@ -38,6 +38,7 @@ const wm_context WM_AZURE_CONTEXT = {
     .dump = (cJSON * (*)(const void *))wm_azure_dump,
     .sync = NULL,
     .stop = NULL,
+    .query = NULL,
 };
 
 // Module main function. It won't return.

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -46,12 +46,12 @@ const char *WM_CISCAT_LOCATION = "wodle_cis-cat";  // Location field for event s
 // CIS-CAT module context definition
 
 const wm_context WM_CISCAT_CONTEXT = {
-    "cis-cat",
-    (wm_routine)wm_ciscat_main,
-    (void(*)(void *))wm_ciscat_destroy,
-    (cJSON * (*)(const void *))wm_ciscat_dump,
-    NULL,
-    NULL
+    .name = "cis-cat",
+    .start = (wm_routine)wm_ciscat_main,
+    .destroy = (void(*)(void *))wm_ciscat_destroy,
+    .dump = (cJSON * (*)(const void *))wm_ciscat_dump,
+    .sync = NULL,
+    .stop = NULL,
 };
 
 // CIS-CAT module main function. It won't return.

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -52,6 +52,7 @@ const wm_context WM_CISCAT_CONTEXT = {
     .dump = (cJSON * (*)(const void *))wm_ciscat_dump,
     .sync = NULL,
     .stop = NULL,
+    .query = NULL,
 };
 
 // CIS-CAT module main function. It won't return.

--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -22,12 +22,12 @@ cJSON *wm_command_dump(const wm_command_t * command);
 // Command module context definition
 
 const wm_context WM_COMMAND_CONTEXT = {
-    "command",
-    (wm_routine)wm_command_main,
-    (void(*)(void *))wm_command_destroy,
-    (cJSON * (*)(const void *))wm_command_dump,
-    NULL,
-    NULL
+    .name = "command",
+    .start = (wm_routine)wm_command_main,
+    .destroy = (void(*)(void *))wm_command_destroy,
+    .dump = (cJSON * (*)(const void *))wm_command_dump,
+    .sync = NULL,
+    .stop = NULL,
 };
 
 // Module module main function. It won't return.

--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -28,6 +28,7 @@ const wm_context WM_COMMAND_CONTEXT = {
     .dump = (cJSON * (*)(const void *))wm_command_dump,
     .sync = NULL,
     .stop = NULL,
+    .query = NULL,
 };
 
 // Module module main function. It won't return.

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -21,12 +21,12 @@ static void wm_control_destroy();
 cJSON *wm_control_dump();
 
 const wm_context WM_CONTROL_CONTEXT = {
-    "control",
-    (wm_routine)wm_control_main,
-    (void(*)(void *))wm_control_destroy,
-    (cJSON * (*)(const void *))wm_control_dump,
-    NULL,
-    NULL
+    .name = "control",
+    .start = (wm_routine)wm_control_main,
+    .destroy = (void(*)(void *))wm_control_destroy,
+    .dump = (cJSON * (*)(const void *))wm_control_dump,
+    .sync = NULL,
+    .stop = NULL,
 };
 void *sysinfo_module = NULL;
 sysinfo_networks_func sysinfo_network_ptr = NULL;

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -27,6 +27,7 @@ const wm_context WM_CONTROL_CONTEXT = {
     .dump = (cJSON * (*)(const void *))wm_control_dump,
     .sync = NULL,
     .stop = NULL,
+    .query = NULL,
 };
 void *sysinfo_module = NULL;
 sysinfo_networks_func sysinfo_network_ptr = NULL;

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -111,6 +111,7 @@ const wm_context WM_DATABASE_CONTEXT = {
     .dump = (cJSON * (*)(const void *))wm_database_dump,
     .sync = NULL,
     .stop = NULL,
+    .query = NULL,
 };
 
 // Module main function. It won't return

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -105,12 +105,12 @@ static int wm_sync_file(const char *dirname, const char *path);
 
 // Database module context definition
 const wm_context WM_DATABASE_CONTEXT = {
-    "database",
-    (wm_routine)wm_database_main,
-    (void(*)(void *))wm_database_destroy,
-    (cJSON * (*)(const void *))wm_database_dump,
-    NULL,
-    NULL
+    .name = "database",
+    .start = (wm_routine)wm_database_main,
+    .destroy = (void(*)(void *))wm_database_destroy,
+    .dump = (cJSON * (*)(const void *))wm_database_dump,
+    .sync = NULL,
+    .stop = NULL,
 };
 
 // Module main function. It won't return

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -65,7 +65,7 @@ int wdb_wmdb_sock = -1;
 // Module main function. It won't return
 static void* wm_database_main(wm_database *data);
 // Destroy data
-static void* wm_database_destroy(wm_database *data);
+static void wm_database_destroy(wm_database *data);
 // Read config
 cJSON *wm_database_dump(const wm_database *data);
 // Update manager information
@@ -711,9 +711,8 @@ cJSON *wm_database_dump(const wm_database *data) {
 
 
 // Destroy data
-void* wm_database_destroy(wm_database *data) {
+void wm_database_destroy(wm_database *data) {
     free(data);
-    return NULL;
 }
 
 // Read configuration and return a module (if enabled) or NULL (if disabled)

--- a/src/wazuh_modules/wm_docker.c
+++ b/src/wazuh_modules/wm_docker.c
@@ -25,12 +25,12 @@ cJSON *wm_docker_dump(const wm_docker_t *docker_conf);         // Dump docker co
 // Docker module context definition
 
 const wm_context WM_DOCKER_CONTEXT = {
-    "docker-listener",
-    (wm_routine)wm_docker_main,
-    (void(*)(void *))wm_docker_destroy,
-    (cJSON * (*)(const void *))wm_docker_dump,
-    NULL,
-    NULL
+    .name = "docker-listener",
+    .start = (wm_routine)wm_docker_main,
+    .destroy = (void(*)(void *))wm_docker_destroy,
+    .dump = (cJSON * (*)(const void *))wm_docker_dump,
+    .sync = NULL,
+    .stop = NULL,
 };
 
 // Module module main function. It won't return.

--- a/src/wazuh_modules/wm_docker.c
+++ b/src/wazuh_modules/wm_docker.c
@@ -31,6 +31,7 @@ const wm_context WM_DOCKER_CONTEXT = {
     .dump = (cJSON * (*)(const void *))wm_docker_dump,
     .sync = NULL,
     .stop = NULL,
+    .query = NULL,
 };
 
 // Module module main function. It won't return.

--- a/src/wazuh_modules/wm_download.c
+++ b/src/wazuh_modules/wm_download.c
@@ -40,6 +40,7 @@ const wm_context WM_DOWNLOAD_CONTEXT = {
     .dump = (cJSON * (*)(const void *))wm_download_dump,
     .sync = NULL,
     .stop = NULL,
+    .query = NULL,
 };
 
 // Module main function. It won't return

--- a/src/wazuh_modules/wm_download.c
+++ b/src/wazuh_modules/wm_download.c
@@ -34,12 +34,12 @@ cJSON *wm_download_dump();     // Read config
 static void wm_download_dispatch(char * buffer);
 
 const wm_context WM_DOWNLOAD_CONTEXT = {
-    "download",
-    (wm_routine)wm_download_main,
-    (void (*)(void *))wm_download_destroy,
-    (cJSON * (*)(const void *))wm_download_dump,
-    NULL,
-    NULL
+    .name = "download",
+    .start = (wm_routine)wm_download_main,
+    .destroy = (void (*)(void *))wm_download_destroy,
+    .dump = (cJSON * (*)(const void *))wm_download_dump,
+    .sync = NULL,
+    .stop = NULL,
 };
 
 // Module main function. It won't return

--- a/src/wazuh_modules/wm_fluent.c
+++ b/src/wazuh_modules/wm_fluent.c
@@ -68,12 +68,12 @@ static int wm_fluent_check_config(wm_fluent_t * fluent);
 static void wm_fluent_poll_server(wm_fluent_t * fluent);
 
 const wm_context WM_FLUENT_CONTEXT = {
-    FLUENT_WM_NAME,
-    (wm_routine)wm_fluent_main,
-    (void(*)(void *))wm_fluent_destroy,
-    (cJSON * (*)(const void *))wm_fluent_dump,
-    NULL,
-    NULL
+    .name = FLUENT_WM_NAME,
+    .start = (wm_routine)wm_fluent_main,
+    .destroy = (void(*)(void *))wm_fluent_destroy,
+    .dump = (cJSON * (*)(const void *))wm_fluent_dump,
+    .sync = NULL,
+    .stop = NULL,
 };
 
 // Module main function. It won't return

--- a/src/wazuh_modules/wm_fluent.c
+++ b/src/wazuh_modules/wm_fluent.c
@@ -74,6 +74,7 @@ const wm_context WM_FLUENT_CONTEXT = {
     .dump = (cJSON * (*)(const void *))wm_fluent_dump,
     .sync = NULL,
     .stop = NULL,
+    .query = NULL,
 };
 
 // Module main function. It won't return

--- a/src/wazuh_modules/wm_gcp.c
+++ b/src/wazuh_modules/wm_gcp.c
@@ -101,6 +101,7 @@ const wm_context WM_GCP_PUBSUB_CONTEXT = {
     .dump = (cJSON * (*)(const void *))wm_gcp_pubsub_dump,
     .sync = NULL,
     .stop = NULL,
+    .query = NULL,
 };
 
 const wm_context WM_GCP_BUCKET_CONTEXT = {
@@ -110,6 +111,7 @@ const wm_context WM_GCP_BUCKET_CONTEXT = {
     .dump = (cJSON * (*)(const void *))wm_gcp_bucket_dump,
     .sync = NULL,
     .stop = NULL,
+    .query = NULL,
 };
 
 #ifdef WAZUH_UNIT_TESTING

--- a/src/wazuh_modules/wm_gcp.c
+++ b/src/wazuh_modules/wm_gcp.c
@@ -95,21 +95,21 @@ static void wm_gcp_parse_output(char *output, char *tag);
 /* Context definition */
 
 const wm_context WM_GCP_PUBSUB_CONTEXT = {
-    GCP_PUBSUB_WM_NAME,
-    (wm_routine)wm_gcp_pubsub_main,
-    (void(*)(void *))wm_gcp_pubsub_destroy,
-    (cJSON * (*)(const void *))wm_gcp_pubsub_dump,
-    NULL,
-    NULL
+    .name = GCP_PUBSUB_WM_NAME,
+    .start = (wm_routine)wm_gcp_pubsub_main,
+    .destroy = (void(*)(void *))wm_gcp_pubsub_destroy,
+    .dump = (cJSON * (*)(const void *))wm_gcp_pubsub_dump,
+    .sync = NULL,
+    .stop = NULL,
 };
 
 const wm_context WM_GCP_BUCKET_CONTEXT = {
-    GCP_BUCKET_WM_NAME,
-    (wm_routine)wm_gcp_bucket_main,
-    (void(*)(void *))wm_gcp_bucket_destroy,
-    (cJSON * (*)(const void *))wm_gcp_bucket_dump,
-    NULL,
-    NULL
+    .name = GCP_BUCKET_WM_NAME,
+    .start = (wm_routine)wm_gcp_bucket_main,
+    .destroy = (void(*)(void *))wm_gcp_bucket_destroy,
+    .dump = (cJSON * (*)(const void *))wm_gcp_bucket_dump,
+    .sync = NULL,
+    .stop = NULL,
 };
 
 #ifdef WAZUH_UNIT_TESTING
@@ -334,7 +334,7 @@ static void wm_gcp_parse_output(char *output, char *tag){
         // 1 is added because it's mandatory to consider the null byte
         int cp_length = 1 + strlen(line) - next_lines_chars > WM_STRING_MAX ? WM_STRING_MAX : 1 + strlen(line) - next_lines_chars;
         snprintf(tokenized_line, cp_length, "%s", line);
-        if (tokenized_line[cp_length - 2] == '\n') tokenized_line[cp_length - 2] = '\0'; 
+        if (tokenized_line[cp_length - 2] == '\n') tokenized_line[cp_length - 2] = '\0';
 
         char *p_line = NULL;
 

--- a/src/wazuh_modules/wm_github.c
+++ b/src/wazuh_modules/wm_github.c
@@ -79,6 +79,7 @@ const wm_context WM_GITHUB_CONTEXT = {
     .dump = (cJSON * (*)(const void *))wm_github_dump,
     .sync = NULL,
     .stop = NULL,
+    .query = NULL,
 };
 
 #ifdef WIN32

--- a/src/wazuh_modules/wm_github.c
+++ b/src/wazuh_modules/wm_github.c
@@ -73,12 +73,12 @@ STATIC void wm_github_scan_failure_action(wm_github_fail **current_fails, char *
 
 /* Context definition */
 const wm_context WM_GITHUB_CONTEXT = {
-    GITHUB_WM_NAME,
-    (wm_routine)wm_github_main,
-    (void(*)(void *))wm_github_destroy,
-    (cJSON * (*)(const void *))wm_github_dump,
-    NULL,
-    NULL
+    .name = GITHUB_WM_NAME,
+    .start = (wm_routine)wm_github_main,
+    .destroy = (void(*)(void *))wm_github_destroy,
+    .dump = (cJSON * (*)(const void *))wm_github_dump,
+    .sync = NULL,
+    .stop = NULL,
 };
 
 #ifdef WIN32

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -113,12 +113,12 @@ STATIC void wm_office365_scan_failure_action(wm_office365_fail** current_fails, 
 
 /* Context definition */
 const wm_context WM_OFFICE365_CONTEXT = {
-    OFFICE365_WM_NAME,
-    (wm_routine)wm_office365_main,
-    (void(*)(void *))wm_office365_destroy,
-    (cJSON * (*)(const void *))wm_office365_dump,
-    NULL,
-    NULL
+    .name = OFFICE365_WM_NAME,
+    .start = (wm_routine)wm_office365_main,
+    .destroy = (void(*)(void *))wm_office365_destroy,
+    .dump = (cJSON * (*)(const void *))wm_office365_dump,
+    .sync = NULL,
+    .stop = NULL,
 };
 
 #ifdef WIN32

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -119,6 +119,7 @@ const wm_context WM_OFFICE365_CONTEXT = {
     .dump = (cJSON * (*)(const void *))wm_office365_dump,
     .sync = NULL,
     .stop = NULL,
+    .query = NULL,
 };
 
 #ifdef WIN32

--- a/src/wazuh_modules/wm_oscap.c
+++ b/src/wazuh_modules/wm_oscap.c
@@ -22,12 +22,12 @@ cJSON *wm_oscap_dump(const wm_oscap *oscap);
 // OpenSCAP module context definition
 
 const wm_context WM_OSCAP_CONTEXT = {
-    "open-scap",
-    (wm_routine)wm_oscap_main,
-    (void(*)(void *))wm_oscap_destroy,
-    (cJSON * (*)(const void *))wm_oscap_dump,
-    NULL,
-    NULL
+    .name = "open-scap",
+    .start = (wm_routine)wm_oscap_main,
+    .destroy = (void(*)(void *))wm_oscap_destroy,
+    .dump = (cJSON * (*)(const void *))wm_oscap_dump,
+    .sync = NULL,
+    .stop = NULL,
 };
 
 #ifndef WIN32
@@ -372,4 +372,3 @@ void wm_oscap_destroy(wm_oscap *oscap) {
 
     free(oscap);
 }
-

--- a/src/wazuh_modules/wm_oscap.c
+++ b/src/wazuh_modules/wm_oscap.c
@@ -28,6 +28,7 @@ const wm_context WM_OSCAP_CONTEXT = {
     .dump = (cJSON * (*)(const void *))wm_oscap_dump,
     .sync = NULL,
     .stop = NULL,
+    .query = NULL,
 };
 
 #ifndef WIN32

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -57,6 +57,7 @@ const wm_context WM_OSQUERYMONITOR_CONTEXT = {
     .dump = (cJSON * (*)(const void *))wm_osquery_dump,
     .sync = NULL,
     .stop = NULL,
+    .query = NULL,
 };
 
 void *Read_Log(wm_osquery_monitor_t * osquery)

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -51,12 +51,12 @@ cJSON *wm_osquery_dump(const wm_osquery_monitor_t *osquery_monitor);
 static volatile int active = 1;
 
 const wm_context WM_OSQUERYMONITOR_CONTEXT = {
-    "osquery",
-    (wm_routine)wm_osquery_monitor_main,
-    (void(*)(void *))wm_osquery_monitor_destroy,
-    (cJSON * (*)(const void *))wm_osquery_dump,
-    NULL,
-    NULL
+    .name = "osquery",
+    .start = (wm_routine)wm_osquery_monitor_main,
+    .destroy = (void(*)(void *))wm_osquery_monitor_destroy,
+    .dump = (cJSON * (*)(const void *))wm_osquery_dump,
+    .sync = NULL,
+    .stop = NULL,
 };
 
 void *Read_Log(wm_osquery_monitor_t * osquery)

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -120,6 +120,7 @@ const wm_context WM_SCA_CONTEXT = {
     .dump = (cJSON * (*)(const void *))wm_sca_dump,
     .sync = NULL,
     .stop = NULL,
+    .query = NULL,
 };
 
 static unsigned int summary_passed = 0;

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -114,12 +114,12 @@ static int wm_sca_winreg_querykey(HKEY hKey, const char *full_key_name, char *re
 cJSON *wm_sca_dump(const wm_sca_t * data);     // Read config
 
 const wm_context WM_SCA_CONTEXT = {
-    SCA_WM_NAME,
-    (wm_routine)wm_sca_main,
-    (void(*)(void *))wm_sca_destroy,
-    (cJSON * (*)(const void *))wm_sca_dump,
-    NULL,
-    NULL
+    .name = SCA_WM_NAME,
+    .start = (wm_routine)wm_sca_main,
+    .destroy = (void(*)(void *))wm_sca_destroy,
+    .dump = (cJSON * (*)(const void *))wm_sca_dump,
+    .sync = NULL,
+    .stop = NULL,
 };
 
 static unsigned int summary_passed = 0;
@@ -1087,7 +1087,7 @@ static int wm_sca_do_scan(cJSON *checks, OSStore *vars, wm_sca_t * data, int id,
 
                 if (!rule_location) {
                     continue;
-                }                   
+                }
 
                 const int result = wm_sca_check_file_list(rule_location, pattern, &reason);
                 if (result == RETURN_FOUND || result == RETURN_INVALID) {
@@ -1107,7 +1107,7 @@ static int wm_sca_do_scan(cJSON *checks, OSStore *vars, wm_sca_t * data, int id,
                 char *aux = NULL;
 
                 os_strdup(value, rule_location);
-                
+
                 if (!data->remote_commands && remote_policy) {
                     mwarn("Ignoring check for policy '%s'. The internal option 'sca.remote_commands' is disabled.", cJSON_GetObjectItem(policy, "name")->valuestring);
                     if (reason == NULL) {
@@ -1136,7 +1136,7 @@ static int wm_sca_do_scan(cJSON *checks, OSStore *vars, wm_sca_t * data, int id,
 
                     if (!rule_location) {
                         continue;
-                    }    
+                    }
 
                     mdebug2("Running command: '%s'", rule_location);
                     const int val = wm_sca_read_command(rule_location, pattern, data, &reason);
@@ -1183,7 +1183,7 @@ static int wm_sca_do_scan(cJSON *checks, OSStore *vars, wm_sca_t * data, int id,
 
                 if (!rule_location) {
                     continue;
-                }    
+                }
 
                 char * const pattern = wm_sca_get_pattern(file);
                 found = wm_sca_check_dir_list(data, rule_location, file, pattern, &reason);
@@ -3182,7 +3182,7 @@ char **wm_sort_variables(const cJSON * const variables) {
         return NULL;
     }
 
-    os_calloc(variables_array_size + 1, sizeof(char *), variables_array); 
+    os_calloc(variables_array_size + 1, sizeof(char *), variables_array);
 
     // Fill array with unsorted variables
     cJSON_ArrayForEach(variable, variables) {
@@ -3190,7 +3190,7 @@ char **wm_sort_variables(const cJSON * const variables) {
         i++;
     }
 
-    // variables_array_size and i should always be the same 
+    // variables_array_size and i should always be the same
     if (variables_array_size != i) {
         free_strarray(variables_array);
         return NULL;

--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -40,6 +40,7 @@ const wm_context WM_SYS_CONTEXT = {
     .dump = (cJSON * (*)(const void *))wm_sys_dump,
     .sync = (int(*)(const char*))wm_sync_message,
     .stop = (void(*)(void *))wm_sys_stop,
+    .query = NULL,
 };
 
 void *syscollector_module = NULL;

--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -34,12 +34,12 @@ pthread_mutex_t sys_reconnect_mutex;
 bool shutdown_process_started = false;
 
 const wm_context WM_SYS_CONTEXT = {
-    "syscollector",
-    (wm_routine)wm_sys_main,
-    (void(*)(void *))wm_sys_destroy,
-    (cJSON * (*)(const void *))wm_sys_dump,
-    (int(*)(const char*))wm_sync_message,
-    (void(*)(void *))wm_sys_stop
+    .name = "syscollector",
+    .start = (wm_routine)wm_sys_main,
+    .destroy = (void(*)(void *))wm_sys_destroy,
+    .dump = (cJSON * (*)(const void *))wm_sys_dump,
+    .sync = (int(*)(const char*))wm_sync_message,
+    .stop = (void(*)(void *))wm_sys_stop,
 };
 
 void *syscollector_module = NULL;

--- a/src/wazuh_modules/wmcom.c
+++ b/src/wazuh_modules/wmcom.c
@@ -15,8 +15,11 @@
 
 size_t wmcom_dispatch(char * command, char ** output){
 
-
     if (strncmp(command, "getconfig", 9) == 0){
+        /*
+         * getconfig wmodules
+         * getconfig internal_options
+        */
         char *rcv_comm = command;
         char *rcv_args = NULL;
 
@@ -31,7 +34,18 @@ size_t wmcom_dispatch(char * command, char ** output){
             return strlen(*output);
         }
         return wmcom_getconfig(rcv_args, output);
+    } else if (strncmp(command, "query ", 6) == 0) {
+        /*
+         * query vulnerability-detector run_now
+        */
+        return wm_module_query(command + 6, output);
     } else if (wmcom_sync(command) == 0) {
+        /*
+         * syscollector_hwinfo dbsync checksum_fail { ... }
+         * syscollector_osinfo dbsync checksum_fail { ... }
+         * syscollector_ports dbsync checksum_fail { ... }
+         * syscollector_processes dbsync checksum_fail { ... }
+        */
         return 0;
     } else {
         mdebug1("WMCOM Unrecognized command '%s'.", command);

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -323,6 +323,47 @@ int modulesSync(char* args) {
     return ret;
 }
 
+// Find a module
+
+wmodule * wm_find_module(const char * name) {
+    for (wmodule * module = wmodules; module != NULL; module = module->next) {
+        if (strcmp(module->context->name, name) == 0) {
+            return module;
+        }
+    }
+
+    return NULL;
+}
+
+// Run a query in a module
+
+size_t wm_module_query(char * query, char ** output) {
+    // vulnerability-detector run_now
+
+    char * module_name = query;
+    char * args = strchr(query, ' ');
+
+    if (args == NULL) {
+        os_strdup("err {\"message\": \"module query needs arguments\"}", *output);
+        return strlen(*output);
+    }
+
+    *args++ = '\0';
+
+    wmodule * module = wm_find_module(module_name);
+    if (module == NULL) {
+        os_strdup("err {\"message\": \"running module not found\"}", *output);
+        return strlen(*output);
+    }
+
+    if (module->context->query == NULL) {
+        os_strdup("err {\"message\": \"module does not support queries\"}", *output);
+        return strlen(*output);
+    }
+
+    return module->context->query(module->data, args, output);
+}
+
 cJSON *getModulesInternalOptions(void) {
 
     cJSON *root = cJSON_CreateObject();

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -202,4 +202,26 @@ size_t wmcom_dispatch(char * command, char ** output);
 size_t wmcom_getconfig(const char * section, char ** output);
 int wmcom_sync(char * buffer);
 
+/**
+ * @brief Find a module
+ *
+ * @param name Name of the module.
+ * @return Pointer to a module structure.
+ * @return NULL if the module was not found.
+ */
+wmodule * wm_find_module(const char * name);
+
+/**
+ * @brief Run a query in a module
+ *
+ * Run a command into a module structure, not in the same thread.
+ * Query format: <module name> <command>
+ * Example: "vulnerability-detector run_now"
+ *
+ * @param query Command query
+ * @param output Output payload
+ * @return Size of the output
+ */
+size_t wm_module_query(char * query, char ** output);
+
 #endif // W_MODULES

--- a/src/wazuh_modules/wmodules_def.h
+++ b/src/wazuh_modules/wmodules_def.h
@@ -33,12 +33,12 @@ typedef void* (*wm_routine)(void*);         // Standard routine pointer
 // Module context: this should be defined for every module
 
 typedef struct wm_context {
-    const char *name;                   // Name for module
-    wm_routine start;                   // Main function
-    void (*destroy)(void *);            // Configuration destructor
-    cJSON *(* dump)(const void *);
-    int (* sync)(const char*);          // Sync
-    void (*stop)(void *);               // Module destructor
+    const char *name;                           // Name for module
+    wm_routine start;                           // Main function
+    void (*destroy)(void *);                    // Configuration destructor
+    cJSON *(* dump)(const void *);              // Dump current configuration
+    int (* sync)(const char*);                  // Sync
+    void (*stop)(void *);                       // Module destructor
 } wm_context;
 
 // Main module structure

--- a/src/wazuh_modules/wmodules_def.h
+++ b/src/wazuh_modules/wmodules_def.h
@@ -39,6 +39,7 @@ typedef struct wm_context {
     cJSON *(* dump)(const void *);              // Dump current configuration
     int (* sync)(const char*);                  // Sync
     void (*stop)(void *);                       // Module destructor
+    size_t (*query)(void *, char *, char **);   // Run a query
 } wm_context;
 
 // Main module structure


### PR DESCRIPTION
|Related issue|
|---|
|Closes #15061|

This PR introduces a query to restart a Vulnerability Detector scan, skipping the delay between scans (`<interval>` option).

## Internal socket query syntax

- Send this payload to socket `/queue/sockets/wmodules`, with the proper 4-byte header:
```
query vulnerability-detector run_now
```

#### Expected responses

|Payload|Description|
|---|---|
|`ok {"data": "ack"}`|The scan has been requested, it will run after the current scan (or immediately if there is no scan running).|
|`ok {"data": "already requested"}`|A scan has already been requested. This operation has no effect.|
|`err {"message": "module does not support queries"}`|Vulnerability Detector has not been set up.|

## Logs

```
2022/10/25 17:06:08 wazuh-modulesd:vulnerability-detector[15085] wm_vuln_detector.c:8256 at wm_vuldet_run_sleep(): DEBUG: Sleeping for 300 seconds...
```

After running `query vulnerability-detector run_now`:
```
2022/10/25 17:06:09 wazuh-modulesd[15085] wm_vuln_detector.c:9196 at wm_vuldet_query(): DEBUG: Scan requested.
2022/10/25 17:06:10 wazuh-modulesd:vulnerability-detector[15085] wm_vuln_detector.c:8194 at wm_vuldet_run_scan(): INFO: (5431): Starting vulnerability scan.
```

## Tests

### Functional tests

- [x] Invalid query syntax returns an error message.
- [x] Valid `run_now` query runs a scan within a 1-second deadline.
- [x] Running a `run_now` query before the next scan starts returns an `already_requested` message.

### Non-functional tests

- [x] AddressSanitizer
- [x] Scan Build
- [x] Coverity
