### PR TITLE
Fix chkconfig detection in pkg_installer.sh 

### DIFF
--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -13,7 +13,6 @@ OSSEC_LIST_FILES=""
 RESTORE_OSSEC_OWN=0
 SYSTEMD_SERVICE_UNIT_PATH=""
 INIT_PATH=""
-CHK_CONFIG=0
 
 # Create the ossec user and group if they don't exist
 function create_ossec_ug {
@@ -155,14 +154,12 @@ fi
 # Init backup
 # REHL <= 6 / Amazon linux
 if [ -f "/etc/rc.d/init.d/${SERVICE}" ] && [ ! -h /etc/rc.d/init.d ]; then
-    CHK_CONFIG=1
     INIT_PATH="/etc/rc.d/init.d/${SERVICE}"
     mkdir -p "${TMP_DIR_BACKUP}/etc/rc.d/init.d/"
     cp -a "${INIT_PATH}" "${TMP_DIR_BACKUP}${INIT_PATH}"
 fi
 
 if [ -f "/etc/init.d/${SERVICE}" ] && [ ! -h /etc/init.d ]; then
-    CHK_CONFIG=1
     INIT_PATH="/etc/init.d/${SERVICE}"
     mkdir -p "${TMP_DIR_BACKUP}/etc/init.d/"
     cp -a "${INIT_PATH}" "${TMP_DIR_BACKUP}${INIT_PATH}"
@@ -263,9 +260,11 @@ else
 
     # Restore service
     if [ -n "${INIT_PATH}" ]; then
-        if [ $CHK_CONFIG -eq 1 ]; then
+        chk=$(which chkconfig &> /dev/null)
+        if [ -n "$chk" ]; then
             /sbin/chkconfig --add ${SERVICE} >> ./logs/upgrade.log 2>&1
         fi
+        systemctl enable ${SERVICE} >> ./logs/upgrade.log 2>&1
     fi
 
     if [ -n "${SYSTEMD_SERVICE_UNIT_PATH}" ]; then

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -260,7 +260,7 @@ else
 
     # Restore service
     if [ -n "${INIT_PATH}" ]; then
-        chk=$(which chkconfig &> /dev/null)
+        chk=$(which chkconfig)
         if [ -n "$chk" ]; then
             /sbin/chkconfig --add ${SERVICE} >> ./logs/upgrade.log 2>&1
         fi


### PR DESCRIPTION
|Related issue|
|---|
|#15613|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR aims to solve a warning in the upgrade.log file after running a WPK upgrade in a Linux agent where `chkconfig` is not installed. The new implementation checks straightly if chkconfig is available running `chk=$(which chkconfig)` if this bash operation returns a text output which will be stored in the `chk` variable it means that chkconfig is installed in the agent. 

In the previous version this check was made by running the following line: `if [ -f "/etc/init.d/${SERVICE}" ] && [ ! -h /etc/init.d ]`, having `SERVICE = wazuh-agent` but it has been proved that the checked file can exist without having `chkconfig` in the agent where the upgrade is being run. Specifically, when the agent is installed in a ubuntu distro and the installation is made via Wazuh packages, the `/etc/init.d/wazuh-agent` is created without `chkconfig`, resulting in unexpected behavior. 

Before the modification, we were getting the following lines in the `upgrade.log`:
```
2023/01/05 11:12:34 - Deleting upgrade files...
2023/01/05 11:12:34 - Restoring backup....
./var/upgrade/src/init/pkg_installer.sh: line 269: /sbin/chkconfig: No such file or directory
Starting Wazuh v4.3.10...
```

After the performed modification we get:
```
2023/01/05 13:18:48 - Deleting upgrade files...
2023/01/05 13:18:48 - Restoring backup....
Synchronizing state of wazuh-agent.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable wazuh-agent
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-agent.service → /lib/systemd/system/wazuh-agent.service.
Starting Wazuh v4.3.10...
```

Now there are no unexpected calls to `chkconfig`. Worth mentioning that the new lines in the upgrade.log file refer to the process of re-enabling the wazuh-agent service. This is not completely necessary because running the WPK upgrade does not modify the enabled disabled state of the wazuh-agent service even if the upgrade fails, as it is in this case. This command will take real effect in situations where the wazuh-agent is not enabled, where, after upgrading, it will be.

It's worth mentioning to that in yum distros, chkconfig should be added as a dependency to cover in the documentation since it's not ensured it's natively installed. 

## Test
<!-- Minimum checks required -->
- Logs without unexpected warnings.
  - [x] Ubuntu 22 agent packages installation - full upgrade
  - [x] Ubuntu 22 agent sources installation - triggering rollback
  - [x] Centos-7 agent packages installation - triggering rollback
