### PR TITLE
Fix for 15616 test_mq_op is failing expecting wrong user id

### DIFF
--- a/src/unit_tests/shared/test_mq_op.c
+++ b/src/unit_tests/shared/test_mq_op.c
@@ -15,6 +15,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <cmocka.h>
+#include <unistd.h>
 
 #include "../headers/shared.h"
 
@@ -56,8 +57,8 @@ void test_start_mq_read_success(void ** state){
     expect_string(__wrap_OS_BindUnixDomainWithPerms, path, path);
     expect_value(__wrap_OS_BindUnixDomainWithPerms, type, SOCK_DGRAM);
     expect_value(__wrap_OS_BindUnixDomainWithPerms, max_msg_size, OS_MAXSTR + 512);
-    expect_value(__wrap_OS_BindUnixDomainWithPerms, uid, 0);
-    expect_value(__wrap_OS_BindUnixDomainWithPerms, gid, 0);
+    expect_value(__wrap_OS_BindUnixDomainWithPerms, uid, getuid() );
+    expect_value(__wrap_OS_BindUnixDomainWithPerms, gid, getgid() );
     expect_value(__wrap_OS_BindUnixDomainWithPerms, perm, 0660);
     will_return(__wrap_OS_BindUnixDomainWithPerms, 0);
 
@@ -78,8 +79,8 @@ void test_start_mq_read_fail(void ** state){
     expect_string(__wrap_OS_BindUnixDomainWithPerms, path, path);
     expect_value(__wrap_OS_BindUnixDomainWithPerms, type, SOCK_DGRAM);
     expect_value(__wrap_OS_BindUnixDomainWithPerms, max_msg_size, OS_MAXSTR + 512);
-    expect_value(__wrap_OS_BindUnixDomainWithPerms, uid, 0);
-    expect_value(__wrap_OS_BindUnixDomainWithPerms, gid, 0);
+    expect_value(__wrap_OS_BindUnixDomainWithPerms, uid, getuid());
+    expect_value(__wrap_OS_BindUnixDomainWithPerms, gid, getgid());
     expect_value(__wrap_OS_BindUnixDomainWithPerms, perm, 0660);
     will_return(__wrap_OS_BindUnixDomainWithPerms, -1);
 


### PR DESCRIPTION
Wazuh version|Component|Install type|Install method|Platform|
|---|---|---|---|---|
| 4.4 - 4.5 | C Mocka unit tests | Manager - Agent | - |  Linux |

## Related Issue
[15616](https://github.com/wazuh/wazuh/issues/15616)

## Description

This issue aims to modify the expected user id in the failing test cases. 
Similar units using the same wrapper use the proposed fix. This seems to be the only one left with the wrong user id.

## Result

After running the individual units or the ctest suit as regular non root user the test passes. 

````
[==========] tests: Running 18 test(s).
[ RUN      ] test_start_mq_read_success
[       OK ] test_start_mq_read_success
[ RUN      ] test_start_mq_read_fail
[       OK ] test_start_mq_read_fail
[ RUN      ] test_start_mq_write_simple_success
[       OK ] test_start_mq_write_simple_success
[ RUN      ] test_start_mq_write_simple_fail
[       OK ] test_start_mq_write_simple_fail
[ RUN      ] test_start_mq_write_multiple_success
[       OK ] test_start_mq_write_multiple_success
[ RUN      ] test_start_mq_write_multiple_fail
[       OK ] test_start_mq_write_multiple_fail
[ RUN      ] test_start_mq_write_inf_success
[       OK ] test_start_mq_write_inf_success
[ RUN      ] test_start_mq_write_inf_fail
[       OK ] test_start_mq_write_inf_fail
[ RUN      ] test_reconnect_mq_simple_fail
[       OK ] test_reconnect_mq_simple_fail
[ RUN      ] test_reconnect_mq_complex_true
[       OK ] test_reconnect_mq_complex_true
[ RUN      ] test_reconnect_mq_simple_success
[       OK ] test_reconnect_mq_simple_success
[ RUN      ] test_SendMSGAction_format_error
[       OK ] test_SendMSGAction_format_error
[ RUN      ] test_SendMSGAction_queue_not_available
[       OK ] test_SendMSGAction_queue_not_available
[ RUN      ] test_SendMSGAction_socket_error
[       OK ] test_SendMSGAction_socket_error
[ RUN      ] test_SendMSGAction_socket_busy
[       OK ] test_SendMSGAction_socket_busy
[ RUN      ] test_SendMSGAction_non_secure_msg
[       OK ] test_SendMSGAction_non_secure_msg
[ RUN      ] test_SendMSGAction_secure_msg
[       OK ] test_SendMSGAction_secure_msg
[ RUN      ] test_SendMSGAction_secure_msg_keepalive
[       OK ] test_SendMSGAction_secure_msg_keepalive
[==========] tests: 18 test(s) run.
[  PASSED  ] 18 test(s).

````
