### PR TITLE
CIS W10: Fixed printer policy registry path

### DIFF
--- a/ruleset/sca/windows/cis_win10_enterprise.yml
+++ b/ruleset/sca/windows/cis_win10_enterprise.yml
@@ -2760,9 +2760,9 @@ checks:
       - cis: ["18.3.5"]
     condition: any
     rules:
-      - 'not r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsNT\Printers\PointAndPrint'
-      - 'not r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsNT\Printers\PointAndPrint -> RestrictDriverInstallationToAdministrators'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsNT\Printers\PointAndPrint -> RestrictDriverInstallationToAdministrators -> 1'
+      - 'not r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\PointAndPrint'
+      - 'not r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\PointAndPrint -> RestrictDriverInstallationToAdministrators'
+      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\PointAndPrint -> RestrictDriverInstallationToAdministrators -> 1'
 
   - id: 15187
     title: "Ensure 'NetBT NodeType configuration' is set to 'Enabled: P-node'."
@@ -3312,9 +3312,9 @@ checks:
       - cis: ["18.6.1"]
     condition: all
     rules:
-      - 'r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsNT\Printers'
-      - 'r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsNT\Printers -> RegisterSpoolerRemoteRpcEndPoint'
-      - 'r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsNT\Printers -> RegisterSpoolerRemoteRpcEndPoint -> 2'
+      - 'r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers'
+      - 'r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers -> RegisterSpoolerRemoteRpcEndPoint'
+      - 'r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers -> RegisterSpoolerRemoteRpcEndPoint -> 2'
 
   - id: 15220
     title: "Ensure 'Point and Print Restrictions: When installing drivers for a new connection' is set to 'Enabled: Show warning and elevation prompt'."
@@ -3325,9 +3325,9 @@ checks:
       - cis: ["18.6.2"]
     condition: any
     rules:
-      - 'not r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsNT\Printers\PointAndPrint'
-      - 'not r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsNT\Printers\PointAndPrint -> NoWarningNoElevationOnInstall'
-      - 'r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsNT\Printers\PointAndPrint -> NoWarningNoElevationOnInstall -> 0'
+      - 'not r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint'
+      - 'not r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint -> NoWarningNoElevationOnInstall'
+      - 'r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint -> NoWarningNoElevationOnInstall -> 0'
 
   - id: 15221
     title: "Ensure 'Point and Print Restrictions: When updating drivers for an existing connection' is set to 'Enabled: Show warning and elevation prompt'."
@@ -3338,9 +3338,9 @@ checks:
       - cis: ["18.6.3"]
     condition: any
     rules:
-      - 'not r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsNT\Printers\PointAndPrint'
-      - 'not r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsNT\Printers\PointAndPrint -> UpdatePromptSettings'
-      - 'r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsNT\Printers\PointAndPrint -> UpdatePromptSettings -> 0'
+      - 'not r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint'
+      - 'not r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint -> UpdatePromptSettings'
+      - 'r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint -> UpdatePromptSettings -> 0'
 
   - id: 15222
     title: "Ensure 'Turn off notifications network usage' is set to 'Enabled'."


### PR DESCRIPTION
The registry path for printer policies is incorrect. The space in "Windows NT" is missing.

|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors