### PR TITLE
Fix agent's reported IP address

### DIFF
--- a/src/unit_tests/wazuh_modules/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/CMakeLists.txt
@@ -25,3 +25,4 @@ endif()
 
 add_subdirectory(github)
 add_subdirectory(office365)
+add_subdirectory(control)

--- a/src/unit_tests/wazuh_modules/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/CMakeLists.txt
@@ -23,6 +23,10 @@ if(${TARGET} STREQUAL "server")
   add_subdirectory(agent_upgrade)
 endif()
 
+if(NOT ${TARGET} STREQUAL "winagent")
+  add_subdirectory(control)
+endif()
+
 add_subdirectory(github)
 add_subdirectory(office365)
-add_subdirectory(control)
+

--- a/src/unit_tests/wazuh_modules/control/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/control/CMakeLists.txt
@@ -1,0 +1,79 @@
+# Copyright (C) 2015, Wazuh Inc.
+#
+# This program is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
+
+#include wrappers
+include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
+
+# Tests list and flags
+list(APPEND tests_names "test_wm_control")
+list(APPEND tests_flags "-Wl,--wrap,sysinfo_networks -Wl,--wrap,sysinfo_free_result ${DEBUG_OP_WRAPPERS}")
+list(APPEND use_shared_libs 1)
+
+
+# Generate wazuh modules library
+file(GLOB control ../../../wazuh_modules/*.o)
+list(REMOVE_ITEM control ../../../wazuh_modules/main.o)
+
+add_library(CONTROL_O STATIC ${control})
+
+set_source_files_properties(
+  ${control}
+  PROPERTIES
+  EXTERNAL_OBJECT true
+  GENERATED true
+  )
+
+set_target_properties(
+  CONTROL_O
+  PROPERTIES
+  LINKER_LANGUAGE C
+  )
+
+target_link_libraries(CONTROL_O ${WAZUHLIB} ${WAZUHEXT} -lpthread)
+
+
+# Compiling tests
+list(LENGTH tests_names count)
+math(EXPR count "${count} - 1")
+foreach(counter RANGE ${count})
+    list(GET tests_names ${counter} test_name)
+    list(GET tests_flags ${counter} test_flags)
+    list(GET use_shared_libs ${counter} use_libs)
+
+    if(use_libs EQUAL "1")
+      add_executable(${test_name} ${test_name}.c ${shared_libs})
+    else ()
+      add_executable(${test_name} ${test_name}.c)
+    endif()
+
+    if(${TARGET} STREQUAL "server")
+        target_link_libraries(
+            ${test_name}
+            ${WAZUHLIB}
+            ${WAZUHEXT}
+            CONTROL_O
+            -lcmocka
+            -ldl
+            -fprofile-arcs
+            -ftest-coverage
+        )
+    else()
+        target_link_libraries(
+            ${test_name}
+            ${TEST_DEPS}
+        )
+    endif()
+
+
+    if(NOT test_flags STREQUAL " ")
+        target_link_libraries(
+            ${test_name}
+            ${test_flags}
+        )
+    endif()
+    add_test(NAME ${test_name} COMMAND ${test_name})
+endforeach()

--- a/src/unit_tests/wazuh_modules/control/test_wm_control.c
+++ b/src/unit_tests/wazuh_modules/control/test_wm_control.c
@@ -1,0 +1,304 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include "../../wrappers/wazuh/data_provider/sysInfo_wrappers.h"
+#include "../../../data_provider/include/sysInfo.h"
+#include "../../../wazuh_modules/wm_control.h"
+
+extern sysinfo_networks_func sysinfo_network_ptr;
+extern sysinfo_free_result_func sysinfo_free_result_ptr;
+
+static void test_wm_control_getPrimaryIP_no_sysinfo_network(void ** state) {
+    sysinfo_network_ptr = NULL;
+
+    char * ip = getPrimaryIP();
+
+    assert_null(ip);
+}
+
+static void test_wm_control_getPrimaryIP_no_sysinfo_free(void ** state) {
+    sysinfo_network_ptr = (int (*)(cJSON **)) 1;
+    sysinfo_free_result_ptr = NULL;
+
+    char * ip = getPrimaryIP();
+
+    assert_null(ip);
+}
+
+static void test_wm_control_getPrimaryIP_sysinfo_network_return_error(void ** state) {
+    sysinfo_network_ptr = __wrap_sysinfo_networks;
+    sysinfo_free_result_ptr = __wrap_sysinfo_free_result;
+    cJSON * networks = NULL;
+
+    will_return(__wrap_sysinfo_networks, networks);
+    will_return(__wrap_sysinfo_networks, 1234);
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:control");
+    expect_string(__wrap__mterror, formatted_msg, "Unable to get system network information. Error code: 1234.");
+
+    char * ip = getPrimaryIP();
+
+    assert_null(ip);
+}
+static void test_wm_control_getPrimaryIP_sysinfo_network_no_object(void ** state) {
+    sysinfo_network_ptr = __wrap_sysinfo_networks;
+    sysinfo_free_result_ptr = __wrap_sysinfo_free_result;
+    cJSON * networks = NULL;
+
+    will_return(__wrap_sysinfo_networks, networks);
+    will_return(__wrap_sysinfo_networks, 0);
+
+    char * ip = getPrimaryIP();
+
+    assert_null(ip);
+}
+
+static void test_wm_control_getPrimaryIP_sysinfo_network_no_iface(void ** state) {
+    sysinfo_network_ptr = __wrap_sysinfo_networks;
+    sysinfo_free_result_ptr = __wrap_sysinfo_free_result;
+    cJSON * networks = cJSON_Parse("{}");
+
+    will_return(__wrap_sysinfo_networks, networks);
+    will_return(__wrap_sysinfo_networks, 0);
+    will_return(__wrap_sysinfo_free_result, networks);
+
+    char * ip = getPrimaryIP();
+
+    assert_null(ip);
+
+    cJSON_Delete(networks);
+}
+
+static void test_wm_control_getPrimaryIP_sysinfo_network_no_iface_array(void ** state) {
+    sysinfo_network_ptr = __wrap_sysinfo_networks;
+    sysinfo_free_result_ptr = __wrap_sysinfo_free_result;
+    cJSON * networks = cJSON_Parse("{\"iface\":{}}");
+
+    will_return(__wrap_sysinfo_networks, networks);
+    will_return(__wrap_sysinfo_networks, 0);
+    will_return(__wrap_sysinfo_free_result, networks);
+
+    char * ip = getPrimaryIP();
+
+    assert_null(ip);
+
+    cJSON_Delete(networks);
+}
+static void test_wm_control_getPrimaryIP_sysinfo_network_iface_empty_array(void ** state) {
+    sysinfo_network_ptr = __wrap_sysinfo_networks;
+    sysinfo_free_result_ptr = __wrap_sysinfo_free_result;
+    cJSON * networks = cJSON_Parse("{\"iface\":[]}");
+
+    will_return(__wrap_sysinfo_networks, networks);
+    will_return(__wrap_sysinfo_networks, 0);
+    will_return(__wrap_sysinfo_free_result, networks);
+
+    char * ip = getPrimaryIP();
+
+    assert_null(ip);
+
+    cJSON_Delete(networks);
+}
+
+static void test_wm_control_getPrimaryIP_sysinfo_network_iface_no_gateway(void ** state) {
+    sysinfo_network_ptr = __wrap_sysinfo_networks;
+    sysinfo_free_result_ptr = __wrap_sysinfo_free_result;
+    cJSON * networks = cJSON_Parse("{\"iface\":[{\"name\":\"eth0\"}]}");
+
+    will_return(__wrap_sysinfo_networks, networks);
+    will_return(__wrap_sysinfo_networks, 0);
+    will_return(__wrap_sysinfo_free_result, networks);
+
+    char * ip = getPrimaryIP();
+
+    assert_null(ip);
+
+    cJSON_Delete(networks);
+}
+
+static void test_wm_control_getPrimaryIP_sysinfo_network_iface_invalid_gateway_type(void ** state) {
+    sysinfo_network_ptr = __wrap_sysinfo_networks;
+    sysinfo_free_result_ptr = __wrap_sysinfo_free_result;
+    cJSON * networks = cJSON_Parse("{\"iface\":[{\"name\":\"eth0\",\"gateway\":1234}]}");
+
+    will_return(__wrap_sysinfo_networks, networks);
+    will_return(__wrap_sysinfo_networks, 0);
+    will_return(__wrap_sysinfo_free_result, networks);
+
+    char * ip = getPrimaryIP();
+
+    assert_null(ip);
+
+    cJSON_Delete(networks);
+}
+
+static void test_wm_control_getPrimaryIP_sysinfo_network_iface_empty_gateway(void ** state) {
+    sysinfo_network_ptr = __wrap_sysinfo_networks;
+    sysinfo_free_result_ptr = __wrap_sysinfo_free_result;
+    cJSON * networks = cJSON_Parse("{\"iface\":[{\"name\":\"eth0\",\"gateway\":\" \"}]}");
+
+    will_return(__wrap_sysinfo_networks, networks);
+    will_return(__wrap_sysinfo_networks, 0);
+    will_return(__wrap_sysinfo_free_result, networks);
+
+    char * ip = getPrimaryIP();
+
+    assert_null(ip);
+
+    cJSON_Delete(networks);
+}
+
+static void test_wm_control_getPrimaryIP_sysinfo_network_iface_ipv6_gateway_ipv6_address(void ** state) {
+    sysinfo_network_ptr = __wrap_sysinfo_networks;
+    sysinfo_free_result_ptr = __wrap_sysinfo_free_result;
+    cJSON * networks = cJSON_Parse("{\"iface\":[{\"name\":\"eth0\",\"gateway\":\"fe80::\",\"IPv6\":[{\"address\":"
+                                   "\"fe80::a00:27ff:fee0:d046\"}]}]}");
+
+    will_return(__wrap_sysinfo_networks, networks);
+    will_return(__wrap_sysinfo_networks, 0);
+    will_return(__wrap_sysinfo_free_result, networks);
+
+    char * ip = getPrimaryIP();
+
+    assert_string_equal(ip, "FE80:0000:0000:0000:0A00:27FF:FEE0:D046");
+
+    os_free(ip);
+    cJSON_Delete(networks);
+}
+
+static void test_wm_control_getPrimaryIP_sysinfo_network_iface_ipv6_gateway_ipv4_address(void ** state) {
+    sysinfo_network_ptr = __wrap_sysinfo_networks;
+    sysinfo_free_result_ptr = __wrap_sysinfo_free_result;
+    cJSON * networks = cJSON_Parse(
+        "{\"iface\":[{\"name\":\"eth0\",\"gateway\":\"fe80::\",\"IPv4\":[{\"address\":\"192.168.1.10\"}]}]}");
+
+    will_return(__wrap_sysinfo_networks, networks);
+    will_return(__wrap_sysinfo_networks, 0);
+    will_return(__wrap_sysinfo_free_result, networks);
+
+    char * ip = getPrimaryIP();
+
+    assert_string_equal(ip, "192.168.1.10");
+
+    os_free(ip);
+    cJSON_Delete(networks);
+}
+
+static void test_wm_control_getPrimaryIP_sysinfo_network_iface_ipv4_gateway_ipv6_address(void ** state) {
+    sysinfo_network_ptr = __wrap_sysinfo_networks;
+    sysinfo_free_result_ptr = __wrap_sysinfo_free_result;
+    cJSON * networks = cJSON_Parse("{\"iface\":[{\"name\":\"eth0\",\"gateway\":\"192.168.1.1\",\"IPv6\":[{\"address\":"
+                                   "\"fe80::a00:27ff:fee0:d046\"}]}]}");
+
+    will_return(__wrap_sysinfo_networks, networks);
+    will_return(__wrap_sysinfo_networks, 0);
+    will_return(__wrap_sysinfo_free_result, networks);
+
+    char * ip = getPrimaryIP();
+
+    assert_string_equal(ip, "FE80:0000:0000:0000:0A00:27FF:FEE0:D046");
+
+    os_free(ip);
+    cJSON_Delete(networks);
+}
+
+static void test_wm_control_getPrimaryIP_sysinfo_network_iface_ipv4_gateway_ipv4_address(void ** state) {
+    sysinfo_network_ptr = __wrap_sysinfo_networks;
+    sysinfo_free_result_ptr = __wrap_sysinfo_free_result;
+    cJSON * networks = cJSON_Parse(
+        "{\"iface\":[{\"name\":\"eth0\",\"gateway\":\"192.168.1.1\",\"IPv4\":[{\"address\":\"192.168.1.10\"}]}]}");
+
+    will_return(__wrap_sysinfo_networks, networks);
+    will_return(__wrap_sysinfo_networks, 0);
+    will_return(__wrap_sysinfo_free_result, networks);
+
+    char * ip = getPrimaryIP();
+
+    assert_string_equal(ip, "192.168.1.10");
+
+    os_free(ip);
+    cJSON_Delete(networks);
+}
+
+static void test_wm_control_getPrimaryIP_sysinfo_network_iface_valid_gateway_no_address_array(void ** state) {
+    sysinfo_network_ptr = __wrap_sysinfo_networks;
+    sysinfo_free_result_ptr = __wrap_sysinfo_free_result;
+    cJSON * networks = cJSON_Parse("{\"iface\":[{\"name\":\"eth0\",\"gateway\":\"192.168.1.1\"}]}");
+
+    will_return(__wrap_sysinfo_networks, networks);
+    will_return(__wrap_sysinfo_networks, 0);
+    will_return(__wrap_sysinfo_free_result, networks);
+
+    char * ip = getPrimaryIP();
+
+    assert_null(ip);
+
+    cJSON_Delete(networks);
+}
+
+static void test_wm_control_getPrimaryIP_sysinfo_network_iface_valid_gateway_address_invalid_type(void ** state) {
+    sysinfo_network_ptr = __wrap_sysinfo_networks;
+    sysinfo_free_result_ptr = __wrap_sysinfo_free_result;
+    cJSON * networks =
+        cJSON_Parse("{\"iface\":[{\"name\":\"eth0\",\"gateway\":\"192.168.1.1\",\"IPv4\":[{\"address\":1234}]}]}");
+
+    will_return(__wrap_sysinfo_networks, networks);
+    will_return(__wrap_sysinfo_networks, 0);
+    will_return(__wrap_sysinfo_free_result, networks);
+
+    char * ip = getPrimaryIP();
+
+    assert_null(ip);
+
+    cJSON_Delete(networks);
+}
+
+static void test_wm_control_getPrimaryIP_sysinfo_network_iface_valid_gateway_multiple_address_array(void ** state) {
+    sysinfo_network_ptr = __wrap_sysinfo_networks;
+    sysinfo_free_result_ptr = __wrap_sysinfo_free_result;
+    cJSON * networks = cJSON_Parse("{\"iface\":[{\"name\":\"eth0\",\"gateway\":\"192.168.1.1\",\"IPv4\":[{\"address\":"
+                                   "\"192.168.1.10\"},{\"address\":\"192.168.1.11\"}]}]}");
+
+    will_return(__wrap_sysinfo_networks, networks);
+    will_return(__wrap_sysinfo_networks, 0);
+    will_return(__wrap_sysinfo_free_result, networks);
+
+    char * ip = getPrimaryIP();
+
+    assert_string_equal(ip, "192.168.1.10");
+
+    os_free(ip);
+    cJSON_Delete(networks);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_wm_control_getPrimaryIP_no_sysinfo_network),
+        cmocka_unit_test(test_wm_control_getPrimaryIP_no_sysinfo_free),
+        cmocka_unit_test(test_wm_control_getPrimaryIP_sysinfo_network_return_error),
+        cmocka_unit_test(test_wm_control_getPrimaryIP_sysinfo_network_no_object),
+        cmocka_unit_test(test_wm_control_getPrimaryIP_sysinfo_network_no_iface),
+        cmocka_unit_test(test_wm_control_getPrimaryIP_sysinfo_network_no_iface_array),
+        cmocka_unit_test(test_wm_control_getPrimaryIP_sysinfo_network_iface_empty_array),
+        cmocka_unit_test(test_wm_control_getPrimaryIP_sysinfo_network_iface_no_gateway),
+        cmocka_unit_test(test_wm_control_getPrimaryIP_sysinfo_network_iface_invalid_gateway_type),
+        cmocka_unit_test(test_wm_control_getPrimaryIP_sysinfo_network_iface_empty_gateway),
+        cmocka_unit_test(test_wm_control_getPrimaryIP_sysinfo_network_iface_ipv6_gateway_ipv6_address),
+        cmocka_unit_test(test_wm_control_getPrimaryIP_sysinfo_network_iface_ipv6_gateway_ipv4_address),
+        cmocka_unit_test(test_wm_control_getPrimaryIP_sysinfo_network_iface_ipv4_gateway_ipv6_address),
+        cmocka_unit_test(test_wm_control_getPrimaryIP_sysinfo_network_iface_ipv4_gateway_ipv4_address),
+        cmocka_unit_test(test_wm_control_getPrimaryIP_sysinfo_network_iface_valid_gateway_no_address_array),
+        cmocka_unit_test(test_wm_control_getPrimaryIP_sysinfo_network_iface_valid_gateway_address_invalid_type),
+        cmocka_unit_test(test_wm_control_getPrimaryIP_sysinfo_network_iface_valid_gateway_multiple_address_array)};
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/win32/test_win_utils.c
+++ b/src/unit_tests/win32/test_win_utils.c
@@ -37,6 +37,14 @@ int mock_sysinfo_networks_func(cJSON **object) {
 
     static const char *ip_update_success =
     "{ \"iface\": [ { \"gateway\":\"mock_gateway\", \"IPv4\": [ { \"address\":\"111.222.333.444\" } ] } ] }";
+    static const char *ipv6_gw_ipv4_addr_update_success =
+    "{ \"iface\": [ { \"gateway\":\"fe80::\", \"IPv4\": [ { \"address\":\"111.222.333.444\" } ] } ] }";
+    static const char *ipv6_gw_ipv6_addr_update_success =
+    "{ \"iface\": [ { \"gateway\":\"fe80::\", \"IPv6\": [ { \"address\":\"fe80::a00:27ff:fee0:d046\" } ] } ] }";
+    static const char *ipv4_gw_ipv4_addr_update_success =
+    "{ \"iface\": [ { \"gateway\":\"192.168.1.1\", \"IPv4\": [ { \"address\":\"111.222.333.444\" } ] } ] }";
+    static const char *ipv4_gw_ipv6_addr_update_success =
+    "{ \"iface\": [ { \"gateway\":\"192.168.1.1\", \"IPv6\": [ { \"address\":\"fe80::a00:27ff:fee0:d046\" } ] } ] }";
     static const char *iface_bad_name = "{\"iface_fail\":[]}";
     static const char *iface_no_elements = "{\"iface\":[]";
     static const char *gateway_unknown = "{ \"iface\": [ { \"gateway\":\"unknown\" } ] }";
@@ -54,6 +62,18 @@ int mock_sysinfo_networks_func(cJSON **object) {
         break;
     case 4:
         json_string = gateway_unknown;
+        break;
+    case 5:
+        json_string = ipv6_gw_ipv4_addr_update_success;
+        break;
+    case 6:
+        json_string = ipv6_gw_ipv6_addr_update_success;
+        break;
+    case 7:
+        json_string = ipv4_gw_ipv4_addr_update_success;
+        break;
+    case  8:
+        json_string = ipv4_gw_ipv6_addr_update_success;
         break;
     }
 
@@ -87,6 +107,58 @@ static void test_get_agent_ip_update_ip_success(void **state) {
     agent_ip = get_agent_ip();
 
     assert_string_equal(agent_ip, address);
+}
+
+static void test_get_agent_ip_update_ipv6_gateway_ipv6_success(void ** state) {
+
+    const char * address = {"FE80:0000:0000:0000:0A00:27FF:FEE0:D046"};
+    time_mock_value += TIME_INCREMENT + 1;
+    error_code_sysinfo_network = 0;
+    test_case_selector = 6;
+
+    char * agent_ip = = get_agent_ip();
+
+    assert_string_equal(agent_ip, address);
+    os_free(agent_ip);
+}
+
+static void test_get_agent_ip_update_ipv6_gateway_ipv4_success(void ** state) {
+
+    const char * address = {"111.222.333.444"};
+    time_mock_value += TIME_INCREMENT + 1;
+    error_code_sysinfo_network = 0;
+    test_case_selector = 5;
+
+    char * agent_ip = get_agent_ip();
+
+    assert_string_equal(agent_ip, address);
+    os_free(agent_ip);
+}
+
+static void test_get_agent_ip_update_ipv4_gateway_ipv4_success(void ** state) {
+
+    const char * address = {"111.222.333.444"};
+    time_mock_value += TIME_INCREMENT + 1;
+    error_code_sysinfo_network = 0;
+    test_case_selector = 7;
+
+    char * agent_ip = get_agent_ip();
+
+    assert_string_equal(agent_ip, address);
+    os_free(agent_ip);
+}
+
+static void test_get_agent_ip_update_ipv4_gateway_ipv6_success(void ** state) {
+
+    const char * address = {"FE80:0000:0000:0000:0A00:27FF:FEE0:D046"};
+    time_mock_value += TIME_INCREMENT + 1;
+    error_code_sysinfo_network = 0;
+    test_case_selector = 8;
+
+    char * agent_ip = get_agent_ip();
+
+    assert_string_equal(agent_ip, address);
+    os_free(agent_ip);
 }
 
 static void test_get_agent_ip_sysinfo_error(void **state) {
@@ -241,6 +313,10 @@ int main(void) {
         cmocka_unit_test(test_get_agent_ip_update_ip_success), cmocka_unit_test(test_get_agent_ip_sysinfo_error),
         cmocka_unit_test(test_get_agent_ip_iface_bad_name),    cmocka_unit_test(test_get_agent_ip_iface_no_elements),
         cmocka_unit_test(test_get_agent_ip_gateway_unknown),   cmocka_unit_test(test_get_agent_ip_no_update),
+        cmocka_unit_test(test_get_agent_ip_update_ipv6_gateway_ipv6_success),
+        cmocka_unit_test(test_get_agent_ip_update_ipv6_gateway_ipv4_success),
+        cmocka_unit_test(test_get_agent_ip_update_ipv4_gateway_ipv4_success),
+        cmocka_unit_test(test_get_agent_ip_update_ipv4_gateway_ipv6_success),
         cmocka_unit_test(test_SendMSGAction_mutex_abandoned), cmocka_unit_test(test_SendMSGAction_mutex_error),
         cmocka_unit_test(test_SendMSGAction_non_escape), cmocka_unit_test(test_SendMSGAction_escape),
         cmocka_unit_test(test_SendMSGAction_multi_escape),

--- a/src/unit_tests/win32/test_win_utils.c
+++ b/src/unit_tests/win32/test_win_utils.c
@@ -116,7 +116,7 @@ static void test_get_agent_ip_update_ipv6_gateway_ipv6_success(void ** state) {
     error_code_sysinfo_network = 0;
     test_case_selector = 6;
 
-    char * agent_ip = = get_agent_ip();
+    char * agent_ip = get_agent_ip();
 
     assert_string_equal(agent_ip, address);
     os_free(agent_ip);

--- a/src/unit_tests/wrappers/wazuh/data_provider/sysInfo_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/data_provider/sysInfo_wrappers.h
@@ -11,7 +11,7 @@
 #ifndef SYSINFO_WRAPPERS_H
 #define SYSINFO_WRAPPERS_H
 
-#include "sysInfo.h"
+#include "cJSON.h"
 
 int __wrap_sysinfo_hardware(cJSON** js_result);
 int __wrap_sysinfo_packages(cJSON** js_result);

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -9,6 +9,13 @@
  * Foundation.
  */
 
+#ifdef WAZUH_UNIT_TESTING
+// Remove static qualifier when unit testing
+#define STATIC
+#else
+#define STATIC static
+#endif
+
 #if defined (__linux__) || defined (__MACH__) || defined (sun) || defined(FreeBSD) || defined(OpenBSD)
 #include "wm_control.h"
 #include "sysInfo.h"
@@ -28,9 +35,9 @@ const wm_context WM_CONTROL_CONTEXT = {
     NULL,
     NULL
 };
-void *sysinfo_module = NULL;
-sysinfo_networks_func sysinfo_network_ptr = NULL;
-sysinfo_free_result_func sysinfo_free_result_ptr = NULL;
+STATIC void *sysinfo_module = NULL;
+STATIC sysinfo_networks_func sysinfo_network_ptr = NULL;
+STATIC sysinfo_free_result_func sysinfo_free_result_ptr = NULL;
 
 /**
  * @brief Get the Primary IP address
@@ -61,10 +68,24 @@ char* getPrimaryIP(){
                         }
                         cJSON *gateway = cJSON_GetObjectItem(element, "gateway");
                         if (gateway && cJSON_GetStringValue(gateway) && 0 != strcmp(gateway->valuestring," ")) {
-                            const cJSON *ip = cJSON_GetObjectItem(element, "IPv6");
-                            if (!ip) {
-                                ip = cJSON_GetObjectItem(element, "IPv4");
-                                if (!ip) {
+                            
+                            const char * primaryIpType = NULL;
+                            const char * secondaryIpType = NULL;
+
+                            if (strchr(gateway->valuestring, ':') != NULL) {
+                                //Assume gateway is IPv6. IPv6 IP will be prioritary
+                                primaryIpType = "IPv6";
+                                secondaryIpType = "IPv4";
+                            } else {
+                                //Assume gateway is IPv4. IPv4 IP will be prioritary
+                                primaryIpType = "IPv4";
+                                secondaryIpType = "IPv6";
+                            }
+
+                            const cJSON * ip = cJSON_GetObjectItem(element, primaryIpType);
+                            if (NULL == ip) {
+                                ip = cJSON_GetObjectItem(element, secondaryIpType);
+                                if (NULL == ip) {
                                     continue;
                                 }
                             }

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -402,9 +402,23 @@ char *get_agent_ip()
                         }
                         cJSON *gateway = cJSON_GetObjectItem(element, "gateway");
                         if(gateway && cJSON_GetStringValue(gateway) && 0 != strcmp(gateway->valuestring, " ")) {
-                            const cJSON *ip = cJSON_GetObjectItem(element, "IPv6");
+
+                            const char * primaryIpType = NULL;
+                            const char * secondaryIpType = NULL;
+
+                            if (strchr(gateway->valuestring, ':') != NULL) {
+                                // Assume gateway is IPv6. IPv6 IP will be prioritary
+                                primaryIpType = "IPv6";
+                                secondaryIpType = "IPv4";
+                            } else {
+                                // Assume gateway is IPv4. IPv4 IP will be prioritary
+                                primaryIpType = "IPv4";
+                                secondaryIpType = "IPv6";
+                            }
+
+                            const cJSON * ip = cJSON_GetObjectItem(element, primaryIpType);
                             if (!ip) {
-                                ip = cJSON_GetObjectItem(element, "IPv4");
+                                ip = cJSON_GetObjectItem(element, secondaryIpType);
                                 if (!ip) {
                                     continue;
                                 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #14988|

## Description

This PR aims to solve #14988 by changing the approach used to retrieve the agent's IP address.

Agent's IP is sent by agent every [`notify_time`](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/client.html#notify-time) seconds within other information like `merge.mg` hash. This information is stored in `global.db` and could be retrieved from different ways

- Wazuh Dashboard
- Wazuh API
- Wazuh CLI tools

Agent IP is retrieved in the next ways depending on the OS
- Linux, Solaris, FreeBSD, OpenBSD: `wazuh-agentd` request such information to `wazuh-modulesd`, in specific to `control` module
- Windows: since there's only one process, information is retrieved internally using `win_utils` function
- Others (HP-UX, AIX)

## Change proposal

Currently, Wazuh picks the first address of the interface that has the gateway (no matter the IP type of this), having IPv6 addresses priority over IPv4, leading to unwanted behavior.

The proposed fix implements the next approach
- IPv4 gateway? try to get any listed IPv4 address. If there's no IPv4, try any IPv6 address listed
- IPv6 gateway? try to get any listed address. If there's no IPv6, try any IPv4 address listed

In cases like no gateway, no IP addresses, etc, behavior it's still the same

NOTE: currently there's no Sysinfo support for IPv6 gateways (feature request [here](https://github.com/wazuh/wazuh/issues/11614) and [here](https://github.com/wazuh/wazuh/issues/11615)). The current fix contemplates this scenario for the future



## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [x] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)
- [ ] Stress test for affected components