### PR TITLE
Fix cluster logs tag inside `cluster.py` module

### DIFF
--- a/framework/scripts/wazuh_clusterd.py
+++ b/framework/scripts/wazuh_clusterd.py
@@ -87,13 +87,14 @@ async def master_main(args: argparse.Namespace, cluster_config: dict, cluster_it
     my_server = master.Master(performance_test=args.performance_test, concurrency_test=args.concurrency_test,
                               configuration=cluster_config, enable_ssl=args.ssl, logger=logger,
                               cluster_items=cluster_items)
+    # Spawn pool processes
+    if my_server.task_pool is not None:
+        my_server.task_pool.map(cluster_utils.process_spawn_sleep, range(my_server.task_pool._max_workers))
+
     my_local_server = local_server.LocalServerMaster(performance_test=args.performance_test, logger=logger,
                                                      concurrency_test=args.concurrency_test, node=my_server,
                                                      configuration=cluster_config, enable_ssl=args.ssl,
                                                      cluster_items=cluster_items)
-    # Spawn pool processes
-    if my_server.task_pool is not None:
-        my_server.task_pool.map(cluster_utils.process_spawn_sleep, range(my_server.task_pool._max_workers))
     await asyncio.gather(my_server.start(), my_local_server.start())
 
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #11941 |

## Description

Cluster logs produced inside `cluster.py` module now show the correct tag after the changes performed in this PR. Master:
```
2022/12/19 13:32:29 INFO: [Worker worker1] [Integrity sync] Starting.
2022/12/19 13:32:29 INFO: [Worker worker1] [Integrity sync] Files to create in worker: 1 | Files to update in worker: 0 | Files to delete in worker: 0
2022/12/19 13:32:29 INFO: [Master] [Main] ¡¡¡¡¡¡¡¡¡¡¡¡¡¡¡¡¡¡¡ TEST
2022/12/19 13:32:29 INFO: [Worker worker1] [Integrity sync] Finished in 0.009s.
```

Worker:
```
2022/12/19 13:32:29 INFO: [Worker worker1] [Integrity check] Starting.
2022/12/19 13:32:29 INFO: [Worker worker1] [Main] ¡¡¡¡¡¡¡¡¡¡¡¡¡¡¡¡¡¡¡ TEST
2022/12/19 13:32:29 INFO: [Worker worker1] [Integrity check] Finished in 0.035s. Sync required.
```

When child processes spawn, they are created as a copy of the parent. Since in the master node the children spawn right at startup, they cannot access loggers created later, such as those with the label of the instantiated worker (for example, `[Worker worker1] [Integrity check]`) since these are created during the connection of each worker node:
https://github.com/wazuh/wazuh/blob/54732493723d9dcc36d78474c458379f7978a3ff/framework/wazuh/core/cluster/master.py#L412-L419

The reason why until now they showed `Local Server` tag:
```
2022/01/25 10:10:51 INFO: [Local Server] [Main] ¡¡¡¡¡¡¡¡¡¡¡¡¡¡¡¡¡¡¡ TEST
```
was because LocalServer was instantiated just before spawning the child processes, and declaring the object sets a contextVar that is used in the loggers:
https://github.com/wazuh/wazuh/blob/54732493723d9dcc36d78474c458379f7978a3ff/framework/scripts/wazuh_clusterd.py#L87-L96

## Things to note

Python's logging module is not intended to be used in multiprocessing (at least, not without some changes), and having multiple file descriptors open for the same file and writing at the same time is a bad practice that we should stop.

However, writes smaller than `PIPE_BUF` are atomic, and the value of `PIPE_BUF` is 4096 on linux systems. This is currently preventing the cluster log files (and/or API) from being corrupted.


## Tests

```
$ PYTHONPATH=/home/selu/Git/wazuh/api:/home/selu/Git/wazuh/framework python3 -m pytest framework/ -x
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.9.16, pytest-7.0.1, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: anyio-3.6.2, asyncio-0.18.1, aiohttp-1.0.4, cov-4.0.0
asyncio: mode=auto
collected 2076 items                                                                                                                                                                                        

framework/scripts/tests/test_agent_groups.py ..............                                                                                                                                           [  0%]
framework/scripts/tests/test_agent_upgrade.py ...............                                                                                                                                         [  1%]
framework/scripts/tests/test_cluster_control.py ......                                                                                                                                                [  1%]
framework/scripts/tests/test_wazuh_clusterd.py .......                                                                                                                                                [  2%]
framework/scripts/tests/test_wazuh_logtest.py ......................                                                                                                                                  [  3%]
framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................................                                                                                                                 [  4%]
framework/wazuh/core/cluster/tests/test_client.py ................                                                                                                                                    [  5%]
framework/wazuh/core/cluster/tests/test_cluster.py ...................................                                                                                                                [  7%]
framework/wazuh/core/cluster/tests/test_common.py ..................................................................................                                                                  [ 11%]
framework/wazuh/core/cluster/tests/test_control.py ......                                                                                                                                             [ 11%]
framework/wazuh/core/cluster/tests/test_local_client.py .............                                                                                                                                 [ 11%]
framework/wazuh/core/cluster/tests/test_local_server.py ........................                                                                                                                      [ 13%]
framework/wazuh/core/cluster/tests/test_master.py ....................................................                                                                                                [ 15%]
framework/wazuh/core/cluster/tests/test_server.py .............................                                                                                                                       [ 17%]
framework/wazuh/core/cluster/tests/test_utils.py ...........                                                                                                                                          [ 17%]
framework/wazuh/core/cluster/tests/test_worker.py ...................................                                                                                                                 [ 19%]
framework/wazuh/core/tests/test_active_response.py ..............                                                                                                                                     [ 19%]
framework/wazuh/core/tests/test_agent.py ...................................................................................................................................................          [ 26%]
framework/wazuh/core/tests/test_cdb_list.py ......................................                                                                                                                    [ 28%]
framework/wazuh/core/tests/test_common.py .........                                                                                                                                                   [ 29%]
framework/wazuh/core/tests/test_configuration.py ......................................................................                                                                               [ 32%]
framework/wazuh/core/tests/test_database.py .............                                                                                                                                             [ 33%]
framework/wazuh/core/tests/test_decoder.py ................                                                                                                                                           [ 34%]
framework/wazuh/core/tests/test_exception.py ...                                                                                                                                                      [ 34%]
framework/wazuh/core/tests/test_input_validator.py ...                                                                                                                                                [ 34%]
framework/wazuh/core/tests/test_logtest.py ..                                                                                                                                                         [ 34%]
framework/wazuh/core/tests/test_manager.py ...............                                                                                                                                            [ 35%]
framework/wazuh/core/tests/test_mitre.py .............                                                                                                                                                [ 35%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                                                                                                                                               [ 35%]
framework/wazuh/core/tests/test_results.py ........................................                                                                                                                   [ 37%]
framework/wazuh/core/tests/test_rootcheck.py .............                                                                                                                                            [ 38%]
framework/wazuh/core/tests/test_rule.py ......................                                                                                                                                        [ 39%]
framework/wazuh/core/tests/test_sca.py ........................                                                                                                                                       [ 40%]
framework/wazuh/core/tests/test_security.py ............                                                                                                                                              [ 41%]
framework/wazuh/core/tests/test_stats.py .................                                                                                                                                            [ 42%]
framework/wazuh/core/tests/test_syscheck.py .......                                                                                                                                                   [ 42%]
framework/wazuh/core/tests/test_syscollector.py ...                                                                                                                                                   [ 42%]
framework/wazuh/core/tests/test_task.py ........                                                                                                                                                      [ 43%]
framework/wazuh/core/tests/test_utils.py ............................................................................................................................................................ [ 50%]
.........................................................................................                                                                                                             [ 54%]
framework/wazuh/core/tests/test_vulnerability.py ..                                                                                                                                                   [ 54%]
framework/wazuh/core/tests/test_wazuh_queue.py ....................                                                                                                                                   [ 55%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                                                  [ 56%]
framework/wazuh/core/tests/test_wdb.py ...............................                                                                                                                                [ 58%]
framework/wazuh/core/tests/test_wlogging.py .........                                                                                                                                                 [ 58%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                                                                                                                                    [ 58%]
framework/wazuh/rbac/tests/test_decorators.py .........................................................................................................                                               [ 63%]
framework/wazuh/rbac/tests/test_default_configuration.py ........................................................                                                                                     [ 66%]
framework/wazuh/rbac/tests/test_orm.py ......................................................                                                                                                         [ 69%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                           [ 69%]
framework/wazuh/tests/test_active_response.py ............                                                                                                                                            [ 70%]
framework/wazuh/tests/test_agent.py ......................................................................................................................                                            [ 76%]
framework/wazuh/tests/test_cdb_list.py .....................................................                                                                                                          [ 78%]
framework/wazuh/tests/test_ciscat.py .................................                                                                                                                                [ 80%]
framework/wazuh/tests/test_cluster.py ..........                                                                                                                                                      [ 80%]
framework/wazuh/tests/test_decoder.py ...................................                                                                                                                             [ 82%]
framework/wazuh/tests/test_group.py .......                                                                                                                                                           [ 82%]
framework/wazuh/tests/test_logtest.py ......                                                                                                                                                          [ 82%]
framework/wazuh/tests/test_manager.py ....................................                                                                                                                            [ 84%]
framework/wazuh/tests/test_mitre.py .......                                                                                                                                                           [ 85%]
framework/wazuh/tests/test_rootcheck.py ..................................................                                                                                                            [ 87%]
framework/wazuh/tests/test_rule.py ........................................................                                                                                                           [ 90%]
framework/wazuh/tests/test_sca.py ...........                                                                                                                                                         [ 90%]
framework/wazuh/tests/test_security.py .........................................................................                                                                                      [ 94%]
framework/wazuh/tests/test_stats.py ...............                                                                                                                                                   [ 94%]
framework/wazuh/tests/test_syscheck.py ..........................                                                                                                                                     [ 96%]
framework/wazuh/tests/test_syscollector.py ............                                                                                                                                               [ 96%]
framework/wazuh/tests/test_task.py ............................                                                                                                                                       [ 98%]
framework/wazuh/tests/test_vulnerability.py ........................................                                                                                                                  [100%]

============================================================================================= warnings summary ==============================================================================================
../../venv/3.9-unittest-env/lib/python3.9/site-packages/pytest_aiohttp/plugin.py:28
  /home/selu/venv/3.9-unittest-env/lib/python3.9/site-packages/pytest_aiohttp/plugin.py:28: DeprecationWarning: The 'asyncio_mode' is 'legacy', switching to 'auto' for the sake of pytest-aiohttp backward compatibility. Please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
    config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)

../../venv/3.9-unittest-env/lib/python3.9/site-packages/jsonschema/compat.py:6
../../venv/3.9-unittest-env/lib/python3.9/site-packages/jsonschema/compat.py:6
  /home/selu/venv/3.9-unittest-env/lib/python3.9/site-packages/jsonschema/compat.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    from collections import MutableMapping, Sequence  # noqa

../../venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:48
  /home/selu/venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:48: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def problems_middleware(request, handler):

../../venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:169
  /home/selu/venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:169: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_openapi_json(self, request):

../../venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:177
  /home/selu/venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:177: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_openapi_yaml(self, request):

../../venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:236
  /home/selu/venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:236: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_swagger_ui_home(self, req):

../../venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:246
  /home/selu/venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:246: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_swagger_ui_config(self, req):

../../venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:295
  /home/selu/venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:295: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def get_request(cls, req):

../../venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:324
  /home/selu/venv/3.9-unittest-env/lib/python3.9/site-packages/connexion/apis/aiohttp_api.py:324: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def get_response(cls, response, mimetype=None, request=None):

framework/wazuh/core/cluster/dapi/tests/test_dapi.py:67
  /home/selu/Git/wazuh/framework/wazuh/core/cluster/dapi/tests/test_dapi.py:67: PytestCollectionWarning: cannot collect test class 'TestingLoggerParent' because it has a __init__ constructor (from: wazuh/core/cluster/dapi/tests/test_dapi.py)
    class TestingLoggerParent:

framework/wazuh/core/cluster/dapi/tests/test_dapi.py:73
  /home/selu/Git/wazuh/framework/wazuh/core/cluster/dapi/tests/test_dapi.py:73: PytestCollectionWarning: cannot collect test class 'TestingLogger' because it has a __init__ constructor (from: wazuh/core/cluster/dapi/tests/test_dapi.py)
    class TestingLogger:

framework/wazuh/core/cluster/tests/test_local_client.py:7
  /home/selu/Git/wazuh/framework/wazuh/core/cluster/tests/test_local_client.py:7: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    from collections import Callable

scripts/tests/test_agent_groups.py::test_show_groups
  /home/selu/Git/wazuh/framework/scripts/tests/test_agent_groups.py:42: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    forward_mock.has_calls([call(func=agent.get_agent_groups, kwargs={}),

scripts/tests/test_agent_groups.py::test_show_group
  /home/selu/Git/wazuh/framework/scripts/tests/test_agent_groups.py:69: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    forward_mock.has_calls(call(func=agent.get_agents, f_kwargs={'agent_list': agent_id}))

scripts/tests/test_agent_groups.py::test_show_synced_agent
  /home/selu/Git/wazuh/framework/scripts/tests/test_agent_groups.py:98: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    forward_mock.has_calls(call(func=agent.get_agents_sync_group, f_kwargs={'agent_list': [agent_id]}))

scripts/tests/test_agent_groups.py::test_show_agents_with_group
  /home/selu/Git/wazuh/framework/scripts/tests/test_agent_groups.py:125: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    forward_mock.has_calls(call(func=agent.get_agents_in_group, f_kwargs={'group_list': 'testing'}))

scripts/tests/test_agent_groups.py::test_show_group_files
  /home/selu/Git/wazuh/framework/scripts/tests/test_agent_groups.py:152: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    forward_mock.has_calls(call(func=agent.get_group_files, f_kwargs={'group_list': 'testing'}))

scripts/tests/test_agent_groups.py::test_unset_group
  /home/selu/Git/wazuh/framework/scripts/tests/test_agent_groups.py:181: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    forward_mock.has_calls(call(func=agent.remove_agent_from_groups,

scripts/tests/test_agent_groups.py::test_remove_group
  /home/selu/Git/wazuh/framework/scripts/tests/test_agent_groups.py:217: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    forward_mock.has_calls(call(func=agent.delete_groups, f_kwargs={'group_list': ['testing']}))

scripts/tests/test_agent_groups.py::test_set_group
  /home/selu/Git/wazuh/framework/scripts/tests/test_agent_groups.py:252: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    forward_mock.has_calls(call(func=agent.assign_agents_to_group,

scripts/tests/test_agent_groups.py::test_create_group
  /home/selu/Git/wazuh/framework/scripts/tests/test_agent_groups.py:291: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    forward_mock.has_calls(call(func=agent.create_group, f_kwargs={'group_id': group_id}))

scripts/tests/test_cluster_control.py::test_main
  /usr/lib/python3.9/unittest/mock.py:328: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    self.__dict__[_the_name] = value

wazuh/core/cluster/tests/test_client.py::test_ac_connection_lost
  /usr/lib/python3.9/unittest/mock.py:2058: RuntimeWarning: coroutine 'Handler.send_request' was never awaited
    setattr(_type, entry, MagicProxy(entry, self))

wazuh/core/cluster/tests/test_client.py::test_ac_connection_lost
wazuh/core/cluster/tests/test_worker.py::test_worker_handler_sync_integrity
wazuh/core/tests/test_common.py::test_origin_module_context_var_api
  /usr/lib/python3.9/unittest/mock.py:2058: RuntimeWarning: coroutine 'Handler.log_exceptions' was never awaited
    setattr(_type, entry, MagicProxy(entry, self))

wazuh/core/cluster/tests/test_common.py::test_response_init
  /usr/lib/python3.9/unittest/mock.py:2104: RuntimeWarning: coroutine 'test_run_in_pool.<locals>.LoopMock.run_in_executor' was never awaited
    self.name = name

wazuh/core/cluster/tests/test_common.py::test_rst_done_callback
  wazuh/core/cluster/tests/test_common.py:259: PytestWarning: The test <Function test_rst_done_callback> is marked with '@pytest.mark.asyncio' but it is not an async function. Please remove asyncio marker. If the test is not marked explicitly, check for global markers applied via 'pytestmark'.
    @pytest.mark.asyncio

wazuh/core/cluster/tests/test_common.py::test_handler_send_request_ko
  /usr/lib/python3.9/unittest/mock.py:2058: RuntimeWarning: coroutine 'Response.read' was never awaited
    setattr(_type, entry, MagicProxy(entry, self))

wazuh/core/cluster/tests/test_common.py::test_handler_wait_for_file_ko
wazuh/core/cluster/tests/test_master.py::test_master_handler_process_sync_error_from_worker
wazuh/core/cluster/tests/test_master.py::test_set_date_end_master
  /usr/lib/python3.9/unittest/mock.py:2104: RuntimeWarning: coroutine 'Event.wait' was never awaited
    self.name = name

wazuh/core/cluster/tests/test_common.py::test_wazuh_common_setup_send_info
  /home/selu/Git/wazuh/framework/wazuh/core/cluster/tests/test_common.py:1230: RuntimeWarning: coroutine 'Event.wait' was never awaited
    class MyTaskMock:

wazuh/core/cluster/tests/test_local_client.py::test_localclient_send_api_request_ko
wazuh/core/cluster/tests/test_utils.py::test_get_manager_status
wazuh/core/cluster/tests/test_worker.py::test_worker_handler_sync_integrity
  /usr/lib/python3.9/unittest/mock.py:2058: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    setattr(_type, entry, MagicProxy(entry, self))

wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandlerMaster_process_request
  /usr/lib/python3.9/unittest/mock.py:2104: RuntimeWarning: coroutine 'test_LocalServerHandler_get_send_file_response.<locals>.func_mock' was never awaited
    self.name = name

wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandlerMaster_process_request
wazuh/core/cluster/tests/test_master.py::test_rit_init
  /usr/lib/python3.9/unittest/mock.py:2104: RuntimeWarning: coroutine 'Handler.log_exceptions' was never awaited
    self.name = name

wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandlerMaster_process_request
wazuh/core/cluster/tests/test_master.py::test_rit_init
wazuh/core/cluster/tests/test_master.py::test_master_handler_process_sync_error_from_worker
  /usr/lib/python3.9/unittest/mock.py:2104: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    self.name = name

wazuh/core/cluster/tests/test_local_server.py::test_LocalServerHandlerWorker_process_request
  /usr/lib/python3.9/unittest/mock.py:328: RuntimeWarning: coroutine 'Handler.log_exceptions' was never awaited
    self.__dict__[_the_name] = value

wazuh/core/cluster/tests/test_master.py::test_master_handler_execute_ok
  /home/selu/venv/3.9-unittest-env/lib/python3.9/site-packages/pytest_asyncio/plugin.py:375: RuntimeWarning: coroutine 'test_LocalServerHandlerMaster_send_file_request.<locals>.func_mock' was never awaited
    old_loop.close()

wazuh/core/cluster/tests/test_master.py::test_master_handler_get_nodes
  /usr/lib/python3.9/unittest/mock.py:1096: RuntimeWarning: coroutine 'Handler.forward_dapi_response' was never awaited
    return self._execute_mock_call(*args, **kwargs)

wazuh/core/cluster/tests/test_worker.py::test_worker_handler_process_request_ok
  /usr/lib/python3.9/unittest/mock.py:2058: RuntimeWarning: coroutine 'WorkerHandler.process_files_from_master' was never awaited
    setattr(_type, entry, MagicProxy(entry, self))

wazuh/core/tests/test_common.py::test_origin_module_context_var_api
  /usr/lib/python3.9/unittest/mock.py:2058: RuntimeWarning: coroutine 'MasterHandler.send_agent_groups_information' was never awaited
    setattr(_type, entry, MagicProxy(entry, self))

wazuh/rbac/tests/test_auth_context.py::test_auth_roles
  /home/selu/Git/wazuh/framework/wazuh/rbac/auth_context.py:225: FutureWarning: Possible nested set at position 2
    regex = re.compile(regex)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================== 2076 passed, 49 warnings in 338.52s (0:05:38) ===============================================================================
```