### PR TITLE
Pre initialize pthread condition variable

### DIFF
--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -32,6 +32,7 @@ pthread_mutex_t sys_stop_mutex;
 bool need_shutdown_wait = false;
 pthread_mutex_t sys_reconnect_mutex;
 bool shutdown_process_started = false;
+bool syscollector_initialized = false;
 
 const wm_context WM_SYS_CONTEXT = {
     .name = "syscollector",
@@ -130,6 +131,7 @@ void* wm_sys_main(wm_sys_t *sys) {
     w_cond_init(&sys_stop_condition, NULL);
     w_mutex_init(&sys_stop_mutex, NULL);
     w_mutex_init(&sys_reconnect_mutex, NULL);
+    syscollector_initialized = true;
 
     if (!sys->flags.enabled) {
         mtinfo(WM_SYS_LOGTAG, "Module disabled. Exiting...");
@@ -212,21 +214,23 @@ void wm_sys_destroy(wm_sys_t *data) {
 }
 
 void wm_sys_stop(__attribute__((unused))wm_sys_t *data) {
-    mtinfo(WM_SYS_LOGTAG, "Stop received for Syscollector.");
-    syscollector_sync_message_ptr = NULL;
-    if (syscollector_stop_ptr){
-        shutdown_process_started = true;
-        syscollector_stop_ptr();
-    }
-    w_mutex_lock(&sys_stop_mutex);
-    if (need_shutdown_wait) {
-        w_cond_wait(&sys_stop_condition, &sys_stop_mutex);
-    }
-    w_mutex_unlock(&sys_stop_mutex);
+    if (syscollector_initialized) {
+        mtinfo(WM_SYS_LOGTAG, "Stop received for Syscollector.");
+        syscollector_sync_message_ptr = NULL;
+        if (syscollector_stop_ptr){
+            shutdown_process_started = true;
+            syscollector_stop_ptr();
+        }
+        w_mutex_lock(&sys_stop_mutex);
+        if (need_shutdown_wait) {
+            w_cond_wait(&sys_stop_condition, &sys_stop_mutex);
+        }
+        w_mutex_unlock(&sys_stop_mutex);
 
-    w_cond_destroy(&sys_stop_condition);
-    w_mutex_destroy(&sys_stop_mutex);
-    w_mutex_destroy(&sys_reconnect_mutex);
+        w_cond_destroy(&sys_stop_condition);
+        w_mutex_destroy(&sys_stop_mutex);
+        w_mutex_destroy(&sys_reconnect_mutex);
+    }
 }
 
 cJSON *wm_sys_dump(const wm_sys_t *sys) {


### PR DESCRIPTION
|Related issue|
|---|
|#15412|

## Description

This PR adds a simple check to avoid executing the stop module task when it was not initialized.

## Configuration options

Any invalid configuration on Syscollector module (or other components in wazuh modules)

![image](https://user-images.githubusercontent.com/13010397/205299427-34539b15-e498-4e0c-8855-c8d2f70e9cf7.png)

## Logs/Alerts example

Invalid config error, same behavior as FIM but different from AR.
![image](https://user-images.githubusercontent.com/13010397/205299502-955aa5f3-7d6d-469e-9c97-2056e72dbdad.png)

No errors
![image](https://user-images.githubusercontent.com/13010397/205299621-bfb773f9-2184-453a-956a-390d37345b55.png)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language