### PR TITLE
Fix rsync UT on Windows

### DIFF
--- a/src/shared_modules/rsync/tests/interface/rsync_test.cpp
+++ b/src/shared_modules/rsync/tests/interface/rsync_test.cpp
@@ -80,6 +80,8 @@ void RSyncTest::SetUp()
 
 void RSyncTest::TearDown()
 {
+    dbsync_teardown();
+    std::remove(DATABASE_TEMP);
     EXPECT_NO_THROW(rsync_teardown());
 };
 
@@ -347,9 +349,9 @@ TEST_F(RSyncTest, startSyncIntegrityGlobal)
 
     ASSERT_EQ(0, rsync_start_sync(rsyncHandle, dbsyncHandle, jsSelect.get(), callbackData));
 
-    dbsync_teardown();
     EXPECT_EQ(messageCounter.load(), TOTAL_EXPECTED_MESSAGES);
 }
+
 TEST_F(RSyncTest, registerIncorrectSyncId)
 {
     const auto handle { rsync_create(THREAD_POOL_SIZE, MAX_QUEUE_SIZE) };
@@ -490,8 +492,6 @@ TEST_F(RSyncTest, RegisterAndPush)
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
     EXPECT_EQ(0, rsync_close(handle_rsync));
-
-    dbsync_teardown();
 }
 
 TEST_F(RSyncTest, RegisterIncorrectQueryAndPush)
@@ -565,8 +565,6 @@ TEST_F(RSyncTest, RegisterIncorrectQueryAndPush)
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
     EXPECT_EQ(0, rsync_close(handle_rsync));
-
-    dbsync_teardown();
 }
 
 TEST_F(RSyncTest, RegisterAndPushCPP)
@@ -1360,4 +1358,3 @@ TEST_F(RSyncTest, RegisterAndPushWithDoubleHandleDisconnect)
     std::this_thread::sleep_for(std::chrono::seconds(1));
     remoteSync.reset();
 }
-


### PR DESCRIPTION
|Related issue|
|---|
|#15417|

## Description

Due to the way `std::remove` works on Linux and Windows. The Rsync tests were failing on the second platform. This PR fixes the issue.

## Logs/Alerts example

![2022-12-12_16-45](https://user-images.githubusercontent.com/13010397/207140370-668296b8-3662-4892-87db-69835f79cc1b.png)

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Source installation
- [x] Source upgrade