### PR TITLE
Modify group_name regex to avoid invalid group names

### DIFF
--- a/api/api/test/test_validator.py
+++ b/api/api/test/test_validator.py
@@ -108,6 +108,9 @@ def test_validation_check_exp_ok(exp, regex_name):
     ('all', _group_names),
     ('.', _group_names),
     ('..', _group_names),
+    ('解放加大了看', _group_names),
+    ('тестирование',_group_names),
+    ('בדיקה', _group_names),
     ('.', _group_names_or_all),
     ('..', _group_names_or_all),
     # IPs

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -21,7 +21,7 @@ _base64 = re.compile(r'^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]
 _boolean = re.compile(r'^true$|^false$')
 _dates = re.compile(r'^\d{8}$')
 _empty_boolean = re.compile(r'^$|(^true$|^false$)')
-_group_names = re.compile(r'^(?!^(\.{1,2}|all)$)[\w.\-]+$')
+_group_names = re.compile(r'^(?!^(\.{1,2}|all)$)[A-Za-z0-9.\-_]+$')
 _group_names_or_all = re.compile(r'^(?!^\.{1,2}$)[\w.\-]+$')
 _hashes = re.compile(r'^(?:[\da-fA-F]{32})?$|(?:[\da-fA-F]{40})?$|(?:[\da-fA-F]{56})?$|(?:[\da-fA-F]{64})?$|(?:['
                      r'\da-fA-F]{96})?$|(?:[\da-fA-F]{128})?$')

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -22,7 +22,7 @@ _boolean = re.compile(r'^true$|^false$')
 _dates = re.compile(r'^\d{8}$')
 _empty_boolean = re.compile(r'^$|(^true$|^false$)')
 _group_names = re.compile(r'^(?!^(\.{1,2}|all)$)[A-Za-z0-9.\-_]+$')
-_group_names_or_all = re.compile(r'^(?!^\.{1,2}$)[\w.\-]+$')
+_group_names_or_all = re.compile(r'^(?!^\.{1,2}$)[A-Za-z0-9.\-_]+$')
 _hashes = re.compile(r'^(?:[\da-fA-F]{32})?$|(?:[\da-fA-F]{40})?$|(?:[\da-fA-F]{56})?$|(?:[\da-fA-F]{64})?$|(?:['
                      r'\da-fA-F]{96})?$|(?:[\da-fA-F]{128})?$')
 _ips = re.compile(


### PR DESCRIPTION
|Related issue|
|---|
|#15572|

## Description

This PR closes #15572. It modifies the `_group_names` regex used to validate the group name used in the `POST /groups` endpoint to avoid invalid group names.


## API Unit Tests
```
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.5, pytest-5.4.3, py-1.11.0, pluggy-0.13.1
rootdir: /home/test_user/git/wazuh/api
plugins: cov-3.0.0, trio-0.7.0, anyio-3.6.2, metadata-2.0.2, asyncio-0.15.1, aiohttp-0.3.0, html-3.0.0
collected 536 items                                                                                                                                                                                               

api/api/controllers/test/test_active_response_controller.py .                                                                                                                                               [  0%]
api/api/controllers/test/test_agent_controller.py ...........................................                                                                                                               [  8%]
api/api/controllers/test/test_cdb_list_controller.py ......                                                                                                                                                 [  9%]
api/api/controllers/test/test_ciscat_controller.py .                                                                                                                                                        [  9%]
api/api/controllers/test/test_cluster_controller.py ........................                                                                                                                                [ 13%]
api/api/controllers/test/test_decoder_controller.py .......                                                                                                                                                 [ 15%]
api/api/controllers/test/test_default_controller.py .                                                                                                                                                       [ 15%]
api/api/controllers/test/test_experimental_controller.py ...............                                                                                                                                    [ 18%]
api/api/controllers/test/test_manager_controller.py ..................                                                                                                                                      [ 21%]
api/api/controllers/test/test_mitre_controller.py .......                                                                                                                                                   [ 22%]
api/api/controllers/test/test_overview_controller.py .                                                                                                                                                      [ 23%]
api/api/controllers/test/test_rootcheck_controller.py ....                                                                                                                                                  [ 23%]
api/api/controllers/test/test_rule_controller.py ........                                                                                                                                                   [ 25%]
api/api/controllers/test/test_sca_controller.py ..                                                                                                                                                          [ 25%]
api/api/controllers/test/test_security_controller.py ...................................................                                                                                                    [ 35%]
api/api/controllers/test/test_syscheck_controller.py ....                                                                                                                                                   [ 36%]
api/api/controllers/test/test_syscollector_controller.py .........                                                                                                                                          [ 37%]
api/api/controllers/test/test_task_controller.py .                                                                                                                                                          [ 37%]
api/api/controllers/test/test_vulnerability_controller.py ....                                                                                                                                              [ 38%]
api/api/models/test/test_model.py ...........................                                                                                                                                               [ 43%]
api/api/test/test_alogging.py ..................                                                                                                                                                            [ 47%]
api/api/test/test_authentication.py ...........                                                                                                                                                             [ 49%]
api/api/test/test_configuration.py ..........................................                                                                                                                               [ 56%]
api/api/test/test_encoder.py ...                                                                                                                                                                            [ 57%]
api/api/test/test_middlewares.py ............                                                                                                                                                               [ 59%]
api/api/test/test_uri_parser.py ...                                                                                                                                                                         [ 60%]
api/api/test/test_util.py ........................................                                                                                                                                          [ 67%]
api/api/test/test_validator.py ............................................................................................................................................................................ [ 99%]
.                                                                                                                                                                                                           [100%]

======================================================================================== 536 passed, 14 warnings in 2.45s =========================================================================================


```

## Group name manual test

```
curl -k -X POST "https://localhost:55555/groups?pretty=true" -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d "{\"group_id\":\"解放扩大苏联飞机苏将\"}"
{"title": "Bad Request", "detail": "'\u89e3\u653e\u6269\u5927\u82cf\u8054\u98de\u673a\u82cf\u5c06' is not a 'group_names' - 'group_id'"}
curl -k -X POST "https://localhost:55555/groups?pretty=true" -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d "{\"group_id\":\"解放扩大\"}"
{"title": "Bad Request", "detail": "'\u89e3\u653e\u6269\u5927' is not a 'group_names' - 'group_id'"}
curl -k -X POST "https://localhost:55555/groups?pretty=true" -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d "{\"group_id\":\"Linux-Machines\"}"
{
   "message": "Group 'Linux-Machines' created.",
   "error": 0
}
```
api.log
```
2022/12/13 15:19:26 INFO: wazuh 172.20.0.1 "POST /groups" with parameters {"pretty": "true"} and body {"group_id": "\u89e3\u653e\u6269\u5927\u82cf\u8054\u98de\u673a\u82cf\u5c06"} done in 0.053s: 400
2022/12/13 15:20:03 INFO: wazuh 172.20.0.1 "POST /groups" with parameters {"pretty": "true"} and body {"group_id": "\u89e3\u653e\u6269\u5927"} done in 0.016s: 400
2022/12/13 15:20:32 INFO: wazuh 172.20.0.1 "POST /groups" with parameters {"pretty": "true"} and body {"group_id": "Linux-Machines"} done in 0.042s: 200
```