### PR TITLE
Allow shutdown message processing even though socket is closed

### DIFF
--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -626,7 +626,7 @@ STATIC void HandleSecureMessage(const message_t *message, int *wdb_sock) {
     if (IsValidHeader(tmp_msg)) {
 
         /* let through new and shutdown messages */
-        if (message->sock == USING_UDP_NO_CLIENT_SOCKET || message->counter >  rem_getCounter(message->sock) || (strncmp(tmp_msg, HC_SHUTDOWN, strlen(HC_SHUTDOWN)) == 0)) {
+        if (message->sock == USING_UDP_NO_CLIENT_SOCKET || message->counter > rem_getCounter(message->sock) || (strncmp(tmp_msg, HC_SHUTDOWN, strlen(HC_SHUTDOWN)) == 0)) {
             /* We need to save the peerinfo if it is a control msg */
 
             w_mutex_lock(&keys.keyentries[agentid]->mutex);

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -50,19 +50,21 @@ list(APPEND remoted_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,w_
                             -Wl,--wrap,rem_inc_recv_ctrl_startup -Wl,--wrap,rem_inc_recv_ctrl_shutdown -Wl,--wrap,unlink -Wl,--wrap,getpid")
 
 list(APPEND remoted_names "test_secure")
-list(APPEND remoted_flags "-Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose -Wl,--wrap,remove \
-                            -Wl,--wrap,sleep -Wl,--wrap,fgets -Wl,--wrap,fflush -Wl,--wrap,fseek \
-                            -Wl,--wrap,stat -Wl,--wrap,getpid -Wl,--wrap=key_lock_write -Wl,--wrap=key_unlock -Wl,--wrap=time \
-                            -Wl,--wrap,fgetpos -Wl,--wrap=fgetc -Wl,--wrap=OS_IsAllowedDynamicID -Wl,--wrap=_mwarn \
-                            -Wl,--wrap=OS_DeleteSocket -Wl,--wrap=nb_close -Wl,--wrap=rem_setCounter -Wl,--wrap=key_lock_read \
-                            -Wl,--wrap=rem_inc_tcp -Wl,--wrap=rem_dec_tcp -Wl,--wrap=close -Wl,--wrap=accept \
-                            -Wl,--wrap=wnotify_add -Wl,--wrap,fcntl -Wl,--wrap,_merror -Wl,--wrap=nb_open -Wl,--wrap=recvfrom \
-                            -Wl,--wrap=rem_msgpush -Wl,--wrap=rem_add_recv -Wl,--wrap=nb_recv -Wl,--wrap=nb_send \
-                            -Wl,--wrap=rem_add_send -Wl,--wrap=OS_IsAllowedIP \
-                            -Wl,--wrap,rem_add_recv -Wl,--wrap,rem_add_send -Wl,--wrap,rem_inc_tcp -Wl,--wrap,rem_dec_tcp \
-                            -Wl,--wrap,rem_inc_recv_unknown -Wl,--wrap,rem_getCounter -Wl,--wrap,ReadSecMSG \
-                            -Wl,--wrap,w_mutex_lock -Wl,--wrap,w_mutex_unlock -Wl,--wrap,time -Wl,--wrap,OS_AddSocket -Wl,--wrap,save_controlmsg \
-                            -Wl,--wrap,rem_inc_recv_ctrl ${DEBUG_OP_WRAPPERS}")
+list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,accept -Wl,--wrap,close \
+                            -Wl,--wrap,fclose -Wl,--wrap,fcntl -Wl,--wrap,fflush -Wl,--wrap,fgetc \
+                            -Wl,--wrap,fgetpos -Wl,--wrap,fgets -Wl,--wrap,fopen -Wl,--wrap,fread \
+                            -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,getpid -Wl,--wrap,key_lock_read \
+                            -Wl,--wrap,key_lock_write -Wl,--wrap,key_unlock -Wl,--wrap,nb_close \
+                            -Wl,--wrap,nb_open -Wl,--wrap,nb_recv -Wl,--wrap,nb_send -Wl,--wrap,OS_AddSocket \
+                            -Wl,--wrap,OS_DeleteSocket -Wl,--wrap,OS_IsAllowedDynamicID -Wl,--wrap,OS_IsAllowedIP \
+                            -Wl,--wrap,ReadSecMSG -Wl,--wrap,recvfrom -Wl,--wrap,rem_add_recv -Wl,--wrap,rem_add_recv \
+                            -Wl,--wrap,rem_add_send -Wl,--wrap,rem_add_send -Wl,--wrap,rem_dec_tcp \
+                            -Wl,--wrap,rem_dec_tcp -Wl,--wrap,rem_getCounter -Wl,--wrap,rem_inc_recv_ctrl \
+                            -Wl,--wrap,rem_inc_recv_unknown -Wl,--wrap,rem_inc_tcp -Wl,--wrap,rem_inc_tcp \
+                            -Wl,--wrap,rem_msgpush -Wl,--wrap,rem_setCounter -Wl,--wrap,remove \
+                            -Wl,--wrap,save_controlmsg -Wl,--wrap,sleep -Wl,--wrap,stat -Wl,--wrap,time \
+                            -Wl,--wrap,time -Wl,--wrap,w_mutex_lock -Wl,--wrap,w_mutex_unlock \
+                            -Wl,--wrap,wnotify_add ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND remoted_names "test_netbuffer")
 list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug1 -Wl,--wrap,wnet_order -Wl,--wrap,wnotify_modify \

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -58,9 +58,11 @@ list(APPEND remoted_flags "-Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -
                             -Wl,--wrap=rem_inc_tcp -Wl,--wrap=rem_dec_tcp -Wl,--wrap=close -Wl,--wrap=accept \
                             -Wl,--wrap=wnotify_add -Wl,--wrap,fcntl -Wl,--wrap,_merror -Wl,--wrap=nb_open -Wl,--wrap=recvfrom \
                             -Wl,--wrap=rem_msgpush -Wl,--wrap=rem_add_recv -Wl,--wrap=nb_recv -Wl,--wrap=nb_send \
-                            -Wl,--wrap=rem_add_send -Wl,--wrap=OS_IsAllowedIP ${DEBUG_OP_WRAPPERS} \
+                            -Wl,--wrap=rem_add_send -Wl,--wrap=OS_IsAllowedIP \
                             -Wl,--wrap,rem_add_recv -Wl,--wrap,rem_add_send -Wl,--wrap,rem_inc_tcp -Wl,--wrap,rem_dec_tcp \
-                            -Wl,--wrap,rem_inc_recv_unknown")
+                            -Wl,--wrap,rem_inc_recv_unknown -Wl,--wrap,rem_getCounter -Wl,--wrap,ReadSecMSG \
+                            -Wl,--wrap,w_mutex_lock -Wl,--wrap,w_mutex_unlock -Wl,--wrap,time -Wl,--wrap,OS_AddSocket -Wl,--wrap,save_controlmsg \
+                            -Wl,--wrap,rem_inc_recv_ctrl ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND remoted_names "test_netbuffer")
 list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug1 -Wl,--wrap,wnet_order -Wl,--wrap,wnotify_modify \

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -444,13 +444,6 @@ void test_HandleSecureMessage_shutdown_message(void **state)
     expect_value(__wrap_rem_getCounter, fd, 1);
     will_return(__wrap_rem_getCounter, 10);
 
-
-    expect_value(__wrap_OS_AddSocket, i, 0);
-    expect_value(__wrap_OS_AddSocket, sock, message.sock);
-    will_return(__wrap_OS_AddSocket, 2);
-
-    expect_string(__wrap__mdebug2, formatted_msg, "TCP socket 1 added to keystore.");
-
     expect_function_call(__wrap_key_unlock);
 
     expect_string(__wrap_save_controlmsg, msg, "agent shutdown ");
@@ -571,6 +564,7 @@ void test_HandleSecureMessage_OldMessage_NoShutdownMessage(void **state)
     expect_value(__wrap_rem_getCounter, fd, 1);
     will_return(__wrap_rem_getCounter, 10);
 
+    expect_function_call(__wrap_key_unlock);
     HandleSecureMessage(&message, &wdb_sock);
 
     os_free(key->id);

--- a/src/unit_tests/wrappers/wazuh/os_crypto/keys_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/os_crypto/keys_wrappers.c
@@ -41,3 +41,10 @@ int __wrap_OS_IsAllowedID(__attribute__((unused)) keystore *keys, const char *id
 
     return mock();
 }
+
+int __wrap_OS_AddSocket(__attribute__((unused)) keystore *keys, unsigned int i, int sock) {
+    check_expected(i);
+    check_expected(sock);
+
+    return mock();
+}

--- a/src/unit_tests/wrappers/wazuh/os_crypto/keys_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/os_crypto/keys_wrappers.h
@@ -19,4 +19,6 @@ int __wrap_OS_IsAllowedIP(__attribute__((unused)) keystore *keys, const char *sr
 
 int __wrap_OS_IsAllowedID(__attribute__((unused)) keystore *keys, const char *id);
 
+int __wrap_OS_AddSocket(__attribute__((unused)) keystore *keys, unsigned int i, int sock);
+
 #endif

--- a/src/unit_tests/wrappers/wazuh/os_crypto/msgs_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/os_crypto/msgs_wrappers.c
@@ -26,3 +26,10 @@ size_t __wrap_CreateSecMSG(__attribute__((unused)) keystore *keys, const char *m
 
     return size;
 }
+
+int __wrap_ReadSecMSG(keystore *keys, char *buffer, char *cleartext, int id, unsigned int buffer_size, size_t *final_size, const char *srcip, char **output) {
+    check_expected(buffer);
+    *final_size = (int)mock();
+    *output = (char*)mock_ptr_type(char *);
+    return (int)mock();
+}

--- a/src/unit_tests/wrappers/wazuh/os_crypto/msgs_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/os_crypto/msgs_wrappers.h
@@ -13,5 +13,6 @@
 #include <sys/types.h>
 
 size_t __wrap_CreateSecMSG(__attribute__((unused)) keystore *keys, const char *msg, size_t msg_length, char *msg_encrypted, unsigned int id);
+int __wrap_ReadSecMSG(keystore *keys, char *buffer, char *cleartext, int id, unsigned int buffer_size, size_t *final_size, const char *srcip, char **output);
 
 #endif

--- a/src/unit_tests/wrappers/wazuh/remoted/netcounter_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/remoted/netcounter_wrappers.c
@@ -21,3 +21,8 @@ void __wrap_rem_setCounter(int fd, size_t counter) {
     check_expected(fd);
     check_expected(counter);
 }
+
+size_t __wrap_rem_getCounter(int fd) {
+    check_expected(fd);
+    return mock();
+}

--- a/src/unit_tests/wrappers/wazuh/remoted/netcounter_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/remoted/netcounter_wrappers.h
@@ -11,5 +11,6 @@
 #define NETCOUNTER_WRAPPERS_H
 
 void __wrap_rem_setCounter(int fd, size_t counter);
+size_t __wrap_rem_getCounter(int fd);
 
 #endif

--- a/src/unit_tests/wrappers/wazuh/remoted/state_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/remoted/state_wrappers.c
@@ -44,6 +44,10 @@ void __wrap_rem_inc_recv_ctrl_keepalive(const char *agent_id) {
     check_expected(agent_id);
 }
 
+void __wrap_rem_inc_recv_ctrl(const char *agent_id) {
+    check_expected(agent_id);
+}
+
 void __wrap_rem_inc_recv_unknown() {
     function_called();
     return;

--- a/src/unit_tests/wrappers/wazuh/remoted/state_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/remoted/state_wrappers.h
@@ -28,6 +28,8 @@ void __wrap_rem_inc_recv_ctrl_shutdown(const char *agent_id);
 
 void __wrap_rem_inc_recv_ctrl_keepalive(const char *agent_id);
 
+void __wrap_rem_inc_recv_ctrl(const char *agent_id);
+
 void __wrap_rem_inc_recv_unknown();
 
 void __wrap_rem_add_send(unsigned long bytes);


### PR DESCRIPTION
|Related issues|Manual Testing|
|---|---|
|https://github.com/wazuh/wazuh/issues/15153|[#3704](https://github.com/wazuh/wazuh-qa/issues/3704)|

## Description
This PR solves the issue https://github.com/wazuh/wazuh/issues/15153, the proposed solution was let through new and shutdown messages, for it to be processed correctly and update the connection status.

### Option test

1.  Run VM with 40 agents.
  - <details><summary>ossec.conf for create image</summary>
    <p>    

    ```xml
    <!--
      Wazuh - Agent - Default configuration for ubuntu 20.04
      More info at: https://documentation.wazuh.com
      Mailing list: https://groups.google.com/forum/#!forum/wazuh
    -->
    
    <ossec_config>
      <client>
        <server>
          <address>192.168.56.90</address>
          <port>1514</port>
          <protocol>tcp</protocol>
        </server>
        <config-profile>ubuntu, ubuntu20, ubuntu20.04</config-profile>
        <notify_time>10</notify_time>
        <time-reconnect>60</time-reconnect>
        <auto_restart>yes</auto_restart>
        <crypto_method>aes</crypto_method>
      </client>
    
      <client_buffer>
        <!-- Agent buffer options -->
        <disabled>no</disabled>
        <queue_size>5000</queue_size>
        <events_per_second>500</events_per_second>
      </client_buffer>
    
      <!-- Policy monitoring -->
      <rootcheck>
        <disabled>no</disabled>
        <check_files>yes</check_files>
        <check_trojans>yes</check_trojans>
        <check_dev>yes</check_dev>
        <check_sys>yes</check_sys>
        <check_pids>yes</check_pids>
        <check_ports>yes</check_ports>
        <check_if>yes</check_if>
    
        <!-- Frequency that rootcheck is executed - every 12 hours -->
        <frequency>300</frequency>
    
        <rootkit_files>etc/shared/rootkit_files.txt</rootkit_files>
        <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
    
        <skip_nfs>yes</skip_nfs>
      </rootcheck>
    
      <wodle name="cis-cat">
        <disabled>yes</disabled>
        <timeout>1800</timeout>
        <interval>1d</interval>
        <scan-on-start>yes</scan-on-start>
    
        <java_path>wodles/java</java_path>
        <ciscat_path>wodles/ciscat</ciscat_path>
      </wodle>
    
      <!-- Osquery integration -->
      <wodle name="osquery">
        <disabled>yes</disabled>
        <run_daemon>yes</run_daemon>
        <log_path>/var/log/osquery/osqueryd.results.log</log_path>
        <config_path>/etc/osquery/osquery.conf</config_path>
        <add_labels>yes</add_labels>
      </wodle>
    
      <!-- System inventory -->
      <wodle name="syscollector">
        <disabled>no</disabled>
        <interval>5m</interval>
        <scan_on_start>yes</scan_on_start>
        <hardware>yes</hardware>
        <os>yes</os>
        <network>yes</network>
        <packages>yes</packages>
        <ports all="no">yes</ports>
        <processes>yes</processes>
    
        <!-- Database synchronization settings -->
        <synchronization>
          <max_eps>10</max_eps>
        </synchronization>
      </wodle>
    
      <sca>
        <enabled>yes</enabled>
        <scan_on_start>yes</scan_on_start>
        <interval>5m</interval>
        <skip_nfs>yes</skip_nfs>
      </sca>
    
      <!-- File integrity monitoring -->
      <syscheck>
        <disabled>no</disabled>
    
        <!-- Frequency that syscheck is executed default every 12 hours -->
        <frequency>300</frequency>
    
        <scan_on_start>yes</scan_on_start>
    
        <!-- Directories to check  (perform all possible verifications) -->
        <directories>/etc,/usr/bin,/usr/sbin</directories>
        <directories>/bin,/sbin,/boot</directories>
    
        <!-- Files/directories to ignore -->
        <ignore>/etc/mtab</ignore>
        <ignore>/etc/hosts.deny</ignore>
        <ignore>/etc/mail/statistics</ignore>
        <ignore>/etc/random-seed</ignore>
        <ignore>/etc/random.seed</ignore>
        <ignore>/etc/adjtime</ignore>
        <ignore>/etc/httpd/logs</ignore>
        <ignore>/etc/utmpx</ignore>
        <ignore>/etc/wtmpx</ignore>
        <ignore>/etc/cups/certs</ignore>
        <ignore>/etc/dumpdates</ignore>
        <ignore>/etc/svc/volatile</ignore>
    
        <!-- File types to ignore -->
        <ignore type="sregex">.log$|.swp$</ignore>
    
        <!-- Check the file, but never compute the diff -->
        <nodiff>/etc/ssl/private.key</nodiff>
    
        <skip_nfs>yes</skip_nfs>
        <skip_dev>yes</skip_dev>
        <skip_proc>yes</skip_proc>
        <skip_sys>yes</skip_sys>
    
        <!-- Nice value for Syscheck process -->
        <process_priority>10</process_priority>
    
        <!-- Maximum output throughput -->
        <max_eps>100</max_eps>
    
        <!-- Database synchronization settings -->
        <synchronization>
          <enabled>yes</enabled>
          <interval>5m</interval>
          <max_interval>1h</max_interval>
          <max_eps>10</max_eps>
        </synchronization>
      </syscheck>
    
      <!-- Log analysis -->
      <localfile>
        <log_format>command</log_format>
        <command>df -P</command>
        <frequency>360</frequency>
      </localfile>
    
      <localfile>
        <log_format>full_command</log_format>
        <command>netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d</command>
        <alias>netstat listening ports</alias>
        <frequency>360</frequency>
      </localfile>
    
      <localfile>
        <log_format>full_command</log_format>
        <command>last -n 20</command>
        <frequency>360</frequency>
      </localfile>
    
      <!-- Active response -->
      <active-response>
        <disabled>no</disabled>
        <ca_store>etc/wpk_root.pem</ca_store>
        <ca_verification>yes</ca_verification>
      </active-response>
    
      <!-- Choose between "plain", "json", or "plain,json" for the format of internal logs -->
      <logging>
        <log_format>plain</log_format>
      </logging>
    
      <github>
          <enabled>yes</enabled>
          <interval>10s</interval>
          <time_delay>30s</time_delay>
          <curl_max_size>1M</curl_max_size>
          <only_future_events>no</only_future_events>
          <api_auth>
              <org_name>alagrandelepusecuca2022</org_name>
              <api_token>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</api_token>
          </api_auth>
          <api_parameters>
              <event_type>all</event_type>
          </api_parameters>
      </github>
    
      <localfile>
        <log_format>syslog</log_format>
        <location>/var/ossec/logs/active-responses.log</location>
      </localfile>
    
      <localfile>
        <log_format>syslog</log_format>
        <location>/var/log/dpkg.log</location>
      </localfile>
    
    </ossec_config>

    ```
    </p>
    </details>
  - <details><summary>Dockerfile</summary>
    <p>

    ```vim
    FROM ubuntu
    RUN apt-get update && \
    apt-get install -y curl gnupg2 && \
    curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add - && \
    echo "deb https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list && \
    apt-get update && \
    apt-get install -y wazuh-agent && \
    rm -rf /var/lib/apt/lists/* 
    RUN rm -f /var/ossec/etc/ossec.conf
    ADD --chown=root:wazuh ossec.conf /var/ossec/etc
    CMD /var/ossec/bin/wazuh-control start && tail -f /dev/null    
    ```
    </p>
    </details>
 - <details><summary>Docker for multiples agents</summary>
    <p>
     Commands:

    1. Build new image
         
            docker build -t wazuh-agent .
    
    3. Stop and delete runing containers
        
            docker rm $(docker stop $(docker ps -a -q --filter ancestor=wazuh-agent --format="{{.ID}}"))
    
    4. Run multiple containers
    
            for i in {1..40}; do HOSTNAME=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 13 ; echo '') && docker run --network="host" -h "$HOSTNAME" -d wazuh-agent && sleep 0.1; done
    
    5. Delete image
         
            docker image rm wazuh-agent
    
    6. Service stop in multiple containers
        
            for con in `docker ps -q` ; do echo "$con" && docker exec -d $con /var/ossec/bin/wazuh-control stop; done
    7. Service start in multiple containers
        
            for con in `docker ps -q` ; do echo "$con" && docker exec -d $con /var/ossec/bin/wazuh-control start; done
    8. Service status in multiple containers
      
            for con in `docker ps -q` ; do echo "$con" && docker exec $con /var/ossec/bin/wazuh-control status; done
            
    9. Stop multiple containers
    
           docker stop $(docker ps -a -q --filter ancestor=wazuh-agent --format="{{.ID}}")
    
    10. Start multiple containers
            
            docker start $(docker ps -a -q --filter ancestor=wazuh-agent --format="{{.ID}}")
    
    11. clean counter of agents from manager (restart manager after)
            
            curl -k -X DELETE "https://192.168.56.90:55000/agents?agents_list=all&status=all&older_than=0s&purge=true" -H "Authorization: Bearer $(curl -u wazuh:wazuh -k -X GET "https://192.168.56.90:55000/security/user/authenticate?raw=true")"
    
</p>
</details>

3.  Run VM with  1 manager.
  - see agent conections `watch -n 2 /var/ossec/bin/agent_control -l`

4. Replicate problem  send the agent start command and immediately the stop command
```  
 for con in `docker ps -q` ; do echo "$con" && docker exec -d $con /var/ossec/bin/wazuh-control start; done && for con in `docker ps -q` ; do echo "$con" && docker exec -d $con /var/ossec/bin/wazuh-control stop; done
```
## Note

1. The manager's IP should be change inside ossec.conf before  create image docker.
2. When some agents appear active after shutdown it is because the agent is still on, in fact the socket is still open.
  some time later (less than 1 minute), the agent shutdown and thus the connection is updated.
  this case is seen when the status request is sent to wazuh-control.
 
    ![correctCase](https://user-images.githubusercontent.com/17997755/204687252-f8b5d74a-4011-48a0-8bc2-99acf1c3ea70.png)



## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

