### PR TITLE
Default Syscollector scan interval not set

### DIFF
--- a/src/config/wmodules-config.c
+++ b/src/config/wmodules-config.c
@@ -88,7 +88,7 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
     }
 #ifdef ENABLE_SYSC
     else if (!strcmp(node->values[0], WM_SYS_CONTEXT.name)) {
-        if (wm_sys_read(xml, children, cur_wmodule) < 0) {
+        if (wm_syscollector_read(xml, children, cur_wmodule) < 0) {
             OS_ClearNode(children);
             return OS_INVALID;
         }

--- a/src/config/wmodules-syscollector.c
+++ b/src/config/wmodules-syscollector.c
@@ -46,7 +46,7 @@ static void parse_synchronization_section(wm_sys_t * syscollector, XML_NODE node
 }
 
 // Parse XML configuration
-int wm_sys_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
+int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
     wm_sys_t *syscollector;
     int i;
 
@@ -54,6 +54,7 @@ int wm_sys_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
         os_calloc(1, sizeof(wm_sys_t), syscollector);
         // System provider config values
         syscollector->flags.enabled = 1;
+        syscollector->interval = WM_SYSCOLLECTOR_DEFAULT_INTERVAL;
         syscollector->flags.scan_on_start = 1;
         syscollector->flags.netinfo = 1;
         syscollector->flags.osinfo = 1;
@@ -96,13 +97,13 @@ int wm_sys_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
 
             switch (*endptr) {
             case 'd':
-                syscollector->interval *= 86400;
+                syscollector->interval *= W_DAY_SECONDS;
                 break;
             case 'h':
-                syscollector->interval *= 3600;
+                syscollector->interval *= W_HOUR_SECONDS;
                 break;
             case 'm':
-                syscollector->interval *= 60;
+                syscollector->interval *= W_MINUTE_SECONDS;
                 break;
             case 's':
             case '\0':

--- a/src/wazuh_modules/wm_syscollector.h
+++ b/src/wazuh_modules/wm_syscollector.h
@@ -18,7 +18,7 @@
 extern const wm_context WM_SYS_CONTEXT;     // Context
 
 #define WM_SYS_LOGTAG ARGV0 ":syscollector" // Tag for log messages
-#define WM_SYSCOLLECTOR_DEFAULT_INTERVAL 3600 // 1 hour
+#define WM_SYSCOLLECTOR_DEFAULT_INTERVAL W_HOUR_SECONDS
 
 typedef struct wm_sys_flags_t {
     unsigned int enabled:1;                 // Main switch

--- a/src/wazuh_modules/wm_syscollector.h
+++ b/src/wazuh_modules/wm_syscollector.h
@@ -18,6 +18,7 @@
 extern const wm_context WM_SYS_CONTEXT;     // Context
 
 #define WM_SYS_LOGTAG ARGV0 ":syscollector" // Tag for log messages
+#define WM_SYSCOLLECTOR_DEFAULT_INTERVAL 3600 // 1 hour
 
 typedef struct wm_sys_flags_t {
     unsigned int enabled:1;                 // Main switch
@@ -48,6 +49,6 @@ typedef struct wm_sys_t {
 } wm_sys_t;
 
 // Parse XML configuration
-int wm_sys_read(const OS_XML *xml, XML_NODE node, wmodule *module);
+int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module);
 
 #endif


### PR DESCRIPTION
|Related issue|
|---|
|#15413|

## Description

This PR sets the scan time interval for Syscollector that was missing. 

## Configuration options
Section commented
![2022-11-17_18-27](https://user-images.githubusercontent.com/13010397/202564010-381fa07e-6537-46f9-a7a5-86a33ae2e7e4.png)

## Logs/Alerts example

Getting Syscollector configuration from API.
![2022-11-17_18-26](https://user-images.githubusercontent.com/13010397/202564040-27e8ba33-e50c-439a-b85c-600614100e8a.png)
Syscollector scan is not triggered one after another in a few seconds.
![image](https://user-images.githubusercontent.com/13010397/202564204-dfc65337-21b8-4865-9d97-8a024e2b19da.png)

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language