### PR TITLE
Fix Rootcheck scan trying to read deleted files

### DIFF
--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -274,10 +274,11 @@ int receive_msg()
                         final_file = strrchr(file, '/');
                         if (final_file) {
                             if (strcmp(final_file + 1, SHAREDCFG_FILENAME) == 0) {
-                                const char **IGNORE_LIST = malloc(2 * sizeof(char *));
-                                *IGNORE_LIST = strdup(SHAREDCFG_FILENAME);
+                                const char **IGNORE_LIST;
+                                os_malloc(2 * sizeof(char *), IGNORE_LIST);
+                                os_strdup(SHAREDCFG_FILENAME, *IGNORE_LIST);
                                 *(IGNORE_LIST + 1) = NULL;
-                                if(!UnmergeFiles(file, SHAREDCFG_DIR, OS_TEXT, &IGNORE_LIST)){
+                                if (!UnmergeFiles(file, SHAREDCFG_DIR, OS_TEXT, &IGNORE_LIST)) {
                                     char msg_output[OS_MAXSTR];
 
                                     snprintf(msg_output, OS_MAXSTR, "%c:%s:%s",  LOCALFILE_MQ, "wazuh-agent", AG_IN_UNMERGE);

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -274,17 +274,17 @@ int receive_msg()
                         final_file = strrchr(file, '/');
                         if (final_file) {
                             if (strcmp(final_file + 1, SHAREDCFG_FILENAME) == 0) {
-                                const char **IGNORE_LIST;
-                                os_calloc(2, sizeof(char *), IGNORE_LIST);
-                                os_strdup(SHAREDCFG_FILENAME, *IGNORE_LIST);
-                                if (!UnmergeFiles(file, SHAREDCFG_DIR, OS_TEXT, &IGNORE_LIST)) {
+                                char **ignore_list;
+                                os_calloc(2, sizeof(char *), ignore_list);
+                                os_strdup(SHAREDCFG_FILENAME, *ignore_list);
+                                if (!UnmergeFiles(file, SHAREDCFG_DIR, OS_TEXT, &ignore_list)) {
                                     char msg_output[OS_MAXSTR];
 
                                     snprintf(msg_output, OS_MAXSTR, "%c:%s:%s",  LOCALFILE_MQ, "wazuh-agent", AG_IN_UNMERGE);
                                     send_msg(msg_output, -1);
                                 }
                                 else {
-                                    if (cldir_ex_ignore(SHAREDCFG_DIR, IGNORE_LIST)) {
+                                    if (cldir_ex_ignore(SHAREDCFG_DIR, ignore_list)) {
                                         mwarn("Could not clean up shared directory.");
                                     }
                                     clear_merged_hash_cache();
@@ -297,8 +297,7 @@ int receive_msg()
                                         }
                                     }
                                 }
-                                w_FreeArray(IGNORE_LIST);
-                                os_free(IGNORE_LIST);
+                                free_strarray(ignore_list);
                             }
                         } else {
                             /* Remove file */

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -275,9 +275,8 @@ int receive_msg()
                         if (final_file) {
                             if (strcmp(final_file + 1, SHAREDCFG_FILENAME) == 0) {
                                 const char **IGNORE_LIST;
-                                os_malloc(2 * sizeof(char *), IGNORE_LIST);
+                                os_calloc(2, sizeof(char *), IGNORE_LIST);
                                 os_strdup(SHAREDCFG_FILENAME, *IGNORE_LIST);
-                                *(IGNORE_LIST + 1) = NULL;
                                 if (!UnmergeFiles(file, SHAREDCFG_DIR, OS_TEXT, &IGNORE_LIST)) {
                                     char msg_output[OS_MAXSTR];
 

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -275,8 +275,8 @@ int receive_msg()
                         if (final_file) {
                             if (strcmp(final_file + 1, SHAREDCFG_FILENAME) == 0) {
                                 const char **IGNORE_LIST = malloc(2 * sizeof(char *));
-                                IGNORE_LIST[0] = SHAREDCFG_FILENAME;
-                                IGNORE_LIST[1] = NULL;
+                                *IGNORE_LIST = strdup(SHAREDCFG_FILENAME);
+                                *(IGNORE_LIST + 1) = NULL;
                                 if(!UnmergeFiles(file, SHAREDCFG_DIR, OS_TEXT, &IGNORE_LIST)){
                                     char msg_output[OS_MAXSTR];
 
@@ -296,6 +296,10 @@ int receive_msg()
                                             minfo("Shared agent configuration has been updated.");
                                         }
                                     }
+                                }
+                                int j = 0;
+                                while (*(IGNORE_LIST + j)) {
+                                    free(*(IGNORE_LIST + j++));
                                 }
                                 os_free(IGNORE_LIST);
                             }

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -297,10 +297,7 @@ int receive_msg()
                                         }
                                     }
                                 }
-                                int j = 0;
-                                while (*(IGNORE_LIST + j)) {
-                                    free(*(IGNORE_LIST + j++));
-                                }
+                                w_FreeArray(IGNORE_LIST);
                                 os_free(IGNORE_LIST);
                             }
                         } else {

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -218,7 +218,7 @@ int MergeAppendFile(FILE *finalfp, const char *files, int path_offset) __attribu
  * @param mode Indicates if the merged file must be readed as a binary file  or not. Use `#OS_TEXT`, `#OS_BINARY`.
  * @return 1 if the file was unmerged, 0 on error.
  */
-int UnmergeFiles(const char *finalpath, const char *optdir, int mode) __attribute__((nonnull(1)));
+int UnmergeFiles(const char *finalpath, const char *optdir, int mode, const char ***unmerged_files) __attribute__((nonnull(1)));
 
 
 /**

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -119,7 +119,7 @@ size_t wcom_unmerge(const char *file_path, char ** output) {
         return strlen(*output);
     }
 
-    if (UnmergeFiles(final_path, INCOMING_DIR, OS_BINARY) == 0) {
+    if (UnmergeFiles(final_path, INCOMING_DIR, OS_BINARY, NULL) == 0) {
         merror("At WCOM unmerge: Error unmerging file '%s.'", final_path);
         os_strdup("err Cannot unmerge file", *output);
         return strlen(*output);

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -768,7 +768,7 @@ int UnmergeFiles(const char *finalpath, const char *optdir, int mode, const char
             }
 
             /* Appends file name to unmerged files list */
-            *unmerged_files = realloc(*unmerged_files, (file_count + 1) * sizeof(char *));
+            *unmerged_files = realloc(*unmerged_files, (file_count + 2) * sizeof(char *));
             *(*unmerged_files + file_count) = strdup(file_name);
             file_count++;
         }

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -644,7 +644,7 @@ int UnmergeFiles(const char *finalpath, const char *optdir, int mode, const char
     }
 
     /* Finds index of the last element on the list */
-    if(unmerged_files != NULL){
+    if (unmerged_files != NULL) {
         for(file_count = 0; *(*unmerged_files + file_count); file_count++);
     }
 
@@ -699,7 +699,6 @@ int UnmergeFiles(const char *finalpath, const char *optdir, int mode, const char
         }
 
         free(copy);
-
 
         /* Create temporary file */
         char tmp_file[strlen(final_name) + 7];
@@ -757,24 +756,24 @@ int UnmergeFiles(const char *finalpath, const char *optdir, int mode, const char
         /* Mv to original name */
         rename_ex(tmp_file, final_name);
 
-        if(unmerged_files != NULL){
+        if (unmerged_files != NULL) {
             /* Removes path from file name */
             file_name = strrchr(final_name, '/');
-            if(file_name){
+            if (file_name) {
                 file_name++;
             }
-            else{
+            else {
                 file_name = final_name;
             }
 
             /* Appends file name to unmerged files list */
-            *unmerged_files = realloc(*unmerged_files, (file_count + 2) * sizeof(char *));
-            *(*unmerged_files + file_count) = strdup(file_name);
+            os_realloc(*unmerged_files, (file_count + 2) * sizeof(char *), *unmerged_files);
+            os_strdup(file_name, *(*unmerged_files + file_count));
             file_count++;
         }
     }
 
-    if(unmerged_files != NULL){
+    if (unmerged_files != NULL) {
         *(*unmerged_files + file_count) = NULL;
     }
 

--- a/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
+++ b/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
@@ -353,7 +353,7 @@ STATIC char * wm_agent_upgrade_com_upgrade(const cJSON* json_object) {
     }
 
     //Unmerge
-    if (UnmergeFiles(merged, UPGRADE_DIR, OS_BINARY) == 0) {
+    if (UnmergeFiles(merged, UPGRADE_DIR, OS_BINARY, NULL) == 0) {
         unlink(merged);
         mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_UNMERGING_FILE_ERROR, "upgrade", merged);
         return wm_agent_upgrade_command_ack(ERROR_UNMERGE, error_messages[ERROR_UNMERGE]);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8309|

## Description

This PR aims to fix a Rootcheck scan issue that occurs because before unmerging the merged.mg file, the files in the shared folder are removed and during that time, Rootcheck might try to read them.

### Previous behavior

The client-agent receiver deletes all files in the shared folder, then unmerges the merged.mg and creates the new files.

### Proposed behavior

The client-agent receiver unmerges the merged.mg and creates the new files with temp names, then renames these files with their original names and add them to the exclude list. After this, all files in the shared folder that are not in the exclude list are deleted.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Source upgrade
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Added unit tests (for new features)
- [x] Stress test for affected components


- Create files in the manager that are not on the agent and vice versa.
- Create heavy files in the manager that are not on the agent and vice versa.
- Delete and create files in the manager and check that the same remain in the agent.
- Set a sleep() function on the code before the files are renamed to check the temp files are created and renamed correctly.