### PR TITLE
Adapt framework and API to SCA database changes removing `status` field

### DIFF
--- a/api/api/controllers/sca_controller.py
+++ b/api/api/controllers/sca_controller.py
@@ -87,7 +87,7 @@ async def get_sca_agent(request, agent_id: str = None, pretty: bool = False, wai
 
 async def get_sca_checks(request, agent_id: str = None, pretty: bool = False, wait_for_complete: bool = False,
                          policy_id: str = None, title: str = None, description: str = None, rationale: str = None,
-                         remediation: str = None, command: str = None, status: str = None, reason: str = None,
+                         remediation: str = None, command: str = None, reason: str = None,
                          file: str = None, process: str = None, directory: str = None, registry: str = None,
                          references: str = None, result: str = None, condition: str = None, offset: int = 0,
                          limit: int = DATABASE_LIMIT, sort: str = None, search: str = None, select: str = None,
@@ -115,8 +115,6 @@ async def get_sca_checks(request, agent_id: str = None, pretty: bool = False, wa
         Filters by remediation.
     command : str
         Filters by command.
-    status : str
-        Filters by status.
     reason : str
         Filters by reason.
     file : str
@@ -160,7 +158,6 @@ async def get_sca_checks(request, agent_id: str = None, pretty: bool = False, wa
                'rationale': rationale,
                'remediation': remediation,
                'command': command,
-               'status': status,
                'reason': reason,
                'file': file,
                'process': process,

--- a/api/api/controllers/test/test_sca_controller.py
+++ b/api/api/controllers/test/test_sca_controller.py
@@ -66,7 +66,6 @@ async def test_get_sca_checks(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock
                'rationale': None,
                'remediation': None,
                'command': None,
-               'status': None,
                'reason': None,
                'file': None,
                'process': None,

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -14318,7 +14318,6 @@ paths:
         - $ref: '#/components/parameters/rationale'
         - $ref: '#/components/parameters/remediation'
         - $ref: '#/components/parameters/command'
-        - $ref: '#/components/parameters/status'
         - $ref: '#/components/parameters/reason'
         - $ref: '#/components/parameters/full_path_filter'
         - $ref: '#/components/parameters/process'
@@ -14363,7 +14362,6 @@ paths:
                       remediation: "1) Edit or create a file in the /etc/modprobe.d/ directory ending in .conf and add
                       the following line: install cramfs /bin/true. 2) Run the following command to unload the cramfs
                       module: # rmmod cramfs"
-                      status: "Not applicable"
                       compliance:
                         - value: "1.1.1.1"
                           key: "cis"

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -14357,7 +14357,7 @@ paths:
                       server. If this filesystem type is not needed, disable it."
                       condition: "all"
                       title: "Ensure mounting of cramfs filesystems is disabled."
-                      result: ""
+                      result: "not applicable"
                       policy_id: "cis_ubuntu20-04"
                       remediation: "1) Edit or create a file in the /etc/modprobe.d/ directory ending in .conf and add
                       the following line: install cramfs /bin/true. 2) Run the following command to unload the cramfs

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -4385,7 +4385,7 @@ components:
           enum:
             - passed
             - failed
-            - ""
+            - "not applicable"
         title:
           type: string
           description: "A brief description of what is being checked"

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -539,7 +539,6 @@ stages:
               compliance: !anything
               rules: !anything
               condition: !anystr
-              status: !anystr
               reason: !anystr
           failed_items: []
           total_affected_items: !anyint
@@ -570,7 +569,6 @@ stages:
               compliance: !anything
               rules: !anything
               condition: !anystr
-              status: !anystr
               reason: !anystr
               command: !anystr
           failed_items: []
@@ -615,7 +613,6 @@ stages:
               compliance: !anything
               rules: !anything
               condition: !anystr
-              status: !anystr
               reason: !anystr
               file: !anystr
           failed_items: []
@@ -1079,7 +1076,6 @@ marks:
         - process
         - rules.type
         - file
-        - status
         - compliance.value
         - directory
         - result

--- a/framework/wazuh/core/sca.py
+++ b/framework/wazuh/core/sca.py
@@ -14,7 +14,7 @@ SCA_CHECK_DB_FIELDS = MappingProxyType(
     {'policy_id': 'policy_id', 'id': 'id', 'title': 'title', 'description': 'description', 'rationale': 'rationale',
      'remediation': 'remediation', 'file': 'file', 'process': 'process', 'directory': 'directory',
      'registry': 'registry', 'command': 'command', 'references': '`references`', 'result': 'result',
-     'status': '`status`', 'reason': 'reason', 'condition': 'condition'})
+     'reason': 'reason', 'condition': 'condition'})
 
 SCA_CHECK_COMPLIANCE_DB_FIELDS = MappingProxyType(
     {'compliance.key': 'key', 'compliance.value': 'value', 'id_check': 'id_check'})


### PR DESCRIPTION
|Related issue|
|---|
|closes #15738 |

## Description

This PR adapts the framework and API to the changes in the `sca_check` database. From now on, the response field `status` will not appear nor be eligible as a query filter.

## Example

### Standard query (`result=not applicable` & `limit=1`)

```json
{
  "data": {
    "affected_items": [
      {
        "description": "The cramfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems. A cramfs image can be used without having to first decompress the image.",
        "rationale": "Removing support for unneeded filesystem types reduces the local attack surface of the server. If this filesystem type is not needed, disable it.",
        "condition": "all",
        "reason": "Invalid path or wrong permissions to run command 'modprobe -n -v cramfs'",
        "policy_id": "cis_ubuntu20-04",
        "title": "Ensure mounting of cramfs filesystems is disabled.",
        "remediation": "Edit or create a file in the /etc/modprobe.d/ directory ending in .conf Example: vim /etc/modprobe.d/cramfs.conf and add the following line: install cramfs /bin/true Run the following command to unload the cramfs module: # rmmod cramfs",
        "result": "not applicable",
        "id": 19000,
        "command": "modprobe -n -v cramfs,lsmod",
        "compliance": [
          {
            "key": "cis",
            "value": "1.1.1.1"
          },
          {
            "key": "cis_csc_v7",
            "value": "5.1"
          },
          {
            "key": "cmmc_v2.0",
            "value": "AC.1.002,CM.2.061,SC.3.180"
          },
          {
            "key": "iso_27001-2013",
            "value": "A.8.1.3,A.14.2.5"
          },
          {
            "key": "mitre_techniques",
            "value": "T1110,T1003,T1081,T1097,T1178,T1072,T1067,T1495,T1019,T1177,T1485,T1486,T1491,T1488,T1487,T1490,T1146,T1148,T1015,T1133,T1200,T1076,T1051,T1176,T1501,T1087,T1098,T1139,T1197,T1092,T1136,T1011,T1147,T1130,T1174,T1053,T1166,T1206,T1503,T1214,T1187,T1208,T1142,T1075,T1201,T1145,T1184,T1537,T1078,T1077,T1134,T1017,T1088,T1175,T1190,T1210,T1525,T1215,T1086,T1055,T1505,T1035,T1218,T1169,T1100,T1047,T1084,T1028,T1156,T1196,T1530,T1089,T1073,T1157,T1054,T1070,T1037,T1036,T1096,T1034,T1150,T1504,T1494,T1489,T1198,T1165,T1492,T1080,T1209,T1112,T1058,T1173,T1137,T1539,T1535,T1506,T1138,T1044,T1199"
          },
          {
            "key": "nist_sp_800-53",
            "value": "AU-2,CM-1,CM-2,CM-6,CM-7,IA-5,IA-6,SC-20,SC-21"
          },
          {
            "key": "pci_dss_v3.2.1",
            "value": "2.2"
          }
        ],
        "rules": [
          {
            "type": "command",
            "rule": "c:modprobe -n -v cramfs -> r:^install /bin/true|^install /bin/false"
          },
          {
            "type": "numeric",
            "rule": "not c:lsmod -> r:cramfs"
          }
        ]
      }
    ],
    "total_affected_items": 31,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected sca/policy information was returned",
  "error": 0
}
```

### Trying to use the `status` filter

```json
{
  "title": "Bad Request",
  "detail": "Field does not exist.: Available fields: policy_id, id, title, description, rationale, remediation, file, process, directory, registry, command, references, result, reason, condition, compliance.key, compliance.value, rules.type, rules.rule. Field: status",
  "dapi_errors": {
    "master-node": {
      "error": "Field does not exist.: Available fields: policy_id, id, title, description, rationale, remediation, file, process, directory, registry, command, references, result, reason, condition, compliance.key, compliance.value, rules.type, rules.rule. Field: status"
    }
  },
  "error": 1408
}
```

## Tests performed

### Unit tests

#### API

```
================================================================================== test session starts ==================================================================================
platform linux -- Python 3.9.9, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: testinfra-5.0.0, metadata-1.11.0, cov-2.12.0, asyncio-0.18.3, aiohttp-0.3.0, html-3.1.1, trio-0.7.0
asyncio: mode=legacy
collected 536 items                                                                                                                                                                     

api/api/controllers/test/test_active_response_controller.py .                                                                                                                     [  0%]
api/api/controllers/test/test_agent_controller.py ...........................................                                                                                     [  8%]
api/api/controllers/test/test_cdb_list_controller.py ......                                                                                                                       [  9%]
api/api/controllers/test/test_ciscat_controller.py .                                                                                                                              [  9%]
api/api/controllers/test/test_cluster_controller.py ........................                                                                                                      [ 13%]
api/api/controllers/test/test_decoder_controller.py .......                                                                                                                       [ 15%]
api/api/controllers/test/test_default_controller.py .                                                                                                                             [ 15%]
api/api/controllers/test/test_experimental_controller.py ...............                                                                                                          [ 18%]
api/api/controllers/test/test_manager_controller.py ..................                                                                                                            [ 21%]
api/api/controllers/test/test_mitre_controller.py .......                                                                                                                         [ 22%]
api/api/controllers/test/test_overview_controller.py .                                                                                                                            [ 23%]
api/api/controllers/test/test_rootcheck_controller.py ....                                                                                                                        [ 23%]
api/api/controllers/test/test_rule_controller.py ........                                                                                                                         [ 25%]
api/api/controllers/test/test_sca_controller.py ..                                                                                                                                [ 25%]
api/api/controllers/test/test_security_controller.py ...................................................                                                                          [ 35%]
api/api/controllers/test/test_syscheck_controller.py ....                                                                                                                         [ 36%]
api/api/controllers/test/test_syscollector_controller.py .........                                                                                                                [ 37%]
api/api/controllers/test/test_task_controller.py .                                                                                                                                [ 37%]
api/api/controllers/test/test_vulnerability_controller.py ....                                                                                                                    [ 38%]
api/api/models/test/test_model.py ...........................                                                                                                                     [ 43%]
api/api/test/test_alogging.py ..................                                                                                                                                  [ 47%]
api/api/test/test_authentication.py ...........                                                                                                                                   [ 49%]
api/api/test/test_configuration.py ..........................................                                                                                                     [ 56%]
api/api/test/test_encoder.py ...                                                                                                                                                  [ 57%]
api/api/test/test_middlewares.py ............                                                                                                                                     [ 59%]
api/api/test/test_uri_parser.py ...                                                                                                                                               [ 60%]
api/api/test/test_util.py ........................................                                                                                                                [ 67%]
api/api/test/test_validator.py .................................................................................................................................................. [ 94%]
...........................                                                                                                                                                       [100%]

=========================================================================== 536 passed, 14 warnings in 3.23s ============================================================================

```

#### Framework

```
================================================================================== test session starts ==================================================================================
platform linux -- Python 3.9.9, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: testinfra-5.0.0, metadata-1.11.0, cov-2.12.0, asyncio-0.18.3, aiohttp-0.3.0, html-3.1.1, trio-0.7.0
asyncio: mode=legacy
collected 35 items                                                                                                                                                                      

framework/wazuh/core/tests/test_sca.py ........................                                                                                                                   [ 68%]
framework/wazuh/tests/test_sca.py ...........                                                                                                                                     [100%]

============================================================================ 35 passed, 3 warnings in 0.27s =============================================================================
```

### AIT

```
test_sca_endpoints_cluster - Cluster environment
	 45 passed, 1 xfailed, 50 warnings

test_rbac_black_sca_endpoints
	 2 passed, 3 warnings

test_rbac_white_sca_endpoints
	 2 passed, 3 warnings

```

Regards,
Víctor