### PR TITLE
Adds missing wdb_finalize function calls to some vuln-detector module functions

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1190,6 +1190,7 @@ int wm_vuldet_fill_report_nvd_cve_info(sqlite3 *db, sqlite3_stmt *stmt, vu_repor
         w_strdup(published, report->published);
         w_strdup(updated, report->updated);
     } else if (SQLITE_DONE != step_result){
+        wdb_finalize(stmt);
         return SQLITE_ERROR;
     }
 
@@ -2285,12 +2286,14 @@ int wm_vuldet_oval_prescan_SUSE_dependencies(sqlite3 *db, scan_agent *agents_it)
         ret = wm_checks_package_vulnerability(version, operation, operation_value, VER_TYPE_RPM);
         if (ret != VU_NOT_VULNERABLE && ret != OS_INVALID) {
             if (wm_vuldet_prepare(db, vu_queries[VU_UPDATE_DEPS_FLAG], -1, &stmt_update, NULL) != SQLITE_OK) {
+                wdb_finalize(stmt);
                 return wm_vuldet_sql_error(db, stmt_update);
             }
             sqlite3_bind_text(stmt_update, 1, pkg_name, -1, NULL);
             sqlite3_bind_text(stmt_update, 2, vu_feed_tag[agents_it->dist_ver], -1, NULL);
             sqlite3_bind_text(stmt_update, 3, operation_value, -1, NULL);
             if (wm_vuldet_step(stmt_update) != SQLITE_DONE) {
+                wdb_finalize(stmt);
                 return wm_vuldet_sql_error(db, stmt_update);
             }
             mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_DEP_FLAG, pkg_name, atoi(agents_it->agent_id), version, operation, operation_value);


### PR DESCRIPTION

|Related issue|
|---|
|#15323|


## Description

This PR adds the missing wdb_finalize function calls reported in issue [15323](https://github.com/wazuh/wazuh/issues/15323), avoiding memory leaks.

The functions involved are the following:

- wm_vuldet_fill_report_nvd_cve_info
- wm_vuldet_oval_prescan_SUSE_dependencies 


## Tests


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
