### PR TITLE
Improve API exceptions when handling socket connection errors

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1115,7 +1115,8 @@ def get_agent_config(agent_list=None, component=None, config=None):
     if my_agent.status != "active":
         raise WazuhError(1740)
 
-    return WazuhResult({'data': my_agent.get_config(component=component, config=config, agent_version=my_agent.version)})
+    return WazuhResult({'data': my_agent.get_config(component=component, config=config,
+                                                    agent_version=my_agent.version)})
 
 
 @expose_resources(actions=["agent:read"], resources=["agent:id:{agent_list}"],

--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -839,8 +839,10 @@ def get_active_configuration(agent_id: str, component: str, configuration: str) 
             # Socket connection
             try:
                 s = wazuh_socket.WazuhSocket(dest_socket)
-            except Exception:
-                raise WazuhInternalError(1121)
+            except WazuhInternalError:
+                raise
+            except Exception as unhandled_exc:
+                raise WazuhInternalError(1121, extra_message=str(unhandled_exc))
 
             # Send message
             s.send(msg.encode())
@@ -865,8 +867,10 @@ def get_active_configuration(agent_id: str, component: str, configuration: str) 
             # Socket connection
             try:
                 s = wazuh_socket.WazuhSocketJSON(dest_socket)
-            except Exception:
-                raise WazuhInternalError(1121)
+            except WazuhInternalError:
+                raise
+            except Exception as unhandled_exc:
+                raise WazuhInternalError(1121, extra_message=str(unhandled_exc))
 
             # Send message
             s.send(msg)
@@ -892,8 +896,10 @@ def get_active_configuration(agent_id: str, component: str, configuration: str) 
         # Socket connection
         try:
             s = wazuh_socket.WazuhSocket(dest_socket)
-        except Exception:
-            raise WazuhInternalError(1121)
+        except WazuhInternalError:
+            raise
+        except Exception as unhandled_exc:
+            raise WazuhInternalError(1121, extra_message=str(unhandled_exc))
 
         # Send message
         s.send(msg.encode())

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -90,7 +90,8 @@ class WazuhException(Exception):
         1117: {'message': "Unable to connect with component. The component might be disabled."},
         1118: {'message': "Could not request component configuration"},
         1119: "Directory '/tmp' needs read, write & execution permission for 'wazuh' user",
-        1121: {'message': "Error connecting with socket"},
+        1121: {'message': "Error connecting with socket",
+               'remediation': "Please ensure the selected module is running and properly configured"},
         1122: {'message': 'Experimental features are disabled',
                'remediation': 'Experimental features can be enabled in WAZUH_PATH/api/configuration/api.yaml or '
                               f"using API endpoint https://documentation.wazuh.com/{DOCU_VERSION}/user-manual/api/"

--- a/framework/wazuh/core/wazuh_socket.py
+++ b/framework/wazuh/core/wazuh_socket.py
@@ -1,14 +1,14 @@
 # Copyright (C) 2015, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
-
-from wazuh.core.exception import WazuhException, WazuhInternalError
-from wazuh import common
+import asyncio
+import os.path
 import socket
 from json import dumps, loads
 from struct import pack, unpack
-import asyncio
 
+from wazuh import common
+from wazuh.core.exception import WazuhException, WazuhInternalError
 
 SOCKET_COMMUNICATION_PROTOCOL_VERSION = 1
 
@@ -25,6 +25,9 @@ class WazuhSocket:
         try:
             self.s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             self.s.connect(self.path)
+        except ConnectionRefusedError:
+            raise WazuhInternalError(1121, extra_message=f"Socket '{os.path.basename(self.path)}' cannot receive "
+                                                         "connections")
         except Exception as e:
             raise WazuhException(1013, str(e))
 

--- a/framework/wazuh/core/wazuh_socket.py
+++ b/framework/wazuh/core/wazuh_socket.py
@@ -25,6 +25,8 @@ class WazuhSocket:
         try:
             self.s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             self.s.connect(self.path)
+        except FileNotFoundError:
+            raise WazuhInternalError(1013, extra_message=os.path.basename(self.path))
         except ConnectionRefusedError:
             raise WazuhInternalError(1121, extra_message=f"Socket '{os.path.basename(self.path)}' cannot receive "
                                                          "connections")


### PR DESCRIPTION
|Related issue|
|---|
|closes #15293 |

## Description

From now on, `ConnectionRefusedError` when trying to connect to a Wazuh socket will be handled as a `WazuhInternalError(1121)` with a better remediation and custom messages depending on the socket.

Also, whenever a socket connection fails because does not exist, a proper `WazuhInternalError(1013)` with the socket name will be returned.

## Tests performed
### Unit tests
```
==================================================================================================================================================== test session starts ====================================================================================================================================================
platform linux -- Python 3.9.9, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: testinfra-5.0.0, metadata-1.11.0, cov-2.12.0, asyncio-0.18.3, aiohttp-0.3.0, html-3.1.1
asyncio: mode=legacy
collected 624 items                                                                                                                                                                                                                                                                                                         

framework/wazuh/tests/test_active_response.py ............                                                                                                                                                                                                                                                            [  1%]
framework/wazuh/tests/test_agent.py ......................................................................................................................                                                                                                                                                            [ 20%]
framework/wazuh/tests/test_cdb_list.py .....................................................                                                                                                                                                                                                                          [ 29%]
framework/wazuh/tests/test_ciscat.py .................................                                                                                                                                                                                                                                                [ 34%]
framework/wazuh/tests/test_cluster.py ..........                                                                                                                                                                                                                                                                      [ 36%]
framework/wazuh/tests/test_decoder.py ...................................                                                                                                                                                                                                                                             [ 41%]
framework/wazuh/tests/test_group.py .......                                                                                                                                                                                                                                                                           [ 42%]
framework/wazuh/tests/test_logtest.py ......                                                                                                                                                                                                                                                                          [ 43%]
framework/wazuh/tests/test_manager.py ....................................                                                                                                                                                                                                                                            [ 49%]
framework/wazuh/tests/test_mitre.py .......                                                                                                                                                                                                                                                                           [ 50%]
framework/wazuh/tests/test_rootcheck.py ..................................................                                                                                                                                                                                                                            [ 58%]
framework/wazuh/tests/test_rule.py ........................................................                                                                                                                                                                                                                           [ 67%]
framework/wazuh/tests/test_sca.py ...........                                                                                                                                                                                                                                                                         [ 69%]
framework/wazuh/tests/test_security.py .........................................................................                                                                                                                                                                                                      [ 81%]
framework/wazuh/tests/test_stats.py ...............                                                                                                                                                                                                                                                                   [ 83%]
framework/wazuh/tests/test_syscheck.py ..........................                                                                                                                                                                                                                                                     [ 87%]
framework/wazuh/tests/test_syscollector.py ............                                                                                                                                                                                                                                                               [ 89%]
framework/wazuh/tests/test_task.py ............................                                                                                                                                                                                                                                                       [ 94%]
framework/wazuh/tests/test_vulnerability.py ....................................                                                                                                                                                                                                                                      [100%]

======================================================================================================================================== 624 passed, 10 warnings in 81.68s (0:01:21) ========================================================================================================================================

```

```
==================================================================================================================================================== test session starts ====================================================================================================================================================
platform linux -- Python 3.9.9, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: testinfra-5.0.0, metadata-1.11.0, cov-2.12.0, asyncio-0.18.3, aiohttp-0.3.0, html-3.1.1
asyncio: mode=legacy
collected 70 items                                                                                                                                                                                                                                                                                                          

framework/wazuh/core/tests/test_configuration.py ......................................................................                                                                                                                                                                                               [100%]

============================================================================================================================================== 70 passed, 3 warnings in 0.44s ===============================================================================================================================================

```

```
==================================================================================================================================================== test session starts ====================================================================================================================================================
platform linux -- Python 3.9.9, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: testinfra-5.0.0, metadata-1.11.0, cov-2.12.0, asyncio-0.18.3, aiohttp-0.3.0, html-3.1.1
asyncio: mode=legacy
collected 20 items                                                                                                                                                                                                                                                                                                          

framework/wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                                                                                                                                                                  [100%]

=============================================================================================================================================== 20 passed, 1 warning in 0.05s ===============================================================================================================================================
```

Regards,
Víctor