### PR TITLE
Fetch ALMA feeds for Vulnerability Detector

### DIFF
--- a/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
+++ b/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
@@ -61,6 +61,14 @@
       <update_interval>1h</update_interval>
     </provider>
 
+    <!-- Alma Linux OS vulnerabilities -->
+    <provider name="almalinux">
+      <enabled>no</enabled>
+      <os>8</os>
+      <os>9</os>
+      <update_interval>1h</update_interval>
+    </provider>
+
     <!-- Windows OS vulnerabilities -->
     <provider name="msu">
       <enabled>yes</enabled>

--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -340,6 +340,30 @@ int wm_vuldet_set_feed_version(char *feed, char *version, update_node **upd_list
         upd->dist_ref = FEED_ARCH;
         upd->json_format = 1;
 
+    } else if (strcasestr(feed, vu_feed_tag[FEED_ALMA])) {
+        if (!version) {
+            retval = OS_INVALID;
+            goto end;
+        }
+        // ALMA9
+        if (!strcmp(version, "9")) {
+            os_index = CVE_ALMA9;
+            upd->dist_tag_ref = FEED_ALMA9;
+            os_strdup(version, upd->version);
+            upd->dist_ext = vu_feed_ext[FEED_ALMA9];
+        // ALMA8
+        } else if (!strcmp(version, "8")) {
+            os_index = CVE_ALMA8;
+            upd->dist_tag_ref = FEED_ALMA8;
+            os_strdup(version, upd->version);
+            upd->dist_ext = vu_feed_ext[FEED_ALMA8];
+        } else {
+            merror("Invalid AlmaLinux version '%s'", version);
+            retval = OS_INVALID;
+            goto end;
+        }
+        upd->dist_ref = FEED_ALMA;
+
     } else if (strcasestr(feed, vu_feed_tag[FEED_MSU])) {
         os_index = CVE_MSU;
         upd->dist_tag_ref = FEED_MSU;
@@ -1067,7 +1091,8 @@ int wm_vuldet_provider_type(char *pr_name) {
         strcasestr(pr_name, vu_feed_tag[FEED_DEBIAN]) ||
         strcasestr(pr_name, vu_feed_tag[FEED_ALAS]) ||
         strcasestr(pr_name, vu_feed_tag[FEED_SUSE]) ||
-        strcasestr(pr_name, vu_feed_tag[FEED_REDHAT])) {
+        strcasestr(pr_name, vu_feed_tag[FEED_REDHAT]) ||
+        strcasestr(pr_name, vu_feed_tag[FEED_ALMA])) {
         return 0;
     } else if (strcasestr(pr_name, vu_feed_tag[FEED_NVD]) ||
         strcasestr(pr_name, vu_feed_tag[FEED_MSU]) ||

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -438,6 +438,7 @@
 #define VU_PKG_INVALID_VER          "(5591): Invalid version for package '%s' of the inventory: '%s'"
 #define VU_SUSE_VERSION_ERROR       "(5592): Invalid SUSE OS version."
 #define VU_INVALID_CPE_VERSION      "(5593): Couldn't get the version of the CPE for the %s package."
+#define VU_ALMA_VERSION_ERROR       "(5594): Invalid AlmaLinux OS version."
 
 /* File integrity monitoring error messages*/
 #define FIM_ERROR_ADD_FILE                          "(6600): Unable to add file to db: '%s'"

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -18967,6 +18967,36 @@ void test_wm_vuldet_set_feed_update_url_suse_invalid(void **state)
     os_free(update);
 }
 
+void test_wm_vuldet_set_feed_update_url_alma(void **state)
+{
+    bool ret;
+    int ind_dist;
+    int dist_tag_ref[] = {FEED_ALMA8, FEED_ALMA9};
+    char * repos[6][2] = {
+        {ALMA_REPO, "8"},
+        {ALMA_REPO, "9"}
+    };
+
+    update_node *update = NULL;
+    char *url = NULL;
+
+    os_calloc(1, sizeof(update_node), update);
+    os_calloc(1, OS_SIZE_2048 + 1, url);
+    update->dist_ref = FEED_ALMA;
+
+    for (ind_dist = 0; ind_dist < sizeof(dist_tag_ref)/sizeof(int); ind_dist++) {
+        update->dist_tag_ref = dist_tag_ref[ind_dist];
+        ret = wm_vuldet_set_feed_update_url(update);
+        assert_true(ret);
+        snprintf(url, OS_SIZE_2048, repos[ind_dist][0], repos[ind_dist][1]);
+        assert_string_equal(update->url, url);
+        os_free(update->url);
+    }
+
+    os_free(url);
+    os_free(update);
+}
+
 void test_wm_vuldet_set_feed_update_url_invalid(void **state)
 {
     bool ret;
@@ -23180,6 +23210,7 @@ int main(void)
         cmocka_unit_test(test_wm_vuldet_set_feed_update_url_redhat_greater_5),
         cmocka_unit_test(test_wm_vuldet_set_feed_update_url_suse),
         cmocka_unit_test(test_wm_vuldet_set_feed_update_url_suse_invalid),
+        cmocka_unit_test(test_wm_vuldet_set_feed_update_url_alma),
         cmocka_unit_test(test_wm_vuldet_set_feed_update_url_invalid),
         // Tests wm_vuldet_oval_append_rhsa
         cmocka_unit_test(test_wm_vuldet_oval_append_rhsa_empty),

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -18997,6 +18997,24 @@ void test_wm_vuldet_set_feed_update_url_alma(void **state)
     os_free(update);
 }
 
+void test_wm_vuldet_set_feed_update_url_alma_invalid(void **state)
+{
+    bool ret;
+    update_node *update = NULL;
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_ALMA;
+    update->dist_tag_ref = -1;
+
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mterror, formatted_msg, "(5594): Invalid AlmaLinux OS version.");
+
+    ret = wm_vuldet_set_feed_update_url(update);
+    assert_false(ret);
+
+    os_free(update);
+}
+
 void test_wm_vuldet_set_feed_update_url_invalid(void **state)
 {
     bool ret;
@@ -23211,6 +23229,7 @@ int main(void)
         cmocka_unit_test(test_wm_vuldet_set_feed_update_url_suse),
         cmocka_unit_test(test_wm_vuldet_set_feed_update_url_suse_invalid),
         cmocka_unit_test(test_wm_vuldet_set_feed_update_url_alma),
+        cmocka_unit_test(test_wm_vuldet_set_feed_update_url_alma_invalid),
         cmocka_unit_test(test_wm_vuldet_set_feed_update_url_invalid),
         // Tests wm_vuldet_oval_append_rhsa
         cmocka_unit_test(test_wm_vuldet_oval_append_rhsa_empty),

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -600,7 +600,7 @@ const char *vu_feed_ext[] = {
     "Amazon Linux",
     "SUSE Linux Enterprise",
     "Arch Linux",
-    "Alma Linux",
+    "AlmaLinux",
     "Microsoft Windows",
     // Ubuntu versions
     "Ubuntu Trusty",
@@ -632,8 +632,8 @@ const char *vu_feed_ext[] = {
     "SUSE Linux Enterprise Server 11",
     "SUSE Linux Enterprise Desktop 11",
     // Alma versions
-    "Alma Linux 8",
-    "Alma Linux 9",
+    "AlmaLinux 8",
+    "AlmaLinux 9",
     // WINDOWS
     "Windows Server 2003",
     "Windows Server 2003 R2",

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4856,7 +4856,7 @@ bool wm_vuldet_set_feed_update_url(update_node *update) {
         } else if (update->dist_tag_ref == FEED_ALMA9) {
             snprintf(repo, OS_SIZE_2048, ALMA_REPO, "9");
         } else {
-            mterror(WM_VULNDETECTOR_LOGTAG, VU_OS_VERSION_ERROR);
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_ALMA_VERSION_ERROR);
             os_free(repo);
             return false;
         }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -485,8 +485,7 @@ const char *vu_os_product_name_list[] = {
     "linux_enterprise_desktop",
     "suse_linux_enterprise_desktop",
     "linux_enterprise_server",
-    "suse_linux_enterprise_server",
-    "alma_linux"
+    "suse_linux_enterprise_server"
 };
 
 const char *vu_vendor_list_ubuntu_debian[] = {
@@ -6597,10 +6596,6 @@ int wm_vuldet_generate_os_and_kernel_package(sqlite3 *db, scan_agent *agent) {
         case FEED_ARCH:
             product_name[0] = vu_os_product_name_list[PR_ARCH];
             vendor = vu_vendor_list[V_ARCH];
-        break;
-        case FEED_ALMA:
-            product_name[0] = vu_os_product_name_list[PR_ALMA];
-            vendor = vu_vendor_list[V_ALMA];
         break;
         case FEED_MAC:
             vendor = "apple";

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -123,7 +123,7 @@ STATIC int wm_vuldet_remove_target_table(sqlite3 *db, char *TABLE, const char *t
 
 /**
  * @brief Set and validate the required URL for the feed.
- * Currently Debian, Ubuntu, Amazon and SUSE and RedHat are supported.
+ * Currently Debian, Ubuntu, Amazon, SUSE, AlmaLinux and RedHat are supported.
  * @param update Update structure of the feed being analyzed.
  * @return False if an unexpected feed is analyzed; True othewise.
  */
@@ -467,7 +467,8 @@ const char *vu_vendor_list[] = {
     "archlinux",
     "linux",
     "amazon",
-    "suse"
+    "suse",
+    "alma"
 };
 
 const char *vu_os_product_name_list[] = {
@@ -484,7 +485,8 @@ const char *vu_os_product_name_list[] = {
     "linux_enterprise_desktop",
     "suse_linux_enterprise_desktop",
     "linux_enterprise_server",
-    "suse_linux_enterprise_server"
+    "suse_linux_enterprise_server",
+    "alma_linux"
 };
 
 const char *vu_vendor_list_ubuntu_debian[] = {
@@ -530,6 +532,7 @@ const char *vu_feed_tag[] = {
     "ALAS",
     "SUSE",
     "ARCH",
+    "ALMA",
     "WIN",
     // Ubuntu versions
     "TRUSTY",
@@ -560,6 +563,9 @@ const char *vu_feed_tag[] = {
     "SLED12",
     "SLES11",
     "SLED11",
+    // Alma versions
+    "AlmaLinux-8",
+    "AlmaLinux-9",
     // WINDOWS
     "WS2003",
     "WS2003R2",
@@ -594,6 +600,7 @@ const char *vu_feed_ext[] = {
     "Amazon Linux",
     "SUSE Linux Enterprise",
     "Arch Linux",
+    "Alma Linux",
     "Microsoft Windows",
     // Ubuntu versions
     "Ubuntu Trusty",
@@ -624,6 +631,9 @@ const char *vu_feed_ext[] = {
     "SUSE Linux Enterprise Desktop 12",
     "SUSE Linux Enterprise Server 11",
     "SUSE Linux Enterprise Desktop 11",
+    // Alma versions
+    "Alma Linux 8",
+    "Alma Linux 9",
     // WINDOWS
     "Windows Server 2003",
     "Windows Server 2003 R2",
@@ -4657,7 +4667,8 @@ int wm_vuldet_index_feed(update_node *update) {
         if (update->dist_ref == FEED_UBUNTU ||
             update->dist_ref == FEED_DEBIAN ||
             update->dist_ref == FEED_REDHAT ||
-            update->dist_ref == FEED_SUSE) {
+            update->dist_ref == FEED_SUSE ||
+            update->dist_ref == FEED_ALMA) {
 
             switch (w_uncompress_bz2_gz_file(path, VU_TEMP_FILE)) {
             case -1:
@@ -4840,6 +4851,16 @@ bool wm_vuldet_set_feed_update_url(update_node *update) {
         else // RHEL6, RHEL7, RHEL8 and RHEL9
             snprintf(repo, OS_SIZE_2048, RED_HAT_REPO, update->version, update->version);
 
+    } else if (update->dist_ref == FEED_ALMA) {
+        if (update->dist_tag_ref == FEED_ALMA8){
+            snprintf(repo, OS_SIZE_2048, ALMA_REPO, "8");
+        } else if (update->dist_tag_ref == FEED_ALMA9) {
+            snprintf(repo, OS_SIZE_2048, ALMA_REPO, "9");
+        } else {
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_OS_VERSION_ERROR);
+            os_free(repo);
+            return false;
+        }
     } else {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_OS_VERSION_ERROR);
         os_free(repo);
@@ -5884,6 +5905,15 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
         } else if (strcasestr(agti_os_name, vu_feed_ext[FEED_ARCH])) {
             agent_dist_ver = FEED_ARCH;
             agent_dist= FEED_ARCH;
+        } else if (strcasestr(agti_os_name, vu_feed_ext[FEED_ALMA])) {
+            if (strstr(agti_os_major, "8")) {
+                agent_dist_ver = FEED_ALMA8;
+            } else if (strstr(agti_os_major, "9")) {
+                agent_dist_ver = FEED_ALMA9;
+            } else {
+                dist_error = FEED_ALMA;
+            }
+            agent_dist = FEED_ALMA;
         } else if (strcasestr(agti_os_name, vu_feed_ext[FEED_WIN])) {
             agent_dist_ver = wm_vuldet_decode_win_os(agti_os_name);
             agent_dist = FEED_WIN;
@@ -6567,6 +6597,10 @@ int wm_vuldet_generate_os_and_kernel_package(sqlite3 *db, scan_agent *agent) {
         case FEED_ARCH:
             product_name[0] = vu_os_product_name_list[PR_ARCH];
             vendor = vu_vendor_list[V_ARCH];
+        break;
+        case FEED_ALMA:
+            product_name[0] = vu_os_product_name_list[PR_ALMA];
+            vendor = vu_vendor_list[V_ALMA];
         break;
         case FEED_MAC:
             vendor = "apple";

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -218,7 +218,6 @@ typedef enum vu_product_name {
     PR_SLED2,
     PR_SLES1,
     PR_SLES2,
-    PR_ALMA,
     PR_NOSYSTEM
 } vu_product_name;
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -52,6 +52,7 @@
 #define ALAS2022_REPO_META "https://feed.wazuh.com/vulnerability-detector/ALAS/2022/alas2022.meta"
 #define SLES_REPO "https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.%s.xml"
 #define SLED_REPO "https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.desktop.%s.xml"
+#define ALMA_REPO "https://security.almalinux.org/oval/org.almalinux.alsa-%s.xml"
 #define RED_HAT_REPO_DEFAULT_MIN_YEAR 2010
 #define RED_HAT_REPO_MAX_REQ_ITS 100
 #define RED_HAT_REPO_MAX_FAIL_ITS 5
@@ -190,7 +191,8 @@ typedef enum vu_vendor {
     V_ARCH,
     V_KERNEL,
     V_AMAZON,
-    V_SUSE
+    V_SUSE,
+    V_ALMA
 } vu_vendor;
 
 typedef enum vu_package_dist_id {
@@ -216,6 +218,7 @@ typedef enum vu_product_name {
     PR_SLED2,
     PR_SLES1,
     PR_SLES2,
+    PR_ALMA,
     PR_NOSYSTEM
 } vu_product_name;
 
@@ -265,6 +268,7 @@ typedef enum vu_feed {
     FEED_ALAS,
     FEED_SUSE,
     FEED_ARCH,
+    FEED_ALMA,
     FEED_WIN,
     // Ubuntu versions
     FEED_TRUSTY,
@@ -295,6 +299,9 @@ typedef enum vu_feed {
     FEED_SLED12,
     FEED_SLES11,
     FEED_SLED11,
+    // ALMA versions
+    FEED_ALMA8,
+    FEED_ALMA9,
     // WINDOWS
     FEED_WS2003,
     FEED_WS2003R2,
@@ -455,6 +462,8 @@ typedef enum cve_db {
     CVE_SLED12,
     CVE_SLES11,
     CVE_SLED11,
+    CVE_ALMA8,
+    CVE_ALMA9,
     CVE_ARCH,
     CVE_NVD,
     CPE_WDIC,


### PR DESCRIPTION
|Related issue|
|---|
| #15772 |

## Description

This pull request adds the configuration block for the new AlmaLinux provider. In addition, it modifies functions needed to fetch the corresponding feeds.

Unit tests have been added to cover the added code.

## Configuration options

```xml
<provider name="almalinux">
  <enabled>no</enabled>
  <os>8</os>
  <os>9</os>
  <update_interval>1h</update_interval>
</provider>
```

## Logs/Alerts example

**Config debug logs**
```
2022/12/30 08:36:05 wazuh-modulesd[298623] wmodules-vuln-detector.c:692 at wm_vuldet_read_provider(): DEBUG: Added almalinux (8) feed. Interval: 3600s | Path: 'none' | Url: 'none' | Timeout: 300s
2022/12/30 08:36:05 wazuh-modulesd[298623] wmodules-vuln-detector.c:692 at wm_vuldet_read_provider(): DEBUG: Added almalinux (9) feed. Interval: 3600s | Path: 'none' | Url: 'none' | Timeout: 300s
```

**Fetch logs**
```
2022/12/30 08:36:05 wazuh-modulesd:vulnerability-detector[298623] wm_vuln_detector.c:5051 at wm_vuldet_check_feed(): INFO: (5400): Starting 'Alma Linux 8' database update.
2022/12/30 08:36:05 wazuh-modulesd:download[298623] wm_download.c:231 at wm_download_dispatch(): DEBUG: Downloading 'https://security.almalinux.org/oval/org.almalinux.alsa-8.xml' to 'tmp/vuln-temp'
2022/12/30 08:36:08 wazuh-modulesd:download[298623] wm_download.c:251 at wm_download_dispatch(): DEBUG: Download of 'https://security.almalinux.org/oval/org.almalinux.alsa-8.xml' finished.
2022/12/30 08:36:08 wazuh-modulesd:vulnerability-detector[298623] wm_vuln_detector.c:5051 at wm_vuldet_check_feed(): INFO: (5400): Starting 'Alma Linux 9' database update.
2022/12/30 08:36:08 wazuh-modulesd:download[298623] wm_download.c:231 at wm_download_dispatch(): DEBUG: Downloading 'https://security.almalinux.org/oval/org.almalinux.alsa-9.xml' to 'tmp/vuln-temp'
2022/12/30 08:36:10 wazuh-modulesd:download[298623] wm_download.c:251 at wm_download_dispatch(): DEBUG: Download of 'https://security.almalinux.org/oval/org.almalinux.alsa-9.xml' finished.
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
- [x] Added unit tests (for new features)
- [x] Stress test for affected components
