### PR TITLE
Fix Alpine compilation errors

### DIFF
--- a/src/rootcheck/os_string.c
+++ b/src/rootcheck/os_string.c
@@ -45,7 +45,7 @@
 
 #ifdef SOLARIS
 #include <sys/exechdr.h>
-#elif defined Darwin || defined HPUX
+#elif defined Darwin || defined HPUX || defined ALPINE
 
 /* For some reason darwin does not have that */
 struct exec {
@@ -69,11 +69,7 @@ struct exec {
 
 #else
 
-#ifdef ALPINE
-#include <linux/a.out.h>
-#else
 #include <a.out.h>
-#endif
 
 #endif
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #15224|

## Description
There are some _Alpine_ architectures where the `a.out.h` library does not exist, or appears in a different directory than the default on Unix systems, so to avoid compilation failures it is necessary to set the `exec` structure and define several variables to make _Rootcheck_ work properly.

For solve it, as this problem also happens for other OSes like _Darwin_ or _HPUX_, we have reused the structure to compile _Alpine_ and not having to define any `a.out.h` library.

After this change, the following commands have been executed for the compilation (for 32 bits, add `linux32` prefix to the commands):
```sh
curl -Ls https://github.com/wazuh/wazuh/tarball/15224-fix-compilation-errors | tar xz
cd wazuh-wazuh-30ebff2/src/
make deps TARGET=agent EXTERNAL_SRC_ONLY=yes
make -j$(nproc) TARGET=agent
```

And it has been tested on the following architectures, working correctly:
- [x] amd64
- [x] i386
- [x] arm64 (arm64v8)
- [x] arm32 (arm32v7)
- [x] ppc64le




## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Alpine
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

