### PR TITLE
Sync number of active agents and number of TCP sessions

### DIFF
--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -719,20 +719,19 @@ STATIC void HandleSecureMessage(const message_t *message, int *wdb_sock) {
 // Close and remove socket from keystore
 int _close_sock(keystore * keys, int sock) {
     int retval = 0;
-
     key_lock_read();
     retval = OS_DeleteSocket(keys, sock);
     key_unlock();
 
-    if (!close(sock)) {
-        nb_close(&netbuffer_recv, sock);
-        nb_close(&netbuffer_send, sock);
-        rem_dec_tcp();
+    if (close(sock)) {
+        mwarn("Unable to close socket %d: %s (%d)", sock, strerror(errno), errno);
     }
+    nb_close(&netbuffer_recv, sock);
+    nb_close(&netbuffer_send, sock);
+    rem_dec_tcp();
 
     rem_setCounter(sock, global_counter);
     mdebug1("TCP peer disconnected [%d]", sock);
-
     return retval;
 }
 

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -907,6 +907,58 @@ void test_handle_outgoing_data_to_tcp_socket_success(void **state)
     handle_outgoing_data_to_tcp_socket(sock_client);
 }
 
+void test_close_sock_success(void ** state)
+{
+
+    expect_function_call(__wrap_key_lock_read);
+    expect_value(__wrap_OS_DeleteSocket, sock, 1);
+    will_return(__wrap_OS_DeleteSocket, 0);
+    expect_function_call(__wrap_key_unlock);
+
+    will_return(__wrap_close, 0);
+
+    // nb_close
+    expect_value(__wrap_nb_close, sock, 1);
+    expect_value(__wrap_nb_close, sock, 1);
+    expect_function_call(__wrap_rem_dec_tcp);
+
+    // rem_setCounter
+    expect_value(__wrap_rem_setCounter, fd, 1);
+    expect_value(__wrap_rem_setCounter, counter, 0);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "TCP peer disconnected [1]");
+
+    int ret = _close_sock(&keys, 1);
+    assert_int_equal(ret, 0);
+}
+
+void test_close_sock_fail(void ** state)
+{
+
+    expect_function_call(__wrap_key_lock_read);
+    expect_value(__wrap_OS_DeleteSocket, sock, 1);
+    will_return(__wrap_OS_DeleteSocket, 0);
+    expect_function_call(__wrap_key_unlock);
+
+    will_return(__wrap_close, 1);
+    errno = ENOTCONN;
+    expect_string(__wrap__mwarn, formatted_msg, "Unable to close socket 1: Transport endpoint is not connected (107)");
+
+    // nb_close
+    expect_value(__wrap_nb_close, sock, 1);
+    expect_value(__wrap_nb_close, sock, 1);
+    expect_function_call(__wrap_rem_dec_tcp);
+
+    // rem_setCounter
+    expect_value(__wrap_rem_setCounter, fd, 1);
+    expect_value(__wrap_rem_setCounter, counter, 0);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "TCP peer disconnected [1]");
+
+    int ret = _close_sock(&keys, 1);
+    assert_int_equal(ret, 0);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -938,7 +990,9 @@ int main(void)
         cmocka_unit_test(test_handle_outgoing_data_to_tcp_socket_case_1_EAGAIN),
         cmocka_unit_test(test_handle_outgoing_data_to_tcp_socket_case_1_EPIPE),
         cmocka_unit_test(test_handle_outgoing_data_to_tcp_socket_success),
-
+        // Test _close_sock
+        cmocka_unit_test(test_close_sock_success),
+        cmocka_unit_test(test_close_sock_fail),
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
|Related issue|Manual Testing|
|---|---|
|https://github.com/wazuh/wazuh/issues/10665|https://github.com/wazuh/wazuh-qa/issues/3554|

## Description
The goal of this PR is keep the  quantity of active agents and the number of tcp sessions sync.
It also avoids memory allocation retention in case the system `close` call fails.
The number of tcp sessions can't be higher than number of active agents. In other hand, it's possible find more active agents than tcp sessions, until this other [issue](https://github.com/wazuh/wazuh/issues/15153) will fix.

## Configuration options
Default configuration

## Logs/Alerts example
Example log in case of system `close` call fails:
`2022/10/31 08:10:44 wazuh-remoted: WARNING: Unable to close socket 1: Transport endpoint is not connected (107)`

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- [x] Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- [x] Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  
<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Added unit tests (for new features)
