### PR TITLE
Fix GCloudError error messages on exception raise

### DIFF
--- a/wodles/gcloud/pubsub/subscriber.py
+++ b/wodles/gcloud/pubsub/subscriber.py
@@ -105,9 +105,9 @@ class WazuhGCloudSubscriber(WazuhGCloudIntegration):
 
         except google.api_core.exceptions.NotFound as e:
             if 'project not found or user does not have access' in e.message:
-                raise exceptions.GCloudError(1204, subscription=self.subscription_path.split('/')[1])
+                raise exceptions.GCloudError(1205, project=self.subscription_path.split('/')[1])
             else:
-                raise exceptions.GCloudError(1205, project=self.subscription_path.split('/')[-1])
+                raise exceptions.GCloudError(1204, subscription=self.subscription_path.split('/')[-1])
 
         if required_permissions.difference(response.permissions) != set():
             raise exceptions.GCloudError(1206)


### PR DESCRIPTION
|Related issue|
|---|
|#15569|


## Description

This PR closes #15569. It fixes the error messages for invalid `project_id` and `subscription_name` parameters.

## Logs/Alerts example
Incorrect `project_id` returns expected `ERROR` message
```
2022/12/02 15:03:03 wazuh-modulesd:gcp-pubsub[1796] wmodules-gcp.c:187 at wm_gcp_pubsub_read(): DEBUG: Tag 'logging' from the 'gcp-pubsub' module is deprecated. This setting will be skipped.
2022/12/02 15:03:12 wazuh-modulesd:gcp-pubsub[2259] wmodules-gcp.c:187 at wm_gcp_pubsub_read(): DEBUG: Tag 'logging' from the 'gcp-pubsub' module is deprecated. This setting will be skipped.
2022/12/02 15:03:12 wazuh-modulesd[2259] main.c:95 at main(): DEBUG: Created new thread for the 'gcp-pubsub' module.
2022/12/02 15:03:12 wazuh-modulesd:gcp-pubsub[2259] wm_gcp.c:131 at wm_gcp_pubsub_main(): INFO: Module started.
2022/12/02 15:03:12 wazuh-modulesd:gcp-pubsub[2259] wm_gcp.c:147 at wm_gcp_pubsub_main(): DEBUG: Starting fetching of logs.
2022/12/02 15:03:12 wazuh-modulesd:gcp-pubsub[2259] wm_gcp.c:248 at wm_gcp_pubsub_run(): DEBUG: Create argument list
2022/12/02 15:03:12 wazuh-modulesd:gcp-pubsub[2259] wm_gcp.c:301 at wm_gcp_pubsub_run(): DEBUG: Launching command: wodles/gcloud/gcloud --integration_type pubsub --project wazuh-dev-error --subscription_id wazuh-framework-test --credentials_file /var/ossec/wodles/gcloud/credentials.json --max_messages 50 --num_threads 4 --log_level 2
2022/12/02 15:03:14 wazuh-modulesd:gcp-pubsub[2259] wm_gcp.c:314 at wm_gcp_pubsub_run(): WARNING: Command returned exit code 181
2022/12/02 15:03:14 wazuh-modulesd:gcp-pubsub[2259] wm_gcp.c:346 at wm_gcp_parse_output(): DEBUG: Setting 4 threads to pull 50 messages in total
2022/12/02 15:03:14 wazuh-modulesd:gcp-pubsub[2259] wm_gcp.c:362 at wm_gcp_parse_output(): ERROR: An exception happened while running the wodle: GCloudPubSubProjectError: The 'wazuh-dev-error' project ID is incorrect or the user does not have permissions to access to it
2022/12/02 15:03:14 wazuh-modulesd:gcp-pubsub[2259] wm_gcp.c:151 at wm_gcp_pubsub_main(): DEBUG: Fetching logs finished.
2022/12/02 15:03:14 wazuh-modulesd:gcp-pubsub[2259] wm_gcp.c:143 at wm_gcp_pubsub_main(): DEBUG: Sleeping until: 2022/12/03 15:03:12
```

## Unit Tests
```
=========================== test session starts ==============================
platform linux -- Python 3.9.5, pytest-6.0.1, py-1.11.0, pluggy-0.13.1 -- /home/test_user/venv/unittest-env/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.14.0-1054-oem-x86_64-with-glibc2.31', 'Packages': {'pytest': '6.0.1', 'py': '1.11.0', 'pluggy': '0.13.1'}, 'Plugins': {'cov': '3.0.0', 'trio': '0.7.0', 'metadata': '2.0.2', 'asyncio': '0.15.1', 'aiohttp': '0.3.0', 'html': '2.1.1'}}
rootdir: /home/test_user/git/wazuh
plugins: cov-3.0.0, trio-0.7.0, metadata-2.0.2, asyncio-0.15.1, aiohttp-0.3.0, html-2.1.1
collecting ... collected 17 items

wodles/gcloud/tests/test_access_logs.py::test_get_access_logs PASSED     [  5%]
wodles/gcloud/tests/test_bucket.py::test_get_bucket[gcloud_bucket0] PASSED [ 11%]
wodles/gcloud/tests/test_bucket.py::test_bucket_ko[unexistent_file-None-test_bucket-GCloudError-1001] PASSED [ 17%]
wodles/gcloud/tests/test_bucket.py::test_bucket_ko[invalid_credentials_file.json-None-test_bucket-GCloudError-1000] PASSED [ 23%]
wodles/gcloud/tests/test_gcloud.py::test_gcloud_ko[parameters0-GCloudError-1002] PASSED [ 29%]
wodles/gcloud/tests/test_gcloud.py::test_gcloud_ko[parameters1-GCloudError-1202] PASSED [ 35%]
wodles/gcloud/tests/test_gcloud.py::test_gcloud_ko[parameters2-GCloudError-1203] PASSED [ 41%]
wodles/gcloud/tests/test_gcloud.py::test_gcloud_ko[parameters3-GCloudError-1103] PASSED [ 47%]
wodles/gcloud/tests/test_gcloud.py::test_gcloud_ko[parameters4-GCloudError-1102] PASSED [ 52%]
wodles/gcloud/tests/test_integration.py::test_send_message_ok PASSED     [ 58%]
wodles/gcloud/tests/test_integration.py::test_send_message_ko PASSED     [ 64%]
wodles/gcloud/tests/test_integration.py::test_format_msg PASSED          [ 70%]
wodles/gcloud/tests/test_integration.py::test_initialize_socket_ko[gcloud_subscriber0-ConnectionRefusedError-WazuhIntegrationInternalError-1] PASSED [ 76%]
wodles/gcloud/tests/test_integration.py::test_initialize_socket_ko[gcloud_subscriber0-OSError-WazuhIntegrationInternalError-2] PASSED [ 82%]
wodles/gcloud/tests/test_subscriber.py::test_get_subscriber[gcloud_subscriber0] PASSED [ 88%]
wodles/gcloud/tests/test_subscriber.py::test_subscription_ko[unexistent_file-None-test_project-test_subscription-GCloudError-GCloudCredentialsNotFoundError] PASSED [ 94%]
wodles/gcloud/tests/test_subscriber.py::test_subscription_ko[invalid_credentials_file.json-None-test_project-test_subscription-GCloudError-GCloudCredentialsStructureError] PASSED [100%]

-------------- generated html file: file:///tmp/gcloud_test.html ---------------
============================== 17 passed in 0.04s ==============================
```