### PR TITLE
fix get force_reconnect response sending ack to api

### DIFF
--- a/src/remoted/request.c
+++ b/src/remoted/request.c
@@ -17,8 +17,7 @@
 #include "wazuh_modules/wmodules.h"
 
 #define COUNTER_LENGTH 64
-#define HC_FORCE_RECONNECT "force_reconnect"
-
+static const char * ACK = "ack";
 // Dispatcher theads entry point
 static void * req_dispatch(req_node_t * node);
 
@@ -178,7 +177,7 @@ void * req_dispatch(req_node_t * node) {
         }
 
         if (isForceReconnect) {
-            if (OS_SendSecureTCP(node->sock, strlen("ack"), "ack") != 0) {
+            if (OS_SendSecureTCP(node->sock, strlen(ACK), ACK) != 0) {
                 mwarn("At OS_SendSecureTCP(): %s", strerror(errno));
             }
             goto cleanup;


### PR DESCRIPTION
Both the sending of the forced reconnect request and the ack must be sent through the socket/sockets/remote queue

|Related issues|Manual Testing|
|---|---|
|#14797 |[#3426](https://github.com/wazuh/wazuh-qa/issues/3426)|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR solves the issue #14797 , the proposed solutions was sending to "ack" to API in response a incoming messages "<agentId> force_reconnect". changed the way to send messages from "queue/alerts/ar" to "queue/sockets/remote" using request of the remoted.

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->
### Tests options
<details><summary>Test with python script(optional)</summary>
<p>

#### Steps in agent:
1. vagrant up (agent VM)
2. vagrant ssh
3. `tail -f ossec.log`   

#### Steps in manager:
1. `tail -f ossec.log`
2. you can see if agent is connected with  `watch -n 1 /var/ossec/bin/agent_control -lc`
3. Run python script when agent is connected, you should see  response from agent -> "ack"
4. Run the python script when the agent is offline but the manager sees it live (go to step 2), for this you need to force the VM to power off and then you will see an error message in the admin ossec.log file and in the python script console ("err Cannot send request").

<details><summary>Python script</summary>
<p>

```python
import socket
from struct import pack, unpack
from json import dumps, loads

class WazuhSocket:
    MAX_SIZE = 65536
    def __init__(self, path):
        self.path = path
        self._connect()

    def _connect(self):
        try:
            self.s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
            self.s.connect(self.path)
        except Exception as e:
            raise e
    def close(self):
        self.s.close()

    def send(self, msg_bytes, header_format="<I"):
        if not isinstance(msg_bytes, bytes):
            raise Exception

        try:
            sent = self.s.send(pack(header_format, len(msg_bytes)) + msg_bytes)
            if sent == 0:
                raise Exception
            return sent
        except Exception as e:
            raise Exception
    def receive(self, header_format="<I", header_size=4):
        try:
            size = unpack(header_format, self.s.recv(header_size, socket.MSG_WAITALL))[0]
            return self.s.recv(size, socket.MSG_WAITALL)
        except Exception as e:
            raise Exception

s = WazuhSocket("/var/ossec/queue/sockets/remote") #4.4  #("/var/ossec/queue/sockets/request")  master
msg ="009 force_reconnect"

msgACK ="ack"
print("-> " + msg)
s.send(msg.encode())
data = s.receive().decode()
print("<- " + data)
if data != "err Cannot send request":
    #s.send(msgACK.encode())
    print("-> " + msgACK)
s.close()
```
</p>
</details>

</p>
</details>


## Logs/Alerts example
When agent is connected :
```vim
-> 009 force_reconnect
<- ack
-> ack
```
In agent `ossec.log` file:
```vim
2022/11/02 10:26:41 wazuh-agentd: INFO: Wazuh Agent will be reconnected because a reconnect message was received
2022/11/02 10:26:41 wazuh-agentd: INFO: Closing connection to server ([192.168.1.72]:1514/tcp).
2022/11/02 10:26:41 wazuh-agentd: INFO: Trying to connect to server ([192.168.1.72]:1514/tcp).
2022/11/02 10:26:41 wazuh-agentd: INFO: (4102): Connected to the server ([192.168.1.72]:1514/tcp).
```

When agent is offline but the manager sees it live :
```vim
-> 009 force_reconnect
<- err Cannot send request
```
Error in manager `ossec.log` file:
```vim
2022/11/02 10:27:02 wazuh-remoted: ERROR: Cannot send request to agent '009'
```

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions