### PR TITLE
Escape the agent's ip in VirusTotal integration

### DIFF
--- a/integrations/virustotal
+++ b/integrations/virustotal
@@ -176,7 +176,9 @@ def send_event(msg, agent = None):
     if not agent or agent["id"] == "000":
         string = '1:virustotal:{0}'.format(json.dumps(msg))
     else:
-        string = '1:[{0}] ({1}) {2}->virustotal:{3}'.format(agent["id"], agent["name"], agent["ip"] if "ip" in agent else "any", json.dumps(msg))
+        location = '[{0}] ({1}) {2}'.format(agent["id"], agent["name"], agent["ip"] if "ip" in agent else "any")
+        location = location.replace("|", "||").replace(":", "|:")
+        string = '1:{0}->virustotal:{1}'.format(location, json.dumps(msg))
 
     debug(string)
     sock = socket(AF_UNIX, SOCK_DGRAM)


### PR DESCRIPTION
|Related issue|Manual Testing|
|---|---|
|https://github.com/wazuh/wazuh/issues/15286|https://github.com/wazuh/wazuh-qa/issues/3568|

## Description
This PR fix the VirusTotal alerts that includs agent's IPv6, it escape special characters as `:` and `|`, every virustotal event from an IPv6 connection, the IP will be escaped to be processed by analysisd module.

example:
From `FE80:0000:0000:0000:ECBF:3082:B8EB:1CB8` to `FE80|:0000|:0000|:0000|:ECBF|:3082|:B8EB|:1CB8`

[Link](https://github.com/wazuh/wazuh/wiki/Proof-of-concept-guide#detecting-and-removing-malware---virustotal-integration) to a guide to reproduce a VirusTotal event.

## Configuration options

### Manager
integratord `ossec.conf` 
```xml
<ossec_config>
    <integration>
    <name>virustotal</name>
    <api_key>${your_virustotal_api_key}</api_key>
    <rule_id>syscheck</rule_id>
    <alert_format>json</alert_format>
    </integration>
</ossec_config>
```

IPv6 `ossec.conf`
  ```xml
<remote>
    <connection>secure</connection>
    <port>1514</port>
    <protocol>tcp</protocol>
    <ipv6>yes</ipv6>                              <-------------
    <queue_size>131072</queue_size>
  </remote>

  <!-- Configuration for wazuh-authd -->
  <auth>
    <disabled>no</disabled>
    <port>1515</port>
    <ipv6>yes</ipv6>                               <-------------
```

### Agent
syscheck  `ossec.conf`
```xml
  <syscheck>
    <directories whodata="yes">/root</directories>
  </syscheck>

```
## Alerts example

Syscheck alert:

```
{"timestamp":"2022-11-03T17:18:46.600-0300","rule":{"level":7,"description":"Integrity checksum changed.","id":"550","mitre":{"id":["T1565.001"],"tactic":["Impact"],"technique":["Stored Data Manipulation"]},"firedtimes":1,"mail":false,"groups":["ossec","syscheck","syscheck_entry_modified","syscheck_file"],"pci_dss":["11.5"],"gpg13":["4.11"],"gdpr":["II_5.1.f"],"hipaa":["164.312.c.1","164.312.c.2"],"nist_800_53":["SI.7"],"tsc":["PI1.4","PI1.5","CC6.1","CC6.8","CC7.2","CC7.3"]},"agent":{"id":"001","name":"DESKTOP","ip":"2803:0000:9882:B7A5:2D8B:FB2E:0000:0050"},"manager":{"name":"VBox"},"id":"1667506726.2227426","full_log":"File 'c:\\users\\workspace\\eicar.com' modified\nMode: realtime\nChanged attributes: mtime\nOld modification time was: '1667506590', now it is '1667506726'\n","syscheck":{"path":"c:\\users\\asus\\workspace\\eicar.com","mode":"realtime","size_after":"68","win_perm_after":[{"name":"SYSTEM","allowed":["DELETE","READ_CONTROL","WRITE_DAC","WRITE_OWNER","SYNCHRONIZE","READ_DATA","WRITE_DATA","APPEND_DATA","READ_EA","WRITE_EA","EXECUTE","READ_ATTRIBUTES","WRITE_ATTRIBUTES"]},{"name":"Administradores","allowed":["DELETE","READ_CONTROL","WRITE_DAC","WRITE_OWNER","SYNCHRONIZE","READ_DATA","WRITE_DATA","APPEND_DATA","READ_EA","WRITE_EA","EXECUTE","READ_ATTRIBUTES","WRITE_ATTRIBUTES"]},{"name":"asus","allowed":["DELETE","READ_CONTROL","WRITE_DAC","WRITE_OWNER","SYNCHRONIZE","READ_DATA","WRITE_DATA","APPEND_DATA","READ_EA","WRITE_EA","EXECUTE","READ_ATTRIBUTES","WRITE_ATTRIBUTES"]}],"uid_after":"S-1-5-21-2446384277-2365750671-1058278366-1001","md5_after":"44d88612fea8a8f36de82e1278abb02f","sha1_after":"3395856ce81f2b7382dee72602f798b642f14140","sha256_after":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","attrs_after":["ARCHIVE"],"uname_after":"asus","mtime_before":"2022-11-03T17:16:30","mtime_after":"2022-11-03T17:18:46","changed_attributes":["mtime"],"event":"modified"},"decoder":{"name":"syscheck_integrity_changed"},"location":"syscheck"}
```

VirusTotal alert:

```
{"timestamp":"2022-11-03T17:18:49.261-0300","rule":{"level":12,"description":"VirusTotal: Alert - c:\\users\\workspace\\eicar.com - 63 engines detected this file","id":"87105","mitre":{"id":["T1203"],"tactic":["Execution"],"technique":["Exploitation for Client Execution"]},"firedtimes":1,"mail":true,"groups":["virustotal"],"pci_dss":["10.6.1","11.4"],"gdpr":["IV_35.7.d"]},"agent":{"id":"001","name":"DESKTOP","ip":"2803:0000:9882:B7A5:2D8B:FB2E:0000:0050"},"manager":{"name":"VBox"},"id":"1667506729.2228767","decoder":{"name":"json"},"data":{"virustotal":{"found":"1","malicious":"1","source":{"alert_id":"1667506726.2227426","file":"c:\\users\\asus\\workspace\\eicar.com","md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140"},"sha1":"3395856ce81f2b7382dee72602f798b642f14140","scan_date":"2022-11-03 20:18:01","positives":"63","total":"68","permalink":"https://www.virustotal.com/gui/file/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f/detection/f-275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f-1667506681"},"integration":"virustotal"},"location":"virustotal"}
```
## Logs example
```
2022/11/03 17:18:49 wazuh-integratord[2094272] integrator.c:403 at OS_IntegratorD(): DEBUG: integratord: Thu Nov 03 17:18:48 -03 2022: 1:[001] (DESKTOP-U8OHD3A) 2803|:9800|:9882|:B7A5|:2D8B|:FB2E|:6100|:C250->vi
rustotal:{"virustotal": {"found": 1, "malicious": 1, "source": {"alert_id": "1667506726.2227426", "file": "c:\\users\\workspace\\eicar.com", "md5": "44d88612fea8a8f36de82e1278abb02f", "sha1": "3395856ce81f
2b7382dee72602f798b642f14140"}, "sha1": "3395856ce81f2b7382dee72602f798b642f14140", "scan_date": "2022-11-03 20:18:01", "positives": 63, "total": 68, "permalink": "https://www.virustotal.com/gui/file/275a021bbfb
6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f/detection/f-275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f-1667506681"}, "integration": "virustotal"}
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- [x] Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
