### PR TITLE
Fix auditd decoder when name_format setting is not 'none' in auditd.conf

### DIFF
--- a/ruleset/decoders/0040-auditd_decoders.xml
+++ b/ruleset/decoders/0040-auditd_decoders.xml
@@ -6,8 +6,21 @@
   Audit decoders (logformat must be "audit")
 -->
 
+<!--
+    By default, /etc/audit/auditd.conf has the setting:
+      name_format = none
+    
+    Then auditd log lines start with:
+      type=xxx
+
+    When /etc/audit/auditd.conf name_format setting is something different:
+      name_format = hostname
+
+    Then auditd log lines start with:
+      node=hostname.domain.tld type=xxx
+-->
 <decoder name="auditd">
-  <prematch>^type=</prematch>
+  <prematch>^type=|^node=\S+ type=</prematch>
 </decoder>
 
 <!--

--- a/ruleset/testing/tests/auditd.ini
+++ b/ruleset/testing/tests/auditd.ini
@@ -197,3 +197,9 @@ log 1 pass = type=ACCT_UNLOCK msg=audit(1630937871.591:892): pid=4172 uid=0 auid
 rule = 80794
 alert = 8
 decoder = auditd
+
+[Auditd: Matches when name_format = hostname.]
+log 1 pass = node=wazuh.domain.tld type=DAEMON_RESUME msg=audit(1300385209.456:8846): auditd resuming logging, sending auid=? pid=? subj=? res=success
+rule = 80701
+alert = 1
+decoder = auditd


### PR DESCRIPTION
## Description
When configuring a RHEL system using the DISA STIG standards it is required by the rule `xccdf_org.ssgproject.content_rule_auditd_name_format` (references below) to configure `/etc/audit/auditd.conf`  with the following option:

```config
name_format = hostname
```

This prepends each line in `/var/log/audit/audit.log` with `node=xxx`. Prepending the log entries, breaks the auditd decoders in Wazuh/ossec. The decoders assume each line starts with the regex `^type=`.  

The PR modifies the auditd parent regex to match either lines that match either `^type=` or `^node=`, allowing for hardened systems to still have their audit logs parsed by wazuh/osset decoders.

References:
- http://static.open-scap.org/ssg-guides/ssg-rhel8-guide-cui.html
- http://static.open-scap.org/ssg-guides/ssg-rhel8-guide-cui.html#xccdf_org.ssgproject.content_rule_auditd_name_format
- https://www.stigviewer.com/stig/red_hat_enterprise_linux_8/2020-11-25/finding/V-230394
 
## Configuration options
N/A

## Logs/Alerts example

Example log with `name_format = none` or commented out:
```
type=CWD msg=audit(1668627710.100:2132771): cwd="/root"
```

Example log with `name_format = hostname` enabled:
```
node=wazuh.domain.tld type=CWD msg=audit(1668627710.100:2132771): cwd="/root"
```

Example of `log-test` able to parse both logs:
```
# /var/ossec/bin/wazuh-logtest
Starting wazuh-logtest v4.3.9
Type one log per line

type=CWD msg=audit(1668627710.100:2132771): cwd="/root"

**Phase 1: Completed pre-decoding.
        full event: 'type=CWD msg=audit(1668627710.100:2132771): cwd="/root"'

**Phase 2: Completed decoding.
        name: 'auditd'
        audit.id: '2132771'
        audit.type: 'CWD'

**Phase 3: Completed filtering (rules).
        id: '80700'
        level: '0'
        description: 'Audit: Messages grouped.'
        groups: '['audit']'
        firedtimes: '1'
        mail: 'False'

node=wazuh.domain.tld type=CWD msg=audit(1668627710.100:2132771): cwd="/root"

**Phase 1: Completed pre-decoding.
        full event: 'node=wazuh.domain.tld type=CWD msg=audit(1668627710.100:2132771): cwd="/root"'

**Phase 2: Completed decoding.
        name: 'auditd'
        audit.id: '2132771'
        audit.type: 'CWD'

**Phase 3: Completed filtering (rules).
        id: '80700'
        level: '0'
        description: 'Audit: Messages grouped.'
        groups: '['audit']'
        firedtimes: '1'
        mail: 'False'
```


## Tests

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [x] Added unit testing files ".ini"
  - [] runtests.py executed without errors