### PR TITLE
FIM DB branch not deleting diff files while using whodata or realtime

### DIFF
--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -700,7 +700,9 @@ void fim_checker(const char *path,
             callback_context_t callback_data;
             callback_data.callback = process_delete_event;
             callback_data.context = &ctx;
-            if (fim_db_get_path(path, callback_data) != FIMDB_OK && configuration->options & CHECK_SEECHANGES)
+            fim_db_get_path(path, callback_data);
+
+            if (configuration->options & CHECK_SEECHANGES)
             {
                 fim_diff_process_delete_file(path);
             }


### PR DESCRIPTION
## Description

Hi team, this PR is to fix a minor bug related to `report_changes` module.
While we are using `realtime` or `whodata` modes, along with `report_changes`, we can observe that the diff files (required for `report_changes` to work), are not correctly deleted when processing the deletion events of their respective files.

The reason is that in the `fim_checker` function, in the part corresponding to the deletes, there was an extra condition to execute the `fim_diff_process_delete_file` function (in charge of deleting the diff files) that was not necessary. Since at that point, we always want to delete the diff file regardless of the result of `fim_db_get_path`.

https://github.com/wazuh/wazuh/blob/58cdd2b90b78a8b5cec53342d74c793780e8af74/src/syscheckd/src/create_db.c#L703-L706
