### PR TITLE
Fix defects found by Coverity in 4.4.0-alpha1

### DIFF
--- a/src/os_auth/key_request.c
+++ b/src/os_auth/key_request.c
@@ -205,7 +205,7 @@ char * key_request_exec_output(request_type_t type, char *request) {
         os_free(output);
         return NULL;
     }
-    
+
     return output;
 }
 
@@ -253,7 +253,7 @@ void* run_key_request_main(__attribute__((unused)) void *arg) {
             }
         }
 
-        if (recv = OS_RecvUnix(sock, OS_MAXSTR, buffer), recv) {
+        if ((recv = OS_RecvUnix(sock, OS_MAXSTR, buffer)) > 0) {
             if(OSHash_Get_ex(request_hash, buffer)){
                 mdebug2("Request '%s' already being processed. Discarding request.", buffer);
                 continue;
@@ -414,7 +414,7 @@ int key_request_dispatch(char * buffer) {
 
     OSHash_Delete_ex(request_hash, buffer);
     return 0;
-} 
+}
 
 void * key_request_dispatch_thread(__attribute__((unused)) void *arg) {
     char *msg = NULL;

--- a/src/os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.c
+++ b/src/os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.c
@@ -64,9 +64,13 @@ int OS_MD5_SHA1_SHA256_File(const char *fname,
         os_strdup(fname, command[cnt]);
 
         wfd = wpopenv(*command, command, W_BIND_STDOUT);
-        fp = wfd->file_out;
-
         free_strarray(command);
+
+        if (wfd == NULL) {
+            return -1;
+        }
+
+        fp = wfd->file_out;
     }
 
     /* Initialize both hashes */

--- a/src/unit_tests/os_crypto/md5_sha1_sha256/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/md5_sha1_sha256/CMakeLists.txt
@@ -8,7 +8,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 list(APPEND md5_sha1_tests_names "test_md5_sha1_sha256_op")
-list(APPEND md5_sha1_tests_flags " ")
+list(APPEND md5_sha1_tests_flags "-Wl,--wrap,wpopenv,--wrap,wpclose,--wrap,fread,--wrap,fclose,--wrap,fflush,--wrap,fgets,--wrap,fgetpos,--wrap,fopen,--wrap,fseek,--wrap,fwrite,--wrap,remove,--wrap,fgetc,--wrap,wfopen")
 
 # Compiling tests
 list(LENGTH md5_sha1_tests_names count)

--- a/src/unit_tests/os_crypto/md5_sha1_sha256/test_md5_sha1_sha256_op.c
+++ b/src/unit_tests/os_crypto/md5_sha1_sha256/test_md5_sha1_sha256_op.c
@@ -17,28 +17,40 @@
 #include "os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.h"
 
 #include "../../wrappers/common.h"
+#include "../../wrappers/libc/stdio_wrappers.h"
+#include "../../wrappers/wazuh/shared/file_op_wrappers.h"
+
+static int setup_group(void ** state) {
+    test_mode = 1;
+    return 0;
+}
+
+static int teardown_group(void ** state) {
+    test_mode = 0;
+    return 0;
+}
 
 // Tests
 
 void test_md5_sha1_sha256_file(void **state)
 {
-    const char *string = "teststring";
+    char *string = "teststring";
     const char *string_md5 = "d67c5cbf5b01c9f91932e3b8def5e5f8";
     const char *string_sha1 = "b8473b86d4c2072ca9b08bd28e373e8253e865c4";
     const char *string_sha256 = "3c8727e019a42b444667a587b6001251becadabbb36bfed8087a92c18882d111";
 
     /* create tmp file */
-    char file_name[256];
-    strncpy(file_name, "/tmp/tmp_file-XXXXXX", 256);
-    int fd = mkstemp(file_name);
+    char file_name[256] = "/tmp/tmp_file-XXXXXX";
 
-    write(fd, string, strlen(string));
-    close(fd);
+    FILE * fp;
+    expect_wfopen(file_name, "r", fp);
+    expect_fread(string, strlen(string));
+    expect_fread(string, 0);
+    expect_fclose(fp, 0);
 
     os_md5 md5buffer;
     os_sha1 sha1buffer;
     os_sha256 sha256buffer;
-
 
     assert_int_equal(OS_MD5_SHA1_SHA256_File(file_name, NULL, md5buffer, sha1buffer, sha256buffer, OS_TEXT, 20), 0);
 
@@ -48,23 +60,23 @@ void test_md5_sha1_sha256_file(void **state)
 
 void test_md5_sha1_sha256_cmd_file(void **state)
 {
-    const char *string = "teststring";
+    char *string = "teststring";
     const char *string_md5 = "d67c5cbf5b01c9f91932e3b8def5e5f8";
     const char *string_sha1 = "b8473b86d4c2072ca9b08bd28e373e8253e865c4";
     const char *string_sha256 = "3c8727e019a42b444667a587b6001251becadabbb36bfed8087a92c18882d111";
 
-    /* create tmp file */
-    char file_name[256];
-    strncpy(file_name, "/tmp/tmp_file-XXXXXX", 256);
-    int fd = mkstemp(file_name);
-
-    write(fd, string, strlen(string));
-    close(fd);
+    char file_name[256] = "/tmp/tmp_file-XXXXXX";
 
     os_md5 md5buffer;
     os_sha1 sha1buffer;
     os_sha256 sha256buffer;
     char *command [] = {"cat", NULL};
+
+    wfd_t wfd = { NULL, NULL, 0 };
+    will_return(__wrap_wpopenv, &wfd);
+    expect_fread(string, strlen(string));
+    expect_fread(string, 0);
+    will_return(__wrap_wpclose, 0);
 
     assert_int_equal(OS_MD5_SHA1_SHA256_File(file_name, command, md5buffer, sha1buffer, sha256buffer, OS_TEXT, 20), 0);
 
@@ -82,7 +94,9 @@ void test_md5_sha1_sha256_cmd_file_fail(void **state)
 
     char *command [] = {"cat", NULL};
 
-    assert_int_equal(OS_MD5_SHA1_SHA256_File("file_name", command, md5buffer, sha1buffer, sha256buffer, OS_TEXT, 20), 0);
+    will_return(__wrap_wpopenv, NULL);
+
+    assert_int_equal(OS_MD5_SHA1_SHA256_File("file_name", command, md5buffer, sha1buffer, sha256buffer, OS_TEXT, 20), -1);
 }
 
 int main(void) {
@@ -91,5 +105,5 @@ int main(void) {
         cmocka_unit_test(test_md5_sha1_sha256_cmd_file),
         cmocka_unit_test(test_md5_sha1_sha256_cmd_file_fail),
     };
-    return cmocka_run_group_tests(tests, NULL, NULL);
+    return cmocka_run_group_tests(tests, setup_group, teardown_group);
 }

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -910,7 +910,7 @@ static void * wm_inotify_start(__attribute__((unused)) void * args) {
                     continue;
                 }
 
-                snprintf(path, PATH_MAX, "%s/%s", dirname?dirname:"", event->name);
+                snprintf(path, PATH_MAX, "%s/%s", dirname, event->name);
 
                 if (event->name[0] == '.' && IsDir(path)) {
                     mtdebug2(WM_DATABASE_LOGTAG, "Discarding hidden file.");


### PR DESCRIPTION
|Related issue|
|---|
|Fixes #15556|

This PR aims to fix the defects described in #15556.

## Defects treated

<details><summary><h3>🟣 Not null-terminated string in Authd</h3></summary>

This issue is a **false positive**.

We expect `OS_RecvUnix()` to null-terminate strings. In fact, it always writes a zero into `ret[sizet]` (`ret` must be `sizet + 1` bytes long).

However, if the underlying function `recvfrom` fails, the returning string may contain undefined data from `ret[0]` to `ret[sizet - 1]`. In that case, `RecvUnix` would return `0` and `run_key_request_main()` would skip the buffer content.

#### Proposed fix

Change the condition of the `if` statement for an equivalent one. This change should be innocuous.

</details>

<details><summary><h3>🟣 Dereference null return value in FIM</h3></summary>

When `prefilter_cmd` is enabled, FIM runs the defined command for each file. If the internal call `wpopenv()` fails, it returns a null pointer. However, the code won't check whether that's null. That would lead FIM to crash when it happens.

#### Proposed fix

Check that `wpopenv()` returned a non-null pointer before using it.

</details>

<details><summary><h3>🟣 Logically dead code in the database synchronization module</h3></summary>

The _inotify_ real-time listener code must populate the `directory` variable, or skip the iteration (`continue`). So no code trace should allow `directory` to be null after the `if-else` block.

However, `snprintf` checks that `directory` is not null, and uses an empty string otherwise. This will never happen (in this version) and is considered dead code. In fact, `wm_inotify_push()` directly uses it.

#### Proposed fix

Remove the expression `directory ? directory : ""`, and get `directory` directly. This change is innocuous.

</details>

<details><summary><h3>🟣 TOCTOU in Wazuh DB and the database synchronization module</h3></summary>

Function `wdb_create_agent_db()` must create a database file, unless that file already exists. However, it explicitly checks that at the beginning of the code. This would lead to undefined behaviour if the file would be created just between the check `stat()` and the actual creation `fopen(w)`. In this case, that would be harmless IMO as `fopen(w)` would truncate and repopulate the file.

#### Proposed fix

Remove the explicit file checking (`stat()`) and create the database file in exclusive mode (`fopen(wx)`).

Flag `x` is a Glibc extension and won't run under other C library implementations (as of _musl_). This is not currently a problem as this code affects the manager only, and it runs on Debian, RedHat, and SUSE families.

</details>

## Tests

<details><summary><h3>🟢 Functional tests</h3></summary>

#### 🟢 Create database in exclusive mode

This test checks that the database synchronization module won't create a database if there is already a file.

```sh
touch /var/ossec/var/db/agents/001-dummy1.db && echo "001 dummy1 any asdfghjkl" >> /var/ossec/etc/client.keys
```

Expected log (debug-2):

```
2022/12/02 10:53:53 wazuh-modulesd[23946] wdb_global_helpers.c:1009 at wdb_create_agent_db(): DEBUG: Agent database already exists.
```

</details>

<details><summary><h3>🟢 Coverity</h3></summary>

|Build ID|Coverity version|Platform|New defects found|Defects eliminated|
|---|---|---|---|---|
| 497903 & 497911 |2022.6.0|Ubuntu 22.04|0|7|

|Status|CID|Type|Impact|Date|Component|Origin|Notes|
|:-:|---|---|---|---|---|---|---|
|🟢|1527747|Waiting while holding a lock|Medium|November 30, 2022|Syscollector|#10249 (4.3.0)|#15556|
|🟣|1527745|String not null terminated|High|November 30, 2022|Authd|#2127 (3.8.0)|#15556|
|⚪|1527744|Missing unlock|Medium|November 30, 2022|Shared library|#14726 (4.4.0)|The function's purpose is to acquire the lock.|
|⚪|1527743|Copy into fixed size buffer|Low|November 30, 2022|Execd|#9407 (4.2.0)|The string size is limited by `get_keys_from_json()`.|
|🟣|1527742|Dereference null return value|Medium|November 30, 2022|Shared library|#13044 (4.4.0)|#15556|
|🟣|1527741|Logically dead code|Medium|November 30, 2022|Database sync module|#11753 (4.4.0)|#15556|
|⚪|1527740|Missing unlock|Medium|November 30, 2022|Shared library|#14726 (4.4.0)|The function's purpose is to acquire the lock.|
|🟣|1527739|Time of check time of use|Low|November 30, 2022|Wazuh DB & sync module|#11753 (4.4.0)|#15556|

#### Legend

🟢 Intentional
🟣 Fixed
⚪ False positive

</details>

<details><summary><h3>🟢 Scan-build</h3></summary>

#### Manager

```
<server>=================== Running Scanbuild   ===================<server>
[CleanAll: PASSED]
[CleanExternals: PASSED]
[MakeDeps: PASSED]
[ScanBuild: PASSED]
<server>[SCANBUILD: PASSED]<server>
```

#### Agent

```
<agent>=================== Running Scanbuild   ===================<agent>
[CleanAll: PASSED]
[CleanExternals: PASSED]
[MakeDeps: PASSED]
[ScanBuild: PASSED]
<agent>[SCANBUILD: PASSED]<agent>
```

</details>

<details><summary><h3>🟢 Unit tests for the manager</h3></summary>

```
Test project /root/wazuh-fix-coverity/src/unit_tests/build
        Start   1: test_analysisd_syscheck
  1/160 Test   #1: test_analysisd_syscheck .................   Passed    0.05 sec
        Start   2: test_cleanevent
  2/160 Test   #2: test_cleanevent .........................   Passed    0.03 sec
        Start   3: test_dbsync
  3/160 Test   #3: test_dbsync .............................   Passed    0.03 sec
        Start   4: test_exec
  4/160 Test   #4: test_exec ...............................   Passed    0.03 sec
        Start   5: test_log
  5/160 Test   #5: test_log ................................   Passed    0.02 sec
        Start   6: test_labels
  6/160 Test   #6: test_labels .............................   Passed    0.03 sec
        Start   7: test_mitre
  7/160 Test   #7: test_mitre ..............................   Passed    0.01 sec
        Start   8: test_rules
  8/160 Test   #8: test_rules ..............................   Passed    0.03 sec
        Start   9: test_same_different_loop
  9/160 Test   #9: test_same_different_loop ................   Passed    0.02 sec
        Start  10: test_logtest
 10/160 Test  #10: test_logtest ............................   Passed    0.02 sec
        Start  11: test_logtest-config
 11/160 Test  #11: test_logtest-config .....................   Passed    0.01 sec
        Start  12: test_decoder_list
 12/160 Test  #12: test_decoder_list .......................   Passed    0.01 sec
        Start  13: test_decode-xml
 13/160 Test  #13: test_decode-xml .........................   Passed    0.02 sec
        Start  14: test_lists_list
 14/160 Test  #14: test_lists_list .........................   Passed    0.01 sec
        Start  15: test_rule_list
 15/160 Test  #15: test_rule_list ..........................   Passed    0.01 sec
        Start  16: test_eventinfo_list
 16/160 Test  #16: test_eventinfo_list .....................   Passed    0.01 sec
        Start  17: test_logmsg
 17/160 Test  #17: test_logmsg .............................   Passed    0.01 sec
        Start  18: test_decoder_rootcheck
 18/160 Test  #18: test_decoder_rootcheck ..................   Passed    0.02 sec
        Start  19: test_decoder_syscollector
 19/160 Test  #19: test_decoder_syscollector ...............   Passed    0.03 sec
        Start  20: test_analysis-state
 20/160 Test  #20: test_analysis-state .....................   Passed    0.03 sec
        Start  21: test_asyscom
 21/160 Test  #21: test_asyscom ............................   Passed    0.03 sec
        Start  22: test_limits
 22/160 Test  #22: test_limits .............................   Passed    0.01 sec
        Start  23: test_manager
 23/160 Test  #23: test_manager ............................   Passed    0.03 sec
        Start  24: test_secure
 24/160 Test  #24: test_secure .............................   Passed    0.02 sec
        Start  25: test_netbuffer
 25/160 Test  #25: test_netbuffer ..........................   Passed    0.03 sec
        Start  26: test_sendmsg
 26/160 Test  #26: test_sendmsg ............................   Passed    0.02 sec
        Start  27: test_remote-config
 27/160 Test  #27: test_remote-config ......................   Passed    0.01 sec
        Start  28: test_syslogtcp
 28/160 Test  #28: test_syslogtcp ..........................   Passed    0.02 sec
        Start  29: test_remote-state
 29/160 Test  #29: test_remote-state .......................   Passed    0.02 sec
        Start  30: test_remcom
 30/160 Test  #30: test_remcom .............................   Passed    0.02 sec
        Start  31: test_wdb_integrity
 31/160 Test  #31: test_wdb_integrity ......................   Passed    0.01 sec
        Start  32: test_wdb_fim
 32/160 Test  #32: test_wdb_fim ............................   Passed    0.01 sec
        Start  33: test_wdb_parser
 33/160 Test  #33: test_wdb_parser .........................   Passed    0.02 sec
        Start  34: test_wdb_global_parser
 34/160 Test  #34: test_wdb_global_parser ..................   Passed    0.02 sec
        Start  35: test_wdb_global
 35/160 Test  #35: test_wdb_global .........................   Passed    0.18 sec
        Start  36: test_wdb_agents
 36/160 Test  #36: test_wdb_agents .........................   Passed    0.01 sec
        Start  37: test_wdb_global_helpers
 37/160 Test  #37: test_wdb_global_helpers .................   Passed    0.01 sec
        Start  38: test_wdb_agents_helpers
 38/160 Test  #38: test_wdb_agents_helpers .................   Passed    0.01 sec
        Start  39: test_wdb
 39/160 Test  #39: test_wdb ................................   Passed    0.01 sec
        Start  40: test_wdb_upgrade
 40/160 Test  #40: test_wdb_upgrade ........................   Passed    0.01 sec
        Start  41: test_wdb_metadata
 41/160 Test  #41: test_wdb_metadata .......................   Passed    0.01 sec
        Start  42: test_wdb_task_parser
 42/160 Test  #42: test_wdb_task_parser ....................   Passed    0.01 sec
        Start  43: test_wdb_rootcheck
 43/160 Test  #43: test_wdb_rootcheck ......................   Passed    0.01 sec
        Start  44: test_wdb_syscollector
 44/160 Test  #44: test_wdb_syscollector ...................   Passed    0.01 sec
        Start  45: test_wdb_task
 45/160 Test  #45: test_wdb_task ...........................   Passed    0.01 sec
        Start  46: test_wdb_delta_event
 46/160 Test  #46: test_wdb_delta_event ....................   Passed    0.01 sec
        Start  47: test_wazuh_db-config
 47/160 Test  #47: test_wazuh_db-config ....................   Passed    0.01 sec
        Start  48: test_wazuh_db_state
 48/160 Test  #48: test_wazuh_db_state .....................   Passed    0.01 sec
        Start  49: test_wdb_com
 49/160 Test  #49: test_wdb_com ............................   Passed    0.01 sec
        Start  50: test_auth_parse
 50/160 Test  #50: test_auth_parse .........................   Passed    0.01 sec
        Start  51: test_auth_validate
 51/160 Test  #51: test_auth_validate ......................   Passed    0.01 sec
        Start  52: test_auth_add
 52/160 Test  #52: test_auth_add ...........................   Passed    0.01 sec
        Start  53: test_ssl
 53/160 Test  #53: test_ssl ................................   Passed    0.01 sec
        Start  54: test_auth_key_request
 54/160 Test  #54: test_auth_key_request ...................   Passed    0.01 sec
        Start  55: test_auth
 55/160 Test  #55: test_auth ...............................   Passed    0.01 sec
        Start  56: test_msgs
 56/160 Test  #56: test_msgs ...............................   Passed    0.01 sec
        Start  57: test_keys
 57/160 Test  #57: test_keys ...............................   Passed    0.01 sec
        Start  58: test_sha1_op
 58/160 Test  #58: test_sha1_op ............................   Passed    0.01 sec
        Start  59: test_blowfish_op
 59/160 Test  #59: test_blowfish_op ........................   Passed    0.01 sec
        Start  60: test_md5_op
 60/160 Test  #60: test_md5_op .............................   Passed    0.01 sec
        Start  61: test_md5_sha1_op
 61/160 Test  #61: test_md5_sha1_op ........................   Passed    0.01 sec
        Start  62: test_md5_sha1_sha256_op
 62/160 Test  #62: test_md5_sha1_sha256_op .................   Passed    0.01 sec
        Start  63: test_sha256_op
 63/160 Test  #63: test_sha256_op ..........................   Passed    0.01 sec
        Start  64: test_wm_aws
 64/160 Test  #64: test_wm_aws .............................   Passed    0.02 sec
        Start  65: test_wm_azure
 65/160 Test  #65: test_wm_azure ...........................   Passed    0.03 sec
        Start  66: test_wm_ciscat
 66/160 Test  #66: test_wm_ciscat ..........................   Passed    0.02 sec
        Start  67: test_wm_command
 67/160 Test  #67: test_wm_command .........................   Passed    0.03 sec
        Start  68: test_wm_database
 68/160 Test  #68: test_wm_database ........................   Passed    0.01 sec
        Start  69: test_wm_docker
 69/160 Test  #69: test_wm_docker ..........................   Passed    0.02 sec
        Start  70: test_wm_gcp
 70/160 Test  #70: test_wm_gcp .............................   Passed    0.12 sec
        Start  71: test_wmodules_gcp
 71/160 Test  #71: test_wmodules_gcp .......................   Passed    0.03 sec
        Start  72: test_wm_oscap
 72/160 Test  #72: test_wm_oscap ...........................   Passed    0.02 sec
        Start  73: test_wm_sca
 73/160 Test  #73: test_wm_sca .............................   Passed    0.02 sec
        Start  74: test_wmodules_scheduling
 74/160 Test  #74: test_wmodules_scheduling ................   Passed    0.01 sec
        Start  75: test_wm_vuln_detector
 75/160 Test  #75: test_wm_vuln_detector ...................   Passed    0.04 sec
        Start  76: test_wm_vuln_detector_evr
 76/160 Test  #76: test_wm_vuln_detector_evr ...............   Passed    0.01 sec
        Start  77: test_wm_vuln_detector_nvd
 77/160 Test  #77: test_wm_vuln_detector_nvd ...............   Passed    0.03 sec
        Start  78: test_wm_vuln_detector_run_now
 78/160 Test  #78: test_wm_vuln_detector_run_now ...........   Passed    0.02 sec
        Start  79: test_wm_task_manager
 79/160 Test  #79: test_wm_task_manager ....................   Passed    0.02 sec
        Start  80: test_wm_task_manager_parsing
 80/160 Test  #80: test_wm_task_manager_parsing ............   Passed    0.01 sec
        Start  81: test_wm_task_manager_commands
 81/160 Test  #81: test_wm_task_manager_commands ...........   Passed    0.01 sec
        Start  82: test_wm_agent_upgrade
 82/160 Test  #82: test_wm_agent_upgrade ...................   Passed    0.01 sec
        Start  83: test_wm_agent_upgrade_manager
 83/160 Test  #83: test_wm_agent_upgrade_manager ...........   Passed    0.02 sec
        Start  84: test_wm_agent_upgrade_parsing
 84/160 Test  #84: test_wm_agent_upgrade_parsing ...........   Passed    0.02 sec
        Start  85: test_wm_agent_upgrade_validate
 85/160 Test  #85: test_wm_agent_upgrade_validate ..........   Passed    0.01 sec
        Start  86: test_wm_agent_upgrade_tasks
 86/160 Test  #86: test_wm_agent_upgrade_tasks .............   Passed    0.01 sec
        Start  87: test_wm_agent_upgrade_tasks_callbacks
 87/160 Test  #87: test_wm_agent_upgrade_tasks_callbacks ...   Passed    0.02 sec
        Start  88: test_wm_agent_upgrade_commands
 88/160 Test  #88: test_wm_agent_upgrade_commands ..........   Passed    0.02 sec
        Start  89: test_wm_agent_upgrade_upgrades
 89/160 Test  #89: test_wm_agent_upgrade_upgrades ..........   Passed    0.03 sec
        Start  90: test_wmodules
 90/160 Test  #90: test_wmodules ...........................   Passed    0.02 sec
        Start  91: test_wm_control
 91/160 Test  #91: test_wm_control .........................   Passed    0.02 sec
        Start  92: test_wm_github
 92/160 Test  #92: test_wm_github ..........................   Passed    0.03 sec
        Start  93: test_wm_office365
 93/160 Test  #93: test_wm_office365 .......................   Passed    0.04 sec
        Start  94: test_monitord
 94/160 Test  #94: test_monitord ...........................   Passed    0.01 sec
        Start  95: test_monitor_actions
 95/160 Test  #95: test_monitor_actions ....................   Passed    0.02 sec
        Start  96: test_logcollector
 96/160 Test  #96: test_logcollector .......................   Passed    0.02 sec
        Start  97: test_read_multiline_regex
 97/160 Test  #97: test_read_multiline_regex ...............   Passed    0.02 sec
        Start  98: test_localfile-config
 98/160 Test  #98: test_localfile-config ...................   Passed    0.02 sec
        Start  99: test_state
 99/160 Test  #99: test_state ..............................   Passed    0.01 sec
        Start 100: test_lccom
100/160 Test #100: test_lccom ..............................   Passed    0.02 sec
        Start 101: test_macos_log
101/160 Test #101: test_macos_log ..........................   Passed    0.01 sec
        Start 102: test_read_macos
102/160 Test #102: test_read_macos .........................   Passed    0.02 sec
        Start 103: test_execd
103/160 Test #103: test_execd ..............................   Passed    0.01 sec
        Start 104: test_get_command_by_name
104/160 Test #104: test_get_command_by_name ................   Passed    0.01 sec
        Start 105: test_create_db
105/160 Test #105: test_create_db ..........................   Passed    0.04 sec
        Start 106: test_syscom
106/160 Test #106: test_syscom .............................   Passed    0.01 sec
        Start 107: test_fim_diff_changes
107/160 Test #107: test_fim_diff_changes ...................   Passed    0.02 sec
        Start 108: test_run_realtime
108/160 Test #108: test_run_realtime .......................   Passed    0.02 sec
        Start 109: test_syscheck_config
109/160 Test #109: test_syscheck_config ....................   Passed    0.04 sec
        Start 110: test_syscheck
110/160 Test #110: test_syscheck ...........................   Passed    0.01 sec
        Start 111: test_fim_sync
111/160 Test #111: test_fim_sync ...........................   Passed    0.10 sec
        Start 112: test_run_check
112/160 Test #112: test_run_check ..........................   Passed    0.12 sec
        Start 113: test_fim_db
113/160 Test #113: test_fim_db .............................   Passed    0.03 sec
        Start 114: test_fim_db_files
114/160 Test #114: test_fim_db_files .......................   Passed    0.03 sec
        Start 115: test_audit_healthcheck
115/160 Test #115: test_audit_healthcheck ..................   Passed    0.02 sec
        Start 116: test_audit_rule_handling
116/160 Test #116: test_audit_rule_handling ................   Passed    0.02 sec
        Start 117: test_syscheck_audit
117/160 Test #117: test_syscheck_audit .....................   Passed    0.03 sec
        Start 118: test_audit_parse
118/160 Test #118: test_audit_parse ........................   Passed    0.04 sec
        Start 119: test_list_op
119/160 Test #119: test_list_op ............................   Passed    0.02 sec
        Start 120: test_file_op
120/160 Test #120: test_file_op ............................   Passed    0.01 sec
        Start 121: test_integrity_op
121/160 Test #121: test_integrity_op .......................   Passed    0.01 sec
        Start 122: test_rbtree_op
122/160 Test #122: test_rbtree_op ..........................   Passed    0.01 sec
        Start 123: test_validate_op
123/160 Test #123: test_validate_op ........................   Passed    0.01 sec
        Start 124: test_string_op
124/160 Test #124: test_string_op ..........................   Passed    0.01 sec
        Start 125: test_expression
125/160 Test #125: test_expression .........................   Passed    0.01 sec
        Start 126: test_version_op
126/160 Test #126: test_version_op .........................   Passed    0.02 sec
        Start 127: test_queue_op
127/160 Test #127: test_queue_op ...........................   Passed    0.01 sec
        Start 128: test_queue_linked_op
128/160 Test #128: test_queue_linked_op ....................   Passed    0.01 sec
        Start 129: test_agent_op
129/160 Test #129: test_agent_op ...........................   Passed    0.01 sec
        Start 130: test_enrollment_op
130/160 Test #130: test_enrollment_op ......................   Passed    0.02 sec
        Start 131: test_time_op
131/160 Test #131: test_time_op ............................   Passed    0.01 sec
        Start 132: test_buffer_op
132/160 Test #132: test_buffer_op ..........................   Passed    0.01 sec
        Start 133: test_utf8_op
133/160 Test #133: test_utf8_op ............................   Passed    0.01 sec
        Start 134: test_log_builder
134/160 Test #134: test_log_builder ........................   Passed    0.01 sec
        Start 135: test_custom_output_search_replace
135/160 Test #135: test_custom_output_search_replace .......   Passed    0.01 sec
        Start 136: test_bzip2_op
136/160 Test #136: test_bzip2_op ...........................   Passed    0.01 sec
        Start 137: test_schedule_scan
137/160 Test #137: test_schedule_scan ......................   Passed    0.01 sec
        Start 138: test_rootcheck_op
138/160 Test #138: test_rootcheck_op .......................   Passed    0.01 sec
        Start 139: test_fs_op
139/160 Test #139: test_fs_op ..............................   Passed    0.01 sec
        Start 140: test_wazuhdb_op
140/160 Test #140: test_wazuhdb_op .........................   Passed    0.01 sec
        Start 141: test_syscheck_op
141/160 Test #141: test_syscheck_op ........................   Passed    0.03 sec
        Start 142: test_audit_op
142/160 Test #142: test_audit_op ...........................   Passed    0.01 sec
        Start 143: test_privsep_op
143/160 Test #143: test_privsep_op .........................   Passed    0.01 sec
        Start 144: test_mq_op
144/160 Test #144: test_mq_op ..............................   Passed    0.01 sec
        Start 145: test_remoted_op
145/160 Test #145: test_remoted_op .........................   Passed    0.01 sec
        Start 146: test_json-queue
146/160 Test #146: test_json-queue .........................   Passed    0.01 sec
        Start 147: test_bqueue
147/160 Test #147: test_bqueue .............................   Passed    0.01 sec
        Start 148: test_atomic
148/160 Test #148: test_atomic .............................   Passed    0.01 sec
        Start 149: test_url
149/160 Test #149: test_url ................................   Passed    0.01 sec
        Start 150: test_sysinfo_utils
150/160 Test #150: test_sysinfo_utils ......................   Passed    0.01 sec
        Start 151: test_json_op
151/160 Test #151: test_json_op ............................   Passed    0.01 sec
        Start 152: test_rwlock_op
152/160 Test #152: test_rwlock_op ..........................   Passed    1.21 sec
        Start 153: test_os_xml
153/160 Test #153: test_os_xml .............................   Passed    0.06 sec
        Start 154: test_os_regex
154/160 Test #154: test_os_regex ...........................   Passed    0.01 sec
        Start 155: test_os_regex_match
155/160 Test #155: test_os_regex_match .....................   Passed    0.01 sec
        Start 156: test_os_regex_execute
156/160 Test #156: test_os_regex_execute ...................   Passed    0.02 sec
        Start 157: test_os_zlib
157/160 Test #157: test_os_zlib ............................   Passed    0.01 sec
        Start 158: test_os_net
158/160 Test #158: test_os_net .............................   Passed    0.01 sec
        Start 159: test_fluentd_forwarder
159/160 Test #159: test_fluentd_forwarder ..................   Passed    0.02 sec
        Start 160: test_active-response
160/160 Test #160: test_active-response ....................   Passed    0.01 sec

100% tests passed, 0 tests failed out of 160

Total Test time (real) =   4.32 sec
```

</details>

<details><summary><h3>🟢 FIM on Valgrind</h3></summary>

**Purpose:** Search for possible memory leaks in the `<prefilter_cmd>` call.



```
==23380== FILE DESCRIPTORS: 7 open (3 std) at exit.
==23380== Open file descriptor 6: /dev/urandom
==23380==    at 0x529D764: open (open64.c:41)
==23380==
==23380== Open file descriptor 5: /var/ossec/queue/fim/db/fim.db
==23380==    at 0x529D764: open (open64.c:41)
==23380==
==23380== Open AF_UNIX socket 4: queue/sockets/syscheck
==23380==    at 0x52B0CEB: socket (syscall-template.S:120)
==23380==
==23380== Open AF_UNIX socket 3: <unknown>
==23380==    at 0x52B0CEB: socket (syscall-template.S:120)
==23380==
==23380==
==23380== HEAP SUMMARY:
==23380==     in use at exit: 369,039 bytes in 502 blocks
==23380==   total heap usage: 13,348 allocs, 12,846 frees, 47,766,849 bytes allocated
==23380==
==23380== LEAK SUMMARY:
==23380==    definitely lost: 0 bytes in 0 blocks
==23380==    indirectly lost: 0 bytes in 0 blocks
==23380==      possibly lost: 1,440 bytes in 5 blocks
==23380==    still reachable: 22,952 bytes in 22 blocks
==23380==                       of which reachable via heuristic:
==23380==                         length64           : 229,144 bytes in 460 blocks
==23380==         suppressed: 344,647 bytes in 475 blocks
```

</details>