### PR TITLE
Modify `dapi_err` command and exception handling

### DIFF
--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -313,11 +313,6 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             return b'ok', b'Added request to API requests queue'
         elif command == b'dapi_res':
             return self.process_dapi_res(data)
-        elif command == b'dapi_err':
-            dapi_client, error_msg = data.split(b' ', 1)
-            asyncio.create_task(self.log_exceptions(
-                self.server.local_server.clients[dapi_client.decode()].send_request(command, error_msg)))
-            return b'ok', b'DAPI error forwarded to worker'
         elif command == b'get_nodes':
             cmd, res = self.get_nodes(json.loads(data))
             return cmd, json.dumps(res).encode()

--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -998,6 +998,24 @@ def test_handler_process_request():
     """Check if request commands are correctly defined."""
     handler = cluster_common.Handler(fernet_key, cluster_items)
 
+    class ClientsMock:
+        """Auxiliary class."""
+
+        def send_request(self, command, error_msg):
+            pass
+
+    class LocalServerDapiMock:
+        """Auxiliary class."""
+
+        def __init__(self):
+            self.clients = {"dapi_client": ClientsMock()}
+
+    class ManagerMock:
+        """Auxiliary class."""
+
+        def __init__(self):
+            self.local_server = LocalServerDapiMock()
+
     with patch('wazuh.core.cluster.common.Handler.echo') as echo_mock:
         handler.process_request(b"echo", b"data")
         echo_mock.assert_called_once_with(b"data")
@@ -1022,9 +1040,47 @@ def test_handler_process_request():
     with patch('wazuh.core.cluster.common.Handler.cancel_task') as cancel_task_mock:
         handler.process_request(b"cancel_task", b"data")
         cancel_task_mock.assert_called_once_with(b"data")
+    with patch("asyncio.create_task", return_value=b"ok") as create_task_mock:
+        handler.server = ManagerMock()
+        with patch.object(ClientsMock, "send_request") as send_request_mock:
+            handler.process_request(command=b"dapi_err", data=b"dapi_client error_msg")
+            send_request_mock.assert_called_once_with(b"dapi_err", b"error_msg")
+            create_task_mock.assert_called_once()
     with patch('wazuh.core.cluster.common.Handler.process_unknown_cmd') as process_unknown_cmd_mock:
         handler.process_request(b"something random", b"data")
         process_unknown_cmd_mock.assert_called_once_with(b"something random")
+
+def test_handler_process_request_ko():
+    """Test the correct exception raise at method 'process_request'."""
+
+    class ClientsMock:
+        """Auxiliary class."""
+
+        def send_request(self, command, error_msg):
+            pass
+
+    class LocalServerDapiMock:
+        """Auxiliary class."""
+
+        def __init__(self):
+            self.clients = {"not_data": ClientsMock()}
+
+    class ManagerMock:
+        """Auxiliary class."""
+
+        def __init__(self):
+            self.local_server = LocalServerDapiMock()
+
+    handler = cluster_common.Handler(fernet_key, cluster_items)
+    with pytest.raises(exception.WazuhClusterError, match=r".* 3032 .*"):
+        handler.server = ManagerMock()
+        handler.process_request(command=b"dapi_err", data=b"data 2")
+
+    with pytest.raises(exception.WazuhClusterError, match=r".* 3025 .*"):
+        with patch("asyncio.create_task", side_effect=exception.WazuhClusterError(1001)):
+            handler.server = ManagerMock()
+            handler.server.local_server.clients = {"data": ClientsMock()}
+            handler.process_request(command=b"dapi_err", data=b"data 2")
 
 
 def test_handler_process_response():

--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -56,7 +56,6 @@ fernet_key = "00000000000000000000000000000000"
 wazuh_common = cluster_common.WazuhCommon()
 in_buffer = cluster_common.InBuffer()
 
-
 asyncio.set_event_loop_policy(EventLoopPolicy())
 loop = new_event_loop()
 
@@ -1050,6 +1049,7 @@ def test_handler_process_request():
         handler.process_request(b"something random", b"data")
         process_unknown_cmd_mock.assert_called_once_with(b"something random")
 
+
 def test_handler_process_request_ko():
     """Test the correct exception raise at method 'process_request'."""
 
@@ -1263,6 +1263,7 @@ async def test_handler_wait_for_file_ko(send_request_mock, wait_for_mock):
     with pytest.raises(exception.WazuhClusterError, match=r".* 3040 .*"):
         await handler.wait_for_file(asyncio.Event(), "task_id")
     send_request_mock.assert_called_with(command=b'cancel_task', data=ANY)
+
 
 # Test 'WazuhCommon' class methods
 

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -514,16 +514,6 @@ def test_master_handler_process_request(logger_mock):
         process_dapi_res_mock.assert_called_once_with(b"data")
 
     # Test the eleventh condition
-    master_handler.server = Server()
-    with patch("asyncio.create_task") as create_task_mock:
-        with patch("wazuh.core.cluster.master.MasterHandler.log_exceptions", return_value=b"ok") as log_exc_mock:
-            assert master_handler.process_request(command=b'dapi_err',
-                                              data=b"dapi_client error_msg") == (b'ok',
-                                                                                 b'DAPI error forwarded to worker')
-            create_task_mock.assert_called_once()
-            log_exc_mock.assert_called_with(None)
-
-    # Test the twelfth condition
     with patch("wazuh.core.cluster.master.MasterHandler.get_nodes", return_value=(["cmd", "res"])) as get_nodes_mock:
         with patch("json.loads", return_value=b"ok") as json_loads_mock:
             with patch("json.dumps", return_value="ok") as json_dumps_mock:
@@ -532,7 +522,8 @@ def test_master_handler_process_request(logger_mock):
                 get_nodes_mock.assert_called_once_with(b"ok")
                 json_dumps_mock.assert_called_once_with("res")
 
-    # Test the thirteenth condition
+    master_handler.server = Server()
+    # Test the twelfth condition
     with patch("wazuh.core.cluster.master.MasterHandler.get_health", return_value=(["cmd", "res"])) as get_health_mock:
         with patch("json.loads", return_value=b"ok") as json_loads_mock:
             with patch("json.dumps", return_value="ok") as json_dumps_mock:
@@ -541,14 +532,14 @@ def test_master_handler_process_request(logger_mock):
                 get_health_mock.assert_called_once_with(b"ok")
                 json_dumps_mock.assert_called_once()
 
-    # Test the fourteenth condition
+    # Test the thirteenth condition
     with patch.object(DapiMock, "add_request") as add_request_mock:
         assert master_handler.process_request(command=b'sendsync', data=b"data") == (b'ok',
                                                                                      b'Added request to SendSync '
                                                                                      b'requests queue')
         add_request_mock.assert_called_once_with(master_handler.name.encode() + b"*" + b"data")
 
-    # Test the fifteenth condition
+    # Test the fourteenth condition
     with patch("wazuh.core.cluster.server.AbstractServerHandler.process_request",
                return_value=b"ok") as process_request_mock:
         assert master_handler.process_request(command=b'random', data=b"data") == b"ok"
@@ -561,7 +552,7 @@ def test_master_handler_process_request(logger_mock):
                                   call("Command received: b'syn_i_w_m_r'"), call("Command received: b'syn_w_g_e'"),
                                   call("Command received: b'syn_wgc_e'"), call("Command received: b'syn_w_g_err'"),
                                   call("Command received: b'syn_wgc_err'"), call("Command received: b'dapi'"),
-                                  call("Command received: b'dapi_res'"), call("Command received: b'dapi_err'"),
+                                  call("Command received: b'dapi_res'"),
                                   call("Command received: b'get_nodes'"), call("Command received: b'get_health'"),
                                   call("Command received: b'sendsync'"), call("Command received: b'random'")])
 

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -452,11 +452,7 @@ def test_worker_handler_process_request_ko(create_task_mock, logger_mock):
     """Test the correct exception raise at method 'process_request'."""
 
     with pytest.raises(exception.WazuhClusterError, match=r".* 1001 .*"):
-        worker_handler.process_request(command=b"dapi_err", data=b"data 2")
-    logger_mock.assert_called_with("Command received: 'b'dapi_err''")
-
-    with pytest.raises(exception.WazuhClusterError, match=r".* 1001 .*"):
-        worker_handler.process_request(command=b"sendsyn_err", data=b"data 2")
+        worker_handler.process_request(command=b"sendsyn_err", data=b"data 1")
     logger_mock.assert_called_with("Command received: 'b'sendsyn_err''")
 
 

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -226,11 +226,6 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         elif command == b'sendsyn_res':
             asyncio.create_task(self.forward_sendsync_response(data))
             return b'ok', b'Response forwarded to worker'
-        elif command == b'dapi_err':
-            dapi_client, error_msg = data.split(b' ', 1)
-            asyncio.create_task(self.log_exceptions(
-                self.server.local_server.clients[dapi_client.decode()].send_request(command, error_msg)))
-            return b'ok', b'DAPI error forwarded to worker'
         elif command == b'sendsyn_err':
             sendsync_client, error_msg = data.split(b' ', 1)
             asyncio.create_task(self.log_exceptions(


### PR DESCRIPTION
|Related issue|
|---|
| Closes #15004 |


## Description

This PR changes how the `WorkerHandler` and the `MasterHandler` manage the `dapi_err` command. Its management is passed to the `Handler` class, from which both inherit, in `common.py`, more specifically in its `process_request` method. It takes into account the case when the command has to be sent to the peer but the same has disconnected before receiving it.

## Logs/Alerts example
When the peer disconnects before receiving the `dapi_err` command, the logs show:
### Master
<details><summary>cluster.log</summary>

    2022/11/03 16:22:12 DEBUG: [Worker worker1] [Main] Command received: b'dapi_err'
    2022/11/03 16:22:12 ERROR: [Worker worker1] [Main] Internal error processing request 'b'dapi_err'': Error 3032 - Could not forward DAPI request. Connection not available.: 273874
    Traceback (most recent call last):
      File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.5.0-py3.9.egg/wazuh/core/cluster/common.py", line 858, in dispatch
        command, payload = self.process_request(command, payload)
      File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.5.0-py3.9.egg/wazuh/core/cluster/master.py", line 328, in process_request
        return super().process_request(command, data)
      File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.5.0-py3.9.egg/wazuh/core/cluster/server.py", line 106, in process_request
        return super().process_request(command, data)
    --
    wazuh.core.exception.WazuhClusterError: Error 3032 - Could not forward DAPI request. Connection not available.: 273874
</details>

### Worker
<details><summary>cluster.log</summary>

    2022/11/03 16:23:15 DEBUG: [Worker worker1] [Main] Command received: 'b'dapi_err''
    2022/11/03 16:23:15 ERROR: [Worker worker1] [Main] Internal error processing request 'b'dapi_err'': Error 3032 - Could not forward DAPI request. Connection not available.: 640520
    Traceback (most recent call last):
      File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.5.0-py3.9.egg/wazuh/core/cluster/common.py", line 858, in dispatch
        command, payload = self.process_request(command, payload)
      File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.5.0-py3.9.egg/wazuh/core/cluster/worker.py", line 241, in process_request
        return super().process_request(command, data)
      File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.5.0-py3.9.egg/wazuh/core/cluster/client.py", line 257, in process_request
        return super().process_request(command, data)
    --
    wazuh.core.exception.WazuhClusterError: Error 3032 - Could not forward DAPI request. Connection not available.: 640520

</details>

## Tests
### Unit tests
New test cases have been added in order to cover the modifications in `common.py`
```
========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.9.5, pytest-6.0.1, py-1.11.0, pluggy-0.13.1
rootdir: /home/test_user/git/wazuh/framework
plugins: cov-3.0.0, trio-0.7.0, metadata-2.0.2, asyncio-0.15.1, aiohttp-0.3.0, html-2.1.1
collected 2073 items                                                                                                                                                                                     

scripts/tests/test_agent_groups.py ..............                                                                                                                                                  [  0%]
scripts/tests/test_agent_upgrade.py ...............                                                                                                                                                [  1%]
scripts/tests/test_cluster_control.py ......                                                                                                                                                       [  1%]
scripts/tests/test_wazuh_clusterd.py .......                                                                                                                                                       [  2%]
scripts/tests/test_wazuh_logtest.py ......................                                                                                                                                         [  3%]
wazuh/core/cluster/dapi/tests/test_dapi.py ................................                                                                                                                        [  4%]
wazuh/core/cluster/tests/test_client.py ................                                                                                                                                           [  5%]
wazuh/core/cluster/tests/test_cluster.py ...................................                                                                                                                       [  7%]
wazuh/core/cluster/tests/test_common.py ...................................................................................                                                                        [ 11%]
wazuh/core/cluster/tests/test_control.py ......                                                                                                                                                    [ 11%]
wazuh/core/cluster/tests/test_local_client.py .............                                                                                                                                        [ 12%]
wazuh/core/cluster/tests/test_local_server.py ........................                                                                                                                             [ 13%]
wazuh/core/cluster/tests/test_master.py ....................................................                                                                                                       [ 15%]
wazuh/core/cluster/tests/test_server.py ..............................                                                                                                                             [ 17%]
wazuh/core/cluster/tests/test_utils.py ...........                                                                                                                                                 [ 17%]
wazuh/core/cluster/tests/test_worker.py ...................................                                                                                                                        [ 19%]
wazuh/core/tests/test_active_response.py ..............                                                                                                                                            [ 20%]
wazuh/core/tests/test_agent.py ...................................................................................................................................................                 [ 27%]
wazuh/core/tests/test_cdb_list.py ......................................                                                                                                                           [ 28%]
wazuh/core/tests/test_common.py .........                                                                                                                                                          [ 29%]
wazuh/core/tests/test_configuration.py ......................................................................                                                                                      [ 32%]
wazuh/core/tests/test_database.py .............                                                                                                                                                    [ 33%]
wazuh/core/tests/test_decoder.py ................                                                                                                                                                  [ 34%]
wazuh/core/tests/test_exception.py ...                                                                                                                                                             [ 34%]
wazuh/core/tests/test_input_validator.py ...                                                                                                                                                       [ 34%]
wazuh/core/tests/test_logtest.py ..                                                                                                                                                                [ 34%]
wazuh/core/tests/test_manager.py ...............                                                                                                                                                   [ 35%]
wazuh/core/tests/test_mitre.py .............                                                                                                                                                       [ 35%]
wazuh/core/tests/test_pyDaemonModule.py .....                                                                                                                                                      [ 36%]
wazuh/core/tests/test_results.py ........................................                                                                                                                          [ 38%]
wazuh/core/tests/test_rootcheck.py .............                                                                                                                                                   [ 38%]
wazuh/core/tests/test_rule.py ......................                                                                                                                                               [ 39%]
wazuh/core/tests/test_sca.py ........................                                                                                                                                              [ 40%]
wazuh/core/tests/test_security.py ............                                                                                                                                                     [ 41%]
wazuh/core/tests/test_stats.py .................                                                                                                                                                   [ 42%]
wazuh/core/tests/test_syscheck.py .......                                                                                                                                                          [ 42%]
wazuh/core/tests/test_syscollector.py ...                                                                                                                                                          [ 42%]
wazuh/core/tests/test_task.py ........                                                                                                                                                             [ 43%]
wazuh/core/tests/test_utils.py ................................................................................................................................................................... [ 51%]
..................................................................................                                                                                                                 [ 54%]
wazuh/core/tests/test_vulnerability.py ..                                                                                                                                                          [ 55%]
wazuh/core/tests/test_wazuh_queue.py ....................                                                                                                                                          [ 56%]
wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                                                         [ 57%]
wazuh/core/tests/test_wdb.py ...............................                                                                                                                                       [ 58%]
wazuh/core/tests/test_wlogging.py .........                                                                                                                                                        [ 58%]
wazuh/rbac/tests/test_auth_context.py ..                                                                                                                                                           [ 59%]
wazuh/rbac/tests/test_decorators.py .........................................................................................................                                                      [ 64%]
wazuh/rbac/tests/test_default_configuration.py .......................................................                                                                                             [ 66%]
wazuh/rbac/tests/test_orm.py ......................................................                                                                                                                [ 69%]
wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                                  [ 69%]
wazuh/tests/test_active_response.py ............                                                                                                                                                   [ 70%]
wazuh/tests/test_agent.py ......................................................................................................................                                                   [ 76%]
wazuh/tests/test_cdb_list.py .....................................................                                                                                                                 [ 78%]
wazuh/tests/test_ciscat.py .................................                                                                                                                                       [ 80%]
wazuh/tests/test_cluster.py ..........                                                                                                                                                             [ 80%]
wazuh/tests/test_decoder.py ...................................                                                                                                                                    [ 82%]
wazuh/tests/test_group.py .......                                                                                                                                                                  [ 82%]
wazuh/tests/test_logtest.py ......                                                                                                                                                                 [ 83%]
wazuh/tests/test_manager.py ....................................                                                                                                                                   [ 84%]
wazuh/tests/test_mitre.py .......                                                                                                                                                                  [ 85%]
wazuh/tests/test_rootcheck.py ..................................................                                                                                                                   [ 87%]
wazuh/tests/test_rule.py ........................................................                                                                                                                  [ 90%]
wazuh/tests/test_sca.py ...........                                                                                                                                                                [ 90%]
wazuh/tests/test_security.py .........................................................................                                                                                             [ 94%]
wazuh/tests/test_stats.py ...............                                                                                                                                                          [ 95%]
wazuh/tests/test_syscheck.py ..........................                                                                                                                                            [ 96%]
wazuh/tests/test_syscollector.py ............                                                                                                                                                      [ 96%]
wazuh/tests/test_task.py ............................                                                                                                                                              [ 98%]
wazuh/tests/test_vulnerability.py ....................................                                                                                                                             [100%]

============================================================================= 2073 passed, 40 warnings in 317.23s (0:05:17) ==============================================================================
```

### Cluster endpoints Integration Tests
```
========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.8.10, pytest-5.4.3, py-1.11.0, pluggy-0.13.1 -- /home/test_user/venv/integrationtest-env/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.10', 'Platform': 'Linux-5.14.0-1054-oem-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.11.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'tavern': '1.2.2', 'metadata': '2.0.2'}}
rootdir: /home/test_user/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: html-3.1.1, tavern-1.2.2, metadata-2.0.2
collected 49 items                                                                                                                                                                                       

test_cluster_endpoints.tavern.yaml::GET /cluster/local/config PASSED                                                                                                                               [  2%]
test_cluster_endpoints.tavern.yaml::GET /cluster/healthcheck PASSED                                                                                                                                [  4%]
test_cluster_endpoints.tavern.yaml::GET /cluster/ruleset/synchronization PASSED                                                                                                                    [  6%]
test_cluster_endpoints.tavern.yaml::GET /cluster/local/info PASSED                                                                                                                                 [  8%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes PASSED                                                                                                                                      [ 10%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[master-node] PASSED                                                                                                                         [ 12%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker1] PASSED                                                                                                                             [ 14%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker2] PASSED                                                                                                                             [ 16%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[ip] PASSED                                                                                                                           [ 18%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[name] PASSED                                                                                                                         [ 20%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[type] PASSED                                                                                                                         [ 22%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[version] PASSED                                                                                                                      [ 24%]
test_cluster_endpoints.tavern.yaml::GET /cluster/status PASSED                                                                                                                                     [ 26%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration PASSED                                                                                                                    [ 28%]
test_cluster_endpoints.tavern.yaml::GET /cluster/configuration/validation PASSED                                                                                                                   [ 30%]
test_cluster_endpoints.tavern.yaml::GET /cluster/api/config PASSED                                                                                                                                 [ 32%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration/{component}/{configuration} PASSED                                                                                        [ 34%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[master-node] PASSED                                                                                                                [ 36%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker1] PASSED                                                                                                                    [ 38%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker2] PASSED                                                                                                                    [ 40%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[master-node] PASSED                                                                                                                [ 42%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker1] PASSED                                                                                                                    [ 44%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker2] PASSED                                                                                                                    [ 46%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker1] PASSED                                                                                                            [ 48%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker2] PASSED                                                                                                            [ 51%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[master-node] PASSED                                                                                                       [ 53%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[worker1] PASSED                                                                                                           [ 55%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[worker2] PASSED                                                                                                           [ 57%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[master-node] PASSED                                                                                                               [ 59%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker1] PASSED                                                                                                                   [ 61%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker2] PASSED                                                                                                                   [ 63%]
test_cluster_endpoints.tavern.yaml::GET /cluster/wrong_node/stats PASSED                                                                                                                           [ 65%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[master-node] PASSED                                                                                                     [ 67%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker1] PASSED                                                                                                         [ 69%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker2] PASSED                                                                                                         [ 71%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[master-node] PASSED                                                                                                        [ 73%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker1] PASSED                                                                                                            [ 75%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker2] PASSED                                                                                                            [ 77%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[master-node] PASSED                                                                                                       [ 79%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker1] PASSED                                                                                                           [ 81%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker2] PASSED                                                                                                           [ 83%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[master-node] PASSED                                                                                                        [ 85%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker1] PASSED                                                                                                            [ 87%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker2] PASSED                                                                                                            [ 89%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[master-node] PASSED                                                                                                              [ 91%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker1] PASSED                                                                                                                  [ 93%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker2] PASSED                                                                                                                  [ 95%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/restart PASSED                                                                                                                                    [ 97%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/configuration PASSED                                                                                                                    [100%]

============================================================================== 49 passed, 62 warnings in 2245.73s (0:37:25) ==============================================================================

```

