### PR TITLE
Fix framework SCA unit test case testing the `_parse_select_filter` class method

### DIFF
--- a/framework/wazuh/core/tests/test_sca.py
+++ b/framework/wazuh/core/tests/test_sca.py
@@ -162,9 +162,9 @@ def test_WazuhDBQuerySCACheck_parse_select_filter(mock_exists, mock_get_basic_in
         wdbq_sca_check._parse_select_filter(['test'])
     except WazuhError as e:
         assert e.code == 1724
-        assert ", ".join(
-            set(wdbq_sca_check.fields.keys()).union(core_sca.SCA_CHECK_COMPLIANCE_DB_FIELDS.keys()).union(
-                core_sca.SCA_CHECK_RULES_DB_FIELDS.keys()) - {'id_check'}) in e.message
+        expected_fields = set(wdbq_sca_check.fields.keys()).union(core_sca.SCA_CHECK_COMPLIANCE_DB_FIELDS.keys()).union(
+            core_sca.SCA_CHECK_RULES_DB_FIELDS.keys()) - {'id_check'}
+        assert all(field in e.message for field in expected_fields)
 
 
 @pytest.mark.parametrize('query', [


### PR DESCRIPTION


## Description

This pull request is related to the issue asking for adding `select` and `distinct` to the SCA endpoints: https://github.com/wazuh/wazuh/issues/14407

This PR fixes a SCA framework unit test case that was failing without consistency. The test was added in the related issue mentioned above.
The error was the following:

```
=================================== FAILURES ===================================
________________ test_WazuhDBQuerySCACheck_parse_select_filter _________________
/tmp/build/wazuh/framework/wazuh/core/tests/test_sca.py:162: in test_WazuhDBQuerySCACheck_parse_select_filter
    wdbq_sca_check._parse_select_filter(['test'])
/tmp/build/wazuh/framework/wazuh/core/sca.py:151: in _parse_select_filter
    raise WazuhError(1724, "Allowed select fields: {0}. Fields {1}".format(
E   wazuh.core.exception.WazuhError: Error 1724 - Not a valid select field: Allowed select fields: compliance.key, references, compliance.value, rules.rule, rationale, registry, condition, remediation, id, directory, file, command, policy_id, process, status, rules.type, reason, description, result, title. Fields test

During handling of the above exception, another exception occurred:
/tmp/build/wazuh/framework/wazuh/core/tests/test_sca.py:165: in test_WazuhDBQuerySCACheck_parse_select_filter
    assert ", ".join(
E   AssertionError: assert 'compliance.key, references, compliance.value, rationale, registry, condition, rules.rule, remediation, id, directory, file, command, policy_id, process, status, rules.type, reason, description, result, title' in 'Not a valid select field: Allowed select fields: compliance.key, references, compliance.value, rules.rule, rationale,... id, directory, file, command, policy_id, process, status, rules.type, reason, description, result, title. Fields test'
E    +  where 'compliance.key, references, compliance.value, rationale, registry, condition, rules.rule, remediation, id, directory, file, command, policy_id, process, status, rules.type, reason, description, result, title' = <built-in method join of str object at 0x7f5a7a6a28f0>(({'command', 'compliance.key', 'compliance.value', 'condition', 'description', 'directory', ...} - {'id_check'}))
E    +    where <built-in method join of str object at 0x7f5a7a6a28f0> = ', '.join
E    +    and   {'command', 'compliance.key', 'compliance.value', 'condition', 'description', 'directory', ...} = <built-in method union of set object at 0x7f5a754b8d60>(dict_keys(['rules.type', 'rules.rule', 'id_check']))
E    +      where <built-in method union of set object at 0x7f5a754b8d60> = {'command', 'compliance.key', 'compliance.value', 'condition', 'description', 'directory', ...}.union
E    +        where {'command', 'compliance.key', 'compliance.value', 'condition', 'description', 'directory', ...} = <built-in method union of set object at 0x7f5a754b8ba0>(dict_keys(['compliance.key', 'compliance.value', 'id_check']))
E    +          where <built-in method union of set object at 0x7f5a754b8ba0> = {'command', 'condition', 'description', 'directory', 'file', 'id', ...}.union
E    +            where {'command', 'condition', 'description', 'directory', 'file', 'id', ...} = set(dict_keys(['policy_id', 'id', 'title', 'description', 'rationale', 'remediation', 'file', 'process', 'directory', 'registry', 'command', 'references', 'result', 'status', 'reason', 'condition']))
E    +              where dict_keys(['policy_id', 'id', 'title', 'description', 'rationale', 'remediation', 'file', 'process', 'directory', 'registry', 'command', 'references', 'result', 'status', 'reason', 'condition']) = <built-in method keys of dict object at 0x7f5a75480fc0>()
E    +                where <built-in method keys of dict object at 0x7f5a75480fc0> = {'command': 'command', 'condition': 'condition', 'description': 'description', 'directory': 'directory', ...}.keys
E    +                  where {'command': 'command', 'condition': 'condition', 'description': 'description', 'directory': 'directory', ...} = <wazuh.core.sca.WazuhDBQuerySCACheck object at 0x7f5a7547b3a0>.fields
E    +          and   dict_keys(['compliance.key', 'compliance.value', 'id_check']) = <built-in method keys of mappingproxy object at 0x7f5a7a5fb730>()
E    +            where <built-in method keys of mappingproxy object at 0x7f5a7a5fb730> = mappingproxy({'compliance.key': 'key', 'compliance.value': 'value', 'id_check': 'id_check'}).keys
E    +              where mappingproxy({'compliance.key': 'key', 'compliance.value': 'value', 'id_check': 'id_check'}) = core_sca.SCA_CHECK_COMPLIANCE_DB_FIELDS
E    +      and   dict_keys(['rules.type', 'rules.rule', 'id_check']) = <built-in method keys of mappingproxy object at 0x7f5a7a5fbf40>()
E    +        where <built-in method keys of mappingproxy object at 0x7f5a7a5fbf40> = mappingproxy({'rules.type': 'type', 'rules.rule': 'rule', 'id_check': 'id_check'}).keys
E    +          where mappingproxy({'rules.type': 'type', 'rules.rule': 'rule', 'id_check': 'id_check'}) = core_sca.SCA_CHECK_RULES_DB_FIELDS
E    +  and   'Not a valid select field: Allowed select fields: compliance.key, references, compliance.value, rules.rule, rationale,... id, directory, file, command, policy_id, process, status, rules.type, reason, description, result, title. Fields test' = {'type': 'about:blank', 'title': 'Bad Request', 'code': 1724, 'extra_message': 'Allowed select fields: compliance.key,... description, result, title. Fields test', 'extra_remediation': None, 'cmd_error': False, 'dapi_errors': {}, 'ids': []}.message
=============================== warnings summary ===============================
```

And it was happening due to the fact that python sets do not preserve the insertion order.

In this PR, I have changed the unit test code snippet where this error was happening. The test is always passing now.