### PR TITLE
SCA: Debian 11. Review section 1-5

### DIFF
--- a/ruleset/sca/debian/cis_debian11.yml
+++ b/ruleset/sca/debian/cis_debian11.yml
@@ -37,7 +37,7 @@ checks:
   # 1.1.1.3 Ensure mounting of udf filesystems is disabled (Automated) - Not implemented
 
   # 1.1.2 Configure /tmp
-
+s
   # 1.1.2.1 Ensure /tmp is separate partition (Automated)
   - id: 3000
     title: "Ensure /tmp is separate partition (Automated)"

--- a/ruleset/sca/debian/cis_debian11.yml
+++ b/ruleset/sca/debian/cis_debian11.yml
@@ -1,0 +1,6284 @@
+# Security Configuration Assessment
+# CIS Checks for Debian Linux 11
+# Copyright (C) 2023, Wazuh Inc.
+#
+# This program is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation
+#
+# Based on:
+# Center for Internet Security Debian Linux 11 Benchmark v1.0.0 - 09-22-2022
+
+policy:
+  id: "cis_debian11"
+  file: "cis_debian11.yml"
+  name: "CIS Benchmark for Debian/Linux 11"
+  description: "This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux 11."
+  references:
+    - https://www.cisecurity.org/cis-benchmarks/
+
+requirements:
+  title: "Check Debian version"
+  description: "Requirements for running the SCA scan against Debian/Ubuntu."
+  condition: all
+  rules:
+    - "f:/etc/debian_version"
+    - "f:/proc/sys/kernel/ostype -> Linux"
+
+checks:
+  ############################################################
+  # 1 Initial Setup
+  ############################################################
+
+  # 1.1 Filesystem configuration
+  # 1.1.1.1 Ensure mounting of cramfs filesystems is disabled (Automated) - Not implemented
+  # 1.1.1.2 Ensure mounting of squashfs filesystems is disabled (Automated) - Not implemented
+  # 1.1.1.3 Ensure mounting of udf filesystems is disabled (Automated) - Not implemented
+
+  # 1.1.2 Configure /tmp
+
+  # 1.1.2.1 Ensure /tmp is separate partition (Automated)
+  - id: 3000
+    title: "Ensure /tmp is separate partition (Automated)"
+    description: "The /tmp directory is a world-writable directory used for temporary storage by all users and some applications."
+    rationale: "Making /tmp its own file system allows an administrator to set additional mount options such as the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hard link to a system setuid program and wait for it to be updated. Once the program was updated, the hard link would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp."
+    remediation: "Configure /etc/fstab as appropriate. Example: tmpfs /tmp tmpfs defaults,rw,nosuid,nodev,noexec,relatime 0 0 or Run the following commands to enable systemd /tmp mounting: systemctl unmask tmp.mount systemctl enable tmp.mount Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to configure the /tmp mount: [Mount] What=tmpfs Where=/tmp Type=tmpfs Options=mode=1777,strictatime,noexec,nodev,nosuid"
+    compliance:
+      - cis: ["1.1.2.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1499","T1499.001"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/
+      - https://www.freedesktop.org/software/systemd/man/systemd-fstab-generator.html
+    condition: any
+    rules:
+      - "c:findmnt --kernel /tmp -> r:\s/tmp\s"
+      - "c:systemctl is-enabled tmp.mount -> enabled"
+
+  - id: 3001
+    title: "Ensure nodev option set on /tmp partition (Automated)"
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /tmp."
+    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp partition. Example: <device> /tmp  <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0. Run the following command to remount /tmp with the configured options: # mount -o remount /tmp"
+    compliance:
+      - cis: ["1.1.2.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1200","T1200.000"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - See the fstab(5) manual page for more information.
+    condition: all
+    rules:
+      - 'c:findmnt --kernel /tmp -> r:\s/tmp\s && r:nodev'
+
+  - id: 3002
+    title: "Ensure noexec option set on /tmp partition (Automated)"
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /tmp."
+    remediation: "Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /tmp partition. Example: <device> /tmp <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0. Run the following command to remount /tmp with the configured options: # mount -o remount /tmp"
+    compliance:
+      - cis: ["1.1.2.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1204","T1204.002"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - See the fstab(5) manual page for more information.
+    condition: all
+    rules:
+      - 'c:findmnt --kernel /tmp -> r:\s/tmp\s && r:noexec'
+
+  - id: 3003
+    title: "Ensure nosuid option set on /tmp partition (Automated)"
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /tmp."
+    remediation: "Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /tmp partition. Example: <device> /tmp <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0. Run the following command to remount /tmp with the configured options: # mount -o remount /tmp"
+    compliance:
+      - cis: ["1.1.2.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1548","T1548.001"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - See the fstab(5) manual page for more information.
+    condition: all
+    rules:
+      - 'c:findmnt --kernel /tmp -> r:\s/tmp\s && r:nosuid'
+
+  # 1.1.3 Configure /var
+  - id: 3004
+    title: "Ensure separate partition exists for /var (Automated)"
+    description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable."
+    rationale: "The reasoning for mounting /var on a separate partition is as follow.(1) Protection from resource exhaustion: The default installation only creates a single / partition. Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /var and cause unintended behavior across the system as the disk is full. See man auditd.conf for details. (2) Fine grained control over the mount: Configuring /var as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. Other options allow for specific behaviour. See man mount for exact details regarding filesystem-independent and filesystem-specific options. (3) Protection from exploitation: An example of exploiting /var may be an attacker establishing a hard-link to a system setuid program and wait for it to be updated. Once the program was updated, the hard-link would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    compliance:
+      - cis: ["1.1.3.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1499","T1499.001"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_mitigations: [""]
+    references:
+      - http://tldp.org/HOWTO/LVM-HOWTO/
+    condition: all
+    rules:
+      - 'c:findmnt --kernel /var -> r:\s/var\s'
+
+  - id: 3005
+    title: "Ensure nodev option set on /var partition (Automated)"
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var filesystem is not intended to support devices, set this option to ensure that users cannot create a block or character special devices in /var."
+    remediation: "IF the /var partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var partition. Example: <device> /var <fstype> defaults,rw,nosuid,nodev,relatime 0 0 . Run the following command to remount /var with the configured options: # mount -o remount /var."
+    compliance:
+      - cis: ["1.1.3.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1200","T1200.000"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1038"]
+    references:
+      - See the fstab(5) manual page for more information.
+    condition: all
+    rules:
+      - 'c:findmnt --kernel /var -> r:\s/var\s && r:nodev'
+
+  - id: 3006
+    title: "Ensure nosuid option set on /var partition (Automated)"
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var filesystem is only intended for variable files such as logs, set this option to ensure that users cannot create setuid files in /var."
+    remediation: "IF the /var partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var partition. Example: <device> /var <fstype> defaults,rw,nosuid,nodev,relatime 0 0 . Run the following command to remount /var with the configured options: # mount -o remount /var"
+    compliance:
+      - cis: ["1.1.3.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1548","T1548.001"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1038"]
+    references:
+      - See the fstab(5) manual page for more information.
+    condition: all
+    rules:
+      - 'c:findmnt --kernel -> r:\s/var\s && r:nosuid'
+
+  # 1.1.4 Configure /var/tmp 
+  - id: 3007
+    title: "Ensure separate partition exists for /var/tmp (Automated)"
+    description: "The /var/tmp directory is a world-writable directory used for temporary storage by all users and some applications. Temporary files residing in /var/tmp are to be preserved between reboots."
+    rationale: "The reasoning for mounting /var/tmp on a separate partition is as follows. (1) Protection from resource exhaustion: The default installation only creates a single / partition. Since the /var/tmp directory may contain world-writable files and directories, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /var/tmp and cause the potential disruption to daemons as the disk is full. (2) Fine grained control over the mount: Configuring /var/tmp as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. Other options allow for specific behavior. See man mount for exact details regarding filesystem-independent and filesystem-specific options. (3) Protection from exploitation: An example of exploiting /var/tmp may be an attacker establishing a hard-link to a system setuid program and wait for it to be updated. Once the program was updated, the hard-link would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/tmp. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    compliance:
+      - cis: ["1.1.4.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1499","T1499.001"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - http://tldp.org/HOWTO/LVM-HOWTO/
+    condition: all
+    rules:
+      - 'c:findmnt --kernel /var/tmp -> r:\s/var/tmp\s'
+
+  - id: 3008
+    title: "Ensure noexec option set on /var/tmp partition (Automated)" 
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
+    remediation: "IF the /var/tmp partition exists, edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /var/tmp partition. Example: <device> /var/tmp <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0 . Run the following command to remount /var/tmp with the configured options: # mount -o remount /var/tmp"
+    compliance:
+      - cis: ["1.1.4.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1204","T1204.002"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - See the fstab(5) manual page for more information.
+    condition: all
+    rules:
+      - 'c:findmnt --kernel /var/tmp -> r:\s/var/tmp\s && r:noexec'
+
+  - id: 3009
+    title: "Ensure nosuid option set on /var/tmp partition (Automated)"
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /var/tmp."
+    remediation: "IF the /var/tmp partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/tmp partition. Example: <device> /var/tmp <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0 . Run the following command to remount /var/tmp with the configured options: # mount -o remount /var/tmp"
+    compliance:
+      - cis: ["1.1.4.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1548","T1548.001"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - See the fstab(5) manual page for more information.
+    condition: all
+    rules:
+      - 'c:findmnt --kernel /var/tmp -> r:\s/var/tmp\s && r:nosuid'
+
+  - id: 3010
+    title: "Ensure nodev option set on /var/tmp partition (Automated)"
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var/tmp filesystem is not intended to support devices, set this option to ensure that users cannot create a block or character special devices in /var/tmp."
+    remediation: "IF the /var/tmp partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var/tmp partition. Example: <device> /var/tmp <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0 . Run the following command to remount /var/tmp with the configured options: # mount -o remount /var/tmp"
+    compliance:
+      - cis: ["1.1.4.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1200","T1200.000"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - See the fstab(5) manual page for more information.
+    condition: all
+    rules:
+      - 'c:findmnt --kernel /var/tmp -> r:\s/var/tmp\s && r:nodev'
+
+  # 1.1.5 Configure /var/log
+  - id: 3011
+    title: "Ensure separate partition exists for /var/log/ (Automated)"
+    description: "The /var/log directory is used by system services to store log data."
+    rationale: "The reasoning for mounting /var/log on a separate partition is as follows. (1) Protection from resource exhaustion: The default installation only creates a single / partition. Since the /var/log directory contains log files which can grow quite large, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. (2) Fine grained control over the mount: Configuring /var/log as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. Other options allow for specific behavior. See man mount for exact details regarding filesystem-independent and filesystem-specific options. (3) Protection of log data: As /var/log contains log files, care should be taken to ensure the security and integrity of the data and mount point."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/log . For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    compliance:
+      - cis: ["1.1.5.1"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - pci_dss_3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - nist_sp_800-53: ["AU-4"]
+      - mitre_techniques: ["T1499","T1499.001"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - http://tldp.org/HOWTO/LVM-HOWTO/
+    condition: all
+    rules:
+      - 'c:findmnt --kernel /var/log -> r:\s/var/log\s'
+
+
+  - id: 3012
+    title: "Ensure nodev option set on /var/log/ partition (Automated)"
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var/log filesystem is not intended to support devices, set this option to ensure that users cannot create a block or character special devices in /var/log."
+    remediation: "IF the /var/log partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var/log partition. Example: <device> /var/log <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0 . Run the following command to remount /var/log with the configured options: # mount -o remount /var/log"
+    compliance:
+      - cis: ["1.1.5.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1200","T1200.000"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - See the fstab(5) manual page for more information.
+    condition: all
+    rules:
+      - 'c:findmnt --kernel /var/log -> r:\s/var/log\s && r:nodev'
+
+  - id: 3013
+    title: "Ensure noexec option set on /var/log/ partition (Automated)"
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /var/log filesystem is only intended for log files, set this option to ensure that users cannot run executable binaries from /var/log."
+    remediation: "IF the /var/log partition exists, edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /var/log partition. Example: <device> /var/log <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0 . Run the following command to remount /var/log with the configured options: # mount -o remount /var/log"
+    compliance:
+      - cis: ["1.1.5.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1204","T1204.002"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - See the fstab(5) manual page for more information.
+    condition: all
+    rules:
+      - 'c:findmnt --kernel /var/log -> r:\s/var/log\s && r:noexec'
+
+  - id: 3014
+    title: "Ensure nosuid option set on /var/log/ partition (Automated)"
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var/log filesystem is only intended for log files, set this option to ensure that users cannot create setuid files in /var/log."
+    remediation: "IF the /var/log partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/log partition. Example: <device> /var/log <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0 . Run the following command to remount /var/log with the configured options: # mount -o remount /var/log"
+    compliance:
+      - cis: ["1.1.5.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1548","T1548.001"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - See the fstab(5) manual page for more information.
+    condition: all
+    rules:
+      - 'c:findmnt --kernel /var/log -> r:\s/var/log\s && r:nosuid'
+
+  # 1.1.6 Configure /var/log/audit
+  - id: 3015
+    title: "Ensure separate partition exists for /var/log/audit (Automated)"
+    description: "The auditing daemon, auditd, stores log data in the /var/log/audit directory."
+    rationale: "The reasoning for mounting /var/log/audit on a separate partition is as follows. (1) Protection from resource exhaustion: The default installation only creates a single / partition. Since the /var/log/audit directory contains the audit.log file which can grow quite large, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /var/log/audit and cause auditd to trigger it's space_left_action as the disk is full. See man auditd.conf for details. (2) Fine grained control over the mount: Configuring /var/log/audit as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. Other options allow for specific behavior. See man mount for exact details regarding filesystem-independent and filesystem-specific options. (3) Protection of audit data: As /var/log/audit contains audit logs, care should be taken to ensure the security and integrity of the data and mount point."
+    remediation: "IF the /var/log partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/log partition. Example: <device> /var/log <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0 . Run the following command to remount /var/log with the configured options: # mount -o remount /var/log"
+    compliance:
+      - cis: ["1.1.6.1"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - pci_dss_3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - nist_sp_800-53: ["AU-4"]
+      - mitre_techniques: ["T1499","T1499.001"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - http://tldp.org/HOWTO/LVM-HOWTO/
+    condition: all
+    rules:
+      - 'c:findmnt --kernel /var/log/audit -> r:\s/var/log/audit\s'
+
+  - id: 3016
+    title: "Ensure noexec option set on /var/log/audit partition (Automated)"
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /var/log/audit filesystem is only intended for audit logs, set this option to ensure that users cannot run executable binaries from /var/log/audit."
+    remediation: "IF the /var/log/audit partition exists, edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /var partition. Example: <device> /var/log/audit <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0 . Run the following command to remount /var/log/audit with the configured options: # mount -o remount /var/log/audit"
+    compliance:
+      - cis: ["1.1.6.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1204","T1204.002"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - See the fstab(5) manual page for more information.
+    condition: all
+    rules:
+      - 'c:findmnt --kernel /var/log/audit -> r:\s/var/log/audit\s && r:noexec'
+
+  - id: 3017
+    title: "Ensure nodev option set on /var/log/audit partition (Automated)"
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var/log/audit filesystem is not intended to support devices, set this option to ensure that users cannot create a block or character special devices in /var/log/audit."
+    remediation: "IF the /var/log/audit partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var/log/audit partition. Example: <device> /var/log/audit <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0 . Run the following command to remount /var/log/audit with the configured options: # mount -o remount /var/log/audit"
+    compliance:
+      - cis: ["1.1.6.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1200","T1200.000"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - See the fstab(5) manual page for more information.
+    condition: all
+    rules:
+      - 'c:findmnt --kernel /var/log/audit -> r:\s/var/log/audit\s && r:nodev'  
+
+  - id: 3018
+    title: "Ensure nosuid option set on /var/log/audit partition (Automated)"
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var/log/audit filesystem is only intended for variable files such as logs, set this option to ensure that users cannot create setuid files in /var/log/audit."
+    remediation: "IF the /var/log/audit partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/log/audit partition. Example: <device> /var/log/audit <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0 . Run the following command to remount /var/log/audit with the configured options: # mount -o remount /var/log/audit"
+    compliance:
+      - cis: ["1.1.6.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1548","T1548.001"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - See the fstab(5) manual page for more information.
+    condition: all
+    rules:
+      - 'c:findmnt --kernel /var/log/audit -> r:\s/var/log/audit\s && r:nosuid'  
+
+
+  # 1.1.7 Configure /home
+
+  - id: 3019
+    title: "Ensure separate partition exists for /home (Automated)"
+    description: "The /home directory is used to support disk storage needs of local users."
+    rationale: "The reasoning for mounting /home on a separate partition is as follows. (1) Protection from resource exhaustion: The default installation only creates a single / partition. Since the /home directory contains user generated data, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /home and impact all local users. (2) Fine grained control over the mount: Configuring /home as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. In the case of /home options such as usrquota/grpquota may be considered to limit the impact that users can have on each other with regards to disk resource exhaustion. Other options allow for specific behavior. See man mount for exact details regarding filesystem-independent and filesystem-specific options. (3) Protection of user data: As /home contains user data, care should be taken to ensure the security and integrity of the data and mount point."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /home. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    compliance:
+      - cis: ["1.1.7.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1499","T1499.001"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1038"]
+    references:
+      - http://tldp.org/HOWTO/LVM-HOWTO/
+    condition: all
+    rules:
+      - 'c:findmnt --kernel /home -> r:\s/home\s'
+
+  - id: 3020
+    title: "Ensure nodev option set on /home partition (Automated)"
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /home filesystem is not intended to support devices, set this option to ensure that users cannot create a block or character special devices in /home."
+    remediation: "IF the /home partition exists, edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /home partition. Example: <device> /home <fstype> defaults,rw,nosuid,nodev,relatime 0 0. Run the following command to remount /home with the configured options: # mount -o remount /home"
+    compliance:
+      - cis: ["1.1.7.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1200, T1200.000"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - See the fstab(5) manual page for more information.
+    condition: all
+    rules:
+      - 'c:findmnt --kernel /home -> r:\s/home\s && r:nodev'  
+
+  - id: 3021
+    title: "Ensure nosuid option set on /home partition (Automated)"
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /home filesystem is only intended for user file storage, set this option to ensure that users cannot create setuid files in /home."
+    remediation: "IF the /home partition exists, edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /home partition. Example: <device> /home <fstype> defaults,rw,nosuid,nodev,relatime 0 0. Run the following command to remount /home with the configured options: # mount -o remount /home"
+    compliance:
+      - cis: ["1.1.7.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1548, T1548.001"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - See the fstab(5) manual page for more information.
+    condition: all
+    rules:
+      - 'c:findmnt --kernel /home -> r:\s/home\s && r:nosuid'  
+
+
+  # 1.1.8 Configure /dev/shm
+
+
+  - id: 3022
+    title: "Ensure nodev option set on /dev/shm partition (Automated)"
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /dev/shm filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create special devices in /dev/shm partitions."
+    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /dev/shm partition. See the fstab(5) manual page for more information. Run the following command to remount /dev/shm using the updated options from /etc/fstab: # mount -o remount /dev/shm"
+    compliance:
+      - cis: ["1.1.8.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1200, T1200.000"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1038"]
+    condition: all
+    rules:
+      - 'c:findmnt --kernel /dev/shm -> r:\s/dev/shm\s && r:nodev'
+
+  - id: 3023
+    title: "Ensure noexec option set on /dev/shm partition (Automated)"
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Setting this option on a file system prevents users from executing programs from shared memory. This deters users from introducing potentially malicious software on the system."
+    remediation: "Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /dev/shm partition. Example: <device> /dev/shm <fstype> defaults,rw,nosuid,nodev,noexec,relatime 0 0. Run the following command to remount /dev/shm with the configured options: # mount -o remount /dev/shm. NOTE It is recommended to use tmpfs as the device/filesystem type as /dev/shm is used as shared memory space by applications."
+    compliance:
+      - cis: ["1.1.8.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1204, T1204.002"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - See the fstab(5) manual page for more information.
+    condition: all
+    rules:
+      - 'c:findmnt --kernel /dev/shm -> r:\s/dev/shm\s && r:noexec'
+
+  - id: 3024
+    title: "Ensure nosuid option set on /dev/shm partition (Automated)"
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Setting this option on a file system prevents users from introducing privileged programs onto the system and allowing non-root users to execute them."
+    remediation: "Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /dev/shm partition. See the fstab(5) manual page for more information. Run the following command to remount /dev/shm using the updated options from /etc/fstab: # mount -o remount /dev/shm"
+    compliance:
+      - cis: ["1.1.8.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1548, T1548.001"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1038"]
+    condition: all
+    rules:
+      - 'c:findmnt --kernel /dev/shm -> r:\s/dev/shm\s && r:nosuid'
+
+  - id: 3025
+    title: "Disable Automounting (Automated)"
+    description: "autofs allows automatic mounting of devices, typically including CD/DVDs and USB drives."
+    rationale: "With automounting enabled anyone with physical access could attach a USB drive or disc and have its contents available in system even if they lacked permissions to mount it themselves."
+    remediation: "If there are no other packages that depends on autofs, remove the package with: # apt purge autofs OR if there are dependencies on the autofs package: Run the following commands to mask autofs: # systemctl stop autofs # systemctl mask autofs"
+    compliance:
+      - cis: ["1.1.9"]
+      - cis_csc_v8: ["10.3"]
+      - cis_csc_v7: ["8.5"]
+      - cmmc_v2.0: ["MP.L2-3.8.7"]
+      - hipaa: ["164.310(d)(1)"]
+      - iso_27001-2013: ["A.12.2.1"]
+      - mitre_techniques: ["T1068, T1068.000, T1203, T1203.000, T1211, T1211.000, T1212, T1212.000"]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: any
+    rules:
+      - "c:systemctl is-enabled autofs -> Failed to get unit file state for autofs.service: No such file or directory"
+      - "c:systemctl is-enabled autofs -> disabled"
+
+  # 1.1.1.1 Disable USB Storage (Automated) - Not implemented
+  - id: 3026
+    title: "Disable USB Storage (Automated)"
+    description: "USB storage provides a means to transfer and store files insuring persistence and availability of the files independent of network connection status. Its popularity and utility has led to USB-based malware being a simple and common means for network infiltration and a first step to establishing a persistent threat within a networked environment."
+    rationale: "Restricting USB access on the system will decrease the physical attack surface for a device and diminish the possible vectors to introduce malware."
+    remediation: ""
+    compliance:
+      - cis: ["1.1.9"]
+      - cis_csc_v8: ["10.3"]
+      - cis_csc_v7: ["8.5, 13.7"]
+      - cmmc_v2.0: ["MP.L2-3.8.7"]
+      - hipaa: ["164.310(d)(1)"]
+      - iso_27001-2013: ["A.12.2.1, A.8.3.1"]
+      - nist_sp_800-53 Rev. 5: ["SC-18(4)"]
+      - mitre_techniques: ["T1052, T1052.001, T1091, T1091.000, T1200, T1200.000"]
+      - mitre_tactics: ["TA0001, TA0010"]
+      - mitre_mitigations: ["M1034"]
+    condition: all
+    rules:
+      - 'c:'
+
+  # 1.2 Configure Software Updates
+
+  - id: 3027
+    title: "Ensure package manager repositories are configured (Manual)"
+    description: "Systems need to have package manager repositories configured to ensure they receive the latest patches and updates."
+    rationale: "If a system's package repositories are misconfigured important patches may not be identified or a rogue repository could introduce compromised software."
+    remediation: "Configure your package manager repositories according to site policy."
+    compliance:
+      - cis: ["1.2.1"]
+      - cis_csc_v8: ["7.3"]
+      - cis_csc_v7: ["3.4, 3.5"]
+      - cmmc_v2.0: ["SI.L1-3.14.1"]
+      - pci_dss_3.2.1: ["6.2"]
+      - nist_sp_800-53: ["SI-2(2)"]
+      - soc_2: ["CC7.1"]
+      - mitre_techniques: ["T1068, T1068.000, T1195, T1195.001, T1195.002, T1203, T1203.000, T1210, T1210.000, T1211, T1211.000, T1212, T1212.000"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_mitigations: ["M1051"]
+    condition: all
+    rules:
+      - "c:apt-cache policy"
+
+  - id: 3028
+    title: "Ensure GPG keys are configured (Manual)"
+    description: "Most packages managers implement GPG key signing to verify package integrity during installation."
+    rationale: "It is important to ensure that updates are obtained from a valid source to protect against spoofing that could lead to the inadvertent installation of malware on the system."
+    remediation: "Update your package manager GPG keys in accordance with site policy."
+    compliance:
+      - cis: ["1.2.2"]
+      - cis_csc_v8: ["7.3"]
+      - cis_csc_v7: ["3.4, 3.5"]
+      - cmmc_v2.0: ["SI.L1-3.14.1"]
+      - pci_dss_3.2.1: ["6.2"]
+      - nist_sp_800-53: ["SI-2(2)"]
+      - soc_2: ["CC7.1"]
+      - mitre_techniques: ["T1195, T1195.001, T1195.002"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_mitigations: ["M1051"]
+    condition: all
+    rules:
+      - "c:apt-key list"
+
+  # 1.3 Filesystem Integrity Checking
+
+  - id: 3029
+    title: "Ensure AIDE is installed (Automated)"
+    description: "AIDE takes a snapshot of filesystem state including modification times, permissions, and file hashes which can then be used to compare against the current state of the filesystem to detect modifications to the system."
+    rationale: "By monitoring the filesystem state compromised files can be detected to prevent or limit the exposure of accidental or malicious misconfigurations or modified binaries."
+    remediation: "Install AIDE using the appropriate package manager or manual installation: # apt install aide aide-common Configure AIDE as appropriate for your environment. Consult the AIDE documentation for options. Run the following commands to initialize AIDE: # aideinit # mv /var/lib/aide/aide.db.new /var/lib/aide/aide.db"
+    compliance:
+      - cis: ["1.3.1"]
+      - cis_csc_v8: ["3.14"]
+      - cis_csc_v7: ["14.9"]
+      - cmmc_v2.0: ["SI.L1-3.14.1"]
+      - pci_dss_3.2.1: ["6.2"]
+      - nist_sp_800-53: ["SI-2(2)"]
+      - soc_2: ["CC7.1"]
+      - mitre_techniques: ["T1036, T1036.002, T1036.003, T1036.004, T1036.005, T1565, T1565.001"]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    references:
+      - https://github.com/konstruktoid/hardening/blob/master/config/aidecheck.service
+      - https://github.com/konstruktoid/hardening/blob/master/config/aidecheck.timer
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' aide aide-common -> r:install ok installed"
+
+  - id: 3030
+    title: "Ensure filesystem integrity is regularly checked (Automated)"
+    description: "Periodic checking of the filesystem integrity is needed to detect changes to the filesystem."
+    rationale: "Periodic file checking allows the system administrator to determine on a regular basis if critical files have been changed in an unauthorized fashion."
+    remediation: "If cron will be used to schedule and run aide check: Run the following command: # crontab -u root -e Add the following line to the crontab: 0 5 * * * /usr/bin/aide.wrapper --config /etc/aide/aide.conf --check OR If aidecheck.service and aidecheck.timer will be used to schedule and run aide check: Create or edit the file /etc/systemd/system/aidecheck.service and add the following lines: [Unit] Description=Aide Check [Service] Type=simple ExecStart=/usr/bin/aide.wrapper --config /etc/aide/aide.conf --check [Install] WantedBy=multi-user.target . Create or edit the file /etc/systemd/system/aidecheck.timer and add the following lines: [Unit] Description=Aide check every day at 5AM [Timer] OnCalendar=*-*-* 05:00:00 Unit=aidecheck.service [Install] WantedBy=multi-user.target .Run the following commands: # chown root:root /etc/systemd/system/aidecheck.* # chmod 0644 /etc/systemd/system/aidecheck.* # systemctl daemon-reload # systemctl enable aidecheck.service # systemctl --now enable aidecheck.timer"
+    compliance:
+      - cis: ["1.3.2"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["14.9"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - pci_dss_3.2.1: ["10.1","10.2.2","10.2.4","10.2.5","10.3"]
+      - pci_dss_4.0: ["9.4.5","10.2","10.2.1","10.2.1.2","10.2.1.5"]
+      - nist_sp_800-53: ["AU-3(1)","AU-7"]
+      - soc_2: ["CC5.2","CC7.2"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - mitre_techniques: ["T1036, T1036.002, T1036.003, T1036.004, T1036.005, T1565, T1565.001"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - https://github.com/konstruktoid/hardening/blob/master/config/aidecheck.service
+      - https://github.com/konstruktoid/hardening/blob/master/config/aidecheck.timer
+    condition: any
+    rules:
+      - 'c:grep -Prs '^([^#\n\r]+\h+)?(\/usr\/s?bin\/|^\h*)aide(\.wrapper)?\h+(-- check|([^#\n\r]+\h+)?\$AIDEARGS)\b' /etc/cron.* /etc/crontab /var/spool/cron/ -> r:\.+'
+      - "c:systemctl is-enabled aidecheck.service -> enabled"
+      - "c:systemctl is-enabled aidecheck.timer -> enabled"
+      - "c:systemctl status aidecheck.timer -> enabled"
+
+  # 1.4 Secure Boot Settings
+  - id: 3031
+    title: "Ensure bootloader password is set (Automated)"
+    description: "Setting the boot loader password will require that anyone rebooting the system must enter a password before being able to set command line boot parameters"
+    rationale: "Requiring a boot password upon execution of the boot loader will prevent an unauthorized user from entering boot parameters or changing the boot partition. This prevents users from weakening security (e.g. turning off AppArmor at boot time)."
+    remediation: 'Create an encrypted password with grub-mkpasswd-pbkdf2 : # grub-mkpasswd-pbkdf2     Enter password: <password>      Reenter password: <password> PBKDF2 hash of your password is <encrypted-password> Add the following into a custom /etc/grub.d configuration file: cat <<EOF     set superusers="<username>"   password_pbkdf2 <username> <encrypted-password>      EOF     The superuser/user information and password should not be contained in the /etc/grub.d/00_header file as this file could be overwritten in a package update. If there is a requirement to be able to boot/reboot without entering the password, edit /etc/grub.d/10_linux and add --unrestricted to the line CLASS=  Example: CLASS="--class gnu-linux --class gnu --class os --unrestricted" Run the following command to update the grub2 configuration: # update-grub'
+    compliance:
+      - cis: ["1.4.1"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - pci_dss_4.0: ["2.2.2","8.3.5","8.3.6","8.6.3"]
+      - soc_2: ["CC6.1"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - nist_sp_800-53: ["IA-5 (1)"]
+      - mitre_techniques: ["T1542, T1542.000"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_mitigations: ["M1046"]
+    references:
+      - https://help.ubuntu.com/community/Grub2/Passwords
+    condition: any
+    rules:
+      - 'f:/boot/grub/grub.cfg -> r:^\s*\t*set superusers'
+      - 'f:/boot/grub/grub.cfg -> r:^\s*\t*password'
+
+  - id: 3032
+    title: "Ensure permissions on bootloader config are configured (Automated)"
+    description: "The grub configuration file contains information on boot settings and passwords for unlocking boot options."
+    rationale: "Setting the permissions to read and write for root only prevents non-root users from seeing the boot parameters or changing them. Non-root users who read the boot parameters may be able to identify weaknesses in security upon boot and be able to exploit them."
+    remediation: "Run the following commands to set permissions on your grub configuration: # chown root:root /boot/grub/grub.cfg # chmod u-wx,go-rwx /boot/grub/grub.cfg .Additional Information: This recommendation is designed around the grub bootloader, if LILO or another bootloader is in use in your environment enact equivalent settings. Replace /boot/grub/grub.cfg with the appropriate grub configuration file for your environment"
+    compliance:
+      - cis: ["1.4.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1542, T1542.000"]
+      - mitre_tactics: ["TA0005, TA0007"]
+      - mitre_mitigations: ["M1022"]
+    condition: all
+    rules:
+      - 'c:stat -L /boot/grub/grub.cfg -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+
+  - id: 3033
+    title: "Ensure authentication required for single user mode (Automated)"
+    description: "Single user mode is used for recovery when the system detects an issue during boot or by manual selection from the bootloader."
+    rationale: "Requiring authentication in single user mode prevents an unauthorized user from rebooting the system into single user to gain root privileges without credentials."
+    remediation: "Run the following command and follow the prompts to set a password for the root user: # passwd root"
+    compliance:
+      - cis: ["1.4.3"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - pci_dss_4.0: ["2.2.2","8.3.5","8.3.6","8.6.3"]
+      - soc_2: ["CC6.1"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - nist_sp_800-53: ["IA-5 (1)"]
+      - mitre_techniques: ["T1548, T1548.000"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    condition: all
+    rules:
+      - "f:/etc/shadow -> r:^root:*:|^root:!:"
+
+  # 1.5 Additional Process Hardening
+
+  # 1.5 Additional Process Hardening - Not implemented
+  - id: 3034
+    title: "Ensure address space layout randomization (ASLR) is enabled (Automated)"
+    description: "Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process."
+    rationale: "Randomly placing virtual memory regions will make it difficult to write memory page exploits as the memory placement will be consistently shifting."
+    remediation: 'Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: Example: # printf " kernel.randomize_va_space = 2 " >> /etc/sysctl.d/60-kernel_sysctl.conf .Run the following command to set the active kernel parameter: # sysctl -w kernel.randomize_va_space=2'
+    compliance:
+      - cis: ["1.5.1"]
+      - cis_csc_v8: ["10.5"]
+      - cis_csc_v7: ["8.3"]
+      - pci_dss_3.2.1: ["1.4"]
+      - nist_sp_800-53: ["SI-16"]
+      - soc_2: ["CC6.8"]
+      - mitre_techniques: ["T1068, T1068.000"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_mitigations: ["M1050"]
+    references:
+      - http://manpages.ubuntu.com/manpages/focal/man5/sysctl.d.5.html
+      - CCI-000366. The organization implements the security configuration settings
+      - NIST SP 800-53 :: CM-6 b
+      - NIST SP 800-53A :: CM-6.1 (iv)
+      - NIST SP 800-53 Revision 4 :: CM-6 b
+    condition: all
+    rules:
+      - 'c:grep -Rh ^kernel\.randomize_va_space /etc/sysctl.conf /etc/sysctl.d -> r:\s*\t*2$'
+      - 'c:sysctl kernel.randomize_va_space -> r:^kernel.randomize_va_space\s*\t*=\s*\t*2'
+
+  - id: 3035
+    title: "Ensure prelink is not installed (Automated)"
+    description: "prelink is a program that modifies ELF shared libraries and ELF dynamically linked binaries in such a way that the time needed for the dynamic linker to perform relocations at startup significantly decreases."
+    rationale: "The prelinking feature can interfere with the operation of AIDE, because it changes binaries. Prelinking can also increase the vulnerability of the system if a malicious user is able to compromise a common library such as libc."
+    remediation: "Run the following command to restore binaries to normal: # prelink -ua . Uninstall prelink using the appropriate package manager or manual installation: # apt purge prelink"
+    compliance:
+      - cis: ["1.5.2"]
+      - cis_csc_v8: ["3.14"]
+      - cis_csc_v7: ["14.9"]
+      - cmmc_v2.0: ["SI.L1-3.14.1"]
+      - pci_dss_3.2.1: ["6.2"]
+      - nist_sp_800-53: ["SI-2(2)"]
+      - soc_2: ["CC7.1"]
+      - mitre_techniques: ["T1055, T1055.009, T1065, T1065.001"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_mitigations: ["M1050"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' prelink -> r:ok not-installed"
+
+  - id: 3036
+    title: "Ensure Automatic Error Reporting is not enabled (Automated)"
+    description: "The Apport Error Reporting Service automatically generates crash reports for debugging."
+    rationale: "Apport collects potentially sensitive data, such as core dumps, stack traces, and log files. They can contain passwords, credit card numbers, serial numbers, and other private material."
+    remediation: "Edit /etc/default/apport and add or edit the enabled parameter to equal 0: enabled=0 Run the following commands to stop and disable the apport service # systemctl stop apport.service # systemctl --now disable apport.service -- OR -- Run the following command to remove the apport package: # apt purge apport"
+    compliance:
+      - cis: ["1.5.3"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1015", "T1133", "T1200", "T1076", "T1051"]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:dpkg-query -s apport > /dev/null 2>&1 && grep -Psi --'^\h*enabled\h*=\h*[^0]\b' /etc/default/apport"
+      - "c:systemctl is-active apport.service | grep '^active -> disabled"
+
+  - id: 3037
+    title: "Ensure core dumps are restricted (Automated)"
+    description: "A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file. The system provides the ability to set a soft limit for core dumps, but this can be overridden by the user."
+    rationale: "Setting a hard limit on core dumps prevents users from overriding the soft variable. If core dumps are required, consider setting limits for user groups (see limits.conf(5) ). In addition, setting the fs.suid_dumpable variable to 0 will prevent setuid programs from dumping core."
+    remediation: "Add the following line to /etc/security/limits.conf or a /etc/security/limits.d/* file: * hard core 0 .Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: fs.suid_dumpable = 0 .Run the following command to set the active kernel parameter: # sysctl -w fs.suid_dumpable=0 .IF systemd-coredump is installed: edit /etc/systemd/coredump.conf and add/modify the following lines: Storage=none ProcessSizeMax=0 .Run the command: systemctl daemon-reload"
+      - mitre_techniques: ["T1005, T1005.000"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - 'c:sysctl fs.suid_dumpable -> r:=\s*\t*0$'
+      - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> !r:^# && r:=\s*\t*0$'
+      - 'c:grep -Rh ^*[[:space:]]*hard[[:space:]][[:space:]]*core[[:space:]][[:space:]]* /etc/security/limits.conf /etc/security/limits.d -> r:\s*\t*0$'
+
+
+  # 1.6 Mandatory Access Control
+
+  - id: 3038
+    title: "Ensure AppArmor is installed (Automated)"
+    description: "AppArmor provides Mandatory Access Controls."
+    rationale: "Without a Mandatory Access Control system installed only the default Discretionary Access Control system will be available."
+    remediation: "Install AppArmor. # apt install apparmor apparmor-utils"
+    compliance:
+      - cis: ["1.6.1.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1068, T1068.000, T1565, T1565.001, T1565.003"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_mitigations: ["M1026"]
+    references:
+      - AppArmor Documentation: http://wiki.apparmor.net/index.php/Documentation
+      - Ubuntu AppArmor Documentation: https://help.ubuntu.com/community/AppArmor
+      - SUSE AppArmor Documentation: https://www.suse.com/documentation/apparmor/
+    condition: all
+    rules:
+      - 'c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' apparmor apparmor-utils -> r:install ok installed'
+
+  - id: 3039
+    title: "Ensure AppArmor is enabled in the bootloader configuration (Automated)"
+    description: "Configure AppArmor to be enabled at boot time and verify that it has not been overwritten by the bootloader boot parameters. Note: This recommendation is designed around the grub bootloader, if LILO or another bootloader is in use in your environment enact equivalent settings."
+    rationale: "AppArmor must be enabled at boot time in your bootloader configuration to ensure that the controls it provides are not overridden."
+    remediation: 'Edit /etc/default/grub and add the apparmor=1 and security=apparmor parameters to the GRUB_CMDLINE_LINUX= line GRUB_CMDLINE_LINUX="apparmor=1 security=apparmor" Run the following command to update the grub2 configuration: # update-grub'
+    compliance:
+      - cis: ["1.6.1.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1068, T1068.000, T1565, T1565.001, T1565.003"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_mitigations: ["M1026"]
+    references:
+      - AppArmor Documentation: http://wiki.apparmor.net/index.php/Documentation
+      - Ubuntu AppArmor Documentation: https://help.ubuntu.com/community/AppArmor
+      - SUSE AppArmor Documentation: https://www.suse.com/documentation/apparmor/
+    condition: all
+    rules:
+      - 'f:/boot/grub/grub.cfg -> r:^\s*linux && !r:apparmor=1'
+      - 'f:/boot/grub/grub.cfg -> r:^\s*linux && !r:security=apparmor'
+
+  - id: 3040
+    title: "Ensure all AppArmor Profiles are in enforce or complain mode (Automated)"
+    description: "AppArmor profiles define what resources applications are able to access."
+    rationale: "Security configuration requirements vary from site to site. Some sites may mandate a policy that is stricter than the default policy, which is perfectly acceptable. This item is intended to ensure that any policies that exist on the system are activated."
+    remediation: "Run the following command to set all profiles to enforce mode: # aa-enforce /etc/apparmor.d/* OR Run the following command to set all profiles to complain mode: # aa-complain /etc/apparmor.d/* Note: Any unconfined processes may need to have a profile created or activated for them and then be restarted"
+    compliance:
+      - cis: ["1.6.1.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: [""]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: [""]
+    references:
+      - AppArmor Documentation: http://wiki.apparmor.net/index.php/Documentation
+      - Ubuntu AppArmor Documentation: https://help.ubuntu.com/community/AppArmor
+      - SUSE AppArmor Documentation: https://www.suse.com/documentation/apparmor/
+    condition: all
+    rules:
+      - "c:apparmor_status -> r:0 processes are unconfined"
+
+  - id: 3041
+    title: "Ensure all AppArmor Profiles are enforcing (Automated)"
+    description: "AppArmor profiles define what resources applications are able to access."
+    rationale: "Security configuration requirements vary from site to site. Some sites may mandate a policy that is stricter than the default policy, which is perfectly acceptable. This item is intended to ensure that any policies that exist on the system are activated."
+    remediation: "Run the following command to set all profiles to enforce mode: # aa-enforce /etc/apparmor.d/* Note: Any unconfined processes may need to have a profile created or activated for them and then be restarted"
+    compliance:
+      - cis: ["1.5.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1068, T1068.000, T1565, T1565.001, T1565.003"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: [""]
+    references:
+      - AppArmor Documentation: http://wiki.apparmor.net/index.php/Documentation
+      - Ubuntu AppArmor Documentation: https://help.ubuntu.com/community/AppArmor
+      - SUSE AppArmor Documentation: https://www.suse.com/documentation/apparmor/
+    condition: all
+    rules:
+      - "c:apparmor_status -> r:0 processes are unconfined"
+
+  # 1.7 Command Line Warning Banners
+
+  - id: 3042
+    title: "Ensure message of the day is configured properly (Automated)"
+    description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \m - machine architecture \r - operating system release \s - operating system name \v - operating system version"
+    rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the " uname -a " command once they have logged in."
+    remediation: "Edit the /etc/motd file with the appropriate contents according to your site policy, remove any instances of \m , \r , \s , \v or references to the OS platform OR if the motd is not used, this file can be removed. Run the following command to remove the motd file: # rm /etc/motd"
+    compliance:
+      - cis: ["1.7.1"]
+      - mitre_techniques: ["T1082, T1082.000, T1592, T1592.004"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_mitigations: [""]
+    references:
+      - http://www.justice.gov/criminal/cybercrime/
+    condition: all
+    rules:
+      - 'not f:/etc/motd -> r:\\v|\\r|\\m|\\s|Debian|Ubuntu'
+
+  - id: 3043
+    title: "Ensure local login warning banner is configured properly (Automated)"
+    description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \m - machine architecture \r - operating system release \s - operating system name \v - operating system version - or the operating system's name"
+    rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the " uname -a " command once they have logged in."
+    remediation: "Edit the /etc/issue file with the appropriate contents according to your site policy, remove any instances of \m , \r , \s , \v or references to the OS platform # echo "Authorized uses only. All activity may be monitored and reported." > /etc/issue"
+    compliance:
+      - cis: ["1.7.2"]
+      - mitre_techniques: ["T1082, T1082.000, T1592, T1592.004"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_mitigations: [""]
+    references:
+      - http://www.justice.gov/criminal/cybercrime/
+    condition: all
+    rules:
+      - 'f:/etc/issue -> r:\\v|\\r|\\m|\\s|Debian|Ubuntu'
+
+  - id: 3044
+    title: "Ensure remote login warning banner is configured properly (Automated)"
+    description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \m - machine architecture \r - operating system release \s - operating system name \v - operating system version"
+    rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the " uname -a " command once they have logged in."
+    remediation: "Edit the /etc/issue.net file with the appropriate contents according to your site policy, remove any instances of \m , \r , \s , \v or references to the OS platform # echo "Authorized uses only. All activity may be monitored and reported." > /etc/issue.net"
+    compliance:
+      - cis: ["1.7.3"]
+      - mitre_techniques: ["T1018, T1018.000, T1082, T1082.000, T1592, T1592.004"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_mitigations: [""]
+    references:
+      - http://www.justice.gov/criminal/cybercrime/
+    condition: all
+    rules:
+      - 'f:/etc/issue.net -> r:\\v|\\r|\\m|\\s|Debian|Ubuntu'
+
+  - id: 3045
+    title: "Ensure permissions on /etc/motd are configured (Automated)"
+    description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users."
+    rationale: "If the /etc/motd file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
+    remediation: "Run the following commands to set permissions on /etc/motd : # chown root:root $(readlink -e /etc/motd) # chmod u-x,go-wx $(readlink -e /etc/motd) OR run the following command to remove the /etc/motd file: # rm /etc/motd"
+    compliance:
+      - cis: ["1.7.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1222, T1222.002"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - http://www.justice.gov/criminal/cybercrime/
+    condition: all
+    rules:
+      - 'c:stat -L /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+
+  - id: 3046
+    title: "Ensure permissions on /etc/issue are configured (Automated)"
+    description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals."
+    rationale: "If the /etc/issue file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
+    remediation: "Run the following commands to set permissions on /etc/issue : # chown root:root $(readlink -e /etc/issue) # chmod u-x,go-wx $(readlink -e /etc/issue)"
+    compliance:
+      - cis: ["1.7.5"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1222, T1222.002"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - http://www.justice.gov/criminal/cybercrime/
+    condition: all
+    rules:
+      - 'c:stat -L /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+
+  - id: 3047
+    title: "Ensure permissions on /etc/issue.net are configured (Automated)"
+    description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services."
+    rationale: "If the /etc/issue.net file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
+    remediation: "Run the following commands to set permissions on /etc/issue.net : # chown root:root $(readlink -e /etc/issue.net) # chmod u-x,go-wx $(readlink -e /etc/issue.net)"
+    compliance:
+      - cis: ["1.7.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1222, T1222.002"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - http://www.justice.gov/criminal/cybercrime/
+    condition: all
+    rules:
+      - 'c:stat -L /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+
+  # 1.8 GNOME Display Manager
+
+  - id: 3048
+    title: "Ensure GNOME Display Manager is removed (Automated)"
+    description: "The GNOME Display Manager (GDM) is a program that manages graphical display servers and handles graphical user logins."
+    rationale: "If a Graphical User Interface (GUI) is not required, it should be removed to reduce the attack surface of the system."
+    remediation: "Run the following command to uninstall gdm3: # apt purge gdm3"
+    compliance:
+      - cis: ["1.8.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1543, T1543.002"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - 'c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' gdm3 -> r: unknown ok not-installed'
+
+  # 1.8.2 Ensure GDM login banner is configured (Automated) - Not implemented
+  - id: 3049
+    title: "Ensure GDM login banner is configured (Automated)"
+    description: "GDM is the GNOME Display Manager which handles graphical login for GNOME based systems."
+    rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place."
+    remediation: ""
+    compliance:
+      - cis: ["1.8.2"]
+      - mitre_techniques: [""]
+      - mitre_tactics: ["TA0007"]
+      - mitre_mitigations: [""]
+    references:
+      - https://help.gnome.org/admin/system-admin-guide/stable/login-banner.html.en
+    condition: all
+    rules:
+      - 'c:'
+
+  # 1.8.3 Ensure GDM disable-user-list option is enabled (Automated) - Not implemented
+  - id: 3050
+    title: "Ensure GDM disable-user-list option is enabled (Automated)"
+    description: "GDM is the GNOME Display Manager which handles graphical login for GNOME based systems. The disable-user-list option controls if a list of users is displayed on the login screen"
+    rationale: "Displaying the user list eliminates half of the Userid/Password equation that an unauthorized person would need to log on."
+    remediation: ""
+    compliance:
+      - cis: ["1.8.3"]
+      - mitre_techniques: ["T1078, T1078.001, T1078.002, T1078.003, T1087, T1087.001, T1087.002"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_mitigations: ["M1028"]
+    references:
+      - https://help.gnome.org/admin/system-admin-guide/stable/login-userlist-disable.html.en
+    condition: all
+    rules:
+      - 'c:'
+
+  # 1.8.4 Ensure GDM screen locks when the user is idle (Automated) - Not implemented
+  - id: 3051
+    title: "Ensure GDM screen locks when the user is idle (Automated)"
+    description: "GNOME Desktop Manager can make the screen lock automatically whenever the user is idle for some amount of time. idle-delay=uint32 {n} - Number of seconds of inactivity before the screen goes blank. lock-delay=uint32 {n} - Number of seconds after the screen is blank before locking the screen"
+    rationale: "Setting a lock-out value reduces the window of opportunity for unauthorized user access to another user's session that has been left unattended."
+    remediation: ""
+    compliance:
+      - cis: ["1.8.4"]
+      - mitre_techniques: ["T1222, T1222.002"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+      references:
+      - 1. https://help.gnome.org/admin/system-admin-guide/stable/desktop
+      - 2. https://help.gnome.org/admin/system-admin-guide/stable/login-userlist-disable.html.en
+    condition: all
+    rules:
+      - 'c:'
+
+  # 1.8.5 Ensure GDM screen locks cannot be overridden (Automated) - Not implemented
+  - id: 3052
+    title: "Ensure GDM screen locks cannot be overridden (Automated)"
+    description: ""
+    rationale: ""
+    remediation: ""
+    compliance:
+      - cis: ["1.8.5"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+
+      - mitre_techniques: ["T1222, T1222.002"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    condition: all
+    rules:
+      - 'c:'
+
+  # 1.8.6 Ensure GDM automatic mounting of removable media is disabled (Automated) - Not implemented
+  - id: 3053
+    title: "Ensure GDM automatic mounting of removable media is disabled (Automated)"
+    description: ""
+    rationale: ""
+    remediation: ""
+    compliance:
+      - cis: ["1.8.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+
+      - mitre_techniques: ["T1222, T1222.002"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    condition: all
+    rules:
+      - 'c:'
+
+# 1.8.7 Ensure GDM disabling automatic mounting of removable media is not overridden - Not implemented
+  - id: 3054
+    title: "Ensure GDM disabling automatic mounting of removable media is not overridden (Automated)"
+    description: ""
+    rationale: ""
+    remediation: ""
+    compliance:
+      - cis: ["1.8.7"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1222, T1222.002"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    condition: all
+    rules:
+      - 'c:'
+
+# 1.8.8 Ensure GDM autorun-never is enabled (Automated) - Not implemented
+  - id: 3055
+    title: "Ensure GDM autorun-never is enabled (Automated)"
+    description: ""
+    rationale: ""
+    remediation: ""
+    compliance:
+      - cis: ["1.8.8"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1222, T1222.002"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    condition: all
+    rules:
+      - 'c:'
+
+# 1.8.9 Ensure GDM autorun-never is not overridden (Automated) - Not implemented
+  - id: 3056
+    title: "Ensure GDM autorun-never is not overridden (Automated)"
+    description: ""
+    rationale: ""
+    remediation: ""
+    compliance:
+      - cis: ["1.8.9"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1222, T1222.002"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    condition: all
+    rules:
+      - 'c:'
+
+  - id: 3057
+    title: "Ensure XDCMP is not enabled (Automated)"
+    description: "X Display Manager Control Protocol (XDMCP) is designed to provide authenticated access to display management services for remote displays"
+    rationale: "XDMCP is inherently insecure. XDMCP is not a ciphered protocol. This may allow an attacker to capture keystrokes entered by a user XDMCP is vulnerable to man-in-the-middle attacks. This may allow an attacker to steal the credentials of legitimate users by impersonating the XDMCP server."
+    remediation: "Edit the file /etc/gdm3/custom.conf and remove the line: Enable=true"
+    compliance:
+      - cis: ["1.8.10"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1040, T1040.000, T1056, T1056.001, T1557"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_mitigations: ["M1050"]
+    condition: all
+    rules:
+      - 'c:grep -Eis '^\s*Enable\s*=\s*true' /etc/gdm3/custom.conf'
+
+  - id: 3058
+    title: "Ensure updates, patches, and additional security software are installed (Automated)"
+    description: "Periodically patches are released for included software either due to security flaws or to include additional functionality."
+    rationale: "Newer patches may contain security enhancements that would not be available through the latest full update. As a result, it is recommended that the latest software patches be used to take advantage of the latest functionality. As with any software installation, organizations need to determine if a given update meets their requirements and verify the compatibility and supportability of any additional software against the update revision that is selected."
+    remediation: "Run the following command to update all packages following local site policy guidance on applying updates and patches: # apt upgrade OR # apt dist-upgrade"
+    compliance:
+      - cis: ["1.9"]
+      - cis_csc_v8: ["7.3"]
+      - cis_csc_v7: ["3.4, 3.5"]
+      - cmmc_v2.0: ["SI.L1-3.14.1"]
+      - pci_dss_3.2.1: ["6.2"]
+      - nist_sp_800-53: ["SI-2(2)"]
+      - soc_2: ["CC7.1"]
+    condition: all
+    rules:
+      - "c:apt -s upgrade -> r:^The following packages will be upgraded"
+
+############################################################
+# 2 Services
+############################################################
+
+# 2.1 Configure Time Synchronization
+# 2.1.1 Ensure time synchronization is in use
+
+# 2.1.1.1 Ensure a single time synchronization daemon is in use (Automated) - Not implemented
+  - id: 3059
+    title: "Ensure a single time synchronization daemon is in use (Automated)"
+    description: "System time should be synchronized between all systems in an environment. This is typically done by establishing an authoritative time server or set of servers and having all systems synchronize their clocks to them."
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and ensures log files have consistent time records across the enterprise, which aids in forensic investigations."
+    remediation: "On physical systems, and virtual systems where host based time synchronization is not available. Select one of the three time synchronization daemons; chrony (1), systemd-timesyncd (2), or ntp (3), and following the remediation procedure for the selected daemon. Note: enabling more than one synchronization daemon could lead to unexpected or unreliable results: 1. chrony .Run the following command to install chrony: # apt install chrony .Run the following commands to stop and mask the systemd-timesyncd daemon: # systemctl stop systemd-timesyncd.service # systemctl --now mask systemd-timesyncd.service .Run the following command to remove the ntp package: # apt purge ntp .NOTE: Subsection: Configure chrony should be followed Subsections: Configure systemd-timesyncd and Configure ntp should be skipped 2. systemd-timesyncd .Run the following command to remove the chrony package: # apt purge chrony .Run the following command to remove the ntp package: # apt purge ntp .NOTE: Subsection: Configure systemd-timesyncd should be followed Subsections: Configure chrony and Configure ntp should be skipped 3. ntp .Run the following command to install ntp: # apt install ntp .Run the following commands to stop and mask the systemd-timesyncd daemon:# systemctl stop systemd-timesyncd.service # systemctl --now mask systemd-timesyncd.service Run the following command to remove the chrony package: # apt purge chrony .NOTE: Subsection: Configure ntp should be followed Subsections: Configure chrony and Configure systemd-timesyncd should be skipped" 
+    compliance:
+      - cis: ["2.1.1.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_techniques: ["T1070, T1070.002, T1562, T1562.001"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: [""]
+    condition: any
+    rules:
+      - "c:dpkg -s ntp -> r:install ok installed"
+      - "c:dpkg -s chrony -> r:install ok installed"
+      - "c:systemctl is-enabled systemd-timesyncd -> enabled"
+
+
+# 2.1.2 Configure chrony
+
+  - id: 3060
+    title: "Ensure chrony is configured with authorized timeserver (Manual)"
+    description: "server: The server directive specifies an NTP server which can be used as a time source. The client-server relationship is strictly hierarchical: a client might synchronize its system time to that of the server, but the server’s system time will never be influenced by that of a client. This directive can be used multiple times to specify multiple servers. The directive is immediately followed by either the name of the server, or its IP address. (2) pool: The syntax of this directive is similar to that for the server directive, except that it is used to specify a pool of NTP servers rather than a single NTP server. The pool name is expected to resolve to multiple addresses which might change over time. This directive can be used multiple times to specify multiple pools. All options valid in the server directive can be used in this directive too."
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "Edit /etc/chrony/chrony.conf or a file ending in .sources in /etc/chrony/sources.d/ and add or edit server or pool lines as appropriate according to local site policy: <[server|pool]> <[remote-server|remote-pool]> Examples: pool directive: pool time.nist.gov iburst maxsources 4 #The maxsources option is unique to the pool directive server directive: server time-a-g.nist.gov iburst server 132.163.97.3 iburst server time-d-b.nist.gov iburst Run one of the following commands to load the updated time sources into chronyd running config: # systemctl restart chronyd - OR if sources are in a .sources file - # chronyc reload sources OR If another time synchronization service is in use on the system, run the following command to remove chrony from the system:# apt purge chrony" 
+    compliance:
+      - cis: ["2.1.2.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_techniques: ["T1070, T1070.002, T1562, T1562.001"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_mitigations: ["M1022"]
+    condition: all
+    rules:
+      - 'f:/etc/chrony/chrony.conf -> r:^server\.+|^pool\.+'
+
+  - id: 3061
+    title: "Ensure chrony is running as user _chrony (Automated)"
+    description: "The chrony package is installed with a dedicated user account _chrony. This account is granted the access required by the chronyd service."
+    rationale: "The chronyd service should run with only the required privlidges"
+    remediation: "Add or edit the user line to /etc/chrony/chrony.conf or a file ending in .conf in /etc/chrony/conf.d/: user _chrony OR If another time synchronization service is in use on the system, run the following command to remove chrony from the system: # apt purge chrony Default Value: user _chrony" 
+    compliance:
+      - cis: ["2.1.2.2"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+    condition: all
+    rules:
+      - 'c:ps -ef | awk '(/[c]hronyd/ && $1!="_chrony") { print $1 }''
+
+  - id: 3062
+    title: "Ensure chrony is enabled and running (Automated)"
+    description: "chrony is a daemon for synchronizing the system clock across the network."
+    rationale: "chrony needs to be enabled and running in order to synchronize the system to a timeserver. Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "IF chrony is in use on the system, run the following commands: Run the following command to unmask chrony.service: # systemctl unmask chrony.service .Run the following command to enable and start chrony.service: # systemctl --now enable chrony.service OR If another time synchronization service is in use on the system, run the following command to remove chrony: # apt purge chrony" 
+    compliance:
+      - cis: ["2.1.2.3"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+    condition: any
+    rules:
+      - 'c:systemctl is-enabled chrony.service -> r:enabled'
+      - 'c:systemctl is-active chrony.service -> r:active'
+
+# 2.1.3 Configure chrony
+
+  - id: 3063
+    title: "Ensure systemd-timesyncd configured with authorized timeserver (Manual)"
+    description: "(1)NTP=A space-separated list of NTP server host names or IP addresses. During runtime this list is combined with any per-interface NTP servers acquired from systemd-networkd.service(8). systemd-timesyncd will contact all configured system or per-interface servers in turn, until one responds. When the empty string is assigned, the list of NTP servers is reset, and all prior assignments will have no effect. This setting defaults to an empty list.(2) FallbackNTP= A space-separated list of NTP server host names or IP addresses to be used as the fallback NTP servers. Any per-interface NTP servers obtained from systemd- networkd.service(8) take precedence over this setting, as do any servers set via NTP= above. This setting is hence only relevant if no other NTP server information is known. When the empty string is assigned, the list of NTP servers is reset, and all prior assignments will have no effect. If this option is not given, a compiled-in list of NTP servers is used."
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations"
+    remediation: "Edit or create a file in /etc/systemd/timesyncd.conf.d ending in .conf and add the NTP= and/or FallbackNTP= lines to the [Time] section: Example:[Time] NTP=time.nist.gov # Uses the generic name for NIST's time servers -AND/OR- FallbackNTP=time-a-g.nist.gov time-b-g.nist.gov time-c-g.nist.gov # Space separated list of NIST time servers Run the following command to reload the systemd-timesyncd configuration: # systemctl try-reload-or-restart systemd-timesyncd OR If another time synchronization service is in use on the system, run the following command to stop and mask systemd-timesyncd: # systemctl --now mask systemd-timesyncd Default Value: #NTP= #FallbackNTP=" 
+    compliance:
+      - cis: ["2.1.3.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_techniques: ["T1070, T1070.002, T1562, T1562.001"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - https://www.freedesktop.org/software/systemd/man/timesyncd.conf.html
+      - https://tf.nist.gov/tf-cgi/servers.cgi
+    condition: all
+    rules:
+      - 'c:find /etc/systemd -type f -name '*.conf' -exec grep -Ph '^\h*(NTP|FallbackNTP)=\H+' {} + -> r:NPT= FallbackNTP='
+
+  - id: 3064
+    title: "Ensure systemd-timesyncd is enabled and running (Automated)"
+    description: "systemd-timesyncd is a daemon that has been added for synchronizing the system clock across the network"
+    rationale: "systemd-timesyncd needs to be enabled and running in order to synchronize the system to a timeserver. Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations"
+    remediation: "IF systemd-timesyncd is in use on the system, run the following commands: Run the following command to unmask systemd-timesyncd.service: # systemctl unmask systemd-timesyncd.service Run the following command to enable and start systemd-timesyncd.service: # systemctl --now enable systemd-timesyncd.service OR If another time synchronization service is in use on the system, run the following command to stop and mask systemd-timesyncd: # systemctl --now mask systemd-timesyncd.service" 
+    compliance:
+      - cis: ["2.1.3.2"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+    condition: any
+    rules:
+      - 'c:systemctl is-enabled systemd-timesyncd.service -> r:enabled'
+      - 'c:systemctl is-active systemd-timesyncd.service -> active'
+
+# 2.1.4 Configure ntp
+
+  - id: 3065
+    title: "Ensure ntp access control is configured (Automated)"
+    description: "ntp Access Control Commands: restrict address [mask mask] [ippeerlimit int] [flag ...] The address argument expressed in dotted-quad form is the address of a host or network. Alternatively, the address argument can be a valid host DNS name. The mask argument expressed in dotted-quad form defaults to 255.255.255.255, meaning that the address is treated as the address of an individual host. A default entry (address 0.0.0.0, mask 0.0.0.0) is always included and is always the first entry in the list. Note: the text string default, with no mask option, may be used to indicate the default entry. The ippeerlimit directive limits the number of peer requests for each IP to int, where a value of -1 means "unlimited", the current default. A value of 0 means "none". There would usually be at most 1 peering request per IP, but if the remote peering requests are behind a proxy there could well be more than 1 per IP. In the current implementation, flag always restricts access, i.e., an entry with no flags indicates that free access to the server is to be given. The flags are not orthogonal, in that more restrictive flags will often make less restrictive ones redundant. The flags can generally be classed into two categories, those which restrict time service and those which restrict informational queries and attempts to do run-time reconfiguration of the server.One or more of the following flags may be specified: kod - If this flag is set when an access violation occurs, a kiss-o'-death (KoD) packet is sent. KoD packets are rate limited to no more than one per second. If another KoD packet occurs within one second after the last one, the packet is dropped. limited - Deny service if the packet spacing violates the lower limits specified in the discard command. A history of clients is kept using the monitoring capability of ntpd. Thus, monitoring is always active as long as there is a restriction entry with the limited flag. lowpriotrap - Declare traps set by matching hosts to be low priority. The number of traps a server can maintain is limited (the current limit is 3). Traps are usually assigned on a first come, first served basis, with later trap requestors being denied service. This flag modifies the assignment algorithm by allowing low priority traps to be overridden by later requests for normal priority traps. noepeer - Deny ephemeral peer requests, even if they come from an authenticated source. Note that the ability to use a symmetric key for authentication may be restricted to one or more IPs or subnets via the third field of the ntp.keys file. This restriction is not enabled by default, to maintain backward compatibility. Expect noepeer to become the default in ntp-4.4. nomodify - Deny ntpq and ntpdc queries which attempt to modify the state of the server (i.e., run time reconfiguration). Queries which return information are permitted. noquery - Deny ntpq and ntpdc queries. Time service is not affected. nopeer - Deny unauthenticated packets which would result in mobilizing a new association. This includes broadcast and symmetric active packets when a configured association does not exist. It also includes pool associations, so if you want to use servers from a pool directive and also want to use nopeer by default you'll want a restrict source ... line as well that does not include the nopeer directive. noserve - Deny all packets except ntpq and ntpdc queries.notrap - Decline to provide mode 6 control message trap service to matching hosts. The trap service is a subsystem of the ntpq control message protocol which is intended for use by remote event logging programs. notrust - Deny service unless the packet is cryptographically authenticated. ntpport - This is actually a match algorithm modifier, rather than a restriction flag. Its presence causes the restriction entry to be matched only if the source port in the packet is the standard NTP UDP port (123). Both ntpport and non- ntpport may be specified. The ntpport is considered more specific and is sorted later in the list."
+    rationale: "If ntp is in use on the system, proper configuration is vital to ensuring time synchronization is accurate."
+    remediation: "Add or edit restrict lines in /etc/ntp.conf to match the following: restrict -4 default kod nomodify notrap nopeer noquery restrict -6 default kod nomodify notrap nopeer noquery ORIf another time synchronization service is in use on the system, run the following command to remove ntp from the system: # apt purge ntp Default Value: restrict -4 default kod notrap nomodify nopeer noquery limited restrict -6 default kod notrap nomodify nopeer noquery limited" 
+    compliance:
+      - cis: ["2.1.4.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+    references:
+      - http://www.ntp.org/
+      - ntp.conf(5)
+      - ntpd(8)
+    condition: any
+    rules:
+      - 'f:/etc/ntp.conf -> r:^restrict\s+-4\s+default|^restrict\s+default && r:\s+kod\s+ && r:\s+nomodify\s+ && r:\s+notrap\s+ && r:\s+nopeer\s+ && r:\s+noquery'
+      - 'f:/etc/ntp.conf -> r:^restrict\s+-6\s+default && r:\s+kod\s+ && r:\s+nomodify\s+ && r:\s+notrap\s+ && r:\s+nopeer\s+ && r:\s+noquery'
+
+  - id: 3066
+    title: "Ensure ntp is configured with authorized timeserver (Manual)"
+    description: "The various modes are determined by the command keyword and the type of the required IP address. Addresses are classed by type as (s) a remote server or peer (IPv4 class A, B and C), (b) the broadcast address of a local interface, (m) a multicast address (IPv4 class D), or (r) a reference clock address (127.127.x.x). Note: That only those options applicable to each command are listed below. Use of options not listed may not be caught as an error, but may result in some weird and even destructive behavior. If the Basic Socket Interface Extensions for IPv6 (RFC-2553) is detected, support for the IPv6 address family is generated in addition to the default support of the IPv4 address family. In a few cases, including the reslist billboard generated by ntpq or ntpdc, IPv6 addresses are automatically generated. IPv6 addresses can be identified by the presence of colons “:” in the address field. IPv6 addresses can be used almost everywhere where IPv4 addresses can be used, with the exception of reference clock addresses, which are always IPv4. Note: In contexts where a host name is expected, a -4 qualifier preceding the host name forces DNS resolution to the IPv4 namespace, while a -6 qualifier forces DNS resolution to the IPv6 namespace. See IPv6 references for the equivalent classes for that address family. (1)pool - For type s addresses, this command mobilizes a persistent client mode association with a number of remote servers. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. (2)server - For type s and r addresses, this command mobilizes a persistent client mode association with the specified remote server or local radio clock. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. This command should not be used for type b or m addresses."
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations"
+    remediation: "Edit /etc/ntp.conf and add or edit server or pool lines as appropriate according to local site policy: <[server|pool]> <[remote-server|remote-pool]> Examples: pool mode: pool time.nist.gov iburst server mode: server time-a-g.nist.gov iburst server 132.163.97.3 iburst server time-d-b.nist.gov iburst Run the following command to load the updated time sources into ntp running config: # systemctl restart ntp OR If another time synchronization service is in use on the system, run the following command to remove ntp from the system: # apt purge ntp" 
+    compliance:
+      - cis: ["2.1.4.2"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_techniques: ["T1070, T1070.002, T1498, T1498.002, T1562, T1562.001"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - http://www.ntp.org/
+      - https://tf.nist.gov/tf-cgi/servers.cgi
+      - ntp.conf(5)
+      - ntpd(8)
+    condition: all
+    rules:
+      - 'c:grep -P -- '^\h*(server|pool)\h+\H+' /etc/ntp.conf -> r: pool server'
+
+  - id: 3067
+    title: "Ensure ntp is running as user ntp (Automated)"
+    description: "The ntp package is installed with a dedicated user account ntp. This account is granted the access required by the ntpd daemon Note: If chrony or systemd-timesyncd are used, ntp should be removed and this section skipped This recommendation only applies if ntp is in use on the system Only one time synchronization method should be in use on the system"
+    rationale: "The ntpd daemon should run with only the required privlidge"
+    remediation: "Add or edit the following line in /etc/init.d/ntp: RUNASUSER=ntp .Run the following command to restart ntp.servocee: # systemctl restart ntp.service OR If another time synchronization service is in use on the system, run the following command to remove ntp from the system: # apt purge ntp Default Value: user ntp" 
+    compliance:
+      - cis: ["2.1.4.3"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+    condition: any
+    rules:
+      - "ps -ef | awk '(/[n]tpd/ && $1!="ntp") { print $1 }'"
+      - 'grep -P -- '^\h*RUNASUSER=' /etc/init.d/ntp -> r:RUNASUSER=ntp'
+
+  - id: 3068
+    title: "Ensure ntp is enabled and running (Automated)"
+    description: "ntp is a daemon for synchronizing the system clock across the network"
+    rationale: "ntp needs to be enabled and running in order to synchronize the system to a timeserver. Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations"
+    remediation: "IF ntp is in use on the system, run the following commands: Run the following command to unmask ntp.service: # systemctl unmask ntp.service Run the following command to enable and start ntp.service: # systemctl --now enable ntp.service OR If another time synchronization service is in use on the system, run the following command to remove ntp: # apt purge ntp" 
+    compliance:
+      - cis: ["2.1.4.4"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+    condition: any
+    rules:
+      - 'c:systemctl is-enabled ntp.service -> r:enabled'
+      - 'c:systemctl is-active ntp.service -> r:active'
+
+
+# 2.2 Special Purpose Services
+
+  - id: 3069
+    title: "Ensure X Window System is not installed (Automated)"
+    description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
+    rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
+    remediation: "Remove the X Windows System packages: apt purge xserver-xorg*" 
+    compliance:
+      - cis: ["2.2.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: none
+    rules:
+      - 'c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' xserver-xorg* | grep -Pi '\h+installed\b' -> r:^\wi\s*xserver-xorg"
+
+  - id: 3070
+    title: "Ensure Avahi Server is not installed (Automated)"
+    description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
+    rationale: "Automatic discovery of network services is not normally required for system functionality. It is recommended to remove this package to reduce the potential attack surface."
+    remediation: "Run the following commands to remove avahi-daemon: # systemctl stop avahi-daaemon.service # systemctl stop avahi-daemon.socket # apt purge avahi-daemon" 
+    compliance:
+      - cis: ["2.2.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - 'c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' avahi-daemon -> r:unknown ok not-installed'
+
+  - id: 3071
+    title: "Ensure CUPS is not installed (Automated)"
+    description: "The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability."
+    rationale: "If the system does not need to print jobs or accept print jobs from other systems, it is recommended that CUPS be removed to reduce the potential attack surface."
+    remediation: "Run one of the following commands to remove cups : # apt purge cups" 
+    compliance:
+      - cis: ["2.2.3"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    references:
+      - More detailed documentation on CUPS is available at the project homepage at http://www.cups.org.
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' cups -> r:unknown ok not-installed"
+
+  - id: 3072
+    title: "Ensure DHCP Server is not installed (Automated)"
+    description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
+    rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that this package be removed to reduce the potential attack surface."
+    remediation: "Run the following command to remove isc-dhcp-server: # apt purge isc-dhcp-server" 
+    compliance:
+      - cis: ["2.2.4"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    references:
+      - More detailed documentation on DHCP is available at http://www.isc.org/software/dhcp.
+    condition: all
+    rules:
+      - "dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' isc-dhcp-server -> r:unknown ok not-installed"
+
+  - id: 3073
+    title: "Ensure LDAP server is not installed (Automated)"
+    description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
+    rationale: "If the system will not need to act as an LDAP server, it is recommended that the software be removed to reduce the potential attack surface."
+    remediation: "Run one of the following commands to remove slapd: # apt purge slapd" 
+    compliance:
+      - cis: ["2.2.5"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    references:
+      - For more detailed documentation on OpenLDAP, go to the project homepage at http://www.openldap.org.
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' slapd -> r:unknown ok not-installed"
+
+  - id: 3074
+    title: "Ensure NFS is not installed (Automated)"
+    description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
+    rationale: "If the system does not export NFS shares, it is recommended that the nfs-kernel-server package be removed to reduce the remote attack surface."
+    remediation: "Run the following command to remove nfs: # apt purge nfs-kernel-server" 
+    compliance:
+      - cis: ["2.2.6"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' nfs-kernel-server -> r:unknown ok not-installed"
+
+  - id: 3075
+    title: "Ensure DNS Server is not installed (Automated)"
+    description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
+    rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the package be deleted to reduce the potential attack surface."
+    remediation: "Run the following commands to disable DNS server: # apt purge bind9" 
+    compliance:
+      - cis: ["2.2.7"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' bind9 -> r:unknown ok not-installed"
+
+  - id: 3076
+    title: "Ensure FTP Server is not installed (Automated)"
+    description: "The File Transfer Protocol (FTP) provides networked computers with the ability to transfer files."
+    rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended SFTP be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the package be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove vsftpd: # apt purge vsftpd" 
+    compliance:
+      - cis: ["2.2.8"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' vsftpd -> unknown ok not-installed"
+
+  - id: 3077
+    title: "Ensure HTTP server is not installed (Automated)"
+    description: "HTTP or web servers provide the ability to host web site content."
+    rationale: "Unless there is a need to run the system as a web server, it is recommended that the package be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove apache: # apt purge apache2" 
+    compliance:
+      - cis: ["2.2.9"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' apache2 -> unknown ok not-installed"
+
+  - id: 3078
+    title: "Ensure IMAP and POP3 server are not installed(Automated)"
+    description: "dovecot-imapd and dovecot-pop3d are an open source IMAP and POP3 server for Linux based systems."
+    rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the package be removed to reduce the potential attack surface."
+    remediation: "Run one of the following commands to remove dovecot-imapd and dovecot-pop3d: # apt purge dovecot-imapd dovecot-pop3d" 
+    compliance:
+      - cis: ["2.2.10"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' dovecot-imapd dovecot-pop3d -> unknown ok not-installed"
+
+  - id: 3079
+    title: "Ensure Samba is not installed (Automated)"
+    description: "The Samba daemon allows system administrators to configure their Linux systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Server Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
+    rationale: "If there is no need to mount directories and file systems to Windows systems, then this service should be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove samba: # apt purge samba" 
+    compliance:
+      - cis: ["2.2.11"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1005, T1005.000, T1039, T1039.000, T1083, T1083.000, T1135, T1135.000, T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' samba -> unknown ok not-installed"
+
+  - id: 3080
+    title: "Ensure HTTP Proxy Server is not installed (Automated)"
+    description: "Squid is a standard proxy server used in many distributions and environments."
+    rationale: "If there is no need for a proxy server, it is recommended that the squid proxy be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove squid: # apt purge squid" 
+    compliance:
+      - cis: ["2.2.12"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' squid -> r:unknown on not-installed"
+
+  - id: 3081
+    title: "Ensure SNMP Server is not installed (Automated)"
+    description: "Simple Network Management Protocol (SNMP) is a widely used protocol for monitoring the health and welfare of network equipment, computer equipment and devices like UPSs. Net-SNMP is a suite of applications used to implement SNMPv1 (RFC 1157), SNMPv2 (RFCs 1901-1908), and SNMPv3 (RFCs 3411-3418) using both IPv4 and IPv6. Support for SNMPv2 classic (a.k.a. "SNMPv2 historic" - RFCs 1441-1452) was dropped with the 4.0 release of the UCD-snmp package. The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system."
+    rationale: "The SNMP server can communicate using SNMPv1, which transmits data in the clear and does not require authentication to execute commands. SNMPv3 replaces the simple/clear text password sharing used in SNMPv2 with more securely encoded parameters. If the the SNMP service is not required, the net-snmp package should be removed to reduce the attack surface of the system. Note: If SNMP is required: The server should be configured for SNMP v3 only. User Authentication and Message Encryption should be configured. If SNMP v2 is absolutely necessary, modify the community strings' values."
+    remediation: "Run the following command to remove snmp: # apt purge snmp"
+    compliance:
+      - cis: ["2.2.13"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' snmp -> unknown ok not-installed"
+
+  - id: 3082
+    title: "Ensure NIS Server is not installed (Automated)"
+    description: "The Network Information Service (NIS) (formally known as Yellow Pages) is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
+    rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed and other, more secure services be used"
+    remediation: "Run the following command to remove nis: # apt purge nis" 
+    compliance:
+      - cis: ["2.2.14"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - "dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' nis -> r:unknown ok not-installed"
+
+  - id: 3083
+    title: "Ensure mail transfer agent is configured for local-only mode (Automated)"
+    description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
+    rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems. Note: This recommendation is designed around the postfix mail server. Depending on your environment you may have an alternative MTA installed such as exim4. If this is the case consult the documentation for your installed MTA to configure the recommended state."
+    remediation: "Edit /etc/postfix/main.cf and add the following line to the RECEIVING MAIL section. If the line already exists, change it to look like the line below: inet_interfaces = loopback-only .Run the following command to restart postfix: # systemctl restart postfix" 
+    compliance:
+      - cis: ["2.2.15"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1018, T1018.000, T1210, T1210.000"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: none
+    rules:
+      - 'c:ss -lntu -> r:\.*:25\.*LISTEN && !r:127.0.0.1:25\.+LISTEN|::1:25\.*LISTEN'
+
+  - id: 3084
+    title: "Ensure rsync service is either not installed or masked (Automated)"
+    description: "The rsync service can be used to synchronize files between systems over network links."
+    rationale: "The rsync service presents a security risk as it uses unencrypted protocols for communication. The rsync package should be removed to reduce the attack area of the system."
+    remediation: "Run the following command to remove rsync: # apt purge rsync OR Run the following commands to stop and mask rsync: # systemctl stop rsync # systemctl mask rsync" 
+    compliance:
+      - cis: ["2.2.16"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1105, T1105.000, T1203, T1203.000, T1210, T1210.000, T1543, T1543.002, T1570, T1570.000"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: any
+    rules:
+      - 'c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' rsync -> r:unknown ok not-installed'
+      - 'c:systemctl is-active rsync -> r:inactive'
+      - 'c:systemctl is-enabled rsync -> r:masked'
+
+# 2.3 Configure chrony
+
+  - id: 3085
+    title: "Ensure NIS Client is not installed (Automated)"
+    description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files. The NIS client was used to bind a machine to an NIS server and receive the distributed configuration files."
+    rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
+    remediation: "Uninstall nis: # apt purge nis" 
+    compliance:
+      - cis: ["2.3.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
+      - nist_sp_800-53: ["CM-11"]
+      - mitre_techniques: ["T1203, T1203.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' nis -> r:unknown ok not-installed"
+
+  - id: 3086
+    title: "Ensure rsh client is not installed (Automated)"
+    description: "The rsh-client package contains the client commands for the rsh services."
+    rationale: "These legacy clients contain numerous security exposures and have been replaced with the more secure SSH package. Even if the server is removed, it is best to ensure the clients are also removed to prevent users from inadvertently attempting to use these commands and therefore exposing their credentials. Note that removing the rsh package removes the clients for rsh , rcp and rlogin ."
+    remediation: "Uninstall rsh: # apt purge rsh-client" 
+    compliance:
+      - cis: ["2.3.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1040, T1040.000, T1203, T1203.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1041, M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' rsh-client -> r:unknown ok not-installed"
+
+  - id: 3087
+    title: "Ensure talk client is not installed (Automated)"
+    description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client, which allows initialization of talk sessions, is installed by default."
+    rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
+    remediation: "Uninstall talk: # apt purge talk" 
+    compliance:
+      - cis: ["2.3.3"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0006, TA0008"]
+      - mitre_mitigations: ["M1041, M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' talk -> r:unknown ok not-installed"
+
+  - id: 3088
+    title: "Ensure telnet client is not installed (Automated)"
+    description: "The telnet package contains the telnet client, which allows users to start connections to other systems via the telnet protocol."
+    rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow an unauthorized user to steal credentials. The ssh package provides an encrypted session and stronger security and is included in most Linux distributions."
+    remediation: "Uninstall telnet: # apt purge telnet" 
+    compliance:
+      - cis: ["2.3.4"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1040, T1040.000, T1203, T1203.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0006, TA0008"]
+      - mitre_mitigations: ["M1041, M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' telnet -> r:unknown ok not-installed"
+
+  - id: 3089
+    title: "Ensure LDAP client is not installed (Automated)"
+    description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
+    rationale: "If the system will not need to act as an LDAP client, it is recommended that the software be removed to reduce the potential attack surface."
+    remediation: "Uninstall ldap-utils: # apt purge ldap-utils" 
+    compliance:
+      - cis: ["2.3.5"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1040, T1040.000, T1203, T1203.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' ldap-utils -> r:unknown ok not-installed"
+
+  - id: 3090
+    title: "Ensure RPC is not installed (Automated)"
+    description: "Remote Procedure Call (RPC) is a method for creating low level client server applications across different system architectures. It requires an RPC compliant client listening on a network port. The supporting package is rpcbind."
+    rationale: "If RPC is not required, it is recommended that this services be removed to reduce the remote attack surface."
+    remediation: "Run the following command to remove rpcbind: # apt purge rpcbind" 
+    compliance:
+      - cis: ["2.3.6"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' rpcbind -> r:unknown ok not-installed"
+
+  - id: 3091
+    title: "Ensure nonessential services are removed or masked (Manual)"
+    description: "A network port is identified by its number, the associated IP address, and the type of the communication protocol such as TCP or UDP. A listening port is a network port on which an application or process listens on, acting as a communication endpoint. Each listening port can be open or closed (filtered) using a firewall. In general terms, an open port is a network port that accepts incoming packets from remote locations."
+    rationale: "Services listening on the system pose a potential risk as an attack vector. These services should be reviewed, and if not required, the service should be stopped, and the package containing the service should be removed. If required packages have a dependency, the service should be stopped and masked to reduce the attack surface of the system."
+    remediation: "Run the following command to remove the package containing the service: # apt purge <package_name> OR If required packages have a dependency: Run the following commands to stop and mask the service: # systemctl stop <service_name>.socket # systemctl stop <service_name>.service # systemctl mask <service_name>.socket # systemctl mask <service_name>.service" 
+    compliance:
+      - cis: ["2.4"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53 Rev. 5: ["CM-7"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - "c:ss -plntu"
+
+############################################################
+# 3 Network Configuration
+############################################################
+# 3.1 Disable unused network protocols and devices
+
+# 3.1.1 Ensure system is checked to determine if IPv6 is enabled (Manual) - Not Implemented
+  - id: 3092
+    title: "Ensure system is checked to determine if IPv6 is enabled (Manual)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["3.1.1"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+# 3.1.2 Ensure wireless interfaces are disabled (Automated) - Not Implemented
+  - id: 3093
+    title: "Ensure wireless interfaces are disabled (Automated)"
+    description: "Wireless networking is used when wired networks are unavailable. Debian contains a wireless tool kit to allow system administrators to configure and use wireless networks."
+    rationale: "If wireless is not to be used, wireless devices can be disabled to reduce the potential attack surface."
+    remediation: "" 
+    compliance:
+      - cis: ["3.1.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["15.4, 15.5"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.8.1.3"]
+      - nist_sp_800-53: ["CM-10"]
+      - mitre_techniques: ["T1011, T1011.000, T1595, T1595.001, T1595.002"]
+      - mitre_tactics: ["TA0010"]
+      - mitre_mitigations: ["M1028"]
+    condition: all
+    rules:
+      - "c:nmcli radio wifi -> r:^disabled"
+      - "c:nmcli radio wwan -> r:^disabled"
+
+# 3.1.3 Ensure DCCP is disabled (Automated) - Not Implemented
+  - id: 3094
+    title: "Ensure DCCP is disabled (Automated)"
+    description: "The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that supports streaming media and telephony. DCCP provides a way to gain access to congestion control, without having to do it at the application layer, but does not provide in-sequence delivery."
+    rationale: "If the protocol is not required, it is recommended that the drivers not be installed to reduce the potential attack surface."
+    remediation: "" 
+    compliance:
+      - cis: ["3.1.3"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1068, T1068.000, T1210, T1210.000"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: none
+    rules:
+      - "not c:modprobe -n -v dccp -> r:install /bin/true"
+      - "c:lsmod -> r:dccp"
+
+# 3.1.4 Ensure SCTP is disabled (Automated) - Not Implemented
+  - id: 3095
+    title: "Ensure SCTP is disabled (Automated)"
+    description: "The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to support message oriented communication, with several streams of messages in one connection. It serves a similar function as TCP and UDP, incorporating features of both. It is message-oriented like UDP, and ensures reliable in-sequence transport of messages with congestion control like TCP."
+    rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
+    remediation: "" 
+    compliance:
+      - cis: ["3.1.4"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1068, T1068.000, T1210, T1210.000"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: none
+    rules:
+      - "not c:modprobe -n -v sctp -> r:install /bin/true"
+      - "c:lsmod -> r:sctp"
+
+# 3.1.5 Ensure RDS is disabled (Automated) - Not Implemented
+  - id: 3096
+    title: "Ensure RDS is disabled (Automated)"
+    description: "The Reliable Datagram Sockets (RDS) protocol is a transport layer protocol designed to provide low-latency, high-bandwidth communications between cluster nodes. It was developed by the Oracle Corporation."
+    rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
+    remediation: "" 
+    compliance:
+      - cis: ["3.1.5"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: none
+    rules:
+      - "not c:modprobe -n -v rds -> r:install /bin/true"
+      - "c:lsmod -> r:rds"
+
+# 3.1.6 Ensure TIPC is disabled (Automated) - Not Implemented
+  - id: 3097
+    title: "Ensure TIPC is disabled (Automated)"
+    description: "The Transparent Inter-Process Communication (TIPC) protocol is designed to provide communication between cluster nodes."
+    rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
+    remediation: "" 
+    compliance:
+      - cis: ["3.1.6"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: none
+    rules:
+      - "not c:modprobe -n -v tipc -> r:install /bin/true"
+      - "c:lsmod -> r:tipc"
+
+   
+# 3.2 Network Parameters (Host Only)
+
+# 3.2.1 Ensure packet redirect sending is disabled (Automated) - Not Implemented
+  - id: 3098
+    title: "Ensure packet redirect sending is disabled (Automated)"
+    description: "ICMP Redirects are used to send routing information to other hosts. As a host itself does not act as a router (in a host only configuration), there is no need to send redirects."
+    rationale: "An attacker could use a compromised host to send invalid ICMP redirects to other router devices in an attempt to corrupt routing and have users access a system set up by the attacker as opposed to a valid system."
+    remediation: "" 
+    compliance:
+      - cis: ["3.2.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - NIST SP 800-53 Rev. 5: ["CM-1 CM-2, CM-6, CM-7, IA-5"]
+      - mitre_techniques: ["T1557, T1557.000"]
+      - mitre_tactics: ["TA0006, TA0009"]
+      - mitre_mitigations: ["M1030, M1042"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.conf.all.send_redirects -> r:=\s*\t*0$'
+      - 'c:sysctl net.ipv4.conf.default.send_redirects -> r:=\s*\t*0$'
+      - 'c:grep -Rh net\.ipv4\.conf\.all\.send_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.send_redirects\s*=\s*0$'
+      - 'c:grep -Rh net\.ipv4\.conf\.default\.send_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.send_redirects\s*=\s*0$'
+
+# 3.2.1 Ensure IP forwarding is disabled (Automated) - Not Implemented
+   - id: 3099
+    title: "Ensure IP forwarding is disabled (Automated)"
+    description: "The net.ipv4.ip_forward and net.ipv6.conf.all.forwarding flags are used to tell the system whether it can forward packets or not."
+    rationale: "Setting: net.ipv4.ip_forward = 0 net.ipv6.conf.all.forwarding = 0 Ensures that a system with multiple interfaces (for example, a hard proxy), will never be able to forward packets, and therefore, never serve as a router."
+    remediation: "" 
+    compliance:
+      - cis: ["3.2.2"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.ip_forward -> r:=\s*\t*0$'
+      - 'c:grep -Rh net\.ipv4\.ip_forward /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.ip_forward\s*=\s*0$'
+      - 'c:sysctl net.ipv6.conf.all.forwarding -> r:=\s*\t*0$'
+      - 'c:grep -Rh net\.ipv6\.conf\.all\.forwarding /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.all.forwarding\s*=\s*0$'
+    
+
+# 3.3 Network Parameters (Host and Router)
+
+# 3.3.1 Ensure source routed packets are not accepted (Automated) - Not Implemented
+  - id: 3100
+    title: "Ensure source routed packets are not accepted (Automated)"
+    description: "In networking, source routing allows a sender to partially or fully specify the route packets take through a network. In contrast, non-source routed packets travel a path determined by routers in the network. In some cases, systems may not be routable or reachable from some locations (e.g. private addresses vs. Internet routable), and so source routed packets would need to be used."
+    rationale: "Setting: net.ipv4.conf.all.accept_source_route = 0 net.ipv4.conf.default.accept_source_route = 0 net.ipv6.conf.all.accept_source_route = 0 net.ipv6.conf.default.accept_source_route = 0 Disables the system from accepting source routed packets. Assume this system was capable of routing packets to Internet routable addresses on one interface and private addresses on another interface. Assume that the private addresses were not routable to the Internet routable addresses and vice versa. Under normal routing circumstances, an attacker from the Internet routable addresses could not use the system as a way to reach the private address systems. If, however, source routed packets were allowed, they could be used to gain access to the private address systems as the route could be specified, rather than rely on routing protocols that did not allow this routing."
+    remediation: "" 
+    compliance:
+      - cis: ["3.3.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - NIST SP 800-53 Rev. 5: ["CM-1 CM-2, CM-6, CM-7, IA-5"]
+      - mitre_techniques: ["T1590, T1590.005"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.conf.all.accept_source_route -> r:=\s*\t*0$'
+      - 'c:sysctl net.ipv4.conf.default.accept_source_route -> r:=\s*\t*0$'
+      - 'c:grep -Rh net\.ipv4\.conf\.all\.accept_source_route /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.accept_source_route\s*=\s*0$'
+      - 'c:grep -Rh net\.ipv4\.conf\.default\.accept_source_route /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.accept_source_route\s*=\s*0$'
+      - 'c:sysctl net.ipv6.conf.all.accept_source_route -> r:=\s*\t*0$'
+      - 'c:sysctl net.ipv6.conf.default.accept_source_route -> r:=\s*\t*0$'
+      - 'c:grep -Rh net\.ipv6\.conf\.all\.accept_source_route /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.all.accept_source_route\s*=\s*0$'
+      - 'c:grep -Rh net\.ipv6\.conf\.default\.accept_source_route /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.default.accept_source_route\s*=\s*0$'
+
+# 3.3.2 Ensure ICMP redirects are not accepted (Automated) - Not Implemented
+  - id: 3101
+    title: "Ensure ICMP redirects are not accepted (Automated)"
+    description: "ICMP redirect messages are packets that convey routing information and tell your host (acting as a router) to send packets via an alternate path. It is a way of allowing an outside routing device to update your system routing tables."
+    rationale: "Attackers could use bogus ICMP redirect messages to maliciously alter the system routing tables and get them to send packets to incorrect networks and allow your system packets to be captured. By setting: net.ipv4.conf.all.accept_redirects = 0 net.ipv4.conf.default.accept_redirects = 0 net.ipv6.conf.all.accept_redirects = 0 net.ipv6.conf.default.accept_redirects = 0 The system will not accept any ICMP redirect messages, and therefore, won't allow outsiders to update the system's routing tables."
+    remediation: "" 
+    compliance:
+      - cis: ["3.3.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - NIST SP 800-53 Rev. 5: ["CM-1 CM-2, CM-6, CM-7, IA-5"]
+      - mitre_techniques: ["T1557, T1557.000"]
+      - mitre_tactics: ["TA0006, TA0009"]
+      - mitre_mitigations: ["M1030, M1042"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.conf.all.accept_redirects -> r:=\s*\t*0$'
+      - 'c:sysctl net.ipv4.conf.default.accept_redirects -> r:=\s*\t*0$'
+      - 'c:grep -Rh net\.ipv4\.conf\.all\.accept_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.accept_redirects\s*=\s*0$'
+      - 'c:grep -Rh net\.ipv4\.conf\.default\.accept_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.accept_redirects\s*=\s*0$'
+      - 'c:sysctl net.ipv6.conf.all.accept_redirects -> r:=\s*\t*0$'
+      - 'c:sysctl net.ipv6.conf.default.accept_redirects -> r:=\s*\t*0$'
+      - 'c:grep -Rh net\.ipv6\.conf\.all\.accept_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.all.accept_redirects\s*=\s*0$'
+      - 'c:grep -Rh net\.ipv6\.conf\.default\.accept_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.default.accept_redirects\s*=\s*0$'
+
+# 3.3.3 Ensure secure ICMP redirects are not accepted (Automated) - Not Implemented
+  - id: 3102
+    title: "Ensure secure ICMP redirects are not accepted (Automated)"
+    description: "Secure ICMP redirects are the same as ICMP redirects, except they come from gateways listed on the default gateway list. It is assumed that these gateways are known to your system, and that they are likely to be secure."
+    rationale: "It is still possible for even known gateways to be compromised. Setting: net.ipv4.conf.default.secure_redirects = 0 net.ipv4.conf.all.secure_redirects = 0 protects the system from routing table updates by possibly compromised known gateways."
+    remediation: "" 
+    compliance:
+      - cis: ["3.3.3"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - NIST SP 800-53 Rev. 5: ["CM-1 CM-2, CM-6, CM-7, IA-5"]
+      - mitre_techniques: ["T1557, T1557.000"]
+      - mitre_tactics: ["TA0006, TA0009"]
+      - mitre_mitigations: ["M1030, M1042"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.conf.all.secure_redirects -> r:=\s*\t*0$'
+      - 'c:sysctl net.ipv4.conf.default.secure_redirects -> r:=\s*\t*0$'
+      - 'c:grep -Rh net\.ipv4\.conf\.all\.secure_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.secure_redirects\s*=\s*0$'
+      - 'c:grep -Rh net\.ipv4\.conf\.default\.secure_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0$'
+
+# 3.3.4 Ensure suspicious packets are logged (Automated) - Not Implemented
+  - id: 3103
+    title: "Ensure suspicious packets are logged (Automated)"
+    description: "When enabled, this feature logs packets with un-routable source addresses to the kernel log."
+    rationale: "Enabling this feature and logging these packets by setting: net.ipv4.conf.all.log_martians = 1 net.ipv4.conf.default.log_martians = 1 allows an administrator to investigate the possibility that an attacker is sending spoofed packets to their system."
+    remediation: "" 
+    compliance:
+      - cis: ["3.3.4"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.2, 6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - pci_dss_3.2.1: ["10.1","10.2.2","10.2.4","10.2.5","10.3"]
+      - pci_dss_4.0: ["9.4.5","10.2","10.2.1","10.2.1.2","10.2.1.5"]
+      - nist_sp_800-53: ["AU-3(1)","AU-7"]
+      - soc_2: ["CC5.2","CC7.2"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_techniques: ["T1562, T1562.006"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.conf.all.log_martians -> r:=\s*\t*1$'
+      - 'c:sysctl net.ipv4.conf.default.log_martians -> r:=\s*\t*1$'
+      - 'c:grep -Rh net\.ipv4\.conf\.all\.log_martians /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.log_martians\s*=\s*1$'
+      - 'c:grep -Rh net\.ipv4\.conf\.default\.log_martians /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.log_martians\s*=\s*1$'
+
+# 3.3.5 Ensure broadcast ICMP requests are ignored (Automated) - Not Implemented
+  - id: 3104
+    title: "Ensure broadcast ICMP requests are ignored (Automated)"
+    description: "Setting net.ipv4.icmp_echo_ignore_broadcasts = 1 will cause the system to ignore all ICMP echo and timestamp requests to broadcast and multicast addresses."
+    rationale: "Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for your network could be used to trick your host into starting (or participating) in a Smurf attack. A Smurf attack relies on an attacker sending large amounts of ICMP broadcast messages with a spoofed source address. All hosts receiving this message and responding would send echo-reply messages back to the spoofed address, which is probably not routable. If many hosts respond to the packets, the amount of traffic on the network could be significantly multiplied."
+    remediation: "" 
+    compliance:
+      - cis: ["3.3.5"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - NIST SP 800-53 Rev. 5: ["CM-1 CM-2, CM-6, CM-7, IA-5"]
+      - mitre_techniques: ["T1498, T1498.001"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_mitigations: ["M1037"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.icmp_echo_ignore_broadcasts -> r:=\s*\t*1$'
+      - 'c:grep -Rh net\.ipv4\.icmp_echo_ignore_broadcasts /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
+
+# 3.3.6 Ensure bogus ICMP responses are ignored (Automated) - Not Implemented
+  - id: 3105
+    title: "Ensure bogus ICMP responses are ignored (Automated"
+    description: "Setting icmp_ignore_bogus_error_responses = 1 prevents the kernel from logging bogus responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from filling up with useless log messages."
+    rationale: "Some routers (and some attackers) will send responses that violate RFC-1122 and attempt to fill up a log file system with many useless error messages."
+    remediation: "" 
+    compliance:
+      - cis: ["3.3.6"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - NIST SP 800-53 Rev. 5: ["CM-1 CM-2, CM-6, CM-7, IA-5"]
+      - mitre_techniques: ["T1562, T1562.006"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_mitigations: ["M1053"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.icmp_ignore_bogus_error_responses -> r:=\s*\t*1$'
+      - 'c:grep -Rh net\.ipv4\.icmp_ignore_bogus_error_responses /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
+
+# 3.3.7 Ensure Reverse Path Filtering is enabled (Automated) - Not Implemented
+  - id: 3106
+    title: "Ensure Reverse Path Filtering is enabled (Automated)"
+    description: "Setting net.ipv4.conf.all.rp_filter and net.ipv4.conf.default.rp_filter to 1 forces the Linux kernel to utilize reverse path filtering on a received packet to determine if the packet was valid. Essentially, with reverse path filtering, if the return packet does not go out the same interface that the corresponding source packet came from, the packet is dropped (and logged if log_martians is set)."
+    rationale: "Setting: net.ipv4.conf.all.rp_filter = 1 net.ipv4.conf.default.rp_filter = 1 is a good way to deter attackers from sending your system bogus packets that cannot be responded to. One instance where this feature breaks down is if asymmetrical routing is employed. This would occur when using dynamic routing protocols (bgp, ospf, etc) on your system."
+    remediation: "" 
+    compliance:
+      - cis: ["3.3.7"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - NIST SP 800-53 Rev. 5: ["CM-1 CM-2, CM-6, CM-7, IA-5"]
+      - mitre_techniques: ["T1498, T1498.001"]
+      - mitre_tactics: ["TA0006, TA0040"]
+      - mitre_mitigations: ["M1030, M1042"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.conf.all.rp_filter -> r:=\s*\t*1$'
+      - 'c:sysctl net.ipv4.conf.default.rp_filter -> r:=\s*\t*1$'
+      - 'c:grep -Rh net\.ipv4\.conf\.all\.rp_filter /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.rp_filter\s*=\s*1$'
+      - 'c:grep -Rh net\.ipv4\.conf\.default\.rp_filter /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.rp_filter\s*=\s*1$'
+
+# 3.3.8 Ensure TCP SYN Cookies is enabled (Automated) - Not Implemented
+  - id: 3107
+    title: "Ensure TCP SYN Cookies is enabled (Automated)"
+    description: "When tcp_syncookies is set, the kernel will handle TCP SYN packets normally until the half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that encodes the source and destination IP address and port number and the time the packet was sent. A legitimate connection would send the ACK packet of the three way handshake with the specially crafted sequence number. This allows the system to verify that it has received a valid response to a SYN cookie and allow the connection, even though there is no corresponding SYN in the queue."
+    rationale: "Attackers use SYN flood attacks to perform a denial of service attacked on a system by sending many SYN packets without completing the three way handshake. This will quickly use up slots in the kernel's half-open connection queue and prevent legitimate connections from succeeding. Setting net.ipv4.tcp_syncookies = 1 enables SYN cookies, allowing the system to keep accepting valid connections, even if under a denial of service attack."
+    remediation: "" 
+    compliance:
+      - cis: ["3.3.8"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - NIST SP 800-53 Rev. 5: ["CM-1 CM-2, CM-6, CM-7, IA-5"]
+      - mitre_techniques: ["T1499, T1499.001"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_mitigations: ["M1037"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.tcp_syncookies -> r:=\s*\t*1$'
+      - 'c:grep -Rh net\.ipv4\.tcp_syncookies /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
+
+
+# 3.3.9 Ensure IPv6 router advertisements are not accepted (Automated) - Not Implemented
+  - id: 3108
+    title: "Ensure IPv6 router advertisements are not accepted (Automated)"
+    description: "This setting disables the system's ability to accept IPv6 router advertisements."
+    rationale: "It is recommended that systems do not accept router advertisements as they could be tricked into routing traffic to compromised machines. Setting hard routes within the system (usually a single default route to a trusted router) protects the system from bad routes. Setting: net.ipv6.conf.all.accept_ra = 0 net.ipv6.conf.default.accept_ra = 0 disables the system's ability to accept IPv6 router advertisements."
+    remediation: "" 
+    compliance:
+      - cis: ["3.3.9"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - NIST SP 800-53 Rev. 5: ["CM-1 CM-2, CM-6, CM-7, IA-5"]
+      - mitre_techniques: ["T1557, T1557.000"]
+      - mitre_tactics: ["TA0006, TA0040"]
+      - mitre_mitigations: ["M1030, M1042"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv6.conf.all.accept_ra -> r:=\s*\t*0$'
+      - 'c:sysctl net.ipv6.conf.default.accept_ra -> r:=\s*\t*0$'
+      - 'c:grep -Rh net\.ipv6\.conf\.all\.accept_ra /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.all.accept_ra\s*=\s*0$'
+      - 'c:grep -Rh net\.ipv6\.conf\.default\.accept_ra /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.default.accept_ra\s*=\s*0$'
+
+# 3.5 Firewall Configuration
+
+# 3.5.1 Configure UncomplicatedFirewall
+
+  - id: 3109
+    title: "Ensure ufw is installed (Automated)"
+    description: "The Uncomplicated Firewall (ufw) is a frontend for iptables and is particularly well-suited for host-based firewalls. ufw provides a framework for managing netfilter, as well as a command-line interface for manipulating the firewall."
+    rationale: "A firewall utility is required to configure the Linux kernel's netfilter framework via the iptables or nftables back-end. The Linux kernel's netfilter framework host-based firewall can protect against threats originating from within a corporate network to include malicious mobile code and poorly configured software on a host. Note: Only one firewall utility should be installed and configured. UFW is dependent on the iptables package."
+    remediation: "Run the following command to install Uncomplicated Firewall (UFW): apt install ufw" 
+    compliance:
+      - cis: ["3.5.1.1"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_mitigations: ["M1031, M1037"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' ufw -> r:install ok installed"
+
+  - id: 3110
+    title: "Ensure iptables-persistent is not installed with ufw (Automated)"
+    description: "The iptables-persistent is a boot-time loader for netfilter rules, iptables plugin"
+    rationale: "Running both ufw and the services included in the iptables-persistent package may lead to conflict"
+    remediation: "Run the following command to remove the iptables-persistent package: # apt purge iptables-persistent" 
+    compliance:
+      - cis: ["3.5.1.2"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:dpkg-query -s iptables-persistent -> r:not installed"
+
+  - id: 3111
+    title: "Ensure ufw service is enabled (Automated)"
+    description: "UncomplicatedFirewall (ufw) is a frontend for iptables. ufw provides a framework for managing netfilter, as well as a command-line and available graphical user interface for manipulating the firewall. Notes: When running ufw enable or starting ufw via its initscript, ufw will flush its chains. This is required so ufw can maintain a consistent state, but it may drop existing connections (eg ssh). ufw does support adding rules before enabling the firewall. Run the following command before running ufw enable. # ufw allow proto tcp from any to any port 22 .The rules will still be flushed, but the ssh port will be open after enabling the firewall. Please note that once ufw is 'enabled', ufw will not flush the chains when adding or removing rules (but will when modifying a rule or changing the default policy) By default, ufw will prompt when enabling the firewall while running under ssh. This can be disabled by using ufw --force enable"
+    rationale: "The ufw service must be enabled and running in order for ufw to protect the system"
+    remediation: "Run the following command to unmask the ufw daemon: # systemctl unmask ufw.service .Run the following command to enable and start the ufw daemon: # systemctl --now enable ufw.service active Run the following command to enable ufw: # ufw enable" 
+    compliance:
+      - cis: ["3.5.1.3"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:systemctl is-enabled ufw.service -> r:enabled"
+      - "c:systemctl is-active ufw -> r:active"
+      - "c:ufw status -> r:active"
+
+  - id: 3112
+    title: "Ensure ufw loopback traffic is configured (Automated)"
+    description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (127.0.0.0/8 for IPv4 and ::1/128 for IPv6)."
+    rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (127.0.0.0/8 for IPv4 and ::1/128 for IPv6) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
+    remediation: "Run the following commands to implement the loopback rules: # ufw allow in on lo # ufw allow out on lo # ufw deny in from 127.0.0.0/8 # ufw deny in from ::1" 
+    compliance:
+      - cis: ["3.5.1.4"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_mitigations: ["M1031, M1037"]
+    condition: all
+    rules:
+      - 'c:ufw status verbose -> r:Anywhere on lo\s*\t*ALLOW IN\s*\t*Anywhere'
+      - 'c:ufw status verbose -> r:Anywhere\s*\t*DENY IN\s*\t*127.0.0.0/8'
+      - 'c:ufw status verbose -> r:Anywhere \(v6\) on lo\s*\t*ALLOW IN\s*\t*Anywhere \(v6\)'
+      - 'c:ufw status verbose -> r:Anywhere \(v6\)\s*\t*DENY IN\s*\t*::1'
+      - 'c:ufw status verbose -> r:Anywhere\s*\t*ALLOW OUT\s*\t*Anywhere on lo'
+      - 'c:ufw status verbose -> r:Anywhere \(v6\)\s*\t*ALLOW OUT\s*\t*Anywhere \(v6\) on lo'
+
+  - id: 3113
+    title: "Ensure ufw outbound connections are configured (Manual)"
+    description: "Configure the firewall rules for new outbound connections. Notes: Changing firewall settings while connected over network can result in being locked out of the system. Unlike iptables, when a new outbound rule is added, ufw automatically takes care of associated established connections, so no rules for the latter kind are required."
+    rationale: "If rules are not in place for new outbound connections all packets will be dropped by the default policy preventing network usage."
+    remediation: "Configure ufw in accordance with site policy. The following commands will implement a policy to allow all outbound connections on all interfaces: # ufw allow out on all" 
+    compliance:
+      - cis: ["3.5.1.5"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: [""]
+      - mitre_tactics: ["TA0011"]
+      - mitre_mitigations: ["M1031, M1037"]
+    condition: all
+    rules:
+      - "c:ufw status numbered"
+
+# 3.5.1.6 Ensure ufw firewall rules exist for all open ports (Automated) - Not Implemented
+  - id: 3114
+    title: "Ensure ufw firewall rules exist for all open ports (Automated)"
+    description: "Any ports that have been opened on non-loopback addresses need firewall rules to govern traffic. Notes: Changing firewall settings while connected over network can result in being locked out of the system .The remediation command opens up the port to traffic from all sources. Consult ufw documentation and set any restrictions in compliance with site policy"
+    rationale: "Without a firewall rule configured for open ports default firewall policy will drop all packets to these ports."
+    remediation: "For each port identified in the audit which does not have a firewall rule, add rule for accepting or denying inbound connections: Example: # ufw allow in <port>/<tcp or udp protocol>" 
+    compliance:
+      - cis: ["3.5.1.6"]
+      - cis_csc_v8: ["4.4"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_mitigations: ["M1031, M1037"]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3115
+    title: "Ensure ufw default deny firewall policy (Automated)"
+    description: "A default deny policy on connections ensures that any unconfigured network usage will be rejected. Note: Any port or protocol without a explicit allow before the default deny will be blocked"
+    rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
+    remediation: "Run the following commands to implement a default deny policy: # ufw default deny incoming # ufw default deny outgoing # ufw default deny routed" 
+    compliance:
+      - cis: ["3.5.1.7"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_mitigations: ["M1031, M1037"]
+    condition: all
+    rules:
+      - 'c:ufw status verbose -> r:^Default && r:deny\W+(incoming)|reject\W+(incoming)'
+      - 'c:ufw status verbose -> r:^Default && r:deny\W+(outgoing)|reject\W+(outgoing)'
+      - 'c:ufw status verbose -> r:^Default && r:deny\W+(routed)|reject\W+(routed)'
+
+# 3.5.2 Configure nftables
+
+  - id: 3117
+    title: "Ensure nftables is installed (Automated)"
+    description: "nftables provides a new in-kernel packet classification framework that is based on a network-specific Virtual Machine (VM) and a new nft userspace command line tool. nftables reuses the existing Netfilter subsystems such as the existing hook infrastructure, the connection tracking system, NAT, userspace queuing and logging subsystem. Notes: nftables is available in Linux kernel 3.13 and newer .Only one firewall utility should be installed and configured .Changing firewall settings while connected over the network can result in being locked out of the system"
+    rationale: "nftables is a subsystem of the Linux kernel that can protect against threats originating from within a corporate network to include malicious mobile code and poorly configured software on a host."
+    remediation: "Run the following command to install nftables: # apt install nftables" 
+    compliance:
+      - cis: ["3.5.2.1"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_mitigations: ["M1031, M1037"]
+    condition: all
+    rules:
+      - "c:dpkg-query -s nftables | grep 'Status: install ok installed' -> r:install ok installed"
+
+  - id: 3118
+    title: "Ensure ufw is uninstalled or disabled with nftables (Automated)"
+    description: "Uncomplicated Firewall (UFW) is a program for managing a netfilter firewall designed to be easy to use."
+    rationale: "Running both the nftables service and ufw may lead to conflict and unexpected results."
+    remediation: "Run one of the following commands to either remove ufw or disable ufw .Run the following command to remove ufw: # apt purge ufw .Run the following command to disable ufw: # ufw disable" 
+    compliance:
+      - cis: ["3.5.2.2"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: [""]
+    condition: any
+    rules:
+      - "c:dpkg-query -s ufw | grep 'Status: install ok installed' -> r: not installed"
+      - "c:ufw status -> r:inactive"
+
+  - id: 3119
+    title: "Ensure iptables are flushed with nftables (Manual)"
+    description: "nftables is a replacement for iptables, ip6tables, ebtables and arptables"
+    rationale: "It is possible to mix iptables and nftables. However, this increases complexity and also the chance to introduce errors. For simplicity flush out all iptables rules, and ensure it is not loaded."
+    remediation: "Run the following commands to flush iptables: For iptables: # iptables -F .For ip6tables: # ip6tables -F" 
+    compliance:
+      - cis: ["3.5.2.3"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: [""]
+    condition: none
+    rules:
+      - "c:iptables -L"
+      - "c:ip6tables -L"
+
+  - id: 3120
+    title: "Ensure a nftables table exists (Automated)"
+    description: "Tables hold chains. Each table only has one address family and only applies to packets of this family. Tables can have one of five families."
+    rationale: "nftables doesn't have any default tables. Without a table being build, nftables will not filter network traffic."
+    remediation: "Run the following command to create a table in nftables # nft create table inet <table name> Example: # nft create table inet filter" 
+    compliance:
+      - cis: ["3.5.2.4"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_mitigations: ["M1031, M1037"]
+    condition: all
+    rules:
+      - 'c:nft list tables -> r:\w+'
+
+  - id: 3121
+    title: "Ensure nftables base chains exist (Automated)"
+    description: "Chains are containers for rules. They exist in two kinds, base chains and regular chains. A base chain is an entry point for packets from the networking stack, a regular chain may be used as jump target and is used for better rule organization."
+    rationale: "If a base chain doesn't exist with a hook for input, forward, and delete, packets that would flow through those chains will not be touched by nftables."
+    remediation: "Run the following command to create the base chains: # nft create chain inet <table name> <base chain name> { type filter hook <(input|forward|output)> priority 0 \; } Example: # nft create chain inet filter input { type filter hook input priority 0 \; } # nft create chain inet filter forward { type filter hook forward priority 0 \; } # nft create chain inet filter output { type filter hook output priority 0 \; }" 
+    compliance:
+      - cis: ["3.5.2.5"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:nft list ruleset -> r:hook input"
+      - "c:nft list ruleset -> r:hook forward"
+      - "c:nft list ruleset -> r:hook output"
+
+  - id: 3122
+    title: "Ensure nftables loopback traffic is configured (Automated)"
+    description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network"
+    rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
+    remediation: "Run the following commands to implement the loopback rules: # nft add rule inet filter input iif lo accept # nft create rule inet filter input ip saddr 127.0.0.0/8 counter drop IF IPv6 is enabled on the system: Run the following command to implement the IPv6 loopback rule: # nft add rule inet filter input ip6 saddr ::1 counter drop" 
+    compliance:
+      - cis: ["3.5.2.6"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - 'c:iptables -L INPUT -v -n -> r:\.*ACCEPT\.*all\.*lo\.**\.*0.0.0.0/0\.*0.0.0.0/0'
+      - 'c:iptables -L INPUT -v -n -> r:\.*DROP\.*all\.**\.**\.*127.0.0.0/8\.*0.0.0.0/0'
+      - 'c:iptables -L OUTPUT -v -n -> r:\.*ACCEPT\.*all\.**\.*lo\.*0.0.0.0/0\.*0.0.0.0/0'
+
+
+  - id: 3123
+    title: "Ensure nftables outbound and established connections are configured (Manual)"
+    description: "Configure the firewall rules for new outbound, and established connections"
+    rationale: "If rules are not in place for new outbound, and established connections all packets will be dropped by the default policy preventing network usage."
+    remediation: "Configure nftables in accordance with site policy. The following commands will implement a policy to allow all outbound connections and all established connections: # nft add rule inet filter input ip protocol tcp ct state established accept # nft add rule inet filter input ip protocol udp ct state established accept # nft add rule inet filter input ip protocol icmp ct state established accept # nft add rule inet filter output ip protocol tcp ct state new,related,established accept # nft add rule inet filter output ip protocol udp ct state new,related,established accept # nft add rule inet filter output ip protocol icmp ct state new,related,established accept" 
+    compliance:
+      - cis: ["3.5.2.7"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_mitigations: ["M1031, M1037"]
+    condition: all
+    rules:
+      - "c:nft list ruleset | awk '/hook input/,/}/' | grep -E 'ip protocol(tcp|udp|icmp) ct state' ->r: tcp"
+      - "c:nft list ruleset | awk '/hook input/,/}/' | grep -E 'ip protocol(tcp|udp|icmp) ct state' ->r: udp"
+      - "c:nft list ruleset | awk '/hook input/,/}/' | grep -E 'ip protocol(tcp|udp|icmp) ct state' ->r: icmp"
+      - "c:nft list ruleset | awk '/hook output/,/}/' | grep -E 'ip protocol(tcp|udp|icmp) ct state' ->r:tcp"
+      - "c:nft list ruleset | awk '/hook output/,/}/' | grep -E 'ip protocol(tcp|udp|icmp) ct state' ->r:udp"
+      - "c:nft list ruleset | awk '/hook output/,/}/' | grep -E 'ip protocol(tcp|udp|icmp) ct state' ->r:icmp"
+
+  - id: 3124
+    title: "Ensure nftables default deny firewall policy (Automated)"
+    description: "Base chain policy is the default verdict that will be applied to packets reaching the end of the chain."
+    rationale: "There are two policies: accept (Default) and drop. If the policy is set to accept, the firewall will accept any packet that is not configured to be denied and the packet will continue transversing the network stack. It is easier to white list acceptable usage than to black list unacceptable usage. Note: Changing firewall settings while connected over network can result in being locked out of the system."
+    remediation: "Run the following command for the base chains with the input, forward, and output hooks to implement a default DROP policy: # nft chain <table family> <table name> <chain name> { policy drop \; } Example: # nft chain inet filter input { policy drop \; } # nft chain inet filter forward { policy drop \; } # nft chain inet filter output { policy drop \; }" 
+    compliance:
+      - cis: ["3.5.2.8"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_mitigations: ["M1031, M1037"]
+    condition: all
+    rules:
+      - "c:nft list ruleset -> r:hook input && r:policy drop"
+      - "c:nft list ruleset -> r:hook forward && r:policy drop"
+      - "c:nft list ruleset -> r:hook output && r:policy drop"
+
+  - id: 3125
+    title: "Ensure nftables service is enabled (Automated)"
+    description: "The nftables service allows for the loading of nftables rulesets during boot, or starting on the nftables service."
+    rationale: "The nftables service restores the nftables rules from the rules files referenced in the /etc/nftables.conf file during boot or the starting of the nftables service."
+    remediation: "Run the following command to enable the nftables service: # systemctl enable nftables" 
+    compliance:
+      - cis: ["3.5.2.9"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_mitigations: ["M1031, M1037"]
+    condition: all
+    rules:
+      - "c:systemctl is-enabled nftables ->r:enabled"
+
+#Further Review
+  - id: 3126
+    title: "Ensure nftables rules are permanent (Automated)"
+    description: "nftables is a subsystem of the Linux kernel providing filtering and classification of network packets/datagrams/frames. The nftables service reads the /etc/nftables.conf file for a nftables file or files to include in the nftables ruleset. A nftables ruleset containing the input, forward, and output base chains allow network traffic to be filtered."
+    rationale: "Changes made to nftables ruleset only affect the live system, you will also need to configure the nftables ruleset to apply on boot"
+    remediation: "Edit the /etc/nftables.conf file and un-comment or add a line with include <Absolute path to nftables rules file> for each nftables file you want included in the nftables ruleset on boot .Example: # vi /etc/nftables.conf .Add the line: include "/etc/nftables.rules"" 
+    compliance:
+      - cis: ["3.5.2.10"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_mitigations: ["M1031"]
+    condition: all
+    rules:
+      - "c:[ -n "$(grep -E '^\s*include' /etc/nftables.conf)" ] && awk '/hook input/,/}/' $(awk '$1 ~ /^\s*include/ { gsub("\"","",$2);print $2 }' /etc/nftables.conf) ->r:"
+      - "c:[ -n "$(grep -E '^\s*include' /etc/nftables.conf)" ] && awk '/hook forward/,/}/' $(awk '$1 ~ /^\s*include/ { gsub("\"","",$2);print $2 }' /etc/nftables.conf)"
+      - "c:[ -n "$(grep -E '^\s*include' /etc/nftables.conf)" ] && awk '/hook output/,/}/' $(awk '$1 ~ /^\s*include/ { gsub("\"","",$2);print $2 }' /etc/nftables.conf)"
+
+# 3.5.3 Configure iptables
+# 3.5.3.1 Configure iptables software
+
+  - id: 3127
+    title: "Ensure iptables packages are installed (Automated)"
+    description: "iptables is a utility program that allows a system administrator to configure the tables provided by the Linux kernel firewall, implemented as different Netfilter modules, and the chains and rules it stores. Different kernel modules and programs are used for different protocols; iptables applies to IPv4, ip6tables to IPv6, arptables to ARP, and ebtables to Ethernet frames."
+    rationale: "A method of configuring and maintaining firewall rules is necessary to configure a Host Based Firewall."
+    remediation: "Run the following command to install iptables and iptables-persistent # apt install iptables iptables-persistent" 
+    compliance:
+      - cis: ["3.5.3.1.1"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_mitigations: ["M1031, M1037"]
+    condition: all
+    rules:
+      - "c:apt list iptables iptables-persistent | grep installed ->r:installed,automatic"
+
+  - id: 3128
+    title: "Ensure nftables is not installed with iptables (Automated)"
+    description: "nftables is a subsystem of the Linux kernel providing filtering and classification of network packets/datagrams/frames and is the successor to iptables."
+    rationale: "Running both iptables and nftables may lead to conflict."
+    remediation: "Run the following command to remove nftables: # apt purge nftables" 
+    compliance:
+      - cis: ["3.5.3.1.2"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' nftables ->r:unknown ok not-installed"
+
+  - id: 3129
+    title: "Ensure ufw is uninstalled or disabled with iptables (Automated)"
+    description: "Uncomplicated Firewall (UFW) is a program for managing a netfilter firewall designed to be easy to use. Uses a command-line interface consisting of a small number of simple commands .Uses iptables for configuration"
+    rationale: "Running iptables.persistent with ufw enabled may lead to conflict and unexpected results."
+    remediation: "Run one of the following commands to either remove ufw or stop and mask ufw Run the following command to remove ufw: # apt purge ufw OR Run the following commands to disable ufw: # ufw disable # systemctl stop ufw # systemctl mask ufw" 
+    compliance:
+      - cis: ["3.5.3.1.3"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_mitigations: [""]
+    condition: any
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' ufw ->r:unknown ok not-installed"
+      - "c:ufw status ->r:inactive"
+      - "c:systemctl is-enabled ufw ->r:masked"
+
+# 3.5.3.2 Configure IPv4 iptables
+
+  - id: 3130
+    title: "Ensure iptables default deny firewall policy (Automated)"
+    description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected. Notes: Changing firewall settings while connected over network can result in being locked out of the system. Remediation will only affect the active system firewall, be sure to configure the default policy in your firewall management to apply on boot as well"
+    rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
+    remediation: "Run the following commands to implement a default DROP policy: # iptables -P INPUT DROP # iptables -P OUTPUT DROP # iptables -P FORWARD DROP" 
+    compliance:
+      - cis: ["3.5.3.2.1"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_mitigations: ["M1031, M1037"]
+    condition: all
+    rules:
+      - 'c:iptables -L -> r:Chain INPUT \(policy DROP\)|Chain INPUT \(policy REJECT\)'
+      - 'c:iptables -L -> r:Chain FORWARD \(policy DROP\)|Chain FORWARD \(policy REJECT\)'
+      - 'c:iptables -L -> r:Chain OUTPUT \(policy DROP\)|Chain OUTPUT \(policy REJECT\)'
+
+  - id: 3131
+    title: "Ensure iptables loopback traffic is configured (Automated)"
+    description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (127.0.0.0/8). Notes: Changing firewall settings while connected over network can result in being locked out of the system .Remediation will only affect the active system firewall, be sure to configure the default policy in your firewall management to apply on boot as well"
+    rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (127.0.0.0/8) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
+    remediation: "Run the following commands to implement the loopback rules: # iptables -A INPUT -i lo -j ACCEPT # iptables -A OUTPUT -o lo -j ACCEPT # iptables -A INPUT -s 127.0.0.0/8 -j DROP" 
+    compliance:
+      - cis: ["3.5.3.2.2"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_mitigations: ["M1031, M1037"]
+    condition: all
+    rules:
+      - 'c:iptables -L INPUT -v -n -> r:\.*ACCEPT\.*all\.*lo\.**\.*0.0.0.0/0\.*0.0.0.0/0'
+      - 'c:iptables -L INPUT -v -n -> r:\.*DROP\.*all\.**\.**\.*127.0.0.0/8\.*0.0.0.0/0'
+      - 'c:iptables -L OUTPUT -v -n -> r:\.*ACCEPT\.*all\.**\.*lo\.*0.0.0.0/0\.*0.0.0.0/0'
+
+  - id: 3132
+    title: "Ensure iptables outbound and established connections are configured (Manual)"
+    description: "Configure the firewall rules for new outbound, and established connections. Notes: Changing firewall settings while connected over network can result in being locked out of the system .Remediation will only affect the active system firewall, be sure to configure the default policy in your firewall management to apply on boot as well"
+    rationale: "If rules are not in place for new outbound, and established connections all packets will be dropped by the default policy preventing network usage."
+    remediation: "Configure iptables in accordance with site policy. The following commands will implement a policy to allow all outbound connections and all established connections: # iptables -A OUTPUT -p tcp -m state --state NEW,ESTABLISHED -j ACCEPT # iptables -A OUTPUT -p udp -m state --state NEW,ESTABLISHED -j ACCEPT # iptables -A OUTPUT -p icmp -m state --state NEW,ESTABLISHED -j ACCEPT # iptables -A INPUT -p tcp -m state --state ESTABLISHED -j ACCEPT # iptables -A INPUT -p udp -m state --state ESTABLISHED -j ACCEPT # iptables -A INPUT -p icmp -m state --state ESTABLISHED -j ACCEPT" 
+    compliance:
+      - cis: ["3.5.3.2.3"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: [""]
+      - mitre_tactics: ["TA0011"]
+      - mitre_mitigations: ["M1031, M1037"]
+    condition: all
+    rules:
+      - "c:iptables -L -v -n"
+
+#further review
+  - id: 3133
+    title: "Ensure iptables firewall rules exist for all open ports (Automated)"
+    description: "Any ports that have been opened on non-loopback addresses need firewall rules to govern traffic. Note: Changing firewall settings while connected over network can result in being locked out of the system .Remediation will only affect the active system firewall, be sure to configure the default policy in your firewall management to apply on boot as well .The remediation command opens up the port to traffic from all sources. Consult iptables documentation and set any restrictions in compliance with site policy."
+    rationale: "Without a firewall rule configured for open ports default firewall policy will drop all packets to these ports."
+    remediation: "For each port identified in the audit which does not have a firewall rule establish a proper rule for accepting inbound connections: # iptables -A INPUT -p <protocol> --dport <port> -m state --state NEW -j ACCEPT" 
+    compliance:
+      - cis: ["3.5.3.2.4"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_mitigations: ["M1031, M1037"]
+    condition: all
+    rules:
+      - "c:ss -4tuln"
+      - "c:iptables -L INPUT -v -n"
+
+# 3.5.3.3 Configure IPv6 ip6tables
+
+  - id: 3134
+    title: "Ensure ip6tables default deny firewall policy (Automated)"
+    description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected. Note: Changing firewall settings while connected over network can result in being locked out of the system. Remediation will only affect the active system firewall, be sure to configure the default policy in your firewall management to apply on boot as well."
+    rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
+    remediation: "Run the following commands to implement a default DROP policy: # ip6tables -P INPUT DROP # ip6tables -P OUTPUT DROP # ip6tables -P FORWARD DROP" 
+    compliance:
+      - cis: ["3.5.3.3.1"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_mitigations: ["M1031, M1037"]
+    condition: all
+    rules:
+      - "c:ip6tables -L -> r:^Chain INPUT && r:policy DROP"
+      - "c:ip6tables -L -> r:^Chain FORWARD && r:policy DROP"
+      - "c:ip6tables -L -> r:^Chain OUTPUT && r:policy DROP"
+
+  - id: 3135
+    title: "Ensure ip6tables loopback traffic is configured (Automated)"
+    description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (::1). Note: Changing firewall settings while connected over network can result in being locked out of the system. Remediation will only affect the active system firewall, be sure to configure the default policy in your firewall management to apply on boot as well."
+    rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (::1) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
+    remediation: "Run the following commands to implement the loopback rules: # ip6tables -A INPUT -i lo -j ACCEPT # ip6tables -A OUTPUT -o lo -j ACCEPT # ip6tables -A INPUT -s ::1 -j DROP" 
+    compliance:
+      - cis: ["3.5.3.3.2"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_mitigations: ["M1031, M1037"]
+    condition: all
+    rules:
+      - 'c:ip6tables -L INPUT -v -n -> r:\.*ACCEPT\.*all\.*lo\.**\.*::/0\.*::/0'
+      - 'c:ip6tables -L INPUT -v -n -> r:\.*DROP\.*all\.**\.**\.*::1\.*::/0'
+      - 'c:ip6tables -L OUTPUT -v -n -> r:\.*ACCEPT\.*all\.**\.*lo\.*::/0\.*::/0'
+
+  - id: 3136
+    title: "Ensure ip6tables outbound and established connections are configured (Manual)"
+    description: "Configure the firewall rules for new outbound, and established IPv6 connections. Note: Changing firewall settings while connected over network can result in being locked out of the system .Remediation will only affect the active system firewall, be sure to configure the default policy in your firewall management to apply on boot as well."
+    rationale: "If rules are not in place for new outbound, and established connections all packets will be dropped by the default policy preventing network usage."
+    remediation: "Configure iptables in accordance with site policy. The following commands will implement a policy to allow all outbound connections and all established connections: # ip6tables -A OUTPUT -p tcp -m state --state NEW,ESTABLISHED -j ACCEPT # ip6tables -A OUTPUT -p udp -m state --state NEW,ESTABLISHED -j ACCEPT # ip6tables -A OUTPUT -p icmp -m state --state NEW,ESTABLISHED -j ACCEPT # ip6tables -A INPUT -p tcp -m state --state ESTABLISHED -j ACCEPT # ip6tables -A INPUT -p udp -m state --state ESTABLISHED -j ACCEPT # ip6tables -A INPUT -p icmp -m state --state ESTABLISHED -j ACCEPT" 
+    compliance:
+      - cis: ["3.5.3.3.3"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: [""]
+      - mitre_tactics: ["TA0011"]
+      - mitre_mitigations: ["M1031, M1037"]
+    condition: all
+    rules:
+      - "c:ip6tables -L -v -n"
+
+# further review
+  - id: 3137
+    title: "Ensure ip6tables firewall rules exist for all open ports (Automated)"
+    description: "Any ports that have been opened on non-loopback addresses need firewall rules to govern traffic. Note: Changing firewall settings while connected over network can result in being locked out of the system Remediation will only affect the active system firewall, be sure to configure the default policy in your firewall management to apply on boot as well. The remediation command opens up the port to traffic from all sources. Consult iptables documentation and set any restrictions in compliance with site policy."
+    rationale: "Without a firewall rule configured for open ports default firewall policy will drop all packets to these ports."
+    remediation: "For each port identified in the audit which does not have a firewall rule establish a proper rule for accepting inbound connections: # ip6tables -A INPUT -p <protocol> --dport <port> -m state --state NEW -j ACCEPT" 
+    compliance:
+      - cis: ["3.5.3.3.4"]
+      - cis_csc_v8: ["4.4, 4.5"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20","CM.L2-3.4.7","SC.L1-3.13.1","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.4","1.3.1","1.4"]
+      - pci_dss_4.0: ["1.2.1","1.4.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - soc_2: ["CC6.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - mitre_techniques: ["T1562, T1562.004"]
+      - mitre_tactics: ["TA0011"]
+      - mitre_mitigations: ["M1031, M1037"]
+    condition: all
+    rules:
+      - "c:ss -6tuln"
+      - "c:ip6tables -L INPUT -v -n"
+
+############################################################
+# 4 Logging and Auditing
+############################################################
+
+# 4.1 Configure System Accounting (auditd)
+# 4.1.1 Ensure auditing is enabled
+
+  - id: 3138
+    title: "Ensure auditd is installed (Automated)"
+    description: "auditd is the userspace component to the Linux Auditing System. It's responsible for writing audit records to the disk."
+    rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
+    remediation: "Run the following command to Install auditd # apt install auditd audispd-plugins" 
+    compliance:
+      - cis: ["4.1.1.1"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - pci_dss_3.2.1: ["10.1","10.2.2","10.2.4","10.2.5","10.3"]
+      - pci_dss_4.0: ["9.4.5","10.2","10.2.1","10.2.1.2","10.2.1.5"]
+      - nist_sp_800-53: ["AU-3(1)","AU-7"]
+      - soc_2: ["CC5.2","CC7.2"]
+      - mitre_techniques: ["T1562, T1562.001"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' auditd audispd-plugins ->r: install ok installed"
+
+  - id: 3139
+    title: "Ensure auditd service is enabled and active (Automated)"
+    description: "Turn on the auditd daemon to record system events."
+    rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
+    remediation: "Run the following command to enable and start auditd: # systemctl --now enable auditd" 
+    compliance:
+      - cis: ["4.1.1.2"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2, 6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - pci_dss_3.2.1: ["10.2","10.3"]
+      - pci_dss_4.0: ["5.3.4","6.4.1","6.4.2","10.2.1","10.2.1.1","10.2.1.2","10.2.1.3","10.2.1.4","10.2.1.5","10.2.1.6","10.2.1.7","10.2.2"]
+      - nist_sp_800-53: ["AU-7"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_techniques: ["T1562, T1562.001"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:systemctl is-enabled auditd ->r:enabled"
+      - "c:systemctl is-active auditd ->r:active"
+
+  - id: 3140
+    title: "Ensure auditing for processes that start prior to auditd is enabled (Automated)"
+    description: "Configure grub2 so that processes that are capable of being audited can be audited even if they start up prior to auditd startup."
+    rationale: "Audit events need to be captured on processes that start up prior to auditd , so that potential malicious activity cannot go undetected."
+    remediation: 'Edit /etc/default/grub and add audit=1 to GRUB_CMDLINE_LINUX: Example: GRUB_CMDLINE_LINUX="audit=1" .Run the following command to update the grub2 configuration: # update-grub' 
+    compliance:
+      - cis: ["4.1.1.3"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - pci_dss_3.2.1: ["10.2","10.3"]
+      - pci_dss_4.0: ["5.3.4","6.4.1","6.4.2","10.2.1","10.2.1.1","10.2.1.2","10.2.1.3","10.2.1.4","10.2.1.5","10.2.1.6","10.2.1.7","10.2.2"]
+      - nist_sp_800-53: ["AU-7"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_techniques: ["T1562, T1562.001"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: [""]
+    condition: none
+    rules:
+      - "c:find /boot -type f -name 'grub.cfg' -exec grep -Ph -- '^\h*linux' {} + | grep -v 'audit=1'"
+
+  - id: 3141
+    title: "Ensure audit_backlog_limit is sufficient (Automated)"
+    description: "In the kernel-level audit subsystem, a socket buffer queue is used to hold audit events. Whenever a new audit event is received, it is logged and prepared to be added to this queue. The kernel boot parameter audit_backlog_limit=N, with N representing the amount of messages, will ensure that a queue cannot grow beyond a certain size. If an audit event is logged which would grow the queue beyond this limit, then a failure occurs and is handled according to the system configuration."
+    rationale: "If an audit event is logged which would grow the queue beyond the audit_backlog_limit, then a failure occurs, auditd records will be lost, and potential malicious activity could go undetected."
+    remediation: 'Edit /etc/default/grub and add audit_backlog_limit=N to GRUB_CMDLINE_LINUX. The recommended size for N is 8192 or larger. Example: GRUB_CMDLINE_LINUX="audit_backlog_limit=8192" Run the following command to update the grub2 configuration: # update-grub' 
+    compliance:
+      - cis: ["4.1.1.4"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2, 6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - pci_dss_3.2.1: ["10.2","10.3"]
+      - pci_dss_4.0: ["5.3.4","6.4.1","6.4.2","10.2.1","10.2.1.1","10.2.1.2","10.2.1.3","10.2.1.4","10.2.1.5","10.2.1.6","10.2.1.7","10.2.2"]
+      - nist_sp_800-53: ["AU-7"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_techniques: ["T1562, T1562.001"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: [""]
+    condition: none
+    rules:
+      - "c:find /boot -type f -name 'grub.cfg' -exec grep -Ph -- '^\h*linux' {} + | grep -Pv 'audit_backlog_limit=\d+\b'"
+
+# 4.1.2 Configure Data Retention
+
+  - id: 3142
+    title: "Ensure audit log storage size is configured (Automated)"
+    description: "Configure the maximum size of the audit log file. Once the log reaches the maximum size, it will be rotated and a new log file will be started."
+    rationale: "It is important that an appropriate size is determined for log files so that they do not impact the system and audit data is not lost."
+    remediation: "Set the following parameter in /etc/audit/auditd.conf in accordance with site policy: max_log_file = <MB>" 
+    compliance:
+      - cis: ["4.1.2.1"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - pci_dss_3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_techniques: ["T1562, T1562.006"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_mitigations: ["M1053"]
+    condition: all
+    rules:
+      - "d:/etc/audit"
+      - "f:/etc/audit/auditd.conf"
+      - 'f:/etc/audit/auditd.conf -> r:^\s*\t*max_log_file\s*\t*=\s*\t*\d+'
+
+  - id: 3143
+    title: "Ensure audit logs are not automatically deleted (Automated)"
+    description: "The max_log_file_action setting determines how to handle the audit log file reaching the max file size. A value of keep_logs will rotate the logs but never delete old logs."
+    rationale: "In high security contexts, the benefits of maintaining a long audit history exceed the cost of storing the audit history."
+    remediation: "Set the following parameter in /etc/audit/auditd.conf: max_log_file_action = keep_logs" 
+    compliance:
+      - cis: ["4.1.2.2"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - pci_dss_3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_techniques: ["T1562, T1562.006"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1053"]
+    condition: all
+    rules:
+      - "d:/etc/audit"
+      - "f:/etc/audit/auditd.conf"
+      - 'f:/etc/audit/auditd.conf -> r:^\s*\t*max_log_file_action\s*\t*=\s*\t*keep_logs'
+
+  - id: 3144
+    title: "Ensure system is disabled when audit logs are full (Automated)"
+    description: "The auditd daemon can be configured to halt the system when the audit logs are full. The admin_space_left_action parameter tells the system what action to take when the system has detected that it is low on disk space. Valid values are ignore, syslog, suspend, single, and halt. ignore, the audit daemon does nothing .Syslog, the audit daemon will issue a warning to syslog .Suspend, the audit daemon will stop writing records to the disk single, the audit daemon will put the computer system in single user mode halt, the audit daemon will shutdown the system"
+    rationale: "In high security contexts, the risk of detecting unauthorized access or nonrepudiation exceeds the benefit of the system's availability."
+    remediation: "Set the following parameters in /etc/audit/auditd.conf: space_left_action = email action_mail_acct = root .set admin_space_left_action to either halt or single in /etc/audit/auditd.conf. Example: admin_space_left_action = halt" 
+    compliance:
+      - cis: ["4.1.2.3"]
+      - cis_csc_v8: ["8.2, 8.3"]
+      - cis_csc_v7: ["6.4"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - pci_dss_3.2.1: ["10.2","10.3", "10.7"]
+      - pci_dss_4.0: ["5.3.4","6.4.1","6.4.2","10.2.1","10.2.1.1","10.2.1.2","10.2.1.3","10.2.1.4","10.2.1.5","10.2.1.6","10.2.1.7","10.2.2"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["A1.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_techniques: ["T1562, T1562.006"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "d:/etc/audit"
+      - "f:/etc/audit/auditd.conf"
+      - 'f:/etc/audit/auditd.conf -> r:^\s*\t*action_mail_acct\s*\t*=\s*\t*root'
+      - 'f:/etc/audit/auditd.conf -> r:^\s*\t*space_left_action\s*\t*=\s*\t*email'
+      - 'f:/etc/audit/auditd.conf -> r:^\s*\t*admin_space_left_action\s*\t*=\s*\t*halt'
+
+
+# 4.1.3 Configure auditd rules
+
+  - id: 3145
+    title: "Ensure changes to system administration scope (sudoers) is collected (Automated)"
+    description: "Monitor scope changes for system administrators. If the system has been properly configured to force system administrators to log in as themselves first and then use the sudo command to execute privileged commands, it is possible to monitor changes in scope. The file /etc/sudoers, or files in /etc/sudoers.d, will be written to when the file(s) or related attributes have changed. The audit records will be tagged with the identifier "scope"."
+    rationale: "Changes in the /etc/sudoers and /etc/sudoers.d files can indicate that an unauthorized change has been made to the scope of system administrator activity."
+    remediation: 'Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor scope changes for system administrators. Example: # printf " -w /etc/sudoers -p wa -k scope -w /etc/sudoers.d -p wa -k scope " >> /etc/audit/rules.d/50-scope.rules .Merge and load the rules into active configuration: # augenrules --load .Check if reboot is required. # if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then printf "Reboot required to load rules\n";'
+    compliance:
+      - cis: ["4.1.3.1"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.8"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - pci_dss_3.2.1: ["10.1","10.2.2","10.2.4","10.2.5","10.3"]
+      - pci_dss_4.0: ["9.4.5","10.2","10.2.1","10.2.1.2","10.2.1.5"]
+      - nist_sp_800-53: ["AU-3(1)","AU-7"]
+      - soc_2: ["CC5.2","CC7.2"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - mitre_techniques: ["T1562, T1562.006"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_mitigations: ["M1047"]
+    condition: all
+    rules:
+      - "c:awk '/^ *-w/ &&/\/etc\/sudoers/ &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules -> r:^-w && r:/etc/sudoers && r:-p wa && r:-k scope"
+      - "c:awk '/^ *-w/ &&/\/etc\/sudoers/ &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules -> r:^-w && r:/etc/sudoers.d/ && r:-p wa && r:-k scope"
+      - "c:auditctl -l | awk '/^ *-w/ &&/\/etc\/sudoers/ &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' -> r:^-w && r:/etc/sudoers && r:-p wa && r:-k scope"
+      - "c:auditctl -l | awk '/^ *-w/ &&/\/etc\/sudoers/ &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' -> r:^-w && r:/etc/sudoers.d/ && r:-p wa && r:-k scope"
+
+  - id: 3146
+    title: "Ensure actions as another user are always logged (Automated)"
+    description: "sudo provides users with temporary elevated privileges to perform operations, either as the superuser or another user."
+    rationale: "Creating an audit log of users with temporary elevated privileges and the operation(s) they performed is essential to reporting. Administrators will want to correlate the events written to the audit trail with the records written to sudo's logfile to verify if unauthorized commands have been executed."
+    remediation: 'Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor elevated privileges. 64 Bit systems .Example: # printf " -a always,exit -F arch=b64 -C euid!=uid -F auid!=unset -S execve -k user_emulation -a always,exit -F arch=b32 -C euid!=uid -F auid!=unset -S execve -k user_emulation " >> /etc/audit/rules.d/50-user_emulation.rules Load audit rules .Merge and load the rules into active configuration: # augenrules --load .Check if reboot is required. # if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then printf "Reboot required to load rules\n"; fi .32 Bit systems:Follow the same procedures as for 64 bit systems and ignore any entries with b64.'
+    compliance:
+      - cis: ["4.1.3.2"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.9"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - pci_dss_3.2.1: ["10.1","10.2.2","10.2.4","10.2.5","10.3"]
+      - pci_dss_4.0: ["9.4.5","10.2","10.2.1","10.2.1.2","10.2.1.5"]
+      - nist_sp_800-53: ["AU-3(1)","AU-7"]
+      - soc_2: ["CC5.2","CC7.2"]
+      - iso_27001-2013: ["A.9.4.2"]
+      - mitre_techniques: ["T1562, T1562.006"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_mitigations: ["M1047"]
+    condition: all
+    rules:
+      - "c:awk '/^ *-a *always,exit/ &&/ -F *arch=b[2346]{2}/ &&(/ -F *auid!=unset/||/ -F *auid!=-1/||/ -F *auid!=4294967295/) &&(/ -C *euid!=uid/||/ -C *uid!=euid/) &&/ -S *execve/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules -> r:^-a && r:exit,always|always,exit && r:-F arch=b64 && r:-C euid!=uid && r:-F auid!=unset && r:-S execve && r:-k user_emulation"
+      - "c:awk '/^ *-a *always,exit/ &&/ -F *arch=b[2346]{2}/ &&(/ -F *auid!=unset/||/ -F *auid!=-1/||/ -F *auid!=4294967295/) &&(/ -C *euid!=uid/||/ -C *uid!=euid/) &&/ -S *execve/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules -> r:^-a && r:exit,always|always,exit && r:-F arch=b32 && r:-C euid!=uid && r:-F auid!=unset && r:-S execve && r:-k user_emulation"
+      - "c:auditctl -l | awk '/^ *-a *always,exit/ &&/ -F *arch=b[2346]{2}/ &&(/ -F *auid!=unset/||/ -F *auid!=-1/||/ -F *auid!=4294967295/) &&(/ -C *euid!=uid/||/ -C *uid!=euid/) &&/ -S *execve/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' -> r:^-a && r:exit,always|always,exit && r:-F arch=b64 && r:-S execve && r:-C uid!=euid && r:-F auid!=-1 && r:-F key=user_emulation"
+      - "c:auditctl -l | awk '/^ *-a *always,exit/ &&/ -F *arch=b[2346]{2}/ &&(/ -F *auid!=unset/||/ -F *auid!=-1/||/ -F *auid!=4294967295/) &&(/ -C *euid!=uid/||/ -C *uid!=euid/) &&/ -S *execve/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' -> r:^-a && r:exit,always|always,exit && r:-F arch=b32 && r:-S execve && r:-C uid!=euid && r:-F auid!=-1 && r:-F key=user_emulation"
+
+# Not Implemented
+  - id: 3147
+    title: "Ensure events that modify the sudo log file are collected (Automated)"
+    description: "Monitor the sudo log file. If the system has been properly configured to disable the use of the su command and force all administrators to have to log in first and then use sudo to execute privileged commands, then all administrator commands will be logged to /var/log/sudo.log . Any time a command is executed, an audit event will be triggered as the /var/log/sudo.log file will be opened for write and the executed administration command will be written to the log."
+    rationale: "Changes in /var/log/sudo.log indicate that an administrator has executed a command or the log file itself has been tampered with. Administrators will want to correlate the events written to the audit trail with the records written to /var/log/sudo.log to verify if unauthorized commands have been executed."
+    remediation: "" 
+    compliance:
+      - cis: ["4.1.3.3"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3148
+    title: "Ensure events that modify date and time information are collected (Automated)"
+    description: "Capture events where the system date and/or time has been modified. The parameters in this section are set to determine if the; adjtimex - tune kernel clock settimeofday - set time using timeval and timezone structures stime - using seconds since 1/1/1970 clock_settime - allows for the setting of several internal clocks and timers system calls have been executed. Further, ensure to write an audit record to the configured audit log file upon exit, tagging the records with a unique identifier such as "time-change"."
+    rationale: "Unexpected changes in system date and/or time could be a sign of malicious activity on the system."
+    remediation: "Create audit rules .Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor events that modify date and time information. 64 Bit systems .Example: # printf "-a always,exit -F arch=b64 -S adjtimex,settimeofday,clock_settime -k time-change -a always,exit -F arch=b32 -S adjtimex,settimeofday,clock_settime -k time-change -w /etc/localtime -p wa -k time-change " >> /etc/audit/rules.d/50-time-change.rules .Load audit rules .Merge and load the rules into active configuration:# augenrules --load .Check if reboot is required. # if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then printf "Reboot required to load rules\n"; fi 32 Bit systems .Follow the same procedures as for 64 bit systems and ignore any entries with b64. In addition, add stime to the system call audit. Example:-a always,exit -F arch=b32 -S adjtimex,settimeofday,clock_settime,stime -k time-change" 
+    compliance:
+      - cis: ["4.1.3.4"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["5.5"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - pci_dss_3.2.1: ["10.1","10.2.2","10.2.4","10.2.5","10.3"]
+      - pci_dss_4.0: ["9.4.5","10.2","10.2.1","10.2.1.2","10.2.1.5"]
+      - nist_sp_800-53: ["AU-3(1)","AU-7"]
+      - soc_2: ["CC5.2","CC7.2"]
+      - iso_27001-2013: ["A.12.1.2"]
+      - mitre_techniques: ["T1562, T1562.006"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:{awk '/^ *-a *always,exit/ &&/ -F *arch=b[2346]{2}/ &&/ -S/ &&(/adjtimex/ ||/settimeofday/ ||/clock_settime/ ) &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules awk '/^ *-w/ &&/\/etc\/localtime/ &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules} -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S adjtimex && r:-S settimeofday && r:-S stime && r:-k time-change"
+      - "c:{awk '/^ *-a *always,exit/ &&/ -F *arch=b[2346]{2}/ &&/ -S/ &&(/adjtimex/ ||/settimeofday/ ||/clock_settime/ ) &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules awk '/^ *-w/ &&/\/etc\/localtime/ &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules} -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S clock_settime && r:-k time-change"
+      - "c:{awk '/^ *-a *always,exit/ &&/ -F *arch=b[2346]{2}/ &&/ -S/ &&(/adjtimex/ ||/settimeofday/ ||/clock_settime/ ) &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules awk '/^ *-w/ &&/\/etc\/localtime/ &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules} -> r:^-w && r:/etc/localtime && r:-p wa && r:-k time-change"
+
+  - id: 3149
+    title: "Ensure events that modify the system's network environment are collected (Automated)"
+    description: "Record changes to network environment files or system calls. The below parameters monitors the following system calls, and write an audit event on system call exit: sethostname - set the systems host name setdomainname - set the systems domain name .The files being monitored are: /etc/issue and /etc/issue.net - messages displayed pre-login . /etc/hosts - file containing host names and associated IP addresses . /etc/networks - symbolic names for networks . /etc/network/ - directory containing network interface scripts and configurations files"
+    rationale: "Monitoring sethostname and setdomainname will identify potential unauthorized changes to host and domainname of a system. The changing of these names could potentially break security parameters that are set based on those names. The /etc/hosts file is monitored for changes that can indicate an unauthorized intruder is trying to change machine associations with IP addresses and trick users and processes into connecting to unintended machines. Monitoring /etc/issue and /etc/issue.net is important, as intruders could put disinformation into those files and trick users into providing information to the intruder. Monitoring /etc/network is important as it can show if network interfaces or scripts are being modified in a way that can lead to the machine becoming unavailable or compromised. All audit records should have a relevant tag associated with them."
+    remediation: 'Create audit rules .Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor events that modify the systems network environment. 64 Bit systems .Example: # printf " -a always,exit -F arch=b64 -S sethostname,setdomainname -k system-locale -a always,exit -F arch=b32 -S sethostname,setdomainname -k system-locale -w /etc/issue -p wa -k system-locale -w /etc/issue.net -p wa -k system-locale -w /etc/hosts -p wa -k system-locale -w /etc/networks -p wa -k system-locale -w /etc/network/ -p wa -k system-locale " >> /etc/audit/rules.d/50-system_local.rules .Load audit rules .Merge and load the rules into active configuration: # augenrules --load .Check if reboot is required. # if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then printf "Reboot required to load rules\n"; fi .32 Bit systems .Follow the same procedures as for 64 bit systems and ignore any entries with b64.'
+    compliance:
+      - cis: ["4.1.3.5"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["5.5"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - pci_dss_3.2.1: ["10.1","10.2.2","10.2.4","10.2.5","10.3"]
+      - pci_dss_4.0: ["9.4.5","10.2","10.2.1","10.2.1.2","10.2.1.5"]
+      - nist_sp_800-53: ["AU-3(1)","AU-7"]
+      - soc_2: ["CC5.2","CC7.2"]
+      - iso_27001-2013: ["A.12.1.2"]
+      - mitre_techniques: ["T1562, T1562.006"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_mitigations: ["M1047"]
+    condition: all
+    rules:
+      - "c:awk '/^ *-a *always,exit/ &&/ -F *arch=b(32|64)/ &&/ -S/ &&(/sethostname/ ||/setdomainname/) &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules -> r:^-a && r:exit,always|always,exit && r:-F arch=b64 && r:-S sethostname,setdomainname && r:-k system-locale"
+      - "c:awk '/^ *-a *always,exit/ &&/ -F *arch=b(32|64)/ &&/ -S/ &&(/sethostname/ ||/setdomainname/) &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules -> r:^-a && r:exit,always|always,exit && r:-F arch=b32 && r:-S sethostname,setdomainname && r:-k system-locale"
+      - "c:awk '/^ *-w/ &&(/\/etc\/issue/ ||/\/etc\/issue.net/ ||/\/etc\/hosts/ ||/\/etc\/network/) &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules -> r:^-w && r:/etc/issue && r:-p wa && r:-k system-locale"
+      - "c:awk '/^ *-w/ &&(/\/etc\/issue/ ||/\/etc\/issue.net/ ||/\/etc\/hosts/ ||/\/etc\/network/) &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules -> r:^-w && r:/etc/issue.net && r:-p wa && r:-k system-locale"
+      - "c:awk '/^ *-w/ &&(/\/etc\/issue/ ||/\/etc\/issue.net/ ||/\/etc\/hosts/ ||/\/etc\/network/) &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules -> r:^-w && r:/etc/hosts && r:-p wa && r:-k system-locale"
+      - "c:awk '/^ *-w/ &&(/\/etc\/issue/ ||/\/etc\/issue.net/ ||/\/etc\/hosts/ ||/\/etc\/network/) &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules -> r:^-w && r:/etc/networks && r:-p wa && r:-k system-locale"
+      - "c:awk '/^ *-w/ &&(/\/etc\/issue/ ||/\/etc\/issue.net/ ||/\/etc\/hosts/ ||/\/etc\/network/) &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules -> r:^-w && r:/etc/network/ && r:-p wa && r:-k system-locale"
+
+# Not Implemented
+#  - id: 3150
+#    title: "Ensure use of privileged commands are collected (Automated)"
+#    description: "Monitor privileged programs, those that have the setuid and/or setgid bit set on execution, to determine if unprivileged users are running these commands."
+#    rationale: "Execution of privileged commands by non-privileged users could be an indication of someone trying to gain unauthorized access to the system."
+#    remediation: "" 
+#    compliance:
+#      - cis: ["4.1.3.6"]
+#      - cis_csc_v8: ["8.5"]
+#      - cis_csc_v7: ["6.2"]
+#      - cmmc_v2.0: ["AU.L2-3.3.1"]
+#      - pci_dss_3.2.1: ["10.1","10.2.2","10.2.4","10.2.5","10.3"]
+#      - pci_dss_4.0: ["9.4.5","10.2","10.2.1","10.2.1.2","10.2.1.5"]
+#      - nist_sp_800-53: ["AU-3(1)","AU-7"]
+#      - soc_2: ["CC5.2","CC7.2"]
+#      - iso_27001-2013: ["A.12.4.1"]
+#      - mitre_techniques: ["T1562, T1562.006"]
+#      - mitre_tactics: ["TA0002"]
+#      - mitre_mitigations: ["M1026"]
+#    condition: all
+#    rules:
+#      - "c:"
+
+#  - id: 3151
+#    title: "Ensure unsuccessful file access attempts are collected (Automated)"
+#    description: "Monitor for unsuccessful attempts to access files. The following parameters are associated with system calls that control files:creation - creat opening - open , openat truncation - truncate , ftruncate An audit log record will only be written if all of the following criteria is met for the user when trying to access a file:a non-privileged user (auid>=UID_MIN) is not a Daemon event (auid=4294967295/unset/-1) if the system call returned EACCES (permission denied) or EPERM (some other permanent error associated with the specific system call)"
+#    rationale: "Failed attempts to open, create or truncate files could be an indication that an individual or process is trying to gain unauthorized access to the system."
+#    remediation: "" 
+#    compliance:
+#      - cis: ["4.1.3.7"]
+#      - cis_csc_v8: ["8.5"]
+#      - cis_csc_v7: ["14.9"]
+#      - cmmc_v2.0: ["AU.L2-3.3.1"]
+#      - pci_dss_3.2.1: ["10.1","10.2.2","10.2.4","10.2.5","10.3"]
+#      - pci_dss_4.0: ["9.4.5","10.2","10.2.1","10.2.1.2","10.2.1.5"]
+#      - nist_sp_800-53: ["AU-3(1)","AU-7"]
+#      - soc_2: ["CC5.2","CC7.2"]
+#      - iso_27001-2013: ["A.12.4.3"]
+#      - mitre_techniques: ["T1562, T1562.006"]
+#      - mitre_tactics: ["TA0007"]
+#      - mitre_mitigations: [""]
+#    condition: all
+#    rules:
+#      - "c:"
+
+  - id: 3152
+    title: "Ensure events that modify user/group information are collected (Automated)"
+    description: "Record events affecting the modification of user or group information, including that of passwords and old passwords if in use. /etc/group - system groups /etc/passwd - system users /etc/gshadow - encrypted password for each group /etc/shadow - system user passwords /etc/security/opasswd - storage of old passwords if the relevant PAM module is in use .The parameters in this section will watch the files to see if they have been opened for write or have had attribute changes (e.g. permissions) and tag them with the identifier "identity" in the audit log file."
+    rationale: "Unexpected changes to these files could be an indication that the system has been compromised and that an unauthorized user is attempting to hide their activities or compromise additional accounts."
+    remediation: 'Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor events that modify user/group information. Example: # printf "-w /etc/group -p wa -k identity -w /etc/passwd -p wa -k identity -w /etc/gshadow -p wa -k identity -w /etc/shadow -p wa -k identity -w /etc/security/opasswd -p wa -k identity " >> /etc/audit/rules.d/50-identity.rules .Merge and load the rules into active configuration: # augenrules --load .Check if reboot is required. # if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then printf "Reboot required to load rules\n"; fi'
+    compliance:
+      - cis: ["4.1.3.8"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.8"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - pci_dss_3.2.1: ["10.1","10.2.2","10.2.4","10.2.5","10.3"]
+      - pci_dss_4.0: ["9.4.5","10.2","10.2.1","10.2.1.2","10.2.1.5"]
+      - nist_sp_800-53: ["AU-3(1)","AU-7"]
+      - soc_2: ["CC5.2","CC7.2"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - mitre_techniques: ["T1562, T1562.006"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_mitigations: ["M1047"]
+    condition: all
+    rules:
+      - "c:awk '/^ *-w/ &&(/\/etc\/group/ ||/\/etc\/passwd/ ||/\/etc\/gshadow/ ||/\/etc\/shadow/ ||/\/etc\/security\/opasswd/) &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules -> r:\.+.rules$"
+      - "c:awk '/^ *-w/ &&(/\/etc\/group/ ||/\/etc\/passwd/ ||/\/etc\/gshadow/ ||/\/etc\/shadow/ ||/\/etc\/security\/opasswd/) &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules -> r:\.+.rules$ -> r:^-w && r:/etc/group && r:-p wa && r:-k identity"
+      - "c:awk '/^ *-w/ &&(/\/etc\/group/ ||/\/etc\/passwd/ ||/\/etc\/gshadow/ ||/\/etc\/shadow/ ||/\/etc\/security\/opasswd/) &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules -> r:\.+.rules$ -> r:^-w && r:/etc/passwd && r:-p wa && r:-k identity"
+      - "c:awk '/^ *-w/ &&(/\/etc\/group/ ||/\/etc\/passwd/ ||/\/etc\/gshadow/ ||/\/etc\/shadow/ ||/\/etc\/security\/opasswd/) &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules -> r:\.+.rules$ -> r:^-w && r:/etc/gshadow && r:-p wa && r:-k identity"
+      - "c:awk '/^ *-w/ &&(/\/etc\/group/ ||/\/etc\/passwd/ ||/\/etc\/gshadow/ ||/\/etc\/shadow/ ||/\/etc\/security\/opasswd/) &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules -> r:\.+.rules$ -> r:^-w && r:/etc/shadow && r:-p wa && r:-k identity"
+      - "c:awk '/^ *-w/ &&(/\/etc\/group/ ||/\/etc\/passwd/ ||/\/etc\/gshadow/ ||/\/etc\/shadow/ ||/\/etc\/security\/opasswd/) &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules -> r:\.+.rules$ -> r:^-w && r:/etc/security/opasswd && r:-p wa && r:-k identity"
+
+# Not Implemented
+#  - id: 3153
+#    title: "Ensure discretionary access control permission modification events are collected (Automated)"
+#    description: "Monitor changes to file permissions, attributes, ownership and group. The parameters in this section track changes for system calls that affect file permissions and attributes. The following commands and system calls effect the permissions, ownership and various attributes of files. chmod, fchmod, fchmodat, chown, fchown, fchownat, lchown, setxattr, lsetxattr, fsetxattr, removexattr, lremovexattr, fremovexattr"
+#    rationale: "Monitoring for changes in file attributes could alert a system administrator to activity that could indicate intruder activity or policy violation."
+#    remediation: "" 
+#    compliance:
+#      - cis: ["4.1.3.9"]
+#      - cis_csc_v8: ["8.5"]
+#      - cis_csc_v7: ["5.5"]
+#      - cmmc_v2.0: ["AU.L2-3.3.1"]
+#      - pci_dss_3.2.1: ["10.1","10.2.2","10.2.4","10.2.5","10.3"]
+#      - pci_dss_4.0: ["9.4.5","10.2","10.2.1","10.2.1.2","10.2.1.5"]
+#      - nist_sp_800-53: ["AU-3(1)","AU-7"]
+#      - soc_2: ["CC5.2","CC7.2"]
+#      - iso_27001-2013: ["A.12.1.2"]
+#      - mitre_techniques: ["T1562, T1562.006"]
+#      - mitre_tactics: ["TA0005"]
+#      - mitre_mitigations: ["M1022"]
+#    condition: all
+#    rules:
+#      - "d:/etc/audit"
+#      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+#      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S chmod && r:-S fchmod && r:-S fchmodat && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k perm_mod'
+#      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S chown && r:-S fchown && r:-S fchownat && r:-S lchown && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k perm_mod'
+#      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S setxattr && r:-S lsetxattr && r:-S fsetxattr && r:-S removexattr && r:-S lremovexattr && r:-S fremovexattr && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k perm_mod'
+
+#  - id: 3154
+#    title: "Ensure successful file system mounts are collected (Automated)"
+#    description: "Monitor the use of the mount system call. The mount (and umount ) system call controls the mounting and unmounting of file systems. The parameters below configure the system to create an audit record when the mount system call is used by a non- privileged user"
+#    rationale: "It is highly unusual for a non privileged user to mount file systems to the system. While tracking mount commands gives the system administrator evidence that external media may have been mounted (based on a review of the source of the mount and confirming it's an external media type), it does not conclusively indicate that data was exported to the media. System administrators who wish to determine if data were exported, would also have to track successful open, creat and truncate system calls requiring write access to a file under the mount point of the external media file system. This could give a fair indication that a write occurred. The only way to truly prove it, would be to track successful writes to the external media. Tracking write system calls could quickly fill up the audit log and is not recommended. Recommendations on configuration options to track data export to media is beyond the scope of this document."
+#    remediation: 'Create audit rules .Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor successful file system mounts. 64 Bit systems .Example: # { UID_MIN=$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs) [ -n "${UID_MIN}" ] && printf " -a always,exit -F arch=b32 -S mount -F auid>=$UID_MIN -F auid!=unset -k mounts -a always,exit -F arch=b64 -S mount -F auid>=$UID_MIN -F auid!=unset -k mounts " >> /etc/audit/rules.d/50-mounts.rules || printf "ERROR: Variable 'UID_MIN' is unset.\n"}Load audit rules .Merge and load the rules into active configuration:# augenrules --load Check if reboot is required.# if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then printf "Reboot required to load rules\n"; fi .32 Bit systems .Follow the same procedures as for 64 bit systems and ignore any entries with b64.' 
+#    compliance:
+#      - cis: ["4.1.3.10"]
+#      - cis_csc_v8: ["8.5"]
+#      - cis_csc_v7: ["6.3"]
+#      - cmmc_v2.0: ["AU.L2-3.3.1"]
+#      - pci_dss_3.2.1: ["10.1","10.2.2","10.2.4","10.2.5","10.3"]
+#      - pci_dss_4.0: ["9.4.5","10.2","10.2.1","10.2.1.2","10.2.1.5"]
+#      - nist_sp_800-53 Rev. 5: ["CM-6"]
+#      - soc_2: ["CC5.2","CC7.2"]
+#      - iso_27001-2013: ["A.12.4.1"]
+#      - mitre_techniques: ["T1562, T1562.006"]
+#      - mitre_tactics: ["TA0010"]
+#      - mitre_mitigations: ["M1034"]
+#    condition: all
+#    rules:
+#      - "d:/etc/audit"
+#      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+#      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S mount && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k mounts'
+
+  - id: 3155
+    title: "Ensure session initiation information is collected (Automated)"
+    description: "Monitor session initiation events. The parameters in this section track changes to the files associated with session events./var/run/utmp - tracks all currently logged in users. /var/log/wtmp - file tracks logins, logouts, shutdown, and reboot events. /var/log/btmp - keeps track of failed login attempts and can be read by entering the command /usr/bin/last -f /var/log/btmp. All audit records will be tagged with the identifier "session."
+    rationale: "Monitoring these files for changes could alert a system administrator to logins occurring at unusual hours, which could indicate intruder activity (i.e. a user logging in at a time when they do not normally log in)."
+    remediation: 'Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor session initiation information. Example: # printf "-w /var/run/utmp -p wa -k session -w /var/log/wtmp -p wa -k session -w /var/log/btmp -p wa -k session " >> /etc/audit/rules.d/50-session.rules .Merge and load the rules into active configuration: # augenrules --load Check if reboot is required. # if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then printf "Reboot required to load rules\n"; fi' 
+    compliance:
+      - cis: ["4.1.3.11"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.9", "16.13"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - pci_dss_3.2.1: ["10.1","10.2.2","10.2.4","10.2.5","10.3"]
+      - pci_dss_4.0: ["9.4.5","10.2","10.2.1","10.2.1.2","10.2.1.5"]
+      - nist_sp_800-53 Rev 5: ["AU-3(1)","AU-3"]
+      - soc_2: ["CC5.2","CC7.2"]
+      - mitre_techniques: ["T1562, T1562.006"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:awk '/^ *-w/ &&(/\/var\/run\/utmp/ ||/\/var\/log\/wtmp/ ||/\/var\/log\/btmp/) &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules -> r:\.+.rules$"
+      - "c:awk '/^ *-w/ &&(/\/var\/run\/utmp/ ||/\/var\/log\/wtmp/ ||/\/var\/log\/btmp/) &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules -> r:\.+.rules$ -> r:^-w && r:/var/run/utmp && r:-p wa && r:-k session"
+      - "c:awk '/^ *-w/ &&(/\/var\/run\/utmp/ ||/\/var\/log\/wtmp/ ||/\/var\/log\/btmp/) &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules -> r:\.+.rules$ -> r:^-w && r:/var/log/wtmp && r:-p wa && r:-k session"
+      - "c:awk '/^ *-w/ &&(/\/var\/run\/utmp/ ||/\/var\/log\/wtmp/ ||/\/var\/log\/btmp/) &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules -> r:\.+.rules$ -> r:^-w && r:/var/log/btmp && r:-p wa && r:-k session"
+
+  - id: 3156
+    title: "Ensure login and logout events are collected (Automated)"
+    description: "Monitor login and logout events. The parameters below track changes to files associated with login/logout events. /var/log/lastlog - maintain records of the last time a user successfully logged in. /var/run/faillock - directory maintains records of login failures via the pam_faillock module."
+    rationale: "Monitoring login/logout events could provide a system administrator with information associated with brute force attacks against user logins."
+    remediation: 'Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor login and logout events. Example: # printf " -w /var/log/lastlog -p wa -k logins -w /var/run/faillock -p wa -k logins " >> /etc/audit/rules.d/50-login.rules Merge and load the rules into active configuration: # augenrules --load Check if reboot is required. # if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then printf "Reboot required to load rules\n"; fi'
+    compliance:
+      - cis: ["4.1.3.12"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.9", "16.11", "16.13"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - pci_dss_3.2.1: ["10.1","10.2.2","10.2.4","10.2.5","10.3"]
+      - pci_dss_4.0: ["9.4.5","10.2","10.2.1","10.2.1.2","10.2.1.5"]
+      - nist_sp_800-53: ["AU-3(1)","AU-7"]
+      - soc_2: ["CC5.2","CC7.2"]
+      - iso_27001-2013: ["A.9.4.2", "A.8.1.3"]
+      - mitre_techniques: ["T1562, T1562.006"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:awk '/^ *-w/ &&(/\/var\/log\/lastlog/ ||/\/var\/run\/faillock/) &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules -> r:^-w && /var/log/lastlog && r:-p wa && r:-k logins"
+      - "c:awk '/^ *-w/ &&(/\/var\/log\/lastlog/ ||/\/var\/run\/faillock/) &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules -> r;^-w /var/run/faillock && r:-p wa && r:-k logins"
+
+# Not implemented
+#  - id: 3157
+#    title: "Ensure file deletion events by users are collected (Automated)"
+#    description: "Monitor the use of system calls associated with the deletion or renaming of files and file attributes. This configuration statement sets up monitoring for: unlink - remove a file .unlinkat - remove a file attribute .rename - rename a file .renameat rename a file attribute system calls and tags them with the identifier "delete"."
+#    rationale: "Monitoring these calls from non-privileged users could provide a system administrator with evidence that inappropriate removal of files and file attributes associated with protected files is occurring. While this audit option will look at all events, system administrators will want to look for specific privileged files that are being deleted or altered."
+#    remediation: "" 
+#    compliance:
+#      - cis: ["4.1.3.13"]
+#      - cis_csc_v8: ["8.5"]
+#      - cis_csc_v7: ["6.2"]
+#      - cmmc_v2.0: ["AU.L2-3.3.1"]
+#      - pci_dss_3.2.1: ["10.1","10.2.2","10.2.4","10.2.5","10.3"]
+#      - pci_dss_4.0: ["9.4.5","10.2","10.2.1","10.2.1.2","10.2.1.5"]
+#      - nist_sp_800-53: ["AU-3(1)","AU-7"]
+#      - soc_2: ["CC5.2","CC7.2"]
+#      - iso_27001-2013: ["A.12.4.1"]
+#      - mitre_techniques: [""]
+#      - mitre_tactics: [""]
+#      - mitre_mitigations: [""]
+#    condition: all
+#    rules:
+#      - "d:/etc/audit"
+#      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+#      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S unlink && r:-S unlinkat && r:-S rename && r:-S renameat && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k delete'
+
+  - id: 3158
+    title: "Ensure events that modify the system's Mandatory Access Controls are collected (Automated)"
+    description: "Monitor AppArmor, an implementation of mandatory access controls. The parameters below monitor any write access (potential additional, deletion or modification of files in the directory) or attribute changes to the /etc/apparmor/ and /etc/apparmor.d/ directories."
+    rationale: "Changes to files in the /etc/apparmor/ and /etc/apparmor.d/ directories could indicate that an unauthorized user is attempting to modify access controls and change security contexts, leading to a compromise of the system."
+    remediation: 'Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor events that modify the systems Mandatory Access Controls. Example:#printf " -w /etc/apparmor/ -p wa -k MAC-policy -w /etc/apparmor.d/ -p wa -k MAC-policy " >> /etc/audit/rules.d/50-MAC-policy.rules .Merge and load the rules into active configuration: # augenrules --load .Check if reboot is required. # if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then printf "Reboot required to load rules\n"; fi'
+    compliance:
+      - cis: ["4.1.3.14"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["5.5"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - pci_dss_3.2.1: ["10.1","10.2.2","10.2.4","10.2.5","10.3"]
+      - pci_dss_4.0: ["9.4.5","10.2","10.2.1","10.2.1.2","10.2.1.5"]
+      - nist_sp_800-53: ["AU-3(1)","AU-7"]
+      - soc_2: ["CC5.2","CC7.2"]
+      - iso_27001-2013: ["A.12.1.2"]
+      - mitre_techniques: ["T1562, T1562.006"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_mitigations: ["M1022"]
+    condition: all
+    rules:
+      - "c:awk '/^ *-w/ &&(/\/etc\/apparmor/ ||/\/etc\/apparmor.d/) &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules ->r:^-w && r;/etc/apparmor/ && r:-p wa && r:-k MAC-policy"
+      - "c:awk '/^ *-w/ &&(/\/etc\/apparmor/ ||/\/etc\/apparmor.d/) &&/ +-p *wa/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules ->r:^-w && r:/etc/apparmor.d/ && r:-p wa && r:-k MAC-policy"
+
+  - id: 3159
+    title: "Ensure successful and unsuccessful attempts to use the chcon command are recorded (Automated)"
+    description: "The operating system must generate audit records for successful/unsuccessful uses of the chcon command."
+    rationale: "The chcon command is used to change file security context. Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. Audit records can be generated from various components within the information system (e.g., module or policy filter)."
+    remediation: "Create audit rules .Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor successful and unsuccessful attempts to use the chcon command.64 Bit systems Example:# {UID_MIN=$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs) [ -n "${UID_MIN}" ] && printf " -a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=${UID_MIN} -F auid!=unset -k perm_chng">> /etc/audit/rules.d/50-perm_chng.rules || printf "ERROR:Variable 'UID_MIN' is unset.\n" } .Load audit rules .Merge and load the rules into active configuration:# augenrules --load .Check if reboot is required.# if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then printf "Reboot required to load rules\n"; fi .32 Bit systems .Follow the same procedures as for 64 bit systems and ignore any entries with b64." 
+    compliance:
+      - cis: ["4.1.3.15"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - pci_dss_3.2.1: ["10.2","10.3"]
+      - pci_dss_4.0: ["5.3.4","6.4.1","6.4.2","10.2.1","10.2.1.1","10.2.1.2","10.2.1.3","10.2.1.4","10.2.1.5","10.2.1.6","10.2.1.7","10.2.2"]
+      - nist_sp_800-53: ["AU-7"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_techniques: ["8.2"]
+      - mitre_tactics: ["6.2"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:{ UID_MIN=$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs); [ -n "${UID_MIN}" ] && auditctl -l | awk "/^ *-a *always,exit/ &&(/ -F *auid!=unset/||/ -F *auid!=-1/||/ -F *auid!=4294967295/) &&/ -F *auid>=${UID_MIN}/ &&/ -F *perm=x/ &&/ -F *path=\/usr\/sbin\/usermod/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)" || printf "ERROR:Variable 'UID_MIN' is unset.\n"; } -> r:^-a && r:always,exit && r:-F path=/usr/bin/chcon && r:-F perm=x && r:-F auid>=1000 && r:-F auid!=unset && r:-k perm_chng"
+
+
+  - id: 3160
+    title: "Ensure successful and unsuccessful attempts to use the setfacl command are recorded (Automated)"
+    description: "The operating system must generate audit records for successful/unsuccessful uses of the setfacl command"
+    rationale: "This utility sets Access Control Lists (ACLs) of files and directories. Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. Audit records can be generated from various components within the information system (e.g., module or policy filter)."
+    remediation: "Create audit rules .Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor successful and unsuccessful attempts to use the setfacl command. 64 Bit systems Example: { UID_MIN=$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs) [ -n "${UID_MIN}" ] && printf " -a always,exit -F path=/usr/bin/setfacl -F perm=x -F auid>=${UID_MIN} -F auid!=unset -k perm_chng " >> /etc/audit/rules.d/50-perm_chng.rules || printf "ERROR:Variable 'UID_MIN' is unset.\n" } Load audit rules .Merge and load the rules into active configuration:# augenrules --load Check if reboot is required.# if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then printf "Reboot required to load rules\n"; fi 32 Bit systems. Follow the same procedures as for 64 bit systems and ignore any entries with b64." 
+    compliance:
+      - cis: ["4.1.3.16"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - pci_dss_3.2.1: ["10.2","10.3"]
+      - pci_dss_4.0: ["5.3.4","6.4.1","6.4.2","10.2.1","10.2.1.1","10.2.1.2","10.2.1.3","10.2.1.4","10.2.1.5","10.2.1.6","10.2.1.7","10.2.2"]
+      - nist_sp_800-53: ["AU-7"]
+      - iso_27001-2013: ["A.12.4.1"]
+    condition: all
+    rules:
+      - "c:{ UID_MIN=$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs); [ -n "${UID_MIN}" ] && awk "/^ *-a *always,exit/ &&(/ -F *auid!=unset/||/ -F *auid!=-1/||/ -F *auid!=4294967295/) &&/ -F *auid>=${UID_MIN}/ &&/ -F *perm=x/ &&/ -F *path=\/usr\/bin\/setfacl/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)" /etc/audit/rules.d/*.rules || printf "ERROR:Variable 'UID_MIN' is unse-a always,exit -F path=/usr/bin/setfacl -F perm=x -F auid>=1000 -F
+auid!=unset -k perm_chngt.\n"; } -> r:^-a && r:always,exit && r:-F path=/usr/bin/setfacl && r:-F perm=x && r:-F auid>=1000 && r:-F auid!=unset && r:-k perm_chng"
+
+  - id: 3161
+    title: "Ensure successful and unsuccessful attempts to use the chacl command are recorded (Automated)"
+    description: "The operating system must generate audit records for successful/unsuccessful uses of the chacl command. chacl is an IRIX-compatibility command, and is maintained for those users who are familiar with its use from either XFS or IRIX."
+    rationale: "chacl changes the ACL(s) for a file or directory. Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. Audit records can be generated from various components within the information system (e.g., module or policy filter)."
+    remediation: "Create audit rules .Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor successful and unsuccessful attempts to use the chacl command.64 Bit systems Example:# {UID_MIN=$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs)[ -n "${UID_MIN}" ] && printf "-a always,exit -F path=/usr/bin/chacl -F perm=x -F auid>=${UID_MIN} -F auid!=unset -k perm_chng" >> /etc/audit/rules.d/50-perm_chng.rules || printf "ERROR:Variable 'UID_MIN' is unset.\n" } Load audit rules Merge and load the rules into active configuration:# augenrules --load Check if reboot is required.# if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then printf "Reboot required to load rules\n"; fi 32 Bit systems Follow the same procedures as for 64 bit systems and ignore any entries with b64." 
+    compliance:
+      - cis: ["4.1.3.17"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - pci_dss_3.2.1: ["10.2","10.3"]
+      - pci_dss_4.0: ["5.3.4","6.4.1","6.4.2","10.2.1","10.2.1.1","10.2.1.2","10.2.1.3","10.2.1.4","10.2.1.5","10.2.1.6","10.2.1.7","10.2.2"]
+      - nist_sp_800-53: ["AU-7"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:{ UID_MIN=$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs); [ -n "${UID_MIN}" ] && awk "/^ *-a *always,exit/ &&(/ -F *auid!=unset/||/ -F *auid!=-1/||/ -F *auid!=4294967295/) &&/ -F *auid>=${UID_MIN}/ &&/ -F *perm=x/ &&/ -F *path=\/usr\/bin\/chacl/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)" /etc/audit/rules.d/*.rules || printf "ERROR:Variable 'UID_MIN' is unset.\n"; } -> r:^-a && r:always,exit && r:-F path=/usr/bin/chacl && r:-F perm=x && r:-F auid>=1000 && r:-F auid!=unset && r:-k priv_cmd"
+
+  - id: 3162
+    title: "Ensure successful and unsuccessful attempts to use the usermod command are recorded (Automated)"
+    description: "The operating system must generate audit records for successful/unsuccessful uses of the usermod command."
+    rationale: "The usermod command modifies the system account files to reflect the changes that are specified on the command line. Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.Audit records can be generated from various components within the information system (e.g., module or policy filter)."
+    remediation: "Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor successful and unsuccessful attempts to use the usermod command.64 Bit systems Example:# {UID_MIN=$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs) [ -n "${UID_MIN}" ] && printf "-a always,exit -F path=/usr/sbin/usermod -F perm=x -F auid>=${UID_MIN} -F auid!=unset -k usermod " >> /etc/audit/rules.d/50-usermod.rules || printf "ERROR:Variable 'UID_MIN' is unset.\n"}Load audit rules .Merge and load the rules into active configuration:# augenrules --load Check if reboot is required.# if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then printf "Reboot required to load rules\n"; fi" 
+    compliance:
+      - cis: ["4.1.3.18"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - pci_dss_3.2.1: ["10.2","10.3"]
+      - pci_dss_4.0: ["5.3.4","6.4.1","6.4.2","10.2.1","10.2.1.1","10.2.1.2","10.2.1.3","10.2.1.4","10.2.1.5","10.2.1.6","10.2.1.7","10.2.2"]
+      - nist_sp_800-53: ["AU-7"]
+      - iso_27001-2013: ["A.12.4.1"]
+    condition: all
+    rules:
+      - "c:{ UID_MIN=$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs); [ -n "${UID_MIN}" ] && awk "/^ *-a *always,exit/ &&(/ -F *auid!=unset/||/ -F *auid!=-1/||/ -F *auid!=4294967295/) &&/ -F *auid>=${UID_MIN}/ &&/ -F *perm=x/ &&/ -F *path=\/usr\/sbin\/usermod/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)" /etc/audit/rules.d/*.rules || printf "ERROR:Variable 'UID_MIN' is unset.\n"; } -> r:^-a && r:always,exit && r:-F path=/usr/sbin/usermod && r:-F perm=x && r:-F auid>=1000 && r:-F auid!=unset && r:-k usermod"
+
+  - id: 3163
+    title: "Ensure kernel module loading unloading and modification is collected (Automated)"
+    description: "Monitor the loading and unloading of kernel modules. All the loading / listing / dependency checking of modules is done by kmod via symbolic links. The following system calls control loading and unloading of modules: init_module - load a module .finit_module - load a module (used when the overhead of using. cryptographically signed modules to determine the authenticity of a module can be avoided) .delete_module - delete a module .create_module - create a loadable module entry .query_module - query the kernel for various bits pertaining to modules .Any execution of the loading and unloading module programs and system calls will trigger an audit record with an identifier of modules."
+    rationale: "Monitoring the use of all the various ways to manipulate kernel modules could provide system administrators with evidence that an unauthorized change was made to a kernel module, possibly compromising the security of the system."
+    remediation: "Create audit rules Edit or create a file in the /etc/audit/rules.d/ directory, ending in .rules extension, with the relevant rules to monitor kernel module modification. 64 Bit systemsExample:# {UID_MIN=$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs) [ -n "${UID_MIN}" ] && printf " -a always,exit -F arch=b64 -S init_module,finit_module,delete_module,create_module,query_module -F auid>=${UID_MIN} -F auid!=unset -k kernel_modules -a always,exit -F path=/usr/bin/kmod -F perm=x -F auid>=${UID_MIN} -F auid!=unset -k kernel_modules" >> /etc/audit/rules.d/50-kernel_modules.rules || printf "ERROR:Variable'UID_MIN' is unset.\n"}Load audit rules .Merge and load the rules into active configuration:# augenrules --load Check if reboot is required.# if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then printf "Reboot required to load rules\n"; fi" 
+    compliance:
+      - cis: ["4.1.3.19"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - pci_dss_3.2.1: ["10.1","10.2.2","10.2.4","10.2.5","10.3"]
+      - pci_dss_4.0: ["9.4.5","10.2","10.2.1","10.2.1.2","10.2.1.5"]
+      - nist_sp_800-53: ["AU-3(1)","AU-7"]
+      - soc_2: ["CC5.2","CC7.2"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_techniques: ["T1562, T1562.006"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_mitigations: ["M1047"]
+    condition: all
+    rules:
+      - "c:{ awk '/^ *-a *always,exit/ &&/ -F *arch=b[2346]{2}/ &&(/ -F auid!=unset/||/ -F auid!=-1/||/ -F auid!=4294967295/) &&/ -S/ &&(/init_module/ ||/finit_module/ ||/delete_module/ ||/create_module/ ||/query_module/) &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules; UID_MIN=$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs); [ -n "${UID_MIN}" ] && awk "/^ *-a *always,exit/ &&(/ -F *auid!=unset/||/ -F *auid!=-1/||/ -F *auid!=4294967295/) &&/ -F *auid>=${UID_MIN}/ &&/ -F *perm=x/ &&/ -F *path=\/usr\/bin\/kmod/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)" /etc/audit/rules.d/*.rules || printf "ERROR:Variable 'UID_MIN' is unset.\n"; } -> r:^-a && r:always,exit -F arch=b64 && r:-S init_module,finit_module,delete_module,create_module,query_module && r:-F auid>=1000 && r:-F auid!=unset && r:-k kernel_modules"
+      - "c:{ awk '/^ *-a *always,exit/ &&/ -F *arch=b[2346]{2}/ &&(/ -F auid!=unset/||/ -F auid!=-1/||/ -F auid!=4294967295/) &&/ -S/ &&(/init_module/ ||/finit_module/ ||/delete_module/ ||/create_module/ ||/query_module/) &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)' /etc/audit/rules.d/*.rules; UID_MIN=$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs); [ -n "${UID_MIN}" ] && awk "/^ *-a *always,exit/ &&(/ -F *auid!=unset/||/ -F *auid!=-1/||/ -F *auid!=4294967295/) &&/ -F *auid>=${UID_MIN}/ &&/ -F *perm=x/ &&/ -F *path=\/usr\/bin\/kmod/ &&(/ key= *[!-~]* *$/||/ -k *[!-~]* *$/)" /etc/audit/rules.d/*.rules || printf "ERROR:Variable 'UID_MIN' is unset.\n"; } -> r:^-a always,exit -F path=/usr/bin/kmod -F perm=x -F auid>=1000 -F auid!=unset && -k kernel_modules"
+
+  - id: 3164
+    title: "Ensure the audit configuration is immutable (Automated)"
+    description: "Set system audit so that audit rules cannot be modified with auditctl . Setting the flag "-e 2" forces audit to be put in immutable mode. Audit changes can only be made on system reboot. Note:This setting will require the system to be rebooted to update the active auditd configuration settings."
+    rationale: "In immutable mode, unauthorized users cannot execute changes to the audit system to potentially hide malicious activity and then put the audit rules back. Users would most likely notice a system reboot and that could alert administrators of an attempt to make unauthorized audit changes."
+    remediation: "Edit or create the file /etc/audit/rules.d/99-finalize.rules and add the line -e 2 at the end of the file: Example:# printf -- "-e 2 " >> /etc/audit/rules.d/99-finalize.rules Load audit rules Merge and load the rules into active configuration:# augenrules --load Check if reboot is required.# if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then printf "Reboot required to load rules\n"; fi" 
+    compliance:
+      - cis: ["4.1.3.20"]
+      - cis_csc_v8: ["3.3","8.5"]
+      - cis_csc_v7: ["6.2","6.3"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2","AU.L2-3.3.1"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["10.1","10.2.2","10.2.4","10.2.5","10.3","7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1","9.4.5","10.2","10.2.1","10.2.1.2","10.2.1.5"]
+      - nist_sp_800-53: ["AC-5","AC-6","AU-3(1)","AU-7"]
+      - soc_2: ["CC5.2","CC6.1","CC7.2"]
+      - mitre_techniques: ["T1562, T1562.001"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "d:/etc/audit"
+      - "d:/etc/audit/rules.d -> r:^99-finalize.rules$"
+      - 'd:/etc/audit/rules.d -> r:^99-finalize.rules$ -> r:^\s*\t*-e 2$'
+
+  - id: 3165
+    title: "Ensure the running and on disk configuration is the same (Manual)"
+    description: "The Audit system have both on disk and running configuration. It is possible for these configuration settings to differ. Note: Due to the limitations of augenrules and auditctl, it is not absolutely guaranteed that loading the rule sets via augenrules --load will result in all rules being loaded or even that the user will be informed if there was a problem loading the rules."
+    rationale: "Configuration differences between what is currently running and what is on disk could cause unexpected problems or may give a false impression of compliance requirements."
+    remediation: "If the rules are not aligned across all three () areas, run the following command to merge and load all rules:# augenrules --load Check if reboot is required. if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then echo "Reboot required to load rules"; fi" 
+    compliance:
+      - cis: ["4.1.3.21"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - pci_dss_3.2.1: ["10.1","10.2.2","10.2.4","10.2.5","10.3"]
+      - pci_dss_4.0: ["9.4.5","10.2","10.2.1","10.2.1.2","10.2.1.5"]
+      - nist_sp_800-53: ["AU-3(1)","AU-7"]
+      - soc_2: ["CC5.2","CC7.2"]
+      - iso_27001-2013: ["A.12.4.1"]
+    condition: all
+    rules:
+      - "c:augenrules --check -> r:/usr/sbin/augenrules: && r:No change"
+      
+# 4.1.4 Configure auditd file access
+
+  - id: 3166
+    title: "Ensure audit log files are mode 0640 or less permissive (Automated)"
+    description: "Audit log files contain information about the system and system activity."
+    rationale: "Access to audit records can reveal system and configuration data to attackers, potentially compromising its confidentiality."
+    remediation: "Run the following command to remove more permissive mode than 0640 from audit log files:# [ -f /etc/audit/auditd.conf ] && find "$(dirname $(awk -F "="'/^\s*log_file/ {print $2}' /etc/audit/auditd.conf | xargs))" -type f \( ! -perm 600 -a ! -perm 0400 -a ! -perm 0200 -a ! -perm 0000 -a ! -perm 0640 -a !-perm 0440 -a ! -perm 0040 \) -exec chmod u-x,g-wx,o-rwx {} +" 
+    compliance:
+      - cis: ["4.1.4.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1070, T1070.002, T1083, T1083.000"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_mitigations: [""]
+    condition: none
+    rules:
+      - "c:[ -f /etc/audit/auditd.conf ] && find "$(dirname $(awk -F "=" '/^\s*log_file/ {print $2}' /etc/audit/auditd.conf | xargs))" -type f \( ! -perm 600 -a ! -perm 0400 -a ! -perm 0200 -a ! -perm 0000 -a ! -perm 0640 -a ! -perm 0440 -a ! -perm 0040 \) -exec stat -Lc "%n %#a" {} +"
+
+  - id: 3167
+    title: "Ensure only authorized users own audit log files (Automated)"
+    description: "Audit log files contain information about the system and system activity."
+    rationale: "Access to audit records can reveal system and configuration data to attackers, potentially compromising its confidentiality."
+    remediation: "Run the following command to configure the audit log files to be owned by the root user: # [ -f /etc/audit/auditd.conf ] && find "$(dirname $(awk -F "=" '/^\s*log_file/ {print $2}' /etc/audit/auditd.conf | xargs))" -type f ! -user root -exec chown root {} +" 
+    compliance:
+      - cis: ["4.1.4.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1070, T1070.002, T1083, T1083.000"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_mitigations: [""]
+    condition: none
+    rules:
+      - "c:[ -f /etc/audit/auditd.conf ] && find "$(dirname $(awk -F "=" '/^\s*log_file/ {print $2}' /etc/audit/auditd.conf | xargs))" -type f ! -user root -exec stat -Lc "%n %U" {} +"
+
+  - id: 3168
+    title: "Ensure only authorized groups are assigned ownership of audit log files (Automated)"
+    description: "Audit log files contain information about the system and system activity."
+    rationale: "Access to audit records can reveal system and configuration data to attackers, potentially compromising its confidentiality."
+    remediation: "Run the following command to configure the audit log files to be owned by adm group: # find $(dirname $(awk -F"=" '/^\s*log_file/ {print $2}' /etc/audit/auditd.conf | xargs)) -type f \( ! -group adm -a ! -group root \) -exec chgrp adm {} + Run the following command to configure the audit log files to be owned by the adm group:# chgrp adm /var/log/audit/ Run the following command to set the log_group parameter in the audit configuration file to log_group = adm:# sed -ri 's/^\s*#?\s*log_group\s*=\s*\S+(\s*#.*)?.*$/log_group = adm\1/' /etc/audit/auditd.conf Run the following command to restart the audit daemon to reload the configuration file:# systemctl restart auditd" 
+    compliance:
+      - cis: ["4.1.4.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1070, T1070.002, T1083, T1083.000"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_mitigations: [""]
+    condition: any
+    rules:
+      - "c:grep -Piw -- '^\h*log_group\h*=\h*(adm|root)\b' /etc/audit/auditd.conf -> r:log_group = adm"
+      - "c:grep -Piw -- '^\h*log_group\h*=\h*(adm|root)\b' /etc/audit/auditd.conf -> r:log_group = root"
+
+  - id: 3169
+    title: "Ensure the audit log directory is 0750 or more restrictive (Automated)"
+    description: "The audit log directory contains audit log files."
+    rationale: "Audit information includes all information including: audit records, audit settings and audit reports. This information is needed to successfully audit system activity. This information must be protected from unauthorized modification or deletion. If this information were to be compromised, forensic analysis and discovery of the true source of potentially malicious system activity is impossible to achieve."
+    remediation: "Run the following command to configure the audit log directory to have a mode of "0750" or less permissive:# chmod g-w,o-rwx "$(dirname $(awk -F"=" '/^\s*log_file/ {print $2}' /etc/audit/auditd.conf))"" 
+    compliance:
+      - cis: ["4.1.4.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1070, T1070.002, T1083, T1083.000"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_mitigations: [""]
+    condition: none
+    rules:
+      - "c:stat -Lc "%n %a" "$(dirname $( awk -F"=" '/^\s*log_file/ {print $2}' /etc/audit/auditd.conf))" | grep -Pv -- '^\h*\H+\h+([0,5,7][0,5]0)'"
+
+  - id: 3170
+    title: "Ensure audit configuration files are 640 or more restrictive (Automated)"
+    description: "Audit configuration files control auditd and what events are audited."
+    rationale: "Access to the audit configuration files could allow unauthorized personnel to prevent the auditing of critical events. Misconfigured audit configuration files may prevent the auditing of critical events or impact the system's performance by overwhelming the audit log. Misconfiguration of the audit configuration files may also make it more difficult to establish and investigate events relating to an incident."
+    remediation: "Run the following command to remove more permissive mode than 0640 from the audit configuration files:# find /etc/audit/ -type f \( -name '*.conf' -o -name '*.rules' \) -execchmod u-x,g-wx,o-rwx {} +" 
+    compliance:
+      - cis: ["4.1.4.5"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1070, T1070.002, T1083, T1083.000"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_mitigations: [""]
+    condition: none
+    rules:
+      - "c:find /etc/audit/ -type f \( -name '*.conf' -o -name '*.rules' \) -exec stat -Lc "%n %a" {} + | grep -Pv -- '^\h*\H+\h*([0,2,4,6][0,4]0)\h*$'"
+
+  - id: 3171
+    title: "Ensure audit configuration files are owned by root (Automated)"
+    description: "Audit configuration files control auditd and what events are audited."
+    rationale: "Access to the audit configuration files could allow unauthorized personnel to prevent the auditing of critical events. Misconfigured audit configuration files may prevent the auditing of critical events or impact the system's performance by overwhelming the audit log. Misconfiguration of the audit configuration files may also make it more difficult to establish and investigate events relating to an incident."
+    remediation: "Run the following command to change ownership to root user: # find /etc/audit/ -type f \( -name '*.conf' -o -name '*.rules' \) ! -user root -exec chown root {} +" 
+    compliance:
+      - cis: ["4.1.4.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1070, T1070.002, T1083, T1083.000"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_mitigations: [""]
+    condition: none
+    rules:
+      - "c:find /etc/audit/ -type f \( -name '*.conf' -o -name '*.rules' \) ! -user root"
+
+  - id: 3172
+    title: "Ensure audit configuration files belong to group root (Automated)"
+    description: "Audit configuration files control auditd and what events are audited."
+    rationale: "Access to the audit configuration files could allow unauthorized personnel to prevent the auditing of critical events. Misconfigured audit configuration files may prevent the auditing of critical events or impact the system's performance by overwhelming the audit log. Misconfiguration of the audit configuration files may also make it more difficult to establish and investigate events relating to an incident."
+    remediation: "Run the following command to change group to root: # find /etc/audit/ -type f \( -name '*.conf' -o -name '*.rules' \) ! -group root -exec chgrp root {} +"
+    compliance:
+      - cis: ["4.1.4.7"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1070, T1070.002, T1083, T1083.000"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:find /etc/audit/ -type f \( -name '*.conf' -o -name '*.rules' \) ! -group root"
+
+  - id: 3173
+    title: "Ensure audit tools are 755 or more restrictive (Automated)"
+    description: "Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators."
+    rationale: "Protecting audit information includes identifying and protecting the tools used to view and manipulate log data. Protecting audit tools is necessary to prevent unauthorized operation on audit information."
+    remediation: "Run the following command to remove more permissive mode from the audit tools:# chmod go-w /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace/sbin/auditd /sbin/augenrules" 
+    compliance:
+      - cis: ["4.1.4.8"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1070, T1070.002, T1083, T1083.000"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:stat -c "%n %a" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace/sbin/auditd /sbin/augenrules | grep -Pv -- '^\h*\H+\h+([0-7][0,1,4,5][0,1,4,5])\h*$'"
+
+  - id: 3174
+    title: "Ensure audit tools are owned by root (Automated)"
+    description: "Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators."
+    rationale: "Protecting audit information includes identifying and protecting the tools used to view and manipulate log data. Protecting audit tools is necessary to prevent unauthorized operation on audit information."
+    remediation: "Run the following command to change the owner of the audit tools to the root user: # chown root /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace/sbin/auditd /sbin/augenrules" 
+    compliance:
+      - cis: ["4.1.4.9"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1070, T1070.002, T1083, T1083.000"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:stat -c "%n %U" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace/sbin/auditd /sbin/augenrules | grep -Pv -- '^\h*\H+\h+root\h*$'"
+
+  - id: 3175
+    title: "Ensure audit tools belong to group root (Automated)"
+    description: "Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators."
+    rationale: "Protecting audit information includes identifying and protecting the tools used to view and manipulate log data. Protecting audit tools is necessary to prevent unauthorized operation on audit information."
+    remediation: "Run the following command to remove more permissive mode from the audit tools: # chmod go-w /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/augenrules .Run the following command to change owner and group of the audit tools to root user and group:# chown root:root /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace/sbin/auditd /sbin/augenrules" 
+    compliance:
+      - cis: ["4.1.4.10"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1070, T1070.002, T1083, T1083.000"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_mitigations: [""]
+    condition: none
+    rules:
+      - "c:stat -c "%n %a %U %G" /sbin/auditctl /sbin/aureport /sbin/ausearch/sbin/autrace /sbin/auditd /sbin/augenrules | grep -Pv -- '^\h*\H+\h+([0-7][0,1,4,5][0,1,4,5])\h+root\h+root\h*$'"
+
+  - id: 3176
+    title: "Ensure cryptographic mechanisms are used to protect the integrity of audit tools (Automated)"
+    description: "Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators."
+    rationale: "Protecting the integrity of the tools used for auditing purposes is a critical step toward ensuring the integrity of audit information. Audit information includes all information (e.g., audit records, audit settings, and audit reports) needed to successfully audit information system activity. Attackers may replace the audit tools or inject code into the existing tools with the purpose of providing the capability to hide or erase system activity from the audit logs. Audit tools should be cryptographically signed in order to provide the capability to identify when the audit tools have been modified, manipulated, or replaced. An example is a checksum hash of the file or files."
+    remediation: "Add or update the following selection lines for to a file ending in .conf in the /etc/aide/aide.conf.d/ or to /etc/aide/aide.conf to protect the integrity of the audit tools:# Audit Tools /sbin/auditctl p+i+n+u+g+s+b+acl+xattrs+sha512 /sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512 /sbin/ausearch p+i+n+u+g+s+b+acl+xattrs+sha512 /sbin/aureport p+i+n+u+g+s+b+acl+xattrs+sha512 /sbin/autrace p+i+n+u+g+s+b+acl+xattrs+sha512 /sbin/augenrules p+i+n+u+g+s+b+acl+xattrs+sha512" 
+    compliance:
+      - cis: ["4.1.4.11"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","CM.L2-3.4.1","CM.L2-3.4.6","CM.L2-3.4.2","CM.L2-3.4.7"]
+      - pci_dss_3.2.1: ["2.2","11.5"]
+      - pci_dss_4.0: ["1.1.1","1.2.1","1.2.6","1.5.1","1.2.7","2.1.1","2.2.1"]
+      - nist_sp_800-53: ["CM-7(1)","CM-9","SA-10"]
+      - soc_2: ["CC7.1","CC8.1"]
+      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
+      - mitre_techniques: ["T1070, T1070.002, T1083, T1083.000"]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:grep -Ps -- '(\/sbin\/(audit|au)\H*\b)' /etc/aide/aide.conf.d/*.conf /etc/aide/aide.conf -> r:/sbin/auditctl p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "c:grep -Ps -- '(\/sbin\/(audit|au)\H*\b)' /etc/aide/aide.conf.d/*.conf /etc/aide/aide.conf -> r:/sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "c:grep -Ps -- '(\/sbin\/(audit|au)\H*\b)' /etc/aide/aide.conf.d/*.conf /etc/aide/aide.conf -> r:/sbin/ausearch p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "c:grep -Ps -- '(\/sbin\/(audit|au)\H*\b)' /etc/aide/aide.conf.d/*.conf /etc/aide/aide.conf -> r:/sbin/aureport p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "c:grep -Ps -- '(\/sbin\/(audit|au)\H*\b)' /etc/aide/aide.conf.d/*.conf /etc/aide/aide.conf -> r:/sbin/autrace p+i+n+u+g+s+b+acl+xattrs+sha512"
+      - "c:grep -Ps -- '(\/sbin\/(audit|au)\H*\b)' /etc/aide/aide.conf.d/*.conf /etc/aide/aide.conf -> r:/sbin/augenrules p+i+n+u+g+s+b+acl+xattrs+sha512"
+
+# 4.2 Configure Logging
+
+# 4.2.1 Configure journald
+
+# 4.2.1.1 Ensure journald is configured to send logs to a remote log host
+
+  - id: 3177
+    title: "Ensure systemd-journal-remote is installed (Automated)"
+    description: "Journald (via systemd-journal-remote) supports the ability to send log events it gathers to a remote log host or to receive messages from remote hosts, thus enabling centralised log management."
+    rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
+    remediation: "Run the following command to install systemd-journal-remote: # apt install systemd-journal-remote" 
+    compliance:
+      - cis: ["4.2.1.1.1"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2","6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - pci_dss_3.2.1: ["10.2","10.3"]
+      - pci_dss_4.0: ["5.3.4","6.4.1","6.4.2","10.2.1","10.2.1.1","10.2.1.2","10.2.1.3","10.2.1.4","10.2.1.5","10.2.1.6","10.2.1.7","10.2.2"]
+      - nist_sp_800-53: ["AU-7"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_techniques: ["T1070, T1070.002, T1562, T1562.006"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_mitigations: ["M1029"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' systemd-journal-remote ->r:install ok installed"
+
+  - id: 3178
+    title: "Ensure systemd-journal-remote is configured (Manual)"
+    description: "Journald (via systemd-journal-remote) supports the ability to send log events it gathers to a remote log host or to receive messages from remote hosts, thus enabling centralised log management."
+    rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
+    remediation: "Edit the /etc/systemd/journal-upload.conf file and ensure the following lines are set per your environment: URL=192.168.50.42 ServerKeyFile=/etc/ssl/private/journal-upload.pem ServerCertificateFile=/etc/ssl/certs/journal-upload.pem TrustedCertificateFile=/etc/ssl/ca/trusted.pem" 
+    compliance:
+      - cis: ["4.2.1.1.2"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2","6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - pci_dss_3.2.1: ["10.2","10.3"]
+      - pci_dss_4.0: ["5.3.4","6.4.1","6.4.2","10.2.1","10.2.1.1","10.2.1.2","10.2.1.3","10.2.1.4","10.2.1.5","10.2.1.6","10.2.1.7","10.2.2"]
+      - nist_sp_800-53: ["AU-7"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_techniques: ["T1070, T1070.002, T1562, T1562.006"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_mitigations: ["M1029"]
+    condition: any
+    rules:
+      - "c:grep -P "^ *URL=|^ *ServerKeyFile=|^ *ServerCertificateFile=|^*TrustedCertificateFile=" /etc/systemd/journal-upload.conf ->r:ServerKeyFile"
+      - "c:grep -P "^ *URL=|^ *ServerKeyFile=|^ *ServerCertificateFile=|^*TrustedCertificateFile=" /etc/systemd/journal-upload.conf ->r:ServerCertificateFile"
+      - "c:grep -P "^ *URL=|^ *ServerKeyFile=|^ *ServerCertificateFile=|^*TrustedCertificateFile=" /etc/systemd/journal-upload.conf ->r:TrustedCertificateFile"
+
+  - id: 3179
+    title: "Ensure systemd-journal-remote is enabled (Manual)"
+    description: "Journald (via systemd-journal-remote) supports the ability to send log events it gathers to a remote log host or to receive messages from remote hosts, thus enabling centralised log management."
+    rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
+    remediation: "Run the following command to enable systemd-journal-remote: # systemctl --now enable systemd-journal-upload.service" 
+    compliance:
+      - cis: ["4.2.1.1.3"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2","6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - pci_dss_3.2.1: ["10.2","10.3"]
+      - pci_dss_4.0: ["5.3.4","6.4.1","6.4.2","10.2.1","10.2.1.1","10.2.1.2","10.2.1.3","10.2.1.4","10.2.1.5","10.2.1.6","10.2.1.7","10.2.2"]
+      - nist_sp_800-53: ["AU-7"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_techniques: ["T1070, T1070.002, T1562, T1562.006"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_mitigations: ["M1029"]
+    condition: all
+    rules:
+      - "c:systemctl is-enabled systemd-journal-upload.service ->r:enabled"
+
+  - id: 3180
+    title: "Ensure journald is not configured to recieve logs from a remote client (Automated)"
+    description: "Journald supports the ability to receive messages from remote hosts, thus acting as a log server. Clients should not receive data from other hosts. NOTE: The same package, systemd-journal-remote, is used for both sending logs to remote hosts and receiving incoming logs.With regards to receiving logs, there are two services; systemd-journal-remote.socket and systemd-journal-remote.service."
+    rationale: "If a client is configured to also receive data, thus turning it into a server, the client system is acting outside it's operational boundary."
+    remediation: "Run the following command to disable systemd-journal-remote.socket:# systemctl --now disable systemd-journal-remote.socket" 
+    compliance:
+      - cis: ["4.2.1.1.4"]
+      - cis_csc_v8: ["8.2","4.8"]
+      - cis_csc_v7: ["6.2","6.3","9.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1""CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - hipaa: ["164.312(b)"]
+      - pci_dss_3.2.1: ["10.2","10.3","1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1","5.3.4","6.4.1","6.4.2","10.2.1","10.2.1.1","10.2.1.2","10.2.1.3","10.2.1.4","10.2.1.5","10.2.1.6","10.2.1.7","10.2.2"]
+      - nist_sp_800-53: ["AU-7"]
+      - iso_27001-2013: ["A.12.4.1","A.13.1.3"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - mitre_techniques: ["T1070, T1070.002, T1562, T1562.006"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_mitigations: ["M1029"]
+    rules:
+      - "c:systemctl is-enabled systemd-journal-remote.socket ->r:disabled"
+
+  - id: 3181
+    title: "Ensure journald service is enabled (Automated)"
+    description: "Ensure that the systemd-journald service is enabled to allow capturing of logging events."
+    rationale: "If the systemd-journald service is not enabled to start on boot, the system will not capture logging events."
+    remediation: "By default the systemd-journald service does not have an [Install] section and thus cannot be enabled / disabled. It is meant to be referenced as Requires or Wants by other unit files. As such, if the status of systemd-journald is not static, investigate why." 
+    compliance:
+      - cis: ["4.2.1.2"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2","6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - pci_dss_3.2.1: ["10.2","10.3"]
+      - pci_dss_4.0: ["5.3.4","6.4.1","6.4.2","10.2.1","10.2.1.1","10.2.1.2","10.2.1.3","10.2.1.4","10.2.1.5","10.2.1.6","10.2.1.7","10.2.2"]
+      - nist_sp_800-53: ["AU-7"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_techniques: ["T1070, T1070.002, T1562, T1562.006"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:systemctl is-enabled systemd-journald.service -> r:static"
+
+  - id: 3182
+    title: "Ensure journald is configured to compress large log files (Automated)"
+    description: "The journald system includes the capability of compressing overly large files to avoid filling up the system with logs or making the logs unmanageably large."
+    rationale: "Uncompressed large files may unexpectedly fill a filesystem leading to resource unavailability. Compressing logs prior to write can prevent sudden, unexpected filesystem impacts."
+    remediation: "Edit the /etc/systemd/journald.conf file and add the following line: Compress=yes Restart the service: # systemctl restart systemd-journald" 
+    compliance:
+      - cis: ["4.2.1.3"]
+      - cis_csc_v8: ["8.2","8.3"]
+      - cis_csc_v7: ["6.2","6.3","6.4"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - pci_dss_3.2.1: ["10.2","10.3"]
+      - pci_dss_4.0: ["5.3.4","6.4.1","6.4.2","10.2.1","10.2.1.1","10.2.1.2","10.2.1.3","10.2.1.4","10.2.1.5","10.2.1.6","10.2.1.7","10.2.2","10.7"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["A1.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_techniques: ["T1562, T1562.002"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_mitigations: ["M1053"]
+    condition: all
+    rules:
+      - "c:grep ^\s*Compress /etc/systemd/journald.conf ->r:Compress=yes"
+
+  - id: 3183
+    title: "Ensure journald is configured to write logfiles to persistent disk (Automated)"
+    description: "Data from journald may be stored in volatile memory or persisted locally on the server. Logs in memory will be lost upon a system reboot. By persisting logs to local disk on the server they are protected from loss due to a reboot."
+    rationale: "Writing log data to disk will provide the ability to forensically reconstruct events which may have impacted the operations or security of a system even after a system crash or reboot."
+    remediation: "Edit the /etc/systemd/journald.conf file and add the following line: Storage=persistent Restart the service: # systemctl restart systemd-journald" 
+    compliance:
+      - cis: ["4.2.1.4"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2","6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - pci_dss_3.2.1: ["10.2","10.3"]
+      - pci_dss_4.0: ["5.3.4","6.4.1","6.4.2","10.2.1","10.2.1.1","10.2.1.2","10.2.1.3","10.2.1.4","10.2.1.5","10.2.1.6","10.2.1.7","10.2.2"]
+      - nist_sp_800-53: ["AU-7"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_techniques: ["T1070, T1070.002, T1562, T1562.006"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    condition: all
+    rules:
+      - "c:grep ^\s*Storage /etc/systemd/journald.conf -> r:Storage=persistent"
+
+  - id: 3184
+    title: "Ensure journald is not configured to send logs to rsyslog (Manual)"
+    description: "Data from journald should be kept in the confines of the service and not forwarded on to other services."
+    rationale: "IF journald is the method for capturing logs, all logs of the system should be handled by journald and not forwarded to other logging mechanisms."
+    remediation: "Edit the /etc/systemd/journald.conf file and ensure that ForwardToSyslog=yes is removed. Restart the service: # systemctl restart systemd-journald" 
+    compliance:
+      - cis: ["4.2.1.5"]
+      - cis_csc_v8: ["8.2","8.9"]
+      - cis_csc_v7: ["6.2","6.3","6.5"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - pci_dss_3.2.1: ["10.2","10.3","10.5.3","10.5.4"]
+      - pci_dss_4.0: ["5.3.4","6.4.1","6.4.2","10.2.1","10.2.1.1","10.2.1.2","10.2.1.3","10.2.1.4","10.2.1.5","10.2.1.6","10.2.1.7","10.2.2","10.3.3"]
+      - nist_sp_800-53: ["AU-7","AU-6(3)"]
+      - soc_2: ["PL1.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_techniques: ["T1070, T1070.002, T1562, T1562.006"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_mitigations: ["M1029"]
+    condition: none
+    rules:
+      - "c:grep ^\s*ForwardToSyslog /etc/systemd/journald.conf"
+
+  - id: 3185
+    title: "Ensure journald log rotation is configured per site policy (Manual)"
+    description: "Journald includes the capability of rotating log files regularly to avoid filling up the system with logs or making the logs unmanageably large. The file /etc/systemd/journald.conf is the configuration file used to specify how logs generated by Journald should be rotated."
+    rationale: "By keeping the log files smaller and more manageable, a system administrator can easily archive these files to another system and spend less time looking through inordinately large log files."
+    remediation: "Review /etc/systemd/journald.conf and verify logs are rotated according to site policy. The settings should be carefully understood as there are specific edge cases and prioritisation of parameters. The specific parameters for log rotation are: .SystemMaxUse= .SystemKeepFree= .RuntimeMaxUse=.  RuntimeKeepFree= .MaxFileSec=" 
+    compliance:
+      - cis: ["4.2.1.6"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2","6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - pci_dss_3.2.1: ["10.2","10.3"]
+      - pci_dss_4.0: ["5.3.4","6.4.1","6.4.2","10.2.1","10.2.1.1","10.2.1.2","10.2.1.3","10.2.1.4","10.2.1.5","10.2.1.6","10.2.1.7","10.2.2"]
+      - nist_sp_800-53: ["AU-7"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_techniques: ["T1070, T1070.002"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_mitigations: ["M1022"]
+    condition: all
+    rules:
+      - "c:/etc/systemd/journald.conf -> r:SystemMaxUse="
+      - "c:/etc/systemd/journald.conf -> r:SystemKeepFree="
+      - "c:/etc/systemd/journald.conf -> r:RuntimeMaxUse="
+      - "c:/etc/systemd/journald.conf -> r:RuntimeKeepFree="
+      - "c:/etc/systemd/journald.conf -> r:MaxFileSec="
+
+# 4.2.1.7 Ensure journald default file permissions configured (Manual) - Not Implemented
+
+# 4.2.2 Configure rsyslog
+
+  - id: 3186
+    title: "Ensure rsyslog is installed (Automated)"
+    description: "The rsyslog software is recommended in environments where journald does not meet operation requirements."
+    rationale: "The security enhancements of rsyslog such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server) justify installing and configuring the package."
+    remediation: "Run the following command to install rsyslog: # apt install rsyslog" 
+    compliance:
+      - cis: ["4.2.2.1"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2","6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - pci_dss_3.2.1: ["10.2","10.3"]
+      - pci_dss_4.0: ["5.3.4","6.4.1","6.4.2","10.2.1","10.2.1.1","10.2.1.2","10.2.1.3","10.2.1.4","10.2.1.5","10.2.1.6","10.2.1.7","10.2.2"]
+      - nist_sp_800-53: ["AU-7"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_techniques: ["T1005, T1005.000, T1070, T1070.002"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' rsyslog -> r:install ok installed"
+
+  - id: 3187
+    title: "Ensure rsyslog service is enabled (Automated)"
+    description: "Once the rsyslog package is installed, ensure that the service is enabled."
+    rationale: "If the rsyslog service is not enabled to start on boot, the system will not capture logging events."
+    remediation: "Run the following command to enable rsyslog: # systemctl --now enable rsyslog" 
+    compliance:
+      - cis: ["4.2.2.2"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2","6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - pci_dss_3.2.1: ["10.2","10.3"]
+      - pci_dss_4.0: ["5.3.4","6.4.1","6.4.2","10.2.1","10.2.1.1","10.2.1.2","10.2.1.3","10.2.1.4","10.2.1.5","10.2.1.6","10.2.1.7","10.2.2"]
+      - nist_sp_800-53: ["AU-7"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_techniques: ["T1070, T1070.002, T1562, T1562.001"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:systemctl is-enabled rsyslog -> r:enabled"
+
+  - id: 3188
+    title: "Ensure journald is configured to send logs to rsyslog (Manual)"
+    description: "Data from journald may be stored in volatile memory or persisted locally on the server. Utilities exist to accept remote export of journald logs, however, use of the RSyslog service provides a consistent means of log collection and export."
+    rationale: "IF RSyslog is the preferred method for capturing logs, all logs of the system should be sent to it for further processing."
+    remediation: "Edit the /etc/systemd/journald.conf file and add the following line: ForwardToSyslog=yes Restart the service: # systemctl restart rsyslog" 
+    compliance:
+      - cis: ["4.2.2.3"]
+      - cis_csc_v8: ["8.2","8.9"]
+      - cis_csc_v7: ["6.2","6.3","6.5"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - pci_dss_3.2.1: ["10.2","10.3","10.5.3","10.5.4"]
+      - pci_dss_4.0: ["5.3.4","6.4.1","6.4.2","10.2.1","10.2.1.1","10.2.1.2","10.2.1.3","10.2.1.4","10.2.1.5","10.2.1.6","10.2.1.7","10.2.2","10.3.3"]
+      - nist_sp_800-53: ["AU-7","AU-6(3)"]
+      - soc_2: ["PL1.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+    condition: all
+    rules:
+      - 'f:/etc/systemd/journald.conf -> r:^\s*\t*ForwardToSyslog\s*=\s*yes'
+
+  - id: 3189
+    title: "Ensure rsyslog default file permissions are configured (Automated)"
+    description: "RSyslog will create logfiles that do not already exist on the system. This setting controls what permissions will be applied to these newly created files."
+    rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive data is archived and protected."
+    remediation: "Edit either /etc/rsyslog.conf or a dedicated .conf file in /etc/rsyslog.d/ and set $FileCreateMode to 0640 or more restrictive: $FileCreateMode 0640 Restart the service: # systemctl restart rsyslog" 
+    compliance:
+      - cis: ["4.2.2.4"]
+      - cis_csc_v8: ["3.3","8.2"]
+      - cis_csc_v7: ["5.1","6.2","6.3"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2","AU.L2-3.3.1"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)","164.312(b)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3","10.2","10.3","5.3.4","6.4.1","6.4.2","10.2.1","10.2.1.1","10.2.1.2","10.2.1.3","10.2.1.4","10.2.1.5","10.2.1.6","10.2.1.7","10.2.2"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6","AU-7"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.8.1.3", "A.14.2.5", "A.12.4.1"]
+      - mitre_techniques: ["T1070, T1070.002, T1083, T1083.000"]
+      - mitre_tactics: ["TA0007"]
+      - mitre_mitigations: [""]
+    references:
+      - See the rsyslog.conf(5) man page for more information.
+    condition: all
+    rules:
+      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0 && r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d00'
+      - 'd:/etc/rsyslog.d/ -> r:\. -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0 && r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d00'
+
+# 4.2.2.5 Ensure logging is configured (Manual) - Not Implemented
+
+# 4.2.2.6 Ensure rsyslog is configured to send logs to a remote log host (Manual) - Not Implemented
+
+
+  - id: 3190
+    title: "Ensure rsyslog is not configured to receive logs from a remote client (Automated)"
+    description: "RSyslog supports the ability to receive messages from remote hosts, thus acting as a log server. Clients should not receive data from other hosts."
+    rationale: "If a client is configured to also receive data, thus turning it into a server, the client system is acting outside it's operational boundary."
+    remediation: "Should there be any active log server configuration found in the auditing section, modify those file and remove the specific lines highlighted by the audit. Ensure none of the following entries are present in any of /etc/rsyslog.conf or /etc/rsyslog.d/*.conf." 
+    compliance:
+      - cis: ["4.2.2.7"]
+      - cis_csc_v8: ["8.2","4.8"]
+      - cis_csc_v7: ["6.2","6.3","9.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1""CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - hipaa: ["164.312(b)"]
+      - pci_dss_3.2.1: ["10.2","10.3","1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1","5.3.4","6.4.1","6.4.2","10.2.1","10.2.1.1","10.2.1.2","10.2.1.3","10.2.1.4","10.2.1.5","10.2.1.6","10.2.1.7","10.2.2"]
+      - nist_sp_800-53: ["AU-7"]
+      - iso_27001-2013: ["A.12.4.1","A.13.1.3"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - mitre_techniques: ["T1070, T1070.002, T1562, T1562.006"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:grep -P -- '^\h*module\(load="imtcp"\)' /etc/rsyslog.conf /etc/rsyslog.d/*.conf"
+      - "c:grep -P -- '^\h*input\(type="imtcp" port="514"\)' /etc/rsyslog.conf /etc/rsyslog.d/*.conf"
+
+# 4.2.2.5 Ensure all logfiles have appropriate permissions and ownership (Automated) - Not Implemented
+
+
+############################################################
+# 5 Access, Authentication and Authorization
+############################################################
+
+# 5.1 Configure time-based job schedulers
+
+  - id: 3191
+    title: "Ensure cron daemon is enabled and running (Automated)"
+    description: "The cron daemon is used to execute batch jobs on the system. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy"
+    rationale: "While there may not be user jobs that need to be run on the system, the system does have maintenance jobs that may include security monitoring that have to run, and cron is used to execute them."
+    remediation: "Run the following command to enable and start cron: # systemctl --now enable cron" 
+    compliance:
+      - cis: ["5.1.1"]
+      - mitre_techniques: ["T1562, T1562.001"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1018"]
+    condition: all
+    rules:
+      - "c:systemctl is-enabled cron -> enabled"
+      - "c:systemctl status cron | grep 'Active: active (running) ' -> r:^Active"
+
+  - id: 3192
+    title: "Ensure permissions on /etc/crontab are configured (Automated)"
+    description: "The /etc/crontab file is used by cron to control its own jobs. The commands in this item make sure that root is the user and group owner of the file and that only the owner can access the file. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy"
+    rationale: "This file contains information on what system jobs are run by cron. Write access to these files could provide unprivileged users with the ability to elevate their privileges. Read access to these files could provide users with the ability to gain insight on system jobs that run on the system and could provide them a way to gain unauthorized privileged access."
+    remediation: "Run the following commands to set ownership and permissions on /etc/crontab : # chown root:root /etc/crontab # chmod og-rwx /etc/crontab" 
+    compliance:
+      - cis: ["5.1.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1053, T1053.003"]
+      - mitre_tactics: ["TA0002, TA0007"]
+      - mitre_mitigations: ["M1018"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/crontab -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+
+  - id: 3193
+    title: "Ensure permissions on /etc/cron.hourly are configured (Automated)"
+    description: "This directory contains system cron jobs that need to run on an hourly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy"
+    rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
+    remediation: "Run the following commands to set ownership and permissions on the /etc/cron.hourly directory: # chown root:root /etc/cron.hourly/ # chmod og-rwx /etc/cron.hourly/" 
+    compliance:
+      - cis: ["5.1.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1053, T1053.003"]
+      - mitre_tactics: ["TA0002, TA0007"]
+      - mitre_mitigations: ["M1018"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+
+
+  - id: 3194
+    title: "Ensure permissions on /etc/cron.daily are configured (Automated)"
+    description: "The /etc/cron.daily directory contains system cron jobs that need to run on a daily basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy"
+    rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
+    remediation: "Run the following commands to set ownership and permissions on the /etc/cron.daily directory: # chown root:root /etc/cron.daily/ # chmod og-rwx /etc/cron.daily/" 
+    compliance:
+      - cis: ["5.1.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1053, T1053.003"]
+      - mitre_tactics: ["TA0002, TA0007"]
+      - mitre_mitigations: ["M1018"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+
+  - id: 3195
+    title: "Ensure permissions on /etc/cron.weekly are configured (Automated)"
+    description: "The /etc/cron.weekly directory contains system cron jobs that need to run on a weekly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy"
+    rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
+    remediation: "Run the following commands to set ownership and permissions on the /etc/cron.weekly directory: # chown root:root /etc/cron.weekly/ # chmod og-rwx /etc/cron.weekly/" 
+    compliance:
+      - cis: ["5.1.5"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1053, T1053.003"]
+      - mitre_tactics: ["TA0002, TA0007"]
+      - mitre_mitigations: ["M1018"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/cron.weekly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+
+  - id: 3196
+    title: "Ensure permissions on /etc/cron.monthly are configured (Automated)"
+    description: "The /etc/cron.monthly directory contains system cron jobs that need to run on a monthly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy"
+    rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
+    remediation: "Run the following commands to set ownership and permissions on the /etc/cron.monthly directory: # chown root:root /etc/cron.monthly/ # chmod og-rwx /etc/cron.monthly/" 
+    compliance:
+      - cis: ["5.1.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1053, T1053.003"]
+      - mitre_tactics: ["TA0002, TA0007"]
+      - mitre_mitigations: ["M1018"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/cron.monthly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+
+  - id: 3197
+    title: "Ensure permissions on /etc/cron.d are configured (Automated)"
+    description: "The /etc/cron.d directory contains system cron jobs that need to run in a similar manner to the hourly, daily weekly and monthly jobs from /etc/crontab, but require more granular control as to when they run. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy"
+    rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
+    remediation: "Run the following commands to set ownership and permissions on the /etc/cron.d directory: # chown root:root /etc/cron.d/ # chmod og-rwx /etc/cron.d/" 
+    compliance:
+      - cis: ["5.1.7"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1053, T1053.003"]
+      - mitre_tactics: ["TA0002, TA0007"]
+      - mitre_mitigations: ["M1018"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+
+  - id: 3198
+    title: "Ensure cron is restricted to authorized users (Automated)"
+    description: "Configure /etc/cron.allow to allow specific users to use this service. If /etc/cron.allow does not exist, then /etc/cron.deny is checked. Any user not specifically defined in this file is allowed to use cron. By removing the file, only users in /etc/cron.allow are allowed to use cron. Notes:Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, cron should be removed, and the alternate method should be secured in accordance with local site policy .Even though a given user is not listed in cron.allow, cron jobs can still be run as that user .The cron.allow file only controls administrative access to the crontab command for scheduling and modifying cron jobs"
+    rationale: "On many systems, only the system administrator is authorized to schedule cron jobs. Using the cron.allow file to control who can run cron jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
+    remediation: "Run the following commands to remove /etc/cron.deny: # rm /etc/cron.deny .Run the following command to create /etc/cron.allow # touch /etc/cron.allow Run the following commands to set permissions and ownership for /etc/cron.allow: # chmod g-wx,o-rwx /etc/cron.allow # chown root:root /etc/cron.allow" 
+    compliance:
+      - cis: ["5.1.8"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1053, T1053.003"]
+      - mitre_tactics: ["TA0002, TA0007"]
+      - mitre_mitigations: ["M1018"]
+    condition: all
+    rules:
+      - "f:/etc/cron.allow"
+      - "not f:/etc/cron.deny"
+      - 'c:stat -L /etc/cron.allow -> r:^Access: \(0\d\d0/\w\w\w\w\w-----\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+
+  - id: 3199
+    title: "Ensure at is restricted to authorized users (Automated)"
+    description: "Configure /etc/at.allow to allow specific users to use this service. If /etc/at.allow does not exist, then /etc/at.deny is checked. Any user not specifically defined in this file is allowed to use at. By removing the file, only users in /etc/at.allow are allowed to use at. Note: Other methods, such as systemd timers, exist for scheduling jobs. If another method is used, at should be removed, and the alternate method should be secured in accordance with local site policy"
+    rationale: "On many systems, only the system administrator is authorized to schedule at jobs. Using the at.allow file to control who can run at jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
+    remediation: "Run the following commands to remove /etc/at.deny: # rm /etc/at.deny .Run the following command to create /etc/at.allow # touch /etc/at.allow .Run the following commands to set permissions and ownership for /etc/at.allow: # chmod g-wx,o-rwx /etc/at.allow # chown root:root /etc/at.allow" 
+    compliance:
+      - cis: ["5.1.9"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1053, T1053.003"]
+      - mitre_tactics: ["TA0002, TA0007"]
+      - mitre_mitigations: ["M1018"]
+    condition: all
+    rules:
+      - "f:/etc/at.allow"
+      - "not f:/etc/at.deny"
+      - 'c:stat -L /etc/at.allow -> r:^Access: \(0\d\d0/\w\w\w\w\w-----\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+
+# 5.2 Configure SSH Server
+
+  - id: 3200
+    title: "Ensure permissions on /etc/ssh/sshd_config are configured (Automated)"
+    description: "The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root."
+    rationale: "The /etc/ssh/sshd_config file needs to be protected from unauthorized changes by non-privileged users."
+    remediation: "Run the following commands to set ownership and permissions on /etc/ssh/sshd_config: # chown root:root /etc/ssh/sshd_config # chmod og-rwx /etc/ssh/sshd_config" 
+    compliance:
+      - cis: ["5.2.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1098, T1098.004, T1543, T1543.002"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1022"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/ssh/sshd_config -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+
+  - id: 3201
+    title: "Ensure permissions on SSH private host key files are configured (Automated)"
+    description: "An SSH private key is one of two files used in SSH public key authentication. In this authentication method, the possession of the private key is proof of identity. Only a private key that corresponds to a public key will be able to authenticate successfully. The private keys need to be stored and handled carefully, and no copies of the private key should be distributed."
+    rationale: "If an unauthorized user obtains the private SSH host key file, the host could be impersonated"
+    remediation: "Run the following commands to set ownership and permissions on the private SSH host key files: # find /etc/ssh -xdev -type f -name 'ssh_host_*_key' -exec chown root:root {} \\; # find /etc/ssh -xdev -type f -name 'ssh_host_*_key' -exec chmod 0600 {} \\;" 
+    compliance:
+      - cis: ["5.2.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1552, T1552.004"]
+      - mitre_tactics: ["TA0003, TA0006"]
+      - mitre_mitigations: ["M1022"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/ssh/ssh_host_rsa_key -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/ssh_host_ecdsa_key -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/ssh_host_ed25519_key -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+
+  - id: 3202
+    title: "Ensure permissions on SSH public host key files are configured (Automated)"
+    description: "An SSH public key is one of two files used in SSH public key authentication. In this authentication method, a public key is a key that can be used for verifying digital signatures generated using a corresponding private key. Only a public key that corresponds to a private key will be able to authenticate successfully."
+    rationale: "If a public host key file is modified by an unauthorized user, the SSH service may be compromised."
+    remediation: "Run the following commands to set permissions and ownership on the SSH host public key files # find /etc/ssh -xdev -type f -name 'ssh_host_*_key.pub' -exec chmod u-x,go-wx {} \; # find /etc/ssh -xdev -type f -name 'ssh_host_*_key.pub' -exec chown root:root {} \;" 
+    compliance:
+      - cis: ["5.2.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
+      - mitre_techniques: ["T1557, T1557.000"]
+      - mitre_tactics: ["TA0003, TA0006"]
+      - mitre_mitigations: ["M1022"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/ssh/ssh_host_rsa_key.pub -> r:^Access: \(0\d\d\d/-\w\w\w\w--\w--\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/ssh_host_ecdsa_key.pub -> r:^Access: \(0\d\d\d/-\w\w\w\w--\w--\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/ssh_host_ed25519_key.pub -> r:^Access: \(0\d\d\d/-\w\w\w\w--\w--\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+
+  - id: 3203
+    title: "Ensure SSH access is limited (Automated)"
+    description: "There are several options available to limit which users and group can access the system via SSH. It is recommended that at least one of the following options be leveraged: AllowUsers: The AllowUsers variable gives the system administrator the option of allowing specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by only allowing the allowed users to log in from a particular host, the entry can be specified in the form of user@host. AllowGroups: The AllowGroups variable gives the system administrator the option of allowing specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable. DenyUsers:The DenyUsers variable gives the system administrator the option of denying specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by specifically denying a user's access from a particular host, the entry can be specified in the form of user@host. DenyGroups: The DenyGroups variable gives the system administrator the option of denying specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable."
+    rationale: "Restricting which users can remotely access the system via SSH will help ensure that only authorized users access the system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set one or more of the parameter as follows: AllowUsers <userlist> OR AllowGroups <grouplist> OR DenyUsers <userlist> OR DenyGroups <grouplist>" 
+    compliance:
+      - cis: ["5.2.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_techniques: ["T1021, T1021.004"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1018"]
+    references:
+      - SSHD_CONFIG(5)
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:AllowUsers\s+\w+|AllowGroups\s+\w+|DenyUsers\s+\w+|DenyGroups\s+\w+'
+
+  - id: 3204
+    title: "Ensure SSH LogLevel is appropriate (Automated)"
+    description: "INFO level is the basic level that only records login activity of SSH users. In many situations, such as Incident Response, it is important to determine when a particular user was active on a system. The logout record can eliminate those users who disconnected, which helps narrow the field. VERBOSE level specifies that login and logout activity as well as the key fingerprint for any SSH key used for login will be logged. This information is important for SSH key management, especially in legacy environments."
+    rationale: "SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically not recommended other than strictly for debugging SSH communications since it provides so much data that it is difficult to identify important security information."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: LogLevel VERBOSE OR LogLevel INFO" 
+    compliance:
+      - cis: ["5.2.5"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2","6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - pci_dss_3.2.1: ["10.2","10.3"]
+      - pci_dss_4.0: ["5.3.4","6.4.1","6.4.2","10.2.1","10.2.1.1","10.2.1.2","10.2.1.3","10.2.1.4","10.2.1.5","10.2.1.6","10.2.1.7","10.2.2"]
+      - nist_sp_800-53: ["AU-7"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_techniques: ["T1562, T1562.006"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: [""]
+    references:
+      - https://www.ssh.com/ssh/sshd_config/
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:LogLevel\s+INFO|LogLevel\s+VERBOSE'
+
+  - id: 3205
+    title: "Ensure SSH PAM is enabled (Automated)"
+    description: "The UsePAM directive enables the Pluggable Authentication Module (PAM) interface. If set to yes this will enable PAM authentication using ChallengeResponseAuthentication and PasswordAuthentication directives in addition to PAM account and session module processing for all authentication types."
+    rationale: "When usePAM is set to yes, PAM runs through account and session types properly. This is important if you want to restrict access to services based off of IP, time or other factors of the account. Additionally, you can make sure users inherit certain environment variables on login or disallow access to the server."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: UsePAM yes" 
+    compliance:
+      - cis: ["5.2.6"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","CM.L2-3.4.1","CM.L2-3.4.6","CM.L2-3.4.2","CM.L2-3.4.7"]
+      - pci_dss_3.2.1: ["2.2","11.5"]
+      - pci_dss_4.0: ["1.1.1","1.2.1","1.2.6","1.5.1","1.2.7","2.1.1","2.2.1"]
+      - nist_sp_800-53: ["CM-7(1)","CM-9","SA-10"]
+      - soc_2: ["CC7.1","CC8.1"]
+      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
+      - mitre_techniques: ["T1021, T1021.004"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_mitigations: ["M1035"]
+    references:
+      - SSHD_CONFIG(5)
+    condition: all
+    rules:
+      - "c:sshd -T -C user=root -C host="$(hostname)" -C addr="$(grep $(hostname) /etc/hosts | awk '{print $1}')" -> r:^\s*usepam\s+yes"
+
+  - id: 3206
+    title: "Ensure SSH root login is disabled (Automated)"
+    description: "The PermitRootLogin parameter specifies if the root user can log in using SSH. The default is prohibit-password."
+    rationale: "Disallowing root logins over SSH requires system admins to authenticate using their own individual account, then escalating to root. This limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: PermitRootLogin no" 
+    compliance:
+      - cis: ["5.2.7"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5","AC.L2-3.1.6","AC.L2-3.1.7","SC.L2-3.13.3"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - nist_sp_800-53: ["AC-6(2)","AC-6(5)"]
+      - soc_2: ["CC6.1","CC6.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_techniques: ["T1021"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    references:
+      - SSHD_CONFIG(5)
+    condition: all
+    rules:
+      - "c:sshd -T -C user=root -C host="$(hostname)" -C addr="$(grep $(hostname) /etc/hosts | awk '{print $1}')" -> r:PermitRootLogin\s+no"
+
+  - id: 3207
+    title: "Ensure SSH HostbasedAuthentication is disabled (Automated)"
+    description: "The HostbasedAuthentication parameter specifies if authentication is allowed through trusted hosts via the user of .rhosts, or /etc/hosts.equiv, along with successful public key client host authentication."
+    rationale: "Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, disabling the ability to use .rhosts files in SSH provides an additional layer of protection."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: HostbasedAuthentication no" 
+    compliance:
+      - cis: ["5.2.8"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["16.3"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","CM.L2-3.4.1","CM.L2-3.4.6","CM.L2-3.4.2","CM.L2-3.4.7"]
+      - pci_dss_3.2.1: ["2.2","11.5"]
+      - pci_dss_4.0: ["1.1.1","1.2.1","1.2.6","1.5.1","1.2.7","2.1.1","2.2.1"]
+      - nist_sp_800-53: ["CM-7(1)","CM-9","SA-10"]
+      - soc_2: ["CC7.1","CC8.1"]
+      - mitre_techniques: ["T1078, T1078.001, T1078.003"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_mitigations: ["M1042"]
+    references:
+      - SSHD_CONFIG(5)
+    condition: all
+    rules:
+      - "c:sshd -T -C user=root -C host="$(hostname)" -C addr="$(grep $(hostname) /etc/hosts | awk '{print $1}')" -> r:HostbasedAuthentication\s+no"
+
+  - id: 3208
+    title: "Ensure SSH PermitEmptyPasswords is disabled (Automated)"
+    description: "The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts with empty password strings."
+    rationale: "Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: PermitEmptyPasswords no" 
+    compliance:
+      - cis: ["5.2.9"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["16.3"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","CM.L2-3.4.1","CM.L2-3.4.6","CM.L2-3.4.2","CM.L2-3.4.7"]
+      - pci_dss_3.2.1: ["2.2","11.5"]
+      - pci_dss_4.0: ["1.1.1","1.2.1","1.2.6","1.5.1","1.2.7","2.1.1","2.2.1"]
+      - nist_sp_800-53: ["CM-7(1)","CM-9","SA-10"]
+      - soc_2: ["CC7.1","CC8.1"]
+      - mitre_techniques: ["T1021"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    references:
+      - SSHD_CONFIG(5)
+    condition: all
+    rules:
+      - 'c:sshd -T -C user=root -C host="$(hostname)" -C addr="$(grep $(hostname) /etc/hosts | awk '{print $1}')" -> r:PermitEmptyPasswords\s+no'
+
+  - id: 3209
+    title: "Ensure SSH PermitUserEnvironment is disabled (Automated)"
+    description: "The PermitUserEnvironment option allows users to present environment options to the SSH daemon."
+    rationale: "Permitting users the ability to set environment variables through the SSH daemon could potentially allow users to bypass security controls (e.g. setting an execution path that has SSH executing trojan'd programs)"
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: PermitUserEnvironment no" 
+    compliance:
+      - cis: ["5.2.10"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["16.3"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","CM.L2-3.4.1","CM.L2-3.4.6","CM.L2-3.4.2","CM.L2-3.4.7"]
+      - pci_dss_3.2.1: ["2.2","11.5"]
+      - pci_dss_4.0: ["1.1.1","1.2.1","1.2.6","1.5.1","1.2.7","2.1.1","2.2.1"]
+      - nist_sp_800-53: ["CM-7(1)","CM-9","SA-10"]
+      - soc_2: ["CC7.1","CC8.1"]
+      - mitre_techniques: ["T1021"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    references:
+      - SSHD_CONFIG(5)
+    condition: all
+    rules:
+      - 'c:sshd -T -C user=root -C host="$(hostname)" -C addr="$(grep $(hostname) /etc/hosts | awk '{print $1}')" -> r:PermitUserEnvironment\s+no'
+
+  - id: 3210
+    title: "Ensure SSH IgnoreRhosts is enabled (Automated)"
+    description: "The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication."
+    rationale: "Setting this parameter forces users to enter a password when authenticating with SSH."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: IgnoreRhosts yes" 
+    compliance:
+      - cis: ["5.2.11"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","CM.L2-3.4.1","CM.L2-3.4.6","CM.L2-3.4.2","CM.L2-3.4.7"]
+      - pci_dss_3.2.1: ["2.2","11.5"]
+      - pci_dss_4.0: ["1.1.1","1.2.1","1.2.6","1.5.1","1.2.7","2.1.1","2.2.1"]
+      - nist_sp_800-53: ["CM-7(1)","CM-9","SA-10"]
+      - soc_2: ["CC7.1","CC8.1"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_techniques: ["T1078, T1078.001, T1078.003"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_mitigations: ["M1027"]
+    references:
+      - SSHD_CONFIG(5)
+    condition: all
+    rules:
+      - 'c:sshd -T -C user=root -C host="$(hostname)" -C addr="$(grep $(hostname) /etc/hosts | awk '{print $1}')" -> r:IgnoreRhosts\s+yes'
+
+  - id: 3211
+    title: "Ensure SSH X11 forwarding is disabled (Automated)"
+    description: "The X11Forwarding parameter provides the ability to tunnel X11 traffic through the connection to enable remote graphic connections."
+    rationale: "Disable X11 forwarding unless there is an operational requirement to use X11 applications directly. There is a small risk that the remote X11 servers of users who are logged in via SSH with X11 forwarding could be compromised by other users on the X11 server. Note that even if X11 forwarding is disabled, users can always install their own forwarders."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: X11Forwarding no" 
+    compliance:
+      - cis: ["5.2.12"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_techniques: ["T1210, T1210.000"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - 'c:sshd -T -C user=root -C host="$(hostname)" -C addr="$(grep $(hostname) /etc/hosts | awk '{print $1}')" -> r:X11Forwarding\s+no'
+
+  - id: 3212
+    title: "Ensure only strong Ciphers are used (Automated)"
+    description: "This variable limits the ciphers that SSH can use during communication. Note:Some organizations may have stricter requirements for approved ciphers. Ensure that ciphers used are in compliance with site policy.The only "strong" ciphers currently FIPS 140-2 compliant are:aes256-ctr, aes192-ctr, aes128-ctr .Supported ciphers in openSSH 8.2:3des-cbc .aes128-cbc .aes192-cbc .aes256-cbc .aes128-ctr .aes192-ctr .aes256-ctr .aes128-gcm@openssh.com .aes256-gcm@openssh.com .chacha20-poly1305@openssh.com"
+    rationale: "Weak ciphers that are used for authentication to the cryptographic module cannot be relied upon to provide confidentiality or integrity, and system data may be compromised. The Triple DES ciphers, as used in SSH, have a birthday bound of approximately four billion blocks, which makes it easier for remote attackers to obtain clear text data via a birthday attack against a long-duration encrypted session, aka a "Sweet32" attack. Error handling in the SSH protocol; Client and Server, when using a block cipher algorithm in Cipher Block Chaining (CBC) mode, makes it easier for remote attackers to recover certain plain text data from an arbitrary block of cipher text in an SSH session via unknown vectors."
+    remediation: "Edit the /etc/ssh/sshd_config file add/modify the Ciphers line to contain a comma separated list of the site approved ciphers. Example: Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr" 
+    compliance:
+      - cis: ["5.2.13"]
+      - cis_csc_v8: ["3.10"]
+      - cis_csc_v7: ["14.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.17","AC.L2-3.1.13","IA.L2-3.5.10","SC.L2-3.13.11","SC.L2-3.13.8","SC.L2-3.13.15"]
+      - hipaa: ["164.312(a)(2)(iv)","164.312(e)(1)","164.312(e)(2)(i)","164.312(e)(2)(ii)"]
+      - pci_dss_3.2.1: ["2.1.1","4.1","4.1.1","8.2.1"]
+      - pci_dss_4.0: ["2.2.7","4.1.1","4.2.1","4.2.1.2","4.2.2","8.3.2"]
+      - nist_sp_800-53: ["AC-17(2)","SC-8","SC-8(1)"]
+      - iso_27001-2013: ["A.13.1.1", "A.10.1.1"]
+      - mitre_techniques: ["T1040, T1040.000, T1557"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_mitigations: ["M1041"]
+    references:
+      - https://nvd.nist.gov/vuln/detail/CVE-2016-2183
+      - https://www.openssh.com/txt/cbc.adv
+      - https://nvd.nist.gov/vuln/detail/CVE-2008-5161
+      - https://www.openssh.com/txt/cbc.adv
+      - SSHD_CONFIG(5)
+    condition: none
+    rules:
+      - 'c:sshd -T -C user=root -C host="$(hostname)" -C addr="$(grep $(hostname) /etc/hosts | awk '{print $1}')" -> r:ciphers && r:3des-cbc|aes128-cbc|aes192-cbc|aes256-cbc|arcfour|arcfour128|arcfour256|blowfish-cbc|cast128-cbc|rijndael-cbc@lysator.liu.se'
+
+  - id: 3213
+    title: "Ensure only strong MAC algorithms are used (Automated)"
+    description: "This variable limits the types of MAC algorithms that SSH can use during communication.Notes:Some organizations may have stricter requirements for approved MACs. Ensure that MACs used are in compliance with site policy. The only "strong" MACs currently FIPS 140-2 approved are:hmac-sha2-256 .hmac-sha2-512 .The Supported MACs are:hmac-md5 .hmac-md5-96 .hmac-sha1 .hmac-sha1-96 .hmac-sha2-256 .hmac-sha2-512 .umac-64@openssh.com .umac-128@openssh.com .hmac-md5-etm@openssh.com .hmac-md5-96-etm@openssh.com .hmac-sha1-etm@openssh.com .hmac-sha1-96-etm@openssh.com .hmac-sha2-256-etm@openssh.com .hmac-sha2-512-etm@openssh.com .umac-64-etm@openssh.com .umac-128-etm@openssh.com"
+    rationale: "MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of attention as a weak spot that can be exploited with expanded computing power. An attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the SSH tunnel and capture credentials and information."
+    remediation: "Edit the /etc/ssh/sshd_config file and add/modify the MACs line to contain a comma separated list of the site approved MACs.Example:MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256" 
+    compliance:
+      - cis: ["5.2.14"]
+      - cis_csc_v8: ["3.10"]
+      - cis_csc_v7: ["14.4","16.5"]
+      - cmmc_v2.0: ["AC.L2-3.1.17","AC.L2-3.1.13","IA.L2-3.5.10","SC.L2-3.13.11","SC.L2-3.13.8","SC.L2-3.13.15"]
+      - hipaa: ["164.312(a)(2)(iv)","164.312(e)(1)","164.312(e)(2)(i)","164.312(e)(2)(ii)"]
+      - pci_dss_3.2.1: ["2.1.1","4.1","4.1.1","8.2.1"]
+      - pci_dss_4.0: ["2.2.7","4.1.1","4.2.1","4.2.1.2","4.2.2","8.3.2"]
+      - nist_sp_800-53: ["AC-17(2)","SC-8","SC-8(1)"]
+      - iso_27001-2013: ["A.13.1.1", "A.10.1.1","A.9.2.1"]
+      - mitre_techniques: ["T1040, T1040.000, T1557, T1557.000"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_mitigations: ["M1041"]
+    references:
+      - http://www.mitls.org/pages/attacks/SLOTH
+      - SSHD_CONFIG(5)
+    condition: all
+    rules:
+      - 'c:sshd -T -C user=root -C host="$(hostname)" -C addr="$(grep $(hostname) /etc/hosts | awk '{print $1}')" -> r:MACs && r:hmac-md5|hmac-md5-96|hmac-ripemd160|hmac-sha1|hmac-sha1-96|umac-64@openssh.com|umac-128@openssh.com|hmac-md5-etm@openssh.com|hmac-md5-96-etm@openssh.com|hmac-ripemd160-etm@openssh.com|hmac-sha1-etm@openssh.com|hmac-sha1-96-etm@openssh.com|umac-64-etm@openssh.com|umac-128-etm@openssh.com'
+
+  - id: 3214
+    title: "Ensure only strong Key Exchange algorithms are used (Automated)"
+    description: "Key exchange is any method in cryptography by which cryptographic keys are exchanged between two parties, allowing use of a cryptographic algorithm. If the sender and receiver wish to exchange encrypted messages, each must be equipped to encrypt messages to be sent and decrypt messages received Notes:Kex algorithms have a higher preference the earlier they appear in the list. Some organizations may have stricter requirements for approved Key exchange algorithms .Ensure that Key exchange algorithms used are in compliance with site policy .The only Key Exchange Algorithms currently FIPS 140-2 approved are:ecdh-sha2-nistp256 .ecdh-sha2-nistp384 .ecdh-sha2-nistp521 .diffie-hellman-group-exchange-sha256 .diffie-hellman-group16-sha512 .diffie-hellman-group18-sha512 .diffie-hellman-group14-sha256 .The Key Exchange algorithms supported by OpenSSH 8.2 are: Page 663curve25519-sha256 .curve25519-sha256@libssh.org .diffie-hellman-group1-sha1 .diffie-hellman-group14-sha1 .diffie-hellman-group14-sha256 .diffie-hellman-group16-sha512 .diffie-hellman-group18-sha512 .diffie-hellman-group-exchange-sha1 .diffie-hellman-group-exchange-sha256 .ecdh-sha2-nistp256 .ecdh-sha2-nistp384 .ecdh-sha2-nistp521 .sntrup4591761x25519-sha512@tinyssh.org"
+    rationale: "Key exchange methods that are considered weak should be removed. A key exchange method may be weak because too few bits are used, or the hashing algorithm is considered too weak. Using weak algorithms could expose connections to man-in-the-middle attacks."
+    remediation: "Edit the /etc/ssh/sshd_config file add/modify the KexAlgorithms line to contain a comma separated list of the site approved key exchange algorithms Example:KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256" 
+    compliance:
+      - cis: ["5.2.15"]
+      - cis_csc_v8: ["3.10"]
+      - cis_csc_v7: ["14.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.17","AC.L2-3.1.13","IA.L2-3.5.10","SC.L2-3.13.11","SC.L2-3.13.8","SC.L2-3.13.15"]
+      - hipaa: ["164.312(a)(2)(iv)","164.312(e)(1)","164.312(e)(2)(i)","164.312(e)(2)(ii)"]
+      - pci_dss_3.2.1: ["2.1.1","4.1","4.1.1","8.2.1"]
+      - pci_dss_4.0: ["2.2.7","4.1.1","4.2.1","4.2.1.2","4.2.2","8.3.2"]
+      - nist_sp_800-53: ["AC-17(2)","SC-8","SC-8(1)"]
+      - iso_27001-2013: ["A.13.1.1", "A.10.1.1"]
+      - mitre_techniques: ["T1040, T1040.000, T1557, T1557.000"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_mitigations: ["M1041"]
+    condition: all
+    rules:
+      - 'c:sshd -T -C user=root -C host="$(hostname)" -C addr="$(grep $(hostname) /etc/hosts | awk '{print $1}')" -> r:kexalgorithms && r:diffie-hellman-group1-sha1|diffie-hellman-group14-sha1|diffie-hellman-group-exchange-sha1'
+
+  - id: 3215
+    title: "Ensure SSH AllowTcpForwarding is disabled (Automated)"
+    description: "SSH port forwarding is a mechanism in SSH for tunneling application ports from the client to the server, or servers to clients. It can be used for adding encryption to legacy applications, going through firewalls, and some system administrators and IT professionals use it for opening backdoors into the internal network from their home machines."
+    rationale: "Leaving port forwarding enabled can expose the organization to security risks and backdoors. SSH connections are protected with strong encryption. This makes their contents invisible to most deployed network monitoring and traffic filtering solutions. This invisibility carries considerable risk potential if it is used for malicious purposes such as data exfiltration. Cybercriminals or malware could exploit SSH to hide their unauthorized communications, or to exfiltrate stolen data from the target network."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: AllowTcpForwarding no" 
+    compliance:
+      - cis: ["5.2.16"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","CM.L2-3.4.1","CM.L2-3.4.6","CM.L2-3.4.2","CM.L2-3.4.7"]
+      - pci_dss_3.2.1: ["2.2","11.5"]
+      - pci_dss_4.0: ["1.1.1","1.2.1","1.2.6","1.5.1","1.2.7","2.1.1","2.2.1"]
+      - nist_sp_800-53: ["CM-7(1)","CM-9","SA-10"]
+      - soc_2: ["CC7.1","CC8.1"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - mitre_techniques: ["T1048, T1048.002, T1572, T1572.000"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - 'c:sshd -T -C user=root -C host="$(hostname)" -C addr="$(grep $(hostname) /etc/hosts | awk '{print $1}')" -> r:^\s*AllowTcpForwarding\s+no'
+
+  - id: 3216
+    title: "Ensure SSH warning banner is configured (Automated)"
+    description: "The Banner parameter specifies a file whose contents must be sent to the remote user before authentication is permitted. By default, no banner is displayed."
+    rationale: "Banners are used to warn connecting users of the particular site's policy regarding connection. Presenting a warning message prior to the normal user login may assist the prosecution of trespassers on the computer system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: Banner /etc/issue.net" 
+    compliance:
+      - cis: ["5.2.17"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","CM.L2-3.4.1","CM.L2-3.4.6","CM.L2-3.4.2","CM.L2-3.4.7"]
+      - pci_dss_3.2.1: ["2.2","11.5"]
+      - pci_dss_4.0: ["1.1.1","1.2.1","1.2.6","1.5.1","1.2.7","2.1.1","2.2.1"]
+      - nist_sp_800-53: ["CM-7(1)","CM-9","SA-10"]
+      - soc_2: ["CC7.1","CC8.1"]
+      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
+      - mitre_techniques: [""]
+      - mitre_tactics: ["TA0001, TA0007"]
+      - mitre_mitigations: ["M1035"]
+    condition: all
+    rules:
+      - 'c:sshd -T -C user=root -C host="$(hostname)" -C addr="$(grep $(hostname) /etc/hosts | awk '{print $1}')" -> r:Banner\s*\t*/etc/issue.net'
+
+  - id: 3217
+    title: "Ensure SSH MaxAuthTries is set to 4 or less (Automated)"
+    description: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure."
+    rationale: "Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. While the recommended setting is 4, set the number based on site policy."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: MaxAuthTries 4" 
+    compliance:
+      - cis: ["5.2.18"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["16.13"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - pci_dss_3.2.1: ["10.1","10.2.2","10.2.4","10.2.5","10.3"]
+      - pci_dss_4.0: ["9.4.5","10.2","10.2.1","10.2.1.2","10.2.1.5"]
+      - nist_sp_800-53: ["AU-3(1)","AU-7"]
+      - soc_2: ["CC5.2","CC7.2"]
+      - mitre_techniques: ["T1110, T1110.001, T1110.003"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_mitigations: ["M1036"]
+    references:
+      - SSHD_CONFIG(5)
+    condition: all
+    rules:
+      - 'c:sshd -T -C user=root -C host="$(hostname)" -C addr="$(grep $(hostname) /etc/hosts | awk '{print $1}')" -> n:^MaxAuthTries\s*\t*(\d+) compare <= 4'
+
+  - id: 3218
+    title: "Ensure SSH MaxStartups is configured (Automated)"
+    description: "The MaxStartups parameter specifies the maximum number of concurrent unauthenticated connections to the SSH daemon."
+    rationale: "To protect a system from denial of service due to a large number of pending authentication connection attempts, use the rate limiting function of MaxStartups to protect availability of sshd logins and prevent overwhelming the daemon."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: MaxStartups 10:30:60" 
+    compliance:
+      - cis: ["5.2.19"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","CM.L2-3.4.1","CM.L2-3.4.6","CM.L2-3.4.2","CM.L2-3.4.7"]
+      - pci_dss_3.2.1: ["2.2","11.5"]
+      - pci_dss_4.0: ["1.1.1","1.2.1","1.2.6","1.5.1","1.2.7","2.1.1","2.2.1"]
+      - nist_sp_800-53: ["CM-7(1)","CM-9","SA-10"]
+      - soc_2: ["CC7.1","CC8.1"]
+      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
+      - mitre_techniques: ["T1499, T1499.002"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_mitigations: [""]
+    references:
+      - SSHD_CONFIG(5)
+    condition: all
+    rules:
+      - 'c:sshd -T -C user=root -C host="$(hostname)" -C addr="$(grep $(hostname) /etc/hosts | awk '{print $1}')" -> r:^\s*maxstartups\s+10:30:60'
+
+  - id: 3219
+    title: "Ensure SSH MaxSessions is set to 10 or less (Automated)"
+    description: "The MaxSessions parameter specifies the maximum number of open sessions permitted from a given connection."
+    rationale: "To protect a system from denial of service due to a large number of concurrent sessions, use the rate limiting function of MaxSessions to protect availability of sshd logins and prevent overwhelming the daemon."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: MaxSessions 10" 
+    compliance:
+      - cis: ["5.2.20"]
+      - mitre_techniques: ["T1499, T1499.002"]
+      - mitre_tactics: ["TA0040"]
+      - mitre_mitigations: [""]
+    references:
+      - SSHD_CONFIG(5)
+    condition: all
+    rules:
+      - 'c:sshd -T -C user=root -C host="$(hostname)" -C addr="$(grep $(hostname) /etc/hosts | awk '{print $1}')" -> r:^\s*maxsessions\s+10'
+
+  - id: 3220
+    title: "Ensure SSH LoginGraceTime is set to one minute or less (Automated)"
+    description: "The LoginGraceTime parameter specifies the time allowed for successful authentication to the SSH server. The longer the Grace period is the more open unauthenticated connections can exist. Like other session controls in this session the Grace Period should be limited to appropriate organizational limits to ensure the service is available for needed access."
+    rationale: "Setting the LoginGraceTime parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. It will also limit the number of concurrent unauthenticated connections. While the recommended setting is 60 seconds(1 Minute), set the number based on site policy."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: LoginGraceTime 60" 
+    compliance:
+      - cis: ["5.2.21"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","CM.L2-3.4.1","CM.L2-3.4.6","CM.L2-3.4.2","CM.L2-3.4.7"]
+      - pci_dss_3.2.1: ["2.2","11.5"]
+      - pci_dss_4.0: ["1.1.1","1.2.1","1.2.6","1.5.1","1.2.7","2.1.1","2.2.1"]
+      - nist_sp_800-53: ["CM-7(1)","CM-9","SA-10"]
+      - soc_2: ["CC7.1","CC8.1"]
+      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
+      - mitre_techniques: ["T1110, T1110.001, T1110.003, T1110.004, T1499, T1499.002"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_mitigations: ["M1036"]
+    references:
+      - SSHD_CONFIG(5)
+    condition: all
+    rules:
+      - 'c:sshd -T -C user=root -C host="$(hostname)" -C addr="$(grep $(hostname) /etc/hosts | awk '{print $1}')" -> r:^\s*logingracetime\s+60'
+
+  - id: 3221
+    title: "Ensure SSH Idle Timeout Interval is configured (Automated)"
+    description: "NOTE: To clarify, the two settings described below is only meant for idle connections from a protocol perspective and not meant to check if the user is active or not. An idle user does not mean an idle connection. SSH does not and never had, intentionally, the capability to drop idle users. In SSH versions before 8.2p1 there was a bug that caused these values to behave in such a manner that they where abused to disconnect idle users. This bug has been resolved in 8.2p1 and thus it can no longer be abused disconnect idle users. The two options ClientAliveInterval and ClientAliveCountMax control the timeout of SSH sessions. Taken directly from man 5 sshd_config: ClientAliveInterval Sets a timeout interval in seconds after which if no data has been received from the client, sshd(8) will send a message through the encrypted channel to request a response from the client. The default is 0, indicating that these messages will not be sent to the client. ClientAliveCountMax Sets the number of client alive messages which may be sent without sshd(8) receiving any messages back from the client. If this threshold is reached while client alive messages are being sent, sshd will disconnect the client, terminating the session. It is important to note that the use of client alive messages is very different from TCPKeepAlive. The client alive messages are sent through the encrypted channel and therefore will not be spoofable. The TCP keepalive option en‐abled by TCPKeepAlive is spoofable. The client alive mechanism is valuable when the client or server depend on knowing when a connection has become unresponsive. The default value is 3. If ClientAliveInterval is set to 15, and ClientAliveCountMax is left at the default, unresponsive SSH clients will be disconnected after approximately 45 seconds. Setting a zero ClientAliveCountMax disables connection termination."
+    rationale: "In order to prevent resource exhaustion, appropriate values should be set for both ClientAliveInterval and ClientAliveCountMax. Specifically, looking at the source code, ClientAliveCountMax must be greater than zero in order to utilize the ability of SSH to drop idle connections. If connections are allowed to stay open indefinately, this can potentially be used as a DDOS attack or simple resource exhaustion could occur over unreliable networks. The example set here is a 45 second timeout. Consult your site policy for network timeouts and apply as appropriate."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameters according to site policy. Example: ClientAliveInterval 15 ClientAliveCountMax 3" 
+    compliance:
+      - cis: ["5.2.22"]
+      - mitre_techniques: ["T1078, T1078.001, T1078.002, T1078.003"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_mitigations: ["M1026"]
+    references:
+      - https://man.openbsd.org/sshd_config
+    condition: all
+    rules:
+      - 'c:shd -T -C user=root -C host="$(hostname)" -C addr="$(grep $(hostname) /etc/hosts | awk '{print $1}')" -> r:^\s*clientaliveinterval\s+15'
+
+
+# 5.3 Configure privilege escalation
+
+  - id: 3222
+    title: "Ensure sudo is installed (Automated)"
+    description: "sudo allows a permitted user to execute a command as the superuser or another user, as specified by the security policy. The invoking user's real (not effective) user ID is used to determine the user name with which to query the security policy."
+    rationale: "sudo supports a plug-in architecture for security policies and input/output logging. Third parties can develop and distribute their own policy and I/O logging plug-ins to work seamlessly with the sudo front end. The default security policy is sudoers, which is configured via the file /etc/sudoers and any entries in /etc/sudoers.d. The security policy determines what privileges, if any, a user has to run sudo. The policy may require that users authenticate themselves with a password or another authentication mechanism. If authentication is required, sudo will exit if the user's password is not entered within a configurable time limit. This limit is policy-specific."
+    remediation: "First determine is LDAP functionality is required. If so, then install sudo-ldap, else install sudo. Example: # apt install sudo"
+    compliance:
+      - cis: ["5.3.1"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5","AC.L2-3.1.6","AC.L2-3.1.7","SC.L2-3.13.3"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - nist_sp_800-53: ["AC-6(2)","AC-6(5)"]
+      - soc_2: ["CC6.1","CC6.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - mitre_techniques: ["T1078, T1078.003"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_mitigations: [""]
+    references:
+      - SUDO(8)
+    condition: all
+    rules:
+      - 'c:dpkg-query -W sudo sudo-ldap > /dev/null 2>&1 && dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' sudo sudo-ldap | awk '($4=="installed" && $NF=="installed") {print "\n""PASS:""\n""Package""\""$1"\""" is installed""\n"}' || echo -e "\nFAIL:\nneither \"sudo\" or \"sudo-ldap\" package is installed\n" -> PASS'
+
+  - id: 3223
+    title: "Ensure sudo commands use pty (Automated)"
+    description: "sudo can be configured to run only from a pseudo terminal (pseudo-pty)."
+    rationale: "Attackers can run a malicious program using sudo which would fork a background process that remains even when the main program has finished executing."
+    remediation: "Edit the file /etc/sudoers with visudo or a file in /etc/sudoers.d/ with visudo -f <PATH TO FILE> and add the following line: Defaults use_pty" 
+    compliance:
+      - cis: ["5.3.2"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L2-3.1.5","AC.L2-3.1.6","AC.L2-3.1.7","SC.L2-3.13.3"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - nist_sp_800-53: ["AC-6(2)","AC-6(5)"]
+      - soc_2: ["CC6.1","CC6.3"]
+      - iso_27001-2013: ["A.8.1.3", "A.14.2.5"]
+      - mitre_techniques: ["T1548, T1548.003"]
+      - mitre_tactics: ["TA0003"]
+      - mitre_mitigations: [""]
+    references:
+      - SUDO(8)
+      - VISUDO(8)
+    condition: any
+    rules:
+      - 'f:/etc/sudoers -> r:^\s*\t*Defaults\s*\t*use_pty'
+      - 'd:/etc/sudoers.d -> r:\.* -> r:^\s*\t*Defaults\s*\t*use_pty'
+
+  - id: 3224
+    title: "Ensure sudo log file exists (Automated)"
+    description: "sudo can use a custom log file"
+    rationale: "A sudo log file simplifies auditing of sudo commands"
+    remediation: "Edit the file /etc/sudoers or a file in /etc/sudoers.d/ with visudo or visudo -f <PATH TO FILE> and add the following line: Example: Defaults logfile="/var/log/sudo.log"" 
+    compliance:
+      - cis: ["5.3.3"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - pci_dss_3.2.1: ["10.1","10.2.2","10.2.4","10.2.5","10.3"]
+      - pci_dss_4.0: ["9.4.5","10.2","10.2.1","10.2.1.2","10.2.1.5"]
+      - nist_sp_800-53: ["AU-3(1)","AU-7"]
+      - soc_2: ["CC5.2","CC7.2"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - mitre_techniques: ["T1562, T1562.006"]
+      - mitre_tactics: ["TA0004"]
+      - mitre_mitigations: [""]
+    references:
+      - SUDO(8)
+      - VISUDO(8)
+    condition: all
+    rules:
+      - 'f:/etc/sudoers -> r:^\s*\t*Defaults\s*\t*logfile='
+      - 'd:/etc/sudoers.d -> r:\.* -> r:^\s*\t*Defaults\s*\t*logfile='
+
+
+  - id: 3225
+    title: "Ensure users must provide password for privilege escalation (Automated)"
+    description: "The operating system must be configured so that users must provide a password for privilege escalation."
+    rationale: "Without (re-)authentication, users may access resources or perform tasks for which they do not have authorization. When operating systems provide the capability to escalate a functional capability, it is critical the user (re-)authenticate."
+    remediation: "Based on the outcome of the audit procedure, use visudo -f <PATH TO FILE> to edit the relevant sudoers file. Remove any line with occurrences of NOPASSWD tags in the file." 
+    compliance:
+      - cis: ["5.3.4"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5","AC.L2-3.1.6","AC.L2-3.1.7","SC.L2-3.13.3"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - nist_sp_800-53: ["AC-6(2)","AC-6(5)"]
+      - soc_2: ["CC6.1","CC6.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+    condition: none
+    rules:
+      - "c:grep -r "^[^#].*NOPASSWD" /etc/sudoers*"
+
+  - id: 3226
+    title: "Ensure re-authentication for privilege escalation is not disabled globally (Automated)"
+    description: "The operating system must be configured so that users must re-authenticate for privilege escalation."
+    rationale: "Without re-authentication, users may access resources or perform tasks for which they do not have authorization. When operating systems provide the capability to escalate a functional capability, it is critical the user re-authenticate."
+    remediation: "Configure the operating system to require users to reauthenticate for privilege escalation.Based on the outcome of the audit procedure, use visudo -f <PATH TO FILE> to edit the relevant sudoers file. Remove any occurrences of !authenticate tags in the file(s)." 
+    compliance:
+      - cis: ["5.3.5"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5","AC.L2-3.1.6","AC.L2-3.1.7","SC.L2-3.13.3"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - nist_sp_800-53: ["AC-6(2)","AC-6(5)"]
+      - soc_2: ["CC6.1","CC6.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+    condition: none
+    rules:
+      - "c:grep -r "^[^#].*\!authenticate" /etc/sudoers*"
+
+  - id: 3227
+    title: "Ensure sudo authentication timeout is configured correctly (Automated)"
+    description: "sudo caches used credentials for a default of 15 minutes. This is for ease of use when there are multiple administrative tasks to perform. The timeout can be modified to suit local security policies. This default is distribution specific. See audit section for further information."
+    rationale: "Setting a timeout value reduces the window of opportunity for unauthorized privileged access to another user."
+    remediation: "If the currently configured timeout is larger than 15 minutes, edit the file listed in the audit section with visudo -f <PATH TO FILE> and modify the entry timestamp_timeout= to 15 minutes or less as per your site policy. The value is in minutes. This particular entry may appear on it's own, or on the same line as env_reset. See the following two examples: Defaults Defaults Defaults env_reset, timestamp_timeout=15 timestamp_timeout=15 env_reset" 
+    compliance:
+      - cis: ["5.3.6"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5","AC.L2-3.1.6","AC.L2-3.1.7","SC.L2-3.13.3"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - nist_sp_800-53: ["AC-6(2)","AC-6(5)"]
+      - soc_2: ["CC6.1","CC6.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+    references:
+      - https://www.sudo.ws/man/1.9.0/sudoers.man.html
+    condition: none
+    rules:
+      - "c:grep -roP "timestamp_timeout=\K[0-9]*" /etc/sudoers*"
+
+  - id: 3228
+    title: "Ensure access to the su command is restricted (Automated)"
+    description: "The su command allows a user to run a command or shell as another user. The program has been superseded by sudo, which allows for more granular control over privileged access. Normally, the su command can be executed by any user. By uncommenting the pam_wheel.so statement in /etc/pam.d/su, the su command will only allow users in a specific groups to execute su. This group should be empty to reinforce the use of sudo for privileged access."
+    rationale: "Restricting the use of su , and using sudo in its place, provides system administrators better control of the escalation of user privileges to execute privileged commands. The sudo utility also provides a better logging and audit mechanism, as it can log each command executed via sudo , whereas su can only record that a user executed the su program."
+    remediation: "Create an empty group that will be specified for use of the su command. The group should be named according to site policy. Example: # groupadd sugroup Add the following line to the /etc/pam.d/su file, specifying the empty group: auth required pam_wheel.so use_uid group=sugroup" 
+    compliance:
+      - cis: ["5.3.7"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1548, T1548.000"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1026"]
+    condition: all
+    rules:
+      - 'f:/etc/pam.d/su -> !r:^# && r:auth\s*\t*required\s*\t*pam_wheel.so && r:use_uid && r:group='
+
+# 5.4 Configure PAM
+
+  - id: 3229
+    title: "Ensure password creation requirements are configured (Automated)"
+    description: "The pam_pwquality.so module checks the strength of passwords. It performs checks such as making sure a password is not a dictionary word, it is a certain length, contains a mix of characters (e.g. alphabet, numeric, other) and more. The following options are set in the /etc/security/pwquality.conf file: Password Length: minlen = 14 - password must be 14 characters or more .Password complexity: minclass = 4 - The minimum number of required classes of characters for the new password (digits, uppercase, lowercase, others) OR dcredit = -1 - provide at least one digit .ucredit = -1 - provide at least one uppercase character .ocredit = -1 - provide at least one special character .lcredit = -1 - provide at least one lowercase character"
+    rationale: "Strong passwords protect systems from being hacked through brute force methods."
+    remediation: "The following setting is a recommend example policy. Alter these values to conform to your own organization's password policies. Run the following command to install the pam_pwquality module: # apt install libpam-pwquality Edit the file /etc/security/pwquality.conf and add or modify the following line for password length to conform to site policy: minlen = 14 .Edit the file /etc/security/pwquality.conf and add or modify the following line for .password complexity to conform to site policy: Option 1 .minclass = 4 .Option 2 .dcredit = -1 .ucredit = -1 .ocredit = -1 .lcredit = -1" 
+    compliance:
+      - cis: ["5.4.1"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - pci_dss_4.0: ["2.2.2","8.3.5","8.3.6","8.6.3"]
+      - soc_2: ["CC6.1"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_techniques: ["T1078, T1078.001, T1078.002, T1078.003, T1078.004, T1110, T1110.001, T1110.002, T1110.003"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_mitigations: ["M1027"]
+    condition: all
+    rules:
+      - 'f:/etc/security/pwquality.conf -> !r:^# && n:minlen\s*\t*=\s*\t*(\d+) compare >= 14'
+      - 'f:/etc/pam.d/common-password -> !r:^# && n:password\s*\t*requisite\s*\t*pam_pwquality.so\s*\t*retry=(\d+) compare <=3'
+
+  - id: 3230
+    title: "Ensure lockout for failed password attempts is configured (Automated)"
+    description: "Lock out users after n unsuccessful consecutive login attempts. The first sets of changes are made to the common PAM configuration files. The second set of changes are applied to the program specific PAM configuration file. The second set of changes must be applied to each program that will lock out users. Check the documentation for each secondary program for instructions on how to configure them to work with PAM. All configuration of faillock is located in /etc/security/faillock.conf and well commented. deny - Deny access if the number of consecutive authentication failures for this user during the recent interval exceeds n tries.fail_interval - The length of the interval, in seconds, during which the consecutive authentication failures must happen for the user account to be locked out unlock_time - The access will be re-enabled after n seconds after the lock out. The value 0 has the same meaning as value never - the access will not be re- enabled without resetting the faillock entries by the faillock command. Set the lockout number and unlock time in accordance with local site policy."
+    rationale: "Locking out user IDs after n unsuccessful consecutive login attempts mitigates brute force password attacks against your systems."
+    remediation: "NOTE: Pay special attention to the configuration. Incorrect configuration can cause system lock outs. This is example configuration. You configuration may differ based on previous changes to the files. Common auth Edit /etc/pam.d/common-auth and ensure that faillock is configured. Note: It is critical to understand each line and the relevant arguments for successful implementation. The order of these entries is very specific. The pam_faillock.so lines surround the pam_unix.so line. The comment "Added to enable faillock" is shown to highlight the additional lines and their order in the file.# here are the per-package modules (the "Primary" block) auth required pam_faillock.so preauth# Added to enable faillock auth [success=1 default=ignore] pam_unix.so nullok auth [default=die] pam_faillock.so authfail# Added to enable faillock auth sufficient pam_faillock.so authsucc# Added to enable faillock# here's the fallback if no module succeeds auth requisite pam_deny.so# prime the stack with a positive return value if there isn't one already;# this avoids us returning an error just because nothing sets a success code# since the modules above will each just jump around auth required pam_permit.so# and here are more per-package modules (the "Additional" block) auth optional pam_cap.so# end of pam-auth-update config Common account .Edit /etc/pam.d/common-account and ensure that the following stanza is at the end of the file. account required .pam_faillock.so .Fail lock configuration .Edit /etc/security/faillock.conf and configure it per your site policy. Example:Page 703deny = 4 .fail_interval = 900 unlock time = 600" 
+    compliance:
+      - cis: ["5.4.2"]
+      - cis_csc_v8: ["6.2"]
+      - cis_csc_v7: ["16.7"]
+      - cmmc_v2.0: ["AC.L1-3.1.1"]
+      - hipaa: ["164.308(a)(3)(ii)(C)"]
+      - pci_dss_3.2.1: ["8.1.3"]
+      - pci_dss_4.0: ["8.2.4","8.2.5"]
+      - nist_sp_800-53: ["AC-2(1)"]
+      - soc_2: ["CC6.2","CC6.3"]
+      - iso_27001-2013: ["A.9.2.6"]
+      - mitre_techniques: ["T1110, T1110.001, T1110.003"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_mitigations: ["M1027"]
+    condition: all
+    rules:
+      - 'f:/etc/pam.d/common-auth -> !r:^# && r:auth\s*\t*required\s*\t*pam_tally2.so && r:onerr=fail && r:audit && r:silent && r:deny\s*=\s*\d+ && r:unlock_time\s*=\s*\d+'
+      - 'f:/etc/pam.d/common-account -> !r:^# && r:account\s*\t*requisite\s*\t*pam_deny.so'
+      - 'f:/etc/pam.d/common-account -> !r:^# && r:account\s*\t*required\s*\t*pam_tally2.so'
+
+  - id: 3231
+    title: "Ensure password reuse is limited (Automated)"
+    description: "The /etc/security/opasswd file stores the users' old passwords and can be checked to ensure that users are not recycling recent passwords."
+    rationale: "Forcing users not to reuse their past 5 passwords make it less likely that an attacker will be able to guess the password."
+    remediation: "NOTE: Pay special attention to the configuration. Incorrect configuration can cause system lock outs. This is example configuration. You configuration may differ based on previous changes to the files. Edit the /etc/pam.d/common-password file to include the remember= option of 5 or more. If this line doesn't exist, add the line directly above the line: password [success=1 default=ignore] pam_unix.so obscure yescrypt: Example: password required pam_pwhistory.so use_authtok remember=5" 
+    compliance:
+      - cis: ["5.4.3"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - pci_dss_4.0: ["2.2.2","8.3.5","8.3.6","8.6.3"]
+      - soc_2: ["CC6.1"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_techniques: ["T1078, T1078.001, T1078.002, T1078.003, T1078.004, T1110, T1110.004"]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: none
+    rules:
+      - 'f:/etc/pam.d/common-password -> !r:^# && r:password\s*\t*required\s*\t*pam_pwhistory.so && n:remember\s*\t*=\s*\t*(\d+) compare < 5'
+      - 'f:/etc/pam.d/common-password -> !r:^# && r:password\s*\t*required\s*\t*pam_pwhistory.so && !r:remember'
+
+  - id: 3232
+    title: "Ensure password hashing algorithm is up to date with the latest standards (Automated)"
+    description: "The commands below change password encryption to yescrypt. All existing accounts will need to perform a password change to upgrade the stored hashes to the new algorithm."
+    rationale: "The yescrypt algorithm provides much stronger hashing than previous available algorithms, thus providing additional protection to the system by increasing the level of effort for an attacker to successfully determine passwords. Note: these change only apply to accounts configured on the local system."
+    remediation: "NOTE: Pay special attention to the configuration. Incorrect configuration can cause system lock outs. This is example configuration. You configuration may differ based on previous changes to the files. PAM Edit the /etc/pam.d/common-password file and ensure that no hashing algorithm option for pam_unix.so is set: password [success=1 default=ignore] try_first_pass remember=5 pam_unix.so obscure use_authtok Login definitions .Edit /etc/login.defs and ensure that ENCRYPT_METHOD is set to yescrypt." 
+    compliance:
+      - cis: ["5.4.4"]
+      - cis_csc_v8: ["3.11"]
+      - cis_csc_v7: ["16.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.19","IA.L2-3.5.10","MP.L2-3.8.1","SC.L2-3.13.11","SC.L2-3.13.16"]
+      - hipaa: ["164.312(a)(2)(iv)","164.312(e)(2)(ii)"]
+      - pci_dss_3.2.1: ["3.4","3.4.1","8.2.1"]
+      - pci_dss_4.0: ["3.1.1","3.3.2","3.3.3","3.5.1","3.5.1.2","3.5.1.3","8.3.2"]
+      - nist_sp_800-53: ["SC-28","SC-28(1)"]
+      - soc_2: ["CC6.1"]
+      - iso_27001-2013: ["A.10.1.1"]
+      - mitre_techniques: ["T1003, T1003.008, T1110, T1110.002"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_mitigations: ["M1041"]
+    condition: none
+    rules:
+      - "c:grep -v ^# /etc/pam.d/common-password | grep -E "(yescrypt|md5|bigcrypt|sha256|sha512|blowfish)""
+
+# 5.4.5 Ensure all current passwords uses the configured hashing algorithm (Manual) - Not Implemented
+
+
+# 5.5 User Accounts and Environment
+# 5.5.1 Set Shadow Password Suite Parameters
+
+  - id: 3233
+    title: "Ensure minimum days between password changes is configured (Automated)"
+    description: "The PASS_MIN_DAYS parameter in /etc/login.defs allows an administrator to prevent users from changing their password until a minimum number of days have passed since the last time the user changed their password. It is recommended that PASS_MIN_DAYS parameter be set to 1 or more days."
+    rationale: "By restricting the frequency of password changes, an administrator can prevent users from repeatedly changing their password in an attempt to circumvent password reuse controls."
+    remediation: "Set the PASS_MIN_DAYS parameter to 1 in /etc/login.defs : PASS_MIN_DAYS 1 Modify user parameters for all users with a password set to match: # chage --mindays 1 <user>" 
+    compliance:
+      - cis: ["5.5.1.1"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - pci_dss_4.0: ["2.2.2","8.3.5","8.3.6","8.6.3"]
+      - soc_2: ["CC6.1"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_techniques: ["T1078, T1078.001, T1078.002, T1078.003, T1078.004, T1110, T1110.004"]
+      - mitre_tactics: ["TA0006"]
+      - mitre_mitigations: ["M1027"]
+    condition: all
+    rules:
+     - 'f:/etc/login.defs -> n:^\s*\t*PASS_MIN_DAYS\s*\t*(\d+) compare >= 1'
+
+  - id: 3234
+    title: "Ensure password expiration is 365 days or less (Automated)"
+    description: "The PASS_MAX_DAYS parameter in /etc/login.defs allows an administrator to force passwords to expire once they reach a defined age."
+    rationale: "The window of opportunity for an attacker to leverage compromised credentials or successfully compromise credentials via an online brute force attack is limited by the age of the password. Therefore, reducing the maximum age of a password also reduces an attacker's window of opportunity. It is recommended that the PASS_MAX_DAYS parameter does not exceed 365 days and is greater than the value of PASS_MIN_DAYS."
+    remediation: "Set the PASS_MAX_DAYS parameter to conform to site policy in /etc/login.defs : PASS_MAX_DAYS 365 Modify user parameters for all users with a password set to match: # chage --maxdays 365 <user>" 
+    compliance:
+      - cis: ["5.5.1.2"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - pci_dss_4.0: ["2.2.2","8.3.5","8.3.6","8.6.3"]
+      - soc_2: ["CC6.1"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_techniques: ["T1078, T1078.001, T1078.002, T1078.003, T1078.004, T1110, T1110.001, T1110.002, T1110.003, T1110.004"]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    references:
+      - https://www.cisecurity.org/white-papers/cis-password-policy-guide/
+    condition: all
+    rules:
+      - 'f:/etc/login.defs -> n:^\s*\t*PASS_MAX_DAYS\s*\t*(\d+) compare <= 365'
+
+  - id: 3235
+    title: "Ensure password expiration warning days is 7 or more (Automated)"
+    description: "The PASS_WARN_AGE parameter in /etc/login.defs allows an administrator to notify users that their password will expire in a defined number of days. It is recommended that the PASS_WARN_AGE parameter be set to 7 or more days."
+    rationale: "Providing an advance warning that a password will be expiring gives users time to think of a secure password. Users caught unaware may choose a simple password or write it down where it may be discovered."
+    remediation: "Set the PASS_WARN_AGE parameter to 7 in /etc/login.defs :PASS_WARN_AGE 7 Modify user parameters for all users with a password set to match: # chage --warndays 7 <user>" 
+    compliance:
+      - cis: ["5.5.1.3"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - pci_dss_4.0: ["2.2.2","8.3.5","8.3.6","8.6.3"]
+      - soc_2: ["CC6.1"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_techniques: [""]
+      - mitre_tactics: ["TA0006"]
+      - mitre_mitigations: ["M1027"]
+    condition: all
+    rules:
+      - 'f:/etc/login.defs -> n:^\s*\t*PASS_WARN_AGE\s*\t*(\d+) compare >= 7'
+
+  - id: 3236
+    title: "Ensure inactive password lock is 30 days or less (Automated)"
+    description: "User accounts that have been inactive for over a given period of time can be automatically disabled. It is recommended that accounts that are inactive for 30 days after password expiration be disabled."
+    rationale: "Inactive accounts pose a threat to system security since the users are not logging in to notice failed login attempts or other anomalies."
+    remediation: "Run the following command to set the default password inactivity period to 30 days: # useradd -D -f 30 Modify user parameters for all users with a password set to match: # chage --inactive 30 <user>"
+    compliance:
+      - cis: ["5.5.1.4"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - pci_dss_4.0: ["2.2.2","8.3.5","8.3.6","8.6.3"]
+      - soc_2: ["CC6.1"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_techniques: ["T1078, T1078.002, T1078.003"]
+      - mitre_tactics: ["TA0001"]
+      - mitre_mitigations: ["M1027"]
+    condition: all
+    rules:
+      - 'c:useradd -D -> n:^INACTIVE=(\d+) compare <= 30'
+      - 'not c:useradd -D -> n:^INACTIVE=(\d+) compare < 0'
+
+  - id: 3237
+    title: "Ensure all users last password change date is in the past (Automated)"
+    description: "All users should have a password change date in the past."
+    rationale: "If a users recorded password change date is in the future then they could bypass any set password expiration."
+    remediation: "Investigate any users with a password change date in the future and correct them. Locking the account, expiring the password, or resetting the password manually may be appropriate." 
+    compliance:
+      - cis: ["5.5.1.5"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - pci_dss_4.0: ["2.2.2","8.3.5","8.3.6","8.6.3"]
+      - soc_2: ["CC6.1"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - mitre_techniques: ["T1078, T1078.001, T1078.002, T1078.003, T1078.004, T1110, T1110.001, T1110.002, T1110.003, T1110.004"]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:sudo awk -F: '/^[^:]+:[^!*]/{print $1}' /etc/shadow | while read -r usr; do change=$(date -d "$(chage --list $usr | grep '^Last password change' | cut -d: -f2 | grep -v 'never$')" +%s); if [[ "$change" -gt "$(date +%s)" ]]; then echo "User: \"$usr\" last password change was \"$(chage --list $usr | grep '^Last password change' | cut -d: -f2)\""; fi; done"
+
+  - id: 3238
+    title: "Ensure system accounts are secured (Automated)"
+    description: "There are a number of accounts provided with most distributions that are used to manage applications and are not intended to provide an interactive shell."
+    rationale: "It is important to make sure that accounts that are not being used by regular users are prevented from being used to provide an interactive shell. By default, most distributions set the password field for these accounts to an invalid string, but it is also recommended that the shell field in the password file be set to the nologin shell. This prevents the account from potentially being used to run any commands."
+    remediation: "Set the shell for any accounts returned by the audit to nologin: # usermod -s $(which nologin) <user> Lock any non root accounts returned by the audit: # usermod -L <user>The following command will set all system accounts to a non login shell: # awk -F: '$1!~/(root|sync|shutdown|halt|^\+)/ && $3<'"$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs)"' && $7!~/((\/usr)?\/sbin\/nologin)/ && $7!~/(\/bin)?\/false/ {print $1}'/etc/passwd | while read -r user; do usermod -s "$(which nologin)" "$user"; done The following command will automatically lock not root system accounts:# awk -F:'($1!~/(root|^\+)/ && $3<'"$(awk '/^\s*UID_MIN/{print $2}'/etc/login.defs)"') {print $1}' /etc/passwd | xargs -I '{}' passwd -S '{}' |awk '($2!~/LK?/) {print $1}' | while read -r user; do usermod -L "$user"; done" 
+    compliance:
+      - cis: ["5.5.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1078, T1078.001, T1078.003"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1026"]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3239
+    title: "Ensure default group for the root account is GID 0 (Automated)"
+    description: "The usermod command can be used to specify which group the root user belongs to. This affects permissions of files that are created by the root user."
+    rationale: "Using GID 0 for the root account helps prevent root -owned files from accidentally becoming accessible to non-privileged users."
+    remediation: "Run the following command to set the root user default group to GID 0 : # usermod -g 0 root" 
+    compliance:
+      - cis: ["5.5.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1","AC.L1-3.1.2","AC.L2-3.1.5","AC.L2-3.1.3","MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)","164.308(a)(3)(ii)(A)","164.312(a)(1)"]
+      - pci_dss_3.2.1: ["7.1","7.1.1","7.1.2","7.1.3"]
+      - pci_dss_4.0: ["1.3.1","7.1"]
+      - nist_sp_800-53: ["AC-5","AC-6"]
+      - soc_2: ["CC5.2","CC6.1"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - mitre_techniques: ["T1548, T1548.000"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: ["M1026"]
+    condition: all
+    rules:
+      - 'f:/etc/passwd -> !r:^# && r:root:\w+:\w+:0:'
+
+# 5.5.4 Ensure default user umask is 027 or more restrictive (Automated) - Not Implemented
+
+# 5.5.5 Ensure default user umask is 027 or more restrictive (Automated) - Not Implemented
+
+
+# 6 System Maintenance
+# 6.1 System File Permissions
+
+  - id: 3241
+    title: "Ensure permissions on /etc/passwd are configured (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.1.1"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3243
+    title: "Ensure permissions on /etc/passwd- are configured (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.1.2"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3244
+    title: "Ensure permissions on /etc/group are configured (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.1.3"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3245
+    title: "Ensure permissions on /etc/group- are configured (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.1.4"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3246
+    title: "Ensure permissions on /etc/shadow are configured (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.1.5"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3247
+    title: "Ensure permissions on /etc/shadow- are configured (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.1.6"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3248
+    title: "Ensure permissions on /etc/gshadow are configured (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.1.7"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 32549
+    title: "Ensure permissions on /etc/gshadow- are configured (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.1.8"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3250
+    title: "Ensure no world writable files exist (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.1.9"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3251
+    title: "Ensure no unowned files or directories exist (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.1.10"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3252
+    title: "Ensure no ungrouped files or directories exist (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.1.11"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3253
+    title: "Audit SUID executables (Manual)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.1.12"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3254
+    title: "Audit SGID executables (Manual)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.1.13"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+# 6.2 Local User and Group Settings
+
+  - id: 3255
+    title: "Ensure accounts in /etc/passwd use shadowed passwords (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.2.1"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3256
+    title: "Ensure /etc/shadow password fields are not empty (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.2.2"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3257
+    title: "Ensure all groups in /etc/passwd exist in /etc/group (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.2.3"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3258
+    title: "Ensure shadow group is empty (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.2.4"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3259
+    title: "Ensure no duplicate UIDs exist (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.2.5"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3260
+    title: "Ensure no duplicate GIDs exist (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.2.6"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3261
+    title: "Ensure no duplicate user names exist (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.2.7"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3262
+    title: "Ensure no duplicate group names exist (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.2.8"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3263
+    title: "Ensure root PATH Integrity (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.2.9"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3264
+    title: "Ensure root is the only UID 0 account (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.2.10"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3265
+    title: "Ensure local interactive user home directories exist (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.2.11"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3266
+    title: "Ensure local interactive users own their home directories (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.2.12"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3267
+    title: "Ensure local interactive user home directories are mode 750 or more restrictive (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.2.13"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3268
+    title: "Ensure no local interactive user has .netrc files (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.2.14"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3269
+    title: "Ensure no local interactive user has .forward files (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.2.15"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3270
+    title: "Ensure no local interactive user has .rhosts files (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.2.16"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+  - id: 3271
+    title: "Ensure local interactive user dot files are not group or world writable (Automated)"
+    description: ""
+    rationale: ""
+    remediation: "" 
+    compliance:
+      - cis: ["6.2.17"]
+      - cis_csc_v8: [""]
+      - cis_csc_v7: [""]
+
+      - mitre_techniques: [""]
+      - mitre_tactics: [""]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
| Component | Action type           | Main Issue 
| --- | --- | ---
| SCA       | Rework |  #14358 


Description:
Debian 11 SCA policy containing section 1 - 5

## Main tasks

- [ ] Use the latest CIS benchmark PDF - CIS Debian Linux 11 Benchmark v1.0.0
- [ ] Verify IDs numbers.
- [ ] Verify texts are correct: Title, Description, Rationale and Remediation.
- [ ] Verify Compliance: CIS, CIS_CSC.
- [ ] Verify condtion and rules:
  - [ ] To Pass.
  - [ ] To Fail.
- [ ] Solve Related issues:

## Checks
### Syntax and semantic

- [ ] a) ID of each policy must be contiguous.
- [ ] b) The order and format set in [Documentation](https://documentation.wazuh.com/current/user-manual/capabilities/sec-config-assessment/creating-custom-policies.html) must be respected.
- [ ] c) YML must be valid to avoid errors.

### Content

- [ ] a) Compare each check with its analog from CIS Benchmark.
- [ ] b) Try maintaining each rule as similar as possible with the `Audit` section from the CIS check.
- [ ] c) Check that the commands provide the expected output.
- [ ] d) When a failure is discovered, check similar policies to avoid repetition of the issue.

### Unit testing

- [ ] a) Output from `ossec.log` after the SCA scan and a raw output of the result of the checks.
<details><summary>Tests results</summary>
<p>

#### Analysisd (server or local)
analysisd.debug=2

#### Auth daemon debug (server)
authd.debug=0

#### Exec daemon debug (server, local, or Unix agent)
execd.debug=0

#### Monitor daemon debug (server, local, or Unix agent)
monitord.debug=0

#### Log collector (server, local or Unix agent)
logcollector.debug=0

#### Integrator daemon debug (server, local or Unix agent)
integrator.debug=0

#### Unix agentd
agent.debug=2

</p>
</details>

### Deployment

- [ ] a) If the policy it's new, it must be added to the `sca.files` templates.
- [ ] b) If the OS has many supported SCA policies, a policy must be set as the default policy. ([as example](https://github.com/wazuh/wazuh/blob/master/etc/templates/config/centos/sca.files))