### PR TITLE
Prevent Logcollector from producing errors on blank lines at audit log files

### DIFF
--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -121,8 +121,8 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
             break;
         }
 
-        if (!((id = strstr(buffer, "type=")) && (id = strstr(id + 5, " msg=audit(")) && (p = strstr(id += 11, "): ")))) {
-            merror("Discarding audit message because of invalid syntax.");
+        if (!((id = strstr(buffer, "type=")) && (id = strstr(id + 5, " msg=audit(")) && (p = strstr(id += 11, "):")))) {
+            mwarn("Discarding audit message because of invalid syntax.");
             break;
         }
 

--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -116,6 +116,11 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
         // Extract header: "\.*type=\.* msg=audit(.*):"
         //                                        --
 
+        if (strlen(buffer) == 0) {
+            mdebug2("audit reader: empty line, skipping.");
+            break;
+        }
+
         if (!((id = strstr(buffer, "type=")) && (id = strstr(id + 5, " msg=audit(")) && (p = strstr(id += 11, "): ")))) {
             merror("Discarding audit message because of invalid syntax.");
             break;


### PR DESCRIPTION
|Related issue|Testing|
|---|---|
|Closes #13710 and #14687|https://github.com/wazuh/wazuh-qa/issues/3633|

This PR aims to fix a double issue in Logcollector, whose `audit` log reader produces errors in these cases:

1. An empty line was found.
2. A log with a valid header but an empty message was found.

## Tests

### Configuration

```xml
<localfile>
  <location>/root/test.log</location>
  <log_format>audit</log_format>
</localfile>
```

- [x] Empty line: no error.

```
2022/11/24 12:03:52 wazuh-logcollector[9178] read_audit.c:120 at read_audit(): DEBUG: audit reader: empty line, skipping.
2022/11/24 12:03:52 wazuh-logcollector[9178] read_audit.c:155 at read_audit(): DEBUG: Read 1 lines from /root/test.log
```

- [x] Line with empty messages:

Input:
```
type=UNKNOWN[1421] msg=audit(1660868417.986:12082):
type=PATH msg=audit(1660868417.986:12082): item=0 name="/usr/bin/df" inode=2097761 dev=fd:00 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=? nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=UNKNOWN[1421] msg=audit(1660868417.986:12082):
```
Archive:
```
2022 Nov 24 12:05:22 ubuntu->/root/test.log type=UNKNOWN[1421] msg=audit(1660868417.986:12082): type=PATH msg=audit(1660868417.986:12082): item=0 name="/usr/bin/df" inode=2097761 dev=fd:> type=UNKNOWN[1421] msg=audit(1660868417.986:12082):
```

- [x] Run on Valgrind:

<details><summary>Report</summary>

```
==9178== FILE DESCRIPTORS: 7 open (3 std) at exit.
==9178== Open AF_UNIX socket 6: queue/sockets/logcollector
==9178==    at 0x52A6CEB: socket (syscall-template.S:120)
==9178==    by 0x21D32E: OS_BindUnixDomainWithPerms (os_net.c:149)
==9178==    by 0x21D52B: OS_BindUnixDomain (os_net.c:192)
==9178==    by 0x11D75D: lccom_main (lccom.c:122)
==9178==    by 0x5213B42: start_thread (pthread_create.c:442)
==9178==    by 0x52A4BB3: clone (clone.S:100)
==9178==
==9178== Open file descriptor 5: /root/test.log
==9178==    at 0x5293764: open (open64.c:41)
==9178==    by 0x520B135: _IO_file_open (fileops.c:188)
==9178==    by 0x520B491: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:280)
==9178==    by 0x51FE72D: __fopen_internal (iofopen.c:75)
==9178==    by 0x51FE72D: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==9178==    by 0x11FEE5: handle_file (logcollector.c:971)
==9178==    by 0x12060C: set_read (logcollector.c:1222)
==9178==    by 0x11E66D: LogCollectorStart (logcollector.c:377)
==9178==    by 0x126451: main (main.c:195)
==9178==
==9178== Open AF_UNIX socket 4: <unknown>
==9178==    at 0x52A6CEB: socket (syscall-template.S:120)
==9178==    by 0x21D5C8: OS_ConnectUnixDomain (os_net.c:211)
==9178==    by 0x20081C: StartMQWithSpecificOwnerAndPerms (mq_op.c:39)
==9178==    by 0x20090B: StartMQ (mq_op.c:61)
==9178==    by 0x126408: main (main.c:190)
==9178==
==9178== Open file descriptor 3: /dev/urandom
==9178==    at 0x52936EB: open (open64.c:41)
==9178==    by 0x203FC1: randombytes (randombytes.c:62)
==9178==    by 0x2040A9: srandom_init (randombytes.c:82)
==9178==    by 0x125E7D: main (main.c:70)
==9178==
==9178==
==9178== LEAK SUMMARY:
==9178==    definitely lost: 0 bytes in 0 blocks
==9178==    indirectly lost: 0 bytes in 0 blocks
==9178==      possibly lost: 2,016 bytes in 7 blocks
==9178==    still reachable: 15,645 bytes in 103 blocks
==9178==         suppressed: 0 bytes in 0 blocks
```

</details>