### PR TITLE
Avoid crash when calling _InternalMatch regex function with NULL parameter

### DIFF
--- a/src/os_regex/os_regex_match.c
+++ b/src/os_regex/os_regex_match.c
@@ -25,7 +25,7 @@
  */
 
 /* Prototypes */
-static int _InternalMatch(const char *pattern, const char *str, size_t count) __attribute__((nonnull));
+static int _InternalMatch(const char *pattern, const char *str, size_t count);
 
 
 /* Search for pattern in the string */
@@ -64,6 +64,10 @@ static int _InternalMatch(const char *pattern, const char *str, size_t pattern_s
     const uchar *pt = (const uchar *)pattern;
     const uchar *st = (const uchar *)str;
     const uchar last_char = (const uchar) pattern[pattern_size];
+
+    if (str == NULL) {
+        return (FALSE);
+    }
 
     if (*pattern == '\0') {
         return (TRUE);

--- a/src/unit_tests/os_regex/CMakeLists.txt
+++ b/src/unit_tests/os_regex/CMakeLists.txt
@@ -1,3 +1,10 @@
+# Copyright (C) 2015, Wazuh Inc.
+#
+# This program is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
+
 # Generate os_regex library
 file(GLOB os_regex_files
     ${SRC_FOLDER}/os_regex/*.o)
@@ -21,6 +28,11 @@ target_link_libraries(OS_REGEX_O ${WAZUHLIB} ${WAZUHEXT} -lpthread)
 
 # Generate os_regex tests
 list(APPEND os_regex_names "test_os_regex")
+list(APPEND os_regex_flags " ")
+list(APPEND os_regex_def " ")
+
+# Generate os_regex_match tests
+list(APPEND os_regex_names "test_os_regex_match")
 list(APPEND os_regex_flags " ")
 list(APPEND os_regex_def " ")
 

--- a/src/unit_tests/os_regex/test_os_regex_match.c
+++ b/src/unit_tests/os_regex/test_os_regex_match.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "../../os_regex/os_regex_match.c"
+
+// Tests
+
+void test__InternalMatch_str_NULL(void **state) {
+    char * str = NULL;
+    char * pattern = "pattern";
+    size_t pattern_size = strlen(pattern);
+
+    int result = _InternalMatch(pattern, str, pattern_size);
+    assert_int_equal(result, FALSE);
+}
+
+void test__InternalMatch_str_empty(void **state) {
+    char * str = "";
+    char * pattern = "pattern";
+    size_t pattern_size = strlen(pattern);
+
+    int result = _InternalMatch(pattern, str, pattern_size);
+    assert_int_equal(result, FALSE);
+}
+
+void test__InternalMatch_pattern_empty(void **state) {
+    char * str = "string";
+    char * pattern = "";
+    size_t pattern_size = strlen(pattern);
+    
+    int result = _InternalMatch(pattern, str, pattern_size);
+    assert_int_equal(result, TRUE);
+}
+
+void test__InternalMatch_fail(void **state) {
+    char * str = "string";
+    char * pattern = "^pattern";
+    size_t pattern_size = strlen(pattern);
+
+    int result = _InternalMatch(pattern, str, pattern_size);
+    assert_int_equal(result, FALSE);
+}
+
+void test__InternalMatch_success(void **state) {
+    char * str = "string";
+    char * pattern = "^string";
+    size_t pattern_size = strlen(pattern);
+
+    int result = _InternalMatch(pattern, str, pattern_size);
+    assert_int_equal(result, TRUE);
+}
+
+void test__InternalMatch_fail_iteration(void **state) {
+    char * str = "this is a str";
+    char * pattern = "string";
+    size_t pattern_size = strlen(pattern);
+
+    int result = _InternalMatch(pattern, str, pattern_size);
+    assert_int_equal(result, FALSE);
+}
+
+void test__InternalMatch_success_iteration(void **state) {
+    char * str = "this is a string";
+    char * pattern = "string";
+    size_t pattern_size = strlen(pattern);
+
+    int result = _InternalMatch(pattern, str, pattern_size);
+    assert_int_equal(result, TRUE);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test__InternalMatch_str_NULL),
+        cmocka_unit_test(test__InternalMatch_str_empty),
+        cmocka_unit_test(test__InternalMatch_pattern_empty),
+        cmocka_unit_test(test__InternalMatch_fail),
+        cmocka_unit_test(test__InternalMatch_success),
+        cmocka_unit_test(test__InternalMatch_fail_iteration),
+        cmocka_unit_test(test__InternalMatch_success_iteration)
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/15280|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The goal of this pull request is to introduce a sanitization for the function `_InternalMatch` in order to avoid the crash described at #15280.

From the trace, we obtained that if `str` was NULL for any reason, `Analysisd` crashes.

```
Program received signal SIGSEGV, Segmentation fault.
0x000000000052dbdb in _InternalMatch (pattern=0x15fbd10 "audit", str=0x0, pattern_size=5) at os_regex/os_regex_match.c:85
85	    else if (*st == '\0') {
(gdb) p str
$1 = 0x0
```

This pull request simply adds a sanitize for `str` to avoid crashing when this situation appears. However, the root problem in this crash is that a rule was loaded with an invalid `if_sid` in the rule tree. As stated in the issue, this was actually solved at https://github.com/wazuh/wazuh/pull/14772 for v4.3.8.

## Tests

Unit tests were created before implementing the fix, that way we can replicate the crash.

```
# ./os_regex/test_os_regex_match
[==========] Running 7 test(s).
[ RUN      ] test__InternalMatch_str_NULL
[  ERROR   ] --- Test failed with exception: Segmentation fault(11)
[  FAILED  ] test__InternalMatch_str_NULL
[ RUN      ] test__InternalMatch_str_empty
[       OK ] test__InternalMatch_str_empty
[ RUN      ] test__InternalMatch_pattern_empty
[       OK ] test__InternalMatch_pattern_empty
[ RUN      ] test__InternalMatch_fail
[       OK ] test__InternalMatch_fail
[ RUN      ] test__InternalMatch_success
[       OK ] test__InternalMatch_success
[ RUN      ] test__InternalMatch_fail_iteration
[       OK ] test__InternalMatch_fail_iteration
[ RUN      ] test__InternalMatch_success_iteration
[       OK ] test__InternalMatch_success_iteration
[==========] 7 test(s) run.
[  PASSED  ] 6 test(s).
[  FAILED  ] 1 test(s), listed below:
[  FAILED  ] test__InternalMatch_str_NULL

 1 FAILED TEST(S)
```

Once the fix is applied, all tests for `_InternalMatch` pass.

```
# ./os_regex/test_os_regex_match
[==========] Running 7 test(s).
[ RUN      ] test__InternalMatch_str_NULL
[       OK ] test__InternalMatch_str_NULL
[ RUN      ] test__InternalMatch_str_empty
[       OK ] test__InternalMatch_str_empty
[ RUN      ] test__InternalMatch_pattern_empty
[       OK ] test__InternalMatch_pattern_empty
[ RUN      ] test__InternalMatch_fail
[       OK ] test__InternalMatch_fail
[ RUN      ] test__InternalMatch_success
[       OK ] test__InternalMatch_success
[ RUN      ] test__InternalMatch_fail_iteration
[       OK ] test__InternalMatch_fail_iteration
[ RUN      ] test__InternalMatch_success_iteration
[       OK ] test__InternalMatch_success_iteration
[==========] 7 test(s) run.
[  PASSED  ] 7 test(s).
```

Also, the coverage test for this function reaches 100% lines:
<img width="1435" alt="Screenshot 2022-11-04 at 11 06 48" src="https://user-images.githubusercontent.com/29475387/199970643-f12c2420-f0b1-45b1-bf95-609e337febd7.png">
