### PR TITLE
Rework RBAC permissions for `PUT /vulnerability` API endpoint

### DIFF
--- a/api/api/controllers/vulnerability_controller.py
+++ b/api/api/controllers/vulnerability_controller.py
@@ -8,7 +8,8 @@ from aiohttp import web
 
 from api.encoder import dumps, prettify
 from api.util import parse_api_param, remove_nones_to_dict, raise_if_exc
-from wazuh import vulnerability
+from wazuh import vulnerability, WazuhError
+from wazuh.core.cluster.control import get_system_nodes
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.core.common import DATABASE_LIMIT
 
@@ -31,12 +32,21 @@ async def run_vulnerability_scan(request, pretty: bool = False, wait_for_complet
     web.Response
         API response.
     """
+    try:
+        nodes = await get_system_nodes()
+        dapi_extra_kwargs = {'f_kwargs': {'node_list': nodes},
+                             'nodes': nodes} \
+            if not isinstance(nodes, WazuhError) else {}
+    except Exception as exc:
+        raise_if_exc(exc)
+
     dapi = DistributedAPI(f=vulnerability.run_vulnerability_scan,
                           request_type='distributed_master',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies'])
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          **dapi_extra_kwargs)
     data = raise_if_exc(await dapi.distribute_function())
 
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)

--- a/api/api/controllers/vulnerability_controller.py
+++ b/api/api/controllers/vulnerability_controller.py
@@ -35,7 +35,8 @@ async def run_vulnerability_scan(request, pretty: bool = False, wait_for_complet
     try:
         nodes = await get_system_nodes()
         dapi_extra_kwargs = {'f_kwargs': {'node_list': nodes},
-                             'nodes': nodes} \
+                             'nodes': nodes,
+                             'remove_denied_nodes': True} \
             if not isinstance(nodes, WazuhError) else {}
     except Exception as exc:
         raise_if_exc(exc)

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -533,11 +533,10 @@ x-rbac-catalog:
     'vulnerability:run':
       description: "Allow running a vulnerability detector scan"
       resources:
-        - $ref: '#/x-rbac-catalog/resources/node:id'
         - $ref: '#/x-rbac-catalog/resources/*:*'
       example:
         actions: [ 'vulnerability:run' ]
-        resources: [ 'node:id:worker1', '*:*:*' ]
+        resources: [ '*:*:*' ]
         effect: "allow"
 
 components:

--- a/api/test/integration/env/configurations/rbac/vulnerability/black_config.txt
+++ b/api/test/integration/env/configurations/rbac/vulnerability/black_config.txt
@@ -3,7 +3,8 @@
 | agent:id    | 000,001,002,003,004,005,006,007,008,009,010,011,012 |
 
 
-| Actions             | Resources | Allow                               | Deny            |
-|---------------------|-----------|-------------------------------------|-----------------|
-| vulnerability:read  | agent:id  | 001,003,005,007,009,011             | *               |
-| vulnerability:run   | node:id   |                                     | *               |
+| Actions             | Resources | Allow                               | Deny                |
+|---------------------|-----------|-------------------------------------|---------------------|
+| vulnerability:read  | agent:id  | 001,003,005,007,009,011             | *                   |
+| vulnerability:run   | *:*       |                                     | *                   |
+| cluster:read        | node:id   | *                                   | master-node,worker2 |

--- a/api/test/integration/env/configurations/rbac/vulnerability/black_config.yaml
+++ b/api/test/integration/env/configurations/rbac/vulnerability/black_config.yaml
@@ -17,7 +17,8 @@
   effect: allow
 
 - actions:
-  - vulnerability:run
+  - cluster:read
   resources:
-  - node:id:*
+  - node:id:master-node
+  - node:id:worker2
   effect: deny

--- a/api/test/integration/env/configurations/rbac/vulnerability/white_config.txt
+++ b/api/test/integration/env/configurations/rbac/vulnerability/white_config.txt
@@ -6,4 +6,5 @@
 | Actions             | Resources | Allow                               | Deny            |
 |---------------------|-----------|-------------------------------------|-----------------|
 | vulnerability:read  | agent:id  | 000,002,004,006,008,010,012         |                 |
-| vulnerability:run   | node:id   | master-node, worker1, worker2       |                 |
+| vulnerability:run   | *:*       |                                     | *               |
+| cluster:read        | node:id   | worker1                             |                 |

--- a/api/test/integration/env/configurations/rbac/vulnerability/white_config.yaml
+++ b/api/test/integration/env/configurations/rbac/vulnerability/white_config.yaml
@@ -12,9 +12,7 @@
   effect: allow
 
 - actions:
-  - vulnerability:run
+  - cluster:read
   resources:
-  - node:id:master-node
   - node:id:worker1
-  - node:id:worker2
   effect: allow

--- a/api/test/integration/test_rbac_black_vulnerability_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_vulnerability_endpoints.tavern.yaml
@@ -90,7 +90,7 @@ test_name: PUT /vulnerability
 
 stages:
 
-  - name: Try to run vulnerability detector scans
+  - name: Try to run vulnerability detector scans (can only see worker1)
     request:
       verify: False
       method: PUT
@@ -98,4 +98,12 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
-      <<: *permission_denied
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - worker1
+          total_affected_items: 1
+          failed_items: [ ]
+          total_failed_items: 0

--- a/api/test/integration/test_rbac_white_vulnerability_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_vulnerability_endpoints.tavern.yaml
@@ -91,7 +91,7 @@ test_name: PUT /vulnerability
 
 stages:
 
-  - name: Run vulnerability detector scans (allowed)
+  - name: Try to run vulnerability detector scans
     request:
       verify: False
       method: PUT
@@ -99,4 +99,4 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
-      status_code: 200
+      <<: *permission_denied

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -81,6 +81,8 @@ class DistributedAPI:
             User who started the request
         api_timeout : int
             Timeout set in source API for the request
+        remove_denied_nodes : bool
+            Whether to remove denied (RBAC) nodes from response's failed items or not.
         """
         self.logger = logger
         self.f = f

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -43,7 +43,8 @@ class DistributedAPI:
                  debug: bool = False, request_type: str = 'local_master', current_user: str = '',
                  wait_for_complete: bool = False, from_cluster: bool = False, is_async: bool = False,
                  broadcasting: bool = False, basic_services: tuple = None, local_client_arg: str = None,
-                 rbac_permissions: Dict = None, nodes: list = None, api_timeout: int = None):
+                 rbac_permissions: Dict = None, nodes: list = None, api_timeout: int = None,
+                 remove_denied_nodes: bool = False):
         """Class constructor.
 
         Parameters
@@ -108,6 +109,7 @@ class DistributedAPI:
         self.local_client_arg = local_client_arg
         self.api_request_timeout = max(api_timeout, aconf.api_conf['intervals']['request_timeout']) \
             if api_timeout else aconf.api_conf['intervals']['request_timeout']
+        self.remove_denied_nodes = remove_denied_nodes
 
     def debug_log(self, message):
         """Use debug or debug2 depending on the log type.
@@ -564,7 +566,8 @@ class DistributedAPI:
         if isinstance(response, wresults.AffectedItemsWazuhResult):
             for failed in copy(allowed_nodes.failed_items):
                 # Avoid errors coming from 'unknown' node (they are included in the forward)
-                if allowed_nodes.failed_items[failed] == {'unknown'}:
+                if allowed_nodes.failed_items[failed] == {'unknown'} or \
+                        (failed.code == 4000 and self.remove_denied_nodes):
                     del allowed_nodes.failed_items[failed]
             response.add_failed_items_from(allowed_nodes)
 

--- a/framework/wazuh/rbac/default/policies.yaml
+++ b/framework/wazuh/rbac/default/policies.yaml
@@ -363,9 +363,3 @@ default_policies:
         resources:
           - '*:*:*'
         effect: allow
-      nodes:
-        actions:
-          - vulnerability:run
-        resources:
-          - node:id:*
-        effect: allow

--- a/framework/wazuh/tests/data/security/rbac_catalog.yml
+++ b/framework/wazuh/tests/data/security/rbac_catalog.yml
@@ -855,13 +855,11 @@ get_rbac_actions:
       vulnerability:run:
         description: Allow running a vulnerability detector scan
         resources:
-          - node:id
           - "*:*"
         example:
           actions:
             - vulnerability:run
           resources:
-            - node:id:worker1
             - "*:*:*"
           effect: allow
         related_endpoints:

--- a/framework/wazuh/vulnerability.py
+++ b/framework/wazuh/vulnerability.py
@@ -19,7 +19,7 @@ cluster_enabled = not read_cluster_config(from_import=True)['disabled']
 node_id = get_node().get('node') if cluster_enabled else 'manager'
 
 
-@expose_resources(actions=["vulnerability:run"], resources=[f"node:id:{node_id}" if cluster_enabled else "*:*:*"])
+@expose_resources(actions=["vulnerability:run"], resources=["*:*:*"])
 def run_vulnerability_scan():
     """Run a vulnerability detector scan.
 


### PR DESCRIPTION
|Related issue|
|---|
|#15062|

## Description

This PR is a RBAC rework of the previous implementation for the `PUT /vulnerability` endpoint. It now handles every possible use case and reduces the visible permissions (to the user) to `vulnerability:run` | `*:*:*`.

As this endpoint is distributed to every cluster node, as long as the user has permission to see each node (`cluster:read`), this endpoint will only return an exception regarding RBAC permissions for `cluster:read` when no cluster node is reachable.

## Manual tests

### `vulnerability:run` and `cluster:read` for `worker1`

```json
{
  "data": {
    "affected_items": [],
    "total_affected_items": 0,
    "total_failed_items": 1,
    "failed_items": [
      {
        "error": {
          "code": 8011,
          "message": "This module is disabled"
        },
        "id": [
          "worker1"
        ]
      }
    ]
  },
  "message": "No vulnerability detector scans were requested",
  "error": 1
}
```

### `vulnerability:run`

```json
{
  "title": "Permission Denied",
  "detail": "Permission denied: Resource type: node:id",
  "remediation": "Please, make sure you have permissions to execute the current request. For more information on how to set up permissions, please visit https://documentation.wazuh.com/4.5/user-manual/api/rbac/configuration.html",
  "dapi_errors": {
    "unknown-node": {
      "error": "Permission denied: Resource type: node:id"
    }
  },
  "error": 4000
}
```

### `cluster:read` for `worker1`

```json
{
  "title": "Permission Denied",
  "detail": "Permission denied: Resource type: *:*",
  "remediation": "Please, make sure you have permissions to execute the current request. For more information on how to set up permissions, please visit https://documentation.wazuh.com/4.5/user-manual/api/rbac/configuration.html",
  "dapi_errors": {
    "worker1": {
      "error": "Permission denied: Resource type: *:*"
    }
  },
  "error": 4000
}
```

Regards,
Víctor