### PR TITLE
Libstdc++ isn't installed with the NSI executable - Implementation

### DIFF
--- a/src/win32/wazuh-installer.nsi
+++ b/src/win32/wazuh-installer.nsi
@@ -210,6 +210,7 @@ Section "Wazuh Agent (required)" MainSec
     File /oname=active-response\bin\netsh.exe netsh.exe
     File /oname=libwinpthread-1.dll libwinpthread-1.dll
     File /oname=libgcc_s_dw2-1.dll libgcc_s_dw2-1.dll
+    File /oname=libstdc++-6.dll libstdc++-6.dll
     File agent-auth.exe
     File /oname=wpk_root.pem ..\..\etc\wpk_root.pem
     File /oname=libwazuhext.dll ..\libwazuhext.dll


### PR DESCRIPTION
|Related issue|
|---|
|Closes #15268 |


## Description

This simple PR adds the library `libstdc++-6.dll` to the Windows Wazuh installer.


## Logs/Alerts example

The installer generated for Wazuh 4.4 doesn't work
 
![cant_load_syscollector](https://user-images.githubusercontent.com/65046601/199291161-56c5928a-6de8-412d-96d4-c9b02e2c76fb.png)

The installer generated in this branch correctly distributes the library

![syscollector_fixed](https://user-images.githubusercontent.com/65046601/199291311-f38765b0-6da0-4313-b474-786c2550a800.png)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Package installation

