### PR TITLE
Improves requests to wazuh-db in process_multi_groups() function

### DIFF
--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -875,7 +875,7 @@ STATIC void process_multi_groups() {
     cJSON *group_item = NULL;
     cJSON *chunk_item = NULL;
 
-    cJSON *groups_array = wdb_get_distinct_agent_groups(NULL, NULL);
+    cJSON *groups_array = wdb_get_distinct_agent_groups(NULL);
 
     if (groups_array != NULL) {
         cJSON_ArrayForEach(chunk_item, groups_array) {

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -146,7 +146,7 @@ LIST(APPEND analysisd_flags "-Wl,--wrap,wdbc_query_ex ${DEBUG_OP_WRAPPERS}")
 list(APPEND analysisd_names "test_analysis-state")
 list(APPEND analysisd_flags "-Wl,--wrap,time -Wl,--wrap,rem_get_qsize -Wl,--wrap,rem_get_tsize \
                             -Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_Add -Wl,--wrap,OSHash_Add_ex -Wl,--wrap,OSHash_Begin \
-                            -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap,OSHash_Delete -Wl,--wrap,OSHash_Get \
+                            -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap,OSHash_Delete -Wl,--wrap,OSHash_Get -Wl,--wrap,OSHash_Clean \
                             -Wl,--wrap,OSHash_Get_ex -Wl,--wrap,OSHash_Next -Wl,--wrap,OSHash_SetFreeDataPointer \
                             -Wl,--wrap,OSHash_Update_ex -Wl,--wrap,OSHash_Update -Wl,--wrap,OSHash_Get_Elem_ex \
                             -Wl,--wrap,wdb_get_agents_ids_of_current_node -Wl,--wrap,_merror -Wl,--wrap,limit_reached")

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -47,7 +47,8 @@ list(APPEND remoted_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,w_
                             -Wl,--wrap,wdb_set_agent_groups_csv -Wl,--wrap,w_is_single_node \
                             -Wl,--wrap,wdb_remove_group_db -Wl,--wrap,wdb_get_all_agents -Wl,--wrap,wdb_get_agent_info \
                             -Wl,--wrap,rem_inc_send_ack -Wl,--wrap,rem_inc_recv_ctrl_request -Wl,--wrap,rem_inc_recv_ctrl_keepalive \
-                            -Wl,--wrap,rem_inc_recv_ctrl_startup -Wl,--wrap,rem_inc_recv_ctrl_shutdown")
+                            -Wl,--wrap,rem_inc_recv_ctrl_startup -Wl,--wrap,rem_inc_recv_ctrl_shutdown -Wl,--wrap,pthread_mutex_lock \
+                            -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,wdb_get_distinct_agent_groups")
 
 list(APPEND remoted_names "test_secure")
 list(APPEND remoted_flags "-Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose -Wl,--wrap,remove \
@@ -81,7 +82,7 @@ list(APPEND remoted_flags "-W")
 list(APPEND remoted_names "test_remote-state")
 list(APPEND remoted_flags "-Wl,--wrap,time -Wl,--wrap,rem_get_qsize -Wl,--wrap,rem_get_tsize \
                             -Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_Add -Wl,--wrap,OSHash_Add_ex -Wl,--wrap,OSHash_Begin \
-                            -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap,OSHash_Delete -Wl,--wrap,OSHash_Get \
+                            -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap,OSHash_Delete -Wl,--wrap,OSHash_Get -Wl,--wrap,OSHash_Clean \
                             -Wl,--wrap,OSHash_Get_ex -Wl,--wrap,OSHash_Next -Wl,--wrap,OSHash_SetFreeDataPointer \
                             -Wl,--wrap,OSHash_Update_ex -Wl,--wrap,OSHash_Update -Wl,--wrap,OSHash_Get_Elem_ex \
                             -Wl,--wrap,wdb_get_agents_ids_of_current_node -Wl,--wrap,_merror")

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -78,7 +78,8 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl
                              -Wl,--wrap,w_inc_global_agent_reset_agents_connection_time -Wl,--wrap,w_inc_global_agent_get_agents_by_connection_status \
                              -Wl,--wrap,w_inc_global_agent_get_agents_by_connection_status_time -Wl,--wrap,w_inc_global_backup -Wl,--wrap,w_inc_global_backup_time \
                              -Wl,--wrap,wdb_commit2 -Wl,--wrap,wdb_vacuum -Wl,--wrap,wdb_get_db_state -Wl,--wrap,wdb_finalize_all_statements \
-                             -Wl,--wrap,wdb_update_last_vacuum_data -Wl,--wrap,wdb_get_db_free_pages_percentage \
+                             -Wl,--wrap,wdb_update_last_vacuum_data -Wl,--wrap,wdb_get_db_free_pages_percentage -Wl,--wrap,wdb_global_get_distinct_agent_groups \
+                             -Wl,--wrap,w_inc_global_agent_get_distinct_groups -Wl,--wrap,w_inc_global_agent_get_distinct_groups_time \
                              ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_global")

--- a/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
@@ -3712,6 +3712,317 @@ void test_wdb_set_agent_groups_success(void **state) {
     assert_int_equal(OS_SUCCESS,res);
 }
 
+/* Tests wdb_get_distinct_agent_groups */
+
+void test_wdb_get_distinct_agent_groups_error_no_json_response(void **state) {
+    cJSON *root = NULL;
+    const char *query_str = "global get-distinct-groups ";
+    const char *response = "err";
+
+    will_return(__wrap_cJSON_CreateArray, NULL);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_INVALID);
+
+    expect_string(__wrap__merror, formatted_msg, "Error querying Wazuh DB to get agent's groups.");
+
+    expect_function_call(__wrap_cJSON_Delete);
+
+    root = wdb_get_distinct_agent_groups(NULL);
+
+    assert_null(root);
+}
+
+void test_wdb_get_distinct_agent_groups_error_parse_chunk(void **state) {
+    cJSON *root = NULL;
+    const char *query_str = "global get-distinct-groups ";
+    const char *response = "ok []";
+
+    will_return(__wrap_cJSON_CreateArray, NULL);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid JSON array.");
+
+    expect_string(__wrap__merror, formatted_msg, "Error querying Wazuh DB to get agent's groups.");
+
+    expect_function_call(__wrap_cJSON_Delete);
+
+    root = wdb_get_distinct_agent_groups(NULL);
+
+    assert_null(root);
+}
+
+void test_wdb_get_distinct_agent_groups_success(void **state) {
+    cJSON *root = NULL;
+    const char *query_str = "global get-distinct-groups ";
+    const char *response = "ok [{\"group\":\"group3,group4\",\"group_hash\":\"abcdef\"}]";
+    cJSON *str_obj = __real_cJSON_CreateString("abcdef");
+    cJSON *parse_json = __real_cJSON_Parse("[{\"group\":\"group3,group4\",\"group_hash\":\"abcdef\"}]");
+
+    will_return(__wrap_cJSON_CreateArray, __real_cJSON_CreateArray());
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    expect_string(__wrap_wdbc_parse_result, result, response);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+
+    will_return(__wrap_cJSON_Parse, parse_json);
+
+    expect_function_call(__wrap_cJSON_AddItemToArray);
+    will_return(__wrap_cJSON_AddItemToArray, true);
+
+    will_return(__wrap_cJSON_GetObjectItem, str_obj);
+
+    root = wdb_get_distinct_agent_groups(NULL);
+
+    __real_cJSON_Delete(root);
+    __real_cJSON_Delete(parse_json);
+    __real_cJSON_Delete(str_obj);
+}
+
+void test_wdb_get_distinct_agent_groups_success_due_ok(void **state) {
+    cJSON *root = NULL;
+    const char *query_str1 = "global get-distinct-groups ";
+    const char *query_str2 = "global get-distinct-groups ef48b4cd";
+    const char *response1 = "ok [{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]";
+    const char *response2 = "ok [{\"group\":\"group3,group4\",\"group_hash\":\"abcdef\"}]";
+    cJSON *str_obj1 = __real_cJSON_CreateString("ef48b4cd");
+    cJSON *str_obj2 = __real_cJSON_CreateString("abcdef");
+    cJSON *parse_json1 = __real_cJSON_Parse("[{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]");
+    cJSON *parse_json2 = __real_cJSON_Parse("[{\"group\":\"group3,group4\",\"group_hash\":\"abcdef\"}]");
+
+    will_return(__wrap_cJSON_CreateArray, __real_cJSON_CreateArray());
+
+    // Calling Wazuh DB 1
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str1);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response1);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    expect_string(__wrap_wdbc_parse_result, result, response1);
+    will_return(__wrap_wdbc_parse_result, WDBC_DUE);
+
+    will_return(__wrap_cJSON_Parse, parse_json1);
+
+    expect_function_call(__wrap_cJSON_AddItemToArray);
+    will_return(__wrap_cJSON_AddItemToArray, true);
+
+    will_return(__wrap_cJSON_GetObjectItem, str_obj1);
+
+    // Calling Wazuh DB 2
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str2);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response2);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    expect_string(__wrap_wdbc_parse_result, result, response2);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+
+    will_return(__wrap_cJSON_Parse, parse_json2);
+
+    expect_function_call(__wrap_cJSON_AddItemToArray);
+    will_return(__wrap_cJSON_AddItemToArray, true);
+
+    will_return(__wrap_cJSON_GetObjectItem, str_obj2);
+
+    root = wdb_get_distinct_agent_groups(NULL);
+
+    __real_cJSON_Delete(root);
+    __real_cJSON_Delete(parse_json1);
+    __real_cJSON_Delete(str_obj1);
+    __real_cJSON_Delete(parse_json2);
+    __real_cJSON_Delete(str_obj2);
+}
+
+/* Tests wdb_parse_chunk_to_json */
+
+void test_wdb_parse_chunk_to_json_output_json_null(void **state) {
+    char *input = "ok [{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]";
+    char *last_group_hash;
+    wdbc_result result;
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid JSON array.");
+
+    result = wdb_parse_chunk_to_json(input, NULL, &last_group_hash);
+
+    assert_int_equal(result, WDBC_ERROR);
+}
+
+void test_wdb_parse_chunk_to_json_output_json_no_array(void **state) {
+    char *input = "ok [{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]";
+    cJSON *output_json = __real_cJSON_CreateString("wrong object");
+    char *last_group_hash;
+    wdbc_result result;
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid JSON array.");
+
+    result = wdb_parse_chunk_to_json(input, &output_json, &last_group_hash);
+
+    assert_int_equal(result, WDBC_ERROR);
+    __real_cJSON_Delete(output_json);
+}
+
+void test_wdb_parse_chunk_to_json_parse_result_error(void **state) {
+    char *input = NULL;
+    os_strdup("ok [{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]", input);
+    cJSON *output_json = __real_cJSON_CreateArray();
+    char *last_group_hash;
+    wdbc_result exc_result;
+
+    expect_string(__wrap_wdbc_parse_result, result, input);
+    will_return(__wrap_wdbc_parse_result, WDBC_ERROR);
+
+    exc_result = wdb_parse_chunk_to_json(input, &output_json, &last_group_hash);
+
+    assert_int_equal(exc_result, WDBC_ERROR);
+    __real_cJSON_Delete(output_json);
+    os_free(input);
+}
+
+void test_wdb_parse_chunk_to_json_cjson_parse_error(void **state) {
+    char *input = NULL;
+    os_strdup("ok [{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]", input);
+    cJSON *output_json = __real_cJSON_CreateArray();
+    char *last_group_hash;
+    wdbc_result exc_result;
+
+    expect_string(__wrap_wdbc_parse_result, result, input);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+
+    will_return(__wrap_cJSON_Parse, NULL);
+
+    exc_result = wdb_parse_chunk_to_json(input, &output_json, &last_group_hash);
+
+    assert_int_equal(exc_result, WDBC_ERROR);
+    __real_cJSON_Delete(output_json);
+    os_free(input);
+}
+
+void test_wdb_parse_chunk_to_json_empty_array(void **state) {
+    char *input = NULL;
+    os_strdup("ok [{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]", input);
+    cJSON *output_json = __real_cJSON_CreateArray();
+    cJSON *parse_json = __real_cJSON_CreateArray();
+    char *last_group_hash;
+    wdbc_result exc_result;
+
+    expect_string(__wrap_wdbc_parse_result, result, input);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+
+    will_return(__wrap_cJSON_Parse, parse_json);
+
+    expect_function_call(__wrap_cJSON_Delete);
+
+    exc_result = wdb_parse_chunk_to_json(input, &output_json, &last_group_hash);
+
+    assert_int_equal(exc_result, WDBC_OK);
+    __real_cJSON_Delete(output_json);
+    __real_cJSON_Delete(parse_json);
+    os_free(input);
+}
+
+void test_wdb_parse_chunk_to_json_last_group_json_null(void **state) {
+    char *input = NULL;
+    os_strdup("ok [{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]", input);
+    cJSON *output_json = __real_cJSON_CreateArray();
+    cJSON *parse_json = __real_cJSON_Parse("[{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]");
+    char *last_group_hash = NULL;
+    wdbc_result exc_result;
+
+    expect_string(__wrap_wdbc_parse_result, result, input);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+
+    will_return(__wrap_cJSON_Parse, parse_json);
+
+    expect_function_call(__wrap_cJSON_AddItemToArray);
+    will_return(__wrap_cJSON_AddItemToArray, true);
+
+    will_return(__wrap_cJSON_GetObjectItem, NULL);
+
+    exc_result = wdb_parse_chunk_to_json(input, &output_json, &last_group_hash);
+
+    assert_int_equal(exc_result, WDBC_OK);
+    assert_null(last_group_hash);
+    __real_cJSON_Delete(output_json);
+    __real_cJSON_Delete(parse_json);
+    os_free(input);
+}
+
+void test_wdb_parse_chunk_to_json_string_value_fail(void **state) {
+    char *input = NULL;
+    os_strdup("ok [{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]", input);
+    cJSON *output_json = __real_cJSON_CreateArray();
+    cJSON *parse_json = __real_cJSON_Parse("[{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]");
+    char *last_group_hash = NULL;
+    wdbc_result exc_result;
+    cJSON *int_obj = cJSON_CreateNumber(1);
+
+    expect_string(__wrap_wdbc_parse_result, result, input);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+
+    will_return(__wrap_cJSON_Parse, parse_json);
+
+    expect_function_call(__wrap_cJSON_AddItemToArray);
+    will_return(__wrap_cJSON_AddItemToArray, true);
+
+    will_return(__wrap_cJSON_GetObjectItem, int_obj);
+
+    exc_result = wdb_parse_chunk_to_json(input, &output_json, &last_group_hash);
+
+    assert_int_equal(exc_result, WDBC_OK);
+    assert_null(last_group_hash);
+    __real_cJSON_Delete(output_json);
+    __real_cJSON_Delete(parse_json);
+    __real_cJSON_Delete(int_obj);
+    os_free(input);
+}
+
+void test_wdb_parse_chunk_to_json_success(void **state) {
+    char *input = NULL;
+    os_strdup("ok [{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]", input);
+    cJSON *output_json = __real_cJSON_CreateArray();
+    cJSON *parse_json = __real_cJSON_Parse("[{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]");
+    char *last_group_hash;
+    wdbc_result exc_result;
+    cJSON *str_obj = __real_cJSON_CreateString("ef48b4cd");
+
+    expect_string(__wrap_wdbc_parse_result, result, input);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+
+    will_return(__wrap_cJSON_Parse, parse_json);
+
+    expect_function_call(__wrap_cJSON_AddItemToArray);
+    will_return(__wrap_cJSON_AddItemToArray, true);
+
+    will_return(__wrap_cJSON_GetObjectItem, str_obj);
+
+    exc_result = wdb_parse_chunk_to_json(input, &output_json, &last_group_hash);
+
+    assert_int_equal(exc_result, WDBC_OK);
+    assert_string_equal(last_group_hash, "ef48b4cd");
+    __real_cJSON_Delete(output_json);
+    __real_cJSON_Delete(parse_json);
+    __real_cJSON_Delete(str_obj);
+    os_free(input);
+    os_free(last_group_hash);
+}
 
 int main()
 {
@@ -3847,6 +4158,20 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_set_agent_groups_error_no_mode, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_set_agent_groups_query_error, setup_wdb_global_helpers_add_agent, teardown_wdb_global_helpers_add_agent),
         cmocka_unit_test_setup_teardown(test_wdb_set_agent_groups_socket_error, setup_wdb_global_helpers_add_agent, teardown_wdb_global_helpers_add_agent),
+        /* Tests wdb_get_distinct_agent_groups */
+        cmocka_unit_test_setup_teardown(test_wdb_get_distinct_agent_groups_error_no_json_response, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_get_distinct_agent_groups_error_parse_chunk, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_get_distinct_agent_groups_success, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_get_distinct_agent_groups_success_due_ok, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        /* Tests wdb_parse_chunk_to_json */
+        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_output_json_null, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_output_json_no_array, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_parse_result_error, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_cjson_parse_error, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_empty_array, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_last_group_json_null, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_string_value_fail, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_success, setup_wdb_global_helpers, teardown_wdb_global_helpers),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
@@ -3851,56 +3851,70 @@ void test_wdb_get_distinct_agent_groups_success_due_ok(void **state) {
     __real_cJSON_Delete(str_obj2);
 }
 
-/* Tests wdb_parse_chunk_to_json */
+/* Tests wdb_parse_chunk_to_json_by_string_item */
 
-void test_wdb_parse_chunk_to_json_output_json_null(void **state) {
+void test_wdb_parse_chunk_to_json_by_string_item_output_json_null(void **state) {
     char *input = "ok [{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]";
-    char *last_group_hash;
+    char *last_item_value;
     wdbc_result result;
 
     expect_string(__wrap__mdebug1, formatted_msg, "Invalid JSON array.");
 
-    result = wdb_parse_chunk_to_json(input, NULL, &last_group_hash);
+    result = wdb_parse_chunk_to_json_by_string_item(input, NULL, "group_hash", &last_item_value);
 
     assert_int_equal(result, WDBC_ERROR);
 }
 
-void test_wdb_parse_chunk_to_json_output_json_no_array(void **state) {
+void test_wdb_parse_chunk_to_json_by_string_item_item_null(void **state) {
     char *input = "ok [{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]";
-    cJSON *output_json = __real_cJSON_CreateString("wrong object");
-    char *last_group_hash;
+    cJSON *output_json = __real_cJSON_CreateArray();
+    char *last_item_value;
     wdbc_result result;
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Invalid JSON array.");
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid item.");
 
-    result = wdb_parse_chunk_to_json(input, &output_json, &last_group_hash);
+    result = wdb_parse_chunk_to_json_by_string_item(input, &output_json, NULL, &last_item_value);
 
     assert_int_equal(result, WDBC_ERROR);
     __real_cJSON_Delete(output_json);
 }
 
-void test_wdb_parse_chunk_to_json_parse_result_error(void **state) {
+void test_wdb_parse_chunk_to_json_by_string_item_output_json_no_array(void **state) {
+    char *input = "ok [{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]";
+    cJSON *output_json = __real_cJSON_CreateString("wrong object");
+    char *last_item_value;
+    wdbc_result result;
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid JSON array.");
+
+    result = wdb_parse_chunk_to_json_by_string_item(input, &output_json, "group_hash", &last_item_value);
+
+    assert_int_equal(result, WDBC_ERROR);
+    __real_cJSON_Delete(output_json);
+}
+
+void test_wdb_parse_chunk_to_json_by_string_item_parse_result_error(void **state) {
     char *input = NULL;
     os_strdup("ok [{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]", input);
     cJSON *output_json = __real_cJSON_CreateArray();
-    char *last_group_hash;
+    char *last_item_value;
     wdbc_result exc_result;
 
     expect_string(__wrap_wdbc_parse_result, result, input);
     will_return(__wrap_wdbc_parse_result, WDBC_ERROR);
 
-    exc_result = wdb_parse_chunk_to_json(input, &output_json, &last_group_hash);
+    exc_result = wdb_parse_chunk_to_json_by_string_item(input, &output_json, "group_hash", &last_item_value);
 
     assert_int_equal(exc_result, WDBC_ERROR);
     __real_cJSON_Delete(output_json);
     os_free(input);
 }
 
-void test_wdb_parse_chunk_to_json_cjson_parse_error(void **state) {
+void test_wdb_parse_chunk_to_json_by_string_item_cjson_parse_error(void **state) {
     char *input = NULL;
     os_strdup("ok [{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]", input);
     cJSON *output_json = __real_cJSON_CreateArray();
-    char *last_group_hash;
+    char *last_item_value;
     wdbc_result exc_result;
 
     expect_string(__wrap_wdbc_parse_result, result, input);
@@ -3908,19 +3922,19 @@ void test_wdb_parse_chunk_to_json_cjson_parse_error(void **state) {
 
     will_return(__wrap_cJSON_Parse, NULL);
 
-    exc_result = wdb_parse_chunk_to_json(input, &output_json, &last_group_hash);
+    exc_result = wdb_parse_chunk_to_json_by_string_item(input, &output_json, "group_hash", &last_item_value);
 
     assert_int_equal(exc_result, WDBC_ERROR);
     __real_cJSON_Delete(output_json);
     os_free(input);
 }
 
-void test_wdb_parse_chunk_to_json_empty_array(void **state) {
+void test_wdb_parse_chunk_to_json_by_string_item_empty_array(void **state) {
     char *input = NULL;
     os_strdup("ok [{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]", input);
     cJSON *output_json = __real_cJSON_CreateArray();
     cJSON *parse_json = __real_cJSON_CreateArray();
-    char *last_group_hash;
+    char *last_item_value;
     wdbc_result exc_result;
 
     expect_string(__wrap_wdbc_parse_result, result, input);
@@ -3930,7 +3944,7 @@ void test_wdb_parse_chunk_to_json_empty_array(void **state) {
 
     expect_function_call(__wrap_cJSON_Delete);
 
-    exc_result = wdb_parse_chunk_to_json(input, &output_json, &last_group_hash);
+    exc_result = wdb_parse_chunk_to_json_by_string_item(input, &output_json, "group_hash", &last_item_value);
 
     assert_int_equal(exc_result, WDBC_OK);
     __real_cJSON_Delete(output_json);
@@ -3938,12 +3952,12 @@ void test_wdb_parse_chunk_to_json_empty_array(void **state) {
     os_free(input);
 }
 
-void test_wdb_parse_chunk_to_json_last_group_json_null(void **state) {
+void test_wdb_parse_chunk_to_json_by_string_item_last_item_json_null(void **state) {
     char *input = NULL;
     os_strdup("ok [{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]", input);
     cJSON *output_json = __real_cJSON_CreateArray();
     cJSON *parse_json = __real_cJSON_Parse("[{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]");
-    char *last_group_hash = NULL;
+    char *last_item_value = NULL;
     wdbc_result exc_result;
 
     expect_string(__wrap_wdbc_parse_result, result, input);
@@ -3956,21 +3970,21 @@ void test_wdb_parse_chunk_to_json_last_group_json_null(void **state) {
 
     will_return(__wrap_cJSON_GetObjectItem, NULL);
 
-    exc_result = wdb_parse_chunk_to_json(input, &output_json, &last_group_hash);
+    exc_result = wdb_parse_chunk_to_json_by_string_item(input, &output_json, "group_hash", &last_item_value);
 
     assert_int_equal(exc_result, WDBC_OK);
-    assert_null(last_group_hash);
+    assert_null(last_item_value);
     __real_cJSON_Delete(output_json);
     __real_cJSON_Delete(parse_json);
     os_free(input);
 }
 
-void test_wdb_parse_chunk_to_json_string_value_fail(void **state) {
+void test_wdb_parse_chunk_to_json_by_string_item_string_value_fail(void **state) {
     char *input = NULL;
     os_strdup("ok [{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]", input);
     cJSON *output_json = __real_cJSON_CreateArray();
     cJSON *parse_json = __real_cJSON_Parse("[{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]");
-    char *last_group_hash = NULL;
+    char *last_item_value = NULL;
     wdbc_result exc_result;
     cJSON *int_obj = cJSON_CreateNumber(1);
 
@@ -3984,22 +3998,22 @@ void test_wdb_parse_chunk_to_json_string_value_fail(void **state) {
 
     will_return(__wrap_cJSON_GetObjectItem, int_obj);
 
-    exc_result = wdb_parse_chunk_to_json(input, &output_json, &last_group_hash);
+    exc_result = wdb_parse_chunk_to_json_by_string_item(input, &output_json, "group_hash", &last_item_value);
 
     assert_int_equal(exc_result, WDBC_OK);
-    assert_null(last_group_hash);
+    assert_null(last_item_value);
     __real_cJSON_Delete(output_json);
     __real_cJSON_Delete(parse_json);
     __real_cJSON_Delete(int_obj);
     os_free(input);
 }
 
-void test_wdb_parse_chunk_to_json_success(void **state) {
+void test_wdb_parse_chunk_to_json_by_string_last_item_value_null(void **state) {
     char *input = NULL;
     os_strdup("ok [{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]", input);
     cJSON *output_json = __real_cJSON_CreateArray();
     cJSON *parse_json = __real_cJSON_Parse("[{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]");
-    char *last_group_hash;
+    char *last_item_value = NULL;
     wdbc_result exc_result;
     cJSON *str_obj = __real_cJSON_CreateString("ef48b4cd");
 
@@ -4013,15 +4027,44 @@ void test_wdb_parse_chunk_to_json_success(void **state) {
 
     will_return(__wrap_cJSON_GetObjectItem, str_obj);
 
-    exc_result = wdb_parse_chunk_to_json(input, &output_json, &last_group_hash);
+    exc_result = wdb_parse_chunk_to_json_by_string_item(input, &output_json, "group_hash", NULL);
 
     assert_int_equal(exc_result, WDBC_OK);
-    assert_string_equal(last_group_hash, "ef48b4cd");
+    assert_null(last_item_value);
     __real_cJSON_Delete(output_json);
     __real_cJSON_Delete(parse_json);
     __real_cJSON_Delete(str_obj);
     os_free(input);
-    os_free(last_group_hash);
+}
+
+void test_wdb_parse_chunk_to_json_by_string_item_success(void **state) {
+    char *input = NULL;
+    os_strdup("ok [{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]", input);
+    cJSON *output_json = __real_cJSON_CreateArray();
+    cJSON *parse_json = __real_cJSON_Parse("[{\"group\":\"group1,group2\",\"group_hash\":\"ef48b4cd\"}]");
+    char *last_item_value;
+    wdbc_result exc_result;
+    cJSON *str_obj = __real_cJSON_CreateString("ef48b4cd");
+
+    expect_string(__wrap_wdbc_parse_result, result, input);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+
+    will_return(__wrap_cJSON_Parse, parse_json);
+
+    expect_function_call(__wrap_cJSON_AddItemToArray);
+    will_return(__wrap_cJSON_AddItemToArray, true);
+
+    will_return(__wrap_cJSON_GetObjectItem, str_obj);
+
+    exc_result = wdb_parse_chunk_to_json_by_string_item(input, &output_json, "group_hash", &last_item_value);
+
+    assert_int_equal(exc_result, WDBC_OK);
+    assert_string_equal(last_item_value, "ef48b4cd");
+    __real_cJSON_Delete(output_json);
+    __real_cJSON_Delete(parse_json);
+    __real_cJSON_Delete(str_obj);
+    os_free(input);
+    os_free(last_item_value);
 }
 
 int main()
@@ -4163,15 +4206,17 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_get_distinct_agent_groups_error_parse_chunk, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_get_distinct_agent_groups_success, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_get_distinct_agent_groups_success_due_ok, setup_wdb_global_helpers, teardown_wdb_global_helpers),
-        /* Tests wdb_parse_chunk_to_json */
-        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_output_json_null, setup_wdb_global_helpers, teardown_wdb_global_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_output_json_no_array, setup_wdb_global_helpers, teardown_wdb_global_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_parse_result_error, setup_wdb_global_helpers, teardown_wdb_global_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_cjson_parse_error, setup_wdb_global_helpers, teardown_wdb_global_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_empty_array, setup_wdb_global_helpers, teardown_wdb_global_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_last_group_json_null, setup_wdb_global_helpers, teardown_wdb_global_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_string_value_fail, setup_wdb_global_helpers, teardown_wdb_global_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_success, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        /* Tests wdb_parse_chunk_to_json_by_string_item */
+        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_by_string_item_output_json_null, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_by_string_item_item_null, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_by_string_item_output_json_no_array, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_by_string_item_parse_result_error, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_by_string_item_cjson_parse_error, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_by_string_item_empty_array, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_by_string_item_last_item_json_null, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_by_string_item_string_value_fail, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_by_string_last_item_value_null, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_json_by_string_item_success, setup_wdb_global_helpers, teardown_wdb_global_helpers),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -3789,6 +3789,113 @@ void test_wdb_parse_global_get_fragmentation_success(void **state) {
     os_free(query);
 }
 
+/* Tests wdb_parse_global_get_distinct_agent_groups */
+
+void test_wdb_parse_global_get_distinct_agent_groups_success(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-distinct-groups";
+    cJSON *group_info = cJSON_Parse("[\"GROUP INFO\"]");
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-distinct-groups");
+    expect_value(__wrap_wdb_global_get_distinct_agent_groups, group_hash, NULL);
+    will_return(__wrap_wdb_global_get_distinct_agent_groups, WDBC_OK);
+    will_return(__wrap_wdb_global_get_distinct_agent_groups, group_info);
+
+    expect_function_call(__wrap_w_inc_queries_total);
+    expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_w_inc_global_agent_get_distinct_groups);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_agent_get_distinct_groups_time);
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "ok [\"GROUP INFO\"]");
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+void test_wdb_parse_global_get_distinct_agent_groups_success_with_last_hash(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-distinct-groups abcdef";
+    cJSON *group_info = cJSON_Parse("[\"GROUP INFO\"]");
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-distinct-groups abcdef");
+    expect_string(__wrap_wdb_global_get_distinct_agent_groups, group_hash, "abcdef");
+    will_return(__wrap_wdb_global_get_distinct_agent_groups, WDBC_OK);
+    will_return(__wrap_wdb_global_get_distinct_agent_groups, group_info);
+
+    expect_function_call(__wrap_w_inc_queries_total);
+    expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_w_inc_global_agent_get_distinct_groups);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_agent_get_distinct_groups_time);
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "ok [\"GROUP INFO\"]");
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+void test_wdb_parse_global_get_distinct_agent_groups_result_null(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-distinct-groups";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-distinct-groups");
+    expect_value(__wrap_wdb_global_get_distinct_agent_groups, group_hash, NULL);
+    will_return(__wrap_wdb_global_get_distinct_agent_groups, WDBC_ERROR);
+    will_return(__wrap_wdb_global_get_distinct_agent_groups, NULL);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Error getting agent groups from global.db.");
+
+    expect_function_call(__wrap_w_inc_queries_total);
+    expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_w_inc_global_agent_get_distinct_groups);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_agent_get_distinct_groups_time);
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Error getting agent groups from global.db.");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_get_distinct_agent_groups_result_null_with_last_hash(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-distinct-groups abcdef";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-distinct-groups abcdef");
+    expect_string(__wrap_wdb_global_get_distinct_agent_groups, group_hash, "abcdef");
+    will_return(__wrap_wdb_global_get_distinct_agent_groups, WDBC_ERROR);
+    will_return(__wrap_wdb_global_get_distinct_agent_groups, NULL);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Error getting agent groups from global.db.");
+
+    expect_function_call(__wrap_w_inc_queries_total);
+    expect_function_call(__wrap_w_inc_global);
+    expect_function_call(__wrap_w_inc_global_agent_get_distinct_groups);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_gettimeofday);
+    expect_function_call(__wrap_w_inc_global_agent_get_distinct_groups_time);
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Error getting agent groups from global.db.");
+    assert_int_equal(ret, OS_INVALID);
+}
 
 int main()
 {
@@ -3890,7 +3997,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_info_set_del_label_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_info_set_set_label_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_info_set_success, test_setup, test_teardown),
-        /* Test wdb_parse_global_set_agent_groups */
+        /* Tests wdb_parse_global_set_agent_groups */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_set_agent_groups_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_set_agent_groups_invalid_json, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_set_agent_groups_missing_field, test_setup, test_teardown),
@@ -3944,25 +4051,30 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agents_by_connection_status_limit_succes, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agents_by_connection_status_query_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agents_by_connection_status_query_fail, test_setup, test_teardown),
-        /* wdb_parse_global_get_backup */
+        /* Tests wdb_parse_global_get_backup */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_backup_failed, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_backup_success, test_setup, test_teardown),
-        /* wdb_parse_global_restore_backup */
+        /* Tests wdb_parse_global_restore_backup */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_restore_backup_invalid_syntax, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_restore_backup_success_missing_snapshot, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_restore_backup_success_pre_restore_true, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_restore_backup_success_pre_restore_false, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_restore_backup_success_pre_restore_missing, test_setup, test_teardown),
-        /* wdb_parse_global_vacuum */
+        /* Tests wdb_parse_global_vacuum */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_vacuum_commit_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_vacuum_vacuum_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_vacuum_success_get_db_state_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_vacuum_success_update_vacuum_data_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_vacuum_success, test_setup, test_teardown),
-        /* wdb_parse_global_get_fragmentation */
+        /* Tests wdb_parse_global_get_fragmentation */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_fragmentation_db_state_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_fragmentation_free_pages_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_fragmentation_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_get_distinct_agent_groups */
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_distinct_agent_groups_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_distinct_agent_groups_result_null, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_distinct_agent_groups_success_with_last_hash, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_distinct_agent_groups_result_null_with_last_hash, test_setup, test_teardown),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.c
@@ -54,7 +54,7 @@ int __wrap_OSHash_Add(OSHash *self, const char *key, void *data) {
 }
 
 int __real_OSHash_Add_ex(OSHash *self, const char *key, void *data);
-int __wrap_OSHash_Add_ex(OSHash *self, const char *key, void *data) {
+int __wrap_OSHash_Add_ex(__attribute__((unused)) OSHash *self, const char *key, void *data) {
     int retval;
 
     if (test_mode){
@@ -66,7 +66,7 @@ int __wrap_OSHash_Add_ex(OSHash *self, const char *key, void *data) {
         retval =  mock();
 
         if (mock_hashmap != NULL && retval != 0) {
-            __real_OSHash_Add(self, key, data);
+            __real_OSHash_Add(mock_hashmap, key, data);
         }
 
         return retval;
@@ -83,6 +83,10 @@ void *__wrap_OSHash_Begin(const OSHash *self, __attribute__((unused)) unsigned i
 void *__real_OSHash_Clean(OSHash *self, void (*cleaner)(void*));
 void *__wrap_OSHash_Clean(__attribute__((unused)) OSHash *self,
                           __attribute__((unused)) void (*cleaner)(void*)) {
+    if (test_mode == 0) {
+        return __real_OSHash_Clean(self, cleaner);
+    }
+
     return mock_type(void *);
 }
 

--- a/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.h
@@ -22,7 +22,7 @@ int __wrap_OSHash_Add(OSHash *self, const char *key, void *data);
 int __real_OSHash_Add(OSHash *hash, const char *key, void *data);
 
 int __real_OSHash_Add_ex(OSHash *self, const char *key, void *data);
-int __wrap_OSHash_Add_ex(OSHash *self, const char *key, void *data);
+int __wrap_OSHash_Add_ex(__attribute__((unused)) OSHash *self, const char *key, void *data);
 
 void *__real_OSHash_Begin(const OSHash *self, unsigned int *i);
 void *__wrap_OSHash_Begin(const OSHash *self, unsigned int *i);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_helpers_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_helpers_wrappers.c
@@ -113,3 +113,7 @@ int __wrap_wdb_remove_agent_db(int id, const char* name) {
     }
     return mock();
 }
+
+cJSON* __wrap_wdb_get_distinct_agent_groups(__attribute__((unused)) int *sock) {
+    return mock_ptr_type(cJSON*);
+}

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_helpers_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_helpers_wrappers.h
@@ -41,4 +41,6 @@ char* __wrap_wdb_get_agent_group(int id, int *wdb_sock);
 char* __wrap_wdb_get_agent_name(int id, __attribute__((unused)) int *wdb_sock);
 
 int __wrap_wdb_remove_agent_db(int id, const char* name);
+
+cJSON* __wrap_wdb_get_distinct_agent_groups(__attribute__((unused)) int *sock);
 #endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -344,3 +344,10 @@ int __wrap_wdb_remove_group_db(const char *name,
     check_expected(name);
     return mock();
 }
+
+cJSON* __wrap_wdb_global_get_distinct_agent_groups(   __attribute__((unused)) wdb_t *wdb, char *group_hash,
+                                                wdbc_result* status) {
+    check_expected(group_hash);
+    *status = mock();
+    return mock_ptr_type(cJSON*);
+}

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -106,4 +106,6 @@ int __wrap_wdb_global_restore_backup(wdb_t** wdb, char* snapshot, bool save_pre_
 
 int __wrap_wdb_remove_group_db(const char *name, int *sock);
 
+cJSON* __wrap_wdb_global_get_distinct_agent_groups(   __attribute__((unused)) wdb_t *wdb, char *group_hash, wdbc_result* status);
+
 #endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_state_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_state_wrappers.c
@@ -216,6 +216,14 @@ void __wrap_w_inc_global_agent_get_groups_integrity_time(__attribute__((unused))
     function_called();
 }
 
+void __wrap_w_inc_global_agent_get_distinct_groups() {
+    function_called();
+}
+
+void __wrap_w_inc_global_agent_get_distinct_groups_time(__attribute__((unused))struct timeval diff) {
+    function_called();
+}
+
 // Global group counters
 
 void __wrap_w_inc_global_group_insert_agent_group() {

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_state_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_state_wrappers.h
@@ -118,6 +118,10 @@ void __wrap_w_inc_global_agent_get_groups_integrity();
 
 void __wrap_w_inc_global_agent_get_groups_integrity_time(__attribute__((unused))struct timeval diff);
 
+void __wrap_w_inc_global_agent_get_distinct_groups();
+
+void __wrap_w_inc_global_agent_get_distinct_groups_time(__attribute__((unused))struct timeval diff);
+
 // Global group counters
 
 void __wrap_w_inc_global_group_insert_agent_group();

--- a/src/wazuh_db/helpers/wdb_global_helpers.c
+++ b/src/wazuh_db/helpers/wdb_global_helpers.c
@@ -1205,7 +1205,7 @@ wdbc_result wdb_parse_chunk_to_json(char* input, cJSON** output_json, char** las
             } else {
                 cJSON_Delete(response);
             }
-        } else if (response == NULL) {
+        } else {
             status = WDBC_ERROR;
         }
     }

--- a/src/wazuh_db/helpers/wdb_global_helpers.c
+++ b/src/wazuh_db/helpers/wdb_global_helpers.c
@@ -38,7 +38,8 @@ static const char *global_db_commands[] = {
     [WDB_RESET_AGENTS_CONNECTION] = "global reset-agents-connection %s",
     [WDB_GET_AGENTS_BY_CONNECTION_STATUS] = "global get-agents-by-connection-status %d %s",
     [WDB_GET_AGENTS_BY_CONNECTION_STATUS_AND_NODE] = "global get-agents-by-connection-status %d %s %s %d",
-    [WDB_DISCONNECT_AGENTS] = "global disconnect-agents %d %d %s"
+    [WDB_DISCONNECT_AGENTS] = "global disconnect-agents %d %d %s",
+    [WDB_GET_DISTINCT_AGENT_GROUP] = "global get-distinct-groups"
 };
 
 int wdb_insert_agent(int id,
@@ -1180,4 +1181,23 @@ int* wdb_get_agents_ids_of_current_node(const char* connection_status, int *sock
     }
 
     return array;
+}
+
+cJSON* wdb_get_distinct_agent_groups(int *sock) {
+    cJSON *root = NULL;
+    char wdboutput[WDBOUTPUT_SIZE] = "";
+    int aux_sock = -1;
+
+    root = wdbc_query_parse_json(sock?sock:&aux_sock, global_db_commands[WDB_GET_DISTINCT_AGENT_GROUP], wdboutput, sizeof(wdboutput));
+
+    if (!sock) {
+        wdbc_close(&aux_sock);
+    }
+
+    if (!root) {
+        merror("Error querying Wazuh DB to get agent's groups.");
+        return NULL;
+    }
+
+    return root;
 }

--- a/src/wazuh_db/helpers/wdb_global_helpers.c
+++ b/src/wazuh_db/helpers/wdb_global_helpers.c
@@ -1223,10 +1223,6 @@ cJSON* wdb_get_distinct_agent_groups(int *sock) {
 
     root = cJSON_CreateArray();
 
-    if (!sock) {
-        wdbc_close(&aux_sock);
-    }
-
     os_strdup("", tmp_last_hash_group);
     while (status == WDBC_DUE) {
         snprintf(wdbquery, sizeof(wdbquery), global_db_commands[WDB_GET_DISTINCT_AGENT_GROUP], tmp_last_hash_group);
@@ -1244,6 +1240,10 @@ cJSON* wdb_get_distinct_agent_groups(int *sock) {
         merror("Error querying Wazuh DB to get agent's groups.");
         cJSON_Delete(root);
         root = NULL;
+    }
+
+    if (!sock) {
+        wdbc_close(&aux_sock);
     }
 
     return root;

--- a/src/wazuh_db/helpers/wdb_global_helpers.c
+++ b/src/wazuh_db/helpers/wdb_global_helpers.c
@@ -39,7 +39,7 @@ static const char *global_db_commands[] = {
     [WDB_GET_AGENTS_BY_CONNECTION_STATUS] = "global get-agents-by-connection-status %d %s",
     [WDB_GET_AGENTS_BY_CONNECTION_STATUS_AND_NODE] = "global get-agents-by-connection-status %d %s %s %d",
     [WDB_DISCONNECT_AGENTS] = "global disconnect-agents %d %d %s",
-    [WDB_GET_DISTINCT_AGENT_GROUP] = "global get-distinct-groups"
+    [WDB_GET_DISTINCT_AGENT_GROUP] = "global get-distinct-groups %s"
 };
 
 int wdb_insert_agent(int id,
@@ -1183,20 +1183,65 @@ int* wdb_get_agents_ids_of_current_node(const char* connection_status, int *sock
     return array;
 }
 
-cJSON* wdb_get_distinct_agent_groups(int *sock) {
+wdbc_result wdb_parse_chunk_to_json(char* input, cJSON** output_json, char** last_group_hash) {
+    char* payload = NULL;
+
+    wdbc_result status = wdbc_parse_result(input, &payload);
+    if (status == WDBC_OK || status == WDBC_DUE) {
+        cJSON* response = cJSON_Parse(payload);
+        int array_size = cJSON_GetArraySize(response);
+        if (response && array_size > 0) {
+            if (output_json) {
+                cJSON_AddItemToArray(*output_json, response);
+                cJSON *last_group_json = cJSON_GetObjectItem(cJSON_GetArrayItem(response, array_size - 1), "group_hash");
+                if (last_group_json && cJSON_GetStringValue(last_group_json)) {
+                    os_strdup(cJSON_GetStringValue(last_group_json), *last_group_hash);
+                }
+            }
+        } else if (response == NULL) {
+            status = WDBC_ERROR;
+        }
+    }
+
+    return status;
+}
+
+cJSON* wdb_get_distinct_agent_groups(int *sock, char *last_group_hash) {
     cJSON *root = NULL;
     char wdboutput[WDBOUTPUT_SIZE] = "";
+    char wdbquery[WDBQUERY_SIZE] = "";
     int aux_sock = -1;
+    wdbc_result status = WDBC_DUE;
+    char *tmp_last_hash_group = NULL;
 
-    root = wdbc_query_parse_json(sock?sock:&aux_sock, global_db_commands[WDB_GET_DISTINCT_AGENT_GROUP], wdboutput, sizeof(wdboutput));
+    root = cJSON_CreateArray();
 
     if (!sock) {
         wdbc_close(&aux_sock);
     }
 
-    if (!root) {
+    if (last_group_hash != NULL) {
+        os_strdup(last_group_hash, tmp_last_hash_group);
+    } else {
+        os_strdup("", tmp_last_hash_group);
+    }
+
+    while (status == WDBC_DUE) {
+        snprintf(wdbquery, sizeof(wdbquery), global_db_commands[WDB_GET_DISTINCT_AGENT_GROUP], tmp_last_hash_group);
+        if (wdbc_query_ex(sock?sock:&aux_sock, wdbquery, wdboutput, sizeof(wdboutput)) == 0) {
+            os_free(tmp_last_hash_group);
+            status = wdb_parse_chunk_to_json(wdboutput, &root, &tmp_last_hash_group);
+        }
+        else {
+            status = WDBC_ERROR;
+        }
+    }
+    os_free(tmp_last_hash_group);
+
+    if (status == WDBC_ERROR) {
         merror("Error querying Wazuh DB to get agent's groups.");
-        return NULL;
+        cJSON_Delete(root);
+        root = NULL;
     }
 
     return root;

--- a/src/wazuh_db/helpers/wdb_global_helpers.h
+++ b/src/wazuh_db/helpers/wdb_global_helpers.h
@@ -293,13 +293,12 @@ time_t get_agent_date_added(int agent_id);
 int* wdb_get_agents_ids_of_current_node(const char* connection_status, int *sock, int last_id, int limit);
 
 /**
- * @brief Returns an array containing the group and group_hash assigned to all agents,
+ * @brief Returns a JSON array containing the group and group_hash assigned to all agents,
  *        if two agents have the same group assigned it is only included once
  *
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
- * @param[in] last_group_hash Filter the query with group hash higer than this value.
  * @return Returns pointer to the array of groups/group_hash, on success. NULL on errors.
  */
-cJSON* wdb_get_distinct_agent_groups(int *sock, char *last_group_hash);
+cJSON* wdb_get_distinct_agent_groups(int *sock);
 
 #endif

--- a/src/wazuh_db/helpers/wdb_global_helpers.h
+++ b/src/wazuh_db/helpers/wdb_global_helpers.h
@@ -35,7 +35,8 @@ typedef enum global_db_access {
     WDB_RESET_AGENTS_CONNECTION,
     WDB_GET_AGENTS_BY_CONNECTION_STATUS,
     WDB_GET_AGENTS_BY_CONNECTION_STATUS_AND_NODE,
-    WDB_DISCONNECT_AGENTS
+    WDB_DISCONNECT_AGENTS,
+    WDB_GET_DISTINCT_AGENT_GROUP
 } global_db_access;
 
 /**
@@ -290,5 +291,14 @@ time_t get_agent_date_added(int agent_id);
  * @return Returns pointer to the array of agents ids, on success. NULL on errors.
  */
 int* wdb_get_agents_ids_of_current_node(const char* connection_status, int *sock, int last_id, int limit);
+
+/**
+ * @brief Returns an array containing the group and group_hash assigned to all agents,
+ *        if two agents have the same group assigned it is only included once
+ *
+ * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
+ * @return Returns pointer to the array of groups/group_hash, on success. NULL on errors.
+ */
+cJSON* wdb_get_distinct_agent_groups(int *sock);
 
 #endif

--- a/src/wazuh_db/helpers/wdb_global_helpers.h
+++ b/src/wazuh_db/helpers/wdb_global_helpers.h
@@ -297,8 +297,9 @@ int* wdb_get_agents_ids_of_current_node(const char* connection_status, int *sock
  *        if two agents have the same group assigned it is only included once
  *
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
+ * @param[in] last_group_hash Filter the query with group hash higer than this value.
  * @return Returns pointer to the array of groups/group_hash, on success. NULL on errors.
  */
-cJSON* wdb_get_distinct_agent_groups(int *sock);
+cJSON* wdb_get_distinct_agent_groups(int *sock, char *last_group_hash);
 
 #endif

--- a/src/wazuh_db/schema_global.sql
+++ b/src/wazuh_db/schema_global.sql
@@ -65,6 +65,8 @@ CREATE TABLE IF NOT EXISTS `group` (
     UNIQUE (name)
 );
 
+CREATE INDEX IF NOT EXISTS group_name ON `group` (name);
+
 CREATE TABLE IF NOT EXISTS belongs (
     id_agent INTEGER REFERENCES agent (id) ON DELETE CASCADE,
     id_group INTEGER,

--- a/src/wazuh_db/schema_global_upgrade_v4.sql
+++ b/src/wazuh_db/schema_global_upgrade_v4.sql
@@ -80,4 +80,6 @@ END;
 DROP TABLE IF EXISTS `group`;
 ALTER TABLE `_group` RENAME TO `group`;
 
+CREATE INDEX IF NOT EXISTS group_name ON `group` (name);
+
 UPDATE metadata SET value = '4' where key = 'db_version';

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -191,7 +191,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_GROUP_CTX_SET] = "UPDATE agent SET 'group' = ?, group_hash = ?, group_sync_status = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_GROUP_HASH_GET] = "SELECT group_hash FROM agent WHERE group_hash IS NOT NULL ORDER BY id;",
     [WDB_STMT_GLOBAL_UPDATE_AGENT_INFO] = "UPDATE agent SET config_sum = :config_sum, ip = :ip, manager_host = :manager_host, merged_sum = :merged_sum, name = :name, node_name = :node_name, os_arch = :os_arch, os_build = :os_build, os_codename = :os_codename, os_major = :os_major, os_minor = :os_minor, os_name = :os_name, os_platform = :os_platform, os_uname = :os_uname, os_version = :os_version, version = :version, last_keepalive = :last_keepalive, connection_status = :connection_status, disconnection_time = :disconnection_time, group_config_status = :group_config_status, sync_status = :sync_status WHERE id = :id;",
-    [WDB_STMT_GLOBAL_GET_GROUPS] = "SELECT DISTINCT `group`, group_hash from agent WHERE id > 0;",
+    [WDB_STMT_GLOBAL_GET_GROUPS] = "SELECT DISTINCT `group`, group_hash from agent WHERE id > 0 AND group_hash > ? ORDER BY group_hash;",
     [WDB_STMT_GLOBAL_GET_AGENTS] = "SELECT id FROM agent WHERE id > ?;",
     [WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS] = "SELECT id FROM agent WHERE id > ? AND connection_status = ?;",
     [WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS_AND_NODE] = "SELECT id FROM agent WHERE id > ? AND connection_status = ? AND node_name = ? ORDER BY id LIMIT ?;",

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -191,6 +191,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_GROUP_CTX_SET] = "UPDATE agent SET 'group' = ?, group_hash = ?, group_sync_status = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_GROUP_HASH_GET] = "SELECT group_hash FROM agent WHERE group_hash IS NOT NULL ORDER BY id;",
     [WDB_STMT_GLOBAL_UPDATE_AGENT_INFO] = "UPDATE agent SET config_sum = :config_sum, ip = :ip, manager_host = :manager_host, merged_sum = :merged_sum, name = :name, node_name = :node_name, os_arch = :os_arch, os_build = :os_build, os_codename = :os_codename, os_major = :os_major, os_minor = :os_minor, os_name = :os_name, os_platform = :os_platform, os_uname = :os_uname, os_version = :os_version, version = :version, last_keepalive = :last_keepalive, connection_status = :connection_status, disconnection_time = :disconnection_time, group_config_status = :group_config_status, sync_status = :sync_status WHERE id = :id;",
+    [WDB_STMT_GLOBAL_GET_GROUPS] = "SELECT DISTINCT `group`, group_hash from agent WHERE id > 0;",
     [WDB_STMT_GLOBAL_GET_AGENTS] = "SELECT id FROM agent WHERE id > ?;",
     [WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS] = "SELECT id FROM agent WHERE id > ? AND connection_status = ?;",
     [WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS_AND_NODE] = "SELECT id FROM agent WHERE id > ? AND connection_status = ? AND node_name = ? ORDER BY id LIMIT ?;",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -631,7 +631,7 @@ wdbc_result wdb_parse_chunk_to_int(char* input, int** output, const char* item, 
  * @param [out] last_item_value Value of the last item. If NULL no value is written.
  * @return wdbc_result representing the status of the command.
  */
-wdbc_result wdb_parse_chunk_to_json_by_string_item(char* input, cJSON** output_json, const char* item, char** last_group_hash);
+wdbc_result wdb_parse_chunk_to_json_by_string_item(char* input, cJSON** output_json, const char* item, char** last_item_value);
 
 /**
  * @brief Function to initialize a new transaction and cache the statement.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -240,6 +240,7 @@ typedef enum wdb_stmt {
     WDB_STMT_GLOBAL_GROUP_CTX_SET,
     WDB_STMT_GLOBAL_GROUP_HASH_GET,
     WDB_STMT_GLOBAL_UPDATE_AGENT_INFO,
+    WDB_STMT_GLOBAL_GET_GROUPS,
     WDB_STMT_GLOBAL_GET_AGENTS,
     WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS,
     WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS_AND_NODE,
@@ -1343,6 +1344,15 @@ int wdb_parse_global_disconnect_agents(wdb_t* wdb, char* input, char* output);
 int wdb_parse_global_get_all_agents(wdb_t* wdb, char* input, char* output);
 
 /**
+ * @brief Function to parse the get-distinct-groups command data.
+ *
+ * @param [in] wdb The global struct database.
+ * @param [out] output Response of the query.
+ * @return 0 Success: response contains the value. -1 On error: invalid DB query syntax.
+ */
+int wdb_parse_global_get_distinct_agent_groups(wdb_t* wdb, char* output);
+
+/**
  * @brief Function to parse the reset agent connection status request.
  *
  * @param [in] wdb The global struct database.
@@ -2192,6 +2202,17 @@ cJSON* wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int ke
  * @retval -1 The table "agent" is missing or an error occurred.
  */
 int wdb_global_check_manager_keepalive(wdb_t *wdb);
+
+/**
+ * @brief Returns an array containing the group and group_hash assigned to all agents,
+ *        if two agents have the same group assigned it is only included once
+ *
+ * @param [in] wdb The Global struct database.
+ * @param [out] status wdbc_result to represent if all group/group_hash has being obtained or any error occurred.
+ * @retval JSON with group/group_hash on success.
+ * @retval NULL on error.
+ */
+cJSON* wdb_global_get_distinct_agent_groups(wdb_t *wdb, wdbc_result* status);
 
 /**
  * @brief Function to insert or update rows with a dynamic query based on metadata.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -2216,7 +2216,7 @@ cJSON* wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int ke
 int wdb_global_check_manager_keepalive(wdb_t *wdb);
 
 /**
- * @brief Returns an array containing the group and group_hash assigned to all agents,
+ * @brief Returns a JSON array containing the group and group_hash assigned to all agents,
  *        if two agents have the same group assigned it is only included once
  *
  * @param [in] wdb The Global struct database.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -627,10 +627,11 @@ wdbc_result wdb_parse_chunk_to_int(char* input, int** output, const char* item, 
  *
  * @param [in] input The chunk obtained from WazuhDB to be parsed.
  * @param [out] output_json Json array in which the new elements will be added.
- * @param [out] last_group_hash Value of the last group_hash item. If NULL no value is written.
+ * @param [in] item Json string to search elements on the chunks.
+ * @param [out] last_item_value Value of the last item. If NULL no value is written.
  * @return wdbc_result representing the status of the command.
  */
-wdbc_result wdb_parse_chunk_to_json(char* input, cJSON** output_json, char** last_group_hash);
+wdbc_result wdb_parse_chunk_to_json_by_string_item(char* input, cJSON** output_json, const char* item, char** last_group_hash);
 
 /**
  * @brief Function to initialize a new transaction and cache the statement.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -622,6 +622,17 @@ void wdb_free_agent_info_data(agent_info_data *agent_data);
 wdbc_result wdb_parse_chunk_to_int(char* input, int** output, const char* item, int* last_item, int* last_size);
 
 /**
+ * @brief Function to parse a chunk response that contains the status of the query and a json array.
+ *        This function will add the parsed response to the output_json (json) array.
+ *
+ * @param [in] input The chunk obtained from WazuhDB to be parsed.
+ * @param [out] output_json Json array in which the new elements will be added.
+ * @param [out] last_group_hash Value of the last group_hash item. If NULL no value is written.
+ * @return wdbc_result representing the status of the command.
+ */
+wdbc_result wdb_parse_chunk_to_json(char* input, cJSON** output_json, char** last_group_hash);
+
+/**
  * @brief Function to initialize a new transaction and cache the statement.
  *
  * @param [in] wdb The global struct database.
@@ -1347,10 +1358,11 @@ int wdb_parse_global_get_all_agents(wdb_t* wdb, char* input, char* output);
  * @brief Function to parse the get-distinct-groups command data.
  *
  * @param [in] wdb The global struct database.
+ * @param [in] input String with 'last_group_hash'.
  * @param [out] output Response of the query.
  * @return 0 Success: response contains the value. -1 On error: invalid DB query syntax.
  */
-int wdb_parse_global_get_distinct_agent_groups(wdb_t* wdb, char* output);
+int wdb_parse_global_get_distinct_agent_groups(wdb_t* wdb, char *input, char* output);
 
 /**
  * @brief Function to parse the reset agent connection status request.
@@ -2208,11 +2220,12 @@ int wdb_global_check_manager_keepalive(wdb_t *wdb);
  *        if two agents have the same group assigned it is only included once
  *
  * @param [in] wdb The Global struct database.
+ * @param [in] group_hash Group hash where to start querying.
  * @param [out] status wdbc_result to represent if all group/group_hash has being obtained or any error occurred.
  * @retval JSON with group/group_hash on success.
  * @retval NULL on error.
  */
-cJSON* wdb_global_get_distinct_agent_groups(wdb_t *wdb, wdbc_result* status);
+cJSON* wdb_global_get_distinct_agent_groups(wdb_t *wdb, char *group_hash, wdbc_result* status);
 
 /**
  * @brief Function to insert or update rows with a dynamic query based on metadata.

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -2099,7 +2099,7 @@ time_t wdb_global_get_oldest_backup(char **oldest_backup_name) {
     return oldest_backup_time;
 }
 
-cJSON* wdb_global_get_distinct_agent_groups(wdb_t *wdb, wdbc_result* status) {
+cJSON* wdb_global_get_distinct_agent_groups(wdb_t *wdb, char *group_hash, wdbc_result* status) {
     //Prepare SQL query
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
         mdebug1("Cannot begin transaction");
@@ -2112,6 +2112,11 @@ cJSON* wdb_global_get_distinct_agent_groups(wdb_t *wdb, wdbc_result* status) {
         return NULL;
     }
     sqlite3_stmt* stmt = wdb->stmt[WDB_STMT_GLOBAL_GET_GROUPS];
+    if (sqlite3_bind_text(stmt, 1, group_hash != NULL ? group_hash : "", -1, NULL) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        *status = WDBC_ERROR;
+        return NULL;
+    }
 
     //Execute SQL query limited by size
     int sql_status = SQLITE_ERROR;

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -1175,7 +1175,7 @@ int wdb_parse(char * input, char * output, int peer) {
         } else if (strcmp(query, "get-distinct-groups") == 0) {
             w_inc_global_agent_get_distinct_groups();
             gettimeofday(&begin, 0);
-            result = wdb_parse_global_get_distinct_agent_groups(wdb, output);
+            result = wdb_parse_global_get_distinct_agent_groups(wdb, next, output);
             gettimeofday(&end, 0);
             timersub(&end, &begin, &diff);
             w_inc_global_agent_get_distinct_groups_time(diff);
@@ -5999,11 +5999,11 @@ int wdb_parse_global_get_all_agents(wdb_t* wdb, char* input, char* output) {
     return OS_SUCCESS;
 }
 
-int wdb_parse_global_get_distinct_agent_groups(wdb_t* wdb, char* output) {
+int wdb_parse_global_get_distinct_agent_groups(wdb_t* wdb, char* input, char* output) {
 
     // Execute command
     wdbc_result status = WDBC_UNKNOWN;
-    cJSON* result = wdb_global_get_distinct_agent_groups(wdb, &status);
+    cJSON* result = wdb_global_get_distinct_agent_groups(wdb, input, &status);
     if (!result) {
         mdebug1("Error getting agent groups from global.db.");
         snprintf(output, OS_MAXSTR + 1, "err Error getting agent groups from global.db.");

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -1172,6 +1172,13 @@ int wdb_parse(char * input, char * output, int peer) {
                 timersub(&end, &begin, &diff);
                 w_inc_global_agent_get_all_agents_time(diff);
             }
+        } else if (strcmp(query, "get-distinct-groups") == 0) {
+            w_inc_global_agent_get_distinct_groups();
+            gettimeofday(&begin, 0);
+            result = wdb_parse_global_get_distinct_agent_groups(wdb, output);
+            gettimeofday(&end, 0);
+            timersub(&end, &begin, &diff);
+            w_inc_global_agent_get_distinct_groups_time(diff);
         } else if (strcmp(query, "get-agent-info") == 0) {
             w_inc_global_agent_get_agent_info();
             if (!next) {
@@ -5979,6 +5986,27 @@ int wdb_parse_global_get_all_agents(wdb_t* wdb, char* input, char* output) {
     if (!result) {
         mdebug1("Error getting agents from global.db.");
         snprintf(output, OS_MAXSTR + 1, "err Error getting agents from global.db.");
+        return OS_INVALID;
+    }
+
+    //Print response
+    char* out = cJSON_PrintUnformatted(result);
+    snprintf(output, OS_MAXSTR + 1, "%s %s",  WDBC_RESULT[status], out);
+
+    cJSON_Delete(result);
+    os_free(out)
+
+    return OS_SUCCESS;
+}
+
+int wdb_parse_global_get_distinct_agent_groups(wdb_t* wdb, char* output) {
+
+    // Execute command
+    wdbc_result status = WDBC_UNKNOWN;
+    cJSON* result = wdb_global_get_distinct_agent_groups(wdb, &status);
+    if (!result) {
+        mdebug1("Error getting agent groups from global.db.");
+        snprintf(output, OS_MAXSTR + 1, "err Error getting agent groups from global.db.");
         return OS_INVALID;
     }
 

--- a/src/wazuh_db/wdb_state.c
+++ b/src/wazuh_db/wdb_state.c
@@ -622,6 +622,18 @@ void w_inc_global_agent_get_all_agents_time(struct timeval time) {
     w_mutex_unlock(&db_state_t_mutex);
 }
 
+void w_inc_global_agent_get_distinct_groups() {
+    w_mutex_lock(&db_state_t_mutex);
+    wdb_state.queries_breakdown.global_breakdown.agent.get_distinct_groups_queries++;
+    w_mutex_unlock(&db_state_t_mutex);
+}
+
+void w_inc_global_agent_get_distinct_groups_time(struct timeval time) {
+    w_mutex_lock(&db_state_t_mutex);
+    timeradd(&wdb_state.queries_breakdown.global_breakdown.agent.get_distinct_groups_time, &time, &wdb_state.queries_breakdown.global_breakdown.agent.get_distinct_groups_time);
+    w_mutex_unlock(&db_state_t_mutex);
+}
+
 void w_inc_global_agent_get_agents_by_connection_status() {
     w_mutex_lock(&db_state_t_mutex);
     wdb_state.queries_breakdown.global_breakdown.agent.get_agents_by_connection_status_queries++;
@@ -1074,6 +1086,7 @@ cJSON* wdb_create_state_json() {
     cJSON_AddNumberToObject(_global_tables_agent, "get-agent-info", wdb_state_cpy.queries_breakdown.global_breakdown.agent.get_agent_info_queries);
     cJSON_AddNumberToObject(_global_tables_agent, "get-agents-by-connection-status", wdb_state_cpy.queries_breakdown.global_breakdown.agent.get_agents_by_connection_status_queries);
     cJSON_AddNumberToObject(_global_tables_agent, "get-all-agents", wdb_state_cpy.queries_breakdown.global_breakdown.agent.get_all_agents_queries);
+    cJSON_AddNumberToObject(_global_tables_agent, "get-distinct-groups", wdb_state_cpy.queries_breakdown.global_breakdown.agent.get_distinct_groups_queries);
     cJSON_AddNumberToObject(_global_tables_agent, "get-groups-integrity", wdb_state_cpy.queries_breakdown.global_breakdown.agent.get_groups_integrity_queries);
     cJSON_AddNumberToObject(_global_tables_agent, "insert-agent", wdb_state_cpy.queries_breakdown.global_breakdown.agent.insert_agent_queries);
     cJSON_AddNumberToObject(_global_tables_agent, "reset-agents-connection", wdb_state_cpy.queries_breakdown.global_breakdown.agent.reset_agents_connection_queries);
@@ -1262,6 +1275,7 @@ cJSON* wdb_create_state_json() {
     cJSON_AddNumberToObject(_global_tables_agent_t, "get-agent-info", timeval_to_milis(wdb_state_cpy.queries_breakdown.global_breakdown.agent.get_agent_info_time));
     cJSON_AddNumberToObject(_global_tables_agent_t, "get-agents-by-connection-status", timeval_to_milis(wdb_state_cpy.queries_breakdown.global_breakdown.agent.get_agents_by_connection_status_time));
     cJSON_AddNumberToObject(_global_tables_agent_t, "get-all-agents", timeval_to_milis(wdb_state_cpy.queries_breakdown.global_breakdown.agent.get_all_agents_time));
+    cJSON_AddNumberToObject(_global_tables_agent_t, "get-distinct-groups", timeval_to_milis(wdb_state_cpy.queries_breakdown.global_breakdown.agent.get_distinct_groups_time));
     cJSON_AddNumberToObject(_global_tables_agent_t, "get-groups-integrity", timeval_to_milis(wdb_state_cpy.queries_breakdown.global_breakdown.agent.get_groups_integrity_time));
     cJSON_AddNumberToObject(_global_tables_agent_t, "insert-agent", timeval_to_milis(wdb_state_cpy.queries_breakdown.global_breakdown.agent.insert_agent_time));
     cJSON_AddNumberToObject(_global_tables_agent_t, "reset-agents-connection", timeval_to_milis(wdb_state_cpy.queries_breakdown.global_breakdown.agent.reset_agents_connection_time));
@@ -1400,6 +1414,7 @@ STATIC uint64_t get_global_time(wdb_state_t *state){
     timeradd(&task_time, &state->queries_breakdown.global_breakdown.agent.find_agent_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.global_breakdown.agent.get_agent_info_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.global_breakdown.agent.get_all_agents_time, &task_time);
+    timeradd(&task_time, &state->queries_breakdown.global_breakdown.agent.get_distinct_groups_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.global_breakdown.agent.get_agents_by_connection_status_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.global_breakdown.agent.disconnect_agents_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.global_breakdown.agent.sync_agent_info_get_time, &task_time);

--- a/src/wazuh_db/wdb_state.h
+++ b/src/wazuh_db/wdb_state.h
@@ -125,6 +125,7 @@ typedef struct _global_agent_t {
     uint64_t get_agent_info_queries;
     uint64_t get_agents_by_connection_status_queries;
     uint64_t get_all_agents_queries;
+    uint64_t get_distinct_groups_queries;
     uint64_t get_groups_integrity_queries;
     uint64_t insert_agent_queries;
     uint64_t reset_agents_connection_queries;
@@ -144,6 +145,7 @@ typedef struct _global_agent_t {
     struct timeval get_agent_info_time;
     struct timeval get_agents_by_connection_status_time;
     struct timeval get_all_agents_time;
+    struct timeval get_distinct_groups_time;
     struct timeval get_groups_integrity_time;
     struct timeval insert_agent_time;
     struct timeval reset_agents_connection_time;
@@ -845,6 +847,19 @@ void w_inc_global_agent_get_all_agents();
  * @param time Value to increment the counter.
  */
 void w_inc_global_agent_get_all_agents_time(struct timeval time);
+
+/**
+ * @brief Increment get-distinct-groups global agent queries counter
+ *
+ */
+void w_inc_global_agent_get_distinct_groups();
+
+/**
+ * @brief Increment get-distinct-groups global agent time counter
+ *
+ * @param time Value to increment the counter.
+ */
+void w_inc_global_agent_get_distinct_groups_time(struct timeval time);
 
 /**
  * @brief Increment get-agents-by-connection-status global agent queries counter


### PR DESCRIPTION
|Related issue|Manual Testing|Integration Tests|Documentation|
|---|---|---|---|
|#15665|https://github.com/wazuh/wazuh-qa/issues/3717|||

## Description
This PR improves requests to wazuh-db in process_multi_groups() function. The changes included are the following

- Creates the query "`SELECT DISTINCT 'group', group_hash from agent WHERE id > 0 AND group_hash > ? ORDER BY group_hash;`"
- New endpoint in wazuh-db for "global" actor: "global get-distinct-groups last_hash_group"
     - Description: Returns an array containing the group and group_hash assigned to all agents, if two agents have the same group assigned it is only included once
     - `last_hash_group`: group hash where to start querying, if not present returns all.
     - Response on success: `ok [{"group": "default","group_hash": "37a8eec1"},...]`
     - Response on error: `err Error getting agent groups from global.db.`
- Adds stats for the new wazuh-db endpoint.
- New helper `wdb_get_distinct_agent_groups()` to use the new wazuh-db endpoint.
- Changes the calls to `wdb_get_all_agents()` and `wdb_get_agent_info()` to a single call to `wdb_get_distinct_agent_groups()`.


## Tests


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity [#report](https://github.com/wazuh/wazuh/pull/15742#issuecomment-1372207742)
  - [x] Valgrind (memcheck and descriptor leaks check) [#report](https://github.com/wazuh/wazuh/pull/15742#issuecomment-1371541655)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Working on cluster environments
- [x] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)
