### PR TITLE
Fix to allow uploading Wazuh configuration files with multiple <ossec_conf> blocks

### DIFF
--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -1879,9 +1879,9 @@ def test_get_utc_now():
 
 
 @pytest.mark.parametrize("configuration", [
-    "<root><global><limits><eps><whatever>yes</whatever></eps></limits></global></root>",
-    "<root><global><logall>no</logall></global><global><limits><eps><whatever>yes</whatever></eps></limits>"
-    "</global></root>"
+    "<global><limits><eps><whatever>yes</whatever></eps></limits></global>",
+    "<global><logall>no</logall></global><global><limits><eps><whatever>yes</whatever></eps></limits>"
+    "</global>"
 ])
 @pytest.mark.parametrize("limits_conf, expect_exc", [
     ({'eps': {'allow': True}}, False),

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -793,7 +793,7 @@ def check_disabled_limits_in_conf(data):
     """
     blocked_configurations = configuration.api_conf['upload_configuration']
 
-    xml_file = fromstring(data)
+    xml_file = fromstring(f"<root_tag>{data}</root_tag>")
     found_limits = []
     for global_section in xml_file.findall("global"):
         found_limits += [limit_section for limit_section in global_section.findall("limits") or []]
@@ -846,7 +846,7 @@ def load_wazuh_xml(xml_path, data=None):
                '\n'.join([f'<!ENTITY {name} "{value}">' for name, value in custom_entities.items()]) + \
                '\n]>\n'
 
-    return fromstring(entities + '<root_tag>' + data + '</root_tag>', forbid_entities=False)
+    return fromstring(f"{entities}<root_tag>{data}</root_tag>", forbid_entities=False)
 
 
 class WazuhVersion:


### PR DESCRIPTION
|Related issue|
|---|
|#15082|

Hello team,

This PR closes #15082. A minor change has been made in /framework/wazuh/core/utils to allow the usage of two `<ossec_conf>` blocks inside a single `ossec.conf` file when we try to update the default configuration through a PUT request.

## Tests

### Framework unittests
```
============================= test session starts ==============================
platform linux -- Python 3.9.9, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/agavila/git/wazuh/framework
plugins: anyio-3.6.2, asyncio-0.18.1
asyncio: mode=legacy
collected 2046 items

framework/scripts/tests/test_agent_groups.py ..............              [  0%]
framework/scripts/tests/test_agent_upgrade.py ...............            [  1%]
framework/scripts/tests/test_cluster_control.py ......                   [  1%]
framework/scripts/tests/test_wazuh_clusterd.py .......                   [  2%]
framework/scripts/tests/test_wazuh_logtest.py ......................     [  3%]
framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................... [  4%]
...........ss                                                            [  4%]
framework/wazuh/core/cluster/tests/test_client.py ................       [  5%]
framework/wazuh/core/cluster/tests/test_cluster.py ..................... [  6%]
.....ss.......                                                           [  7%]
framework/wazuh/core/cluster/tests/test_common.py ...................... [  8%]
.......................................................                  [ 10%]
framework/wazuh/core/cluster/tests/test_control.py ......                [ 11%]
framework/wazuh/core/cluster/tests/test_local_client.py .......ss....    [ 11%]
framework/wazuh/core/cluster/tests/test_local_server.py ................ [ 12%]
........                                                                 [ 13%]
framework/wazuh/core/cluster/tests/test_master.py ...................... [ 14%]
...........................                                              [ 15%]
framework/wazuh/core/cluster/tests/test_server.py ...................    [ 16%]
framework/wazuh/core/cluster/tests/test_utils.py ...........             [ 16%]
framework/wazuh/core/cluster/tests/test_worker.py ...................... [ 17%]
...............                                                          [ 18%]
framework/wazuh/core/tests/test_active_response.py ..............        [ 19%]
framework/wazuh/core/tests/test_agent.py ............................... [ 20%]
........................................................................ [ 24%]
.........................................                                [ 26%]
framework/wazuh/core/tests/test_cdb_list.py ............................ [ 27%]
..........                                                               [ 28%]
framework/wazuh/core/tests/test_common.py .......                        [ 28%]
framework/wazuh/core/tests/test_configuration.py ....................... [ 29%]
...............................................                          [ 32%]
framework/wazuh/core/tests/test_database.py .............                [ 32%]
framework/wazuh/core/tests/test_decoder.py ................              [ 33%]
framework/wazuh/core/tests/test_exception.py ...                         [ 33%]
framework/wazuh/core/tests/test_input_validator.py ...                   [ 33%]
framework/wazuh/core/tests/test_logtest.py ..                            [ 33%]
framework/wazuh/core/tests/test_manager.py ...............               [ 34%]
framework/wazuh/core/tests/test_mitre.py .............                   [ 35%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                  [ 35%]
framework/wazuh/core/tests/test_results.py ............................. [ 36%]
...........                                                              [ 37%]
framework/wazuh/core/tests/test_rootcheck.py .............               [ 38%]
framework/wazuh/core/tests/test_rule.py ......................           [ 39%]
framework/wazuh/core/tests/test_sca.py ........................          [ 40%]
framework/wazuh/core/tests/test_security.py ............                 [ 40%]
framework/wazuh/core/tests/test_stats.py .................               [ 41%]
framework/wazuh/core/tests/test_syscheck.py .......                      [ 42%]
framework/wazuh/core/tests/test_syscollector.py ...                      [ 42%]
framework/wazuh/core/tests/test_task.py ........                         [ 42%]
framework/wazuh/core/tests/test_utils.py ............................... [ 44%]
........................................................................ [ 47%]
........................................................................ [ 51%]
..................................................................       [ 54%]
framework/wazuh/core/tests/test_vulnerability.py ..                      [ 54%]
framework/wazuh/core/tests/test_wazuh_queue.py ....................      [ 55%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................     [ 56%]
framework/wazuh/core/tests/test_wdb.py .s.ssssss......................   [ 57%]
framework/wazuh/core/tests/test_wlogging.py .........                    [ 58%]
framework/wazuh/rbac/tests/test_auth_context.py ..                       [ 58%]
framework/wazuh/rbac/tests/test_decorators.py .......................... [ 59%]
........................................................................ [ 63%]
.......                                                                  [ 63%]
framework/wazuh/rbac/tests/test_default_configuration.py ............... [ 64%]
........................................                                 [ 66%]
framework/wazuh/rbac/tests/test_orm.py ................................. [ 67%]
.....................                                                    [ 68%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........              [ 69%]
framework/wazuh/tests/test_active_response.py ............               [ 70%]
framework/wazuh/tests/test_agent.py .................................... [ 71%]
........................................................................ [ 75%]
..........                                                               [ 75%]
framework/wazuh/tests/test_cdb_list.py ................................. [ 77%]
....................                                                     [ 78%]
framework/wazuh/tests/test_ciscat.py .................................   [ 80%]
framework/wazuh/tests/test_cluster.py ..........                         [ 80%]
framework/wazuh/tests/test_decoder.py .................................. [ 82%]
.                                                                        [ 82%]
framework/wazuh/tests/test_group.py .......                              [ 82%]
framework/wazuh/tests/test_logtest.py ......                             [ 82%]
framework/wazuh/tests/test_manager.py .................................. [ 84%]
..                                                                       [ 84%]
framework/wazuh/tests/test_mitre.py .......                              [ 84%]
framework/wazuh/tests/test_rootcheck.py ................................ [ 86%]
..................                                                       [ 87%]
framework/wazuh/tests/test_rule.py ..................................... [ 89%]
...................                                                      [ 90%]
framework/wazuh/tests/test_sca.py ...........                            [ 90%]
framework/wazuh/tests/test_security.py ................................. [ 92%]
........................................                                 [ 94%]
framework/wazuh/tests/test_stats.py ...............                      [ 95%]
framework/wazuh/tests/test_syscheck.py ..........................        [ 96%]
framework/wazuh/tests/test_syscollector.py ............                  [ 96%]
framework/wazuh/tests/test_task.py ............................          [ 98%]
framework/wazuh/tests/test_vulnerability.py ............................ [ 99%]
........                                                                 [100%]

========== 2033 passed, 13 skipped, 57 warnings in 389.00s (0:06:28) ===========
```

### Integration tests

```
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.9.9, pytest-5.0.0, py-1.11.0, pluggy-0.13.1 -- /home/agavila/venv/integration/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.9', 'Platform': 'Linux-5.15.0-52-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '5.0.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '2.1.1', 'tavern': '1.2.2', 'metadata': '2.0.4'}}
rootdir: /home/agavila/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: html-2.1.1, tavern-1.2.2, metadata-2.0.4
collected 32 items                                                                                                                                                                                          

test_manager_endpoints.tavern.yaml::GET /manager/status PASSED                                                                                                                                        [  3%]
test_manager_endpoints.tavern.yaml::GET /manager/info PASSED                                                                                                                                          [  6%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[alerts] PASSED                                                                                                               [  9%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[auth] PASSED                                                                                                                 [ 12%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cis-cat] PASSED                                                                                                              [ 15%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cluster] PASSED                                                                                                              [ 18%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[command] PASSED                                                                                                              [ 21%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[global] PASSED                                                                                                               [ 25%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[localfile] PASSED                                                                                                            [ 28%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[osquery] PASSED                                                                                                              [ 31%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[remote] PASSED                                                                                                               [ 34%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[rootcheck] PASSED                                                                                                            [ 37%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[ruleset] PASSED                                                                                                              [ 40%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[sca] PASSED                                                                                                                  [ 43%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscheck] PASSED                                                                                                             [ 46%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscollector] PASSED                                                                                                         [ 50%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[vulnerability-detector] PASSED                                                                                               [ 53%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED                                                                                                                                 [ 56%]
test_manager_endpoints.tavern.yaml::GET /manager/daemons/stats PASSED                                                                                                                                 [ 59%]
test_manager_endpoints.tavern.yaml::GET /manager/stats PASSED                                                                                                                                         [ 62%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED                                                                                                                                  [ 65%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED                                                                                                                                  [ 68%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED                                                                                                                               [ 71%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED                                                                                                                                 [ 75%]
test_manager_endpoints.tavern.yaml::GET /manager/logs PASSED                                                                                                                                          [ 78%]
test_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED                                                                                                                                  [ 81%]
test_manager_endpoints.tavern.yaml::GET /manager/api/config PASSED                                                                                                                                    [ 84%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/validation (OK) PASSED                                                                                                                 [ 87%]
test_manager_endpoints.tavern.yaml::GET /manager/validation (KO) PASSED                                                                                                                               [ 90%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED                                                                                                     [ 93%]
test_manager_endpoints.tavern.yaml::PUT /manager/configuration PASSED                                                                                                                                 [ 96%]
test_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED                                                                                                                                       [100%]

======================================================================================== 32 passed in 182.59 seconds ========================================================================================
```
Regards,
Álvaro