### PR TITLE
SCA: Debian 11. Review section 2

### DIFF
--- a/ruleset/sca/debian/cis_debian11.yml
+++ b/ruleset/sca/debian/cis_debian11.yml
@@ -1,0 +1,801 @@
+# Security Configuration Assessment
+# CIS Checks for Debian Linux 10
+# Copyright (C) 2015, Wazuh Inc.
+#
+# This program is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation
+#
+# Based on:
+# Center for Internet Security Debian Linux 10 Benchmark v1.0.0 - 02-13-2020
+
+policy:
+  id: "cis_debian11"
+  file: "cis_debian11.yml"
+  name: "CIS Benchmark for Debian/Linux 11"
+  description: "This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux 11."
+  references:
+    - https://www.cisecurity.org/cis-benchmarks/
+
+requirements:
+  title: "Check Debian version"
+  description: "Requirements for running the SCA scan against Debian/Ubuntu."
+  condition: all
+  rules:
+    - "f:/etc/debian_version"
+    - "f:/proc/sys/kernel/ostype -> Linux"
+
+checks:
+
+  ############################################################
+  # 2 Services
+  ############################################################
+
+  ############################################################
+  # 2.1 Configure Time Synchronization
+  # 2.1.1 Ensure time synchronization is in use
+  ############################################################
+
+  # 2.1.1.1 Ensure a single time synchronization daemon is in use (Automated) - Not implemented
+  - id: 3048
+    title: "Ensure a single time synchronization daemon is in use (Automated)"
+    description: "System time should be synchronized between all systems in an environment. This is typically done by establishing an authoritative time server or set of servers and having all systems synchronize their clocks to them."
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and ensures log files have consistent time records across the enterprise, which aids in forensic investigations."
+    remediation: "On physical systems, and virtual systems where host based time synchronization is not available. Select one of the three time synchronization daemons; chrony (1), systemd-timesyncd (2), or ntp (3), and following the remediation procedure for the selected daemon. Note: enabling more than one synchronization daemon could lead to unexpected or unreliable results: 1. chrony .Run the following command to install chrony: # apt install chrony .Run the following commands to stop and mask the systemd-timesyncd daemon: # systemctl stop systemd-timesyncd.service # systemctl --now mask systemd-timesyncd.service .Run the following command to remove the ntp package: # apt purge ntp .NOTE: Subsection: Configure chrony should be followed Subsections: Configure systemd-timesyncd and Configure ntp should be skipped 2. systemd-timesyncd .Run the following command to remove the chrony package: # apt purge chrony .Run the following command to remove the ntp package: # apt purge ntp .NOTE: Subsection: Configure systemd-timesyncd should be followed Subsections: Configure chrony and Configure ntp should be skipped 3. ntp .Run the following command to install ntp: # apt install ntp .Run the following commands to stop and mask the systemd-timesyncd daemon:# systemctl stop systemd-timesyncd.service # systemctl --now mask systemd-timesyncd.service Run the following command to remove the chrony package: # apt purge chrony .NOTE: Subsection: Configure ntp should be followed Subsections: Configure chrony and Configure systemd-timesyncd should be skipped" 
+    compliance:
+      - cis: ["2.1.1.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_techniques: ["T1070, T1070.002, T1562, T1562.001"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_mitigations: [""]
+    condition: any
+    rules:
+      - "c:dpkg -s ntp -> r:install ok installed"
+      - "c:dpkg -s chrony -> r:install ok installed"
+      - "c:systemctl is-enabled systemd-timesyncd -> enabled"
+
+  ############################################################
+  # 2.1.2 Configure chrony
+  ############################################################
+
+  # 2.1.2.1 Ensure chrony is configured with authorized timeserver (Manual)
+  - id: 3049
+    title: "Ensure chrony is configured with authorized timeserver (Manual)"
+    description: "server: The server directive specifies an NTP server which can be used as a time source. The client-server relationship is strictly hierarchical: a client might synchronize its system time to that of the server, but the server’s system time will never be influenced by that of a client. This directive can be used multiple times to specify multiple servers. The directive is immediately followed by either the name of the server, or its IP address. (2) pool: The syntax of this directive is similar to that for the server directive, except that it is used to specify a pool of NTP servers rather than a single NTP server. The pool name is expected to resolve to multiple addresses which might change over time. This directive can be used multiple times to specify multiple pools. All options valid in the server directive can be used in this directive too."
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "Edit /etc/chrony/chrony.conf or a file ending in .sources in /etc/chrony/sources.d/ and add or edit server or pool lines as appropriate according to local site policy: <[server|pool]> <[remote-server|remote-pool]> Examples: pool directive: pool time.nist.gov iburst maxsources 4 #The maxsources option is unique to the pool directive server directive: server time-a-g.nist.gov iburst server 132.163.97.3 iburst server time-d-b.nist.gov iburst Run one of the following commands to load the updated time sources into chronyd running config: # systemctl restart chronyd - OR if sources are in a .sources file - # chronyc reload sources OR If another time synchronization service is in use on the system, run the following command to remove chrony from the system:# apt purge chrony" 
+    compliance:
+      - cis: ["2.1.2.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_techniques: ["T1070, T1070.002, T1562, T1562.001"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_mitigations: ["M1022"]
+    condition: all
+    rules:
+      - 'f:/etc/chrony/chrony.conf -> r:^server\.+|^pool\.+'
+
+  # 2.1.2.2 Ensure chrony is running as user _chrony (Automated)
+  - id: 3050
+    title: "Ensure chrony is running as user _chrony (Automated)"
+    description: "The chrony package is installed with a dedicated user account _chrony. This account is granted the access required by the chronyd service."
+    rationale: "The chronyd service should run with only the required privlidges"
+    remediation: "Add or edit the user line to /etc/chrony/chrony.conf or a file ending in .conf in /etc/chrony/conf.d/: user _chrony OR If another time synchronization service is in use on the system, run the following command to remove chrony from the system: # apt purge chrony Default Value: user _chrony" 
+    compliance:
+      - cis: ["2.1.2.2"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+    condition: all
+    rules:
+      - 'c:ps -ef | awk '(/[c]hronyd/ && $1!="_chrony") { print $1 }''
+
+  # 2.1.2.3 Ensure chrony is enabled and running (Automated)
+  - id: 3051
+    title: "Ensure chrony is enabled and running (Automated)"
+    description: "chrony is a daemon for synchronizing the system clock across the network."
+    rationale: "chrony needs to be enabled and running in order to synchronize the system to a timeserver. Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
+    remediation: "IF chrony is in use on the system, run the following commands: Run the following command to unmask chrony.service: # systemctl unmask chrony.service .Run the following command to enable and start chrony.service: # systemctl --now enable chrony.service OR If another time synchronization service is in use on the system, run the following command to remove chrony: # apt purge chrony" 
+    compliance:
+      - cis: ["2.1.2.3"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+    condition: any
+    rules:
+      - 'c:systemctl is-enabled chrony.service -> r:enabled'
+      - 'c:systemctl is-active chrony.service -> r:active'
+
+  ############################################################
+  # 2.1.3 Configure systemd-timesyncd
+  ############################################################
+
+  # 2.1.3.1 Ensure systemd-timesyncd configured with authorized timeserver (Manual)
+  - id: 3052
+    title: "Ensure systemd-timesyncd configured with authorized timeserver (Manual)"
+    description: "(1)NTP=A space-separated list of NTP server host names or IP addresses. During runtime this list is combined with any per-interface NTP servers acquired from systemd-networkd.service(8). systemd-timesyncd will contact all configured system or per-interface servers in turn, until one responds. When the empty string is assigned, the list of NTP servers is reset, and all prior assignments will have no effect. This setting defaults to an empty list.(2) FallbackNTP= A space-separated list of NTP server host names or IP addresses to be used as the fallback NTP servers. Any per-interface NTP servers obtained from systemd- networkd.service(8) take precedence over this setting, as do any servers set via NTP= above. This setting is hence only relevant if no other NTP server information is known. When the empty string is assigned, the list of NTP servers is reset, and all prior assignments will have no effect. If this option is not given, a compiled-in list of NTP servers is used."
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations"
+    remediation: "Edit or create a file in /etc/systemd/timesyncd.conf.d ending in .conf and add the NTP= and/or FallbackNTP= lines to the [Time] section: Example:[Time] NTP=time.nist.gov # Uses the generic name for NIST's time servers -AND/OR- FallbackNTP=time-a-g.nist.gov time-b-g.nist.gov time-c-g.nist.gov # Space separated list of NIST time servers Run the following command to reload the systemd-timesyncd configuration: # systemctl try-reload-or-restart systemd-timesyncd OR If another time synchronization service is in use on the system, run the following command to stop and mask systemd-timesyncd: # systemctl --now mask systemd-timesyncd Default Value: #NTP= #FallbackNTP=" 
+    compliance:
+      - cis: ["2.1.3.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_techniques: ["T1070, T1070.002, T1562, T1562.001"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - https://www.freedesktop.org/software/systemd/man/timesyncd.conf.html
+      - https://tf.nist.gov/tf-cgi/servers.cgi
+    condition: all
+    rules:
+      - 'c:find /etc/systemd -type f -name '*.conf' -exec grep -Ph '^\h*(NTP|FallbackNTP)=\H+' {} + -> r:NPT= FallbackNTP='
+
+  # 2.1.3.2 Ensure systemd-timesyncd is enabled and running (Automated)
+  - id: 3053
+    title: "Ensure systemd-timesyncd is enabled and running (Automated)"
+    description: "systemd-timesyncd is a daemon that has been added for synchronizing the system clock across the network"
+    rationale: "systemd-timesyncd needs to be enabled and running in order to synchronize the system to a timeserver. Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations"
+    remediation: "IF systemd-timesyncd is in use on the system, run the following commands: Run the following command to unmask systemd-timesyncd.service: # systemctl unmask systemd-timesyncd.service Run the following command to enable and start systemd-timesyncd.service: # systemctl --now enable systemd-timesyncd.service OR If another time synchronization service is in use on the system, run the following command to stop and mask systemd-timesyncd: # systemctl --now mask systemd-timesyncd.service" 
+    compliance:
+      - cis: ["2.1.3.2"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+    condition: any
+    rules:
+      - 'c:systemctl is-enabled systemd-timesyncd.service -> r:enabled'
+      - 'c:systemctl is-active systemd-timesyncd.service -> active'
+
+  ############################################################
+  # 2.1.4 Configure ntp
+  ############################################################
+
+  # 2.1.4.1 Ensure ntp access control is configured (Automated)
+  - id: 3054
+    title: "Ensure ntp access control is configured (Automated)"
+    description: "ntp Access Control Commands: restrict address [mask mask] [ippeerlimit int] [flag ...] The address argument expressed in dotted-quad form is the address of a host or network. Alternatively, the address argument can be a valid host DNS name. The mask argument expressed in dotted-quad form defaults to 255.255.255.255, meaning that the address is treated as the address of an individual host. A default entry (address 0.0.0.0, mask 0.0.0.0) is always included and is always the first entry in the list. Note: the text string default, with no mask option, may be used to indicate the default entry. The ippeerlimit directive limits the number of peer requests for each IP to int, where a value of -1 means "unlimited", the current default. A value of 0 means "none". There would usually be at most 1 peering request per IP, but if the remote peering requests are behind a proxy there could well be more than 1 per IP. In the current implementation, flag always restricts access, i.e., an entry with no flags indicates that free access to the server is to be given. The flags are not orthogonal, in that more restrictive flags will often make less restrictive ones redundant. The flags can generally be classed into two categories, those which restrict time service and those which restrict informational queries and attempts to do run-time reconfiguration of the server.One or more of the following flags may be specified: kod - If this flag is set when an access violation occurs, a kiss-o'-death (KoD) packet is sent. KoD packets are rate limited to no more than one per second. If another KoD packet occurs within one second after the last one, the packet is dropped. limited - Deny service if the packet spacing violates the lower limits specified in the discard command. A history of clients is kept using the monitoring capability of ntpd. Thus, monitoring is always active as long as there is a restriction entry with the limited flag. lowpriotrap - Declare traps set by matching hosts to be low priority. The number of traps a server can maintain is limited (the current limit is 3). Traps are usually assigned on a first come, first served basis, with later trap requestors being denied service. This flag modifies the assignment algorithm by allowing low priority traps to be overridden by later requests for normal priority traps. noepeer - Deny ephemeral peer requests, even if they come from an authenticated source. Note that the ability to use a symmetric key for authentication may be restricted to one or more IPs or subnets via the third field of the ntp.keys file. This restriction is not enabled by default, to maintain backward compatibility. Expect noepeer to become the default in ntp-4.4. nomodify - Deny ntpq and ntpdc queries which attempt to modify the state of the server (i.e., run time reconfiguration). Queries which return information are permitted. noquery - Deny ntpq and ntpdc queries. Time service is not affected. nopeer - Deny unauthenticated packets which would result in mobilizing a new association. This includes broadcast and symmetric active packets when a configured association does not exist. It also includes pool associations, so if you want to use servers from a pool directive and also want to use nopeer by default you'll want a restrict source ... line as well that does not include the nopeer directive. noserve - Deny all packets except ntpq and ntpdc queries.notrap - Decline to provide mode 6 control message trap service to matching hosts. The trap service is a subsystem of the ntpq control message protocol which is intended for use by remote event logging programs. notrust - Deny service unless the packet is cryptographically authenticated. ntpport - This is actually a match algorithm modifier, rather than a restriction flag. Its presence causes the restriction entry to be matched only if the source port in the packet is the standard NTP UDP port (123). Both ntpport and non- ntpport may be specified. The ntpport is considered more specific and is sorted later in the list."
+    rationale: "If ntp is in use on the system, proper configuration is vital to ensuring time synchronization is accurate."
+    remediation: "Add or edit restrict lines in /etc/ntp.conf to match the following: restrict -4 default kod nomodify notrap nopeer noquery restrict -6 default kod nomodify notrap nopeer noquery ORIf another time synchronization service is in use on the system, run the following command to remove ntp from the system: # apt purge ntp Default Value: restrict -4 default kod notrap nomodify nopeer noquery limited restrict -6 default kod notrap nomodify nopeer noquery limited" 
+    compliance:
+      - cis: ["2.1.4.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+    references:
+      - http://www.ntp.org/
+      - ntp.conf(5)
+      - ntpd(8)
+    condition: any
+    rules:
+      - 'f:/etc/ntp.conf -> r:^restrict\s+-4\s+default|^restrict\s+default && r:\s+kod\s+ && r:\s+nomodify\s+ && r:\s+notrap\s+ && r:\s+nopeer\s+ && r:\s+noquery'
+      - 'f:/etc/ntp.conf -> r:^restrict\s+-6\s+default && r:\s+kod\s+ && r:\s+nomodify\s+ && r:\s+notrap\s+ && r:\s+nopeer\s+ && r:\s+noquery'
+
+  # 2.1.4.2 Ensure ntp is configured with authorized timeserver (Manual)
+  - id: 3055
+    title: "Ensure ntp is configured with authorized timeserver (Manual)"
+    description: "The various modes are determined by the command keyword and the type of the required IP address. Addresses are classed by type as (s) a remote server or peer (IPv4 class A, B and C), (b) the broadcast address of a local interface, (m) a multicast address (IPv4 class D), or (r) a reference clock address (127.127.x.x). Note: That only those options applicable to each command are listed below. Use of options not listed may not be caught as an error, but may result in some weird and even destructive behavior. If the Basic Socket Interface Extensions for IPv6 (RFC-2553) is detected, support for the IPv6 address family is generated in addition to the default support of the IPv4 address family. In a few cases, including the reslist billboard generated by ntpq or ntpdc, IPv6 addresses are automatically generated. IPv6 addresses can be identified by the presence of colons “:” in the address field. IPv6 addresses can be used almost everywhere where IPv4 addresses can be used, with the exception of reference clock addresses, which are always IPv4. Note: In contexts where a host name is expected, a -4 qualifier preceding the host name forces DNS resolution to the IPv4 namespace, while a -6 qualifier forces DNS resolution to the IPv6 namespace. See IPv6 references for the equivalent classes for that address family. (1)pool - For type s addresses, this command mobilizes a persistent client mode association with a number of remote servers. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. (2)server - For type s and r addresses, this command mobilizes a persistent client mode association with the specified remote server or local radio clock. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. This command should not be used for type b or m addresses."
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations"
+    remediation: "Edit /etc/ntp.conf and add or edit server or pool lines as appropriate according to local site policy: <[server|pool]> <[remote-server|remote-pool]> Examples: pool mode: pool time.nist.gov iburst server mode: server time-a-g.nist.gov iburst server 132.163.97.3 iburst server time-d-b.nist.gov iburst Run the following command to load the updated time sources into ntp running config: # systemctl restart ntp OR If another time synchronization service is in use on the system, run the following command to remove ntp from the system: # apt purge ntp" 
+    compliance:
+      - cis: ["2.1.4.2"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_techniques: ["T1070, T1070.002, T1498, T1498.002, T1562, T1562.001"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_mitigations: ["M1022"]
+    references:
+      - http://www.ntp.org/
+      - https://tf.nist.gov/tf-cgi/servers.cgi
+      - ntp.conf(5)
+      - ntpd(8)
+    condition: all
+    rules:
+      - "c:grep -P -- '^\h*(server|pool)\h+\H+' /etc/ntp.conf -> r: pool server"
+
+  # 2.1.4.3 Ensure ntp is running as user ntp (Automated) 
+  - id: 3056
+    title: "Ensure ntp is running as user ntp (Automated)"
+    description: "The ntp package is installed with a dedicated user account ntp. This account is granted the access required by the ntpd daemon Note: If chrony or systemd-timesyncd are used, ntp should be removed and this section skipped This recommendation only applies if ntp is in use on the system Only one time synchronization method should be in use on the system"
+    rationale: "The ntpd daemon should run with only the required privlidge"
+    remediation: "Add or edit the following line in /etc/init.d/ntp: RUNASUSER=ntp .Run the following command to restart ntp.servocee: # systemctl restart ntp.service OR If another time synchronization service is in use on the system, run the following command to remove ntp from the system: # apt purge ntp Default Value: user ntp" 
+    compliance:
+      - cis: ["2.1.4.3"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+    condition: any
+    rules:
+      - "ps -ef | awk '(/[n]tpd/ && $1!="ntp") { print $1 }'"
+      - 'grep -P -- '^\h*RUNASUSER=' /etc/init.d/ntp -> r:RUNASUSER=ntp'
+
+  # 2.1.4.4 Ensure ntp is enabled and running (Automated)
+  - id: 3057
+    title: "Ensure ntp is enabled and running (Automated)"
+    description: "ntp is a daemon for synchronizing the system clock across the network"
+    rationale: "ntp needs to be enabled and running in order to synchronize the system to a timeserver. Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations"
+    remediation: "IF ntp is in use on the system, run the following commands: Run the following command to unmask ntp.service: # systemctl unmask ntp.service Run the following command to enable and start ntp.service: # systemctl --now enable ntp.service OR If another time synchronization service is in use on the system, run the following command to remove ntp: # apt purge ntp" 
+    compliance:
+      - cis: ["2.1.4.4"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+    condition: any
+    rules:
+      - 'c:systemctl is-enabled ntp.service -> r:enabled'
+      - 'c:systemctl is-active ntp.service -> r:active'
+
+  ############################################################
+  # 2.2 Special Purpose Services
+  ############################################################
+
+  # 2.2.1 Ensure X Window System is not installed (Automated)
+  - id: 3058
+    title: "Ensure X Window System is not installed (Automated)"
+    description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
+    rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
+    remediation: "Remove the X Windows System packages: apt purge xserver-xorg*" 
+    compliance:
+      - cis: ["2.2.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: none
+    rules:
+      - 'c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' xserver-xorg* | grep -Pi '\h+installed\b' -> r:^\wi\s*xserver-xorg"
+
+  # 2.2.2 Ensure Avahi Server is not installed (Automated)
+  - id: 3059
+    title: "Ensure Avahi Server is not installed (Automated)"
+    description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
+    rationale: "Automatic discovery of network services is not normally required for system functionality. It is recommended to remove this package to reduce the potential attack surface."
+    remediation: "Run the following commands to remove avahi-daemon: # systemctl stop avahi-daaemon.service # systemctl stop avahi-daemon.socket # apt purge avahi-daemon" 
+    compliance:
+      - cis: ["2.2.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - 'c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' avahi-daemon -> r:unknown ok not-installed'
+
+  # 2.2.3 Ensure CUPS is not installed (Automated)
+  - id: 3060
+    title: "Ensure CUPS is not installed (Automated)"
+    description: "The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability."
+    rationale: "If the system does not need to print jobs or accept print jobs from other systems, it is recommended that CUPS be removed to reduce the potential attack surface."
+    remediation: "Run one of the following commands to remove cups : # apt purge cups" 
+    compliance:
+      - cis: ["2.2.3"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    references:
+      - More detailed documentation on CUPS is available at the project homepage at http://www.cups.org.
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' cups -> r:unknown ok not-installed"
+
+  # 2.2.4 Ensure DHCP Server is not installed (Automated)
+  - id: 3061
+    title: "Ensure DHCP Server is not installed (Automated)"
+    description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
+    rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that this package be removed to reduce the potential attack surface."
+    remediation: "Run the following command to remove isc-dhcp-server: # apt purge isc-dhcp-server" 
+    compliance:
+      - cis: ["2.2.4"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    references:
+      - More detailed documentation on DHCP is available at http://www.isc.org/software/dhcp.
+    condition: all
+    rules:
+      - "dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' isc-dhcp-server -> r:unknown ok not-installed"
+
+  # 2.2.5 Ensure LDAP server is not installed (Automated)
+  - id: 3062
+    title: "Ensure LDAP server is not installed (Automated)"
+    description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
+    rationale: "If the system will not need to act as an LDAP server, it is recommended that the software be removed to reduce the potential attack surface."
+    remediation: "Run one of the following commands to remove slapd: # apt purge slapd" 
+    compliance:
+      - cis: ["2.2.5"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    references:
+      - For more detailed documentation on OpenLDAP, go to the project homepage at http://www.openldap.org.
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' slapd -> r:unknown ok not-installed"
+
+  # 2.2.6 Ensure NFS is not installed (Automated)
+  - id: 3063
+    title: "Ensure NFS is not installed (Automated)"
+    description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
+    rationale: "If the system does not export NFS shares, it is recommended that the nfs-kernel-server package be removed to reduce the remote attack surface."
+    remediation: "Run the following command to remove nfs: # apt purge nfs-kernel-server" 
+    compliance:
+      - cis: ["2.2.6"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' nfs-kernel-server -> r:unknown ok not-installed"
+
+  # 2.2.7 Ensure DNS Server is not installed (Automated)
+  - id: 3064
+    title: "Ensure DNS Server is not installed (Automated)"
+    description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
+    rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the package be deleted to reduce the potential attack surface."
+    remediation: "Run the following commands to disable DNS server: # apt purge bind9" 
+    compliance:
+      - cis: ["2.2.7"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' bind9 -> r:unknown ok not-installed"
+
+  # 2.2.8 Ensure FTP Server is not installed (Automated)
+  - id: 3065
+    title: "Ensure FTP Server is not installed (Automated)"
+    description: "The File Transfer Protocol (FTP) provides networked computers with the ability to transfer files."
+    rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended SFTP be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the package be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove vsftpd: # apt purge vsftpd" 
+    compliance:
+      - cis: ["2.2.8"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' vsftpd -> unknown ok not-installed"
+
+  # 2.2.9 Ensure HTTP server is not installed (Automated)
+  - id: 3066
+    title: "Ensure HTTP server is not installed (Automated)"
+    description: "HTTP or web servers provide the ability to host web site content."
+    rationale: "Unless there is a need to run the system as a web server, it is recommended that the package be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove apache: # apt purge apache2" 
+    compliance:
+      - cis: ["2.2.9"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' apache2 -> unknown ok not-installed"
+
+  # 2.2.10 Ensure IMAP and POP3 server are not installed(Automated)
+  - id: 3067
+    title: "Ensure IMAP and POP3 server are not installed(Automated)"
+    description: "dovecot-imapd and dovecot-pop3d are an open source IMAP and POP3 server for Linux based systems."
+    rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the package be removed to reduce the potential attack surface."
+    remediation: "Run one of the following commands to remove dovecot-imapd and dovecot-pop3d: # apt purge dovecot-imapd dovecot-pop3d" 
+    compliance:
+      - cis: ["2.2.10"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' dovecot-imapd dovecot-pop3d -> unknown ok not-installed"
+
+  # 2.2.11 Ensure Samba is not installed (Automated)
+  - id: 3068
+    title: "Ensure Samba is not installed (Automated)"
+    description: "The Samba daemon allows system administrators to configure their Linux systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Server Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
+    rationale: "If there is no need to mount directories and file systems to Windows systems, then this service should be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove samba: # apt purge samba" 
+    compliance:
+      - cis: ["2.2.11"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1005, T1005.000, T1039, T1039.000, T1083, T1083.000, T1135, T1135.000, T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: [""]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' samba -> unknown ok not-installed"
+
+  # 2.2.12 Ensure HTTP Proxy Server is not installed (Automated)
+  - id: 3069
+    title: "Ensure HTTP Proxy Server is not installed (Automated)"
+    description: "Squid is a standard proxy server used in many distributions and environments."
+    rationale: "If there is no need for a proxy server, it is recommended that the squid proxy be deleted to reduce the potential attack surface."
+    remediation: "Run the following command to remove squid: # apt purge squid" 
+    compliance:
+      - cis: ["2.2.12"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' squid -> r:unknown on not-installed"
+
+  # 2.2.13 Ensure SNMP Server is not installed (Automated)
+  - id: 3070
+    title: "Ensure SNMP Server is not installed (Automated)"
+    description: "Simple Network Management Protocol (SNMP) is a widely used protocol for monitoring the health and welfare of network equipment, computer equipment and devices like UPSs. Net-SNMP is a suite of applications used to implement SNMPv1 (RFC 1157), SNMPv2 (RFCs 1901-1908), and SNMPv3 (RFCs 3411-3418) using both IPv4 and IPv6. Support for SNMPv2 classic (a.k.a. "SNMPv2 historic" - RFCs 1441-1452) was dropped with the 4.0 release of the UCD-snmp package. The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system."
+    rationale: "The SNMP server can communicate using SNMPv1, which transmits data in the clear and does not require authentication to execute commands. SNMPv3 replaces the simple/clear text password sharing used in SNMPv2 with more securely encoded parameters. If the the SNMP service is not required, the net-snmp package should be removed to reduce the attack surface of the system. Note: If SNMP is required: The server should be configured for SNMP v3 only. User Authentication and Message Encryption should be configured. If SNMP v2 is absolutely necessary, modify the community strings' values."
+    remediation: "Run the following command to remove snmp: # apt purge snmp"
+    compliance:
+      - cis: ["2.2.13"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' snmp -> unknown ok not-installed"
+
+  # 2.2.14 Ensure NIS Server is not installed (Automated)
+  - id: 3071
+    title: "Ensure NIS Server is not installed (Automated)"
+    description: "The Network Information Service (NIS) (formally known as Yellow Pages) is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
+    rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed and other, more secure services be used"
+    remediation: "Run the following command to remove nis: # apt purge nis" 
+    compliance:
+      - cis: ["2.2.14"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - "dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' nis -> r:unknown ok not-installed"
+
+  # 2.2.15 Ensure mail transfer agent is configured for local-only mode (Automated)
+  - id: 3072
+    title: "Ensure mail transfer agent is configured for local-only mode (Automated)"
+    description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
+    rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems. Note: This recommendation is designed around the postfix mail server. Depending on your environment you may have an alternative MTA installed such as exim4. If this is the case consult the documentation for your installed MTA to configure the recommended state."
+    remediation: "Edit /etc/postfix/main.cf and add the following line to the RECEIVING MAIL section. If the line already exists, change it to look like the line below: inet_interfaces = loopback-only .Run the following command to restart postfix: # systemctl restart postfix" 
+    compliance:
+      - cis: ["2.2.15"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1018, T1018.000, T1210, T1210.000"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: none
+    rules:
+      - 'c:ss -lntu -> r:\.*:25\.*LISTEN && !r:127.0.0.1:25\.+LISTEN|::1:25\.*LISTEN'
+
+  # 2.2.16 Ensure rsync service is either not installed or masked (Automated)
+  - id: 3073
+    title: "Ensure rsync service is either not installed or masked (Automated)"
+    description: "The rsync service can be used to synchronize files between systems over network links."
+    rationale: "The rsync service presents a security risk as it uses unencrypted protocols for communication. The rsync package should be removed to reduce the attack area of the system."
+    remediation: "Run the following command to remove rsync: # apt purge rsync OR Run the following commands to stop and mask rsync: # systemctl stop rsync # systemctl mask rsync" 
+    compliance:
+      - cis: ["2.2.16"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1105, T1105.000, T1203, T1203.000, T1210, T1210.000, T1543, T1543.002, T1570, T1570.000"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: any
+    rules:
+      - 'c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' rsync -> r:unknown ok not-installed'
+      - 'c:systemctl is-active rsync -> r:inactive'
+      - 'c:systemctl is-enabled rsync -> r:masked'
+
+
+  ############################################################
+  # 2.3 Service Clients
+  ############################################################
+  # 2.3.1 Ensure NIS Client is not installed (Automated)
+  - id: 3074
+    title: "Ensure NIS Client is not installed (Automated)"
+    description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files. The NIS client was used to bind a machine to an NIS server and receive the distributed configuration files."
+    rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
+    remediation: "Uninstall nis: # apt purge nis" 
+    compliance:
+      - cis: ["2.3.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
+      - nist_sp_800-53: ["CM-11"]
+      - mitre_techniques: ["T1203, T1203.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' nis -> r:unknown ok not-installed"
+
+  # 2.3.2 Ensure rsh client is not installed (Automated)
+  - id: 3075
+    title: "Ensure rsh client is not installed (Automated)"
+    description: "The rsh-client package contains the client commands for the rsh services."
+    rationale: "These legacy clients contain numerous security exposures and have been replaced with the more secure SSH package. Even if the server is removed, it is best to ensure the clients are also removed to prevent users from inadvertently attempting to use these commands and therefore exposing their credentials. Note that removing the rsh package removes the clients for rsh , rcp and rlogin ."
+    remediation: "Uninstall rsh: # apt purge rsh-client" 
+    compliance:
+      - cis: ["2.3.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1040, T1040.000, T1203, T1203.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1041, M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' rsh-client -> r:unknown ok not-installed"
+
+  # 2.3.3 Ensure talk client is not installed (Automated)
+  - id: 3076
+    title: "Ensure talk client is not installed (Automated)"
+    description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client, which allows initialization of talk sessions, is installed by default."
+    rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
+    remediation: "Uninstall talk: # apt purge talk" 
+    compliance:
+      - cis: ["2.3.3"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0006, TA0008"]
+      - mitre_mitigations: ["M1041, M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' talk -> r:unknown ok not-installed"
+
+  # 2.3.4 Ensure telnet client is not installed (Automated)
+  - id: 3077
+    title: "Ensure telnet client is not installed (Automated)"
+    description: "The telnet package contains the telnet client, which allows users to start connections to other systems via the telnet protocol."
+    rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow an unauthorized user to steal credentials. The ssh package provides an encrypted session and stronger security and is included in most Linux distributions."
+    remediation: "Uninstall telnet: # apt purge telnet" 
+    compliance:
+      - cis: ["2.3.4"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1040, T1040.000, T1203, T1203.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0006, TA0008"]
+      - mitre_mitigations: ["M1041, M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' telnet -> r:unknown ok not-installed"
+
+  # 2.3.5 Ensure LDAP client is not installed (Automated)
+  - id: 3078
+    title: "Ensure LDAP client is not installed (Automated)"
+    description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
+    rationale: "If the system will not need to act as an LDAP client, it is recommended that the software be removed to reduce the potential attack surface."
+    remediation: "Uninstall ldap-utils: # apt purge ldap-utils" 
+    compliance:
+      - cis: ["2.3.5"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1040, T1040.000, T1203, T1203.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' ldap-utils -> r:unknown ok not-installed"
+
+  # 2.3.6 Ensure RPC is not installed (Automated)
+  - id: 3079
+    title: "Ensure RPC is not installed (Automated)"
+    description: "Remote Procedure Call (RPC) is a method for creating low level client server applications across different system architectures. It requires an RPC compliant client listening on a network port. The supporting package is rpcbind."
+    rationale: "If RPC is not required, it is recommended that this services be removed to reduce the remote attack surface."
+    remediation: "Run the following command to remove rpcbind: # apt purge rpcbind" 
+    compliance:
+      - cis: ["2.3.6"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7","CM.L2-3.4.8","SC.L2-3.13.6"]
+      - pci_dss_3.2.1: ["1.1.6","1.2.1","2.2.2","2.2.5"]
+      - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
+      - soc_2: ["CC6.3","CC6.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["SI-4"]
+      - mitre_techniques: ["T1203, T1203.000, T1543, T1543.002"]
+      - mitre_tactics: ["TA0008"]
+      - mitre_mitigations: ["M1042"]
+    condition: all
+    rules:
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' rpcbind -> r:unknown ok not-installed"
+
+  # 2.4 Ensure nonessential services are removed or masked (Manual) - Not Implemented

--- a/ruleset/sca/debian/cis_debian11.yml
+++ b/ruleset/sca/debian/cis_debian11.yml
@@ -38,40 +38,21 @@ checks:
   ############################################################
 
   # 2.1.1.1 Ensure a single time synchronization daemon is in use (Automated) - Not implemented
-  - id: 3048
-    title: "Ensure a single time synchronization daemon is in use (Automated)"
-    description: "System time should be synchronized between all systems in an environment. This is typically done by establishing an authoritative time server or set of servers and having all systems synchronize their clocks to them."
-    rationale: "Time synchronization is important to support time sensitive security mechanisms and ensures log files have consistent time records across the enterprise, which aids in forensic investigations."
-    remediation: "On physical systems, and virtual systems where host based time synchronization is not available. Select one of the three time synchronization daemons; chrony (1), systemd-timesyncd (2), or ntp (3), and following the remediation procedure for the selected daemon. Note: enabling more than one synchronization daemon could lead to unexpected or unreliable results: 1. chrony .Run the following command to install chrony: # apt install chrony .Run the following commands to stop and mask the systemd-timesyncd daemon: # systemctl stop systemd-timesyncd.service # systemctl --now mask systemd-timesyncd.service .Run the following command to remove the ntp package: # apt purge ntp .NOTE: Subsection: Configure chrony should be followed Subsections: Configure systemd-timesyncd and Configure ntp should be skipped 2. systemd-timesyncd .Run the following command to remove the chrony package: # apt purge chrony .Run the following command to remove the ntp package: # apt purge ntp .NOTE: Subsection: Configure systemd-timesyncd should be followed Subsections: Configure chrony and Configure ntp should be skipped 3. ntp .Run the following command to install ntp: # apt install ntp .Run the following commands to stop and mask the systemd-timesyncd daemon:# systemctl stop systemd-timesyncd.service # systemctl --now mask systemd-timesyncd.service Run the following command to remove the chrony package: # apt purge chrony .NOTE: Subsection: Configure ntp should be followed Subsections: Configure chrony and Configure systemd-timesyncd should be skipped" 
-    compliance:
-      - cis: ["2.1.1.1"]
-      - cis_csc_v8: ["8.4"]
-      - cis_csc_v7: ["6.1"]
-      - cmmc_v2.0: ["AU.L2-3.3.7"]
-      - pci_dss_3.2.1: ["10.4"]
-      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
-      - nist_sp_800-53: ["AU-7"]
-      - soc_2: ["CC4.1","CC5.2"]
-      - iso_27001-2013: ["A.12.4.4"]
-      - mitre_techniques: ["T1070, T1070.002, T1562, T1562.001"]
-      - mitre_tactics: ["TA0005"]
-      - mitre_mitigations: [""]
-    condition: any
-    rules:
-      - "c:dpkg -s ntp -> r:install ok installed"
-      - "c:dpkg -s chrony -> r:install ok installed"
-      - "c:systemctl is-enabled systemd-timesyncd -> enabled"
 
   ############################################################
   # 2.1.2 Configure chrony
   ############################################################
 
   # 2.1.2.1 Ensure chrony is configured with authorized timeserver (Manual)
-  - id: 3049
-    title: "Ensure chrony is configured with authorized timeserver (Manual)"
+  - id: 3047
+    title: "Ensure chrony is configured with authorized timeserver"
     description: "server: The server directive specifies an NTP server which can be used as a time source. The client-server relationship is strictly hierarchical: a client might synchronize its system time to that of the server, but the server’s system time will never be influenced by that of a client. This directive can be used multiple times to specify multiple servers. The directive is immediately followed by either the name of the server, or its IP address. (2) pool: The syntax of this directive is similar to that for the server directive, except that it is used to specify a pool of NTP servers rather than a single NTP server. The pool name is expected to resolve to multiple addresses which might change over time. This directive can be used multiple times to specify multiple pools. All options valid in the server directive can be used in this directive too."
     rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
     remediation: "Edit /etc/chrony/chrony.conf or a file ending in .sources in /etc/chrony/sources.d/ and add or edit server or pool lines as appropriate according to local site policy: <[server|pool]> <[remote-server|remote-pool]> Examples: pool directive: pool time.nist.gov iburst maxsources 4 #The maxsources option is unique to the pool directive server directive: server time-a-g.nist.gov iburst server 132.163.97.3 iburst server time-d-b.nist.gov iburst Run one of the following commands to load the updated time sources into chronyd running config: # systemctl restart chronyd - OR if sources are in a .sources file - # chronyc reload sources OR If another time synchronization service is in use on the system, run the following command to remove chrony from the system:# apt purge chrony" 
+    additional information: "If pool and/or server directive(s) are set in a sources file in /etc/chrony/sources.d, the line: sourcedir /etc/chrony/sources.d must be present in /etc/chrony/chrony.conf"
+    references:
+      - chrony.conf(5) Manual Page
+      - https://tf.nist.gov/tf-cgi/servers.cgi
     compliance:
       - cis: ["2.1.2.1"]
       - cis_csc_v8: ["8.4"]
@@ -82,7 +63,7 @@ checks:
       - nist_sp_800-53: ["AU-7"]
       - soc_2: ["CC4.1","CC5.2"]
       - iso_27001-2013: ["A.12.4.4"]
-      - mitre_techniques: ["T1070, T1070.002, T1562, T1562.001"]
+      - mitre_techniques: ["T1070","T1070.002","T1562","T1562.001"]
       - mitre_tactics: ["TA0002"]
       - mitre_mitigations: ["M1022"]
     condition: all
@@ -90,11 +71,12 @@ checks:
       - 'f:/etc/chrony/chrony.conf -> r:^server\.+|^pool\.+'
 
   # 2.1.2.2 Ensure chrony is running as user _chrony (Automated)
-#  - id: 3050
-#    title: "Ensure chrony is running as user _chrony (Automated)"
+#  - id: 3048
+#    title: "Ensure chrony is running as user _chrony"
 #    description: "The chrony package is installed with a dedicated user account _chrony. This account is granted the access required by the chronyd service."
 #    rationale: "The chronyd service should run with only the required privlidges"
 #    remediation: "Add or edit the user line to /etc/chrony/chrony.conf or a file ending in .conf in /etc/chrony/conf.d/: user _chrony OR If another time synchronization service is in use on the system, run the following command to remove chrony from the system: # apt purge chrony Default Value: user _chrony" 
+#    default value: "user _chrony"
 #    compliance:
 #      - cis: ["2.1.2.2"]
 #      - cis_csc_v8: ["8.4"]
@@ -110,8 +92,8 @@ checks:
 #      - 'c:ps -ef -> r:^\s*chronyd && r:^chrony'
 
   # 2.1.2.3 Ensure chrony is enabled and running (Automated)
-  - id: 3051
-    title: "Ensure chrony is enabled and running (Automated)"
+  - id: 3049
+    title: "Ensure chrony is enabled and running"
     description: "chrony is a daemon for synchronizing the system clock across the network."
     rationale: "chrony needs to be enabled and running in order to synchronize the system to a timeserver. Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations."
     remediation: "IF chrony is in use on the system, run the following commands: Run the following command to unmask chrony.service: # systemctl unmask chrony.service .Run the following command to enable and start chrony.service: # systemctl --now enable chrony.service OR If another time synchronization service is in use on the system, run the following command to remove chrony: # apt purge chrony" 
@@ -135,11 +117,14 @@ checks:
   ############################################################
 
   # 2.1.3.1 Ensure systemd-timesyncd configured with authorized timeserver (Manual)
-  - id: 3052
-    title: "Ensure systemd-timesyncd configured with authorized timeserver (Manual)"
+  - id: 3050
+    title: "Ensure systemd-timesyncd configured with authorized timeserver"
     description: "(1)NTP=A space-separated list of NTP server host names or IP addresses. During runtime this list is combined with any per-interface NTP servers acquired from systemd-networkd.service(8). systemd-timesyncd will contact all configured system or per-interface servers in turn, until one responds. When the empty string is assigned, the list of NTP servers is reset, and all prior assignments will have no effect. This setting defaults to an empty list.(2) FallbackNTP= A space-separated list of NTP server host names or IP addresses to be used as the fallback NTP servers. Any per-interface NTP servers obtained from systemd- networkd.service(8) take precedence over this setting, as do any servers set via NTP= above. This setting is hence only relevant if no other NTP server information is known. When the empty string is assigned, the list of NTP servers is reset, and all prior assignments will have no effect. If this option is not given, a compiled-in list of NTP servers is used."
     rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations"
     remediation: "Edit or create a file in /etc/systemd/timesyncd.conf.d ending in .conf and add the NTP= and/or FallbackNTP= lines to the [Time] section: Example:[Time] NTP=time.nist.gov # Uses the generic name for NIST's time servers -AND/OR- FallbackNTP=time-a-g.nist.gov time-b-g.nist.gov time-c-g.nist.gov # Space separated list of NIST time servers Run the following command to reload the systemd-timesyncd configuration: # systemctl try-reload-or-restart systemd-timesyncd OR If another time synchronization service is in use on the system, run the following command to stop and mask systemd-timesyncd: # systemctl --now mask systemd-timesyncd Default Value: #NTP= #FallbackNTP=" 
+    references:
+      - https://www.freedesktop.org/software/systemd/man/timesyncd.conf.html
+      - https://tf.nist.gov/tf-cgi/servers.cgi
     compliance:
       - cis: ["2.1.3.1"]
       - cis_csc_v8: ["8.4"]
@@ -150,12 +135,9 @@ checks:
       - nist_sp_800-53: ["AU-7"]
       - soc_2: ["CC4.1","CC5.2"]
       - iso_27001-2013: ["A.12.4.4"]
-      - mitre_techniques: ["T1070, T1070.002, T1562, T1562.001"]
+      - mitre_techniques: ["T1070","T1070.002","T1562","T1562.001"]
       - mitre_tactics: ["TA0002"]
       - mitre_mitigations: ["M1022"]
-    references:
-      - https://www.freedesktop.org/software/systemd/man/timesyncd.conf.html
-      - https://tf.nist.gov/tf-cgi/servers.cgi
     condition: all
     rules:
       - "d:/etc/systemd"
@@ -163,8 +145,8 @@ checks:
       - 'd:/etc/systemd -> r:\.+.conf$ ->r:^\h*(NTP|FallbackNTP)=\H+'
 
   # 2.1.3.2 Ensure systemd-timesyncd is enabled and running (Automated)
-  - id: 3053
-    title: "Ensure systemd-timesyncd is enabled and running (Automated)"
+  - id: 3051
+    title: "Ensure systemd-timesyncd is enabled and running"
     description: "systemd-timesyncd is a daemon that has been added for synchronizing the system clock across the network"
     rationale: "systemd-timesyncd needs to be enabled and running in order to synchronize the system to a timeserver. Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations"
     remediation: "IF systemd-timesyncd is in use on the system, run the following commands: Run the following command to unmask systemd-timesyncd.service: # systemctl unmask systemd-timesyncd.service Run the following command to enable and start systemd-timesyncd.service: # systemctl --now enable systemd-timesyncd.service OR If another time synchronization service is in use on the system, run the following command to stop and mask systemd-timesyncd: # systemctl --now mask systemd-timesyncd.service" 
@@ -187,37 +169,19 @@ checks:
   # 2.1.4 Configure ntp
   ############################################################
 
-  # 2.1.4.1 Ensure ntp access control is configured (Automated)
-#  - id: 3054
-#    title: "Ensure ntp access control is configured (Automated)"
-#    description: 'ntp Access Control Commands: restrict address [mask mask] [ippeerlimit int] [flag ...] The address argument expressed in dotted-quad form is the address of a host or network. Alternatively, the address argument can be a valid host DNS name. The mask argument expressed in dotted-quad form defaults to 255.255.255.255, meaning that the address is treated as the address of an individual host. A default entry (address 0.0.0.0, mask 0.0.0.0) is always included and is always the first entry in the list. Note: the text string default, with no mask option, may be used to indicate the default entry. The ippeerlimit directive limits the number of peer requests for each IP to int, where a value of -1 means "unlimited", the current default. A value of 0 means "none". There would usually be at most 1 peering request per IP, but if the remote peering requests are behind a proxy there could well be more than 1 per IP. In the current implementation, flag always restricts access, i.e., an entry with no flags indicates that free access to the server is to be given. The flags are not orthogonal, in that more restrictive flags will often make less restrictive ones redundant. The flags can generally be classed into two categories, those which restrict time service and those which restrict informational queries and attempts to do run-time reconfiguration of the server.One or more of the following flags may be specified: kod - If this flag is set when an access violation occurs, a kiss-o-death (KoD) packet is sent. KoD packets are rate limited to no more than one per second. If another KoD packet occurs within one second after the last one, the packet is dropped. limited - Deny service if the packet spacing violates the lower limits specified in the discard command. A history of clients is kept using the monitoring capability of ntpd. Thus, monitoring is always active as long as there is a restriction entry with the limited flag. lowpriotrap - Declare traps set by matching hosts to be low priority. The number of traps a server can maintain is limited (the current limit is 3). Traps are usually assigned on a first come, first served basis, with later trap requestors being denied service. This flag modifies the assignment algorithm by allowing low priority traps to be overridden by later requests for normal priority traps. noepeer - Deny ephemeral peer requests, even if they come from an authenticated source. Note that the ability to use a symmetric key for authentication may be restricted to one or more IPs or subnets via the third field of the ntp.keys file. This restriction is not enabled by default, to maintain backward compatibility. Expect noepeer to become the default in ntp-4.4. nomodify - Deny ntpq and ntpdc queries which attempt to modify the state of the server (i.e., run time reconfiguration). Queries which return information are permitted. noquery - Deny ntpq and ntpdc queries. Time service is not affected. nopeer - Deny unauthenticated packets which would result in mobilizing a new association. This includes broadcast and symmetric active packets when a configured association does not exist. It also includes pool associations, so if you want to use servers from a pool directive and also want to use nopeer by default you'll want a restrict source ... line as well that does not include the nopeer directive. noserve - Deny all packets except ntpq and ntpdc queries.notrap - Decline to provide mode 6 control message trap service to matching hosts. The trap service is a subsystem of the ntpq control message protocol which is intended for use by remote event logging programs. notrust - Deny service unless the packet is cryptographically authenticated. ntpport - This is actually a match algorithm modifier, rather than a restriction flag. Its presence causes the restriction entry to be matched only if the source port in the packet is the standard NTP UDP port (123). Both ntpport and non- ntpport may be specified. The ntpport is considered more specific and is sorted later in the list.'
-#    rationale: "If ntp is in use on the system, proper configuration is vital to ensuring time synchronization is accurate."
-#    remediation: "Add or edit restrict lines in /etc/ntp.conf to match the following: restrict -4 default kod nomodify notrap nopeer noquery restrict -6 default kod nomodify notrap nopeer noquery ORIf another time synchronization service is in use on the system, run the following command to remove ntp from the system: # apt purge ntp Default Value: restrict -4 default kod notrap nomodify nopeer noquery limited restrict -6 default kod notrap nomodify nopeer noquery limited" 
-#    compliance:
-#      - cis: ["2.1.4.1"]
-#      - cis_csc_v8: ["8.4"]
-#      - cis_csc_v7: ["6.1"]
-#      - cmmc_v2.0: ["AU.L2-3.3.7"]
-#      - pci_dss_3.2.1: ["10.4"]
-#      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
-#      - nist_sp_800-53: ["AU-7"]
-#      - soc_2: ["CC4.1","CC5.2"]
-#      - iso_27001-2013: ["A.12.4.4"]
-#    references:
-#      - http://www.ntp.org/
-#      - ntp.conf(5)
-#      - ntpd(8)
-#    condition: any
-#    rules:
-#      - 'f:/etc/ntp.conf -> r:^restrict\s+-4\s+default|^restrict\s+default && r:\s+kod\s+ && r:\s+nomodify\s+ && r:\s+notrap\s+ && r:\s+nopeer\s+ && r:\s+noquery'
-#      - 'f:/etc/ntp.conf -> r:^restrict\s+-6\s+default && r:\s+kod\s+ && r:\s+nomodify\s+ && r:\s+notrap\s+ && r:\s+nopeer\s+ && r:\s+noquery'
+  # 2.1.4.1 Ensure ntp access control is configured (Automated) - Not Implemented
 #
   # 2.1.4.2 Ensure ntp is configured with authorized timeserver (Manual)
-#  - id: 3055
-#    title: "Ensure ntp is configured with authorized timeserver (Manual)"
+#  - id: 3052
+#    title: "Ensure ntp is configured with authorized timeserver"
 #    description: 'The various modes are determined by the command keyword and the type of the required IP address. Addresses are classed by type as (s) a remote server or peer (IPv4 class A, B and C), (b) the broadcast address of a local interface, (m) a multicast address (IPv4 class D), or (r) a reference clock address (127.127.x.x). Note: That only those options applicable to each command are listed below. Use of options not listed may not be caught as an error, but may result in some weird and even destructive behavior. If the Basic Socket Interface Extensions for IPv6 (RFC-2553) is detected, support for the IPv6 address family is generated in addition to the default support of the IPv4 address family. In a few cases, including the reslist billboard generated by ntpq or ntpdc, IPv6 addresses are automatically generated. IPv6 addresses can be identified by the presence of colons “:” in the address field. IPv6 addresses can be used almost everywhere where IPv4 addresses can be used, with the exception of reference clock addresses, which are always IPv4. Note: In contexts where a host name is expected, a -4 qualifier preceding the host name forces DNS resolution to the IPv4 namespace, while a -6 qualifier forces DNS resolution to the IPv6 namespace. See IPv6 references for the equivalent classes for that address family. (1)pool - For type s addresses, this command mobilizes a persistent client mode association with a number of remote servers. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. (2)server - For type s and r addresses, this command mobilizes a persistent client mode association with the specified remote server or local radio clock. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. This command should not be used for type b or m addresses.'
 #    rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations"
 #    remediation: "Edit /etc/ntp.conf and add or edit server or pool lines as appropriate according to local site policy: <[server|pool]> <[remote-server|remote-pool]> Examples: pool mode: pool time.nist.gov iburst server mode: server time-a-g.nist.gov iburst server 132.163.97.3 iburst server time-d-b.nist.gov iburst Run the following command to load the updated time sources into ntp running config: # systemctl restart ntp OR If another time synchronization service is in use on the system, run the following command to remove ntp from the system: # apt purge ntp" 
+#    references:
+#      - http://www.ntp.org/
+#      - https://tf.nist.gov/tf-cgi/servers.cgi
+#      - ntp.conf(5)
+#      - ntpd(8)
 #    compliance:
 #      - cis: ["2.1.4.2"]
 #      - cis_csc_v8: ["8.4"]
@@ -228,24 +192,22 @@ checks:
 #      - nist_sp_800-53: ["AU-7"]
 #      - soc_2: ["CC4.1","CC5.2"]
 #      - iso_27001-2013: ["A.12.4.4"]
-#      - mitre_techniques: ["T1070, T1070.002, T1498, T1498.002, T1562, T1562.001"]
+#      - mitre_techniques: ["T1070","T1070.002","T1498","T1498.002","T1562","T1562.001"]
 #      - mitre_tactics: ["TA0002"]
 #      - mitre_mitigations: ["M1022"]
-#    references:
-#      - http://www.ntp.org/
-#      - https://tf.nist.gov/tf-cgi/servers.cgi
-#      - ntp.conf(5)
-#      - ntpd(8)
 #    condition: all
 #    rules:
 #      - "c:grep -Rh ^*.* /etc/ntp.conf -> r:^\h*(server|pool)\h+\H+"
 #
   # 2.1.4.3 Ensure ntp is running as user ntp (Automated) 
-#  - id: 3056
-#    title: "Ensure ntp is running as user ntp (Automated)"
+#  - id: 3053
+#    title: "Ensure ntp is running as user ntp"
 #    description: "The ntp package is installed with a dedicated user account ntp. This account is granted the access required by the ntpd daemon Note: If chrony or systemd-timesyncd are used, ntp should be removed and this section skipped This recommendation only applies if ntp is in use on the system Only one time synchronization method should be in use on the system"
 #    rationale: "The ntpd daemon should run with only the required privlidge"
 #    remediation: "Add or edit the following line in /etc/init.d/ntp: RUNASUSER=ntp .Run the following command to restart ntp.servocee: # systemctl restart ntp.service OR If another time synchronization service is in use on the system, run the following command to remove ntp from the system: # apt purge ntp Default Value: user ntp" 
+#    default value: "user ntp"
+#    references:
+#      - http://www.ntp.org/
 #    compliance:
 #      - cis: ["2.1.4.3"]
 #      - cis_csc_v8: ["8.4"]
@@ -262,8 +224,8 @@ checks:
 #      - 'grep -P -- '^\h*RUNASUSER=' /etc/init.d/ntp -> r:RUNASUSER=ntp'
 
   # 2.1.4.4 Ensure ntp is enabled and running (Automated)
-  - id: 3057
-    title: "Ensure ntp is enabled and running (Automated)"
+  - id: 3054
+    title: "Ensure ntp is enabled and running"
     description: "ntp is a daemon for synchronizing the system clock across the network"
     rationale: "ntp needs to be enabled and running in order to synchronize the system to a timeserver. Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations"
     remediation: "IF ntp is in use on the system, run the following commands: Run the following command to unmask ntp.service: # systemctl unmask ntp.service Run the following command to enable and start ntp.service: # systemctl --now enable ntp.service OR If another time synchronization service is in use on the system, run the following command to remove ntp: # apt purge ntp" 
@@ -287,8 +249,8 @@ checks:
   ############################################################
 
   # 2.2.1 Ensure X Window System is not installed (Automated)
-  - id: 3058
-    title: "Ensure X Window System is not installed (Automated)"
+  - id: 3055
+    title: "Ensure X Window System is not installed"
     description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
     rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
     remediation: "Remove the X Windows System packages: apt purge xserver-xorg*" 
@@ -301,7 +263,7 @@ checks:
       - pci_dss_4.0: ["1.2.5","2.2.4","6.4.1"]
       - soc_2: ["CC6.3","CC6.6"]
       - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
-      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_techniques: ["T1203","T1203.000","T1210","T1210.000","T1543","T1543.002"]
       - mitre_tactics: ["TA0008"]
       - mitre_mitigations: ["M1042"]
     condition: all
@@ -309,8 +271,8 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' xserver-xorg -> r:unknown ok not-installed"
 
   # 2.2.2 Ensure Avahi Server is not installed (Automated)
-  - id: 3059
-    title: "Ensure Avahi Server is not installed (Automated)"
+  - id: 3056
+    title: "Ensure Avahi Server is not installed"
     description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
     rationale: "Automatic discovery of network services is not normally required for system functionality. It is recommended to remove this package to reduce the potential attack surface."
     remediation: "Run the following commands to remove avahi-daemon: # systemctl stop avahi-daaemon.service # systemctl stop avahi-daemon.socket # apt purge avahi-daemon" 
@@ -324,7 +286,7 @@ checks:
       - soc_2: ["CC6.3","CC6.6"]
       - iso_27001-2013: ["A.13.1.3"]
       - nist_sp_800-53: ["SI-4"]
-      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_techniques: ["T1203","T1203.000","T1210","T1210.000","T1543","T1543.002"]
       - mitre_tactics: ["TA0008"]
       - mitre_mitigations: ["M1042"]
     condition: all
@@ -332,11 +294,13 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' avahi-daemon -> r:unknown ok not-installed"
 
   # 2.2.3 Ensure CUPS is not installed (Automated)
-  - id: 3060
-    title: "Ensure CUPS is not installed (Automated)"
+  - id: 3057
+    title: "Ensure CUPS is not installed"
     description: "The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability."
     rationale: "If the system does not need to print jobs or accept print jobs from other systems, it is recommended that CUPS be removed to reduce the potential attack surface."
     remediation: "Run one of the following commands to remove cups : # apt purge cups" 
+    references:
+      - More detailed documentation on CUPS is available at the project homepage at http://www.cups.org.
     compliance:
       - cis: ["2.2.3"]
       - cis_csc_v8: ["4.8"]
@@ -347,21 +311,21 @@ checks:
       - soc_2: ["CC6.3","CC6.6"]
       - iso_27001-2013: ["A.13.1.3"]
       - nist_sp_800-53: ["SI-4"]
-      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_techniques: ["T1203","T1203.000","T1210","T1210.000","T1543","T1543.002"]
       - mitre_tactics: ["TA0008"]
       - mitre_mitigations: ["M1042"]
-    references:
-      - More detailed documentation on CUPS is available at the project homepage at http://www.cups.org.
     condition: all
     rules:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' cups -> r:unknown ok not-installed"
 
   # 2.2.4 Ensure DHCP Server is not installed (Automated)
-  - id: 3061
-    title: "Ensure DHCP Server is not installed (Automated)"
+  - id: 3058
+    title: "Ensure DHCP Server is not installed"
     description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
     rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that this package be removed to reduce the potential attack surface."
     remediation: "Run the following command to remove isc-dhcp-server: # apt purge isc-dhcp-server" 
+    references:
+      - More detailed documentation on DHCP is available at http://www.isc.org/software/dhcp.
     compliance:
       - cis: ["2.2.4"]
       - cis_csc_v8: ["4.8"]
@@ -372,21 +336,21 @@ checks:
       - soc_2: ["CC6.3","CC6.6"]
       - iso_27001-2013: ["A.13.1.3"]
       - nist_sp_800-53: ["SI-4"]
-      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_techniques: ["T1203","T1203.000","T1210","T1210.000","T1543","T1543.002"]
       - mitre_tactics: ["TA0008"]
       - mitre_mitigations: ["M1042"]
-    references:
-      - More detailed documentation on DHCP is available at http://www.isc.org/software/dhcp.
     condition: all
     rules:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' isc-dhcp-server -> r:unknown ok not-installed"
 
   # 2.2.5 Ensure LDAP server is not installed (Automated)
-  - id: 3062
-    title: "Ensure LDAP server is not installed (Automated)"
+  - id: 3059
+    title: "Ensure LDAP server is not installed"
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP server, it is recommended that the software be removed to reduce the potential attack surface."
     remediation: "Run one of the following commands to remove slapd: # apt purge slapd" 
+    references:
+      - For more detailed documentation on OpenLDAP, go to the project homepage at http://www.openldap.org.
     compliance:
       - cis: ["2.2.5"]
       - cis_csc_v8: ["4.8"]
@@ -397,18 +361,16 @@ checks:
       - soc_2: ["CC6.3","CC6.6"]
       - iso_27001-2013: ["A.13.1.3"]
       - nist_sp_800-53: ["SI-4"]
-      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_techniques: ["T1203","T1203.000","T1210","T1210.000","T1543","T1543.002"]
       - mitre_tactics: ["TA0008"]
       - mitre_mitigations: ["M1042"]
-    references:
-      - For more detailed documentation on OpenLDAP, go to the project homepage at http://www.openldap.org.
     condition: all
     rules:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' slapd -> r:unknown ok not-installed"
 
   # 2.2.6 Ensure NFS is not installed (Automated)
-  - id: 3063
-    title: "Ensure NFS is not installed (Automated)"
+  - id: 3060
+    title: "Ensure NFS is not installed"
     description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
     rationale: "If the system does not export NFS shares, it is recommended that the nfs-kernel-server package be removed to reduce the remote attack surface."
     remediation: "Run the following command to remove nfs: # apt purge nfs-kernel-server" 
@@ -427,8 +389,8 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' nfs-kernel-server -> r:unknown ok not-installed"
 
   # 2.2.7 Ensure DNS Server is not installed (Automated)
-  - id: 3064
-    title: "Ensure DNS Server is not installed (Automated)"
+  - id: 3061
+    title: "Ensure DNS Server is not installed"
     description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
     rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the package be deleted to reduce the potential attack surface."
     remediation: "Run the following commands to disable DNS server: # apt purge bind9" 
@@ -442,7 +404,7 @@ checks:
       - soc_2: ["CC6.3","CC6.6"]
       - iso_27001-2013: ["A.13.1.3"]
       - nist_sp_800-53: ["SI-4"]
-      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_techniques: ["T1203","T1203.000","T1210","T1210.000","T1543","T1543.002"]
       - mitre_tactics: ["TA0008"]
       - mitre_mitigations: ["M1042"]
     condition: all
@@ -450,11 +412,12 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' bind9 -> r:unknown ok not-installed"
 
   # 2.2.8 Ensure FTP Server is not installed (Automated)
-  - id: 3065
-    title: "Ensure FTP Server is not installed (Automated)"
+  - id: 3062
+    title: "Ensure FTP Server is not installed"
     description: "The File Transfer Protocol (FTP) provides networked computers with the ability to transfer files."
     rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended SFTP be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the package be deleted to reduce the potential attack surface."
     remediation: "Run the following command to remove vsftpd: # apt purge vsftpd" 
+    additional information: "Additional FTP servers also exist and should be audited."
     compliance:
       - cis: ["2.2.8"]
       - cis_csc_v8: ["4.8"]
@@ -465,7 +428,7 @@ checks:
       - soc_2: ["CC6.3","CC6.6"]
       - iso_27001-2013: ["A.13.1.3"]
       - nist_sp_800-53: ["SI-4"]
-      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_techniques: ["T1203","T1203.000","T1210","T1210.000","T1543","T1543.002"]
       - mitre_tactics: ["TA0008"]
       - mitre_mitigations: ["M1042"]
     condition: all
@@ -473,11 +436,12 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' vsftpd -> r:unknown ok not-installed"
 
   # 2.2.9 Ensure HTTP server is not installed (Automated)
-  - id: 3066
-    title: "Ensure HTTP server is not installed (Automated)"
+  - id: 3063
+    title: "Ensure HTTP server is not installed"
     description: "HTTP or web servers provide the ability to host web site content."
     rationale: "Unless there is a need to run the system as a web server, it is recommended that the package be deleted to reduce the potential attack surface."
     remediation: "Run the following command to remove apache: # apt purge apache2" 
+    additional information: "Several httpd servers exist and can use other service names. apache2 and nginx are example services that provide an HTTP server. These and other services should also be audited"
     compliance:
       - cis: ["2.2.9"]
       - cis_csc_v8: ["4.8"]
@@ -488,7 +452,7 @@ checks:
       - soc_2: ["CC6.3","CC6.6"]
       - iso_27001-2013: ["A.13.1.3"]
       - nist_sp_800-53: ["SI-4"]
-      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_techniques: ["T1203","T1203.000","T1210","T1210.000","T1543","T1543.002"]
       - mitre_tactics: ["TA0008"]
       - mitre_mitigations: ["M1042"]
     condition: all
@@ -496,11 +460,12 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' apache2 -> r:unknown ok not-installed"
 
   # 2.2.10 Ensure IMAP and POP3 server are not installed(Automated)
-  - id: 3067
-    title: "Ensure IMAP and POP3 server are not installed(Automated)"
+  - id: 3064
+    title: "Ensure IMAP and POP3 server are not installed"
     description: "dovecot-imapd and dovecot-pop3d are an open source IMAP and POP3 server for Linux based systems."
     rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the package be removed to reduce the potential attack surface."
     remediation: "Run one of the following commands to remove dovecot-imapd and dovecot-pop3d: # apt purge dovecot-imapd dovecot-pop3d" 
+    additional information: "Several IMAP/POP3 servers exist and can use other service names. courier-imap and cyrus-imap are example services that provide a mail server. These and other services should also be audited."
     compliance:
       - cis: ["2.2.10"]
       - cis_csc_v8: ["4.8"]
@@ -511,7 +476,7 @@ checks:
       - soc_2: ["CC6.3","CC6.6"]
       - iso_27001-2013: ["A.13.1.3"]
       - nist_sp_800-53: ["SI-4"]
-      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_techniques: ["T1203","T1203.000","T1210","T1210.000","T1543","T1543.002"]
       - mitre_tactics: ["TA0008"]
       - mitre_mitigations: ["M1042"]
     condition: all
@@ -519,8 +484,8 @@ checks:
       - "not c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' dovecot-imapd dovecot-pop3d -> r:install ok installed"
 
   # 2.2.11 Ensure Samba is not installed (Automated)
-  - id: 3068
-    title: "Ensure Samba is not installed (Automated)"
+  - id: 3065
+    title: "Ensure Samba is not installed"
     description: "The Samba daemon allows system administrators to configure their Linux systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Server Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
     rationale: "If there is no need to mount directories and file systems to Windows systems, then this service should be deleted to reduce the potential attack surface."
     remediation: "Run the following command to remove samba: # apt purge samba" 
@@ -534,16 +499,15 @@ checks:
       - soc_2: ["CC6.3","CC6.6"]
       - iso_27001-2013: ["A.13.1.3"]
       - nist_sp_800-53: ["SI-4"]
-      - mitre_techniques: ["T1005, T1005.000, T1039, T1039.000, T1083, T1083.000, T1135, T1135.000, T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_techniques: ["T1005","T1005.000","T1039","T1039.000","T1083","T1083.000","T1135","T1135.000","T1203","T1203.000","T1210","T1210.000","T1543","T1543.002"]
       - mitre_tactics: ["TA0008"]
-      - mitre_mitigations: [""]
     condition: all
     rules:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' samba -> r:unknown ok not-installed"
 
   # 2.2.12 Ensure HTTP Proxy Server is not installed (Automated)
-  - id: 3069
-    title: "Ensure HTTP Proxy Server is not installed (Automated)"
+  - id: 3066
+    title: "Ensure HTTP Proxy Server is not installed"
     description: "Squid is a standard proxy server used in many distributions and environments."
     rationale: "If there is no need for a proxy server, it is recommended that the squid proxy be deleted to reduce the potential attack surface."
     remediation: "Run the following command to remove squid: # apt purge squid" 
@@ -557,7 +521,7 @@ checks:
       - soc_2: ["CC6.3","CC6.6"]
       - iso_27001-2013: ["A.13.1.3"]
       - nist_sp_800-53: ["SI-4"]
-      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_techniques: ["T1203","T1203.000","T1210","T1210.000","T1543","T1543.002"]
       - mitre_tactics: ["TA0008"]
       - mitre_mitigations: ["M1042"]
     condition: all
@@ -565,8 +529,8 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' squid -> r:unknown ok not-installed"
 
   # 2.2.13 Ensure SNMP Server is not installed (Automated)
-  - id: 3070
-    title: "Ensure SNMP Server is not installed (Automated)"
+  - id: 3067
+    title: "Ensure SNMP Server is not installed"
     description: 'Simple Network Management Protocol (SNMP) is a widely used protocol for monitoring the health and welfare of network equipment, computer equipment and devices like UPSs. Net-SNMP is a suite of applications used to implement SNMPv1 (RFC 1157), SNMPv2 (RFCs 1901-1908), and SNMPv3 (RFCs 3411-3418) using both IPv4 and IPv6. Support for SNMPv2 classic (a.k.a. "SNMPv2 historic" - RFCs 1441-1452) was dropped with the 4.0 release of the UCD-snmp package. The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system.'
     rationale: "The SNMP server can communicate using SNMPv1, which transmits data in the clear and does not require authentication to execute commands. SNMPv3 replaces the simple/clear text password sharing used in SNMPv2 with more securely encoded parameters. If the the SNMP service is not required, the net-snmp package should be removed to reduce the attack surface of the system. Note: If SNMP is required: The server should be configured for SNMP v3 only. User Authentication and Message Encryption should be configured. If SNMP v2 is absolutely necessary, modify the community strings' values."
     remediation: "Run the following command to remove snmp: # apt purge snmp"
@@ -580,7 +544,7 @@ checks:
       - soc_2: ["CC6.3","CC6.6"]
       - iso_27001-2013: ["A.13.1.3"]
       - nist_sp_800-53: ["SI-4"]
-      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_techniques: ["T1203","T1203.000","T1210","T1210.000","T1543","T1543.002"]
       - mitre_tactics: ["TA0008"]
       - mitre_mitigations: ["M1042"]
     condition: all
@@ -588,8 +552,8 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' snmp -> r:unknown ok not-installed"
 
   # 2.2.14 Ensure NIS Server is not installed (Automated)
-  - id: 3071
-    title: "Ensure NIS Server is not installed (Automated)"
+  - id: 3068
+    title: "Ensure NIS Server is not installed"
     description: "The Network Information Service (NIS) (formally known as Yellow Pages) is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed and other, more secure services be used"
     remediation: "Run the following command to remove nis: # apt purge nis" 
@@ -603,7 +567,7 @@ checks:
       - soc_2: ["CC6.3","CC6.6"]
       - iso_27001-2013: ["A.13.1.3"]
       - nist_sp_800-53: ["SI-4"]
-      - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
+      - mitre_techniques: ["T1203","T1203.000","T1210","T1210.000","T1543","T1543.002"]
       - mitre_tactics: ["TA0008"]
       - mitre_mitigations: ["M1042"]
     condition: all
@@ -611,8 +575,8 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' nis -> r:unknown ok not-installed"
 
   # 2.2.15 Ensure mail transfer agent is configured for local-only mode (Automated)
-  - id: 3072
-    title: "Ensure mail transfer agent is configured for local-only mode (Automated)"
+  - id: 3069
+    title: "Ensure mail transfer agent is configured for local-only mode"
     description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
     rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems. Note: This recommendation is designed around the postfix mail server. Depending on your environment you may have an alternative MTA installed such as exim4. If this is the case consult the documentation for your installed MTA to configure the recommended state."
     remediation: "Edit /etc/postfix/main.cf and add the following line to the RECEIVING MAIL section. If the line already exists, change it to look like the line below: inet_interfaces = loopback-only .Run the following command to restart postfix: # systemctl restart postfix" 
@@ -626,7 +590,7 @@ checks:
       - soc_2: ["CC6.3","CC6.6"]
       - iso_27001-2013: ["A.13.1.3"]
       - nist_sp_800-53: ["SI-4"]
-      - mitre_techniques: ["T1018, T1018.000, T1210, T1210.000"]
+      - mitre_techniques: ["T1018","T1018.000","T1210","T1210.000"]
       - mitre_tactics: ["TA0008"]
       - mitre_mitigations: ["M1042"]
     condition: none
@@ -634,8 +598,8 @@ checks:
       - 'c:ss -lntu -> r:\.*:25\.*LISTEN && !r:127.0.0.1:25\.+LISTEN|::1:25\.*LISTEN'
 
   # 2.2.16 Ensure rsync service is either not installed or masked (Automated)
-  - id: 3073
-    title: "Ensure rsync service is either not installed or masked (Automated)"
+  - id: 3070
+    title: "Ensure rsync service is either not installed or masked"
     description: "The rsync service can be used to synchronize files between systems over network links."
     rationale: "The rsync service presents a security risk as it uses unencrypted protocols for communication. The rsync package should be removed to reduce the attack area of the system."
     remediation: "Run the following command to remove rsync: # apt purge rsync OR Run the following commands to stop and mask rsync: # systemctl stop rsync # systemctl mask rsync" 
@@ -649,7 +613,7 @@ checks:
       - soc_2: ["CC6.3","CC6.6"]
       - iso_27001-2013: ["A.13.1.3"]
       - nist_sp_800-53: ["SI-4"]
-      - mitre_techniques: ["T1105, T1105.000, T1203, T1203.000, T1210, T1210.000, T1543, T1543.002, T1570, T1570.000"]
+      - mitre_techniques: ["T1105","T1105.000","T1203","T1203.000","T1210","T1210.000","T1543","T1543.002","T1570","T1570.000"]
       - mitre_tactics: ["TA0008"]
       - mitre_mitigations: ["M1042"]
     condition: any
@@ -662,11 +626,12 @@ checks:
   # 2.3 Service Clients
   ############################################################
   # 2.3.1 Ensure NIS Client is not installed (Automated)
-  - id: 3074
-    title: "Ensure NIS Client is not installed (Automated)"
+  - id: 3071
+    title: "Ensure NIS Client is not installed"
     description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files. The NIS client was used to bind a machine to an NIS server and receive the distributed configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
     remediation: "Uninstall nis: # apt purge nis" 
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
     compliance:
       - cis: ["2.3.1"]
       - cis_csc_v8: ["4.8"]
@@ -677,7 +642,7 @@ checks:
       - soc_2: ["CC6.3","CC6.6"]
       - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
       - nist_sp_800-53: ["CM-11"]
-      - mitre_techniques: ["T1203, T1203.000, T1543, T1543.002"]
+      - mitre_techniques: ["T1203","T1203.000","T1543","T1543.002"]
       - mitre_tactics: ["TA0008"]
       - mitre_mitigations: ["M1042"]
     condition: all
@@ -685,11 +650,12 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' nis -> r:unknown ok not-installed"
 
   # 2.3.2 Ensure rsh client is not installed (Automated)
-  - id: 3075
-    title: "Ensure rsh client is not installed (Automated)"
+  - id: 3072
+    title: "Ensure rsh client is not installed"
     description: "The rsh-client package contains the client commands for the rsh services."
     rationale: "These legacy clients contain numerous security exposures and have been replaced with the more secure SSH package. Even if the server is removed, it is best to ensure the clients are also removed to prevent users from inadvertently attempting to use these commands and therefore exposing their credentials. Note that removing the rsh package removes the clients for rsh , rcp and rlogin ."
     remediation: "Uninstall rsh: # apt purge rsh-client" 
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
     compliance:
       - cis: ["2.3.2"]
       - cis_csc_v8: ["4.8"]
@@ -700,19 +666,20 @@ checks:
       - soc_2: ["CC6.3","CC6.6"]
       - iso_27001-2013: ["A.13.1.3"]
       - nist_sp_800-53: ["SI-4"]
-      - mitre_techniques: ["T1040, T1040.000, T1203, T1203.000, T1543, T1543.002"]
+      - mitre_techniques: ["T1040","T1040.000","T1203","T1203.000","T1543","T1543.002"]
       - mitre_tactics: ["TA0008"]
-      - mitre_mitigations: ["M1041, M1042"]
+      - mitre_mitigations: ["M1041","M1042"]
     condition: all
     rules:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' rsh-client -> r:unknown ok not-installed"
 
   # 2.3.3 Ensure talk client is not installed (Automated)
-  - id: 3076
-    title: "Ensure talk client is not installed (Automated)"
+  - id: 3073
+    title: "Ensure talk client is not installed"
     description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client, which allows initialization of talk sessions, is installed by default."
     rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
     remediation: "Uninstall talk: # apt purge talk" 
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
     compliance:
       - cis: ["2.3.3"]
       - cis_csc_v8: ["4.8"]
@@ -723,19 +690,20 @@ checks:
       - soc_2: ["CC6.3","CC6.6"]
       - iso_27001-2013: ["A.13.1.3"]
       - nist_sp_800-53: ["SI-4"]
-      - mitre_techniques: ["T1203, T1203.000, T1543, T1543.002"]
-      - mitre_tactics: ["TA0006, TA0008"]
-      - mitre_mitigations: ["M1041, M1042"]
+      - mitre_techniques: ["T1203","T1203.000","T1543","T1543.002"]
+      - mitre_tactics: ["TA0006","TA0008"]
+      - mitre_mitigations: ["M1041","M1042"]
     condition: all
     rules:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' talk -> r:unknown ok not-installed"
 
   # 2.3.4 Ensure telnet client is not installed (Automated)
-  - id: 3077
-    title: "Ensure telnet client is not installed (Automated)"
+  - id: 3074
+    title: "Ensure telnet client is not installed"
     description: "The telnet package contains the telnet client, which allows users to start connections to other systems via the telnet protocol."
     rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow an unauthorized user to steal credentials. The ssh package provides an encrypted session and stronger security and is included in most Linux distributions."
     remediation: "Uninstall telnet: # apt purge telnet" 
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
     compliance:
       - cis: ["2.3.4"]
       - cis_csc_v8: ["4.8"]
@@ -746,19 +714,20 @@ checks:
       - soc_2: ["CC6.3","CC6.6"]
       - iso_27001-2013: ["A.13.1.3"]
       - nist_sp_800-53: ["SI-4"]
-      - mitre_techniques: ["T1040, T1040.000, T1203, T1203.000, T1543, T1543.002"]
-      - mitre_tactics: ["TA0006, TA0008"]
-      - mitre_mitigations: ["M1041, M1042"]
+      - mitre_techniques: ["T1040","T1040.000","T1203","T1203.000","T1543","T1543.002"]
+      - mitre_tactics: ["TA0006","TA0008"]
+      - mitre_mitigations: ["M1041","M1042"]
     condition: all
     rules:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' telnet -> r:unknown ok not-installed"
 
   # 2.3.5 Ensure LDAP client is not installed (Automated)
-  - id: 3078
-    title: "Ensure LDAP client is not installed (Automated)"
+  - id: 3075
+    title: "Ensure LDAP client is not installed"
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP client, it is recommended that the software be removed to reduce the potential attack surface."
     remediation: "Uninstall ldap-utils: # apt purge ldap-utils" 
+    impact: "Removing the LDAP client will prevent or inhibit using LDAP for authentication in your environment."
     compliance:
       - cis: ["2.3.5"]
       - cis_csc_v8: ["4.8"]
@@ -769,7 +738,7 @@ checks:
       - soc_2: ["CC6.3","CC6.6"]
       - iso_27001-2013: ["A.13.1.3"]
       - nist_sp_800-53: ["SI-4"]
-      - mitre_techniques: ["T1040, T1040.000, T1203, T1203.000, T1543, T1543.002"]
+      - mitre_techniques: ["T1040","T1040.000","T1203","T1203.000","T1543","T1543.002"]
       - mitre_tactics: ["TA0008"]
       - mitre_mitigations: ["M1042"]
     condition: all
@@ -777,8 +746,8 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' ldap-utils -> r:unknown ok not-installed"
 
   # 2.3.6 Ensure RPC is not installed (Automated)
-  - id: 3079
-    title: "Ensure RPC is not installed (Automated)"
+  - id: 3076
+    title: "Ensure RPC is not installed"
     description: "Remote Procedure Call (RPC) is a method for creating low level client server applications across different system architectures. It requires an RPC compliant client listening on a network port. The supporting package is rpcbind."
     rationale: "If RPC is not required, it is recommended that this services be removed to reduce the remote attack surface."
     remediation: "Run the following command to remove rpcbind: # apt purge rpcbind" 
@@ -792,7 +761,7 @@ checks:
       - soc_2: ["CC6.3","CC6.6"]
       - iso_27001-2013: ["A.13.1.3"]
       - nist_sp_800-53: ["SI-4"]
-      - mitre_techniques: ["T1203, T1203.000, T1543, T1543.002"]
+      - mitre_techniques: ["T1203","T1203.000","T1543","T1543.002"]
       - mitre_tactics: ["TA0008"]
       - mitre_mitigations: ["M1042"]
     condition: all

--- a/ruleset/sca/debian/cis_debian11.yml
+++ b/ruleset/sca/debian/cis_debian11.yml
@@ -90,24 +90,24 @@ checks:
       - 'f:/etc/chrony/chrony.conf -> r:^server\.+|^pool\.+'
 
   # 2.1.2.2 Ensure chrony is running as user _chrony (Automated)
-  - id: 3050
-    title: "Ensure chrony is running as user _chrony (Automated)"
-    description: "The chrony package is installed with a dedicated user account _chrony. This account is granted the access required by the chronyd service."
-    rationale: "The chronyd service should run with only the required privlidges"
-    remediation: "Add or edit the user line to /etc/chrony/chrony.conf or a file ending in .conf in /etc/chrony/conf.d/: user _chrony OR If another time synchronization service is in use on the system, run the following command to remove chrony from the system: # apt purge chrony Default Value: user _chrony" 
-    compliance:
-      - cis: ["2.1.2.2"]
-      - cis_csc_v8: ["8.4"]
-      - cis_csc_v7: ["6.1"]
-      - cmmc_v2.0: ["AU.L2-3.3.7"]
-      - pci_dss_3.2.1: ["10.4"]
-      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
-      - nist_sp_800-53: ["AU-7"]
-      - soc_2: ["CC4.1","CC5.2"]
-      - iso_27001-2013: ["A.12.4.4"]
-    condition: all
-    rules:
-      - 'c:ps -ef | awk '(/[c]hronyd/ && $1!="_chrony") { print $1 }''
+#  - id: 3050
+#    title: "Ensure chrony is running as user _chrony (Automated)"
+#    description: "The chrony package is installed with a dedicated user account _chrony. This account is granted the access required by the chronyd service."
+#    rationale: "The chronyd service should run with only the required privlidges"
+#    remediation: "Add or edit the user line to /etc/chrony/chrony.conf or a file ending in .conf in /etc/chrony/conf.d/: user _chrony OR If another time synchronization service is in use on the system, run the following command to remove chrony from the system: # apt purge chrony Default Value: user _chrony" 
+#    compliance:
+#      - cis: ["2.1.2.2"]
+#      - cis_csc_v8: ["8.4"]
+#      - cis_csc_v7: ["6.1"]
+#      - cmmc_v2.0: ["AU.L2-3.3.7"]
+#      - pci_dss_3.2.1: ["10.4"]
+#      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+#      - nist_sp_800-53: ["AU-7"]
+#      - soc_2: ["CC4.1","CC5.2"]
+#      - iso_27001-2013: ["A.12.4.4"]
+#    condition: all
+#    rules:
+#      - 'c:ps -ef -> r:^\s*chronyd && r:^chrony'
 
   # 2.1.2.3 Ensure chrony is enabled and running (Automated)
   - id: 3051
@@ -127,8 +127,8 @@ checks:
       - iso_27001-2013: ["A.12.4.4"]
     condition: any
     rules:
-      - 'c:systemctl is-enabled chrony.service -> r:enabled'
-      - 'c:systemctl is-active chrony.service -> r:active'
+      - 'c:systemctl is-enabled chrony.service -> r:^enabled'
+      - 'c:systemctl is-active chrony.service -> r:^active'
 
   ############################################################
   # 2.1.3 Configure systemd-timesyncd
@@ -158,7 +158,9 @@ checks:
       - https://tf.nist.gov/tf-cgi/servers.cgi
     condition: all
     rules:
-      - 'c:find /etc/systemd -type f -name '*.conf' -exec grep -Ph '^\h*(NTP|FallbackNTP)=\H+' {} + -> r:NPT= FallbackNTP='
+      - "d:/etc/systemd"
+      - 'd:/etc/systemd -> r:\.+.conf$'
+      - 'd:/etc/systemd -> r:\.+.conf$ ->r:^\h*(NTP|FallbackNTP)=\H+'
 
   # 2.1.3.2 Ensure systemd-timesyncd is enabled and running (Automated)
   - id: 3053
@@ -178,86 +180,86 @@ checks:
       - iso_27001-2013: ["A.12.4.4"]
     condition: any
     rules:
-      - 'c:systemctl is-enabled systemd-timesyncd.service -> r:enabled'
-      - 'c:systemctl is-active systemd-timesyncd.service -> active'
+      - 'c:systemctl is-enabled systemd-timesyncd.service -> r:^enabled'
+      - 'c:systemctl is-active systemd-timesyncd.service -> r:^active'
 
   ############################################################
   # 2.1.4 Configure ntp
   ############################################################
 
   # 2.1.4.1 Ensure ntp access control is configured (Automated)
-  - id: 3054
-    title: "Ensure ntp access control is configured (Automated)"
-    description: "ntp Access Control Commands: restrict address [mask mask] [ippeerlimit int] [flag ...] The address argument expressed in dotted-quad form is the address of a host or network. Alternatively, the address argument can be a valid host DNS name. The mask argument expressed in dotted-quad form defaults to 255.255.255.255, meaning that the address is treated as the address of an individual host. A default entry (address 0.0.0.0, mask 0.0.0.0) is always included and is always the first entry in the list. Note: the text string default, with no mask option, may be used to indicate the default entry. The ippeerlimit directive limits the number of peer requests for each IP to int, where a value of -1 means "unlimited", the current default. A value of 0 means "none". There would usually be at most 1 peering request per IP, but if the remote peering requests are behind a proxy there could well be more than 1 per IP. In the current implementation, flag always restricts access, i.e., an entry with no flags indicates that free access to the server is to be given. The flags are not orthogonal, in that more restrictive flags will often make less restrictive ones redundant. The flags can generally be classed into two categories, those which restrict time service and those which restrict informational queries and attempts to do run-time reconfiguration of the server.One or more of the following flags may be specified: kod - If this flag is set when an access violation occurs, a kiss-o'-death (KoD) packet is sent. KoD packets are rate limited to no more than one per second. If another KoD packet occurs within one second after the last one, the packet is dropped. limited - Deny service if the packet spacing violates the lower limits specified in the discard command. A history of clients is kept using the monitoring capability of ntpd. Thus, monitoring is always active as long as there is a restriction entry with the limited flag. lowpriotrap - Declare traps set by matching hosts to be low priority. The number of traps a server can maintain is limited (the current limit is 3). Traps are usually assigned on a first come, first served basis, with later trap requestors being denied service. This flag modifies the assignment algorithm by allowing low priority traps to be overridden by later requests for normal priority traps. noepeer - Deny ephemeral peer requests, even if they come from an authenticated source. Note that the ability to use a symmetric key for authentication may be restricted to one or more IPs or subnets via the third field of the ntp.keys file. This restriction is not enabled by default, to maintain backward compatibility. Expect noepeer to become the default in ntp-4.4. nomodify - Deny ntpq and ntpdc queries which attempt to modify the state of the server (i.e., run time reconfiguration). Queries which return information are permitted. noquery - Deny ntpq and ntpdc queries. Time service is not affected. nopeer - Deny unauthenticated packets which would result in mobilizing a new association. This includes broadcast and symmetric active packets when a configured association does not exist. It also includes pool associations, so if you want to use servers from a pool directive and also want to use nopeer by default you'll want a restrict source ... line as well that does not include the nopeer directive. noserve - Deny all packets except ntpq and ntpdc queries.notrap - Decline to provide mode 6 control message trap service to matching hosts. The trap service is a subsystem of the ntpq control message protocol which is intended for use by remote event logging programs. notrust - Deny service unless the packet is cryptographically authenticated. ntpport - This is actually a match algorithm modifier, rather than a restriction flag. Its presence causes the restriction entry to be matched only if the source port in the packet is the standard NTP UDP port (123). Both ntpport and non- ntpport may be specified. The ntpport is considered more specific and is sorted later in the list."
-    rationale: "If ntp is in use on the system, proper configuration is vital to ensuring time synchronization is accurate."
-    remediation: "Add or edit restrict lines in /etc/ntp.conf to match the following: restrict -4 default kod nomodify notrap nopeer noquery restrict -6 default kod nomodify notrap nopeer noquery ORIf another time synchronization service is in use on the system, run the following command to remove ntp from the system: # apt purge ntp Default Value: restrict -4 default kod notrap nomodify nopeer noquery limited restrict -6 default kod notrap nomodify nopeer noquery limited" 
-    compliance:
-      - cis: ["2.1.4.1"]
-      - cis_csc_v8: ["8.4"]
-      - cis_csc_v7: ["6.1"]
-      - cmmc_v2.0: ["AU.L2-3.3.7"]
-      - pci_dss_3.2.1: ["10.4"]
-      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
-      - nist_sp_800-53: ["AU-7"]
-      - soc_2: ["CC4.1","CC5.2"]
-      - iso_27001-2013: ["A.12.4.4"]
-    references:
-      - http://www.ntp.org/
-      - ntp.conf(5)
-      - ntpd(8)
-    condition: any
-    rules:
-      - 'f:/etc/ntp.conf -> r:^restrict\s+-4\s+default|^restrict\s+default && r:\s+kod\s+ && r:\s+nomodify\s+ && r:\s+notrap\s+ && r:\s+nopeer\s+ && r:\s+noquery'
-      - 'f:/etc/ntp.conf -> r:^restrict\s+-6\s+default && r:\s+kod\s+ && r:\s+nomodify\s+ && r:\s+notrap\s+ && r:\s+nopeer\s+ && r:\s+noquery'
-
+#  - id: 3054
+#    title: "Ensure ntp access control is configured (Automated)"
+#    description: 'ntp Access Control Commands: restrict address [mask mask] [ippeerlimit int] [flag ...] The address argument expressed in dotted-quad form is the address of a host or network. Alternatively, the address argument can be a valid host DNS name. The mask argument expressed in dotted-quad form defaults to 255.255.255.255, meaning that the address is treated as the address of an individual host. A default entry (address 0.0.0.0, mask 0.0.0.0) is always included and is always the first entry in the list. Note: the text string default, with no mask option, may be used to indicate the default entry. The ippeerlimit directive limits the number of peer requests for each IP to int, where a value of -1 means "unlimited", the current default. A value of 0 means "none". There would usually be at most 1 peering request per IP, but if the remote peering requests are behind a proxy there could well be more than 1 per IP. In the current implementation, flag always restricts access, i.e., an entry with no flags indicates that free access to the server is to be given. The flags are not orthogonal, in that more restrictive flags will often make less restrictive ones redundant. The flags can generally be classed into two categories, those which restrict time service and those which restrict informational queries and attempts to do run-time reconfiguration of the server.One or more of the following flags may be specified: kod - If this flag is set when an access violation occurs, a kiss-o-death (KoD) packet is sent. KoD packets are rate limited to no more than one per second. If another KoD packet occurs within one second after the last one, the packet is dropped. limited - Deny service if the packet spacing violates the lower limits specified in the discard command. A history of clients is kept using the monitoring capability of ntpd. Thus, monitoring is always active as long as there is a restriction entry with the limited flag. lowpriotrap - Declare traps set by matching hosts to be low priority. The number of traps a server can maintain is limited (the current limit is 3). Traps are usually assigned on a first come, first served basis, with later trap requestors being denied service. This flag modifies the assignment algorithm by allowing low priority traps to be overridden by later requests for normal priority traps. noepeer - Deny ephemeral peer requests, even if they come from an authenticated source. Note that the ability to use a symmetric key for authentication may be restricted to one or more IPs or subnets via the third field of the ntp.keys file. This restriction is not enabled by default, to maintain backward compatibility. Expect noepeer to become the default in ntp-4.4. nomodify - Deny ntpq and ntpdc queries which attempt to modify the state of the server (i.e., run time reconfiguration). Queries which return information are permitted. noquery - Deny ntpq and ntpdc queries. Time service is not affected. nopeer - Deny unauthenticated packets which would result in mobilizing a new association. This includes broadcast and symmetric active packets when a configured association does not exist. It also includes pool associations, so if you want to use servers from a pool directive and also want to use nopeer by default you'll want a restrict source ... line as well that does not include the nopeer directive. noserve - Deny all packets except ntpq and ntpdc queries.notrap - Decline to provide mode 6 control message trap service to matching hosts. The trap service is a subsystem of the ntpq control message protocol which is intended for use by remote event logging programs. notrust - Deny service unless the packet is cryptographically authenticated. ntpport - This is actually a match algorithm modifier, rather than a restriction flag. Its presence causes the restriction entry to be matched only if the source port in the packet is the standard NTP UDP port (123). Both ntpport and non- ntpport may be specified. The ntpport is considered more specific and is sorted later in the list.'
+#    rationale: "If ntp is in use on the system, proper configuration is vital to ensuring time synchronization is accurate."
+#    remediation: "Add or edit restrict lines in /etc/ntp.conf to match the following: restrict -4 default kod nomodify notrap nopeer noquery restrict -6 default kod nomodify notrap nopeer noquery ORIf another time synchronization service is in use on the system, run the following command to remove ntp from the system: # apt purge ntp Default Value: restrict -4 default kod notrap nomodify nopeer noquery limited restrict -6 default kod notrap nomodify nopeer noquery limited" 
+#    compliance:
+#      - cis: ["2.1.4.1"]
+#      - cis_csc_v8: ["8.4"]
+#      - cis_csc_v7: ["6.1"]
+#      - cmmc_v2.0: ["AU.L2-3.3.7"]
+#      - pci_dss_3.2.1: ["10.4"]
+#      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+#      - nist_sp_800-53: ["AU-7"]
+#      - soc_2: ["CC4.1","CC5.2"]
+#      - iso_27001-2013: ["A.12.4.4"]
+#    references:
+#      - http://www.ntp.org/
+#      - ntp.conf(5)
+#      - ntpd(8)
+#    condition: any
+#    rules:
+#      - 'f:/etc/ntp.conf -> r:^restrict\s+-4\s+default|^restrict\s+default && r:\s+kod\s+ && r:\s+nomodify\s+ && r:\s+notrap\s+ && r:\s+nopeer\s+ && r:\s+noquery'
+#      - 'f:/etc/ntp.conf -> r:^restrict\s+-6\s+default && r:\s+kod\s+ && r:\s+nomodify\s+ && r:\s+notrap\s+ && r:\s+nopeer\s+ && r:\s+noquery'
+#
   # 2.1.4.2 Ensure ntp is configured with authorized timeserver (Manual)
-  - id: 3055
-    title: "Ensure ntp is configured with authorized timeserver (Manual)"
-    description: "The various modes are determined by the command keyword and the type of the required IP address. Addresses are classed by type as (s) a remote server or peer (IPv4 class A, B and C), (b) the broadcast address of a local interface, (m) a multicast address (IPv4 class D), or (r) a reference clock address (127.127.x.x). Note: That only those options applicable to each command are listed below. Use of options not listed may not be caught as an error, but may result in some weird and even destructive behavior. If the Basic Socket Interface Extensions for IPv6 (RFC-2553) is detected, support for the IPv6 address family is generated in addition to the default support of the IPv4 address family. In a few cases, including the reslist billboard generated by ntpq or ntpdc, IPv6 addresses are automatically generated. IPv6 addresses can be identified by the presence of colons “:” in the address field. IPv6 addresses can be used almost everywhere where IPv4 addresses can be used, with the exception of reference clock addresses, which are always IPv4. Note: In contexts where a host name is expected, a -4 qualifier preceding the host name forces DNS resolution to the IPv4 namespace, while a -6 qualifier forces DNS resolution to the IPv6 namespace. See IPv6 references for the equivalent classes for that address family. (1)pool - For type s addresses, this command mobilizes a persistent client mode association with a number of remote servers. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. (2)server - For type s and r addresses, this command mobilizes a persistent client mode association with the specified remote server or local radio clock. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. This command should not be used for type b or m addresses."
-    rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations"
-    remediation: "Edit /etc/ntp.conf and add or edit server or pool lines as appropriate according to local site policy: <[server|pool]> <[remote-server|remote-pool]> Examples: pool mode: pool time.nist.gov iburst server mode: server time-a-g.nist.gov iburst server 132.163.97.3 iburst server time-d-b.nist.gov iburst Run the following command to load the updated time sources into ntp running config: # systemctl restart ntp OR If another time synchronization service is in use on the system, run the following command to remove ntp from the system: # apt purge ntp" 
-    compliance:
-      - cis: ["2.1.4.2"]
-      - cis_csc_v8: ["8.4"]
-      - cis_csc_v7: ["6.1"]
-      - cmmc_v2.0: ["AU.L2-3.3.7"]
-      - pci_dss_3.2.1: ["10.4"]
-      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
-      - nist_sp_800-53: ["AU-7"]
-      - soc_2: ["CC4.1","CC5.2"]
-      - iso_27001-2013: ["A.12.4.4"]
-      - mitre_techniques: ["T1070, T1070.002, T1498, T1498.002, T1562, T1562.001"]
-      - mitre_tactics: ["TA0002"]
-      - mitre_mitigations: ["M1022"]
-    references:
-      - http://www.ntp.org/
-      - https://tf.nist.gov/tf-cgi/servers.cgi
-      - ntp.conf(5)
-      - ntpd(8)
-    condition: all
-    rules:
-      - "c:grep -P -- '^\h*(server|pool)\h+\H+' /etc/ntp.conf -> r: pool server"
-
+#  - id: 3055
+#    title: "Ensure ntp is configured with authorized timeserver (Manual)"
+#    description: 'The various modes are determined by the command keyword and the type of the required IP address. Addresses are classed by type as (s) a remote server or peer (IPv4 class A, B and C), (b) the broadcast address of a local interface, (m) a multicast address (IPv4 class D), or (r) a reference clock address (127.127.x.x). Note: That only those options applicable to each command are listed below. Use of options not listed may not be caught as an error, but may result in some weird and even destructive behavior. If the Basic Socket Interface Extensions for IPv6 (RFC-2553) is detected, support for the IPv6 address family is generated in addition to the default support of the IPv4 address family. In a few cases, including the reslist billboard generated by ntpq or ntpdc, IPv6 addresses are automatically generated. IPv6 addresses can be identified by the presence of colons “:” in the address field. IPv6 addresses can be used almost everywhere where IPv4 addresses can be used, with the exception of reference clock addresses, which are always IPv4. Note: In contexts where a host name is expected, a -4 qualifier preceding the host name forces DNS resolution to the IPv4 namespace, while a -6 qualifier forces DNS resolution to the IPv6 namespace. See IPv6 references for the equivalent classes for that address family. (1)pool - For type s addresses, this command mobilizes a persistent client mode association with a number of remote servers. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. (2)server - For type s and r addresses, this command mobilizes a persistent client mode association with the specified remote server or local radio clock. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. This command should not be used for type b or m addresses.'
+#    rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations"
+#    remediation: "Edit /etc/ntp.conf and add or edit server or pool lines as appropriate according to local site policy: <[server|pool]> <[remote-server|remote-pool]> Examples: pool mode: pool time.nist.gov iburst server mode: server time-a-g.nist.gov iburst server 132.163.97.3 iburst server time-d-b.nist.gov iburst Run the following command to load the updated time sources into ntp running config: # systemctl restart ntp OR If another time synchronization service is in use on the system, run the following command to remove ntp from the system: # apt purge ntp" 
+#    compliance:
+#      - cis: ["2.1.4.2"]
+#      - cis_csc_v8: ["8.4"]
+#      - cis_csc_v7: ["6.1"]
+#      - cmmc_v2.0: ["AU.L2-3.3.7"]
+#      - pci_dss_3.2.1: ["10.4"]
+#      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+#      - nist_sp_800-53: ["AU-7"]
+#      - soc_2: ["CC4.1","CC5.2"]
+#      - iso_27001-2013: ["A.12.4.4"]
+#      - mitre_techniques: ["T1070, T1070.002, T1498, T1498.002, T1562, T1562.001"]
+#      - mitre_tactics: ["TA0002"]
+#      - mitre_mitigations: ["M1022"]
+#    references:
+#      - http://www.ntp.org/
+#      - https://tf.nist.gov/tf-cgi/servers.cgi
+#      - ntp.conf(5)
+#      - ntpd(8)
+#    condition: all
+#    rules:
+#      - "c:grep -Rh ^*.* /etc/ntp.conf -> r:^\h*(server|pool)\h+\H+"
+#
   # 2.1.4.3 Ensure ntp is running as user ntp (Automated) 
-  - id: 3056
-    title: "Ensure ntp is running as user ntp (Automated)"
-    description: "The ntp package is installed with a dedicated user account ntp. This account is granted the access required by the ntpd daemon Note: If chrony or systemd-timesyncd are used, ntp should be removed and this section skipped This recommendation only applies if ntp is in use on the system Only one time synchronization method should be in use on the system"
-    rationale: "The ntpd daemon should run with only the required privlidge"
-    remediation: "Add or edit the following line in /etc/init.d/ntp: RUNASUSER=ntp .Run the following command to restart ntp.servocee: # systemctl restart ntp.service OR If another time synchronization service is in use on the system, run the following command to remove ntp from the system: # apt purge ntp Default Value: user ntp" 
-    compliance:
-      - cis: ["2.1.4.3"]
-      - cis_csc_v8: ["8.4"]
-      - cis_csc_v7: ["6.1"]
-      - cmmc_v2.0: ["AU.L2-3.3.7"]
-      - pci_dss_3.2.1: ["10.4"]
-      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
-      - nist_sp_800-53: ["AU-7"]
-      - soc_2: ["CC4.1","CC5.2"]
-      - iso_27001-2013: ["A.12.4.4"]
-    condition: any
-    rules:
-      - "ps -ef | awk '(/[n]tpd/ && $1!="ntp") { print $1 }'"
-      - 'grep -P -- '^\h*RUNASUSER=' /etc/init.d/ntp -> r:RUNASUSER=ntp'
+#  - id: 3056
+#    title: "Ensure ntp is running as user ntp (Automated)"
+#    description: "The ntp package is installed with a dedicated user account ntp. This account is granted the access required by the ntpd daemon Note: If chrony or systemd-timesyncd are used, ntp should be removed and this section skipped This recommendation only applies if ntp is in use on the system Only one time synchronization method should be in use on the system"
+#    rationale: "The ntpd daemon should run with only the required privlidge"
+#    remediation: "Add or edit the following line in /etc/init.d/ntp: RUNASUSER=ntp .Run the following command to restart ntp.servocee: # systemctl restart ntp.service OR If another time synchronization service is in use on the system, run the following command to remove ntp from the system: # apt purge ntp Default Value: user ntp" 
+#    compliance:
+#      - cis: ["2.1.4.3"]
+#      - cis_csc_v8: ["8.4"]
+#      - cis_csc_v7: ["6.1"]
+#      - cmmc_v2.0: ["AU.L2-3.3.7"]
+#      - pci_dss_3.2.1: ["10.4"]
+#      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+#      - nist_sp_800-53: ["AU-7"]
+#      - soc_2: ["CC4.1","CC5.2"]
+#      - iso_27001-2013: ["A.12.4.4"]
+#    condition: any
+#    rules:
+#      - "ps -ef | awk '(/[n]tpd/ && $1!="ntp") { print $1 }'"
+#      - 'grep -P -- '^\h*RUNASUSER=' /etc/init.d/ntp -> r:RUNASUSER=ntp'
 
   # 2.1.4.4 Ensure ntp is enabled and running (Automated)
   - id: 3057
@@ -277,8 +279,8 @@ checks:
       - iso_27001-2013: ["A.12.4.4"]
     condition: any
     rules:
-      - 'c:systemctl is-enabled ntp.service -> r:enabled'
-      - 'c:systemctl is-active ntp.service -> r:active'
+      - 'c:systemctl is-enabled ntp.service -> r:^enabled'
+      - 'c:systemctl is-active ntp.service -> r:^active'
 
   ############################################################
   # 2.2 Special Purpose Services
@@ -302,9 +304,9 @@ checks:
       - mitre_techniques: ["T1203, T1203.000, T1210, T1210.000, T1543, T1543.002"]
       - mitre_tactics: ["TA0008"]
       - mitre_mitigations: ["M1042"]
-    condition: none
+    condition: all
     rules:
-      - 'c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' xserver-xorg* | grep -Pi '\h+installed\b' -> r:^\wi\s*xserver-xorg"
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' xserver-xorg -> r:unknown ok not-installed"
 
   # 2.2.2 Ensure Avahi Server is not installed (Automated)
   - id: 3059
@@ -327,7 +329,7 @@ checks:
       - mitre_mitigations: ["M1042"]
     condition: all
     rules:
-      - 'c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' avahi-daemon -> r:unknown ok not-installed'
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' avahi-daemon -> r:unknown ok not-installed"
 
   # 2.2.3 Ensure CUPS is not installed (Automated)
   - id: 3060
@@ -377,7 +379,7 @@ checks:
       - More detailed documentation on DHCP is available at http://www.isc.org/software/dhcp.
     condition: all
     rules:
-      - "dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' isc-dhcp-server -> r:unknown ok not-installed"
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' isc-dhcp-server -> r:unknown ok not-installed"
 
   # 2.2.5 Ensure LDAP server is not installed (Automated)
   - id: 3062
@@ -468,7 +470,7 @@ checks:
       - mitre_mitigations: ["M1042"]
     condition: all
     rules:
-      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' vsftpd -> unknown ok not-installed"
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' vsftpd -> r:unknown ok not-installed"
 
   # 2.2.9 Ensure HTTP server is not installed (Automated)
   - id: 3066
@@ -491,7 +493,7 @@ checks:
       - mitre_mitigations: ["M1042"]
     condition: all
     rules:
-      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' apache2 -> unknown ok not-installed"
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' apache2 -> r:unknown ok not-installed"
 
   # 2.2.10 Ensure IMAP and POP3 server are not installed(Automated)
   - id: 3067
@@ -514,7 +516,7 @@ checks:
       - mitre_mitigations: ["M1042"]
     condition: all
     rules:
-      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' dovecot-imapd dovecot-pop3d -> unknown ok not-installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' dovecot-imapd dovecot-pop3d -> r:install ok installed"
 
   # 2.2.11 Ensure Samba is not installed (Automated)
   - id: 3068
@@ -537,7 +539,7 @@ checks:
       - mitre_mitigations: [""]
     condition: all
     rules:
-      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' samba -> unknown ok not-installed"
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' samba -> r:unknown ok not-installed"
 
   # 2.2.12 Ensure HTTP Proxy Server is not installed (Automated)
   - id: 3069
@@ -560,12 +562,12 @@ checks:
       - mitre_mitigations: ["M1042"]
     condition: all
     rules:
-      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' squid -> r:unknown on not-installed"
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' squid -> r:unknown ok not-installed"
 
   # 2.2.13 Ensure SNMP Server is not installed (Automated)
   - id: 3070
     title: "Ensure SNMP Server is not installed (Automated)"
-    description: "Simple Network Management Protocol (SNMP) is a widely used protocol for monitoring the health and welfare of network equipment, computer equipment and devices like UPSs. Net-SNMP is a suite of applications used to implement SNMPv1 (RFC 1157), SNMPv2 (RFCs 1901-1908), and SNMPv3 (RFCs 3411-3418) using both IPv4 and IPv6. Support for SNMPv2 classic (a.k.a. "SNMPv2 historic" - RFCs 1441-1452) was dropped with the 4.0 release of the UCD-snmp package. The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system."
+    description: 'Simple Network Management Protocol (SNMP) is a widely used protocol for monitoring the health and welfare of network equipment, computer equipment and devices like UPSs. Net-SNMP is a suite of applications used to implement SNMPv1 (RFC 1157), SNMPv2 (RFCs 1901-1908), and SNMPv3 (RFCs 3411-3418) using both IPv4 and IPv6. Support for SNMPv2 classic (a.k.a. "SNMPv2 historic" - RFCs 1441-1452) was dropped with the 4.0 release of the UCD-snmp package. The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system.'
     rationale: "The SNMP server can communicate using SNMPv1, which transmits data in the clear and does not require authentication to execute commands. SNMPv3 replaces the simple/clear text password sharing used in SNMPv2 with more securely encoded parameters. If the the SNMP service is not required, the net-snmp package should be removed to reduce the attack surface of the system. Note: If SNMP is required: The server should be configured for SNMP v3 only. User Authentication and Message Encryption should be configured. If SNMP v2 is absolutely necessary, modify the community strings' values."
     remediation: "Run the following command to remove snmp: # apt purge snmp"
     compliance:
@@ -583,7 +585,7 @@ checks:
       - mitre_mitigations: ["M1042"]
     condition: all
     rules:
-      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' snmp -> unknown ok not-installed"
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' snmp -> r:unknown ok not-installed"
 
   # 2.2.14 Ensure NIS Server is not installed (Automated)
   - id: 3071
@@ -606,7 +608,7 @@ checks:
       - mitre_mitigations: ["M1042"]
     condition: all
     rules:
-      - "dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' nis -> r:unknown ok not-installed"
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' nis -> r:unknown ok not-installed"
 
   # 2.2.15 Ensure mail transfer agent is configured for local-only mode (Automated)
   - id: 3072
@@ -652,10 +654,9 @@ checks:
       - mitre_mitigations: ["M1042"]
     condition: any
     rules:
-      - 'c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' rsync -> r:unknown ok not-installed'
-      - 'c:systemctl is-active rsync -> r:inactive'
+      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' rsync -> r:unknown ok not-installed"
+      - 'c:systemctl is-active rsync -> r:^inactive'
       - 'c:systemctl is-enabled rsync -> r:masked'
-
 
   ############################################################
   # 2.3 Service Clients

--- a/ruleset/sca/debian/cis_debian11.yml
+++ b/ruleset/sca/debian/cis_debian11.yml
@@ -71,25 +71,25 @@ checks:
       - 'f:/etc/chrony/chrony.conf -> r:^server\.+|^pool\.+'
 
   # 2.1.2.2 Ensure chrony is running as user _chrony (Automated)
-#  - id: 3048
-#    title: "Ensure chrony is running as user _chrony"
-#    description: "The chrony package is installed with a dedicated user account _chrony. This account is granted the access required by the chronyd service."
-#    rationale: "The chronyd service should run with only the required privlidges"
-#    remediation: "Add or edit the user line to /etc/chrony/chrony.conf or a file ending in .conf in /etc/chrony/conf.d/: user _chrony OR If another time synchronization service is in use on the system, run the following command to remove chrony from the system: # apt purge chrony Default Value: user _chrony" 
-#    default value: "user _chrony"
-#    compliance:
-#      - cis: ["2.1.2.2"]
-#      - cis_csc_v8: ["8.4"]
-#      - cis_csc_v7: ["6.1"]
-#      - cmmc_v2.0: ["AU.L2-3.3.7"]
-#      - pci_dss_3.2.1: ["10.4"]
-#      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
-#      - nist_sp_800-53: ["AU-7"]
-#      - soc_2: ["CC4.1","CC5.2"]
-#      - iso_27001-2013: ["A.12.4.4"]
-#    condition: all
-#    rules:
-#      - 'c:ps -ef -> r:^\s*chronyd && r:^chrony'
+  - id: 3048
+    title: "Ensure chrony is running as user _chrony"
+    description: "The chrony package is installed with a dedicated user account _chrony. This account is granted the access required by the chronyd service."
+    rationale: "The chronyd service should run with only the required privlidges"
+    remediation: "Add or edit the user line to /etc/chrony/chrony.conf or a file ending in .conf in /etc/chrony/conf.d/: user _chrony OR If another time synchronization service is in use on the system, run the following command to remove chrony from the system: # apt purge chrony Default Value: user _chrony" 
+    default value: "user _chrony"
+    compliance:
+      - cis: ["2.1.2.2"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+    condition: all
+    rules:
+      - 'f:/etc/chrony/chrony.conf -> r:^user _chrony'
 
   # 2.1.2.3 Ensure chrony is enabled and running (Automated)
   - id: 3049
@@ -169,62 +169,86 @@ checks:
   # 2.1.4 Configure ntp
   ############################################################
 
-  # 2.1.4.1 Ensure ntp access control is configured (Automated) - Not Implemented
-#
+  # 2.1.4.1 Ensure ntp access control is configured (Automated)
+  - id: 3052
+    title: "Ensure ntp access control is configured"
+    description: "ntp Access Control Commands: restrict address [mask mask] [ippeerlimit int] [flag ...] The address argument expressed in dotted-quad form is the address of a host or network. Alternatively, the address argument can be a valid host DNS name. The mask argument expressed in dotted-quad form defaults to 255.255.255.255, meaning that the address is treated as the address of an individual host. A default entry (address 0.0.0.0, mask 0.0.0.0) is always included and is always the first entry in the list. Note: the text string default, with no mask option, may be used to indicate the default entry. The ippeerlimit directive limits the number of peer requests for each IP to int, where a value of -1 means'unlimited', the current default. A value of 0 means 'none'. There would usually be at most 1 peering request per IP, but if the remote peering requests are behind a proxy there could well be more than 1 per IP. In the current implementation, flag always restricts access, i.e., an entry with no flags indicates that free access to the server is to be given. The flags are not orthogonal, in that more restrictive flags will often make less restrictive ones redundant. The flags can generally be classed into two categories, those which restrict time service and those which restrict informational queries and attempts to do run-time reconfiguration of the server.One or more of the following flags may be specified kod - If this flag is set when an access violation occurs, a kiss-o-death (KoD) packet is sent. KoD packets are rate limited to no more than one per second. If another KoD packet occurs within one second after the last one, the packet is dropped. limited - Deny service if the packet spacing violates the lower limits specified in the discard command. A history of clients is kept using the monitoring capability of ntpd. Thus, monitoring is always active as long as there is a restriction entry with the limited flag. lowpriotrap - Declare traps set by matching hosts to be low priority. The number of traps a server can maintain is limited (the current limit is 3). Traps are usually assigned on a first come, first served basis, with later trap requestors being denied service. This flag modifies the assignment algorithm by allowing low priority traps to be overridden by later requests for normal priority traps. noepeer - Deny ephemeral peer requests, even if they come from an authenticated source. Note that the ability to use a symmetric key for authentication may be restricted to one or more IPs or subnets via the third field of the ntp.keys file. This restriction is not enabled by default, to maintain backward compatibility. Expect noepeer to become the default in ntp-4.4. nomodify - Deny ntpq and ntpdc queries which attempt to modify the state of the server (i.e., run time reconfiguration). Queries which return information are permitted. noquery - Deny ntpq and ntpdc queries. Time service is not affected. nopeer - Deny unauthenticated packets which would result in mobilizing a new association. This includes broadcast and symmetric active packets when a configured association does not exist. It also includes pool associations, so if you want to use servers from a pool directive and also want to use nopeer by default you'll want a restrict source ... line as well that does not include the nopeer directive. noserve - Deny all packets except ntpq and ntpdc queries.notrap - Decline to provide mode 6 control message trap service to matching hosts. The trap service is a subsystem of the ntpq control message protocol which is intended for use by remote event logging programs. notrust - Deny service unless the packet is cryptographically authenticated. ntpport - This is actually a match algorithm modifier, rather than a restriction flag. Its presence causes the restriction entry to be matched only if the source port in the packet is the standard NTP UDP port (123). Both ntpport and non- ntpport may be specified. The ntpport is considered more specific and is sorted later in the list."
+    rationale: "If ntp is in use on the system, proper configuration is vital to ensuring time synchronization is accurate."
+    remediation: "Add or edit restrict lines in /etc/ntp.conf to match the following: restrict -4 default kod nomodify notrap nopeer noquery restrict -6 default kod nomodify notrap nopeer noquery ORIf another time synchronization service is in use on the system, run the following command to remove ntp from the system: # apt purge ntp Default Value: restrict -4 default kod notrap nomodify nopeer noquery limited restrict -6 default kod notrap nomodify nopeer noquery limited" 
+    default value: "restrict -4 default kod notrap nomodify nopeer noquery limited ;restrict -6 default kod notrap nomodify nopeer noquery limited"
+    references:
+      - http://www.ntp.org/
+      - ntp.conf(5)
+      - ntpd(8)
+    compliance:
+      - cis: ["2.1.4.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+    condition: any
+    rules:
+      - 'f:/etc/ntp.conf -> r:^restrict\s+-4\s+default && r:\s+kod\s+ && r:\s+nomodify\s+ && r:\s+notrap\s+ && r:\s+nopeer\s+ && r:\s+noquery'
+      - 'f:/etc/ntp.conf -> r:^restrict\s+-6\s+default && r:\s+kod\s+ && r:\s+nomodify\s+ && r:\s+notrap\s+ && r:\s+nopeer\s+ && r:\s+noquery'
+
   # 2.1.4.2 Ensure ntp is configured with authorized timeserver (Manual)
-#  - id: 3052
-#    title: "Ensure ntp is configured with authorized timeserver"
-#    description: 'The various modes are determined by the command keyword and the type of the required IP address. Addresses are classed by type as (s) a remote server or peer (IPv4 class A, B and C), (b) the broadcast address of a local interface, (m) a multicast address (IPv4 class D), or (r) a reference clock address (127.127.x.x). Note: That only those options applicable to each command are listed below. Use of options not listed may not be caught as an error, but may result in some weird and even destructive behavior. If the Basic Socket Interface Extensions for IPv6 (RFC-2553) is detected, support for the IPv6 address family is generated in addition to the default support of the IPv4 address family. In a few cases, including the reslist billboard generated by ntpq or ntpdc, IPv6 addresses are automatically generated. IPv6 addresses can be identified by the presence of colons “:” in the address field. IPv6 addresses can be used almost everywhere where IPv4 addresses can be used, with the exception of reference clock addresses, which are always IPv4. Note: In contexts where a host name is expected, a -4 qualifier preceding the host name forces DNS resolution to the IPv4 namespace, while a -6 qualifier forces DNS resolution to the IPv6 namespace. See IPv6 references for the equivalent classes for that address family. (1)pool - For type s addresses, this command mobilizes a persistent client mode association with a number of remote servers. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. (2)server - For type s and r addresses, this command mobilizes a persistent client mode association with the specified remote server or local radio clock. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. This command should not be used for type b or m addresses.'
-#    rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations"
-#    remediation: "Edit /etc/ntp.conf and add or edit server or pool lines as appropriate according to local site policy: <[server|pool]> <[remote-server|remote-pool]> Examples: pool mode: pool time.nist.gov iburst server mode: server time-a-g.nist.gov iburst server 132.163.97.3 iburst server time-d-b.nist.gov iburst Run the following command to load the updated time sources into ntp running config: # systemctl restart ntp OR If another time synchronization service is in use on the system, run the following command to remove ntp from the system: # apt purge ntp" 
-#    references:
-#      - http://www.ntp.org/
-#      - https://tf.nist.gov/tf-cgi/servers.cgi
-#      - ntp.conf(5)
-#      - ntpd(8)
-#    compliance:
-#      - cis: ["2.1.4.2"]
-#      - cis_csc_v8: ["8.4"]
-#      - cis_csc_v7: ["6.1"]
-#      - cmmc_v2.0: ["AU.L2-3.3.7"]
-#      - pci_dss_3.2.1: ["10.4"]
-#      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
-#      - nist_sp_800-53: ["AU-7"]
-#      - soc_2: ["CC4.1","CC5.2"]
-#      - iso_27001-2013: ["A.12.4.4"]
-#      - mitre_techniques: ["T1070","T1070.002","T1498","T1498.002","T1562","T1562.001"]
-#      - mitre_tactics: ["TA0002"]
-#      - mitre_mitigations: ["M1022"]
-#    condition: all
-#    rules:
-#      - "c:grep -Rh ^*.* /etc/ntp.conf -> r:^\h*(server|pool)\h+\H+"
-#
+  - id: 3053
+    title: "Ensure ntp is configured with authorized timeserver"
+    description: "The various modes are determined by the command keyword and the type of the required IP address. Addresses are classed by type as (s) a remote server or peer (IPv4 class A, B and C), (b) the broadcast address of a local interface, (m) a multicast address (IPv4 class D), or (r) a reference clock address (127.127.x.x). Note: That only those options applicable to each command are listed below. Use of options not listed may not be caught as an error, but may result in some weird and even destructive behavior. If the Basic Socket Interface Extensions for IPv6 (RFC-2553) is detected, support for the IPv6 address family is generated in addition to the default support of the IPv4 address family. In a few cases, including the reslist billboard generated by ntpq or ntpdc, IPv6 addresses are automatically generated. IPv6 addresses can be identified by the presence of colons : in the address field. IPv6 addresses can be used almost everywhere where IPv4 addresses can be used, with the exception of reference clock addresses, which are always IPv4. Note: In contexts where a host name is expected, a -4 qualifier preceding the host name forces DNS resolution to the IPv4 namespace, while a -6 qualifier forces DNS resolution to the IPv6 namespace. See IPv6 references for the equivalent classes for that address family. (1)pool - For type s addresses, this command mobilizes a persistent client mode association with a number of remote servers. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. (2)server - For type s and r addresses, this command mobilizes a persistent client mode association with the specified remote server or local radio clock. In this mode the local clock can synchronized to the remote server, but the remote server can never be synchronized to the local clock. This command should not be used for type b or m addresses."
+    rationale: "Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations"
+    remediation: "Edit /etc/ntp.conf and add or edit server or pool lines as appropriate according to local site policy: <[server|pool]> <[remote-server|remote-pool]> Examples: pool mode: pool time.nist.gov iburst server mode: server time-a-g.nist.gov iburst server 132.163.97.3 iburst server time-d-b.nist.gov iburst Run the following command to load the updated time sources into ntp running config: # systemctl restart ntp OR If another time synchronization service is in use on the system, run the following command to remove ntp from the system: # apt purge ntp" 
+    references:
+      - http://www.ntp.org/
+      - https://tf.nist.gov/tf-cgi/servers.cgi
+      - ntp.conf(5)
+      - ntpd(8)
+    compliance:
+      - cis: ["2.1.4.2"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - mitre_techniques: ["T1070","T1070.002","T1498","T1498.002","T1562","T1562.001"]
+      - mitre_tactics: ["TA0002"]
+      - mitre_mitigations: ["M1022"]
+    condition: all
+    rules:
+      - 'f:/etc/ntp.conf -> r:pool'
+      - 'f:/etc/ntp.conf -> r:server'
+
   # 2.1.4.3 Ensure ntp is running as user ntp (Automated) 
-#  - id: 3053
-#    title: "Ensure ntp is running as user ntp"
-#    description: "The ntp package is installed with a dedicated user account ntp. This account is granted the access required by the ntpd daemon Note: If chrony or systemd-timesyncd are used, ntp should be removed and this section skipped This recommendation only applies if ntp is in use on the system Only one time synchronization method should be in use on the system"
-#    rationale: "The ntpd daemon should run with only the required privlidge"
-#    remediation: "Add or edit the following line in /etc/init.d/ntp: RUNASUSER=ntp .Run the following command to restart ntp.servocee: # systemctl restart ntp.service OR If another time synchronization service is in use on the system, run the following command to remove ntp from the system: # apt purge ntp Default Value: user ntp" 
-#    default value: "user ntp"
-#    references:
-#      - http://www.ntp.org/
-#    compliance:
-#      - cis: ["2.1.4.3"]
-#      - cis_csc_v8: ["8.4"]
-#      - cis_csc_v7: ["6.1"]
-#      - cmmc_v2.0: ["AU.L2-3.3.7"]
-#      - pci_dss_3.2.1: ["10.4"]
-#      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
-#      - nist_sp_800-53: ["AU-7"]
-#      - soc_2: ["CC4.1","CC5.2"]
-#      - iso_27001-2013: ["A.12.4.4"]
-#    condition: any
-#    rules:
-#      - "ps -ef | awk '(/[n]tpd/ && $1!="ntp") { print $1 }'"
-#      - 'grep -P -- '^\h*RUNASUSER=' /etc/init.d/ntp -> r:RUNASUSER=ntp'
+  - id: 3054
+    title: "Ensure ntp is running as user ntp"
+    description: "The ntp package is installed with a dedicated user account ntp. This account is granted the access required by the ntpd daemon Note: If chrony or systemd-timesyncd are used, ntp should be removed and this section skipped This recommendation only applies if ntp is in use on the system Only one time synchronization method should be in use on the system"
+    rationale: "The ntpd daemon should run with only the required privlidge"
+    remediation: "Add or edit the following line in /etc/init.d/ntp: RUNASUSER=ntp .Run the following command to restart ntp.servocee: # systemctl restart ntp.service OR If another time synchronization service is in use on the system, run the following command to remove ntp from the system: # apt purge ntp Default Value: user ntp" 
+    default value: "user ntp"
+    references:
+      - http://www.ntp.org/
+    compliance:
+      - cis: ["2.1.4.3"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - pci_dss_3.2.1: ["10.4"]
+      - pci_dss_4.0: ["10.6","10.6.1","10.6.2","10.6.3"]
+      - nist_sp_800-53: ["AU-7"]
+      - soc_2: ["CC4.1","CC5.2"]
+      - iso_27001-2013: ["A.12.4.4"]
+    condition: all
+    rules:
+      - "f:/etc/init.d/ntp -> r:RUNASUSER=ntp"
 
   # 2.1.4.4 Ensure ntp is enabled and running (Automated)
-  - id: 3054
+  - id: 3055
     title: "Ensure ntp is enabled and running"
     description: "ntp is a daemon for synchronizing the system clock across the network"
     rationale: "ntp needs to be enabled and running in order to synchronize the system to a timeserver. Time synchronization is important to support time sensitive security mechanisms and to ensure log files have consistent time records across the enterprise to aid in forensic investigations"
@@ -249,7 +273,7 @@ checks:
   ############################################################
 
   # 2.2.1 Ensure X Window System is not installed (Automated)
-  - id: 3055
+  - id: 3056
     title: "Ensure X Window System is not installed"
     description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
     rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
@@ -271,7 +295,7 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' xserver-xorg -> r:unknown ok not-installed"
 
   # 2.2.2 Ensure Avahi Server is not installed (Automated)
-  - id: 3056
+  - id: 3057
     title: "Ensure Avahi Server is not installed"
     description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
     rationale: "Automatic discovery of network services is not normally required for system functionality. It is recommended to remove this package to reduce the potential attack surface."
@@ -294,7 +318,7 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' avahi-daemon -> r:unknown ok not-installed"
 
   # 2.2.3 Ensure CUPS is not installed (Automated)
-  - id: 3057
+  - id: 3058
     title: "Ensure CUPS is not installed"
     description: "The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability."
     rationale: "If the system does not need to print jobs or accept print jobs from other systems, it is recommended that CUPS be removed to reduce the potential attack surface."
@@ -319,7 +343,7 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' cups -> r:unknown ok not-installed"
 
   # 2.2.4 Ensure DHCP Server is not installed (Automated)
-  - id: 3058
+  - id: 3059
     title: "Ensure DHCP Server is not installed"
     description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
     rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that this package be removed to reduce the potential attack surface."
@@ -344,7 +368,7 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' isc-dhcp-server -> r:unknown ok not-installed"
 
   # 2.2.5 Ensure LDAP server is not installed (Automated)
-  - id: 3059
+  - id: 3060
     title: "Ensure LDAP server is not installed"
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP server, it is recommended that the software be removed to reduce the potential attack surface."
@@ -369,7 +393,7 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' slapd -> r:unknown ok not-installed"
 
   # 2.2.6 Ensure NFS is not installed (Automated)
-  - id: 3060
+  - id: 3061
     title: "Ensure NFS is not installed"
     description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
     rationale: "If the system does not export NFS shares, it is recommended that the nfs-kernel-server package be removed to reduce the remote attack surface."
@@ -389,7 +413,7 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' nfs-kernel-server -> r:unknown ok not-installed"
 
   # 2.2.7 Ensure DNS Server is not installed (Automated)
-  - id: 3061
+  - id: 3062
     title: "Ensure DNS Server is not installed"
     description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
     rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the package be deleted to reduce the potential attack surface."
@@ -412,7 +436,7 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' bind9 -> r:unknown ok not-installed"
 
   # 2.2.8 Ensure FTP Server is not installed (Automated)
-  - id: 3062
+  - id: 3063
     title: "Ensure FTP Server is not installed"
     description: "The File Transfer Protocol (FTP) provides networked computers with the ability to transfer files."
     rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended SFTP be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the package be deleted to reduce the potential attack surface."
@@ -436,7 +460,7 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' vsftpd -> r:unknown ok not-installed"
 
   # 2.2.9 Ensure HTTP server is not installed (Automated)
-  - id: 3063
+  - id: 3064
     title: "Ensure HTTP server is not installed"
     description: "HTTP or web servers provide the ability to host web site content."
     rationale: "Unless there is a need to run the system as a web server, it is recommended that the package be deleted to reduce the potential attack surface."
@@ -460,7 +484,7 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' apache2 -> r:unknown ok not-installed"
 
   # 2.2.10 Ensure IMAP and POP3 server are not installed(Automated)
-  - id: 3064
+  - id: 3065
     title: "Ensure IMAP and POP3 server are not installed"
     description: "dovecot-imapd and dovecot-pop3d are an open source IMAP and POP3 server for Linux based systems."
     rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the package be removed to reduce the potential attack surface."
@@ -481,10 +505,11 @@ checks:
       - mitre_mitigations: ["M1042"]
     condition: all
     rules:
-      - "not c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' dovecot-imapd dovecot-pop3d -> r:install ok installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' dovecot-imapd -> r:install ok installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' dovecot-pop3d -> r:install ok installed"
 
   # 2.2.11 Ensure Samba is not installed (Automated)
-  - id: 3065
+  - id: 3066
     title: "Ensure Samba is not installed"
     description: "The Samba daemon allows system administrators to configure their Linux systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Server Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
     rationale: "If there is no need to mount directories and file systems to Windows systems, then this service should be deleted to reduce the potential attack surface."
@@ -506,7 +531,7 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' samba -> r:unknown ok not-installed"
 
   # 2.2.12 Ensure HTTP Proxy Server is not installed (Automated)
-  - id: 3066
+  - id: 3067
     title: "Ensure HTTP Proxy Server is not installed"
     description: "Squid is a standard proxy server used in many distributions and environments."
     rationale: "If there is no need for a proxy server, it is recommended that the squid proxy be deleted to reduce the potential attack surface."
@@ -529,7 +554,7 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' squid -> r:unknown ok not-installed"
 
   # 2.2.13 Ensure SNMP Server is not installed (Automated)
-  - id: 3067
+  - id: 3068
     title: "Ensure SNMP Server is not installed"
     description: 'Simple Network Management Protocol (SNMP) is a widely used protocol for monitoring the health and welfare of network equipment, computer equipment and devices like UPSs. Net-SNMP is a suite of applications used to implement SNMPv1 (RFC 1157), SNMPv2 (RFCs 1901-1908), and SNMPv3 (RFCs 3411-3418) using both IPv4 and IPv6. Support for SNMPv2 classic (a.k.a. "SNMPv2 historic" - RFCs 1441-1452) was dropped with the 4.0 release of the UCD-snmp package. The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system.'
     rationale: "The SNMP server can communicate using SNMPv1, which transmits data in the clear and does not require authentication to execute commands. SNMPv3 replaces the simple/clear text password sharing used in SNMPv2 with more securely encoded parameters. If the the SNMP service is not required, the net-snmp package should be removed to reduce the attack surface of the system. Note: If SNMP is required: The server should be configured for SNMP v3 only. User Authentication and Message Encryption should be configured. If SNMP v2 is absolutely necessary, modify the community strings' values."
@@ -552,7 +577,7 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' snmp -> r:unknown ok not-installed"
 
   # 2.2.14 Ensure NIS Server is not installed (Automated)
-  - id: 3068
+  - id: 3069
     title: "Ensure NIS Server is not installed"
     description: "The Network Information Service (NIS) (formally known as Yellow Pages) is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed and other, more secure services be used"
@@ -575,7 +600,7 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' nis -> r:unknown ok not-installed"
 
   # 2.2.15 Ensure mail transfer agent is configured for local-only mode (Automated)
-  - id: 3069
+  - id: 3070
     title: "Ensure mail transfer agent is configured for local-only mode"
     description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
     rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems. Note: This recommendation is designed around the postfix mail server. Depending on your environment you may have an alternative MTA installed such as exim4. If this is the case consult the documentation for your installed MTA to configure the recommended state."
@@ -598,7 +623,7 @@ checks:
       - 'c:ss -lntu -> r:\.*:25\.*LISTEN && !r:127.0.0.1:25\.+LISTEN|::1:25\.*LISTEN'
 
   # 2.2.16 Ensure rsync service is either not installed or masked (Automated)
-  - id: 3070
+  - id: 3071
     title: "Ensure rsync service is either not installed or masked"
     description: "The rsync service can be used to synchronize files between systems over network links."
     rationale: "The rsync service presents a security risk as it uses unencrypted protocols for communication. The rsync package should be removed to reduce the attack area of the system."
@@ -620,13 +645,13 @@ checks:
     rules:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' rsync -> r:unknown ok not-installed"
       - 'c:systemctl is-active rsync -> r:^inactive'
-      - 'c:systemctl is-enabled rsync -> r:masked'
+      - 'c:systemctl is-enabled rsync -> r:^masked'
 
   ############################################################
   # 2.3 Service Clients
   ############################################################
   # 2.3.1 Ensure NIS Client is not installed (Automated)
-  - id: 3071
+  - id: 3072
     title: "Ensure NIS Client is not installed"
     description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files. The NIS client was used to bind a machine to an NIS server and receive the distributed configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
@@ -650,7 +675,7 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' nis -> r:unknown ok not-installed"
 
   # 2.3.2 Ensure rsh client is not installed (Automated)
-  - id: 3072
+  - id: 3073
     title: "Ensure rsh client is not installed"
     description: "The rsh-client package contains the client commands for the rsh services."
     rationale: "These legacy clients contain numerous security exposures and have been replaced with the more secure SSH package. Even if the server is removed, it is best to ensure the clients are also removed to prevent users from inadvertently attempting to use these commands and therefore exposing their credentials. Note that removing the rsh package removes the clients for rsh , rcp and rlogin ."
@@ -674,7 +699,7 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' rsh-client -> r:unknown ok not-installed"
 
   # 2.3.3 Ensure talk client is not installed (Automated)
-  - id: 3073
+  - id: 3074
     title: "Ensure talk client is not installed"
     description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client, which allows initialization of talk sessions, is installed by default."
     rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
@@ -695,10 +720,10 @@ checks:
       - mitre_mitigations: ["M1041","M1042"]
     condition: all
     rules:
-      - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' talk -> r:unknown ok not-installed"
+      - "not c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' talk -> r:install ok installed"
 
   # 2.3.4 Ensure telnet client is not installed (Automated)
-  - id: 3074
+  - id: 3075
     title: "Ensure telnet client is not installed"
     description: "The telnet package contains the telnet client, which allows users to start connections to other systems via the telnet protocol."
     rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow an unauthorized user to steal credentials. The ssh package provides an encrypted session and stronger security and is included in most Linux distributions."
@@ -722,7 +747,7 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' telnet -> r:unknown ok not-installed"
 
   # 2.3.5 Ensure LDAP client is not installed (Automated)
-  - id: 3075
+  - id: 3076
     title: "Ensure LDAP client is not installed"
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP client, it is recommended that the software be removed to reduce the potential attack surface."
@@ -746,7 +771,7 @@ checks:
       - "c:dpkg-query -W -f='${binary:Package}\t${Status}\t${db:Status-Status}\n' ldap-utils -> r:unknown ok not-installed"
 
   # 2.3.6 Ensure RPC is not installed (Automated)
-  - id: 3076
+  - id: 3077
     title: "Ensure RPC is not installed"
     description: "Remote Procedure Call (RPC) is a method for creating low level client server applications across different system architectures. It requires an RPC compliant client listening on a network port. The supporting package is rpcbind."
     rationale: "If RPC is not required, it is recommended that this services be removed to reduce the remote attack surface."


### PR DESCRIPTION
| Component | Action type           | Main Issue 
| --- | --- | ---
| SCA       | Rework |  #14358 

# Description
This is the Second Section of the SCA policy for Debian 11 based on the CIS benchmark

## Main tasks

- [ ] Use the latest CIS benchmark PDF - CIS Debian Linux 11 Benchmark v1.0.0
- [ ] Verify IDs numbers.
- [ ] Verify texts are correct: Title, Description, Rationale and Remediation.
- [ ] Verify Compliance: CIS, CIS_CSC.
- [ ] Verify condtion and rules:
  - [ ] To Pass.
  - [ ] To Fail.
- [ ] Solve Related issues:

## Checks
### Syntax and semantic

- [ ] a) ID of each policy must be contiguous.
- [ ] b) The order and format set in [Documentation](https://documentation.wazuh.com/current/user-manual/capabilities/sec-config-assessment/creating-custom-policies.html) must be respected.
- [ ] c) YML must be valid to avoid errors.

### Content

- [ ] a) Compare each check with its analog from CIS Benchmark.
- [ ] b) Try maintaining each rule as similar as possible with the `Audit` section from the CIS check.
- [ ] c) Check that the commands provide the expected output.
- [ ] d) When a failure is discovered, check similar policies to avoid repetition of the issue.

### Unit testing

- [ ] a) Output from `ossec.log` after the SCA scan and a raw output of the result of the checks.
<details><summary>Tests results</summary>
<p>

#### Analysisd (server or local)
analysisd.debug=2

#### Auth daemon debug (server)
authd.debug=0

#### Exec daemon debug (server, local, or Unix agent)
execd.debug=0

#### Monitor daemon debug (server, local, or Unix agent)
monitord.debug=0

#### Log collector (server, local or Unix agent)
logcollector.debug=0

#### Integrator daemon debug (server, local or Unix agent)
integrator.debug=0

#### Unix agentd
agent.debug=2

</p>
</details>

### Deployment

- [ ] a) If the policy it's new, it must be added to the `sca.files` templates.
- [ ] b) If the OS has many supported SCA policies, a policy must be set as the default policy. ([as example](https://github.com/wazuh/wazuh/blob/master/etc/templates/config/centos/sca.files))