### PR TITLE
Do not allow the start of the auth process in case the registration password file is empty.

### DIFF
--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -521,7 +521,6 @@ int main(int argc, char **argv)
             exit(1);
         }
 
-
         /* Check if password is enabled */
         if (config.flags.use_password) {
             fp = fopen(AUTHD_PASS, "r");

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -521,10 +521,18 @@ int main(int argc, char **argv)
             exit(1);
         }
 
+
         /* Check if password is enabled */
         if (config.flags.use_password) {
             fp = fopen(AUTHD_PASS, "r");
             buf[0] = '\0';
+
+            fseek(fp, 0, SEEK_END);
+
+            if (ftell(fp) <= 1) {
+                merror("Empty password provided.");
+                return OS_INVALID;
+            }
 
             /* Checking if there is a custom password file */
             if (fp) {

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -530,8 +530,10 @@ int main(int argc, char **argv)
 
             if (ftell(fp) <= 1) {
                 merror("Empty password provided.");
-                return OS_INVALID;
+                exit(1);
             }
+
+            fseek(fp, 0, SEEK_SET);
 
             /* Checking if there is a custom password file */
             if (fp) {

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -526,17 +526,17 @@ int main(int argc, char **argv)
             fp = fopen(AUTHD_PASS, "r");
             buf[0] = '\0';
 
-            fseek(fp, 0, SEEK_END);
-
-            if (ftell(fp) <= 1) {
-                merror("Empty password provided.");
-                exit(1);
-            }
-
-            fseek(fp, 0, SEEK_SET);
-
             /* Checking if there is a custom password file */
             if (fp) {
+                fseek(fp, 0, SEEK_END);
+
+                if (ftell(fp) <= 1) {
+                    merror("Empty password provided.");
+                    exit(1);
+                }
+
+                fseek(fp, 0, SEEK_SET);
+
                 buf[4096] = '\0';
                 char *ret = fgets(buf, 4095, fp);
 


### PR DESCRIPTION
|Related issue|Manual Testing|Integration Tests|
|---|---|---|
|https://github.com/wazuh/wazuh/issues/15230|https://github.com/wazuh/wazuh-qa/issues/3701|https://github.com/wazuh/wazuh-qa/pull/3721|

## Description
This PR solves issue #15230, it adds a new condition in `main-server.c` and checks if `authd.pass` is empty, if so, the manager stops and sends an error message to "ossec.log"

### Option Test

1. Run VM Ubuntu
2. Install Wazuh manager
3. Remove content `/var/ossec/etc/authd.pass`
4. Open `/var/ossec/logs/ossec.logs` (to view messages)
5. Run install.sh

## Logs/Alerts example
Try an empty `authd.pass`

```
root@ubuntu-2204:/home/ubuntu# tail -f /var/ossec/logs/ossec.log

2022/12/22 12:21:24 wazuh-integratord: INFO: Remote integrations not configured. Clean exit.

2022/12/22 12:21:24 wazuh-agentlessd: INFO: Not configured. Exiting.

2022/12/22 12:21:24 wazuh-authd: INFO: Started (pid: 1404).

2022/12/22 12:21:24 wazuh-authd: ERROR: Empty password provided.

2022/12/22 16:47:27 wazuh-csyslogd: INFO: Remote syslog server not configured. Clean exit.

2022/12/22 16:47:27 wazuh-dbd: INFO: Database not configured. Clean exit.

2022/12/22 16:47:27 wazuh-integratord: INFO: Remote integrations not configured. Clean exit.

2022/12/22 16:47:27 wazuh-agentlessd: INFO: Not configured. Exiting.

2022/12/22 16:47:27 wazuh-authd: INFO: Started (pid: 1395).

2022/12/22 16:47:27 wazuh-authd: ERROR: Empty password provided.
```

Try a password on `authd.pass`

![image](https://user-images.githubusercontent.com/114432526/209174226-e1f28d27-5392-4663-bc9e-1b07a9c75ae4.png)

```
root@ubuntu-2204:/home/ubuntu# tail -f /var/ossec/logs/ossec.log

2022/12/22 17:11:08 wazuh-logcollector: INFO: (1950): Analyzing file: '/var/log/dpkg.log'.

2022/12/22 17:11:08 wazuh-logcollector: INFO: (1950): Analyzing file: '/var/log/kern.log'.

2022/12/22 17:11:08 wazuh-logcollector: INFO: Monitoring output of command(360): df -P

2022/12/22 17:11:08 wazuh-logcollector: INFO: Monitoring full output of command(360): netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d

2022/12/22 17:11:08 wazuh-logcollector: INFO: Monitoring full output of command(360): last -n 20

2022/12/22 17:11:08 wazuh-logcollector: INFO: Started (pid: 8375).

2022/12/22 17:11:14 sca: INFO: Evaluation finished for policy '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'

2022/12/22 17:11:14 sca: INFO: Security Configuration Assessment scan finished. Duration: 7 seconds.

2022/12/22 17:11:46 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.

2022/12/22 17:12:42 rootcheck: INFO: Ending rootcheck scan.

2022/12/22 17:15:55 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.

2022/12/22 17:15:55 wazuh-modulesd:syscollector: INFO: Module finished.

2022/12/22 17:15:55 wazuh-monitord: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...

2022/12/22 17:15:55 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...

2022/12/22 17:15:56 wazuh-remoted: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...

2022/12/22 17:15:56 wazuh-syscheckd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...

2022/12/22 17:15:56 wazuh-analysisd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...

2022/12/22 17:15:56 wazuh-execd: INFO: (1314): Shutdown received. Deleting responses.

2022/12/22 17:15:56 wazuh-execd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...

2022/12/22 17:15:56 wazuh-db: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...

2022/12/22 17:15:57 wazuh-authd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...

2022/12/22 17:15:57 wazuh-authd: INFO: Exiting...
```

![image](https://user-images.githubusercontent.com/114432526/209177747-df27f391-ac69-46d8-983d-34a2f4b34227.png)




## Comment
No unit_test is done due to cmocka conflicts with main-server.c

A new issue is created #15744  for a new distribution of the main-server code for better functionality and efficiency. Due to the difficulty of compatibility with unit_tests and to reduce the possibility of committing serious errors when modifying the main


## Compilation
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities


