### PR TITLE
Fix Coverity time_t errors in FIM DB development

### DIFF
--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -277,7 +277,7 @@ typedef struct fim_file_data {
     char * gid;
     char * user_name;
     char * group_name;
-    unsigned int mtime;
+    time_t mtime;
     unsigned long long int inode;
     os_md5 hash_md5;
     os_sha1 hash_sha1;
@@ -302,7 +302,7 @@ typedef struct fim_registry_key {
     char* gid;
     char* user_name;
     char* group_name;
-    unsigned int mtime;
+    time_t mtime;
     int arch;
 
     unsigned int scanned;

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -1353,7 +1353,7 @@ void fim_get_checksum (fim_file_data * data) {
 
     size = snprintf(0,
             0,
-            "%d:%s:%s:%s:%s:%s:%s:%u:%llu:%s:%s:%s",
+            "%d:%s:%s:%s:%s:%s:%s:%lu:%llu:%s:%s:%s",
             data->size,
             data->perm ? data->perm : "",
             data->attributes ? data->attributes : "",
@@ -1370,7 +1370,7 @@ void fim_get_checksum (fim_file_data * data) {
     os_calloc(size + 1, sizeof(char), checksum);
     snprintf(checksum,
             size + 1,
-            "%d:%s:%s:%s:%s:%s:%s:%u:%llu:%s:%s:%s",
+            "%d:%s:%s:%s:%s:%s:%s:%lu:%llu:%s:%s:%s",
             data->size,
             data->perm ? data->perm : "",
             data->attributes ? data->attributes : "",


### PR DESCRIPTION
|Related issue|
|---|
|#15425|

## Description

In the Coverity report run on issue https://github.com/wazuh/wazuh/issues/15425#issuecomment-1330847148, two _'Use of 32-bit `time_t`'_ errors were reported, which are as follows:

- [CID 300027](https://scan9.scan.coverity.com/reports.htm#v42681/p12779/fileInstanceId=105346362&defectInstanceId=8959675&mergedDefectId=300027) (1 of 1): **Use of 32-bit `time_t`** (Y2K38_SAFETY)
> store_truncates_time_t: A time_t value is stored in an integer with too few bits to accommodate it. The expression this->m_time is cast to unsigned int.

- [CID 300028](https://scan9.scan.coverity.com/reports.htm#v42681/p12779/fileInstanceId=105346373&defectInstanceId=8959654&mergedDefectId=300028) (1 of 1): **Use of 32-bit `time_t`** (Y2K38_SAFETY)
> store_truncates_time_t: A time_t value is stored in an integer with too few bits to accommodate it. The expression this->m_time is cast to unsigned int.

These two errors were in the `fim_file_data` and `fim_registry_key` structures, as the `mtime` variable was of type `unsigned int`. 

To fix these errors, both variables have been converted to type `time_t` (aka `long`), and in the case of `snprintf`, they have been converted from `unsigned int` to `long unsigned int`.

## Logs/Alerts example

After running Coverity again with the new arrangements, we can see that the errors reported with ID: _300027_ and _300028_, no longer appear.

- https://scan9.scan.coverity.com/reports.htm#v42681/p12779

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

