### PR TITLE
Let Logcollector try to open missing files perpetually

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -94,8 +94,8 @@ analysisd.state_interval=5
 # Logcollector file loop timeout (check every 2 seconds for file changes)
 logcollector.loop_timeout=2
 
-# Logcollector number of attempts to open a log file [2..998]
-logcollector.open_attempts=8
+# Logcollector number of attempts to open a log file [2..998] (0=infinite)
+logcollector.open_attempts=0
 
 # Logcollector - If it should accept remote commands from the manager
 logcollector.remote_commands=0


### PR DESCRIPTION
|Related issue|
|---|
|Closes #13256|

This PR aims to modify the default value of Logcollector's internal option `open_attempts`, so that the program does not stop trying to open missing log files.

### Previous behavior

Logcollector tries to open log files 8 times, then it gives up and ignores them forever. The program attempts to open them in the file-checking stage, with an interval of `vcheck_files` seconds (64 by default).

### Proposed behavior

Logcollector shall attempt to open missing files every time by default. Obviously, this option is still still user-settable.

## Tests

### 🟢 Create and remove a log file

#### Configuration

```xml
<localfile>
  <log_format>syslog</log_format>
  <location>/root/test.log</location>
</localfile>
```

#### Previous: up to 8 opening attempts

<details><summary><h5>Start Logcollector and then remove the file</h5></summary>

```
2022/12/09 10:50:53 wazuh-logcollector[19182] logcollector.c:598 at LogCollectorStart(): INFO: (1959): File '/root/test.log' no longer exists.
2022/12/09 10:50:53 wazuh-logcollector[19182] logcollector.c:616 at LogCollectorStart(): DEBUG: (1962): Unable to open file '/root/test.log'. Remaining attempts: 7
2022/12/09 10:50:55 wazuh-logcollector[19182] logcollector.c:475 at LogCollectorStart(): DEBUG: Performing file check.
2022/12/09 10:50:55 wazuh-logcollector[19182] logcollector.c:616 at LogCollectorStart(): DEBUG: (1962): Unable to open file '/root/test.log'. Remaining attempts: 6
2022/12/09 10:50:57 wazuh-logcollector[19182] logcollector.c:475 at LogCollectorStart(): DEBUG: Performing file check.
2022/12/09 10:50:57 wazuh-logcollector[19182] logcollector.c:616 at LogCollectorStart(): DEBUG: (1962): Unable to open file '/root/test.log'. Remaining attempts: 5
2022/12/09 10:50:59 wazuh-logcollector[19182] logcollector.c:475 at LogCollectorStart(): DEBUG: Performing file check.
2022/12/09 10:50:59 wazuh-logcollector[19182] logcollector.c:616 at LogCollectorStart(): DEBUG: (1962): Unable to open file '/root/test.log'. Remaining attempts: 4
2022/12/09 10:51:01 wazuh-logcollector[19182] logcollector.c:475 at LogCollectorStart(): DEBUG: Performing file check.
2022/12/09 10:51:01 wazuh-logcollector[19182] logcollector.c:616 at LogCollectorStart(): DEBUG: (1962): Unable to open file '/root/test.log'. Remaining attempts: 3
2022/12/09 10:51:03 wazuh-logcollector[19182] logcollector.c:475 at LogCollectorStart(): DEBUG: Performing file check.
2022/12/09 10:51:03 wazuh-logcollector[19182] logcollector.c:616 at LogCollectorStart(): DEBUG: (1962): Unable to open file '/root/test.log'. Remaining attempts: 2
2022/12/09 10:51:05 wazuh-logcollector[19182] logcollector.c:475 at LogCollectorStart(): DEBUG: Performing file check.
2022/12/09 10:51:05 wazuh-logcollector[19182] logcollector.c:616 at LogCollectorStart(): DEBUG: (1962): Unable to open file '/root/test.log'. Remaining attempts: 1
2022/12/09 10:51:07 wazuh-logcollector[19182] logcollector.c:475 at LogCollectorStart(): DEBUG: Performing file check.
2022/12/09 10:51:07 wazuh-logcollector[19182] logcollector.c:616 at LogCollectorStart(): DEBUG: (1962): Unable to open file '/root/test.log'. Remaining attempts: 0
2022/12/09 10:51:07 wazuh-logcollector[19182] logcollector.c:811 at LogCollectorStart(): INFO: (1904): File not available, ignoring it: '/root/test.log'.
```
</details>
<details><summary><h5>Start Logcollector with the file missing</h5></summary>

```
2022/12/09 11:24:56 wazuh-logcollector[1489] logcollector.c:974 at handle_file(): ERROR: (1103): Could not open file '/root/test.log' due to [(2)-(No such file or directory)].
2022/12/09 11:24:56 wazuh-logcollector[1489] logcollector.c:1070 at handle_file(): DEBUG: (1962): Unable to open file '/root/test.log'. Remaining attempts: 7
2022/12/09 11:24:56 wazuh-logcollector[1489] logcollector.c:1228 at set_read(): DEBUG: Socket target for '/root/test.log' -> agent
2022/12/09 11:24:56 wazuh-logcollector[1489] logcollector.c:379 at LogCollectorStart(): INFO: (1950): Analyzing file: '/root/test.log'.
2022/12/09 11:24:56 wazuh-logcollector[1489] logcollector.c:430 at LogCollectorStart(): INFO: Started (pid: 1489).
2022/12/09 11:24:56 wazuh-logcollector[1489] logcollector.c:431 at LogCollectorStart(): DEBUG: (1961): Files being monitored: 1/1000.
2022/12/09 11:24:56 wazuh-logcollector[1489] lccom.c:120 at lccom_main(): DEBUG: Local requests thread ready
2022/12/09 11:24:58 wazuh-logcollector[1489] logcollector.c:475 at LogCollectorStart(): DEBUG: Performing file check.
2022/12/09 11:24:58 wazuh-logcollector[1489] logcollector.c:1070 at handle_file(): DEBUG: (1962): Unable to open file '/root/test.log'. Remaining attempts: 6
2022/12/09 11:25:00 wazuh-logcollector[1489] logcollector.c:475 at LogCollectorStart(): DEBUG: Performing file check.
2022/12/09 11:25:00 wazuh-logcollector[1489] logcollector.c:1070 at handle_file(): DEBUG: (1962): Unable to open file '/root/test.log'. Remaining attempts: 5
2022/12/09 11:25:02 wazuh-logcollector[1489] logcollector.c:475 at LogCollectorStart(): DEBUG: Performing file check.
2022/12/09 11:25:02 wazuh-logcollector[1489] logcollector.c:1070 at handle_file(): DEBUG: (1962): Unable to open file '/root/test.log'. Remaining attempts: 4
2022/12/09 11:25:04 wazuh-logcollector[1489] logcollector.c:475 at LogCollectorStart(): DEBUG: Performing file check.
2022/12/09 11:25:04 wazuh-logcollector[1489] logcollector.c:1070 at handle_file(): DEBUG: (1962): Unable to open file '/root/test.log'. Remaining attempts: 3
2022/12/09 11:25:06 wazuh-logcollector[1489] logcollector.c:475 at LogCollectorStart(): DEBUG: Performing file check.
2022/12/09 11:25:06 wazuh-logcollector[1489] logcollector.c:1070 at handle_file(): DEBUG: (1962): Unable to open file '/root/test.log'. Remaining attempts: 2
2022/12/09 11:25:08 wazuh-logcollector[1489] logcollector.c:475 at LogCollectorStart(): DEBUG: Performing file check.
2022/12/09 11:25:08 wazuh-logcollector[1489] logcollector.c:1070 at handle_file(): DEBUG: (1962): Unable to open file '/root/test.log'. Remaining attempts: 1
2022/12/09 11:25:10 wazuh-logcollector[1489] logcollector.c:475 at LogCollectorStart(): DEBUG: Performing file check.
2022/12/09 11:25:10 wazuh-logcollector[1489] logcollector.c:1070 at handle_file(): DEBUG: (1962): Unable to open file '/root/test.log'. Remaining attempts: 0
2022/12/09 11:25:12 wazuh-logcollector[1489] logcollector.c:475 at LogCollectorStart(): DEBUG: Performing file check.
2022/12/09 11:25:12 wazuh-logcollector[1489] logcollector.c:811 at LogCollectorStart(): INFO: (1904): File not available, ignoring it: '/root/test.log'.
```

</details>

#### Proposed: infinite attempts

<details><summary><h5>🟢 Start Logcollector with the file missing</h5></summary>

```
2022/12/09 11:23:21 wazuh-logcollector: ERROR: (1103): Could not open file '/root/test.log' due to [(2)-(No such file or directory)].
2022/12/09 11:23:21 wazuh-logcollector: INFO: (1950): Analyzing file: '/root/test.log'.
```

</details>
<details><summary><h5>🟢 Start Logcollector and then remove the file</h5></summary>

```
2022/12/09 11:04:07 wazuh-logcollector: INFO: (1959): File '/root/test.log' no longer exists.
```

</details>
<details><summary><h5>🟢 Create the file back and fill it</h5></summary>

###### Script

```sh
touch /root/test.log
grep "^logcollector\.vcheck_files=" /var/ossec/etc/{,local_}internal_options.conf | tail -n1 | cut -d= -f2 | xargs sleep
echo "Hello" >> /root/test.log
```

###### Archives

```
2022 Dec 09 11:05:48 ubuntu->/root/test.log Hello
```

</details>
<details><summary><h5>🟢 Delete the file again</h5></summary>

```
2022/12/09 11:04:57 wazuh-logcollector: INFO: (1959): File '/root/test.log' no longer exists.
```

</details>

### ⚪ Memory and static code analysis

We decided not to run these tests as no executable code has been modified. This PR affects the default configuration only.