### PR TITLE
Fix UTs for Vulnerability Detector

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -4876,6 +4876,7 @@ void test_wm_vuldet_oval_prescan_SUSE_dependencies_failed_update_prepare(void **
 
     will_return(__wrap_sqlite3_prepare_v2, 1);
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
     will_return_always(__wrap_sqlite3_bind_text, 0);
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
     expect_string(__wrap_sqlite3_bind_text, buffer, agents_it->agent_id);
@@ -4914,6 +4915,7 @@ void test_wm_vuldet_oval_prescan_SUSE_dependencies_failed_update_step(void **sta
 
     will_return(__wrap_sqlite3_prepare_v2, 1);
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
     will_return_always(__wrap_sqlite3_bind_text, 0);
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
     expect_string(__wrap_sqlite3_bind_text, buffer, agents_it->agent_id);
@@ -5299,6 +5301,7 @@ void test_wm_vuldet_fill_report_nvd_cve_info_error_step(void **state) {
 
     will_return(__wrap_sqlite3_prepare_v2, 1);
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
     expect_string(__wrap_sqlite3_bind_text, buffer, "CVE-2016-6489");
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);


### PR DESCRIPTION
|Related issue|
|---|
|#15323|


## Description

This PR fixes UTs for Vulnerability Detector: adds missing calls to `__wrap_sqlite3_finalize`

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade


<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Valgrind (memcheck and descriptor leaks check)

