### PR TITLE
Fixing FIM DB RTR tests after last changes and merges 

### DIFF
--- a/src/shared_modules/dbsync/tests/interface/dbsync_test.cpp
+++ b/src/shared_modules/dbsync/tests/interface/dbsync_test.cpp
@@ -2246,8 +2246,8 @@ TEST_F(DBSyncTest, createTxnAtomicOperation)
     EXPECT_NO_THROW(dbSync = std::make_unique<DBSync>(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql));
 
     CallbackMock wrapper;
-    EXPECT_CALL(wrapper, callbackMock(INSERTED, nlohmann::json::parse(R"([{"name":"System","pid":4, "time":100100}])"))).Times(1);
-    EXPECT_CALL(wrapper, callbackMock(INSERTED, nlohmann::json::parse(R"([{"name":"Guake","pid":7,"time":100101}])"))).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(INSERTED, nlohmann::json::parse(R"({"name":"System","pid":4, "time":100100})"))).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(INSERTED, nlohmann::json::parse(R"({"name":"Guake","pid":7,"time":100101})"))).Times(1);
 
     ResultCallbackData callbackData
     {

--- a/src/syscheckd/src/db/smokeTests/config.json
+++ b/src/syscheckd/src/db/smokeTests/config.json
@@ -5,5 +5,7 @@
     "registry_limit": 1,
     "registry_sync": true,
     "sync_response_timeout": 10,
-    "sync_max_interval": 100
+    "sync_max_interval": 100,
+    "thread_pool": 1,
+    "queue_size": 100
 }

--- a/src/syscheckd/src/db/smokeTests/configWindows.json
+++ b/src/syscheckd/src/db/smokeTests/configWindows.json
@@ -5,5 +5,7 @@
     "registry_limit": 20,
     "registry_sync": true,
     "sync_response_timeout": 10,
-    "sync_max_interval": 100
+    "sync_max_interval": 100,
+    "thread_pool": 1,
+    "queue_size": 100
 }

--- a/src/syscheckd/src/db/src/db.cpp
+++ b/src/syscheckd/src/db/src/db.cpp
@@ -146,11 +146,13 @@ FIMDBErrorCode fim_db_init(int storage,
                     {
                         std::string perm_string = json["data"]["attributes"]["perm"];
                         auto perm_json = nlohmann::json::parse(perm_string, nullptr, false);
+
                         if (!perm_json.is_discarded())
                         {
                             json["data"]["attributes"].erase("perm");
                             json["data"]["attributes"]["perm"] = perm_json;
                         }
+
                         json["data"]["attributes"]["type"] = "file";
                         json["data"]["attributes"].erase("dev");
                         json["data"]["attributes"].erase("last_event");
@@ -196,11 +198,13 @@ FIMDBErrorCode fim_db_init(int storage,
                         {
                             std::string perm_string = json["data"]["attributes"]["perm"];
                             auto perm_json = nlohmann::json::parse(perm_string, nullptr, false);
+
                             if (!perm_json.is_discarded())
                             {
                                 json["data"]["attributes"].erase("perm");
                                 json["data"]["attributes"]["perm"] = perm_json;
                             }
+
                             json["data"]["attributes"]["type"] = "registry_key";
                             json["data"]["attributes"]["gid"] = std::to_string(json.at("data").at("attributes").at("gid")
                                                                                .get<uint32_t>());

--- a/src/syscheckd/src/db/tests/db/FIMDB/fimDBTests/fimDBImpTests.cpp
+++ b/src/syscheckd/src/db/tests/db/FIMDB/fimDBTests/fimDBImpTests.cpp
@@ -179,10 +179,10 @@ class FimDBFixture : public ::testing::Test
 
             EXPECT_CALL((*mockDBSync), setTableMaxRow("file_entry", mockMaxRowsFile));
 
-            #ifdef WIN32
+#ifdef WIN32
             EXPECT_CALL((*mockDBSync), setTableMaxRow("registry_key", mockMaxRowsReg));
             EXPECT_CALL((*mockDBSync), setTableMaxRow("registry_data", mockMaxRowsReg));
-            #endif
+#endif
 
             fimDBMock.init(mockIntervalSync,
                            syncMaxInterval,

--- a/src/syscheckd/src/db/tests/db/dbItem/FileItem/dbFileItemTestWindows.cpp
+++ b/src/syscheckd/src/db/tests/db/dbItem/FileItem/dbFileItemTestWindows.cpp
@@ -16,7 +16,7 @@
 void FileItemTest::SetUp()
 {
     fimEntryTest = reinterpret_cast<fim_entry*>(std::calloc(1, sizeof(fim_entry)));
-    fim_file_data * data = reinterpret_cast<fim_file_data*>(std::calloc(1, sizeof(fim_file_data)));
+    fim_file_data* data = reinterpret_cast<fim_file_data*>(std::calloc(1, sizeof(fim_file_data)));
 
     fimEntryTest->type = FIM_TYPE_FILE;
     fimEntryTest->file_entry.path = const_cast<char*>("/etc/wgetrc");
@@ -34,31 +34,33 @@ void FileItemTest::SetUp()
     data->mtime = 1578075431;
     data->options = 131583;
     data->scanned = 1;
-    data->perm = "{\"S-1-5-32-544\":{\"name\":\"Administrators\",\"allowed\":[\"delete\",\"read_control\",\"write_dac\",\"write_owner\",\"synchronize\",\"read_data\",\"write_data\",\"append_data\",\"read_ea\",\"write_ea\",\"execute\",\"read_attributes\",\"write_attributes\"]},\"S-1-5-18\":{\"name\":\"SYSTEM\",\"allowed\":[\"delete\",\"read_control\",\"write_dac\",\"write_owner\",\"synchronize\",\"read_data\",\"write_data\",\"append_data\",\"read_ea\",\"write_ea\",\"execute\",\"read_attributes\",\"write_attributes\"]},\"S-1-5-32-545\":{\"name\":\"Users\",\"allowed\":[\"read_control\",\"synchronize\",\"read_data\",\"read_ea\",\"execute\",\"read_attributes\"]},\"S-1-5-11\":{\"name\":\"Authenticated Users\",\"allowed\":[\"delete\",\"read_control\",\"synchronize\",\"read_data\",\"write_data\",\"append_data\",\"read_ea\",\"write_ea\",\"execute\",\"read_attributes\",\"write_attributes\"]}}";
+    data->perm =
+        "{\"S-1-5-32-544\":{\"name\":\"Administrators\",\"allowed\":[\"delete\",\"read_control\",\"write_dac\",\"write_owner\",\"synchronize\",\"read_data\",\"write_data\",\"append_data\",\"read_ea\",\"write_ea\",\"execute\",\"read_attributes\",\"write_attributes\"]},\"S-1-5-18\":{\"name\":\"SYSTEM\",\"allowed\":[\"delete\",\"read_control\",\"write_dac\",\"write_owner\",\"synchronize\",\"read_data\",\"write_data\",\"append_data\",\"read_ea\",\"write_ea\",\"execute\",\"read_attributes\",\"write_attributes\"]},\"S-1-5-32-545\":{\"name\":\"Users\",\"allowed\":[\"read_control\",\"synchronize\",\"read_data\",\"read_ea\",\"execute\",\"read_attributes\"]},\"S-1-5-11\":{\"name\":\"Authenticated Users\",\"allowed\":[\"delete\",\"read_control\",\"synchronize\",\"read_data\",\"write_data\",\"append_data\",\"read_ea\",\"write_ea\",\"execute\",\"read_attributes\",\"write_attributes\"]}}";
     data->size = 4925;
     data->uid = const_cast<char*>("0");
     data->user_name = const_cast<char*>("fakeUser");
     fimEntryTest->file_entry.data = data;
-    json = {
-            {"attributes", "10"},
-            {"checksum", "a2fbef8f81af27155dcee5e3927ff6243593b91a"},
-            {"dev", 2051},
-            {"gid", 0},
-            {"group_name", "root"},
-            {"hash_md5", "4b531524aa13c8a54614100b570b3dc7"},
-            {"hash_sha1", "7902feb66d0bcbe4eb88e1bfacf28befc38bd58b"},
-            {"hash_sha256", "e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a"},
-            {"inode", 1152921500312810880},
-            {"last_event", 1596489275},
-            {"mode", 0},
-            {"mtime", 1578075431},
-            {"options", 131583},
-            {"path", "/etc/wgetrc"},
-            {"perm", "{\"S-1-5-32-544\":{\"name\":\"Administrators\",\"allowed\":[\"delete\",\"read_control\",\"write_dac\",\"write_owner\",\"synchronize\",\"read_data\",\"write_data\",\"append_data\",\"read_ea\",\"write_ea\",\"execute\",\"read_attributes\",\"write_attributes\"]},\"S-1-5-18\":{\"name\":\"SYSTEM\",\"allowed\":[\"delete\",\"read_control\",\"write_dac\",\"write_owner\",\"synchronize\",\"read_data\",\"write_data\",\"append_data\",\"read_ea\",\"write_ea\",\"execute\",\"read_attributes\",\"write_attributes\"]},\"S-1-5-32-545\":{\"name\":\"Users\",\"allowed\":[\"read_control\",\"synchronize\",\"read_data\",\"read_ea\",\"execute\",\"read_attributes\"]},\"S-1-5-11\":{\"name\":\"Authenticated Users\",\"allowed\":[\"delete\",\"read_control\",\"synchronize\",\"read_data\",\"write_data\",\"append_data\",\"read_ea\",\"write_ea\",\"execute\",\"read_attributes\",\"write_attributes\"]}}"},
-            {"scanned", 1},
-            {"size", 4925},
-            {"uid", 0},
-            {"user_name", "fakeUser"}
+    json =
+    {
+        {"attributes", "10"},
+        {"checksum", "a2fbef8f81af27155dcee5e3927ff6243593b91a"},
+        {"dev", 2051},
+        {"gid", 0},
+        {"group_name", "root"},
+        {"hash_md5", "4b531524aa13c8a54614100b570b3dc7"},
+        {"hash_sha1", "7902feb66d0bcbe4eb88e1bfacf28befc38bd58b"},
+        {"hash_sha256", "e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a"},
+        {"inode", 1152921500312810880},
+        {"last_event", 1596489275},
+        {"mode", 0},
+        {"mtime", 1578075431},
+        {"options", 131583},
+        {"path", "/etc/wgetrc"},
+        {"perm", "{\"S-1-5-32-544\":{\"name\":\"Administrators\",\"allowed\":[\"delete\",\"read_control\",\"write_dac\",\"write_owner\",\"synchronize\",\"read_data\",\"write_data\",\"append_data\",\"read_ea\",\"write_ea\",\"execute\",\"read_attributes\",\"write_attributes\"]},\"S-1-5-18\":{\"name\":\"SYSTEM\",\"allowed\":[\"delete\",\"read_control\",\"write_dac\",\"write_owner\",\"synchronize\",\"read_data\",\"write_data\",\"append_data\",\"read_ea\",\"write_ea\",\"execute\",\"read_attributes\",\"write_attributes\"]},\"S-1-5-32-545\":{\"name\":\"Users\",\"allowed\":[\"read_control\",\"synchronize\",\"read_data\",\"read_ea\",\"execute\",\"read_attributes\"]},\"S-1-5-11\":{\"name\":\"Authenticated Users\",\"allowed\":[\"delete\",\"read_control\",\"synchronize\",\"read_data\",\"write_data\",\"append_data\",\"read_ea\",\"write_ea\",\"execute\",\"read_attributes\",\"write_attributes\"]}}"},
+        {"scanned", 1},
+        {"size", 4925},
+        {"uid", 0},
+        {"user_name", "fakeUser"}
     };
 }
 


### PR DESCRIPTION
## Description
This PR is to fix some problems encountered when launching the RTR of our FIM DB development branch.

### Minor fixes

- [x] Config files in fim db testtool filled with new settings added to rsync
- [x] Fixed createTxnAtomicOperation test from dbsync testtool after merge
- [x] Some changes needed requested by AStyle