### PR TITLE
Add helpers dependency injection to the Engine

### DIFF
--- a/src/engine/benchmark/kvdb/kvdb_bench.cpp
+++ b/src/engine/benchmark/kvdb/kvdb_bench.cpp
@@ -8,10 +8,11 @@
 #include <logging/logging.hpp>
 
 static constexpr char kBenchDbName[] = "bench";
+static auto kvdbManager = std::make_shared<KVDBManager>("/tmp/");
 
 static void dbSetup(const benchmark::State& s)
 {
-    auto db = KVDBManager::get().addDb(kBenchDbName);
+    auto db = kvdbManager->addDb(kBenchDbName);
 
     for (int i = 0; i < s.range(0); ++i)
     {
@@ -21,12 +22,12 @@ static void dbSetup(const benchmark::State& s)
 
 static void dbTeardown(const benchmark::State& s)
 {
-    KVDBManager::get().deleteDB(kBenchDbName);
+    kvdbManager->deleteDB(kBenchDbName);
 }
 
 static void kvdbRead(benchmark::State& state)
 {
-    auto db = KVDBManager::get().getDB(kBenchDbName);
+    auto db = kvdbManager->getDB(kBenchDbName);
 
     std::random_device rd;
     std::mt19937 gen(rd());
@@ -48,7 +49,7 @@ BENCHMARK(kvdbRead)
 
 static void kvdbHasKey(benchmark::State& state)
 {
-    auto db = KVDBManager::get().getDB(kBenchDbName);
+    auto db = kvdbManager->getDB(kBenchDbName);
 
     std::random_device rd;
     std::mt19937 gen(rd());
@@ -70,7 +71,7 @@ BENCHMARK(kvdbHasKey)
 
 static void kvdbWrite(benchmark::State& state)
 {
-    auto db = KVDBManager::get().getDB(kBenchDbName);
+    auto db = kvdbManager->getDB(kBenchDbName);
 
     std::vector<std::string> keys;
     for (int i = 0; i < state.range(0); ++i)
@@ -95,7 +96,7 @@ BENCHMARK(kvdbWrite)->Setup(dbSetup)->Teardown(dbTeardown)->Range(8, 16 << 10);
 
 static void kvdbWriteTx(benchmark::State& state)
 {
-    auto db = KVDBManager::get().getDB(kBenchDbName);
+    auto db = kvdbManager->getDB(kBenchDbName);
 
     std::vector<std::pair<std::string, std::string>> keysList;
     for (int i = 0; i < state.range(0); ++i)

--- a/src/engine/benchmark/wazuhBenchMain.cpp
+++ b/src/engine/benchmark/wazuhBenchMain.cpp
@@ -9,8 +9,6 @@ int main(int argc, char **argv)
     logConfig.logLevel = logging::LogLevel::Off;
     logging::loggingInit(logConfig);
 
-    KVDBManager::init("/tmp/");
-
     benchmark::Initialize(&argc, argv);
     if (benchmark::ReportUnrecognizedArguments(argc, argv))
         return 1;

--- a/src/engine/source/builder/asset.cpp
+++ b/src/engine/source/builder/asset.cpp
@@ -28,7 +28,7 @@ Asset::Asset(std::string name, Asset::Type type)
 {
 }
 
-Asset::Asset(const json::Json& jsonDefinition, Asset::Type type)
+Asset::Asset(const json::Json& jsonDefinition, Asset::Type type, std::shared_ptr<internals::Registry> registry)
     : m_type {type}
 {
     if (!jsonDefinition.isObject())
@@ -105,7 +105,7 @@ Asset::Asset(const json::Json& jsonDefinition, Asset::Type type)
         try
         {
             m_check =
-                internals::Registry::getBuilder("stage.check")({std::get<1>(*checkPos)});
+                registry->getBuilder("stage.check")({std::get<1>(*checkPos)});
             objectDefinition.erase(checkPos);
         }
         catch (const std::exception& e)
@@ -126,7 +126,7 @@ Asset::Asset(const json::Json& jsonDefinition, Asset::Type type)
         try
         {
             auto parseExpression =
-                internals::Registry::getBuilder("stage.parse")({std::get<1>(*parsePos)});
+                registry->getBuilder("stage.parse")({std::get<1>(*parsePos)});
             objectDefinition.erase(parsePos);
             if (m_check)
             {
@@ -153,7 +153,7 @@ Asset::Asset(const json::Json& jsonDefinition, Asset::Type type)
         auto stageName = "stage." + std::get<0>(tuple);
         auto stageDefinition = std::get<1>(tuple);
         auto stageExpression =
-            internals::Registry::getBuilder(stageName)({stageDefinition});
+            registry->getBuilder(stageName)({stageDefinition});
         asOp->getOperands().push_back(stageExpression);
     }
 }

--- a/src/engine/source/builder/asset.hpp
+++ b/src/engine/source/builder/asset.hpp
@@ -1,15 +1,13 @@
 #ifndef _ASSET_H
 #define _ASSET_H
 
+#include <memory>
 #include <string>
 #include <unordered_set>
 
-//#include <fmt/format.h>
-
-///#include "definitions.hpp"
 #include "expression.hpp"
+#include "registry.hpp"
 #include <json/json.hpp>
-//#include "registry.hpp"
 
 namespace builder
 {
@@ -76,9 +74,13 @@ public:
      *
      * @param jsonDefinition JSON object containing the definition of the asset.
      * @param type Type of the asset.
+     * @param registry Registry of builders.
+
      * @throws std::runtime_error if the Asset could not be constructed.
      */
-    Asset(const json::Json& jsonDefinition, Type type);
+    Asset(const json::Json& jsonDefinition,
+          Type type,
+          std::shared_ptr<internals::Registry> registry);
 
     /**
      * @brief Get the Expression object of the Asset.

--- a/src/engine/source/builder/builder.hpp
+++ b/src/engine/source/builder/builder.hpp
@@ -23,6 +23,7 @@ class Builder : public IValidator
 {
 private:
     std::shared_ptr<store::IStoreRead> m_storeRead;
+    std::shared_ptr<internals::Registry> m_registry;
 
     // TODO: Fix catalog to include asset type as a member of Catalog object
     enum class AssetType
@@ -36,8 +37,10 @@ private:
     };
 
 public:
-    Builder(std::shared_ptr<store::IStoreRead> storeRead)
+    Builder(std::shared_ptr<store::IStoreRead> storeRead,
+            std::shared_ptr<internals::Registry> registry)
         : m_storeRead {storeRead}
+        , m_registry {registry}
     {
     }
 
@@ -52,7 +55,8 @@ public:
                 std::get<base::Error>(envJson).message));
         }
 
-        auto environment = Environment {std::get<json::Json>(envJson), m_storeRead};
+        auto environment =
+            Environment {std::get<json::Json>(envJson), m_storeRead, m_registry};
 
         return environment;
     }
@@ -61,7 +65,7 @@ public:
     {
         try
         {
-            Environment env {json, m_storeRead};
+            Environment env {json, m_storeRead, m_registry};
             env.getExpression();
         }
         catch (const std::exception& e)
@@ -77,7 +81,7 @@ public:
         try
         {
             // TODO: Remove asset type in Asset
-            Asset asset {json, Asset::Type::DECODER};
+            Asset asset {json, Asset::Type::DECODER, m_registry};
             asset.getExpression();
         }
         catch (const std::exception& e)

--- a/src/engine/source/builder/builders/opBuilderHelperNetInfoAddress.cpp
+++ b/src/engine/source/builder/builders/opBuilderHelperNetInfoAddress.cpp
@@ -13,7 +13,6 @@
 #include <variant>
 
 #include <baseHelper.hpp>
-#include <kvdb/kvdbManager.hpp>
 #include <wdb/wdb.hpp>
 
 namespace

--- a/src/engine/source/builder/builders/opBuilderKVDB.hpp
+++ b/src/engine/source/builder/builders/opBuilderKVDB.hpp
@@ -2,8 +2,12 @@
 #define _OP_BUILDER_KVDB_H
 
 #include <any>
+#include <memory>
+
+#include <kvdb/kvdbManager.hpp>
 
 #include "expression.hpp"
+#include "registry.hpp"
 
 namespace builder::internals::builders
 {
@@ -18,39 +22,42 @@ namespace builder::internals::builders
  * @param merge
  * @return base::Expression
  */
-base::Expression KVDBExtract(const std::any& definition, bool merge);
+base::Expression KVDBExtract(const std::any& definition,
+                             bool merge,
+                             std::shared_ptr<KVDBManager> kvdbManager);
 
 /**
  * @brief Builds KVDB extract function helper
  *
- * @param definition
- * @return base::Expression
+ * @param kvdbManager KVDB manager
+ * @return Builder
  */
-base::Expression opBuilderKVDBExtract(const std::any& definition);
+Builder getOpBuilderKVDBExtract(std::shared_ptr<KVDBManager> kvdbManager);
 
 /**
  * @brief Builds KVDB extract and merge function helper
  *
- * @param definition
- * @return base::Expression
+ * @param kvdbManager KVDB manager
+ * @return Builder
  */
-base::Expression opBuilderKVDBExtractMerge(const std::any& definition);
+Builder getOpBuilderKVDBExtractMerge(std::shared_ptr<KVDBManager> kvdbManager);
 
 /**
- * @brief Builds KVDB match function helper
+ * @brief get the KVDB match function helper builder
  *
- * @param definition
- * @return base::Expression
+ * @param kvdbManager KVDB manager
+ * @return Builder
  */
-base::Expression opBuilderKVDBMatch(const std::any& definition);
+Builder getOpBuilderKVDBMatch(std::shared_ptr<KVDBManager> kvdbManager);
 
 /**
- * @brief Builds KVDB not-match function helper
+ * @brief Get the KVDB not-match function helper builder
  *
- * @param definition
- * @return base::Expression
+ * @param kvdbManager KVDB manager
+ * @return Builder
  */
-base::Expression opBuilderKVDBNotMatch(const std::any& definition);
+Builder getOpBuilderKVDBNotMatch(std::shared_ptr<KVDBManager> kvdbManager);
+
 } // namespace builder::internals::builders
 
 // namespace builder::internals::builders

--- a/src/engine/source/builder/builders/operationBuilder.hpp
+++ b/src/engine/source/builder/builders/operationBuilder.hpp
@@ -2,15 +2,30 @@
 #define _OPERATION_BUILDER_H
 
 #include <any>
+#include <memory>
 
-#include "expression.hpp"
+#include <expression.hpp>
+
+#include "registry.hpp"
 
 namespace builder::internals::builders
 {
 
-base::Expression operationConditionBuilder(std::any definition);
+/**
+ * @brief Get the Operation Condition Builder
+ *
+ * @param registry Registry of builders.
+ * @return Builder
+ */
+Builder getOperationConditionBuilder(std::shared_ptr<Registry> registry);
 
-base::Expression operationMapBuilder(std::any definition);
+/**
+ * @brief Get the Operation Map Builder
+ *
+ * @param registry Registry of builders.
+ * @return Builder
+ */
+Builder getOperationMapBuilder(std::shared_ptr<Registry> registry);
 
 } // namespace builder::internals::builders
 

--- a/src/engine/source/builder/builders/stageBuilderCheck.hpp
+++ b/src/engine/source/builder/builders/stageBuilderCheck.hpp
@@ -2,13 +2,22 @@
 #define _STAGE_BUILDER_CHECK_H
 
 #include <any>
+#include <memory>
 
-#include "expression.hpp"
+#include <expression.hpp>
+
+#include "registry.hpp"
 
 namespace builder::internals::builders
 {
 
-base::Expression stageBuilderCheck(std::any definition);
+/**
+ * @brief Get the Stage Builder Check
+ *
+ * @param registry Registry of builders.
+ * @return Builder
+ */
+Builder getStageBuilderCheck(std::shared_ptr<Registry> registry);
 
 } // namespace builder::internals::builders
 

--- a/src/engine/source/builder/builders/stageBuilderMap.cpp
+++ b/src/engine/source/builder/builders/stageBuilderMap.cpp
@@ -5,60 +5,64 @@
 
 #include "baseTypes.hpp"
 #include "expression.hpp"
-#include <json/json.hpp>
 #include "registry.hpp"
+#include <json/json.hpp>
 
 namespace builder::internals::builders
 {
-
-base::Expression stageMapBuilder(std::any definition)
+Builder getStageMapBuilder(std::shared_ptr<Registry> registry)
 {
-    json::Json jsonDefinition;
-
-    try
+    return [registry](std::any definition)
     {
-        jsonDefinition = std::any_cast<json::Json>(definition);
-    }
-    catch (std::exception& e)
-    {
-        throw std::runtime_error(
-            "[builders::stageMapBuilder(json)] Received unexpected argument type");
-    }
+        json::Json jsonDefinition;
 
-    if (!jsonDefinition.isArray())
-    {
-        throw std::runtime_error(
-            fmt::format("[builders::stageMapBuilder(json)] Invalid json definition "
-                        "type: expected [array] but got [{}]",
-                        jsonDefinition.typeName()));
-    }
-
-    auto mappings = jsonDefinition.getArray().value();
-    std::vector<base::Expression> mappingExpressions;
-    std::transform(mappings.begin(),
-        mappings.end(),
-        std::back_inserter(mappingExpressions),
-        [](auto arrayMember)
+        try
         {
-            if(!arrayMember.isObject())
-            {
-                throw std::runtime_error(
-                    fmt::format("[builders::stageMapBuilder(json)] "
-                                "Invalid array item type: expected [object] but got [{}]",
-                                arrayMember.typeName()));
-            }
-            if(arrayMember.size() != 1)
-            {
-                throw std::runtime_error(fmt::format(
-                    "[builders::stageMapBuilder(json)] "
-                    "Invalid array item object size: expected [1] but got [{}]",
-                    arrayMember.size()));
-            }
-            return Registry::getBuilder("operation.map")(arrayMember.getObject().value()[0]);
-        });
+            jsonDefinition = std::any_cast<json::Json>(definition);
+        }
+        catch (std::exception& e)
+        {
+            throw std::runtime_error(
+                "[builders::stageMapBuilder(json)] Received unexpected argument type");
+        }
 
-    auto expression = base::Chain::create("stage.map", mappingExpressions);
-    return expression;
+        if (!jsonDefinition.isArray())
+        {
+            throw std::runtime_error(
+                fmt::format("[builders::stageMapBuilder(json)] Invalid json definition "
+                            "type: expected [array] but got [{}]",
+                            jsonDefinition.typeName()));
+        }
+
+        auto mappings = jsonDefinition.getArray().value();
+        std::vector<base::Expression> mappingExpressions;
+        std::transform(
+            mappings.begin(),
+            mappings.end(),
+            std::back_inserter(mappingExpressions),
+            [registry](auto arrayMember)
+            {
+                if (!arrayMember.isObject())
+                {
+                    throw std::runtime_error(fmt::format(
+                        "[builders::stageMapBuilder(json)] "
+                        "Invalid array item type: expected [object] but got [{}]",
+                        arrayMember.typeName()));
+                }
+                if (arrayMember.size() != 1)
+                {
+                    throw std::runtime_error(fmt::format(
+                        "[builders::stageMapBuilder(json)] "
+                        "Invalid array item object size: expected [1] but got [{}]",
+                        arrayMember.size()));
+                }
+                return registry->getBuilder("operation.map")(
+                    arrayMember.getObject().value()[0]);
+            });
+
+        auto expression = base::Chain::create("stage.map", mappingExpressions);
+        return expression;
+    };
 }
 
 } // namespace builder::internals::builders

--- a/src/engine/source/builder/builders/stageBuilderMap.hpp
+++ b/src/engine/source/builder/builders/stageBuilderMap.hpp
@@ -3,13 +3,22 @@
 #define _STAGE_BUILDER_MAP_H
 
 #include <any>
+#include <memory>
 
-#include "expression.hpp"
+#include <expression.hpp>
+
+#include "registry.hpp"
 
 namespace builder::internals::builders
 {
 
-base::Expression stageMapBuilder(std::any definition);
+/**
+ * @brief Get the Stage Map Builder
+ *
+ * @param registry Registry of builders.
+ * @return Builder
+ */
+Builder getStageMapBuilder(std::shared_ptr<Registry> registry);
 
 } // namespace builder::internals::builders
 

--- a/src/engine/source/builder/builders/stageBuilderNormalize.cpp
+++ b/src/engine/source/builder/builders/stageBuilderNormalize.cpp
@@ -12,70 +12,74 @@
 namespace builder::internals::builders
 {
 
-base::Expression stageNormalizeBuilder(const std::any& definition)
+Builder getStageNormalizeBuilder(std::shared_ptr<Registry> registry)
 {
-    json::Json jsonDefinition;
-
-    try
+    return [registry](const std::any& definition)
     {
-        jsonDefinition = std::any_cast<json::Json>(definition);
-    }
-    catch (std::exception& e)
-    {
-        throw std::runtime_error(
-            "[builders::stageNormalizeBuilder(json)] Received unexpected argument type");
-    }
+        json::Json jsonDefinition;
 
-    if (!jsonDefinition.isArray())
-    {
-        throw std::runtime_error(
-            fmt::format("[builders::stageNormalizeBuilder(json)] Invalid json definition "
-                        "type: expected [array] but got [{}]",
-                        jsonDefinition.typeName()));
-    }
-
-    auto blocks = jsonDefinition.getArray().value();
-    std::vector<base::Expression> blockExpressions;
-    std::transform(
-        blocks.begin(),
-        blocks.end(),
-        std::back_inserter(blockExpressions),
-        [](auto block)
+        try
         {
-            if (!block.isObject())
-            {
-                throw std::runtime_error(
-                    fmt::format("[builders::stageNormalizeBuilder(json)] "
-                                "Invalid array item type: expected [object] but got "
-                                "[{}]",
-                                block.typeName()));
-            }
-            auto blockObj = block.getObject().value();
-            std::vector<base::Expression> subBlocksExpressions;
+            jsonDefinition = std::any_cast<json::Json>(definition);
+        }
+        catch (std::exception& e)
+        {
+            throw std::runtime_error("[builders::stageNormalizeBuilder(json)] Received "
+                                     "unexpected argument type");
+        }
 
-            std::transform(blockObj.begin(),
-                           blockObj.end(),
-                           std::back_inserter(subBlocksExpressions),
-                           [](auto& tuple)
-                           {
-                               auto& [key, value] = tuple;
-                               try
-                               {
-                                   return Registry::getBuilder("stage." + key)(value);
-                               }
-                               catch (const std::exception& e)
-                               {
-                                   std::throw_with_nested(std::runtime_error(fmt::format(
-                                       "[builders::stageNormalizeBuilder(json)] "
-                                       "Exception building stage block [{}]",
-                                       key)));
-                               }
-                           });
-            auto expression = base::And::create("subblock", subBlocksExpressions);
-            return expression;
-        });
-    auto expression = base::Chain::create("stage.normalize", blockExpressions);
-    return expression;
+        if (!jsonDefinition.isArray())
+        {
+            throw std::runtime_error(fmt::format(
+                "[builders::stageNormalizeBuilder(json)] Invalid json definition "
+                "type: expected [array] but got [{}]",
+                jsonDefinition.typeName()));
+        }
+
+        auto blocks = jsonDefinition.getArray().value();
+        std::vector<base::Expression> blockExpressions;
+        std::transform(
+            blocks.begin(),
+            blocks.end(),
+            std::back_inserter(blockExpressions),
+            [registry](auto block)
+            {
+                if (!block.isObject())
+                {
+                    throw std::runtime_error(
+                        fmt::format("[builders::stageNormalizeBuilder(json)] "
+                                    "Invalid array item type: expected [object] but got "
+                                    "[{}]",
+                                    block.typeName()));
+                }
+                auto blockObj = block.getObject().value();
+                std::vector<base::Expression> subBlocksExpressions;
+
+                std::transform(
+                    blockObj.begin(),
+                    blockObj.end(),
+                    std::back_inserter(subBlocksExpressions),
+                    [registry](auto& tuple)
+                    {
+                        auto& [key, value] = tuple;
+                        try
+                        {
+                            return registry->getBuilder("stage." + key)(value);
+                        }
+                        catch (const std::exception& e)
+                        {
+                            std::throw_with_nested(std::runtime_error(
+                                fmt::format("[builders::stageNormalizeBuilder(json)] "
+                                            "Exception building stage block [{}]",
+                                            key)));
+                        }
+                    });
+                auto expression = base::And::create("subblock", subBlocksExpressions);
+                return expression;
+            });
+        auto expression = base::Chain::create("stage.normalize", blockExpressions);
+        return expression;
+    };
 }
 
 } // namespace builder::internals::builders

--- a/src/engine/source/builder/builders/stageBuilderNormalize.hpp
+++ b/src/engine/source/builder/builders/stageBuilderNormalize.hpp
@@ -2,13 +2,22 @@
 #define _STAGE_BUILDER_NORMALIZE_H
 
 #include <any>
+#include <memory>
 
-#include "expression.hpp"
+#include <expression.hpp>
+
+#include "registry.hpp"
 
 namespace builder::internals::builders
 {
 
-base::Expression stageNormalizeBuilder(const std::any& definition);
+/**
+ * @brief Get the Stage Normalize Builder
+ *
+ * @param registry Registry of builders.
+ * @return Builder
+ */
+Builder getStageNormalizeBuilder(std::shared_ptr<Registry> registry);
 
 } // namespace builder::internals::builders
 

--- a/src/engine/source/builder/builders/stageBuilderOutputs.cpp
+++ b/src/engine/source/builder/builders/stageBuilderOutputs.cpp
@@ -6,96 +6,97 @@
 #include <string>
 #include <vector>
 
-#include <logging/logging.hpp>
-
-#include "expression.hpp"
+#include <expression.hpp>
 #include <json/json.hpp>
-#include "registry.hpp"
+#include <logging/logging.hpp>
 
 namespace builder::internals::builders
 {
 
-base::Expression stageBuilderOutputs(const std::any& definition)
+Builder getStageBuilderOutputs(std::shared_ptr<Registry> registry)
 {
-    json::Json jsonDefinition;
-
-    // Get json and check is as expected
-    try
+    return [registry](const std::any& definition)
     {
-        jsonDefinition = std::any_cast<json::Json>(definition);
-    }
-    catch (const std::exception& e)
-    {
-        throw std::runtime_error(
-            "[builders::stageBuilderOutputs(json)] Received unexpected argument type");
-    }
+        json::Json jsonDefinition;
 
-    if (!jsonDefinition.isArray())
-    {
-        throw std::runtime_error(
-            fmt::format("[builders::stageBuilderOutputs(json)] Invalid json definition "
-                        "type: expected [array] but got [{}]",
-                        jsonDefinition.typeName()));
-    }
-    if (jsonDefinition.size() == 0)
-    {
-        throw std::runtime_error(
-            "[builders::stageBuilderOutputs(json)] Invalid json definition: expected "
-            "at least one element");
-    }
+        // Get json and check is as expected
+        try
+        {
+            jsonDefinition = std::any_cast<json::Json>(definition);
+        }
+        catch (const std::exception& e)
+        {
+            throw std::runtime_error("[builders::stageBuilderOutputs(json)] Received "
+                                     "unexpected argument type");
+        }
 
-    // All output expressions
-    std::vector<base::Expression> outputExpressions;
+        if (!jsonDefinition.isArray())
+        {
+            throw std::runtime_error(fmt::format(
+                "[builders::stageBuilderOutputs(json)] Invalid json definition "
+                "type: expected [array] but got [{}]",
+                jsonDefinition.typeName()));
+        }
+        if (jsonDefinition.size() == 0)
+        {
+            throw std::runtime_error(
+                "[builders::stageBuilderOutputs(json)] Invalid json definition: expected "
+                "at least one element");
+        }
 
-    // Obtain array and call appropriate builder for each item, adding the expression to
-    // the outputExpressions vector
-    auto outputObjects = jsonDefinition.getArray().value();
-    std::transform(outputObjects.begin(),
-                   outputObjects.end(),
-                   std::back_inserter(outputExpressions),
-                   [](auto outputDefinition)
-                   {
-                       if (!outputDefinition.isObject())
+        // All output expressions
+        std::vector<base::Expression> outputExpressions;
+
+        // Obtain array and call appropriate builder for each item, adding the expression
+        // to the outputExpressions vector
+        auto outputObjects = jsonDefinition.getArray().value();
+        std::transform(outputObjects.begin(),
+                       outputObjects.end(),
+                       std::back_inserter(outputExpressions),
+                       [registry](auto outputDefinition)
                        {
-                           throw std::runtime_error(fmt::format(
-                               "[builders::stageBuilderOutputs(json)] "
-                               "Invalid array item type: expected [object] but "
-                               "got [{}]",
-                               outputDefinition.typeName()));
-                       }
+                           if (!outputDefinition.isObject())
+                           {
+                               throw std::runtime_error(fmt::format(
+                                   "[builders::stageBuilderOutputs(json)] "
+                                   "Invalid array item type: expected [object] but "
+                                   "got [{}]",
+                                   outputDefinition.typeName()));
+                           }
 
-                       if (outputDefinition.size() != 1)
-                       {
-                           throw std::runtime_error(
-                               fmt::format("[builders::stageBuilderOutputs(json)] "
-                                           "Invalid object item syze: expected "
-                                           "exactly one key/value pair, but got [{}]",
-                                           outputDefinition.size()));
-                       }
+                           if (outputDefinition.size() != 1)
+                           {
+                               throw std::runtime_error(
+                                   fmt::format("[builders::stageBuilderOutputs(json)] "
+                                               "Invalid object item syze: expected "
+                                               "exactly one key/value pair, but got [{}]",
+                                               outputDefinition.size()));
+                           }
 
-                       auto outputObject = outputDefinition.getObject().value();
-                       auto outputName = std::get<0>(outputObject.front());
-                       auto outputValue = std::get<1>(outputObject.front());
+                           auto outputObject = outputDefinition.getObject().value();
+                           auto outputName = std::get<0>(outputObject.front());
+                           auto outputValue = std::get<1>(outputObject.front());
 
-                       base::Expression outputExpression;
-                       try
-                       {
-                           outputExpression =
-                               Registry::getBuilder("output." + outputName)(outputValue);
-                       }
-                       catch (const std::exception& e)
-                       {
-                           std::throw_with_nested(std::runtime_error(
-                               fmt::format("[builders::stageBuilderOutputs(json)] "
-                                           "Exception building output [{}]",
-                                           outputName)));
-                       }
+                           base::Expression outputExpression;
+                           try
+                           {
+                               outputExpression = registry->getBuilder(
+                                   "output." + outputName)(outputValue);
+                           }
+                           catch (const std::exception& e)
+                           {
+                               std::throw_with_nested(std::runtime_error(
+                                   fmt::format("[builders::stageBuilderOutputs(json)] "
+                                               "Exception building output [{}]",
+                                               outputName)));
+                           }
 
-                       return outputExpression;
-                   });
+                           return outputExpression;
+                       });
 
-    // Create stage expression and return
-    return base::Broadcast::create("outputs", outputExpressions);
+        // Create stage expression and return
+        return base::Broadcast::create("outputs", outputExpressions);
+    };
 }
 
 } // namespace builder::internals::builders

--- a/src/engine/source/builder/builders/stageBuilderOutputs.hpp
+++ b/src/engine/source/builder/builders/stageBuilderOutputs.hpp
@@ -2,19 +2,22 @@
 #define _STAGE_BUILDER_OUTPUTS_H
 
 #include <any>
+#include <memory>
 
-#include "expression.hpp"
+#include <expression.hpp>
+
+#include "registry.hpp"
 
 namespace builder::internals::builders
 {
 
 /**
- * @brief Builds stage outputs
+ * @brief Get the builder that builds stage outputs
  *
- * @param definition
- * @return base::Expression
+ * @param registry Registry of builders.
+ * @return Builder
  */
-base::Expression stageBuilderOutputs(const std::any& definition);
+Builder getStageBuilderOutputs(std::shared_ptr<Registry> registry);
 
 } // namespace builder::internals::builders
 

--- a/src/engine/source/builder/builders/stageBuilderParse.cpp
+++ b/src/engine/source/builder/builders/stageBuilderParse.cpp
@@ -6,61 +6,65 @@
 #include <string>
 
 #include "expression.hpp"
-#include <json/json.hpp>
 #include "registry.hpp"
+#include <json/json.hpp>
 
 namespace builder::internals::builders
 {
-base::Expression stageBuilderParse(const std::any& definition)
+
+Builder getStageBuilderParse(std::shared_ptr<Registry> registry)
 {
-    // Assert value is as expected
-    json::Json jsonDefinition;
-    try
+    return [registry](const std::any& definition)
     {
-        jsonDefinition = std::any_cast<json::Json>(definition);
-    }
-    catch (const std::exception& e)
-    {
-        throw std::runtime_error(
-            "[builder::stageBuilderParse(json)] Received unexpected argument type");
-    }
-    if (!jsonDefinition.isObject())
-    {
-        throw std::runtime_error(
-            fmt::format("[builder::stageBuilderParse(json)] Invalid json definition "
-                        "type: expected [object] but got [{}]",
-                        jsonDefinition.typeName()));
-    }
+        // Assert value is as expected
+        json::Json jsonDefinition;
+        try
+        {
+            jsonDefinition = std::any_cast<json::Json>(definition);
+        }
+        catch (const std::exception& e)
+        {
+            throw std::runtime_error(
+                "[builder::stageBuilderParse(json)] Received unexpected argument type");
+        }
+        if (!jsonDefinition.isObject())
+        {
+            throw std::runtime_error(
+                fmt::format("[builder::stageBuilderParse(json)] Invalid json definition "
+                            "type: expected [object] but got [{}]",
+                            jsonDefinition.typeName()));
+        }
 
-    std::vector<base::Expression> parserExpressions;
-    auto parseObj = jsonDefinition.getObject().value();
+        std::vector<base::Expression> parserExpressions;
+        auto parseObj = jsonDefinition.getObject().value();
 
-    std::transform(parseObj.begin(),
-                   parseObj.end(),
-                   std::back_inserter(parserExpressions),
-                   [](auto& tuple)
-                   {
-                       auto& parserName = std::get<0>(tuple);
-                       auto& parserValue = std::get<1>(tuple);
-                       base::Expression parserExpression;
-                       try
+        std::transform(parseObj.begin(),
+                       parseObj.end(),
+                       std::back_inserter(parserExpressions),
+                       [registry](auto& tuple)
                        {
-                           parserExpression =
-                               Registry::getBuilder("parser." + parserName)(parserValue);
-                       }
-                       catch (const std::exception& e)
-                       {
-                           std::throw_with_nested(std::runtime_error(
-                               fmt::format("[builder::stageBuilderParse(json)] "
-                                           "Error building parser [{}]: {}",
-                                           parserName,
-                                           e.what())));
-                       }
+                           auto& parserName = std::get<0>(tuple);
+                           auto& parserValue = std::get<1>(tuple);
+                           base::Expression parserExpression;
+                           try
+                           {
+                               parserExpression = registry->getBuilder(
+                                   "parser." + parserName)(parserValue);
+                           }
+                           catch (const std::exception& e)
+                           {
+                               std::throw_with_nested(std::runtime_error(
+                                   fmt::format("[builder::stageBuilderParse(json)] "
+                                               "Error building parser [{}]: {}",
+                                               parserName,
+                                               e.what())));
+                           }
 
-                       return parserExpression;
-                   });
+                           return parserExpression;
+                       });
 
-    return base::Or::create("parse", parserExpressions);
+        return base::Or::create("parse", parserExpressions);
+    };
 }
 
 } // namespace builder::internals::builders

--- a/src/engine/source/builder/builders/stageBuilderParse.hpp
+++ b/src/engine/source/builder/builders/stageBuilderParse.hpp
@@ -2,20 +2,23 @@
 #define _STAGE_BUILDER_PARSE_H
 
 #include <any>
+#include <memory>
 
-#include "expression.hpp"
+#include <expression.hpp>
+
+#include "registry.hpp"
 
 namespace builder::internals::builders
 {
 
 /**
- * @brief Builds parsing stage to be able to get information from the original
- * logged event
+ * @brief Return the builder that builds parsing stage to be able to get information from
+ * the original logged event
  *
- * @param definition JSON with the definition of the stage
- * @return base::Expression
+ * @param registry Registry of builders.
+ * @return Builder
  */
-base::Expression stageBuilderParse(const std::any& definition);
+Builder getStageBuilderParse(std::shared_ptr<Registry> registry);
 
 } // namespace builder::internals::builders
 

--- a/src/engine/source/builder/environment.cpp
+++ b/src/engine/source/builder/environment.cpp
@@ -31,7 +31,8 @@ Asset::Type getAssetType(const std::string& name)
 void Environment::buildGraph(
     const std::unordered_map<std::string, json::Json>& assetsDefinitons,
     const std::string& graphName,
-    Asset::Type type)
+    Asset::Type type,
+    std::shared_ptr<internals::Registry> registry)
 {
     auto graphPos = std::find_if(m_graphs.begin(),
                                  m_graphs.end(),
@@ -44,7 +45,7 @@ void Environment::buildGraph(
         std::shared_ptr<Asset> asset;
         try
         {
-            asset = std::make_shared<Asset>(json, type);
+            asset = std::make_shared<Asset>(json, type, registry);
         }
         catch (const std::exception& e)
         {

--- a/src/engine/source/builder/register.hpp
+++ b/src/engine/source/builder/register.hpp
@@ -22,25 +22,32 @@ namespace builder::internals
 {
 struct dependencies
 {
+    std::shared_ptr<KVDBManager> kvdbManager;
 };
 
-static void registerBuilders(std::shared_ptr<Registry> registry, const dependencies& dependencies = {})
+static void registerBuilders(std::shared_ptr<Registry> registry,
+                             const dependencies& dependencies = {})
 {
     // Basic operations
-    registry->registerBuilder(builders::getOperationMapBuilder(registry), "operation.map");
-    registry->registerBuilder(builders::getOperationConditionBuilder(registry), "operation.condition");
+    registry->registerBuilder(builders::getOperationMapBuilder(registry),
+                              "operation.map");
+    registry->registerBuilder(builders::getOperationConditionBuilder(registry),
+                              "operation.condition");
 
     // Stages
-    registry->registerBuilder(builders::getStageBuilderCheck(registry), "stage.check", "stage.allow");
+    registry->registerBuilder(
+        builders::getStageBuilderCheck(registry), "stage.check", "stage.allow");
     registry->registerBuilder(builders::getStageMapBuilder(registry), "stage.map");
-    registry->registerBuilder(builders::getStageNormalizeBuilder(registry), "stage.normalize");
+    registry->registerBuilder(builders::getStageNormalizeBuilder(registry),
+                              "stage.normalize");
 
     // Parsers
     registry->registerBuilder(builders::getStageBuilderParse(registry), "stage.parse");
     registry->registerBuilder(builders::opBuilderLogParser, "parser.logpar");
 
     // Outputs
-    registry->registerBuilder(builders::getStageBuilderOutputs(registry), "stage.outputs");
+    registry->registerBuilder(builders::getStageBuilderOutputs(registry),
+                              "stage.outputs");
     registry->registerBuilder(builders::opBuilderFileOutput, "output.file");
 
     // Filter Helpers
@@ -129,11 +136,16 @@ static void registerBuilders(std::shared_ptr<Registry> registry, const dependenc
     registry->registerBuilder(builders::opBuilderWdbUpdate, "helper.wdb_update");
 
     // KVDB
-    registry->registerBuilder(builders::opBuilderKVDBExtract, "helper.kvdb_get");
-    registry->registerBuilder(builders::opBuilderKVDBExtractMerge,
-                              "helper.kvdb_get_merge");
-    registry->registerBuilder(builders::opBuilderKVDBMatch, "helper.kvdb_match");
-    registry->registerBuilder(builders::opBuilderKVDBNotMatch, "helper.kvdb_not_match");
+    registry->registerBuilder(builders::getOpBuilderKVDBExtract(dependencies.kvdbManager),
+                              "helper.kvdb_get");
+    registry->registerBuilder(
+        builders::getOpBuilderKVDBExtractMerge(dependencies.kvdbManager),
+        "helper.kvdb_get_merge");
+    registry->registerBuilder(builders::getOpBuilderKVDBMatch(dependencies.kvdbManager),
+                              "helper.kvdb_match");
+    registry->registerBuilder(
+        builders::getOpBuilderKVDBNotMatch(dependencies.kvdbManager),
+        "helper.kvdb_not_match");
 
     // SCA decoder
     registry->registerBuilder(builders::opBuilderSCAdecoder, "helper.sca_decoder");

--- a/src/engine/source/builder/register.hpp
+++ b/src/engine/source/builder/register.hpp
@@ -20,124 +20,128 @@
 
 namespace builder::internals
 {
-static void registerBuilders()
+struct dependencies
+{
+};
+
+static void registerBuilders(std::shared_ptr<Registry> registry, const dependencies& dependencies = {})
 {
     // Basic operations
-    Registry::registerBuilder(builders::operationMapBuilder, "operation.map");
-    Registry::registerBuilder(builders::operationConditionBuilder, "operation.condition");
+    registry->registerBuilder(builders::getOperationMapBuilder(registry), "operation.map");
+    registry->registerBuilder(builders::getOperationConditionBuilder(registry), "operation.condition");
 
     // Stages
-    Registry::registerBuilder(builders::stageBuilderCheck, "stage.check", "stage.allow");
-    Registry::registerBuilder(builders::stageMapBuilder, "stage.map");
-    Registry::registerBuilder(builders::stageNormalizeBuilder, "stage.normalize");
+    registry->registerBuilder(builders::getStageBuilderCheck(registry), "stage.check", "stage.allow");
+    registry->registerBuilder(builders::getStageMapBuilder(registry), "stage.map");
+    registry->registerBuilder(builders::getStageNormalizeBuilder(registry), "stage.normalize");
 
     // Parsers
-    Registry::registerBuilder(builders::stageBuilderParse, "stage.parse");
-    Registry::registerBuilder(builders::opBuilderLogParser, "parser.logpar");
+    registry->registerBuilder(builders::getStageBuilderParse(registry), "stage.parse");
+    registry->registerBuilder(builders::opBuilderLogParser, "parser.logpar");
 
     // Outputs
-    Registry::registerBuilder(builders::stageBuilderOutputs, "stage.outputs");
-    Registry::registerBuilder(builders::opBuilderFileOutput, "output.file");
+    registry->registerBuilder(builders::getStageBuilderOutputs(registry), "stage.outputs");
+    registry->registerBuilder(builders::opBuilderFileOutput, "output.file");
 
     // Filter Helpers
-    Registry::registerBuilder(builders::opBuilderHelperContainsString,
+    registry->registerBuilder(builders::opBuilderHelperContainsString,
                               "helper.a_contains");
-    Registry::registerBuilder(builders::opBuilderHelperIntEqual, "helper.i_eq");
-    Registry::registerBuilder(builders::opBuilderHelperIntGreaterThan, "helper.i_gt");
-    Registry::registerBuilder(builders::opBuilderHelperIntGreaterThanEqual,
+    registry->registerBuilder(builders::opBuilderHelperIntEqual, "helper.i_eq");
+    registry->registerBuilder(builders::opBuilderHelperIntGreaterThan, "helper.i_gt");
+    registry->registerBuilder(builders::opBuilderHelperIntGreaterThanEqual,
                               "helper.i_ge");
-    Registry::registerBuilder(builders::opBuilderHelperIntLessThan, "helper.i_lt");
-    Registry::registerBuilder(builders::opBuilderHelperIntLessThanEqual, "helper.i_le");
-    Registry::registerBuilder(builders::opBuilderHelperIntNotEqual, "helper.i_ne");
-    Registry::registerBuilder(builders::opBuilderHelperIPCIDR, "helper.ip_cidr");
-    Registry::registerBuilder(builders::opBuilderHelperIsArray, "helper.t_is_array");
-    Registry::registerBuilder(builders::opBuilderHelperIsBool, "helper.t_is_bool");
-    Registry::registerBuilder(builders::opBuilderHelperIsFalse, "helper.t_is_false");
-    Registry::registerBuilder(builders::opBuilderHelperIsNotArray,
+    registry->registerBuilder(builders::opBuilderHelperIntLessThan, "helper.i_lt");
+    registry->registerBuilder(builders::opBuilderHelperIntLessThanEqual, "helper.i_le");
+    registry->registerBuilder(builders::opBuilderHelperIntNotEqual, "helper.i_ne");
+    registry->registerBuilder(builders::opBuilderHelperIPCIDR, "helper.ip_cidr");
+    registry->registerBuilder(builders::opBuilderHelperIsArray, "helper.t_is_array");
+    registry->registerBuilder(builders::opBuilderHelperIsBool, "helper.t_is_bool");
+    registry->registerBuilder(builders::opBuilderHelperIsFalse, "helper.t_is_false");
+    registry->registerBuilder(builders::opBuilderHelperIsNotArray,
                               "helper.t_is_not_array");
-    Registry::registerBuilder(builders::opBuilderHelperIsNotBool, "helper.t_is_not_bool");
-    Registry::registerBuilder(builders::opBuilderHelperIsNotNull, "helper.t_is_not_null");
-    Registry::registerBuilder(builders::opBuilderHelperIsNotNumber,
+    registry->registerBuilder(builders::opBuilderHelperIsNotBool, "helper.t_is_not_bool");
+    registry->registerBuilder(builders::opBuilderHelperIsNotNull, "helper.t_is_not_null");
+    registry->registerBuilder(builders::opBuilderHelperIsNotNumber,
                               "helper.t_is_not_num");
-    Registry::registerBuilder(builders::opBuilderHelperIsNotObject,
+    registry->registerBuilder(builders::opBuilderHelperIsNotObject,
                               "helper.t_is_not_object");
-    Registry::registerBuilder(builders::opBuilderHelperIsNotString,
+    registry->registerBuilder(builders::opBuilderHelperIsNotString,
                               "helper.t_is_not_string");
-    Registry::registerBuilder(builders::opBuilderHelperIsNull, "helper.t_is_null");
-    Registry::registerBuilder(builders::opBuilderHelperIsNumber, "helper.t_is_num");
-    Registry::registerBuilder(builders::opBuilderHelperIsObject, "helper.t_is_object");
-    Registry::registerBuilder(builders::opBuilderHelperIsString, "helper.t_is_string");
-    Registry::registerBuilder(builders::opBuilderHelperIsTrue, "helper.t_is_true");
-    Registry::registerBuilder(builders::opBuilderHelperRegexMatch, "helper.r_match");
-    Registry::registerBuilder(builders::opBuilderHelperRegexNotMatch,
+    registry->registerBuilder(builders::opBuilderHelperIsNull, "helper.t_is_null");
+    registry->registerBuilder(builders::opBuilderHelperIsNumber, "helper.t_is_num");
+    registry->registerBuilder(builders::opBuilderHelperIsObject, "helper.t_is_object");
+    registry->registerBuilder(builders::opBuilderHelperIsString, "helper.t_is_string");
+    registry->registerBuilder(builders::opBuilderHelperIsTrue, "helper.t_is_true");
+    registry->registerBuilder(builders::opBuilderHelperRegexMatch, "helper.r_match");
+    registry->registerBuilder(builders::opBuilderHelperRegexNotMatch,
                               "helper.r_not_match");
-    Registry::registerBuilder(builders::opBuilderHelperStringEqual, "helper.s_eq");
-    Registry::registerBuilder(builders::opBuilderHelperStringGreaterThan, "helper.s_gt");
-    Registry::registerBuilder(builders::opBuilderHelperStringGreaterThanEqual,
+    registry->registerBuilder(builders::opBuilderHelperStringEqual, "helper.s_eq");
+    registry->registerBuilder(builders::opBuilderHelperStringGreaterThan, "helper.s_gt");
+    registry->registerBuilder(builders::opBuilderHelperStringGreaterThanEqual,
                               "helper.s_ge");
-    Registry::registerBuilder(builders::opBuilderHelperStringLessThan, "helper.s_lt");
-    Registry::registerBuilder(builders::opBuilderHelperStringLessThanEqual,
+    registry->registerBuilder(builders::opBuilderHelperStringLessThan, "helper.s_lt");
+    registry->registerBuilder(builders::opBuilderHelperStringLessThanEqual,
                               "helper.s_le");
-    Registry::registerBuilder(builders::opBuilderHelperStringNotEqual, "helper.s_ne");
-    Registry::registerBuilder(builders::opBuilderHelperStringStarts, "helper.s_starts");
+    registry->registerBuilder(builders::opBuilderHelperStringNotEqual, "helper.s_ne");
+    registry->registerBuilder(builders::opBuilderHelperStringStarts, "helper.s_starts");
     // Filter helpers: Event Field functions
-    Registry::registerBuilder(builders::opBuilderHelperExists, "helper.ef_exists");
-    Registry::registerBuilder(builders::opBuilderHelperNotExists, "helper.ef_not_exists");
+    registry->registerBuilder(builders::opBuilderHelperExists, "helper.ef_exists");
+    registry->registerBuilder(builders::opBuilderHelperNotExists, "helper.ef_not_exists");
 
     // Map Helpers
-    Registry::registerBuilder(builders::opBuilderHelperIntCalc, "helper.i_calc");
-    Registry::registerBuilder(builders::opBuilderHelperRegexExtract, "helper.r_ext");
+    registry->registerBuilder(builders::opBuilderHelperIntCalc, "helper.i_calc");
+    registry->registerBuilder(builders::opBuilderHelperRegexExtract, "helper.r_ext");
     // Map helpers: Event Field functions
-    Registry::registerBuilder(builders::opBuilderHelperDeleteField, "helper.ef_delete");
-    Registry::registerBuilder(builders::opBuilderHelperMerge, "helper.ef_merge");
-    Registry::registerBuilder(builders::opBuilderHelperRenameField, "helper.ef_rename");
+    registry->registerBuilder(builders::opBuilderHelperDeleteField, "helper.ef_delete");
+    registry->registerBuilder(builders::opBuilderHelperMerge, "helper.ef_merge");
+    registry->registerBuilder(builders::opBuilderHelperRenameField, "helper.ef_rename");
     // Map helpers: Hash functions
-    Registry::registerBuilder(builders::opBuilderHelperHashSHA1, "helper.h_sha1");
+    registry->registerBuilder(builders::opBuilderHelperHashSHA1, "helper.h_sha1");
     // Map helpers: String functions
-    Registry::registerBuilder(builders::opBuilderHelperAppendSplitString,
+    registry->registerBuilder(builders::opBuilderHelperAppendSplitString,
                               "helper.s_to_array");
-    Registry::registerBuilder(builders::opBuilderHelperAppend, "helper.a_append");
-    Registry::registerBuilder(builders::opBuilderHelperHexToNumber,
+    registry->registerBuilder(builders::opBuilderHelperAppend, "helper.a_append");
+    registry->registerBuilder(builders::opBuilderHelperHexToNumber,
                               "helper.s_hex_to_num");
-    Registry::registerBuilder(builders::opBuilderHelperIPVersionFromIPStr,
+    registry->registerBuilder(builders::opBuilderHelperIPVersionFromIPStr,
                               "helper.s_ip_version");
-    Registry::registerBuilder(builders::opBuilderHelperStringConcat, "helper.s_concat");
-    Registry::registerBuilder(builders::opBuilderHelperStringFromArray,
+    registry->registerBuilder(builders::opBuilderHelperStringConcat, "helper.s_concat");
+    registry->registerBuilder(builders::opBuilderHelperStringFromArray,
                               "helper.s_from_array");
-    Registry::registerBuilder(builders::opBuilderHelperStringFromHexa,
+    registry->registerBuilder(builders::opBuilderHelperStringFromHexa,
                               "helper.s_from_hexa");
-    Registry::registerBuilder(builders::opBuilderHelperStringLO, "helper.s_lo");
-    Registry::registerBuilder(builders::opBuilderHelperStringReplace, "helper.s_replace");
-    Registry::registerBuilder(builders::opBuilderHelperStringTrim, "helper.s_trim");
-    Registry::registerBuilder(builders::opBuilderHelperStringUP, "helper.s_up");
+    registry->registerBuilder(builders::opBuilderHelperStringLO, "helper.s_lo");
+    registry->registerBuilder(builders::opBuilderHelperStringReplace, "helper.s_replace");
+    registry->registerBuilder(builders::opBuilderHelperStringTrim, "helper.s_trim");
+    registry->registerBuilder(builders::opBuilderHelperStringUP, "helper.s_up");
     // Map helpers: Time functions
-    Registry::registerBuilder(builders::opBuilderHelperEpochTimeFromSystem,
+    registry->registerBuilder(builders::opBuilderHelperEpochTimeFromSystem,
                               "helper. sys_epoch");
 
     // Special helpers
 
     // Active Response
-    Registry::registerBuilder(builders::opBuilderHelperCreateAR, "helper.ar_create");
-    Registry::registerBuilder(builders::opBuilderHelperSendAR, "helper.ar_send");
+    registry->registerBuilder(builders::opBuilderHelperCreateAR, "helper.ar_create");
+    registry->registerBuilder(builders::opBuilderHelperSendAR, "helper.ar_send");
 
     // DB sync
-    Registry::registerBuilder(builders::opBuilderWdbQuery, "helper.wdb_query");
-    Registry::registerBuilder(builders::opBuilderWdbUpdate, "helper.wdb_update");
+    registry->registerBuilder(builders::opBuilderWdbQuery, "helper.wdb_query");
+    registry->registerBuilder(builders::opBuilderWdbUpdate, "helper.wdb_update");
 
     // KVDB
-    Registry::registerBuilder(builders::opBuilderKVDBExtract, "helper.kvdb_get");
-    Registry::registerBuilder(builders::opBuilderKVDBExtractMerge,
+    registry->registerBuilder(builders::opBuilderKVDBExtract, "helper.kvdb_get");
+    registry->registerBuilder(builders::opBuilderKVDBExtractMerge,
                               "helper.kvdb_get_merge");
-    Registry::registerBuilder(builders::opBuilderKVDBMatch, "helper.kvdb_match");
-    Registry::registerBuilder(builders::opBuilderKVDBNotMatch, "helper.kvdb_not_match");
+    registry->registerBuilder(builders::opBuilderKVDBMatch, "helper.kvdb_match");
+    registry->registerBuilder(builders::opBuilderKVDBNotMatch, "helper.kvdb_not_match");
 
     // SCA decoder
-    Registry::registerBuilder(builders::opBuilderSCAdecoder, "helper.sca_decoder");
+    registry->registerBuilder(builders::opBuilderSCAdecoder, "helper.sca_decoder");
 
     // SysCollector - netInfo
-    Registry::registerBuilder(builders::opBuilderHelperSaveNetInfoIPv4,
+    registry->registerBuilder(builders::opBuilderHelperSaveNetInfoIPv4,
                               "helper.sysc_ni_save_ipv4");
-    Registry::registerBuilder(builders::opBuilderHelperSaveNetInfoIPv6,
+    registry->registerBuilder(builders::opBuilderHelperSaveNetInfoIPv6,
                               "helper.sysc_ni_save_ipv6");
 }
 } // namespace builder::internals

--- a/src/engine/source/builder/registry.cpp
+++ b/src/engine/source/builder/registry.cpp
@@ -3,28 +3,19 @@
 namespace builder::internals
 {
 
-using Builder = std::function<base::Expression(std::any)>;
-
-Registry& Registry::instance()
+Builder Registry::getBuilder(const std::string& name)
 {
-    static Registry instance;
-    return instance;
-}
-
-Builder& Registry::getBuilder(const std::string& name)
-{
-    if (Registry::instance().m_builders.find(name)
-        == Registry::instance().m_builders.end())
+    if (m_builders.find(name) == m_builders.end())
     {
-        throw std::runtime_error(fmt::format(
-            "[getBuilder(name)] name not found in the registry: [{}]", name));
+        throw std::runtime_error(
+            fmt::format("[getBuilder(name)] name not found in the registry: [{}]", name));
     }
-    return Registry::instance().m_builders.at(name);
+    return m_builders.at(name);
 }
 
 void Registry::clear()
 {
-    Registry::instance().m_builders.clear();
+    m_builders.clear();
 }
 
 } // namespace builder::internals

--- a/src/engine/source/builder/registry.hpp
+++ b/src/engine/source/builder/registry.hpp
@@ -26,27 +26,20 @@ class Registry
 private:
     std::unordered_map<std::string, Builder> m_builders;
 
+public:
     Registry() = default;
     Registry(const Registry&) = delete;
     Registry& operator=(const Registry&) = delete;
     Registry(Registry&&) = delete;
     Registry& operator=(Registry&&) = delete;
 
-public:
-    /**
-     * @brief Get Registry instance.
-     *
-     * @return auto& Registry instance.
-     */
-    static Registry& instance();
-
     /**
      * @brief Get the Builder object
      *
      * @param name Name of the builder.
-     * @return Builder& Builder object reference.
+     * @return Builder Builder object reference.
      */
-    static Builder& getBuilder(const std::string& name);
+    Builder getBuilder(const std::string& name);
 
     /**
      * @brief Register a builder.
@@ -55,14 +48,13 @@ public:
      * @param names Names of the builder.
      */
     template<typename... Names>
-    static void registerBuilder(Builder builder, Names... names)
+    void registerBuilder(Builder builder, Names... names)
     {
         for (auto name : {names...})
         {
-            if (Registry::instance().m_builders.find(name)
-                == Registry::instance().m_builders.end())
+            if (m_builders.find(name) == m_builders.end())
             {
-                Registry::instance().m_builders.insert(std::make_pair(name, builder));
+                m_builders.insert(std::make_pair(name, builder));
             }
             else
             {
@@ -78,7 +70,7 @@ public:
      * @brief Clear the registry.
      *
      */
-    static void clear();
+    void clear();
 };
 
 } // namespace builder::internals

--- a/src/engine/source/cmds/src/cmdGraph.cpp
+++ b/src/engine/source/cmds/src/cmdGraph.cpp
@@ -37,8 +37,8 @@ void graph(const std::string& kvdbPath,
     logging::loggingInit(logConfig);
     g_exitHanlder.add([]() { logging::loggingTerm(); });
 
-    KVDBManager::init(kvdbPath);
-    g_exitHanlder.add([]() { KVDBManager::get().clear(); });
+    auto kvdb = std::make_shared<KVDBManager>(kvdbPath);
+    g_exitHanlder.add([kvdb]() { kvdb->clear(); });
 
     auto store = std::make_shared<store::FileDriver>(fileStorage);
     base::Name hlpConfigFileName({"schema", "wazuh-logpar-types", "0"});
@@ -58,7 +58,7 @@ void graph(const std::string& kvdbPath,
     auto registry = std::make_shared<builder::internals::Registry>();
     try
     {
-        builder::internals::registerBuilders(registry);
+        builder::internals::registerBuilders(registry, {kvdb});
     }
     catch (const std::exception& e)
     {

--- a/src/engine/source/cmds/src/cmdGraph.cpp
+++ b/src/engine/source/cmds/src/cmdGraph.cpp
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <memory>
 
 #include <hlp/hlp.hpp>
 #include <kvdb/kvdbManager.hpp>
@@ -12,6 +13,7 @@
 #include "base/utils/getExceptionStack.hpp"
 #include "builder.hpp"
 #include "register.hpp"
+#include "registry.hpp"
 #include "stackExecutor.hpp"
 
 namespace
@@ -53,10 +55,10 @@ void graph(const std::string& kvdbPath,
     // TODO because builders don't have access to the catalog we are configuring
     // the parser mappings on start up for now
     hlp::configureParserMappings(std::get<json::Json>(hlpParsers).str());
-
+    auto registry = std::make_shared<builder::internals::Registry>();
     try
     {
-        builder::internals::registerBuilders();
+        builder::internals::registerBuilders(registry);
     }
     catch (const std::exception& e)
     {
@@ -66,7 +68,7 @@ void graph(const std::string& kvdbPath,
         return;
     }
 
-    builder::Builder _builder(store);
+    builder::Builder _builder(store, registry);
     decltype(_builder.buildEnvironment({environment})) env;
     try
     {

--- a/src/engine/source/cmds/src/cmdKvdb.cpp
+++ b/src/engine/source/cmds/src/cmdKvdb.cpp
@@ -34,10 +34,10 @@ void kvdb(const std::string& kvdbPath,
     logging::LoggingConfig logConfig;
     logConfig.logLevel = logging::LogLevel::Debug;
     logging::loggingInit(logConfig);
-
+    std::shared_ptr<KVDBManager> kvdbManager;
     try
     {
-        KVDBManager::init(kvdbPath);
+        kvdbManager = std::make_shared<KVDBManager>(kvdbPath);
     }
     catch (const std::exception& e)
     {
@@ -85,9 +85,8 @@ void kvdb(const std::string& kvdbPath,
                 return;
             }
             auto entries = jKv.getObject();
-            KVDBManager& kvdbManager = KVDBManager::get();
-            kvdbManager.addDb(kvdbName);
-            auto kvdbHandle = kvdbManager.getDB(kvdbName);
+            kvdbManager->addDb(kvdbName);
+            auto kvdbHandle = kvdbManager->getDB(kvdbName);
             for (const auto& [key, value] : entries.value())
             {
 

--- a/src/engine/source/cmds/src/cmdTest.cpp
+++ b/src/engine/source/cmds/src/cmdTest.cpp
@@ -1,6 +1,7 @@
 #include "cmds/cmdTest.hpp"
 
 #include <atomic>
+#include <memory>
 
 #include <re2/re2.h>
 
@@ -15,6 +16,7 @@
 #include "base/utils/getExceptionStack.hpp"
 #include "builder.hpp"
 #include "register.hpp"
+#include "registry.hpp"
 #include "server/wazuhStreamProtocol.hpp"
 #include "stackExecutor.hpp"
 
@@ -83,9 +85,10 @@ void test(const std::string& kvdbPath,
     // the parser mappings on start up for now
     hlp::configureParserMappings(std::get<json::Json>(hlpParsers).str());
 
+    auto registry = std::make_shared<builder::internals::Registry>();
     try
     {
-        builder::internals::registerBuilders();
+        builder::internals::registerBuilders(registry);
     }
     catch (const std::exception& e)
     {
@@ -141,7 +144,7 @@ void test(const std::string& kvdbPath,
     _testDriver->testEnvironment = envTmp;
 
     // TODO: Handle errors on construction
-    builder::Builder _builder(_testDriver);
+    builder::Builder _builder(_testDriver, registry);
     decltype(_builder.buildEnvironment({environment})) env;
     try
     {

--- a/src/engine/source/kvdb/include/kvdb/kvdbManager.hpp
+++ b/src/engine/source/kvdb/include/kvdb/kvdbManager.hpp
@@ -16,17 +16,13 @@ class KVDBManager
 {
     WAZUH_DISABLE_COPY_ASSIGN(KVDBManager);
 
-    KVDBManager();
-    static bool mInitialized;
-    static std::filesystem::path mDbFolder;
+    std::filesystem::path mDbFolder;
     std::unordered_map<std::string, KVDBHandle> m_availableKVDBs;
     std::shared_mutex mMtx;
-    static KVDBManager sInstance;
 
 public:
+    KVDBManager(const std::filesystem::path& DbFolder);
     ~KVDBManager() = default;
-    static bool init(const std::filesystem::path& DbFolder);
-    static KVDBManager& get();
     KVDBHandle addDb(const std::string& Name, bool createIfMissing = true);
     bool createDBfromCDB(const std::filesystem::path& path, bool createIfMissing = true);
     bool deleteDB(const std::string& name);

--- a/src/engine/source/kvdb/src/kvdbManager.cpp
+++ b/src/engine/source/kvdb/src/kvdbManager.cpp
@@ -14,32 +14,14 @@
 #include <utils/baseMacros.hpp>
 #include <utils/stringUtils.hpp>
 
-bool KVDBManager::mInitialized;
-std::filesystem::path KVDBManager::mDbFolder;
-bool KVDBManager::init(const std::filesystem::path& path)
-{
-    WAZUH_ASSERT_MSG(!mInitialized,
-                     "The manager should be initialized only once.");
-    mInitialized = true;
-
-    // TODO Remove this when Engine is integrated in Wazuh installation
-    std::filesystem::create_directories(path);
-    mDbFolder = path;
-
-    return true;
-}
-
-KVDBManager& KVDBManager::get()
-{
-    WAZUH_ASSERT_MSG(mInitialized, "Trying to use an un-initialized manager");
-    static KVDBManager instance;
-    return instance;
-}
-
-KVDBManager::KVDBManager()
+KVDBManager::KVDBManager(const std::filesystem::path& DbFolder)
 {
     // TODO should we read and load all the dbs inside the folder?
     // shouldn't be better to just load the configured ones at start instead?
+
+    // TODO Remove this when Engine is integrated in Wazuh installation
+    std::filesystem::create_directories(DbFolder);
+    mDbFolder = DbFolder;
 
     auto legacyPath = mDbFolder;
     legacyPath.append("legacy");

--- a/src/engine/test/engineTestMain.cpp
+++ b/src/engine/test/engineTestMain.cpp
@@ -5,8 +5,6 @@
 
 int main(int argc, char** argv)
 {
-    KVDBManager::init("/tmp/");
-
     logging::LoggingConfig logConfig;
     logConfig.logLevel = logging::LogLevel::Off;
     logging::loggingInit(logConfig);

--- a/src/engine/test/source/builder/builders/operationBuilder_test.cpp
+++ b/src/engine/test/source/builder/builders/operationBuilder_test.cpp
@@ -58,23 +58,26 @@ auto operationArray {operations.getArray().value()};
 
 TEST(OperationConditionBuilderTest, Builds)
 {
+    auto registry = std::make_shared<Registry>();
     for (auto operationDef : operationArray)
     {
         auto def = operationDef.getObject().value()[0];
-        ASSERT_NO_THROW(operationConditionBuilder(def));
+        ASSERT_NO_THROW(getOperationConditionBuilder(registry)(def));
     }
 }
 
 TEST(OperationConditionBuilderTest, UnexpectedDefinition)
 {
+    auto registry = std::make_shared<Registry>();
     for (auto operationDef : operationArray)
     {
-        ASSERT_THROW(operationConditionBuilder(operationDef), std::runtime_error);
+        ASSERT_THROW(getOperationConditionBuilder(registry)(operationDef), std::runtime_error);
     }
 }
 
 TEST(OperationConditionBuilderTest, BuildsOperates)
 {
+    auto registry = std::make_shared<Registry>();
     auto eventOk = std::make_shared<Json>(R"({
         "string": "value",
         "int": 1,
@@ -178,7 +181,7 @@ TEST(OperationConditionBuilderTest, BuildsOperates)
     for (auto operationDef : operationArray)
     {
         auto def = operationDef.getObject().value()[0];
-        auto op = operationConditionBuilder(def)->getPtr<Term<EngineOp>>()->getFn();
+        auto op = getOperationConditionBuilder(registry)(def)->getPtr<Term<EngineOp>>()->getFn();
         auto result = op(eventOk);
         if (!result)
         {
@@ -190,7 +193,7 @@ TEST(OperationConditionBuilderTest, BuildsOperates)
     for (auto operationDef : operationArray)
     {
         auto def = operationDef.getObject().value()[0];
-        auto op = operationConditionBuilder(def)->getPtr<Term<EngineOp>>()->getFn();
+        auto op = getOperationConditionBuilder(registry)(def)->getPtr<Term<EngineOp>>()->getFn();
         auto result = op(eventNotOk);
         if (result)
         {
@@ -202,7 +205,7 @@ TEST(OperationConditionBuilderTest, BuildsOperates)
     for (auto operationDef : operationArray)
     {
         auto def = operationDef.getObject().value()[0];
-        auto op = operationConditionBuilder(def)->getPtr<Term<EngineOp>>()->getFn();
+        auto op = getOperationConditionBuilder(registry)(def)->getPtr<Term<EngineOp>>()->getFn();
         auto result = op(eventNull);
         if (result)
         {
@@ -214,6 +217,7 @@ TEST(OperationConditionBuilderTest, BuildsOperates)
 
 TEST(OperationConditionBuilderTest, BuildsOperatesArray)
 {
+    auto registry = std::make_shared<Registry>();
     std::string targetField = "array";
     json::Json operation(R"([
         "string",
@@ -271,7 +275,7 @@ TEST(OperationConditionBuilderTest, BuildsOperatesArray)
         ]
     })");
 
-    auto expression = operationConditionBuilder(definition);
+    auto expression = getOperationConditionBuilder(registry)(definition);
     auto expressionRootLevel = expression->getPtr<base::Operation>()->getOperands();
     auto expressionNestedLevel =
         expressionRootLevel[6]->getPtr<base::Operation>()->getOperands();
@@ -313,6 +317,7 @@ TEST(OperationConditionBuilderTest, BuildsOperatesArray)
 
 TEST(OperationConditionBuilderTest, BuildsOperatesObject)
 {
+    auto registry = std::make_shared<Registry>();
     std::string targetField = "object";
     json::Json operation(R"({
         "string": "string",
@@ -370,7 +375,7 @@ TEST(OperationConditionBuilderTest, BuildsOperatesObject)
         }
     })");
 
-    auto expression = operationConditionBuilder(definition);
+    auto expression = getOperationConditionBuilder(registry)(definition);
     auto expressionRootLevel = expression->getPtr<base::Operation>()->getOperands();
     auto expressionNestedLevel =
         expressionRootLevel[6]->getPtr<base::Operation>()->getOperands();
@@ -412,24 +417,27 @@ TEST(OperationConditionBuilderTest, BuildsOperatesObject)
 
 TEST(OperationMapBuilderTest, Builds)
 {
+    auto registry = std::make_shared<Registry>();
     for (auto operationDef : operationArray)
     {
         auto def = operationDef.getObject().value()[0];
-        ASSERT_NO_THROW(operationMapBuilder(def));
+        ASSERT_NO_THROW(getOperationMapBuilder(registry)(def));
     }
 }
 
 TEST(OperationMapBuilderTest, UnexpectedDefinition)
 {
+    auto registry = std::make_shared<Registry>();
     for (auto operationDef : operationArray)
     {
-        ASSERT_THROW(operationMapBuilder(operationDef), std::runtime_error);
+        ASSERT_THROW(getOperationMapBuilder(registry)(operationDef), std::runtime_error);
     }
 }
 
 // TODO: add failed map reference test.
 TEST(OperationMapBuilderTest, BuildsOperatesLiterals)
 {
+    auto registry = std::make_shared<Registry>();
     auto expected = std::make_shared<Json>(R"({
         "string": "value",
         "int": 1,
@@ -490,7 +498,7 @@ TEST(OperationMapBuilderTest, BuildsOperatesLiterals)
     for (auto operationDef : operationArray)
     {
         auto def = operationDef.getObject().value()[0];
-        auto op = operationMapBuilder(def)->getPtr<Term<EngineOp>>()->getFn();
+        auto op = getOperationMapBuilder(registry)(def)->getPtr<Term<EngineOp>>()->getFn();
         auto result = op(eventOk);
         if (!result)
         {
@@ -503,6 +511,7 @@ TEST(OperationMapBuilderTest, BuildsOperatesLiterals)
 
 TEST(OperationMapBuilderTest, BuildsOperatesArray)
 {
+    auto registry = std::make_shared<Registry>();
     std::string targetField("array");
     json::Json operationJson(R"([
         "string",
@@ -541,7 +550,7 @@ TEST(OperationMapBuilderTest, BuildsOperatesArray)
         ]
     })");
     auto event = std::make_shared<Json>();
-    auto expression = operationMapBuilder(definition);
+    auto expression = getOperationMapBuilder(registry)(definition);
     auto expressionsRootLevel = expression->getPtr<base::Operation>()->getOperands();
     auto expressionsNestedLevel =
         expressionsRootLevel[6]->getPtr<base::Operation>()->getOperands();
@@ -572,6 +581,7 @@ TEST(OperationMapBuilderTest, BuildsOperatesArray)
 
 TEST(OperationMapBuilderTest, BuildsOperatesObject)
 {
+    auto registry = std::make_shared<Registry>();
     std::string targetField = "object";
     json::Json operationJson(R"({
         "string": "value",
@@ -611,7 +621,7 @@ TEST(OperationMapBuilderTest, BuildsOperatesObject)
     })");
 
     auto event = std::make_shared<Json>();
-    auto expression = operationMapBuilder(definition);
+    auto expression = getOperationMapBuilder(registry)(definition);
     auto expressionsRootLevel = expression->getPtr<base::Operation>()->getOperands();
     auto expressionsNestedLevel =
         expressionsRootLevel[6]->getPtr<base::Operation>()->getOperands();

--- a/src/engine/test/source/builder/builders/stageBuilderCheck_test.cpp
+++ b/src/engine/test/source/builder/builders/stageBuilderCheck_test.cpp
@@ -13,21 +13,11 @@ using namespace base;
 
 #define GTEST_COUT std::cout << "[          ] [ INFO ] "
 
-class StageBuilderCheckTest : public ::testing::Test
+TEST(StageBuilderCheckTest, ListBuilds)
 {
-protected:
-    void SetUp() override
-    {
-        Registry::registerBuilder(operationConditionBuilder, "operation.condition");
-    }
-    void TearDown() override
-    {
-        Registry::clear();
-    }
-};
-
-TEST_F(StageBuilderCheckTest, ListBuilds)
-{
+    auto registry = std::make_shared<Registry>();
+    registry->registerBuilder(getOperationConditionBuilder(registry),
+                              "operation.condition");
     auto checkJson = Json {R"([
         {"string": "value"},
         {"int": 1},
@@ -39,18 +29,24 @@ TEST_F(StageBuilderCheckTest, ListBuilds)
         {"object": {"a": 1, "b": 2}}
 ])"};
 
-    ASSERT_NO_THROW(stageBuilderCheck(checkJson));
+    ASSERT_NO_THROW(getStageBuilderCheck(registry)(checkJson));
 }
 
-TEST_F(StageBuilderCheckTest, UnexpectedDefinition)
+TEST(StageBuilderCheckTest, UnexpectedDefinition)
 {
+    auto registry = std::make_shared<Registry>();
+    registry->registerBuilder(getOperationConditionBuilder(registry),
+                              "operation.condition");
     auto checkJson = Json {R"({})"};
 
-    ASSERT_THROW(stageBuilderCheck(checkJson), std::runtime_error);
+    ASSERT_THROW(getStageBuilderCheck(registry)(checkJson), std::runtime_error);
 }
 
-TEST_F(StageBuilderCheckTest, ListArrayWrongSizeItem)
+TEST(StageBuilderCheckTest, ListArrayWrongSizeItem)
 {
+    auto registry = std::make_shared<Registry>();
+    registry->registerBuilder(getOperationConditionBuilder(registry),
+                              "operation.condition");
     auto checkJson = Json {R"([
         {"string": "value"},
         {"int": 1},
@@ -63,20 +59,26 @@ TEST_F(StageBuilderCheckTest, ListArrayWrongSizeItem)
         {"object": {"a": 1, "b": 2}}
 ])"};
 
-    ASSERT_THROW(stageBuilderCheck(checkJson), std::runtime_error);
+    ASSERT_THROW(getStageBuilderCheck(registry)(checkJson), std::runtime_error);
 }
 
-TEST_F(StageBuilderCheckTest, ListArrayWrongTypeItem)
+TEST(StageBuilderCheckTest, ListArrayWrongTypeItem)
 {
+    auto registry = std::make_shared<Registry>();
+    registry->registerBuilder(getOperationConditionBuilder(registry),
+                              "operation.condition");
     auto checkJson = Json {R"([
         ["string", "value"]
 ])"};
 
-    ASSERT_THROW(stageBuilderCheck(checkJson), std::runtime_error);
+    ASSERT_THROW(getStageBuilderCheck(registry)(checkJson), std::runtime_error);
 }
 
-TEST_F(StageBuilderCheckTest, ListBuildsCorrectExpression)
+TEST(StageBuilderCheckTest, ListBuildsCorrectExpression)
 {
+    auto registry = std::make_shared<Registry>();
+    registry->registerBuilder(getOperationConditionBuilder(registry),
+                              "operation.condition");
     auto checkJson = Json {R"([
         {"string": "value"},
         {"int": 1},
@@ -88,7 +90,7 @@ TEST_F(StageBuilderCheckTest, ListBuildsCorrectExpression)
         {"object": {"a": 1, "b": 2}}
 ])"};
 
-    auto expression = stageBuilderCheck(checkJson);
+    auto expression = getStageBuilderCheck(registry)(checkJson);
 
     ASSERT_TRUE(expression->isOperation());
     ASSERT_TRUE(expression->isAnd());
@@ -98,18 +100,24 @@ TEST_F(StageBuilderCheckTest, ListBuildsCorrectExpression)
     }
 }
 
-TEST_F(StageBuilderCheckTest, ExpressionBuilds)
+TEST(StageBuilderCheckTest, ExpressionBuilds)
 {
+    auto registry = std::make_shared<Registry>();
+    registry->registerBuilder(getOperationConditionBuilder(registry),
+                              "operation.condition");
     auto checkJson = Json {R"("field==value")"};
 
-    ASSERT_NO_THROW(stageBuilderCheck(checkJson));
+    ASSERT_NO_THROW(getStageBuilderCheck(registry)(checkJson));
 }
 
-TEST_F(StageBuilderCheckTest, ExpressionBuildsCorrectExpression)
+TEST(StageBuilderCheckTest, ExpressionBuildsCorrectExpression)
 {
+    auto registry = std::make_shared<Registry>();
+    registry->registerBuilder(getOperationConditionBuilder(registry),
+                              "operation.condition");
     auto checkJson = Json {R"("field==value")"};
 
-    auto expression = stageBuilderCheck(checkJson);
+    auto expression = getStageBuilderCheck(registry)(checkJson);
 
     ASSERT_TRUE(expression->isTerm());
 }

--- a/src/engine/test/source/builder/builders/stageBuilderMap_test.cpp
+++ b/src/engine/test/source/builder/builders/stageBuilderMap_test.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <memory>
+
 #include "baseTypes.hpp"
 #include "builder/builders/operationBuilder.hpp"
 #include "builder/builders/stageBuilderMap.hpp"
@@ -13,21 +15,10 @@ using namespace base;
 
 #define GTEST_COUT std::cout << "[          ] [ INFO ] "
 
-class StageBuilderMapTest : public ::testing::Test
+TEST(StageBuilderMapTest, Builds)
 {
-protected:
-    void SetUp() override
-    {
-        Registry::registerBuilder(operationMapBuilder, "operation.map");
-    }
-    void TearDown() override
-    {
-        Registry::clear();
-    }
-};
-
-TEST_F(StageBuilderMapTest, Builds)
-{
+    auto registry = std::make_shared<Registry>();
+    registry->registerBuilder(getOperationMapBuilder(registry), "operation.map");
     auto mapJson = Json {R"([
         {"string": "value"},
         {"int": 1},
@@ -39,18 +30,22 @@ TEST_F(StageBuilderMapTest, Builds)
         {"object": {"a": 1, "b": 2}}
 ])"};
 
-    ASSERT_NO_THROW(stageMapBuilder(mapJson));
+    ASSERT_NO_THROW(getStageMapBuilder(registry)(mapJson));
 }
 
-TEST_F(StageBuilderMapTest, UnexpectedDefinition)
+TEST(StageBuilderMapTest, UnexpectedDefinition)
 {
+    auto registry = std::make_shared<Registry>();
+    registry->registerBuilder(getOperationMapBuilder(registry), "operation.map");
     auto mapJson = Json {R"({})"};
 
-    ASSERT_THROW(stageMapBuilder(mapJson), std::runtime_error);
+    ASSERT_THROW(getStageMapBuilder(registry)(mapJson), std::runtime_error);
 }
 
-TEST_F(StageBuilderMapTest, BuildsCorrectExpression)
+TEST(StageBuilderMapTest, BuildsCorrectExpression)
 {
+    auto registry = std::make_shared<Registry>();
+    registry->registerBuilder(getOperationMapBuilder(registry), "operation.map");
     auto mapJson = Json {R"([
         {"string": "value"},
         {"int": 1},
@@ -62,7 +57,7 @@ TEST_F(StageBuilderMapTest, BuildsCorrectExpression)
         {"object": {"a": 1, "b": 2}}
 ])"};
 
-    auto expression = stageMapBuilder(mapJson);
+    auto expression = getStageMapBuilder(registry)(mapJson);
 
     ASSERT_TRUE(expression->isOperation());
     ASSERT_TRUE(expression->isChain());

--- a/src/engine/test/source/builder/builders/stageBuilderNormalize_test.cpp
+++ b/src/engine/test/source/builder/builders/stageBuilderNormalize_test.cpp
@@ -15,24 +15,20 @@ using namespace base;
 
 #define GTEST_COUT std::cout << "[          ] [ INFO ] "
 
-class StageBuilderNormalizeTest : public ::testing::Test
+auto initTest()
 {
-protected:
-    void SetUp() override
-    {
-        Registry::registerBuilder(operationConditionBuilder, "operation.condition");
-        Registry::registerBuilder(operationMapBuilder, "operation.map");
-        Registry::registerBuilder(stageBuilderCheck, "stage.check");
-        Registry::registerBuilder(stageMapBuilder, "stage.map");
-    }
-    void TearDown() override
-    {
-        Registry::clear();
-    }
-};
+    auto registry = std::make_shared<Registry>();
+    registry->registerBuilder(getOperationConditionBuilder(registry),
+                              "operation.condition");
+    registry->registerBuilder(getOperationMapBuilder(registry), "operation.map");
+    registry->registerBuilder(getStageBuilderCheck(registry), "stage.check");
+    registry->registerBuilder(getStageMapBuilder(registry), "stage.map");
+    return registry;
+}
 
-TEST_F(StageBuilderNormalizeTest, Builds)
+TEST(StageBuilderNormalizeTest, Builds)
 {
+    auto registry = initTest();
     auto normalizeJson = Json {R"([
         {"map": [
             {"string": "value"},
@@ -66,27 +62,30 @@ TEST_F(StageBuilderNormalizeTest, Builds)
         ]}
 ])"};
 
-    ASSERT_NO_THROW(stageNormalizeBuilder(normalizeJson));
+    ASSERT_NO_THROW(getStageNormalizeBuilder(registry)(normalizeJson));
 }
 
-TEST_F(StageBuilderNormalizeTest, UnexpectedDefinition)
+TEST(StageBuilderNormalizeTest, UnexpectedDefinition)
 {
+    auto registry = initTest();
     auto normalizeJson = Json {R"({})"};
 
-    ASSERT_THROW(stageNormalizeBuilder(normalizeJson), std::runtime_error);
+    ASSERT_THROW(getStageNormalizeBuilder(registry)(normalizeJson), std::runtime_error);
 }
 
-TEST_F(StageBuilderNormalizeTest, ArrayWrongTypeItem)
+TEST(StageBuilderNormalizeTest, ArrayWrongTypeItem)
 {
+    auto registry = initTest();
     auto normalizeJson = Json {R"([
         ["string", "value"]
 ])"};
 
-    ASSERT_THROW(stageNormalizeBuilder(normalizeJson), std::runtime_error);
+    ASSERT_THROW(getStageNormalizeBuilder(registry)(normalizeJson), std::runtime_error);
 }
 
-TEST_F(StageBuilderNormalizeTest, BuildsCorrectExpression)
+TEST(StageBuilderNormalizeTest, BuildsCorrectExpression)
 {
+    auto registry = initTest();
     auto normalizeJson = Json {R"([
         {"map": [
             {"string": "value"},
@@ -120,7 +119,7 @@ TEST_F(StageBuilderNormalizeTest, BuildsCorrectExpression)
         ]}
 ])"};
 
-    auto expression = stageNormalizeBuilder(normalizeJson);
+    auto expression = getStageNormalizeBuilder(registry)(normalizeJson);
 
     ASSERT_TRUE(expression->isOperation());
     ASSERT_TRUE(expression->isChain());

--- a/src/engine/test/source/builder/builders/stageBuilderOutputs_test.cpp
+++ b/src/engine/test/source/builder/builders/stageBuilderOutputs_test.cpp
@@ -15,21 +15,10 @@ using namespace builder::internals::builders;
 using namespace json;
 using namespace base;
 
-class StageBuilderOutputsTest : public ::testing::Test
+TEST(StageBuilderOutputsTest, Builds)
 {
-protected:
-    void SetUp() override
-    {
-        Registry::registerBuilder(opBuilderFileOutput, "output.file");
-    }
-    void TearDown() override
-    {
-        Registry::clear();
-    }
-};
-
-TEST_F(StageBuilderOutputsTest, Builds)
-{
+    auto registry = std::make_shared<Registry>();
+    registry->registerBuilder(opBuilderFileOutput, "output.file");
     Json doc {R"([
             {"file":
                 {"path": "/tmp/stageOutputsTest1.txt"}
@@ -39,39 +28,47 @@ TEST_F(StageBuilderOutputsTest, Builds)
             }
     ])"};
 
-    ASSERT_NO_THROW(builders::stageBuilderOutputs(doc));
+    ASSERT_NO_THROW(builders::getStageBuilderOutputs(registry)(doc));
 }
 
-TEST_F(StageBuilderOutputsTest, UnexpectedDefinition)
+TEST(StageBuilderOutputsTest, UnexpectedDefinition)
 {
+    auto registry = std::make_shared<Registry>();
+    registry->registerBuilder(opBuilderFileOutput, "output.file");
     Json doc {R"({
             "file":
                 {"path": "/tmp/stageOutputsTest1.txt"}
     })"};
 
-    ASSERT_THROW(builders::stageBuilderOutputs(doc), std::runtime_error);
+    ASSERT_THROW(builders::getStageBuilderOutputs(registry)(doc), std::runtime_error);
 }
 
-TEST_F(StageBuilderOutputsTest, NotFoundOutput)
+TEST(StageBuilderOutputsTest, NotFoundOutput)
 {
+    auto registry = std::make_shared<Registry>();
+    registry->registerBuilder(opBuilderFileOutput, "output.file");
     Json doc {R"([
             {"nonExistingOutput":
                 {"path": "/tmp/stageOutputsTest1.txt"}
             }
     ])"};
 
-    ASSERT_THROW(builders::stageBuilderOutputs(doc), std::runtime_error);
+    ASSERT_THROW(builders::getStageBuilderOutputs(registry)(doc), std::runtime_error);
 }
 
-TEST_F(StageBuilderOutputsTest, EmptyList)
+TEST(StageBuilderOutputsTest, EmptyList)
 {
+    auto registry = std::make_shared<Registry>();
+    registry->registerBuilder(opBuilderFileOutput, "output.file");
     Json doc {R"([])"};
 
-    ASSERT_THROW(builders::stageBuilderOutputs(doc), std::runtime_error);
+    ASSERT_THROW(builders::getStageBuilderOutputs(registry)(doc), std::runtime_error);
 }
 
-TEST_F(StageBuilderOutputsTest, ArrayWrongSizeItem)
+TEST(StageBuilderOutputsTest, ArrayWrongSizeItem)
 {
+    auto registry = std::make_shared<Registry>();
+    registry->registerBuilder(opBuilderFileOutput, "output.file");
     Json doc {R"([
             {"file":
                 {"path": "/tmp/stageOutputsTest1.txt"},
@@ -79,11 +76,13 @@ TEST_F(StageBuilderOutputsTest, ArrayWrongSizeItem)
             }
     ])"};
 
-    ASSERT_THROW(builders::stageBuilderOutputs(doc), std::runtime_error);
+    ASSERT_THROW(builders::getStageBuilderOutputs(registry)(doc), std::runtime_error);
 }
 
-TEST_F(StageBuilderOutputsTest, BuildsCorrectExpression)
+TEST(StageBuilderOutputsTest, BuildsCorrectExpression)
 {
+    auto registry = std::make_shared<Registry>();
+    registry->registerBuilder(opBuilderFileOutput, "output.file");
     Json doc {R"([
             {"file":
                 {"path": "/tmp/stageOutputsTest1.txt"}
@@ -93,7 +92,7 @@ TEST_F(StageBuilderOutputsTest, BuildsCorrectExpression)
             }
     ])"};
 
-    auto expression = builders::stageBuilderOutputs(doc);
+    auto expression = builders::getStageBuilderOutputs(registry)(doc);
 
     ASSERT_TRUE(expression->isOperation());
     ASSERT_TRUE(expression->isBroadcast());

--- a/src/engine/test/source/builder/builders/stageBuilderParse_test.cpp
+++ b/src/engine/test/source/builder/builders/stageBuilderParse_test.cpp
@@ -10,50 +10,48 @@ using namespace builder::internals::builders;
 using namespace json;
 using namespace base;
 
-class StageBuilderParseTest : public ::testing::Test
+TEST(StageBuilderParseTest, Builds)
 {
-protected:
-    void SetUp() override
-    {
-        Registry::registerBuilder(opBuilderLogParser, "parser.logpar");
-    }
-
-    void TearDown() override { Registry::clear(); }
-};
-
-TEST_F(StageBuilderParseTest, Builds)
-{
+    auto registry = std::make_shared<Registry>();
+    registry->registerBuilder(opBuilderLogParser, "parser.logpar");
     Json doc = Json {R"({
             "logpar":[
                 {"~field": "<~field>"}
             ]
     })"};
-    ASSERT_NO_THROW(stageBuilderParse(doc));
+    ASSERT_NO_THROW(getStageBuilderParse(registry)(doc));
 }
 
-TEST_F(StageBuilderParseTest, NotJson)
+TEST(StageBuilderParseTest, NotJson)
 {
-    ASSERT_THROW(stageBuilderParse(std::string {}), std::runtime_error);
+    auto registry = std::make_shared<Registry>();
+    registry->registerBuilder(opBuilderLogParser, "parser.logpar");
+
+    ASSERT_THROW(getStageBuilderParse(registry)(std::string {}), std::runtime_error);
 }
 
-TEST_F(StageBuilderParseTest, NotObject)
+TEST(StageBuilderParseTest, NotObject)
 {
+    auto registry = std::make_shared<Registry>();
+    registry->registerBuilder(opBuilderLogParser, "parser.logpar");
     Json doc = Json {R"([
             {"logpar":[
                 {"~field": "<~field>"}
             ]}
     ])"};
-    ASSERT_THROW(stageBuilderParse(doc), std::runtime_error);
+    ASSERT_THROW(getStageBuilderParse(registry)(doc), std::runtime_error);
 }
 
-TEST_F(StageBuilderParseTest, BuildsCorrectExpression)
+TEST(StageBuilderParseTest, BuildsCorrectExpression)
 {
+    auto registry = std::make_shared<Registry>();
+    registry->registerBuilder(opBuilderLogParser, "parser.logpar");
     Json doc = Json {R"({
             "logpar":[
                 {"~field": "<~field>"}
             ]
     })"};
-    auto expression = stageBuilderParse(doc);
+    auto expression = getStageBuilderParse(registry)(doc);
     ASSERT_TRUE(expression->isOr());
     ASSERT_EQ(expression->getPtr<Operation>()->getOperands().size(), 1);
 }

--- a/src/engine/test/source/builder/environment_test.cpp
+++ b/src/engine/test/source/builder/environment_test.cpp
@@ -21,7 +21,6 @@ class EnvironmentTest : public ::testing::Test
         {
             std::filesystem::remove(outputPath);
         }
-        registerBuilders();
     }
 
     void TearDown() override
@@ -30,7 +29,6 @@ class EnvironmentTest : public ::testing::Test
         {
             std::filesystem::remove(outputPath);
         }
-        Registry::clear();
     }
 };
 
@@ -62,11 +60,13 @@ TEST_F(EnvironmentTest, GetAssets)
 
 TEST_F(EnvironmentTest, OneDecoderEnvironment)
 {
+    auto registry = std::make_shared<Registry>();
+    registerBuilders(registry);
     auto storeRead = std::make_shared<FakeStoreRead>();
-    auto envJson = std::get<json::Json>(
-        storeRead->get(base::Name ("environment/oneDecEnv/version")));
-    ASSERT_NO_THROW(Environment(envJson, storeRead));
-    auto env = Environment(envJson, storeRead);
+    auto envJson =
+        std::get<json::Json>(storeRead->get(base::Name("environment/oneDecEnv/version")));
+    ASSERT_NO_THROW(Environment(envJson, storeRead, registry));
+    auto env = Environment(envJson, storeRead, registry);
     ASSERT_EQ(env.name(), "environment/oneDecEnv/version");
     ASSERT_EQ(env.assets().size(), 1);
     ASSERT_NO_THROW(env.getExpression());
@@ -85,11 +85,13 @@ TEST_F(EnvironmentTest, OneDecoderEnvironment)
 
 TEST_F(EnvironmentTest, OneRuleEnvironment)
 {
+    auto registry = std::make_shared<Registry>();
+    registerBuilders(registry);
     auto storeRead = std::make_shared<FakeStoreRead>();
     auto envJson = std::get<json::Json>(
         storeRead->get(base::Name {"environment/oneRuleEnv/version"}));
-    ASSERT_NO_THROW(Environment(envJson, storeRead));
-    auto env = Environment(envJson, storeRead);
+    ASSERT_NO_THROW(Environment(envJson, storeRead, registry));
+    auto env = Environment(envJson, storeRead, registry);
     ASSERT_EQ(env.name(), "environment/oneRuleEnv/version");
     ASSERT_EQ(env.assets().size(), 1);
     ASSERT_NO_THROW(env.getExpression());
@@ -108,11 +110,13 @@ TEST_F(EnvironmentTest, OneRuleEnvironment)
 
 TEST_F(EnvironmentTest, OneOutputEnvironment)
 {
+    auto registry = std::make_shared<Registry>();
+    registerBuilders(registry);
     auto storeRead = std::make_shared<FakeStoreRead>();
     auto envJson = std::get<json::Json>(
         storeRead->get(base::Name {"environment/oneOutEnv/version"}));
-    ASSERT_NO_THROW(Environment(envJson, storeRead));
-    auto env = Environment(envJson, storeRead);
+    ASSERT_NO_THROW(Environment(envJson, storeRead, registry));
+    auto env = Environment(envJson, storeRead, registry);
     ASSERT_EQ(env.name(), "environment/oneOutEnv/version");
     ASSERT_EQ(env.assets().size(), 1);
     ASSERT_NO_THROW(env.getExpression());
@@ -131,38 +135,43 @@ TEST_F(EnvironmentTest, OneOutputEnvironment)
 
 TEST_F(EnvironmentTest, OneFilterEnvironment)
 {
+    auto registry = std::make_shared<Registry>();
+    registerBuilders(registry);
     auto storeRead = std::make_shared<FakeStoreRead>();
     auto envJson = std::get<json::Json>(
         storeRead->get(base::Name {"environment/oneFilEnv/version"}));
-    ASSERT_THROW(Environment(envJson, storeRead),
-                 std::runtime_error);
+    ASSERT_THROW(Environment(envJson, storeRead, registry), std::runtime_error);
 }
 
 TEST_F(EnvironmentTest, OrphanAsset)
 {
+    auto registry = std::make_shared<Registry>();
+    registerBuilders(registry);
     auto storeRead = std::make_shared<FakeStoreRead>();
     auto envJson = std::get<json::Json>(
         storeRead->get(base::Name {"environment/orphanAssetEnv/version"}));
-    ASSERT_THROW(Environment(envJson, storeRead),
-                 std::runtime_error);
+    ASSERT_THROW(Environment(envJson, storeRead, registry), std::runtime_error);
 }
 
 TEST_F(EnvironmentTest, OrphanFilter)
 {
+    auto registry = std::make_shared<Registry>();
+    registerBuilders(registry);
     auto storeRead = std::make_shared<FakeStoreRead>();
     auto envJson = std::get<json::Json>(
         storeRead->get(base::Name {"environment/orphanFilterEnv/version"}));
-    ASSERT_THROW(Environment(envJson, storeRead),
-                 std::runtime_error);
+    ASSERT_THROW(Environment(envJson, storeRead, registry), std::runtime_error);
 }
 
 TEST_F(EnvironmentTest, CompleteEnvironment)
 {
+    auto registry = std::make_shared<Registry>();
+    registerBuilders(registry);
     auto storeRead = std::make_shared<FakeStoreRead>();
     auto envJson = std::get<json::Json>(
         storeRead->get(base::Name {"environment/completeEnv/version"}));
-    ASSERT_NO_THROW(Environment(envJson, storeRead));
-    auto env = Environment(envJson, storeRead);
+    ASSERT_NO_THROW(Environment(envJson, storeRead, registry));
+    auto env = Environment(envJson, storeRead, registry);
     ASSERT_EQ(env.name(), "environment/completeEnv/version");
     ASSERT_EQ(env.assets().size(), 11);
     ASSERT_NO_THROW(env.getExpression());

--- a/src/engine/test/source/builder/register_test.cpp
+++ b/src/engine/test/source/builder/register_test.cpp
@@ -1,66 +1,63 @@
 #include <gtest/gtest.h>
 
+#include <memory>
+
 #include "builder/register.hpp"
 #include "builder/registry.hpp"
 
 using namespace builder::internals;
 
-class RegisterTest : public ::testing::Test
+TEST(RegisterTest, AllBuildersRegistered)
 {
-protected:
-    void TearDown() override { Registry::clear(); }
-};
-
-TEST_F(RegisterTest, AllBuildersRegistered)
-{
-    ASSERT_NO_THROW(registerBuilders());
+    auto registry = std::make_shared<Registry>();
+    ASSERT_NO_THROW(registerBuilders(registry));
 
     // Check all builders have been registered
-    ASSERT_NO_THROW(Registry::getBuilder("operation.map"));
-    ASSERT_NO_THROW(Registry::getBuilder("operation.condition"));
+    ASSERT_NO_THROW(registry->getBuilder("operation.map"));
+    ASSERT_NO_THROW(registry->getBuilder("operation.condition"));
 
-    ASSERT_NO_THROW(Registry::getBuilder("stage.check"));
-    ASSERT_NO_THROW(Registry::getBuilder("stage.allow"));
-    ASSERT_NO_THROW(Registry::getBuilder("stage.map"));
-    ASSERT_NO_THROW(Registry::getBuilder("stage.normalize"));
+    ASSERT_NO_THROW(registry->getBuilder("stage.check"));
+    ASSERT_NO_THROW(registry->getBuilder("stage.allow"));
+    ASSERT_NO_THROW(registry->getBuilder("stage.map"));
+    ASSERT_NO_THROW(registry->getBuilder("stage.normalize"));
 
-    ASSERT_NO_THROW(Registry::getBuilder("stage.parse"));
-    ASSERT_NO_THROW(Registry::getBuilder("parser.logpar"));
+    ASSERT_NO_THROW(registry->getBuilder("stage.parse"));
+    ASSERT_NO_THROW(registry->getBuilder("parser.logpar"));
 
-    ASSERT_NO_THROW(Registry::getBuilder("stage.outputs"));
-    ASSERT_NO_THROW(Registry::getBuilder("output.file"));
+    ASSERT_NO_THROW(registry->getBuilder("stage.outputs"));
+    ASSERT_NO_THROW(registry->getBuilder("output.file"));
 
-    ASSERT_NO_THROW(Registry::getBuilder("helper.kvdb_get"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.kvdb_get_merge"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.kvdb_match"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.kvdb_not_match"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.kvdb_get"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.kvdb_get_merge"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.kvdb_match"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.kvdb_not_match"));
 
-    ASSERT_NO_THROW(Registry::getBuilder("helper.ef_exists"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.ef_not_exists"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.i_eq"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.i_ne"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.i_gt"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.i_ge"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.i_lt"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.i_le"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.s_eq"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.s_ne"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.s_gt"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.s_ge"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.s_lt"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.s_le"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.r_match"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.r_not_match"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.ip_cidr"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.a_contains"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.ef_exists"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.ef_not_exists"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.i_eq"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.i_ne"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.i_gt"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.i_ge"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.i_lt"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.i_le"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.s_eq"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.s_ne"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.s_gt"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.s_ge"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.s_lt"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.s_le"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.r_match"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.r_not_match"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.ip_cidr"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.a_contains"));
 
-    ASSERT_NO_THROW(Registry::getBuilder("helper.i_calc"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.s_up"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.s_lo"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.s_trim"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.r_ext"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.a_append"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.s_to_array"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.s_hex_to_num"));
-    ASSERT_NO_THROW(Registry::getBuilder("helper.ef_merge"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.i_calc"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.s_up"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.s_lo"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.s_trim"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.r_ext"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.a_append"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.s_to_array"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.s_hex_to_num"));
+    ASSERT_NO_THROW(registry->getBuilder("helper.ef_merge"));
 }

--- a/src/engine/test/source/builder/registry_test.cpp
+++ b/src/engine/test/source/builder/registry_test.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
-#include "registry.hpp"
 #include "baseTypes.hpp"
+#include "registry.hpp"
 
 using namespace builder::internals;
 using namespace base;
@@ -12,79 +12,79 @@ Expression builderDummy(std::any)
     return expression;
 }
 
-class RegistryTest : public ::testing::Test
+TEST(RegistryTest, RegisterBuilder)
 {
-protected:
-    void TearDown() override
-    {
-        Registry::clear();
-    }
-};
-
-TEST_F(RegistryTest, RegisterBuilder)
-{
-    ASSERT_NO_THROW(Registry::registerBuilder(builderDummy, "test"));
+    Registry registry;
+    ASSERT_NO_THROW(registry.registerBuilder(builderDummy, "test"));
 }
 
-TEST_F(RegistryTest, RegisterBuilderMultipleNames)
+TEST(RegistryTest, RegisterBuilderMultipleNames)
 {
-    ASSERT_NO_THROW(Registry::registerBuilder(builderDummy, "test", "test2", "test3"));
+    Registry registry;
+    ASSERT_NO_THROW(registry.registerBuilder(builderDummy, "test", "test2", "test3"));
 }
 
-TEST_F(RegistryTest, RegisterBuilderDuplicateName)
+TEST(RegistryTest, RegisterBuilderDuplicateName)
 {
-    ASSERT_NO_THROW(Registry::registerBuilder(builderDummy, "test"));
-    ASSERT_THROW(Registry::registerBuilder(builderDummy, "test"), std::logic_error);
+    Registry registry;
+    ASSERT_NO_THROW(registry.registerBuilder(builderDummy, "test"));
+    ASSERT_THROW(registry.registerBuilder(builderDummy, "test"), std::logic_error);
 }
 
-TEST_F(RegistryTest, GetBuilder)
+TEST(RegistryTest, GetBuilder)
 {
-    ASSERT_NO_THROW(Registry::registerBuilder(builderDummy, "test"));
-    ASSERT_NO_THROW(Registry::getBuilder("test"));
+    Registry registry;
+    ASSERT_NO_THROW(registry.registerBuilder(builderDummy, "test"));
+    ASSERT_NO_THROW(registry.getBuilder("test"));
 }
 
-TEST_F(RegistryTest, GetBuilderMultipleNames)
+TEST(RegistryTest, GetBuilderMultipleNames)
 {
-    ASSERT_NO_THROW(Registry::registerBuilder(builderDummy, "test", "test2", "test3"));
-    ASSERT_NO_THROW(Registry::getBuilder("test"));
-    ASSERT_NO_THROW(Registry::getBuilder("test2"));
-    ASSERT_NO_THROW(Registry::getBuilder("test3"));
+    Registry registry;
+    ASSERT_NO_THROW(registry.registerBuilder(builderDummy, "test", "test2", "test3"));
+    ASSERT_NO_THROW(registry.getBuilder("test"));
+    ASSERT_NO_THROW(registry.getBuilder("test2"));
+    ASSERT_NO_THROW(registry.getBuilder("test3"));
 }
 
-TEST_F(RegistryTest, GetBuilderNotRegistered)
+TEST(RegistryTest, GetBuilderNotRegistered)
 {
-    ASSERT_THROW(Registry::getBuilder("test"), std::runtime_error);
+    Registry registry;
+    ASSERT_THROW(registry.getBuilder("test"), std::runtime_error);
 }
 
-TEST_F(RegistryTest, Clear)
+TEST(RegistryTest, Clear)
 {
-    ASSERT_NO_THROW(Registry::registerBuilder(builderDummy, "test"));
-    ASSERT_NO_THROW(Registry::clear());
-    ASSERT_THROW(Registry::getBuilder("test"), std::runtime_error);
+    Registry registry;
+    ASSERT_NO_THROW(registry.registerBuilder(builderDummy, "test"));
+    ASSERT_NO_THROW(registry.clear());
+    ASSERT_THROW(registry.getBuilder("test"), std::runtime_error);
 }
 
-TEST_F(RegistryTest, ClearTwice)
+TEST(RegistryTest, ClearTwice)
 {
-    ASSERT_NO_THROW(Registry::clear());
-    ASSERT_NO_THROW(Registry::clear());
+    Registry registry;
+    ASSERT_NO_THROW(registry.clear());
+    ASSERT_NO_THROW(registry.clear());
 }
 
-TEST_F(RegistryTest, UseCase)
+TEST(RegistryTest, UseCase)
 {
-    ASSERT_NO_THROW(Registry::registerBuilder(builderDummy, "test"));
+    Registry registry;
+    ASSERT_NO_THROW(registry.registerBuilder(builderDummy, "test"));
     Builder builder;
-    ASSERT_NO_THROW(builder = Registry::getBuilder("test"));
+    ASSERT_NO_THROW(builder = registry.getBuilder("test"));
     ASSERT_NO_THROW(builder(std::any {}));
 
-    ASSERT_THROW(Registry::getBuilder("test2"), std::runtime_error);
+    ASSERT_THROW(registry.getBuilder("test2"), std::runtime_error);
 
-    ASSERT_NO_THROW(Registry::registerBuilder(builderDummy, "test2"));
-    ASSERT_NO_THROW(builder = Registry::getBuilder("test2"));
+    ASSERT_NO_THROW(registry.registerBuilder(builderDummy, "test2"));
+    ASSERT_NO_THROW(builder = registry.getBuilder("test2"));
     ASSERT_NO_THROW(builder(std::any {}));
 
-    ASSERT_THROW(Registry::registerBuilder(builderDummy, "test"), std::logic_error);
+    ASSERT_THROW(registry.registerBuilder(builderDummy, "test"), std::logic_error);
 
-    ASSERT_NO_THROW(Registry::clear());
-    ASSERT_THROW(Registry::getBuilder("test"), std::runtime_error);
-    ASSERT_THROW(Registry::getBuilder("test2"), std::runtime_error);
+    ASSERT_NO_THROW(registry.clear());
+    ASSERT_THROW(registry.getBuilder("test"), std::runtime_error);
+    ASSERT_THROW(registry.getBuilder("test2"), std::runtime_error);
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #15275 |

A simple context function wrapper is used to pass dependencies to the builders.

Changes:
- The builder Registry is no longer a singleton and it is injected.
- The kvdb manager is no longer a singleton and it is injected.

## Checks
- [x] Tests
- [x] Documentation -> [here](https://docs.google.com/document/d/125d8tpj192MNdggLcNjk_R0tQWEuhjBEmtjONHbUkHo/edit#heading=h.srmipnc5vku7)
- [ ] QA Validattion