### PR TITLE
Sync number of active agents and number of TCP sessions 

### DIFF
--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -724,11 +724,12 @@ int _close_sock(keystore * keys, int sock) {
     retval = OS_DeleteSocket(keys, sock);
     key_unlock();
 
-    if (!close(sock)) {
-        nb_close(&netbuffer_recv, sock);
-        nb_close(&netbuffer_send, sock);
-        rem_dec_tcp();
+    if (close(sock)) {
+        mwarn("Unable to close socket %d: %s (%d)", sock, strerror(errno), errno);
     }
+    nb_close(&netbuffer_recv, sock);
+    nb_close(&netbuffer_send, sock);
+    rem_dec_tcp();
 
     rem_setCounter(sock, global_counter);
     mdebug1("TCP peer disconnected [%d]", sock);


### PR DESCRIPTION
|Related issue|Manual Testing|
|---|---|
|https://github.com/wazuh/wazuh/issues/10665||

## Description
The goal of this PR is keep the  quantity of active agents and the number of tcp sessions sync.
It also avoids memory allocation retention in case the system `close` call fails.
The number of tcp sessions can't be higher than number of active agents. In other hand, it's possible find more active agents than tcp sessions, until this other [issue](https://github.com/wazuh/wazuh/issues/15153) will fix.

## Configuration options
Default configuration

## Logs/Alerts example
Example log in case of system `close` call fails:
`2022/10/31 08:10:44 wazuh-remoted: WARNING: Unable to close socket 1: Transport endpoint is not connected (107)`

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- [x] Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- [x] Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  
<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Added unit tests (for new features)
