### PR TITLE
Fix descriptors leak when cleaning agents state

### DIFF
--- a/src/analysisd/state.c
+++ b/src/analysisd/state.c
@@ -58,7 +58,7 @@ STATIC analysisd_agent_state_t * get_node(const char *agent_id);
  * @brief Clean non active agents from agents state
  * @param sock Wazuh DB socket
  */
-STATIC void w_analysisd_clean_agents_state(int * sock);
+STATIC void w_analysisd_clean_agents_state(int *sock);
 
 /**
  * @brief Increment agent decoded events counter for agents
@@ -547,7 +547,7 @@ STATIC analysisd_agent_state_t * get_node(const char *agent_id) {
     }
 }
 
-STATIC void w_analysisd_clean_agents_state(int * sock) {
+STATIC void w_analysisd_clean_agents_state(int *sock) {
     int *active_agents = NULL;
     OSHashNode *hash_node;
     unsigned int inode_it = 0;

--- a/src/analysisd/state.c
+++ b/src/analysisd/state.c
@@ -55,9 +55,10 @@ static void w_get_initial_queues_size();
 STATIC analysisd_agent_state_t * get_node(const char *agent_id);
 
 /**
- * @brief Clean non active agents from agents state.
+ * @brief Clean non active agents from agents state
+ * @param sock Wazuh DB socket
  */
-STATIC void w_analysisd_clean_agents_state();
+STATIC void w_analysisd_clean_agents_state(int * sock);
 
 /**
  * @brief Increment agent decoded events counter for agents
@@ -247,11 +248,16 @@ void * w_analysisd_state_main() {
     w_get_initial_queues_size();
     w_mutex_unlock(&queue_mutex);
 
+    int sock = -1;
+    sock = wdbc_connect();
+
     while (1) {
         w_analysisd_write_state();
         sleep(interval);
-        w_analysisd_clean_agents_state();
+        w_analysisd_clean_agents_state(&sock);
     }
+
+    wdbc_close(&sock);
 
     return NULL;
 }
@@ -541,9 +547,8 @@ STATIC analysisd_agent_state_t * get_node(const char *agent_id) {
     }
 }
 
-STATIC void w_analysisd_clean_agents_state() {
+STATIC void w_analysisd_clean_agents_state(int * sock) {
     int *active_agents = NULL;
-    int sock = -1;
     OSHashNode *hash_node;
     unsigned int inode_it = 0;
 
@@ -553,7 +558,7 @@ STATIC void w_analysisd_clean_agents_state() {
         return;
     }
 
-    if (active_agents = wdb_get_agents_ids_of_current_node(AGENT_CS_ACTIVE, &sock, 0, -1), active_agents == NULL) {
+    if (active_agents = wdb_get_agents_ids_of_current_node(AGENT_CS_ACTIVE, sock, 0, -1), active_agents == NULL) {
         return;
     }
 

--- a/src/unit_tests/analysisd/test_analysis-state.c
+++ b/src/unit_tests/analysisd/test_analysis-state.c
@@ -35,7 +35,7 @@ extern queue_status_t queue_status;
 extern OSHash *analysisd_agents_state;
 
 analysisd_agent_state_t * get_node(const char *agent_id);
-void w_analysisd_clean_agents_state();
+void w_analysisd_clean_agents_state(int *sock);
 /* setup/teardown */
 
 static int test_setup(void ** state) {
@@ -710,7 +710,9 @@ void test_w_analysisd_clean_agents_state_empty_table(void ** state) {
     expect_value(__wrap_OSHash_Begin, self, analysisd_agents_state);
     will_return(__wrap_OSHash_Begin, NULL);
 
-    w_analysisd_clean_agents_state();
+    int sock = 1;
+
+    w_analysisd_clean_agents_state(&sock);
 }
 
 void test_w_analysisd_clean_agents_state_completed(void ** state) {
@@ -735,7 +737,9 @@ void test_w_analysisd_clean_agents_state_completed(void ** state) {
     expect_value(__wrap_OSHash_Delete_ex, key, "001");
     will_return(__wrap_OSHash_Delete_ex, test_data->agent_state);
 
-    w_analysisd_clean_agents_state();
+    int sock = 1;
+
+    w_analysisd_clean_agents_state(&sock);
 }
 
 void test_w_analysisd_clean_agents_state_completed_without_delete(void ** state) {
@@ -756,7 +760,9 @@ void test_w_analysisd_clean_agents_state_completed_without_delete(void ** state)
     expect_value(__wrap_OSHash_Next, self, analysisd_agents_state);
     will_return(__wrap_OSHash_Next, NULL);
 
-    w_analysisd_clean_agents_state();
+    int sock = 1;
+
+    w_analysisd_clean_agents_state(&sock);
 
     os_free(test_data->agent_state);
 }
@@ -774,7 +780,9 @@ void test_w_analysisd_clean_agents_state_query_fail(void ** state) {
     expect_value(__wrap_wdb_get_agents_ids_of_current_node, limit, -1);
     will_return(__wrap_wdb_get_agents_ids_of_current_node, connected_agents);
 
-    w_analysisd_clean_agents_state();
+    int sock = 1;
+
+    w_analysisd_clean_agents_state(&sock);
 
     os_free(test_data->agent_state);
 }

--- a/src/unit_tests/remoted/test_remote-state.c
+++ b/src/unit_tests/remoted/test_remote-state.c
@@ -35,7 +35,7 @@ extern remoted_state_t remoted_state;
 extern OSHash *remoted_agents_state;
 
 remoted_agent_state_t * get_node(const char *agent_id);
-void w_remoted_clean_agents_state();
+void w_remoted_clean_agents_state(int *sock);
 
 /* setup/teardown */
 
@@ -336,7 +336,9 @@ void test_w_remoted_clean_agents_state_empty_table(void ** state) {
     expect_value(__wrap_OSHash_Begin, self, remoted_agents_state);
     will_return(__wrap_OSHash_Begin, NULL);
 
-    w_remoted_clean_agents_state();
+    int sock = 1;
+
+    w_remoted_clean_agents_state(&sock);
 }
 
 void test_w_remoted_clean_agents_state_completed(void ** state) {
@@ -361,7 +363,9 @@ void test_w_remoted_clean_agents_state_completed(void ** state) {
     expect_value(__wrap_OSHash_Delete_ex, key, "001");
     will_return(__wrap_OSHash_Delete_ex, test_data->agent_state);
 
-    w_remoted_clean_agents_state();
+    int sock = 1;
+
+    w_remoted_clean_agents_state(&sock);
 }
 
 void test_w_remoted_clean_agents_state_completed_without_delete(void ** state) {
@@ -382,7 +386,9 @@ void test_w_remoted_clean_agents_state_completed_without_delete(void ** state) {
     expect_value(__wrap_OSHash_Next, self, remoted_agents_state);
     will_return(__wrap_OSHash_Next, NULL);
 
-    w_remoted_clean_agents_state();
+    int sock = 1;
+
+    w_remoted_clean_agents_state(&sock);
 
     os_free(test_data->agent_state);
 }
@@ -400,7 +406,9 @@ void test_w_remoted_clean_agents_state_query_fail(void ** state) {
     expect_value(__wrap_wdb_get_agents_ids_of_current_node, limit, -1);
     will_return(__wrap_wdb_get_agents_ids_of_current_node, connected_agents);
 
-    w_remoted_clean_agents_state();
+    int sock = 1;
+
+    w_remoted_clean_agents_state(&sock);
 
     os_free(test_data->agent_state);
 }


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/15426 |

## Description

The goal of this issue is to fix the descriptor leaks reported at https://github.com/wazuh/wazuh/issues/15426 for 4.4, affecting Wazuh DB, Analysisd and Remoted.

Once reproduced, the following `valgrind` report shows where the leak is located for Analysisd:
```
==51123== Open AF_UNIX socket 36: <unknown>
==51123==    at 0x52C57DB: socket (syscall-template.S:78)
==51123==    by 0x27FF22: OS_ConnectUnixDomain (os_net.c:211)
==51123==    by 0x27F054: wdbc_connect (wazuhdb_op.c:29)
==51123==    by 0x27F28A: wdbc_query_ex (wazuhdb_op.c:120)
==51123==    by 0x24260C: wdb_get_agents_ids_of_current_node (wdb_global_helpers.c:1161)
==51123==    by 0x11E4EC: w_analysisd_clean_agents_state (state.c:556)
==51123==    by 0x11D32C: w_analysisd_state_main (state.c:253)
==51123==    by 0x518A608: start_thread (pthread_create.c:477)
==51123==    by 0x52C4162: clone (clone.S:95)
```

same as for Remoted:
```
==17214== Open AF_UNIX socket 17: <unknown>
==17214==    at 0x52C57DB: socket (syscall-template.S:78)
==17214==    by 0x2240BF: OS_ConnectUnixDomain (os_net.c:211)
==17214==    by 0x2231F1: wdbc_connect (wazuhdb_op.c:29)
==17214==    by 0x223427: wdbc_query_ex (wazuhdb_op.c:120)
==17214==    by 0x1E8B88: wdb_get_agents_ids_of_current_node (wdb_global_helpers.c:1161)
==17214==    by 0x12246E: w_remoted_clean_agents_state (state.c:242)
==17214==    by 0x121E85: rem_state_main (state.c:138)
==17214==    by 0x518A608: start_thread (pthread_create.c:477)
==17214==    by 0x52C4162: clone (clone.S:95)
```

This behavior makes Wazuh DB increase its opened socket descriptors as well for every opened connection from Analysisd and Remoted.

For every `state_interval` (which is 5 seconds by default), a request is made to Wazuh DB to get the agents status. For that request, a new socket descriptor was opened without closing it when the request was finished. 

To avoid this situation, now the socket is opened when starting the thread that handles the agents state, so it is reused every iteration.


## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

- [x] Added unit tests (for new features)
- [x] Stress test for affected components (Report [here](https://github.com/wazuh/wazuh/issues/15426#issuecomment-1324489006))
<img width="1913" alt="image" src="https://user-images.githubusercontent.com/29475387/203509990-5bcdf769-76fd-4c8d-9863-8ab78bdeb4e8.png">

- Manual tests
- [x] Agents state is clean properly
- [x] Once applied the fix, no descriptor leak is found in affected components (Wazuh DB, Remoted and Analysisd)
- [x] Killing Wazuh DB doesn't produce any leaks. The connections are recovered when Wazuh DB is up again.