### PR TITLE
Make `local_clients` send keepalives in cluster

### DIFF
--- a/framework/wazuh/core/cluster/control.py
+++ b/framework/wazuh/core/cluster/control.py
@@ -49,9 +49,7 @@ async def get_nodes(lc: local_client.LocalClient, filter_node=None, offset=0, li
     else:
         arguments = {'filter_node': filter_node, 'offset': offset, 'limit': limit, 'sort': sort, 'search': search,
                      'select': select, 'filter_type': filter_type}
-    response = await lc.execute(command=b'get_nodes',
-                                data=json.dumps(arguments).encode(),
-                                wait_for_complete=False)
+    response = await lc.execute(command=b'get_nodes', data=json.dumps(arguments).encode())
     try:
         result = json.loads(response, object_hook=as_wazuh_object)
     except json.JSONDecodeError as e:
@@ -90,8 +88,7 @@ async def get_node(lc: local_client.LocalClient, filter_node=None, select=None):
     arguments = {'filter_node': filter_node, 'offset': 0, 'limit': common.DATABASE_LIMIT, 'sort': None, 'search': None,
                  'select': select, 'filter_type': 'all'}
 
-    response = await lc.execute(command=b'get_nodes', data=json.dumps(arguments).encode(),
-                                wait_for_complete=False)
+    response = await lc.execute(command=b'get_nodes', data=json.dumps(arguments).encode())
     try:
         node_info_array = json.loads(response, object_hook=as_wazuh_object)
     except json.JSONDecodeError as e:
@@ -121,9 +118,7 @@ async def get_health(lc: local_client.LocalClient, filter_node=None):
     result : dict
         Basic information of each node and synchronization process related information.
     """
-    response = await lc.execute(command=b'get_health',
-                                data=json.dumps(filter_node).encode(),
-                                wait_for_complete=False)
+    response = await lc.execute(command=b'get_health', data=json.dumps(filter_node).encode())
 
     try:
         result = json.loads(response, object_hook=as_wazuh_object)
@@ -167,9 +162,7 @@ async def get_agents(lc: local_client.LocalClient, filter_node=None, filter_stat
                   'wait_for_complete': False
                   }
 
-    response = await lc.execute(command=b'dapi',
-                                data=json.dumps(input_json, cls=WazuhJSONEncoder).encode(),
-                                wait_for_complete=False)
+    response = await lc.execute(command=b'dapi', data=json.dumps(input_json, cls=WazuhJSONEncoder).encode())
 
     try:
         result = json.loads(response, object_hook=as_wazuh_object)
@@ -216,7 +209,7 @@ async def get_node_ruleset_integrity(lc: local_client.LocalClient) -> dict:
     dict
         Dictionary with results
     """
-    response = await lc.execute(command=b"get_hash", data=b"", wait_for_complete=False)
+    response = await lc.execute(command=b"get_hash", data=b"")
 
     try:
         result = json.loads(response, object_hook=as_wazuh_object)

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -415,8 +415,7 @@ class DistributedAPI:
         client = self.get_client()
         node_response = await client.execute(command=b'dapi',
                                              data=json.dumps(self.to_dict(),
-                                                             cls=c_common.WazuhJSONEncoder).encode(),
-                                             wait_for_complete=self.wait_for_complete)
+                                                             cls=c_common.WazuhJSONEncoder).encode())
         return json.loads(node_response,
                           object_hook=c_common.as_wazuh_object)
 
@@ -463,8 +462,8 @@ class DistributedAPI:
                                                              "{} {}".format(node_name,
                                                                             json.dumps(kcopy,
                                                                                        cls=c_common.WazuhJSONEncoder)
-                                                                            ).encode(),
-                                                             self.wait_for_complete),
+                                                                            ).encode()
+                                                             ),
                                         object_hook=c_common.as_wazuh_object)
                 except WazuhClusterError as e:
                     if e.code == 3022:

--- a/framework/wazuh/core/cluster/tests/test_control.py
+++ b/framework/wazuh/core/cluster/tests/test_control.py
@@ -17,7 +17,7 @@ with patch('wazuh.common.getgrnam'):
                 from wazuh import WazuhInternalError, WazuhError
 
 
-async def async_local_client(command, data, wait_for_complete):
+async def async_local_client(command, data):
     return None
 
 
@@ -147,7 +147,7 @@ async def test_get_node_ruleset_integrity():
     with patch('wazuh.core.cluster.local_client.LocalClient.execute', side_effect=async_local_client) as execute_mock:
         with patch('json.loads'):
             await control.get_node_ruleset_integrity(lc=local_client)
-        execute_mock.assert_called_once_with(command=b'get_hash', data=b'', wait_for_complete=False)
+        execute_mock.assert_called_once_with(command=b'get_hash', data=b'')
 
         with patch('json.loads', return_value=KeyError(1)):
             with pytest.raises(KeyError):

--- a/framework/wazuh/core/cluster/tests/test_local_client.py
+++ b/framework/wazuh/core/cluster/tests/test_local_client.py
@@ -5,7 +5,7 @@
 from asyncio import Event, Transport
 from asyncio.transports import BaseTransport
 from collections import Callable
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock, call
 
 import pytest
 from uvloop import EventLoopPolicy, new_event_loop
@@ -185,17 +185,16 @@ async def test_localclient_send_api_request(mock_get_running_loop):
 
     with patch("wazuh.core.cluster.common.Handler.send_request", side_effect=Protocol.send_request):
         result = b"There are no connected worker nodes"
-        assert await lc.send_api_request(command=b"dapi", data=result, wait_for_complete=True) == {}
+        assert await lc.send_api_request(command=b"dapi", data=result) == {}
 
         result = b"Testing"
-        assert await lc.send_api_request(command=b"testing", data=result, wait_for_complete=True) == result.decode()
+        assert await lc.send_api_request(command=b"testing", data=result) == result.decode()
 
     with patch("wazuh.core.cluster.common.Handler.send_request", side_effect=Protocol.send_request):
         with patch("asyncio.wait_for"):
             with patch("asyncio.Event.wait"):
                 result = b"Testing"
-                assert await lc.send_api_request(
-                    command=b"dapi", data=result, wait_for_complete=True) == Protocol.response.decode()
+                assert await lc.send_api_request(command=b"dapi", data=result) == Protocol.response.decode()
 
 
 @pytest.mark.asyncio
@@ -207,16 +206,14 @@ async def test_localclient_send_api_request_ko(mock_get_running_loop):
         def __init__(self):
             self.response_available = asyncio.Event()
 
-        @staticmethod
-        async def send_request(command, data):
-            return data
-
     lc = LocalClient()
     lc.protocol = Protocol()
-    with patch("wazuh.core.cluster.common.Handler.send_request", side_effect=Protocol.send_request):
-        with patch("asyncio.Event.wait", side_effect=asyncio.TimeoutError):
-            with pytest.raises(WazuhInternalError, match=rf".* 3020 .*"):
-                await lc.send_api_request(command=b"dapi", data=b"None", wait_for_complete=False)
+    lc.protocol.send_request = AsyncMock()
+    lc.protocol.send_request.side_effect = [b"None", exception.WazuhClusterError(3018)]
+    with patch("asyncio.Event.wait", side_effect=asyncio.TimeoutError):
+        with pytest.raises(WazuhInternalError, match=rf".* 3020 .*"):
+            await lc.send_api_request(command=b"dapi", data=b"None")
+    lc.protocol.send_request.assert_has_calls([call(b'dapi', b'None'), call(b'echo-c', b'keepalive')])
 
 
 @pytest.mark.asyncio
@@ -237,7 +234,7 @@ async def test_localclient_execute():
                 lc = LocalClient()
                 lc.transport = BaseTransport()
                 lc.protocol = Protocol()
-                assert await lc.execute(command=b"0", data=b"1", wait_for_complete=False) == "Test"
+                assert await lc.execute(command=b"0", data=b"1") == "Test"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
|Related issue|
|---|
| Closes #15003 |

## Description

This PR changes the` LocalClient.execute()` method so it sends a keepalive every 60 seconds until a response or timeout is obtained.  Thanks to this, the Local Server will not disconnect the client in the rare cases where the response takes more than 120-180s to be ready, as reported at #15003:
```
2022/09/26 07:59:05 ERROR: [Local Server] [Keep alive] No keep alives have been received from 186452 in the last minute. Disconnecting
2022/09/26 07:59:14 ERROR: [Worker worker1] [Main] Internal error processing request 'b'dapi_res'': Error 3032 - Could not forward DAPI request. Connection not available.: 186452
```

The `wait_for_complete` parameter has been removed from the method, but it shouldn't be a real behavior change since previously you couldn't get responses after 180s even with `wait_for_complete` being True. In fact, in those cases, the API would keep the resource always busy since the response would never be obtained.
https://github.com/wazuh/wazuh/blob/6d972907c90cdfe709fa021d384519c02dd0b24a/framework/wazuh/core/cluster/local_client.py#L194

## Logs/Alerts example

Now, everything is working fine as it can be seen in this api log message, where a distributed API request that took 197s still returned a 200 status code:
```
2022/10/31 15:34:35 INFO: wazuh 172.18.0.1 "GET /cluster/api/config" with parameters {"wait_for_complete": "true", "nodes_list": "worker1"} and body {} done in 197.073s: 200
```

## Tests
```
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.9.15, pytest-7.0.1, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: anyio-3.6.2, asyncio-0.18.1, aiohttp-1.0.4, cov-4.0.0
asyncio: mode=auto
collected 2025 items                                                                                                                                                                                        

framework/scripts/tests/test_agent_groups.py ..............                                                                                                                                           [  0%]
framework/scripts/tests/test_agent_upgrade.py ...............                                                                                                                                         [  1%]
framework/scripts/tests/test_cluster_control.py ......                                                                                                                                                [  1%]
framework/scripts/tests/test_wazuh_clusterd.py .......                                                                                                                                                [  2%]
framework/scripts/tests/test_wazuh_logtest.py ......................                                                                                                                                  [  3%]
framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................................                                                                                                                 [  4%]
framework/wazuh/core/cluster/tests/test_client.py ................                                                                                                                                    [  5%]
framework/wazuh/core/cluster/tests/test_cluster.py ...................................                                                                                                                [  7%]
framework/wazuh/core/cluster/tests/test_common.py ..................................................................................                                                                  [ 11%]
framework/wazuh/core/cluster/tests/test_control.py ......                                                                                                                                             [ 11%]
framework/wazuh/core/cluster/tests/test_local_client.py .............                                                                                                                                 [ 12%]
framework/wazuh/core/cluster/tests/test_local_server.py ........................                                                                                                                      [ 13%]
framework/wazuh/core/cluster/tests/test_master.py ....................................................                                                                                                [ 16%]
framework/wazuh/core/cluster/tests/test_server.py ..............................                                                                                                                      [ 17%]
framework/wazuh/core/cluster/tests/test_utils.py ...........                                                                                                                                          [ 18%]
framework/wazuh/core/cluster/tests/test_worker.py ...................................                                                                                                                 [ 19%]
framework/wazuh/core/tests/test_active_response.py ..............                                                                                                                                     [ 20%]
framework/wazuh/core/tests/test_agent.py ...................................................................................................................................................          [ 27%]
framework/wazuh/core/tests/test_cdb_list.py ......................................                                                                                                                    [ 29%]
framework/wazuh/core/tests/test_common.py .........                                                                                                                                                   [ 30%]
framework/wazuh/core/tests/test_configuration.py ....................................                                                                                                                 [ 31%]
framework/wazuh/core/tests/test_database.py .............                                                                                                                                             [ 32%]
framework/wazuh/core/tests/test_decoder.py ................                                                                                                                                           [ 33%]
framework/wazuh/core/tests/test_exception.py ...                                                                                                                                                      [ 33%]
framework/wazuh/core/tests/test_input_validator.py ...                                                                                                                                                [ 33%]
framework/wazuh/core/tests/test_logtest.py ..                                                                                                                                                         [ 33%]
framework/wazuh/core/tests/test_manager.py ...............                                                                                                                                            [ 34%]
framework/wazuh/core/tests/test_mitre.py .............                                                                                                                                                [ 35%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                                                                                                                                               [ 35%]
framework/wazuh/core/tests/test_results.py ........................................                                                                                                                   [ 37%]
framework/wazuh/core/tests/test_rootcheck.py .............                                                                                                                                            [ 37%]
framework/wazuh/core/tests/test_rule.py ......................                                                                                                                                        [ 38%]
framework/wazuh/core/tests/test_sca.py ........................                                                                                                                                       [ 40%]
framework/wazuh/core/tests/test_security.py ............                                                                                                                                              [ 40%]
framework/wazuh/core/tests/test_stats.py ............                                                                                                                                                 [ 41%]
framework/wazuh/core/tests/test_syscheck.py .......                                                                                                                                                   [ 41%]
framework/wazuh/core/tests/test_syscollector.py ...                                                                                                                                                   [ 41%]
framework/wazuh/core/tests/test_task.py ........                                                                                                                                                      [ 42%]
framework/wazuh/core/tests/test_utils.py ............................................................................................................................................................ [ 49%]
.........................................................................................                                                                                                             [ 54%]
framework/wazuh/core/tests/test_vulnerability.py ..                                                                                                                                                   [ 54%]
framework/wazuh/core/tests/test_wazuh_queue.py ....................                                                                                                                                   [ 55%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                                                  [ 56%]
framework/wazuh/core/tests/test_wdb.py ...............................                                                                                                                                [ 57%]
framework/wazuh/core/tests/test_wlogging.py .........                                                                                                                                                 [ 58%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                                                                                                                                    [ 58%]
framework/wazuh/rbac/tests/test_decorators.py .........................................................................................................                                               [ 63%]
framework/wazuh/rbac/tests/test_default_configuration.py .......................................................                                                                                      [ 66%]
framework/wazuh/rbac/tests/test_orm.py ......................................................                                                                                                         [ 69%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                           [ 69%]
framework/wazuh/tests/test_active_response.py ............                                                                                                                                            [ 70%]
framework/wazuh/tests/test_agent.py ......................................................................................................................                                            [ 76%]
framework/wazuh/tests/test_cdb_list.py .....................................................                                                                                                          [ 78%]
framework/wazuh/tests/test_ciscat.py .................................                                                                                                                                [ 80%]
framework/wazuh/tests/test_cluster.py ..........                                                                                                                                                      [ 80%]
framework/wazuh/tests/test_decoder.py ...................................                                                                                                                             [ 82%]
framework/wazuh/tests/test_group.py .......                                                                                                                                                           [ 82%]
framework/wazuh/tests/test_logtest.py ......                                                                                                                                                          [ 83%]
framework/wazuh/tests/test_manager.py ....................................                                                                                                                            [ 84%]
framework/wazuh/tests/test_mitre.py .......                                                                                                                                                           [ 85%]
framework/wazuh/tests/test_rootcheck.py ..................................................                                                                                                            [ 87%]
framework/wazuh/tests/test_rule.py ........................................................                                                                                                           [ 90%]
framework/wazuh/tests/test_sca.py ...........                                                                                                                                                         [ 91%]
framework/wazuh/tests/test_security.py .........................................................................                                                                                      [ 94%]
framework/wazuh/tests/test_stats.py .......                                                                                                                                                           [ 94%]
framework/wazuh/tests/test_syscheck.py ..........................                                                                                                                                     [ 96%]
framework/wazuh/tests/test_syscollector.py ............                                                                                                                                               [ 96%]
framework/wazuh/tests/test_task.py ............................                                                                                                                                       [ 98%]
framework/wazuh/tests/test_vulnerability.py ....................................                                                                                                                      [100%]

=============================================================================== 2025 passed, 45 warnings in 318.85s (0:05:18) ===============================================================================
