### PR TITLE
Fix geoLocation processing for AWS Macie

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2177,7 +2177,8 @@ class AWSCustomBucket(AWSBucket):
                     lat = float(match.group(1))
                     lon = float(match.group(2))
                     new_pattern = f'"lat":{lat},"lon":{lon}'
-                    json_data, json_index = decoder.raw_decode(re.sub(self.macie_location_pattern, new_pattern, data))
+                    data = re.sub(self.macie_location_pattern, new_pattern, data)
+                    json_data, json_index = decoder.raw_decode(data)
                 data = data[json_index:]
                 yield json_data
 


### PR DESCRIPTION
|Related issue|
|---|
| #15305|

## Description
This PR closes #15305 by fixing a bug found in the Macie `ipGelocation` field processing.

A bug caused that if during the substitution process of the `lon` and `lan` values present in the `ipGeolocation` field the total length of the event was modified, an invalid json was produced, causing an error when trying to process it. 

Details of the bug, as well as the fix, can be found at https://github.com/wazuh/wazuh/issues/15305#issuecomment-1310102374.