### PR TITLE
Fix to change "Timeout" strings that caused wrong exception to raise

### DIFF
--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -1731,7 +1731,7 @@ def send_data_to_wdb(data, timeout, info_type='agent-info'):
                 except Exception as e:
                     result['error_messages']['chunks'].append((i, str(e)))
     except TimeoutError:
-        result['error_messages']['others'].append(f'Timeout while processing {info_type} chunks.')
+        result['error_messages']['others'].append(f'timeout while processing {info_type} chunks.')
     except Exception as e:
         result['error_messages']['others'].append(f'Error while processing {info_type} chunks: {e}')
 

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -985,7 +985,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                         except Exception as e:
                             result['errors_per_folder'][item_key].append(str(e))
         except TimeoutError:
-            result['generic_errors'].append("Timeout processing extra-valid files.")
+            result['generic_errors'].append("timeout processing extra-valid files.")
         except Exception as e:
             result['generic_errors'].append(f"Error updating worker files (extra valid): '{str(e)}'.")
 

--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -1496,7 +1496,7 @@ def test_send_data_to_wdb_ko(WazuhDBConnection_mock):
 
     result = cluster_common.send_data_to_wdb(data={'chunks': ['[{"data": ""}]'], 'payload': {}, 'set_data_command': ''},
                                              timeout=15, info_type='agent-groups')
-    assert result['error_messages']['others'] == ['Timeout while processing agent-groups chunks.']
+    assert result['error_messages']['others'] == ['timeout while processing agent-groups chunks.']
 
     WazuhDBConnection_mock.return_value.exceptions += 1
     result = cluster_common.send_data_to_wdb(data={'chunks': ['1chunk', '2chunk'], 'set_data_command': ''},

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -1480,7 +1480,7 @@ def test_master_handler_process_files_from_worker_ok(gid_mock, uid_mock, basenam
                                                               timeout=timeout)
 
             assert result == {'total_updated': 0, 'errors_per_folder': defaultdict(list),
-                              'generic_errors': ['Timeout processing extra-valid files.']}
+                              'generic_errors': ['timeout processing extra-valid files.']}
 
             # Test the Except present in the second if
             isfile_mock.side_effect = Exception


### PR DESCRIPTION
|Related issue|
|---|
|#14882|

Hello team, 

This PR closes #14882. The issue was already fixed with changes implemented in this other PR: #15220.

## Tests
### Framework unittests
```
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.9.9, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/agavila/git/wazuh/api
plugins: anyio-3.6.2, asyncio-0.18.1
asyncio: mode=legacy
collected 532 items                                                                                                                                                                                         

api/api/controllers/test/test_active_response_controller.py .                                                                                                                                         [  0%]
api/api/controllers/test/test_agent_controller.py ...........................................                                                                                                         [  8%]
api/api/controllers/test/test_cdb_list_controller.py ......                                                                                                                                           [  9%]
api/api/controllers/test/test_ciscat_controller.py .                                                                                                                                                  [  9%]
api/api/controllers/test/test_cluster_controller.py ........................                                                                                                                          [ 14%]
api/api/controllers/test/test_decoder_controller.py .......                                                                                                                                           [ 15%]
api/api/controllers/test/test_default_controller.py .                                                                                                                                                 [ 15%]
api/api/controllers/test/test_experimental_controller.py ...............                                                                                                                              [ 18%]
api/api/controllers/test/test_manager_controller.py ..................                                                                                                                                [ 21%]
api/api/controllers/test/test_mitre_controller.py .......                                                                                                                                             [ 23%]
api/api/controllers/test/test_overview_controller.py .                                                                                                                                                [ 23%]
api/api/controllers/test/test_rootcheck_controller.py ....                                                                                                                                            [ 24%]
api/api/controllers/test/test_rule_controller.py ........                                                                                                                                             [ 25%]
api/api/controllers/test/test_sca_controller.py ..                                                                                                                                                    [ 25%]
api/api/controllers/test/test_security_controller.py ...................................................                                                                                              [ 35%]
api/api/controllers/test/test_syscheck_controller.py ....                                                                                                                                             [ 36%]
api/api/controllers/test/test_syscollector_controller.py .........                                                                                                                                    [ 37%]
api/api/controllers/test/test_task_controller.py .                                                                                                                                                    [ 38%]
api/api/controllers/test/test_vulnerability_controller.py ...                                                                                                                                         [ 38%]
api/api/models/test/test_model.py ...........................                                                                                                                                         [ 43%]
api/api/test/test_alogging.py ..................                                                                                                                                                      [ 47%]
api/api/test/test_authentication.py ...........                                                                                                                                                       [ 49%]
api/api/test/test_configuration.py ..........................................                                                                                                                         [ 57%]
api/api/test/test_encoder.py ...                                                                                                                                                                      [ 57%]
api/api/test/test_middlewares.py ............                                                                                                                                                         [ 59%]
api/api/test/test_uri_parser.py ...                                                                                                                                                                   [ 60%]
api/api/test/test_util.py ........................................                                                                                                                                    [ 68%]
api/api/test/test_validator.py ...................................................................................................................................................................... [ 99%]
....                                                                                                                                                                                                  [100%]

===================================================================================== 532 passed, 17 warnings in 7.41s ======================================================================================

```
```
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.9.9, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/agavila/git/wazuh/framework
plugins: anyio-3.6.2, asyncio-0.18.1
asyncio: mode=legacy
collected 2071 items                                                                                                                                                                                        

framework/scripts/tests/test_agent_groups.py ..............                                                                                                                                           [  0%]
framework/scripts/tests/test_agent_upgrade.py ...............                                                                                                                                         [  1%]
framework/scripts/tests/test_cluster_control.py ......                                                                                                                                                [  1%]
framework/scripts/tests/test_wazuh_clusterd.py .......                                                                                                                                                [  2%]
framework/scripts/tests/test_wazuh_logtest.py ......................                                                                                                                                  [  3%]
framework/wazuh/core/cluster/dapi/tests/test_dapi.py ..............................ss                                                                                                                 [  4%]
framework/wazuh/core/cluster/tests/test_client.py ................                                                                                                                                    [  5%]
framework/wazuh/core/cluster/tests/test_cluster.py ...................................                                                                                                                [  7%]
framework/wazuh/core/cluster/tests/test_common.py ..................................................................................                                                                  [ 11%]
framework/wazuh/core/cluster/tests/test_control.py ......                                                                                                                                             [ 11%]
framework/wazuh/core/cluster/tests/test_local_client.py .............                                                                                                                                 [ 11%]
framework/wazuh/core/cluster/tests/test_local_server.py ........................                                                                                                                      [ 13%]
framework/wazuh/core/cluster/tests/test_master.py ....................................................                                                                                                [ 15%]
framework/wazuh/core/cluster/tests/test_server.py .............................                                                                                                                       [ 17%]
framework/wazuh/core/cluster/tests/test_utils.py ...........                                                                                                                                          [ 17%]
framework/wazuh/core/cluster/tests/test_worker.py ...................................                                                                                                                 [ 19%]
framework/wazuh/core/tests/test_active_response.py ..............                                                                                                                                     [ 19%]
framework/wazuh/core/tests/test_agent.py ...................................................................................................................................................          [ 27%]
framework/wazuh/core/tests/test_cdb_list.py ......................................                                                                                                                    [ 28%]
framework/wazuh/core/tests/test_common.py .........                                                                                                                                                   [ 29%]
framework/wazuh/core/tests/test_configuration.py ......................................................................                                                                               [ 32%]
framework/wazuh/core/tests/test_database.py .............                                                                                                                                             [ 33%]
framework/wazuh/core/tests/test_decoder.py ................                                                                                                                                           [ 34%]
framework/wazuh/core/tests/test_exception.py ...                                                                                                                                                      [ 34%]
framework/wazuh/core/tests/test_input_validator.py ...                                                                                                                                                [ 34%]
framework/wazuh/core/tests/test_logtest.py ..                                                                                                                                                         [ 34%]
framework/wazuh/core/tests/test_manager.py ...............                                                                                                                                            [ 35%]
framework/wazuh/core/tests/test_mitre.py .............                                                                                                                                                [ 35%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                                                                                                                                               [ 36%]
framework/wazuh/core/tests/test_results.py ........................................                                                                                                                   [ 38%]
framework/wazuh/core/tests/test_rootcheck.py .............                                                                                                                                            [ 38%]
framework/wazuh/core/tests/test_rule.py ......................                                                                                                                                        [ 39%]
framework/wazuh/core/tests/test_sca.py ........................                                                                                                                                       [ 40%]
framework/wazuh/core/tests/test_security.py ............                                                                                                                                              [ 41%]
framework/wazuh/core/tests/test_stats.py .................                                                                                                                                            [ 42%]
framework/wazuh/core/tests/test_syscheck.py .......                                                                                                                                                   [ 42%]
framework/wazuh/core/tests/test_syscollector.py ...                                                                                                                                                   [ 42%]
framework/wazuh/core/tests/test_task.py ........                                                                                                                                                      [ 43%]
framework/wazuh/core/tests/test_utils.py ............................................................................................................................................................ [ 50%]
.........................................................................................                                                                                                             [ 54%]
framework/wazuh/core/tests/test_vulnerability.py ..                                                                                                                                                   [ 55%]
framework/wazuh/core/tests/test_wazuh_queue.py ....................                                                                                                                                   [ 56%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                                                  [ 56%]
framework/wazuh/core/tests/test_wdb.py .s.ssssss......................                                                                                                                                [ 58%]
framework/wazuh/core/tests/test_wlogging.py .........                                                                                                                                                 [ 58%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                                                                                                                                    [ 59%]
framework/wazuh/rbac/tests/test_decorators.py .........................................................................................................                                               [ 64%]
framework/wazuh/rbac/tests/test_default_configuration.py .......................................................                                                                                      [ 66%]
framework/wazuh/rbac/tests/test_orm.py ......................................................                                                                                                         [ 69%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                           [ 69%]
framework/wazuh/tests/test_active_response.py ............                                                                                                                                            [ 70%]
framework/wazuh/tests/test_agent.py ......................................................................................................................                                            [ 76%]
framework/wazuh/tests/test_cdb_list.py .....................................................                                                                                                          [ 78%]
framework/wazuh/tests/test_ciscat.py .................................                                                                                                                                [ 80%]
framework/wazuh/tests/test_cluster.py ..........                                                                                                                                                      [ 80%]
framework/wazuh/tests/test_decoder.py ...................................                                                                                                                             [ 82%]
framework/wazuh/tests/test_group.py .......                                                                                                                                                           [ 82%]
framework/wazuh/tests/test_logtest.py ......                                                                                                                                                          [ 83%]
framework/wazuh/tests/test_manager.py ....................................                                                                                                                            [ 84%]
framework/wazuh/tests/test_mitre.py .......                                                                                                                                                           [ 85%]
framework/wazuh/tests/test_rootcheck.py ..................................................                                                                                                            [ 87%]
framework/wazuh/tests/test_rule.py ........................................................                                                                                                           [ 90%]
framework/wazuh/tests/test_sca.py ...........                                                                                                                                                         [ 90%]
framework/wazuh/tests/test_security.py .........................................................................                                                                                      [ 94%]
framework/wazuh/tests/test_stats.py ...............                                                                                                                                                   [ 95%]
framework/wazuh/tests/test_syscheck.py ..........................                                                                                                                                     [ 96%]
framework/wazuh/tests/test_syscollector.py ............                                                                                                                                               [ 96%]
framework/wazuh/tests/test_task.py ............................                                                                                                                                       [ 98%]
framework/wazuh/tests/test_vulnerability.py ....................................                                                                                                                      [100%]

========================================================================= 2062 passed, 9 skipped, 57 warnings in 386.32s (0:06:26) ==========================================================================

```

### Integration tests
```

============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.9.9, pytest-5.0.0, py-1.11.0, pluggy-0.13.1 -- /home/agavila/venv/integration/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.9', 'Platform': 'Linux-5.15.0-53-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '5.0.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '2.1.1', 'tavern': '1.2.2', 'metadata': '2.0.4'}}
rootdir: /home/agavila/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: html-2.1.1, tavern-1.2.2, metadata-2.0.4
collected 49 items                                                                                                                                                                                          

test_cluster_endpoints.tavern.yaml::GET /cluster/local/config PASSED                                                                                                                                  [  2%]
test_cluster_endpoints.tavern.yaml::GET /cluster/healthcheck PASSED                                                                                                                                   [  4%]
test_cluster_endpoints.tavern.yaml::GET /cluster/ruleset/synchronization PASSED                                                                                                                       [  6%]
test_cluster_endpoints.tavern.yaml::GET /cluster/local/info PASSED                                                                                                                                    [  8%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes PASSED                                                                                                                                         [ 10%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[master-node] PASSED                                                                                                                            [ 12%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker1] PASSED                                                                                                                                [ 14%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker2] PASSED                                                                                                                                [ 16%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[ip] PASSED                                                                                                                              [ 18%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[name] PASSED                                                                                                                            [ 20%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[type] PASSED                                                                                                                            [ 22%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[version] PASSED                                                                                                                         [ 24%]
test_cluster_endpoints.tavern.yaml::GET /cluster/status PASSED                                                                                                                                        [ 26%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration PASSED                                                                                                                       [ 28%]
test_cluster_endpoints.tavern.yaml::GET /cluster/configuration/validation PASSED                                                                                                                      [ 30%]
test_cluster_endpoints.tavern.yaml::GET /cluster/api/config PASSED                                                                                                                                    [ 32%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration/{component}/{configuration} PASSED                                                                                           [ 34%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[master-node] PASSED                                                                                                                   [ 36%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker1] PASSED                                                                                                                       [ 38%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker2] PASSED                                                                                                                       [ 40%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[master-node] PASSED                                                                                                                   [ 42%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker1] PASSED                                                                                                                       [ 44%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker2] PASSED                                                                                                                       [ 46%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker1] PASSED                                                                                                               [ 48%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker2] PASSED                                                                                                               [ 51%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[master-node] PASSED                                                                                                          [ 53%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[worker1] PASSED                                                                                                              [ 55%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[worker2] PASSED                                                                                                              [ 57%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[master-node] PASSED                                                                                                                  [ 59%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker1] PASSED                                                                                                                      [ 61%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker2] PASSED                                                                                                                      [ 63%]
test_cluster_endpoints.tavern.yaml::GET /cluster/wrong_node/stats PASSED                                                                                                                              [ 65%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[master-node] PASSED                                                                                                        [ 67%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker1] PASSED                                                                                                            [ 69%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker2] PASSED                                                                                                            [ 71%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[master-node] PASSED                                                                                                           [ 73%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker1] PASSED                                                                                                               [ 75%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker2] PASSED                                                                                                               [ 77%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[master-node] PASSED                                                                                                          [ 79%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker1] PASSED                                                                                                              [ 81%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker2] PASSED                                                                                                              [ 83%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[master-node] PASSED                                                                                                           [ 85%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker1] PASSED                                                                                                               [ 87%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker2] PASSED                                                                                                               [ 89%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[master-node] PASSED                                                                                                                 [ 91%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker1] PASSED                                                                                                                     [ 93%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker2] PASSED                                                                                                                     [ 95%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/restart PASSED                                                                                                                                       [ 97%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/configuration PASSED                                                                                                                       [100%]

======================================================================================= 49 passed in 1222.65 seconds ========================================================================================

```
