### PR TITLE
EPS remove multiple logs to show the same configuration warning message

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -984,7 +984,7 @@ void OS_ReadMSG_analysisd(int m_queue)
     }
 
     /* Initialize EPS limits */
-    load_limits(Config.eps.maximum, Config.eps.timeframe);
+    load_limits(Config.eps.maximum, Config.eps.timeframe, Config.eps.maximum_found);
 
     /* Create message handler thread */
     w_create_thread(ad_input_main, &m_queue);

--- a/src/analysisd/config.c
+++ b/src/analysisd/config.c
@@ -61,7 +61,7 @@ int GlobalConf(const char *cfgfile)
     Config.hostname_white_list = NULL;
 
     Config.eps.maximum = EPS_LIMITS_MIN_EPS;
-    Config.eps.timeframe = EPS_LIMITS_DEFAULT_TIMEFRAME;
+    Config.eps.timeframe = 0;
 
     /* Default actions -- only log above level 1 */
     Config.mailbylevel = 7;

--- a/src/analysisd/limits.c
+++ b/src/analysisd/limits.c
@@ -53,7 +53,7 @@ void load_limits(unsigned int eps, unsigned int timeframe, bool maximum_found) {
         minfo("EPS limit enabled, EPS: '%d', timeframe: '%d'", eps, timeframe);
     } else {
         limits.enabled = false;
-        if (!maximum_found) {
+        if (!maximum_found && timeframe > 0) {
             mwarn("EPS limit disabled. The maximum value is missing in the configuration block.");
         } else {
             minfo("EPS limit disabled");

--- a/src/analysisd/limits.c
+++ b/src/analysisd/limits.c
@@ -38,7 +38,8 @@ STATIC limits_t limits;
 STATIC pthread_mutex_t limit_eps_mutex = PTHREAD_MUTEX_INITIALIZER;
 STATIC sem_t credits_eps_semaphore;
 
-void load_limits(unsigned int eps, unsigned int timeframe) {
+void load_limits(unsigned int eps, unsigned int timeframe, bool maximum_found) {
+
     if (eps > 0 && timeframe > 0) {
         limits.eps = eps;
         limits.timeframe = timeframe;
@@ -52,7 +53,11 @@ void load_limits(unsigned int eps, unsigned int timeframe) {
         minfo("EPS limit enabled, EPS: '%d', timeframe: '%d'", eps, timeframe);
     } else {
         limits.enabled = false;
-        minfo("EPS limit disabled");
+        if (!maximum_found) {
+            mwarn("EPS limit disabled. The maximum value is missing in the configuration block.");
+        } else {
+            minfo("EPS limit disabled");
+        }
     }
 }
 

--- a/src/analysisd/limits.h
+++ b/src/analysisd/limits.h
@@ -27,8 +27,9 @@ typedef struct _limits_t {
  * @brief Load the limits structure
  * @param eps eps amount
  * @param timeframe timeframe size
+ * @param maximum_found eps amount block found
  */
-void load_limits(unsigned int eps, unsigned int timeframe);
+void load_limits(unsigned int eps, unsigned int timeframe, bool maximum_found);
 
 /**
  * @brief Update and validate limits

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -853,12 +853,13 @@ int Read_Global_limits_eps(XML_NODE node, _Config *Config) {
     /* XML definitions */
     static const char *xml_max_eps = "maximum";
     static const char *xml_timeframe_eps = "timeframe";
-    bool maximum = false;
+    if (Config) {
+        Config->eps.maximum_found = false;
+    }
 
     for (int i = 0; node[i]; i++) {
         // max_eps
         if (!strcmp(node[i]->element, xml_max_eps)) {
-            maximum = true;
 
             if (!OS_StrIsNum(node[i]->content)) {
                 merror(XML_VALUEERR, node[i]->element, node[i]->content);
@@ -866,6 +867,7 @@ int Read_Global_limits_eps(XML_NODE node, _Config *Config) {
             }
 
             if (Config) {
+                Config->eps.maximum_found = true;
                 Config->eps.maximum = (unsigned int) atoi(node[i]->content);
                 if (Config->eps.maximum > EPS_LIMITS_MAX_EPS) {
                     merror(XML_VALUEERR, node[i]->element, node[i]->content);
@@ -888,10 +890,6 @@ int Read_Global_limits_eps(XML_NODE node, _Config *Config) {
                 }
             }
         }
-    }
-
-    if (!maximum) {
-        mwarn("EPS limit disabled. The maximum value is missing in the configuration block.");
     }
 
     return OS_SUCCESS;

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -855,6 +855,7 @@ int Read_Global_limits_eps(XML_NODE node, _Config *Config) {
     static const char *xml_timeframe_eps = "timeframe";
     if (Config) {
         Config->eps.maximum_found = false;
+        Config->eps.timeframe = EPS_LIMITS_DEFAULT_TIMEFRAME;
     }
 
     for (int i = 0; node[i]; i++) {

--- a/src/config/global-config.h
+++ b/src/config/global-config.h
@@ -23,6 +23,7 @@ typedef struct __eps {
     // EPS limits configuration
     unsigned int maximum;
     unsigned int timeframe;
+    bool maximum_found;
 } _eps;
 
 /* Configuration structure */

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -157,7 +157,7 @@ list(APPEND analysisd_flags "-Wl,--wrap,asys_create_state_json -Wl,--wrap,OS_Bin
                              -Wl,--wrap,wdb_get_agents_ids_of_current_node -Wl,--wrap,json_parse_agents -Wl,--wrap,getpid ${DEBUG_OP_WRAPPERS}")
 
 LIST(APPEND analysisd_names "test_limits")
-LIST(APPEND analysisd_flags "-Wl,--wrap,_minfo")
+LIST(APPEND analysisd_flags "-Wl,--wrap,_minfo -Wl,--wrap,_mwarn")
 
 list(LENGTH analysisd_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/analysisd/test_limits.c
+++ b/src/unit_tests/analysisd/test_limits.c
@@ -158,7 +158,20 @@ void test_load_limits_disabled(void ** state)
 
     expect_string(__wrap__minfo, formatted_msg, "EPS limit disabled");
 
-    load_limits(0, 5);
+    load_limits(0, 5, true);
+
+    assert_false(limits.enabled);
+}
+
+// load_limits
+void test_load_limits_maximun_block_not_found(void ** state)
+{
+    int current_credits;
+    limits.enabled = false;
+
+    expect_string(__wrap__mwarn, formatted_msg, "EPS limit disabled. The maximum value is missing in the configuration block.");
+
+    load_limits(0, 5, false);
 
     assert_false(limits.enabled);
 }
@@ -170,7 +183,7 @@ void test_load_limits_timeframe_zero(void ** state)
 
     expect_string(__wrap__minfo, formatted_msg, "EPS limit disabled");
 
-    load_limits(100, 0);
+    load_limits(100, 0, true);
 
     assert_false(limits.enabled);
 }
@@ -182,7 +195,7 @@ void test_load_limits_ok(void ** state)
 
     expect_string(__wrap__minfo, formatted_msg, "EPS limit enabled, EPS: '100', timeframe: '5'");
 
-    load_limits(100, 5);
+    load_limits(100, 5, true);
 
     assert_int_equal(limits.eps, 100);
     assert_int_equal(limits.timeframe, 5);
@@ -247,6 +260,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_get_eps_credit_ok, test_setup, test_teardown),
         // Test load_limits
         cmocka_unit_test_teardown(test_load_limits_disabled, test_teardown),
+        cmocka_unit_test_teardown(test_load_limits_maximun_block_not_found, test_teardown),
         cmocka_unit_test_teardown(test_load_limits_timeframe_zero, test_teardown),
         cmocka_unit_test_teardown(test_load_limits_ok, test_teardown),
         // // Test update_limits


### PR DESCRIPTION
|Related issue|Manual Testing|Integration Tests|
|---|---|---|
|https://github.com/wazuh/wazuh/issues/15188|https://github.com/wazuh/wazuh-qa/issues/3549|https://github.com/wazuh/wazuh-qa/pull/3564|

## Description

The goal of this pr is avoid multiple warnings come up, when starting the `wazuh-manager` with the EPS limitation block but without the `<maximum>` tag.

## Configuration options

- Configuration block to the `<global>` section of `ossec.conf` (missing `<maximum>`)

```
<limits>
  <eps>
    <timeframe>30</timeframe>
  </eps>
</limits>
```
## Log example
It only will be shown on modules that use EPS configuration, in this case `wazuh-analysisd`.
`2022/11/02 09:26:40 wazuh-analysisd: WARNING: EPS limit disabled. The maximum value is missing in the configuration block.
`

config 1:
```xml
    <!--limits>
      <eps>
       <maximum>50</maximum>
       <timeframe>30</timeframe>
      </eps>
    </limits-->
```

result:
`2022/11/02 11:35:01 wazuh-analysisd: INFO: EPS limit disabled`


config 2:
```xml
    <limits>
      <eps>
       <!--maximum>50</maximum-->
       <timeframe>30</timeframe>
      </eps>
    </limits>
```

result:
`2022/11/02 11:39:03 wazuh-analysisd: WARNING: EPS limit disabled. The maximum value is missing in the configuration block.`


config 3:
```xml
    <limits>
      <eps>
       <maximum>50</maximum>
       <timeframe>30</timeframe>
      </eps>
    </limits>
```

result:
`2022/11/02 11:41:35 wazuh-analysisd: INFO: EPS limit enabled, EPS: '50', timeframe: '30'`


config 4:
```xml
    <limits>
      <eps>
       <maximum>50</maximum>
       <!--timeframe>30</timeframe-->
      </eps>
    </limits>
```

result:
`2022/11/02 11:42:26 wazuh-analysisd: INFO: EPS limit enabled, EPS: '50', timeframe: '10'
`
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
-[x] Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Added unit tests (for new features)
