### PR TITLE
Unifying coverage folder location for shared_modules

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -83,7 +83,7 @@ SELINUX_POLICY=selinux/wazuh.pp
 SHARED_MODULES=shared_modules/
 DBSYNC=${SHARED_MODULES}dbsync/
 RSYNC=${SHARED_MODULES}rsync/
-SHARED_UTILS_TEST=${SHARED_MODULES}utils/tests/
+SHARED_UTILS_TEST=${SHARED_MODULES}utils
 SYSCOLLECTOR=wazuh_modules/syscollector/
 SYSINFO=data_provider/
 
@@ -789,7 +789,7 @@ win32/shared_modules: $(WAZUHEXT_LIB)
 	cd ${RSYNC} &&  mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${RSYNC_TEST} ${SHARED_MODULES_RELEASE_TYPE} .. && ${MAKE}
 ifneq (,$(filter ${TEST},YES yes y Y 1))
 ifneq (,$(filter ${DEBUG},YES yes y Y 1))
-	cd ${SHARED_UTILS_TEST} &&  mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SHARED_MODULES_RELEASE_TYPE} .. && ${MAKE}
+	cd ${SHARED_UTILS_TEST} &&  mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SHARED_MODULES_RELEASE_TYPE} ../tests && ${MAKE}
 endif
 endif
 
@@ -1550,7 +1550,7 @@ build_shared_modules: $(WAZUHEXT_LIB)
 	cd ${RSYNC} && mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${RSYNC_TEST} ${SOLARIS_CMAKE_OPTS} ${SHARED_MODULES_RELEASE_TYPE} .. && ${MAKE}
 ifneq (,$(filter ${TEST},YES yes y Y 1))
 ifneq (,$(filter ${DEBUG},YES yes y Y 1))
-	cd ${SHARED_UTILS_TEST} &&  mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SHARED_MODULES_RELEASE_TYPE} .. && ${MAKE}
+	cd ${SHARED_UTILS_TEST} &&  mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SHARED_MODULES_RELEASE_TYPE} ../tests && ${MAKE}
 endif
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -83,7 +83,7 @@ SELINUX_POLICY=selinux/wazuh.pp
 SHARED_MODULES=shared_modules/
 DBSYNC=${SHARED_MODULES}dbsync/
 RSYNC=${SHARED_MODULES}rsync/
-SHARED_UTILS_TEST=${SHARED_MODULES}utils
+SHARED_UTILS_TEST=${SHARED_MODULES}utils/tests/
 SYSCOLLECTOR=wazuh_modules/syscollector/
 SYSINFO=data_provider/
 
@@ -789,7 +789,7 @@ win32/shared_modules: $(WAZUHEXT_LIB)
 	cd ${RSYNC} &&  mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${RSYNC_TEST} ${SHARED_MODULES_RELEASE_TYPE} .. && ${MAKE}
 ifneq (,$(filter ${TEST},YES yes y Y 1))
 ifneq (,$(filter ${DEBUG},YES yes y Y 1))
-	cd ${SHARED_UTILS_TEST} &&  mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SHARED_MODULES_RELEASE_TYPE} ../tests && ${MAKE}
+	cd ${SHARED_UTILS_TEST} &&  mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SHARED_MODULES_RELEASE_TYPE} .. && ${MAKE}
 endif
 endif
 
@@ -1550,7 +1550,7 @@ build_shared_modules: $(WAZUHEXT_LIB)
 	cd ${RSYNC} && mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${RSYNC_TEST} ${SOLARIS_CMAKE_OPTS} ${SHARED_MODULES_RELEASE_TYPE} .. && ${MAKE}
 ifneq (,$(filter ${TEST},YES yes y Y 1))
 ifneq (,$(filter ${DEBUG},YES yes y Y 1))
-	cd ${SHARED_UTILS_TEST} &&  mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SHARED_MODULES_RELEASE_TYPE} ../tests && ${MAKE}
+	cd ${SHARED_UTILS_TEST} &&  mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SHARED_MODULES_RELEASE_TYPE} .. && ${MAKE}
 endif
 endif
 

--- a/src/ci/utils.py
+++ b/src/ci/utils.py
@@ -125,6 +125,8 @@ def currentDirPath(moduleName):
     :return Lib dir path
     """
     currentDir = os.path.join(currentBuildDir.parent, str(moduleName))
+    if str(moduleName) == 'shared_modules/utils':
+        currentDir = os.path.join(currentDir, 'tests/')
 
     return currentDir
 
@@ -264,7 +266,11 @@ def runCoverage(moduleName):
     :param moduleName: Lib to be analyzed using gcov and lcov tools.
     """
     currentDir = currentDirPath(moduleName)
-    reportFolder = os.path.join(currentDir, 'coverage_report')
+    if moduleName == 'shared_modules/utils':
+        reportFolder = os.path.join(moduleName, 'coverage_report')
+    else:
+        reportFolder = os.path.join(currentDir, 'coverage_report')
+
     includeDir = Path(currentDir)
     moduleCMakeFiles = ""
 
@@ -435,12 +441,7 @@ def makeTarget(targetName, tests, debug):
 
 def configureCMake(moduleName, debugMode, testMode, withAsan):
     printHeader(moduleName, 'configurecmake')
-
-    if moduleName == 'shared_modules/utils':
-        currentModuleNameDir = os.path.join(currentDirPath(moduleName), "tests")
-    else:
-        currentModuleNameDir = currentDirPath(moduleName)
-
+    currentModuleNameDir = currentDirPath(moduleName)
     currentPathDir = currentDirPathBuild(moduleName)
 
     if not os.path.exists(currentPathDir):

--- a/src/ci/utils.py
+++ b/src/ci/utils.py
@@ -125,8 +125,6 @@ def currentDirPath(moduleName):
     :return Lib dir path
     """
     currentDir = os.path.join(currentBuildDir.parent, str(moduleName))
-    if str(moduleName) == 'shared_modules/utils':
-        currentDir = os.path.join(currentDir, 'tests/')
 
     return currentDir
 
@@ -437,7 +435,12 @@ def makeTarget(targetName, tests, debug):
 
 def configureCMake(moduleName, debugMode, testMode, withAsan):
     printHeader(moduleName, 'configurecmake')
-    currentModuleNameDir = currentDirPath(moduleName)
+
+    if moduleName == 'shared_modules/utils':
+        currentModuleNameDir = os.path.join(currentDirPath(moduleName), "tests")
+    else:
+        currentModuleNameDir = currentDirPath(moduleName)
+
     currentPathDir = currentDirPathBuild(moduleName)
 
     if not os.path.exists(currentPathDir):

--- a/src/os_auth/key_request.c
+++ b/src/os_auth/key_request.c
@@ -253,7 +253,7 @@ void* run_key_request_main(__attribute__((unused)) void *arg) {
             }
         }
 
-        if ((recv = OS_RecvUnix(sock, OS_MAXSTR, buffer)) > 0) {
+        if (recv = OS_RecvUnix(sock, OS_MAXSTR, buffer), recv > 0) {
             if(OSHash_Get_ex(request_hash, buffer)){
                 mdebug2("Request '%s' already being processed. Discarding request.", buffer);
                 continue;


### PR DESCRIPTION
|Related issue|
|---|
|#15691|

## Description

Some RTR checks are failing due to the location of the coverage_report folder. This PRs unifies the location of that folder with the rest of the components inside `shared_modules`.

## Logs/Alerts example

<details>
<summary>Click to expand</summary>

![2022-12-15_17-54](https://user-images.githubusercontent.com/13010397/207968198-3f2fafa4-2568-4aff-9194-40b5e771fd48.png)
![2022-12-15_17-59](https://user-images.githubusercontent.com/13010397/207968202-5adc2ad5-26e0-4af8-a5a7-cdb2b1696859.png)
![2022-12-15_18-02](https://user-images.githubusercontent.com/13010397/207968203-eb0c32ad-f6b4-48b5-879d-64e0e99916e9.png)
![2022-12-15_18-05](https://user-images.githubusercontent.com/13010397/207968210-e4874cd1-79fc-46f7-af7e-dd9968ec4600.png)
![2022-12-15_18-09](https://user-images.githubusercontent.com/13010397/207968211-7d14748b-9df6-45dc-ba6d-a05ffdd25531.png)

</details>

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Review logs syntax and correct language