### PR TITLE
Fix Windows `wazuh-agent` upgrade using WPK

### DIFF
--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -43,7 +43,9 @@ function stop_wazuh_agent
         $process_name
     )
 
+    write-output "$(Get-Date -format u) - Trying to stop Wazuh service." >> .\upgrade\upgrade.log
     Get-Service -Name "Wazuh" | Stop-Service -ErrorAction SilentlyContinue -Force
+    Start-Sleep 2
     $process_id = (Get-Process $process_name -ErrorAction SilentlyContinue).id
     $counter = 5
 
@@ -52,11 +54,15 @@ function stop_wazuh_agent
         write-output "$(Get-Date -format u) - Trying to stop Wazuh service again. Remaining attempts: $counter." >> .\upgrade\upgrade.log
         $counter--
         Get-Service -Name "Wazuh" | Stop-Service
-        taskkill /pid $process_id /f /T
         Start-Sleep 2
         $process_id = (Get-Process $process_name -ErrorAction SilentlyContinue).id
     }
 
+    if ($process_id -ne $null) {
+        write-output "$(Get-Date -format u) - Killing process." >> .\upgrade\upgrade.log
+        taskkill /pid $process_id /f /T
+        Start-Sleep 10
+    }
 }
 
 function backup_home
@@ -310,3 +316,5 @@ Else
 
 Remove-Item $Env:WAZUH_BACKUP_DIR -recurse -ErrorAction SilentlyContinue
 Remove-Item -Path ".\upgrade\*"  -Exclude "*.log", "upgrade_result" -ErrorAction SilentlyContinue
+Remove-Item -Path ".\wazuh-agent*.msi" -ErrorAction SilentlyContinue
+Remove-Item -Path ".\do_upgrade.ps1" -ErrorAction SilentlyContinue

--- a/src/win32/upgrade.bat
+++ b/src/win32/upgrade.bat
@@ -11,10 +11,8 @@ GOTO end
 
 :background
 SLEEP 5 2> NUL || ping -n 5 127.0.0.1 > NUL
-powershell -ExecutionPolicy ByPass -File do_upgrade.ps1
+powershell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process powershell '-File \".\do_upgrade.ps1\"'}"
 
-DEL do_upgrade.ps1
-DEL wazuh-agent-*.msi
 DEL upgrade.bat
 
 :end


### PR DESCRIPTION
|Related issue|Manual Testing|
|---|---|
|https://github.com/wazuh/wazuh/issues/14857|https://github.com/wazuh/wazuh-qa/issues/3513|

## Description

The scripts used to upgrade winagents using WPK were modified to terminate correctly wazuh-agent service and complete the upgrade process. 

The function in charge of stopping the service was modified so that it tries to use "Stop service" 5 times and then in case of fail, do it using "taskkill".

On the other hand, the upgrade script is now executed in a new powershell process so that the agent can release all resources on time.

## Configuration options

Default configuration

## Logs/Alerts example

**Upgrade process**

```
/var/ossec/bin/agent_upgrade -a 004 -f /home/vagrant/wazuh_agent_v4.4.0.wpk

Upgrading...

Upgraded agents:
    Agent 004 upgraded:  Wazuh v4.3.9 -> Wazuh v4.4.0
```

**Upgrade log**

```
2022-11-07 21:20:36Z - Current version: v4.3.9.
2022-11-07 21:20:36Z - Generating backup.
2022-11-07 21:20:36Z - Backing up Wazuh home files.
2022-11-07 21:20:38Z - Searching Wazuh-Agent cached MSI through the registry.
2022-11-07 21:20:38Z - Backing up Wazuh-Agent cached MSI: "C:\Windows\Installer\328f8.msi".
2022-11-07 21:20:38Z - Trying to stop Wazuh service.
2022-11-07 21:20:40Z - Starting upgrade processs.
2022-11-07 21:20:40Z - Waiting for the Wazuh-Agent installation to end.
2022-11-07 21:20:42Z - Restarting Wazuh-Agent service.
2022-11-07 21:20:42Z - Installation finished.
2022-11-07 21:20:42Z - Process ID: 6008.
2022-11-07 21:20:52Z - Reading status file: status='connected'.
2022-11-07 21:20:52Z - Upgrade finished successfully.
2022-11-07 21:20:52Z - New version: v4.4.0.
```

**Manager log**

```
2022/11/07 22:20:38 wazuh-remoted: WARNING: Agent DESKTOP-F365SUT sent HC_SHUTDOWN from '192.168.56.200' '1007'
2022/11/07 22:20:38 wazuh-remoted: WARNING: handle incoming close socket [1007].
2022/11/07 22:21:12 wazuh-modulesd:agent-upgrade: INFO: (8164): Received upgrade notification from agent '4'. Error code: '0', message: 'Upgrade was successful'

```

## Tests

<!-- Minimum checks required -->
- [x] Compilation without warnings in every supported platform
  - [x] Windows
- [x] Package installation
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Working on cluster environments
