### PR TITLE
Restrict agent upgrade module configuration to local settings

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -217,7 +217,7 @@ static int read_main_elements(const OS_XML *xml, int modules,
                 goto fail;
             }
         } else if (chld_node && (strcmp(node[i]->element, agent_upgrade) == 0)) {
-            if ((modules & CWMODULE) && (Read_AgentUpgrade(xml, node[i], d1) < 0)) {
+            if ((modules & CWMODULE) && !(modules & CAGENT_CONFIG) && (Read_AgentUpgrade(xml, node[i], d1) < 0)) {
                 goto fail;
             }
         } else if (chld_node && (strcmp(node[i]->element, task_manager) == 0)) {


### PR DESCRIPTION
|Wazuh version|Component|Install type|
|---|---|---|
| 4.1.0 | Agent upgrade module | Agent |

This PR aims to prevent the agent from parsing `<agent-upgrade>` configuration from file _agent.conf_.

## Tests

- [x] The `<agent-upgrade>` block is not parsed when defined at _agent.conf_.