### PR TITLE
Add geoip for AWS ALB client IP addresses

### DIFF
--- a/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
@@ -47,6 +47,24 @@
     },
     {
       "geoip": {
+        "field": "data.aws.client_ip",
+        "target_field": "GeoLocation",
+        "properties": ["city_name", "country_name", "region_name", "location"],
+        "ignore_missing": true,
+        "ignore_failure": true
+      }
+    },
+    {
+      "geoip": {
+        "field": "data.aws.target_ip",
+        "target_field": "GeoLocation",
+        "properties": ["city_name", "country_name", "region_name", "location"],
+        "ignore_missing": true,
+        "ignore_failure": true
+      }
+    },
+    {
+      "geoip": {
         "field": "data.aws.service.action.networkConnectionAction.remoteIpDetails.ipAddressV4",
         "target_field": "GeoLocation",
         "properties": ["city_name", "country_name", "region_name", "location"],
@@ -77,7 +95,7 @@
         "field": "timestamp",
         "target_field": "@timestamp",
         "formats": ["ISO8601"],
-        "ignore_failure": false 
+        "ignore_failure": false
       }
     },
     {
@@ -86,7 +104,7 @@
         "date_rounding": "d",
         "index_name_prefix": "{{fields.index_prefix}}",
         "index_name_format": "yyyy.MM.dd",
-        "ignore_failure": false 
+        "ignore_failure": false
       }
     },
 

--- a/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
@@ -56,15 +56,6 @@
     },
     {
       "geoip": {
-        "field": "data.aws.target_ip",
-        "target_field": "GeoLocation",
-        "properties": ["city_name", "country_name", "region_name", "location"],
-        "ignore_missing": true,
-        "ignore_failure": true
-      }
-    },
-    {
-      "geoip": {
         "field": "data.aws.service.action.networkConnectionAction.remoteIpDetails.ipAddressV4",
         "target_field": "GeoLocation",
         "properties": ["city_name", "country_name", "region_name", "location"],

--- a/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
@@ -56,15 +56,6 @@
     },
     {
       "geoip": {
-        "field": "data.aws.target_ip",
-        "target_field": "GeoLocation",
-        "properties": ["city_name", "country_name", "region_name", "location"],
-        "ignore_missing": true,
-        "ignore_failure": true
-      }
-    },
-    {
-      "geoip": {
         "field": "data.aws.service.action.networkConnectionAction.remoteIpDetails.ipAddressV4",
         "target_field": "GeoLocation",
         "properties": ["city_name", "country_name", "region_name", "location"],

--- a/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
@@ -47,6 +47,24 @@
     },
     {
       "geoip": {
+        "field": "data.aws.client_ip",
+        "target_field": "GeoLocation",
+        "properties": ["city_name", "country_name", "region_name", "location"],
+        "ignore_missing": true,
+        "ignore_failure": true
+      }
+    },
+    {
+      "geoip": {
+        "field": "data.aws.target_ip",
+        "target_field": "GeoLocation",
+        "properties": ["city_name", "country_name", "region_name", "location"],
+        "ignore_missing": true,
+        "ignore_failure": true
+      }
+    },
+    {
+      "geoip": {
         "field": "data.aws.service.action.networkConnectionAction.remoteIpDetails.ipAddressV4",
         "target_field": "GeoLocation",
         "properties": ["city_name", "country_name", "region_name", "location"],
@@ -77,7 +95,7 @@
         "field": "timestamp",
         "target_field": "@timestamp",
         "formats": ["ISO8601"],
-        "ignore_failure": false 
+        "ignore_failure": false
       }
     },
     {
@@ -86,7 +104,7 @@
         "date_rounding": "d",
         "index_name_prefix": "{{fields.index_prefix}}",
         "index_name_format": "yyyy.MM.dd",
-        "ignore_failure": false 
+        "ignore_failure": false
       }
     },
     { "remove": { "field": "message", "ignore_missing": true, "ignore_failure": true } },


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/13095|
|https://github.com/wazuh/wazuh/pull/14525|

Closes: #16198 
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

As part of release `4.4`, the AWS S3 Wodle will now extract IP addresses from AWS ALB logs, as per https://github.com/wazuh/wazuh/issues/13095 and https://github.com/wazuh/wazuh/pull/14525.  The IP addresses are extracted to the following fields: `data.aws.target_ip` and `data.aws.source_ip`.  This PR is to preprocess those fields so that they are geolocated by Filebeat (to add country, latitude, longitude, etc.) before being stored in Elasticsearch.