### PR TITLE
Fix in log date parsing at predecoding stage

### DIFF
--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -86,6 +86,7 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
      * ( ex: Dec 29 10:00:01
      *   or  2015 Dec 29 10:00:01
      *   or  2007-06-14T15:48:55-04:00 for syslog-ng isodate
+     *   or  2022-12-19T15:02:53.288+00:00 for syslog isodate
      *   or  2009-05-22T09:36:46.214994-07:00 for rsyslog )
      *   or  2015-04-16 21:51:02,805 (proftpd 1.3.5)
      *   or  2021-04-21 10:16:09.404756-0700 (for macos ULS --syslog output)
@@ -124,9 +125,11 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
                  (pieces[25] == ' ') && (lf->log += 26)) ||
 
                 ((pieces[19] == '.') &&
-                 (pieces[29] == ':') && (lf->log += 33))  ||
-
-                ((pieces[19] == '.') && (lf->log += 32))
+                (
+                    ((pieces[26] == ':') && (lf->log += 30))  ||
+                    ((pieces[29] == ':') && (lf->log += 33))  ||
+                    (lf->log += 32)
+                ))
             )
         )
      ||

--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -109,7 +109,7 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
 	    (pieces[13] == ':') &&
 	    (pieces[16] == ':') &&
 	    (pieces[19] == ',') &&
-	    (lf->log += 23)
+	    (lf->log += 24)
 	)
 	||
         (

--- a/src/unit_tests/analysisd/test_cleanevent.c
+++ b/src/unit_tests/analysisd/test_cleanevent.c
@@ -174,6 +174,126 @@ static void test_OS_CleanMSG_syslog_ipv6_msg(void **state) {
     os_free(msg);
 }
 
+static void test_OS_CleanMSG_timestamp(void **state){
+
+    Eventinfo *lf = (Eventinfo *)*state;
+    
+    char *msg;
+    os_calloc(OS_BUFFER_SIZE, sizeof(char), msg);
+    snprintf(msg, OS_BUFFER_SIZE, "%c:%s:%s", '1', "/var/log/syslog", "2015 Dec 29 10:00:01 wazuh-agent01 AUTH:INFO sshd[223468]: LOG BODY");
+
+    int value = OS_CleanMSG(msg, lf);
+
+    assert_int_equal(value, 0);
+    assert_string_equal(lf->program_name, "AUTH");
+    assert_string_equal(lf->agent_id, "000");
+    assert_string_equal(lf->location, "/var/log/syslog");
+    assert_string_equal(lf->full_log, "2015 Dec 29 10:00:01 wazuh-agent01 AUTH:INFO sshd[223468]: LOG BODY");
+    assert_string_equal(lf->dec_timestamp, "2015 Dec 29 10:00:01");
+       
+    os_free(msg);
+}
+
+static void test_OS_CleanMSG_macos_ULS_syslog_timestamp(void **state){
+
+    Eventinfo *lf = (Eventinfo *)*state;
+    
+    char *msg;
+    os_calloc(OS_BUFFER_SIZE, sizeof(char), msg);
+    snprintf(msg, OS_BUFFER_SIZE, "%c:%s:%s", '1', "/var/log/syslog", "2021-04-21 10:16:09.404756-0700 wazuh-agent01 AUTH:INFO sshd[223468]: LOG BODY");
+
+    int value = OS_CleanMSG(msg, lf);
+
+    assert_int_equal(value, 0);
+    assert_string_equal(lf->program_name, "AUTH");
+    assert_string_equal(lf->agent_id, "000");
+    assert_string_equal(lf->location, "/var/log/syslog");
+    assert_string_equal(lf->full_log, "2021-04-21 10:16:09.404756-0700 wazuh-agent01 AUTH:INFO sshd[223468]: LOG BODY");
+    assert_string_equal(lf->dec_timestamp, "2021-04-21 10:16:09.404756-0700");
+       
+    os_free(msg);
+}
+
+static void test_OS_CleanMSG_proftpd_1_3_5_timestamp(void **state){
+
+    Eventinfo *lf = (Eventinfo *)*state;
+    
+    char *msg;
+    os_calloc(OS_BUFFER_SIZE, sizeof(char), msg);
+    snprintf(msg, OS_BUFFER_SIZE, "%c:%s:%s", '1', "/var/log/syslog", "2015-04-16 21:51:02,805 wazuh-agent01 AUTH:INFO sshd[223468]: LOG BODY");
+
+    int value = OS_CleanMSG(msg, lf);
+
+    assert_int_equal(value, 0);
+    assert_string_equal(lf->program_name, "AUTH");
+    assert_string_equal(lf->agent_id, "000");
+    assert_string_equal(lf->location, "/var/log/syslog");
+    assert_string_equal(lf->full_log, "2015-04-16 21:51:02,805 wazuh-agent01 AUTH:INFO sshd[223468]: LOG BODY");
+    assert_string_equal(lf->dec_timestamp, "2015-04-16 21:51:02,805");
+
+    os_free(msg);
+}
+
+static void test_OS_CleanMSG_syslog_ng_isodate_timestamp(void **state){
+
+    Eventinfo *lf = (Eventinfo *)*state;
+    
+    char *msg;
+    os_calloc(OS_BUFFER_SIZE, sizeof(char), msg);
+    snprintf(msg, OS_BUFFER_SIZE, "%c:%s:%s", '1', "/var/log/syslog", "2007-06-14T15:48:55-04:00 wazuh-agent01 AUTH:INFO sshd[223468]: LOG BODY");
+
+    int value = OS_CleanMSG(msg, lf);
+
+    assert_int_equal(value, 0);
+    assert_string_equal(lf->program_name, "AUTH");
+    assert_string_equal(lf->agent_id, "000");
+    assert_string_equal(lf->location, "/var/log/syslog");
+    assert_string_equal(lf->full_log, "2007-06-14T15:48:55-04:00 wazuh-agent01 AUTH:INFO sshd[223468]: LOG BODY");
+    assert_string_equal(lf->dec_timestamp, "2007-06-14T15:48:55-04:00");
+       
+    os_free(msg);
+}
+
+static void test_OS_CleanMSG_rsyslog_timestamp(void **state){
+
+    Eventinfo *lf = (Eventinfo *)*state;
+    
+    char *msg;
+    os_calloc(OS_BUFFER_SIZE, sizeof(char), msg);
+    snprintf(msg, OS_BUFFER_SIZE, "%c:%s:%s", '1', "/var/log/syslog", "2009-05-22T09:36:46.214994-07:00 wazuh-agent01 AUTH:INFO sshd[223468]: LOG BODY");
+
+    int value = OS_CleanMSG(msg, lf);
+
+    assert_int_equal(value, 0);
+    assert_string_equal(lf->program_name, "AUTH");
+    assert_string_equal(lf->agent_id, "000");
+    assert_string_equal(lf->location, "/var/log/syslog");
+    assert_string_equal(lf->full_log, "2009-05-22T09:36:46.214994-07:00 wazuh-agent01 AUTH:INFO sshd[223468]: LOG BODY");
+    assert_string_equal(lf->dec_timestamp, "2009-05-22T09:36:46.214994-07:00");
+       
+    os_free(msg);
+}
+
+static void test_OS_CleanMSG_syslog_isodate_timestamp(void **state){
+
+    Eventinfo *lf = (Eventinfo *)*state;
+    
+    char *msg;
+    os_calloc(OS_BUFFER_SIZE, sizeof(char), msg);
+    snprintf(msg, OS_BUFFER_SIZE, "%c:%s:%s", '1', "/var/log/syslog", "2022-12-19T15:02:53.288+00:00 wazuh-agent01 AUTH:INFO sshd[223468]: LOG BODY");
+
+    int value = OS_CleanMSG(msg, lf);
+
+    assert_int_equal(value, 0);
+    assert_string_equal(lf->program_name, "AUTH");
+    assert_string_equal(lf->agent_id, "000");
+    assert_string_equal(lf->location, "/var/log/syslog");
+    assert_string_equal(lf->full_log, "2022-12-19T15:02:53.288+00:00 wazuh-agent01 AUTH:INFO sshd[223468]: LOG BODY");
+    assert_string_equal(lf->dec_timestamp, "2022-12-19T15:02:53.288+00:00");
+       
+    os_free(msg);
+}
+
 void test_extract_module_from_message(void ** state) {
     char message[32] = "1:/var/log/demo.log:Hello world";
 
@@ -237,6 +357,13 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_OS_CleanMSG_ossec_syslog_msg, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_OS_CleanMSG_syslog_ipv4_msg, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_OS_CleanMSG_syslog_ipv6_msg, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_OS_CleanMSG_syslog_isodate_timestamp, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_OS_CleanMSG_rsyslog_timestamp, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_OS_CleanMSG_syslog_ng_isodate_timestamp, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_OS_CleanMSG_proftpd_1_3_5_timestamp, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_OS_CleanMSG_macos_ULS_syslog_timestamp, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_OS_CleanMSG_timestamp, test_setup, test_teardown),
+        
         // Test extract_module_from_message
         cmocka_unit_test(test_extract_module_from_message),
         cmocka_unit_test(test_extract_module_from_message_arrow),

--- a/src/unit_tests/analysisd/test_cleanevent.c
+++ b/src/unit_tests/analysisd/test_cleanevent.c
@@ -332,6 +332,46 @@ static void test_OS_CleanMSG_suricata_timestamp(void **state){
     os_free(msg);
 }
 
+static void test_OS_CleanMSG_osx_asl_timestamp(void **state){
+
+    Eventinfo *lf = (Eventinfo *)*state;
+    
+    char *msg;
+    os_calloc(OS_BUFFER_SIZE, sizeof(char), msg);
+    snprintf(msg, OS_BUFFER_SIZE, "%c:%s:%s", '1', "/var/log/syslog", "[Time 2006.12.28 15:53:55 UTC] [Facility auth] [Sender sshd] [PID 483] [Message error: PAM: Authentication failure for username from 192.168.0.2] [Level 3] [UID -2] [GID -2] [Host Hostname]");
+
+    int value = OS_CleanMSG(msg, lf);
+
+    assert_int_equal(value, 0);
+    assert_string_equal(lf->program_name, "sshd");
+    assert_string_equal(lf->agent_id, "000");
+    assert_string_equal(lf->location, "/var/log/syslog");
+    assert_string_equal(lf->full_log, "[Time 2006.12.28 15:53:55 UTC] [Facility auth] [Sender sshd] [PID 483] [Message error: PAM: Authentication failure for username from 192.168.0.2] [Level 3] [UID -2] [GID -2] [Host Hostname]");
+    assert_null(lf->dec_timestamp);
+       
+    os_free(msg);
+}
+
+static void test_OS_CleanMSG_snort_timestamp(void **state){
+
+    Eventinfo *lf = (Eventinfo *)*state;
+    
+    char *msg;
+    os_calloc(OS_BUFFER_SIZE, sizeof(char), msg);
+    snprintf(msg, OS_BUFFER_SIZE, "%c:%s:%s", '1', "/var/log/syslog", "01/28-09:13:16.240702  [Facility auth] [Sender sshd] [PID 483] [Message error: PAM: Authentication failure for username from 192.168.0.2] [Level 3] [UID -2] [GID -2] [Host Hostname]");
+
+    int value = OS_CleanMSG(msg, lf);
+
+    assert_int_equal(value, 0);
+    
+    assert_string_equal(lf->agent_id, "000");
+    assert_string_equal(lf->location, "/var/log/syslog");
+    assert_string_equal(lf->full_log, "01/28-09:13:16.240702  [Facility auth] [Sender sshd] [PID 483] [Message error: PAM: Authentication failure for username from 192.168.0.2] [Level 3] [UID -2] [GID -2] [Host Hostname]");
+    assert_string_equal(lf->dec_timestamp, "01/28-09:13:16.240702");
+       
+    os_free(msg);
+}
+
 static void test_OS_CleanMSG_xferlog_timestamp(void **state){
 
     Eventinfo *lf = (Eventinfo *)*state;
@@ -420,8 +460,10 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_OS_CleanMSG_proftpd_1_3_5_timestamp, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_OS_CleanMSG_macos_ULS_syslog_timestamp, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_OS_CleanMSG_timestamp, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_OS_CleanMSG_osx_asl_timestamp, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_OS_CleanMSG_apache_timestamp, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_OS_CleanMSG_suricata_timestamp, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_OS_CleanMSG_snort_timestamp, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_OS_CleanMSG_xferlog_timestamp, test_setup, test_teardown),
         
         // Test extract_module_from_message

--- a/src/unit_tests/analysisd/test_cleanevent.c
+++ b/src/unit_tests/analysisd/test_cleanevent.c
@@ -294,6 +294,63 @@ static void test_OS_CleanMSG_syslog_isodate_timestamp(void **state){
     os_free(msg);
 }
 
+static void test_OS_CleanMSG_apache_timestamp(void **state){
+
+    Eventinfo *lf = (Eventinfo *)*state;
+    
+    char *msg;
+    os_calloc(OS_BUFFER_SIZE, sizeof(char), msg);
+    snprintf(msg, OS_BUFFER_SIZE, "%c:%s:%s", '1', "/var/log/apache", "[Fri Feb 11 18:06:35 2004] [Facility auth] [Sender sshd] [PID 483] [Message error: PAM: Authentication failure for username from 192.168.0.2] [Level 3] [UID -2] [GID -2] [Host Hostname]");
+
+    int value = OS_CleanMSG(msg, lf);
+
+    assert_int_equal(value, 0);
+    assert_string_equal(lf->agent_id, "000");
+    assert_string_equal(lf->location, "/var/log/apache");
+    assert_string_equal(lf->full_log, "[Fri Feb 11 18:06:35 2004] [Facility auth] [Sender sshd] [PID 483] [Message error: PAM: Authentication failure for username from 192.168.0.2] [Level 3] [UID -2] [GID -2] [Host Hostname]");
+    assert_string_equal(lf->dec_timestamp, "Fri Feb 11 18:06:35 2004");
+       
+    os_free(msg);
+}
+
+static void test_OS_CleanMSG_suricata_timestamp(void **state){
+
+    Eventinfo *lf = (Eventinfo *)*state;
+    
+    char *msg;
+    os_calloc(OS_BUFFER_SIZE, sizeof(char), msg);
+    snprintf(msg, OS_BUFFER_SIZE, "%c:%s:%s", '1', "/var/log/syslog", "01/28/1979-09:13:16.240702  [Facility auth] [Sender sshd] [PID 483] [Message error: PAM: Authentication failure for username from 192.168.0.2] [Level 3] [UID -2] [GID -2] [Host Hostname]");
+
+    int value = OS_CleanMSG(msg, lf);
+
+    assert_int_equal(value, 0);
+    assert_string_equal(lf->agent_id, "000");
+    assert_string_equal(lf->location, "/var/log/syslog");
+    assert_string_equal(lf->full_log, "01/28/1979-09:13:16.240702  [Facility auth] [Sender sshd] [PID 483] [Message error: PAM: Authentication failure for username from 192.168.0.2] [Level 3] [UID -2] [GID -2] [Host Hostname]");
+    assert_string_equal(lf->dec_timestamp, "01/28/1979-09:13:16.240702");
+       
+    os_free(msg);
+}
+
+static void test_OS_CleanMSG_xferlog_timestamp(void **state){
+
+    Eventinfo *lf = (Eventinfo *)*state;
+    
+    char *msg;
+    os_calloc(OS_BUFFER_SIZE, sizeof(char), msg);
+    snprintf(msg, OS_BUFFER_SIZE, "%c:%s:%s", '1', "/var/log/syslog", "Mon Apr 17 18:27:14 2006 1 64.160.42.130");
+
+    int value = OS_CleanMSG(msg, lf);
+
+    assert_int_equal(value, 0);
+    assert_string_equal(lf->agent_id, "000");
+    assert_string_equal(lf->location, "/var/log/syslog");
+    assert_string_equal(lf->full_log, "Mon Apr 17 18:27:14 2006 1 64.160.42.130");
+    assert_string_equal(lf->dec_timestamp, "Mon Apr 17 18:27:14 2006");
+       
+    os_free(msg);
+}
+
 void test_extract_module_from_message(void ** state) {
     char message[32] = "1:/var/log/demo.log:Hello world";
 
@@ -363,6 +420,9 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_OS_CleanMSG_proftpd_1_3_5_timestamp, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_OS_CleanMSG_macos_ULS_syslog_timestamp, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_OS_CleanMSG_timestamp, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_OS_CleanMSG_apache_timestamp, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_OS_CleanMSG_suricata_timestamp, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_OS_CleanMSG_xferlog_timestamp, test_setup, test_teardown),
         
         // Test extract_module_from_message
         cmocka_unit_test(test_extract_module_from_message),


### PR DESCRIPTION
|Related issue|
|---|
|[#15772](https://github.com/wazuh/wazuh/issues/15730)|

## Description

This pull request fixes an incorrect log date parsing reported by a community user, where a syslog-ng date format has a fraction of seconds with 3 digits instead of 6.

Along with the fix, several date format unit tests have been added to perform verifications.

Thanks to these unit tests, a problem in parsing proftpd 1.3.5 date format was also found and fixed.

### ProFTPD 1.3.5 log fixed error

An error was found when a unit test was developed for this use case. The date format is similar to:
`2015-04-16 21:51:02,805`. But the parsed date missed the last character, resulting in `2015-04-16 21:51:02,80`.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Review logs syntax and correct language
- [x] Added unit tests

## Unit Tests Log

```console
2/160 Testing: test_cleanevent
2/160 Test: test_cleanevent
Command: "/home/beto/wazuh/wazuh/src/unit_tests/build/analysisd/test_cleanevent"
Directory: /home/beto/wazuh/wazuh/src/unit_tests/build/analysisd
"test_cleanevent" start time: Jan 04 19:32 -03
Output:
----------------------------------------------------------
[==========] Running 25 test(s).
[ RUN      ] test_OS_CleanMSG_fail
[       OK ] test_OS_CleanMSG_fail
[ RUN      ] test_OS_CleanMSG_fail_short_msg
[       OK ] test_OS_CleanMSG_fail_short_msg
[ RUN      ] test_OS_CleanMSG_ossec_min_msg
[       OK ] test_OS_CleanMSG_ossec_min_msg
[ RUN      ] test_OS_CleanMSG_ossec_arrow_msg
[       OK ] test_OS_CleanMSG_ossec_arrow_msg
[ RUN      ] test_OS_CleanMSG_ossec_test_msg
[       OK ] test_OS_CleanMSG_ossec_test_msg
[ RUN      ] test_OS_CleanMSG_ossec_syslog_msg
[       OK ] test_OS_CleanMSG_ossec_syslog_msg
[ RUN      ] test_OS_CleanMSG_syslog_ipv4_msg
[       OK ] test_OS_CleanMSG_syslog_ipv4_msg
[ RUN      ] test_OS_CleanMSG_syslog_ipv6_msg
[       OK ] test_OS_CleanMSG_syslog_ipv6_msg
[ RUN      ] test_OS_CleanMSG_syslog_isodate_timestamp
[       OK ] test_OS_CleanMSG_syslog_isodate_timestamp
[ RUN      ] test_OS_CleanMSG_rsyslog_timestamp
[       OK ] test_OS_CleanMSG_rsyslog_timestamp
[ RUN      ] test_OS_CleanMSG_syslog_ng_isodate_timestamp
[       OK ] test_OS_CleanMSG_syslog_ng_isodate_timestamp
[ RUN      ] test_OS_CleanMSG_proftpd_1_3_5_timestamp
[       OK ] test_OS_CleanMSG_proftpd_1_3_5_timestamp
[ RUN      ] test_OS_CleanMSG_macos_ULS_syslog_timestamp
[       OK ] test_OS_CleanMSG_macos_ULS_syslog_timestamp
[ RUN      ] test_OS_CleanMSG_timestamp
[       OK ] test_OS_CleanMSG_timestamp
[ RUN      ] test_OS_CleanMSG_osx_asl_timestamp
[       OK ] test_OS_CleanMSG_osx_asl_timestamp
[ RUN      ] test_OS_CleanMSG_apache_timestamp
[       OK ] test_OS_CleanMSG_apache_timestamp
[ RUN      ] test_OS_CleanMSG_suricata_timestamp
[       OK ] test_OS_CleanMSG_suricata_timestamp
[ RUN      ] test_OS_CleanMSG_snort_timestamp
[       OK ] test_OS_CleanMSG_snort_timestamp
[ RUN      ] test_OS_CleanMSG_xferlog_timestamp
[       OK ] test_OS_CleanMSG_xferlog_timestamp
[ RUN      ] test_extract_module_from_message
[       OK ] test_extract_module_from_message
[ RUN      ] test_extract_module_from_message_arrow
[       OK ] test_extract_module_from_message_arrow
[ RUN      ] test_extract_module_from_message_end_error
[       OK ] test_extract_module_from_message_end_error
[ RUN      ] test_extract_module_from_message_arrow_error
[       OK ] test_extract_module_from_message_arrow_error
[ RUN      ] test_extract_module_from_location
[       OK ] test_extract_module_from_location
[ RUN      ] test_extract_module_from_location_arrow
[       OK ] test_extract_module_from_location_arrow
[==========] 25 test(s) run.
[  PASSED  ] 25 test(s).
<end of output>
Test time =   0.15 sec
----------------------------------------------------------
Test Passed.
"test_cleanevent" end time: Jan 04 19:32 -03
"test_cleanevent" time elapsed: 00:00:00
----------------------------------------------------------
```