### PR TITLE
Wildcard support in Windows registers

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -637,8 +637,8 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
                 paths_wildcard++;
             }
             paths_wildcard = start_vector;
-		    w_FreeArray(paths_wildcard);
-		    os_free(paths_wildcard);
+            w_FreeArray(paths_wildcard);
+            os_free(paths_wildcard);
             mdebug1(FIM_WILDCARDS_REGISTERS_FINALIZE);
         } else {
             /* Add new entry */

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -620,10 +620,10 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
         /* Expand any wildcard */
         char** paths_wildcard = NULL;
         char** start_vector   = paths_wildcard;
-        os_calloc(OS_SIZE_8192,sizeof(char*),paths_wildcard);
-        expand_wildcard_registers(entry[i],paths_wildcard);
+        os_calloc(OS_SIZE_8192, sizeof(char*), paths_wildcard);
+        expand_wildcard_registers(entry[i], paths_wildcard);
 
-        if(*paths_wildcard != NULL){
+        if (*paths_wildcard != NULL) {
             mdebug1(FIM_WILDCARDS_REGISTERS_START);
             while(*paths_wildcard != NULL){
                 mdebug2(FIM_WILDCARDS_ADD_REGISTER, entry[i], *paths_wildcard);
@@ -637,8 +637,7 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
                 paths_wildcard++;
             }
             paths_wildcard = start_vector;
-            w_FreeArray(paths_wildcard);
-            os_free(paths_wildcard);
+            free_strarray(paths_wildcard);
             mdebug1(FIM_WILDCARDS_REGISTERS_FINALIZE);
         } else {
             /* Add new entry */

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -619,25 +619,23 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
 
         /* Expand any wildcard */
         char** paths_wildcard = NULL;
-        char** start_vector   = paths_wildcard;
         os_calloc(OS_SIZE_8192, sizeof(char*), paths_wildcard);
         expand_wildcard_registers(entry[i], paths_wildcard);
 
         if (*paths_wildcard != NULL) {
             mdebug1(FIM_WILDCARDS_REGISTERS_START);
-            while(*paths_wildcard != NULL){
-                mdebug2(FIM_WILDCARDS_ADD_REGISTER, entry[i], *paths_wildcard);
+            char** current_path = paths_wildcard;
+            while(*current_path != NULL){
+                mdebug2(FIM_WILDCARDS_ADD_REGISTER, entry[i], *current_path);
                 /* Add new entry */
                 if (arch == ARCH_BOTH) {
-                    dump_syscheck_registry(syscheck, *paths_wildcard, opts, restrict_key, restrict_value, recursion_level, tag, ARCH_64BIT, tmp_diff_size);
-                    dump_syscheck_registry(syscheck, *paths_wildcard, opts, restrict_key, restrict_value, recursion_level, tag, ARCH_32BIT, tmp_diff_size);
+                    dump_syscheck_registry(syscheck, *current_path, opts, restrict_key, restrict_value, recursion_level, tag, ARCH_64BIT, tmp_diff_size);
+                    dump_syscheck_registry(syscheck, *current_path, opts, restrict_key, restrict_value, recursion_level, tag, ARCH_32BIT, tmp_diff_size);
                 } else {
-                    dump_syscheck_registry(syscheck, *paths_wildcard, opts, restrict_key, restrict_value, recursion_level, tag, arch, tmp_diff_size);
+                    dump_syscheck_registry(syscheck, *current_path, opts, restrict_key, restrict_value, recursion_level, tag, arch, tmp_diff_size);
                 }
-                paths_wildcard++;
+                current_path++;
             }
-            paths_wildcard = start_vector;
-            free_strarray(paths_wildcard);
             mdebug1(FIM_WILDCARDS_REGISTERS_FINALIZE);
         } else {
             /* Add new entry */
@@ -648,6 +646,7 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
                 dump_syscheck_registry(syscheck, tmp_entry, opts, restrict_key, restrict_value, recursion_level, tag, arch, tmp_diff_size);
             }
         }
+        free_strarray(paths_wildcard);
         /* Next entry */
         free(entry[i]);
     }

--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -276,6 +276,9 @@
 #define FIM_WHODATA_SUCCESS_POLICY          "(6369): Found Audit %s subcategory configured to success. GUID: %s"
 #define FIM_REGISTRY_LIMIT_VALUE            "(6370): Maximum number of registry values to be monitored: '%u'"
 #define FIM_REGISTRY_VALUES_ENTRIES_INFO    "(6371): Fim registry values entries count: '%d'"
+#define FIM_WILDCARDS_REGISTERS_START       "(6372): Starting configuration for Windows registry wildcards."
+#define FIM_WILDCARDS_ADD_REGISTER          "(6373): Expanding entry '%s' to '%s' to monitor FIM events."
+#define FIM_WILDCARDS_REGISTERS_FINALIZE    "(6374): Wildcard configuration successfully completed."
 
 /* Modules messages */
 #define WM_UPGRADE_RESULT_AGENT_INFO         "(8151): Agent Information obtained: '%s'"

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -474,10 +474,9 @@ void w_expand_by_wildcard(reg_path_struct **array_struct,char wildcard_chr);
  * @brief Extract the subkey from path (Windows)
  *
  * @param [in] key String path that contains the key and subkey.
- * @param [out] chrwildcard Delimiter of the wildcard.
  * @return Allocated subkey or NULL if there is not one.
  */ 
-char* get_subkey(char* key, char chrwildcard);
+char* get_subkey(char* key);
 
 /**
  * @brief Return all possible paths based in a entry  (Windows)

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -78,9 +78,8 @@ extern const char *SYSCHECK_EVENT_STRINGS[];
 #define check_wildcard(x)                       strchr(x,'*') || strchr(x,'?')
 
 /* Fields for paths */
-typedef struct __path_strct{
+typedef struct __path_strct {
     char* path;
-
     int has_wildcard;
     int checked;
 } reg_path_struct;

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -78,7 +78,7 @@ extern const char *SYSCHECK_EVENT_STRINGS[];
 #define check_wildcard(x)                       strchr(x,'*') || strchr(x,'?')
 
 /* Fields for paths */
-typedef struct __path_strct {
+typedef struct _reg_path_struct {
     char* path;
     int has_wildcard;
     int checked;
@@ -466,7 +466,7 @@ char** w_list_all_keys(HKEY root_key, char* str_subkey);
  * @param [in] array_struct Array of all possible paths.
  * @param [out] array_struct Array of paths with tag checked in 1 and has_wildcard in 0.
  */
-void w_expand_by_wildcard(reg_path_struct **array_struct,char wildcard_chr);
+void w_expand_by_wildcard(reg_path_struct **array_struct, char wildcard_chr);
 
 
 /**
@@ -483,7 +483,7 @@ char* get_subkey(char* key);
  * @param [in] entry Raw entry read from config file.
  * @param [out] paths Array of paths expanded with tag checked in 1 and has_wildcard in 0.
  */
-void expand_wildcard_registers(char* entry,char** paths);
+void expand_wildcard_registers(char* entry, char** paths);
 
 #endif
 

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -465,7 +465,7 @@ char** w_list_all_keys(HKEY root_key, char* str_subkey);
  *
  * @param [in] array_struct Array of all possible paths.
  * @param [out] array_struct Array of paths with tag checked in 1 and has_wildcard in 0.
- */ 
+ */
 void w_expand_by_wildcard(reg_path_struct **array_struct,char wildcard_chr);
 
 
@@ -474,7 +474,7 @@ void w_expand_by_wildcard(reg_path_struct **array_struct,char wildcard_chr);
  *
  * @param [in] key String path that contains the key and subkey.
  * @return Allocated subkey or NULL if there is not one.
- */ 
+ */
 char* get_subkey(char* key);
 
 /**
@@ -482,7 +482,7 @@ char* get_subkey(char* key);
  *
  * @param [in] entry Raw entry read from config file.
  * @param [out] paths Array of paths expanded with tag checked in 1 and has_wildcard in 0.
- */ 
+ */
 void expand_wildcard_registers(char* entry,char** paths);
 
 #endif

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -64,8 +64,26 @@ extern const char *SYSCHECK_EVENT_STRINGS[];
 #include "shared.h"
 #include "aclapi.h"
 #include <sddl.h>
+#include <winreg.h>
 
 #define BUFFER_LEN 1024
+
+//Windows registers
+#define STR_HKEY_CLASSES_ROOT                   "HKEY_CLASSES_ROOT"
+#define STR_HKEY_CURRENT_CONFIG                 "HKEY_CURRENT_CONFIG"
+#define STR_HKEY_CURRENT_USER                   "HKEY_CURRENT_USER"
+#define STR_HKEY_LOCAL_MACHINE                  "HKEY_LOCAL_MACHINE"
+#define STR_HKEY_PERFORMANCE_DATA               "HKEY_PERFORMANCE_DATA"
+#define STR_HKEY_USERS                          "HKEY_USERS"
+#define check_wildcard(x)                       strchr(x,'*') || strchr(x,'?')
+
+/* Fields for paths */
+typedef struct __path_strct{
+    char* path;
+
+    int has_wildcard;
+    int checked;
+} reg_path_struct;
 
 #endif
 
@@ -415,6 +433,59 @@ unsigned int get_registry_mtime(HKEY hndl);
  * @return 0 on success, error code on failure
  */
 int w_get_account_info(SID *sid, char **account_name, char **account_domain);
+
+/**
+ * @brief Checks if at least one structure exists whose path has a wildcard  (Windows)
+ *
+ * @param [in] array_struct Arrangement of structures.
+ * @retval 1 on success.
+ * @retval 0 if there is not more wildcards.
+ */
+int w_is_still_a_wildcard(reg_path_struct **array_struct);
+
+/**
+ * @brief Returns the HKEY corresponding to the root key name  (Windows)
+ *
+ * @param [in] str_rootkey String that represents the root key.
+ * @retval HKEY on success.
+ * @retval NULL if there is not match.
+ */
+HKEY w_switch_root_key(char* str_rootkey);
+
+/**
+ * @brief Return all keys based on a root key and subkey  (Windows)
+ *
+ * @param [in] root_key HKEY that represents the root key.
+ * @param [in] str_subkey String that represents the main subkey, this could be NULL.
+ * @retval A non empty array of string on success.
+ */
+char** w_list_all_keys(HKEY root_key, char* str_subkey);
+
+/**
+ * @brief Generate all valid paths that contains a * or ? (Windows)
+ *
+ * @param [in] array_struct Array of all possible paths.
+ * @param [out] array_struct Array of paths with tag checked in 1 and has_wildcard in 0.
+ */ 
+void w_expand_by_wildcard(reg_path_struct **array_struct,char wildcard_chr);
+
+
+/**
+ * @brief Extract the subkey from path (Windows)
+ *
+ * @param [in] key String path that contains the key and subkey.
+ * @param [out] chrwildcard Delimiter of the wildcard.
+ * @return Allocated subkey or NULL if there is not one.
+ */ 
+char* get_subkey(char* key, char chrwildcard);
+
+/**
+ * @brief Return all possible paths based in a entry  (Windows)
+ *
+ * @param [in] entry Raw entry read from config file.
+ * @param [out] paths Array of paths expanded with tag checked in 1 and has_wildcard in 0.
+ */ 
+void expand_wildcard_registers(char* entry,char** paths);
 
 #endif
 

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1259,9 +1259,9 @@ void expand_wildcard_registers(char* entry,char** paths) {
     // ----- End expansion path section -----
 
     current_position = aux_vector;
-    while(*current_position != NULL){
-        if(!(*current_position)->has_wildcard && (*current_position)->checked){
-            *paths = strdup((*current_position)->path);
+    while(*current_position != NULL) {
+        if(!(*current_position)->has_wildcard && (*current_position)->checked) {
+            os_strdup((*current_position)->path,*paths);
             os_free((*current_position)->path);
             os_free(*current_position);
             paths++;
@@ -1278,11 +1278,14 @@ void expand_wildcard_registers(char* entry,char** paths) {
 }
 
 char* get_subkey(char* key) {
-    char* remaining_key = strdup(strchr(key, '\\') + 1);
+    char* remaining_key = NULL;
     char* subkey        = NULL;
-    char* aux_token;
+
+    os_strdup(strchr(key, '\\') + 1,remaining_key);
     os_calloc(OS_SIZE_128, sizeof(char), subkey);
 
+    char* aux_token;
+    
     aux_token = strtok(remaining_key, "\\");
     while (aux_token !=NULL && !(strchr(aux_token, '?') || strchr(aux_token, '*'))) {
         strcat(subkey, aux_token);
@@ -1302,7 +1305,7 @@ char* get_subkey(char* key) {
     }
 }
 
-int w_is_still_a_wildcard(reg_path_struct **array_struct){
+int w_is_still_a_wildcard(reg_path_struct **array_struct) {
     while(*array_struct) {
         if((*array_struct)->has_wildcard && !(*array_struct)->checked) {
             return 1;

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1288,8 +1288,12 @@ char* get_subkey(char* key) {
         strcpy(subkey, aux_token);
         aux_token = strtok(NULL, "\\");
     }
+    int path_len = strlen(subkey) - 1;
     os_free(remaining_key);
-    if (strlen(subkey)) {
+    if (path_len) {
+        if (subkey[path_len] == '\\') {
+            subkey[path_len] = '\0';
+        }
         return subkey;
     }
     else {

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1373,7 +1373,6 @@ char** w_list_all_keys(HKEY root_key, char* str_subkey) {
                     NULL,
                     &ftLastWriteTime);
                 if (retCode == ERROR_SUCCESS) {
-                    mdebug1("Key %s",achKey);
                     os_strdup(achKey,*(key_list + i));
                 }
             }

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1276,8 +1276,8 @@ char* get_subkey(char* key) {
             subkey[path_len] = '\0';
         }
         return subkey;
-    }
-    else {
+    } else {
+        os_free(subkey);
         return strdup("");
     }
 }

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1533,9 +1533,9 @@ void w_expand_by_wildcard(reg_path_struct **array_struct,char wildcard_chr) {
                     //Increment pointers.
                     first_empty++;
                     query_keys++;
-                    }
                 }
             }
+        }
     }
 
     //Release memory after leaves function. Common variables

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1177,6 +1177,388 @@ void ag_send_syscheck(char * message) {
     free(response);
 }
 
+HKEY w_switch_root_key(char* str_rootkey) {
+    if (!strcmp(str_rootkey, STR_HKEY_CLASSES_ROOT)) {
+        return HKEY_CLASSES_ROOT;
+    }
+    else if (!strcmp(str_rootkey, STR_HKEY_CURRENT_CONFIG)) {
+        return HKEY_CURRENT_CONFIG;
+    }
+    else if (!strcmp(str_rootkey, STR_HKEY_CURRENT_USER)) {
+        return HKEY_CURRENT_USER;
+    }
+    else if (!strcmp(str_rootkey, STR_HKEY_LOCAL_MACHINE)) {
+        return HKEY_LOCAL_MACHINE;
+    }
+    else if (!strcmp(str_rootkey, STR_HKEY_USERS)) {
+        return HKEY_USERS;
+    }
+    else {
+        mdebug1("Invalid value of 'HKEY'. Please check your ossec.conf.");
+        return NULL;
+    }
+}
+
+void expand_wildcard_registers(char* entry,char** paths) {
+    reg_path_struct** aux_vector;
+    reg_path_struct** current_position;
+    os_calloc(OS_SIZE_8192,sizeof(reg_path_struct*),aux_vector);
+
+    reg_path_struct* first_e;
+    os_calloc(1,sizeof(reg_path_struct),first_e);
+
+    first_e->path           = strdup(entry);
+    first_e->has_wildcard   = check_wildcard(entry);
+    first_e->checked        = 0;
+    *aux_vector             = first_e;
+    current_position        = aux_vector; //Save the current pointer for future iteration
+
+    // ----- Begin expansion path section -----
+
+    //If we have a combination, we need to iterate over all possible paths
+    if (strchr((*current_position)->path, '*') && strchr((*current_position)->path, '?')) {
+        while (w_is_still_a_wildcard(current_position)) {
+            //We have two ways to analyze this case. When the ? is before * and when * is before ?
+            //so we check who came first.
+
+            char* pos_qk = strchr((*current_position)->path, '?');
+            char* pos_sr = strchr((*current_position)->path, '*');
+            if (pos_qk < pos_sr) {
+                if (strchr((*current_position)->path, '?')) {
+                    w_expand_by_wildcard(current_position, '?');
+                }
+                else {
+                    w_expand_by_wildcard(current_position, '*');
+                }
+                current_position++;
+            } else {
+                if (strchr((*current_position)->path, '*')) {
+                    w_expand_by_wildcard(current_position, '*');
+                }
+                else {
+                    w_expand_by_wildcard(current_position, '?');
+                }
+                current_position++;
+            }
+        }
+    }
+    //Check first if there is a *, for a single expansion
+    else if (strchr((*current_position)->path, '*')) {
+        do {
+            w_expand_by_wildcard(current_position, '*');
+            current_position++;
+        } while (w_is_still_a_wildcard(current_position));
+    }
+    //Then check if there is a ?
+    else if (strchr((*current_position)->path, '?')) {
+        mdebug1("Enter with ? only...");
+        do {
+            w_expand_by_wildcard(current_position, '?');
+            current_position++;
+        } while (w_is_still_a_wildcard(current_position));
+    }
+    // ----- End expansion path section -----
+
+    current_position = aux_vector;
+    while(*current_position != NULL){
+        if(!(*current_position)->has_wildcard && (*current_position)->checked){
+            *paths = strdup((*current_position)->path);
+            os_free((*current_position)->path);
+            os_free(*current_position);
+            paths++;
+        } else {
+            os_free((*current_position)->path);
+            os_free(*current_position);
+        }
+        current_position++;
+    }
+
+    //Release memory before leaves function
+    os_free(*current_position);
+    os_free(aux_vector);
+}
+
+char* get_subkey(char* key, char chrwildcard) {
+
+    char* rootkey = strchr(key, '\\') + 1;
+    char* wildcard = strchr(key, chrwildcard);
+    int   pathLen = wildcard - rootkey;
+    char* subkey = NULL;
+
+    if (!pathLen) {
+        return strdup("");
+    }
+
+    os_calloc(pathLen + 1, sizeof(char), subkey);
+    memcpy(subkey, rootkey, pathLen);
+
+    if (subkey[pathLen - 1] == '\\') {
+        subkey[pathLen - 1] = '\0';
+    }
+
+    subkey[pathLen] = '\0';
+    if (chrwildcard == '?') {
+        if (strstr(subkey, "\\")) {
+            for (int letter = strlen(subkey) - 1; letter >= 0; letter--) {
+                if (subkey[letter] != '\\') {
+                    subkey[letter] = '\0';
+                } else {
+                    subkey[letter] = '\0';
+                    return subkey;
+                }
+            }
+        } else {
+            os_free(subkey);
+            return strdup("");
+        }
+    } else {
+        return subkey;
+    }
+    os_free(subkey);
+}
+
+int w_is_still_a_wildcard(reg_path_struct **array_struct){
+    while(*array_struct) {
+        if((*array_struct)->has_wildcard && !(*array_struct)->checked) {
+            return 1;
+        }
+        array_struct++;
+    }
+    return 0;
+}
+
+char** w_list_all_keys(HKEY root_key, char* str_subkey) {
+    HKEY keyhandle;
+    char** key_list = NULL;
+    if (RegOpenKeyEx(root_key, str_subkey, 0, KEY_READ | KEY_WOW64_64KEY, &keyhandle) == ERROR_SUCCESS) {
+        TCHAR    achKey[OS_SIZE_256];
+        DWORD    cbName;
+        TCHAR    achClass[OS_SIZE_256] = TEXT("");
+        DWORD    cchClassName = OS_SIZE_256;
+        DWORD    cSubKeys = 0;
+        DWORD    cbMaxSubKey;
+        DWORD    cchMaxClass;
+        DWORD    cValues;
+        DWORD    cchMaxValue;
+        DWORD    cbMaxValueData;
+        DWORD    cbSecurityDescriptor;
+        FILETIME ftLastWriteTime;
+
+        DWORD i, retCode;
+
+        // Get the class name and the value count. 
+        RegQueryInfoKey(
+            keyhandle,               // key handle 
+            achClass,                // buffer for class name 
+            &cchClassName,           // size of class string 
+            NULL,                    // reserved 
+            &cSubKeys,               // number of subkeys 
+            &cbMaxSubKey,            // longest subkey size 
+            &cchMaxClass,            // longest class string 
+            &cValues,                // number of values for this key 
+            &cchMaxValue,            // longest value name 
+            &cbMaxValueData,         // longest value data 
+            &cbSecurityDescriptor,   // security descriptor 
+            &ftLastWriteTime);       // last write time
+
+        if (cSubKeys) {
+            os_calloc(cSubKeys + 1, sizeof(char*),key_list);
+            for (i = 0; i < cSubKeys; i++) {
+                cbName = OS_SIZE_256;
+                retCode = RegEnumKeyEx(keyhandle, i,
+                    achKey,
+                    &cbName,
+                    NULL,
+                    NULL,
+                    NULL,
+                    &ftLastWriteTime);
+                if (retCode == ERROR_SUCCESS) {
+                    mdebug1("Key %s",achKey);
+                    os_strdup(achKey,*(key_list + i));
+                }
+            }
+            *(key_list + i) = NULL;
+        }
+
+    } 
+    RegCloseKey(keyhandle);
+    return key_list;
+}
+
+void w_expand_by_wildcard(reg_path_struct **array_struct,char wildcard_chr) {
+    // ----- Begin setup variables section -----
+    char* wildcard_str          = NULL;
+    os_calloc(2,sizeof(char),wildcard_str);
+    wildcard_str[0]             = wildcard_chr;
+    wildcard_str[1]             = '\0';
+
+    char** first_position       = NULL;
+
+    char* matcher               = NULL; //Only used when wildcard is ?.
+
+    //Create a copy of the path to be able to modify it.
+    char* aux_path              = NULL;
+    os_strdup((*array_struct)->path,aux_path);
+
+    //Take the first part of the wildcard, splitting by wildcard. Clean any chars after a slash bar.
+    char* first_part            = strtok(aux_path, wildcard_str);
+    for (int letter = strlen(first_part) - 1; letter >= 0; letter--) {
+        if (first_part[letter] != '\\') {
+            first_part[letter] = '\0';
+        }
+        else {
+            break;
+        }
+    }
+
+    if(wildcard_chr == '?') {
+        //Usar strtok_r
+        char* temp          = NULL;
+        char* aux_matcher   = NULL;
+        os_strdup((*array_struct)->path,temp);
+
+        //Search through all tokens until you find the one that has the wildcard
+        aux_matcher = strtok(temp, "\\");
+        while (!strchr(aux_matcher, '?')) {
+            aux_matcher = strtok(NULL, "\\");
+        }
+        os_strdup(aux_matcher,matcher);
+        os_free(temp);
+    }
+
+    //Take the remainder part of the path.
+    char* second_part           = strchr(strchr((*array_struct)->path, wildcard_chr),'\\');
+
+    //Duplicate key part
+    char* temp = NULL;
+    os_strdup(first_part,temp);
+
+    char* str_root_key          = NULL;
+    //Obtain the subkey. If it's empty, it's a NULL value.
+    char* subkey                = get_subkey((*array_struct)->path,wildcard_chr);
+        
+    os_strdup(strtok(temp, "\\"),str_root_key);
+    os_free(temp);
+
+    HKEY root_key               = w_switch_root_key(str_root_key);
+    
+    // ----- End setup variables section -----
+
+    (*array_struct)->checked    = 1; //Mark path as checked.
+
+    //Get first empty position of the vector.
+    int first_empty             = 0;
+    while (array_struct[first_empty] != NULL) {
+        first_empty++;
+    }
+    //----------------------------------------
+
+    //There is two possibles branches to take depending of the wildcard.
+    if (wildcard_chr=='?') {
+        if (root_key != NULL && matcher != NULL) {
+            //Get all keys from Windows API.
+            char** query_keys = w_list_all_keys(root_key, subkey);
+            first_position = query_keys;
+            if (query_keys) {
+                //Itarate over string vector.
+                while (*query_keys != NULL) {
+                    //Use Windows API and check wildcar coincidences.
+                    if (PathMatchSpecA(*query_keys, matcher)) {
+                        // ----- Begin final path variable section -----
+
+                        char* full_path = NULL;
+                        os_calloc(OS_SIZE_256, sizeof(char),full_path);
+
+                        //Copy first part.
+                        strcpy(full_path, first_part);
+
+                        //Add key result.
+                        strcat(full_path, *query_keys);
+
+                        //Copy second part.
+                        second_part != NULL ? strcat(full_path, second_part) : strcat(full_path,"\0");
+
+                        // ----- End final path variable section -----
+
+                        //Create new struct and add it to vector.
+                        reg_path_struct* new_struct = NULL;
+                        os_calloc(1, sizeof(reg_path_struct),new_struct);
+
+                        int path_length             = strlen(full_path);
+                        if(full_path[path_length - 1] == '\\'){
+                            full_path[path_length - 1] = '\0';
+                        }
+
+                        new_struct->path            = full_path;
+                        new_struct->has_wildcard    = (check_wildcard(full_path)) && !(check_wildcard(*query_keys)) ? 1 : 0;
+                        new_struct->checked         = 1 & !new_struct->has_wildcard;
+                        array_struct[first_empty]   = new_struct; 
+
+                        //Increment pointers.
+                        first_empty++;
+                    }
+                    //Increment pointers.
+                    query_keys++;
+                    }
+                }
+            //Release memory before leaves function.
+            os_free(matcher);
+        }
+    } else {
+        if (root_key != NULL) {
+            //Get all keys from Windows API.
+            char** query_keys = w_list_all_keys(root_key, subkey);
+            first_position    = query_keys;
+            if (query_keys) {
+                //Itarate over string vector.
+                while (*query_keys != NULL) {
+
+                    // ----- Begin final path variable section -----
+
+                    char* full_path = NULL;
+                    os_calloc(OS_SIZE_256, sizeof(char),full_path);
+
+                    //Copy first part.
+                    strcpy(full_path, first_part);
+
+                    //Add key result.
+                    strcat(full_path, *query_keys);
+
+                    //Copy second part.
+                    second_part != NULL ? strcat(full_path, second_part) : strcat(full_path, "\0");
+
+                    // ----- End final path variable section -----
+
+                    //Create new struct and add it to vector.
+                    reg_path_struct* new_struct = NULL;
+                    os_calloc(1, sizeof(reg_path_struct),new_struct);
+
+                    int path_length             = strlen(full_path);
+                    if(full_path[path_length - 1] == '\\') {
+                        full_path[path_length - 1] = '\0';
+                    }
+                    
+                    new_struct->path            = full_path;
+                    new_struct->has_wildcard    = (check_wildcard(full_path)) && !(check_wildcard(*query_keys)) ? 1 : 0;
+                    new_struct->checked         = 1 & !new_struct->has_wildcard;
+                    array_struct[first_empty]   = new_struct; 
+
+                    //Increment pointers.
+                    first_empty++;
+                    query_keys++;
+                    }
+                }
+            }
+    }
+
+    //Release memory after leaves function. Common variables
+    os_free(wildcard_str);
+    os_free(aux_path);
+    os_free(str_root_key);
+    os_free(subkey);
+    w_FreeArray(first_position);
+}
+
 #endif /* # else (ifndef WIN32) */
 
 void decode_win_attributes(char *str, unsigned int attrs) {

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1557,6 +1557,8 @@ void w_expand_by_wildcard(reg_path_struct **array_struct,char wildcard_chr) {
     os_free(str_root_key);
     os_free(subkey);
     w_FreeArray(first_position);
+    os_free(first_position);
+    os_free(matcher);
 }
 
 #endif /* # else (ifndef WIN32) */

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1285,8 +1285,9 @@ char* get_subkey(char* key) {
 
     aux_token = strtok(remaining_key, "\\");
     while (aux_token !=NULL && !(strchr(aux_token, '?') || strchr(aux_token, '*'))) {
-        strcpy(subkey, aux_token);
+        strcat(subkey, aux_token);
         aux_token = strtok(NULL, "\\");
+        strcat(subkey, "\\");
     }
     int path_len = strlen(subkey) - 1;
     os_free(remaining_key);

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1285,7 +1285,7 @@ char* get_subkey(char* key) {
     os_calloc(OS_SIZE_128, sizeof(char), subkey);
 
     char* aux_token;
-    
+
     aux_token = strtok(remaining_key, "\\");
     while (aux_token !=NULL && !(strchr(aux_token, '?') || strchr(aux_token, '*'))) {
         strcat(subkey, aux_token);
@@ -1334,19 +1334,19 @@ char** w_list_all_keys(HKEY root_key, char* str_subkey) {
 
         DWORD i, retCode;
 
-        // Get the class name and the value count. 
+        // Get the class name and the value count.
         RegQueryInfoKey(
-            keyhandle,               // key handle 
-            achClass,                // buffer for class name 
-            &cchClassName,           // size of class string 
-            NULL,                    // reserved 
-            &cSubKeys,               // number of subkeys 
-            &cbMaxSubKey,            // longest subkey size 
-            &cchMaxClass,            // longest class string 
-            &cValues,                // number of values for this key 
-            &cchMaxValue,            // longest value name 
-            &cbMaxValueData,         // longest value data 
-            &cbSecurityDescriptor,   // security descriptor 
+            keyhandle,               // key handle
+            achClass,                // buffer for class name
+            &cchClassName,           // size of class string
+            NULL,                    // reserved
+            &cSubKeys,               // number of subkeys
+            &cbMaxSubKey,            // longest subkey size
+            &cchMaxClass,            // longest class string
+            &cValues,                // number of values for this key
+            &cchMaxValue,            // longest value name
+            &cbMaxValueData,         // longest value data
+            &cbSecurityDescriptor,   // security descriptor
             &ftLastWriteTime);       // last write time
 
         if (cSubKeys) {
@@ -1361,13 +1361,13 @@ char** w_list_all_keys(HKEY root_key, char* str_subkey) {
                     NULL,
                     &ftLastWriteTime);
                 if (retCode == ERROR_SUCCESS) {
-                    os_strdup(achKey,*(key_list + i));
+                    os_strdup(achKey, *(key_list + i));
                 }
             }
             *(key_list + i) = NULL;
         }
 
-    } 
+    }
     RegCloseKey(keyhandle);
     return key_list;
 }
@@ -1423,12 +1423,12 @@ void w_expand_by_wildcard(reg_path_struct **array_struct,char wildcard_chr) {
     char* str_root_key          = NULL;
     //Obtain the subkey. If it's empty, it's a NULL value.
     char* subkey                = get_subkey((*array_struct)->path);
-        
+
     os_strdup(strtok(temp, "\\"),str_root_key);
     os_free(temp);
 
     HKEY root_key               = w_switch_root_key(str_root_key);
-    
+
     // ----- End setup variables section -----
 
     (*array_struct)->checked    = 1; //Mark path as checked.
@@ -1479,7 +1479,7 @@ void w_expand_by_wildcard(reg_path_struct **array_struct,char wildcard_chr) {
                         new_struct->path            = full_path;
                         new_struct->has_wildcard    = (check_wildcard(full_path)) && !(check_wildcard(*query_keys)) ? 1 : 0;
                         new_struct->checked         = 1 & !new_struct->has_wildcard;
-                        array_struct[first_empty]   = new_struct; 
+                        array_struct[first_empty]   = new_struct;
 
                         //Increment pointers.
                         first_empty++;
@@ -1524,11 +1524,11 @@ void w_expand_by_wildcard(reg_path_struct **array_struct,char wildcard_chr) {
                     if(full_path[path_length - 1] == '\\') {
                         full_path[path_length - 1] = '\0';
                     }
-                    
+
                     new_struct->path            = full_path;
                     new_struct->has_wildcard    = (check_wildcard(full_path)) && !(check_wildcard(*query_keys)) ? 1 : 0;
                     new_struct->checked         = 1 & !new_struct->has_wildcard;
-                    array_struct[first_empty]   = new_struct; 
+                    array_struct[first_empty]   = new_struct;
 
                     //Increment pointers.
                     first_empty++;

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1214,44 +1214,25 @@ void expand_wildcard_registers(char* entry, char** paths) {
     current_position        = aux_vector; //Save the current pointer for future iteration
 
     // ----- Begin expansion path section -----
+    // New algorithm form proposal
 
-    //If we have a combination, we need to iterate over all possible paths
-    if (strchr((*current_position)->path, '*') && strchr((*current_position)->path, '?')) {
-        while (w_is_still_a_wildcard(current_position)) {
-            //We have two ways to analyze this case. When the ? is before * and when * is before ?
-            //so we check who came first.
-
-            char* pos_qk = strchr((*current_position)->path, '?');
-            char* pos_sr = strchr((*current_position)->path, '*');
+    while (w_is_still_a_wildcard(current_position)) {
+        char* pos_qk = strchr((*current_position)->path, '?');
+        char* pos_sr = strchr((*current_position)->path, '*');
+        if (pos_qk != NULL && pos_sr != NULL) {
             if (pos_qk < pos_sr) {
-                if (strchr((*current_position)->path, '?')) {
-                    w_expand_by_wildcard(current_position, '?');
-                }
-                else {
-                    w_expand_by_wildcard(current_position, '*');
-                }
-                current_position++;
+                w_expand_by_wildcard(current_position, '?');
             } else {
-                if (strchr((*current_position)->path, '*')) {
-                    w_expand_by_wildcard(current_position, '*');
-                }
-                else {
-                    w_expand_by_wildcard(current_position, '?');
-                }
-                current_position++;
+                w_expand_by_wildcard(current_position, '*');
             }
-        }
-    } else if (strchr((*current_position)->path, '*')) { //Check first if there is a *, for a single expansion
-        do {
+        } else if (pos_sr != NULL) {
             w_expand_by_wildcard(current_position, '*');
-            current_position++;
-        } while (w_is_still_a_wildcard(current_position));
-    } else if (strchr((*current_position)->path, '?')) { //Then check if there is a ?
-        do {
+        } else if (pos_qk != NULL) {
             w_expand_by_wildcard(current_position, '?');
-            current_position++;
-        } while (w_is_still_a_wildcard(current_position));
+        }
+        current_position++;
     }
+
     // ----- End expansion path section -----
 
     current_position = aux_vector;

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1194,18 +1194,18 @@ HKEY w_switch_root_key(char* str_rootkey) {
         return HKEY_USERS;
     }
     else {
-        mdebug1("Invalid value of 'HKEY'. Please check your ossec.conf.");
+        mdebug1("Invalid value of root Handle to Registry Key.");
         return NULL;
     }
 }
 
-void expand_wildcard_registers(char* entry,char** paths) {
+void expand_wildcard_registers(char* entry, char** paths) {
     reg_path_struct** aux_vector;
     reg_path_struct** current_position;
-    os_calloc(OS_SIZE_8192,sizeof(reg_path_struct*),aux_vector);
+    os_calloc(OS_SIZE_8192, sizeof(reg_path_struct*), aux_vector);
 
     reg_path_struct* first_e;
-    os_calloc(1,sizeof(reg_path_struct),first_e);
+    os_calloc(1, sizeof(reg_path_struct), first_e);
 
     first_e->path           = strdup(entry);
     first_e->has_wildcard   = check_wildcard(entry);
@@ -1241,16 +1241,12 @@ void expand_wildcard_registers(char* entry,char** paths) {
                 current_position++;
             }
         }
-    }
-    //Check first if there is a *, for a single expansion
-    else if (strchr((*current_position)->path, '*')) {
+    } else if (strchr((*current_position)->path, '*')) { //Check first if there is a *, for a single expansion
         do {
             w_expand_by_wildcard(current_position, '*');
             current_position++;
         } while (w_is_still_a_wildcard(current_position));
-    }
-    //Then check if there is a ?
-    else if (strchr((*current_position)->path, '?')) {
+    } else if (strchr((*current_position)->path, '?')) { //Then check if there is a ?
         do {
             w_expand_by_wildcard(current_position, '?');
             current_position++;
@@ -1259,9 +1255,9 @@ void expand_wildcard_registers(char* entry,char** paths) {
     // ----- End expansion path section -----
 
     current_position = aux_vector;
-    while(*current_position != NULL) {
-        if(!(*current_position)->has_wildcard && (*current_position)->checked) {
-            os_strdup((*current_position)->path,*paths);
+    while (*current_position != NULL) {
+        if (!(*current_position)->has_wildcard && (*current_position)->checked) {
+            os_strdup((*current_position)->path, *paths);
             os_free((*current_position)->path);
             os_free(*current_position);
             paths++;
@@ -1281,7 +1277,7 @@ char* get_subkey(char* key) {
     char* remaining_key = NULL;
     char* subkey        = NULL;
 
-    os_strdup(strchr(key, '\\') + 1,remaining_key);
+    os_strdup(strchr(key, '\\') + 1, remaining_key);
     os_calloc(OS_SIZE_128, sizeof(char), subkey);
 
     char* aux_token;
@@ -1294,7 +1290,7 @@ char* get_subkey(char* key) {
     }
     int path_len = strlen(subkey) - 1;
     os_free(remaining_key);
-    if (path_len) {
+    if (path_len > 0) {
         if (subkey[path_len] == '\\') {
             subkey[path_len] = '\0';
         }
@@ -1306,8 +1302,8 @@ char* get_subkey(char* key) {
 }
 
 int w_is_still_a_wildcard(reg_path_struct **array_struct) {
-    while(*array_struct) {
-        if((*array_struct)->has_wildcard && !(*array_struct)->checked) {
+    while (*array_struct) {
+        if ((*array_struct)->has_wildcard && !(*array_struct)->checked) {
             return 1;
         }
         array_struct++;
@@ -1372,10 +1368,10 @@ char** w_list_all_keys(HKEY root_key, char* str_subkey) {
     return key_list;
 }
 
-void w_expand_by_wildcard(reg_path_struct **array_struct,char wildcard_chr) {
+void w_expand_by_wildcard(reg_path_struct **array_struct, char wildcard_chr) {
     // ----- Begin setup variables section -----
     char* wildcard_str          = NULL;
-    os_calloc(2,sizeof(char),wildcard_str);
+    os_calloc(2, sizeof(char), wildcard_str);
     wildcard_str[0]             = wildcard_chr;
     wildcard_str[1]             = '\0';
 
@@ -1385,7 +1381,7 @@ void w_expand_by_wildcard(reg_path_struct **array_struct,char wildcard_chr) {
 
     //Create a copy of the path to be able to modify it.
     char* aux_path              = NULL;
-    os_strdup((*array_struct)->path,aux_path);
+    os_strdup((*array_struct)->path, aux_path);
 
     //Take the first part of the wildcard, splitting by wildcard. Clean any chars after a slash bar.
     char* first_part            = strtok(aux_path, wildcard_str);
@@ -1398,11 +1394,11 @@ void w_expand_by_wildcard(reg_path_struct **array_struct,char wildcard_chr) {
         }
     }
 
-    if(wildcard_chr == '?') {
+    if (wildcard_chr == '?') {
         //Usar strtok_r
         char* temp          = NULL;
         char* aux_matcher   = NULL;
-        os_strdup((*array_struct)->path,temp);
+        os_strdup((*array_struct)->path, temp);
 
         //Search through all tokens until you find the one that has the wildcard
         aux_matcher = strtok(temp, "\\");
@@ -1414,7 +1410,7 @@ void w_expand_by_wildcard(reg_path_struct **array_struct,char wildcard_chr) {
     }
 
     //Take the remainder part of the path.
-    char* second_part           = strchr(strchr((*array_struct)->path, wildcard_chr),'\\');
+    char* second_part           = strchr(strchr((*array_struct)->path, wildcard_chr), '\\');
 
     //Duplicate key part
     char* temp = NULL;
@@ -1424,7 +1420,7 @@ void w_expand_by_wildcard(reg_path_struct **array_struct,char wildcard_chr) {
     //Obtain the subkey. If it's empty, it's a NULL value.
     char* subkey                = get_subkey((*array_struct)->path);
 
-    os_strdup(strtok(temp, "\\"),str_root_key);
+    os_strdup(strtok(temp, "\\"), str_root_key);
     os_free(temp);
 
     HKEY root_key               = w_switch_root_key(str_root_key);
@@ -1454,7 +1450,7 @@ void w_expand_by_wildcard(reg_path_struct **array_struct,char wildcard_chr) {
                         // ----- Begin final path variable section -----
 
                         char* full_path = NULL;
-                        os_calloc(OS_SIZE_256, sizeof(char),full_path);
+                        os_calloc(OS_SIZE_256, sizeof(char), full_path);
 
                         //Copy first part.
                         strcpy(full_path, first_part);
@@ -1469,7 +1465,7 @@ void w_expand_by_wildcard(reg_path_struct **array_struct,char wildcard_chr) {
 
                         //Create new struct and add it to vector.
                         reg_path_struct* new_struct = NULL;
-                        os_calloc(1, sizeof(reg_path_struct),new_struct);
+                        os_calloc(1, sizeof(reg_path_struct), new_struct);
 
                         int path_length             = strlen(full_path);
                         if(full_path[path_length - 1] == '\\'){
@@ -1503,7 +1499,7 @@ void w_expand_by_wildcard(reg_path_struct **array_struct,char wildcard_chr) {
                     // ----- Begin final path variable section -----
 
                     char* full_path = NULL;
-                    os_calloc(OS_SIZE_256, sizeof(char),full_path);
+                    os_calloc(OS_SIZE_256, sizeof(char), full_path);
 
                     //Copy first part.
                     strcpy(full_path, first_part);
@@ -1518,7 +1514,7 @@ void w_expand_by_wildcard(reg_path_struct **array_struct,char wildcard_chr) {
 
                     //Create new struct and add it to vector.
                     reg_path_struct* new_struct = NULL;
-                    os_calloc(1, sizeof(reg_path_struct),new_struct);
+                    os_calloc(1, sizeof(reg_path_struct), new_struct);
 
                     int path_length             = strlen(full_path);
                     if(full_path[path_length - 1] == '\\') {
@@ -1543,8 +1539,7 @@ void w_expand_by_wildcard(reg_path_struct **array_struct,char wildcard_chr) {
     os_free(aux_path);
     os_free(str_root_key);
     os_free(subkey);
-    w_FreeArray(first_position);
-    os_free(first_position);
+    free_strarray(first_position);
     os_free(matcher);
 }
 

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1312,7 +1312,7 @@ char** w_list_all_keys(HKEY root_key, char* str_subkey) {
         DWORD i, retCode;
 
         // Get the class name and the value count.
-        RegQueryInfoKey(
+        retCode = RegQueryInfoKey(
             keyhandle,               // key handle
             achClass,                // buffer for class name
             &cchClassName,           // size of class string
@@ -1326,8 +1326,9 @@ char** w_list_all_keys(HKEY root_key, char* str_subkey) {
             &cbSecurityDescriptor,   // security descriptor
             &ftLastWriteTime);       // last write time
 
-        if (cSubKeys) {
-            os_calloc(cSubKeys + 1, sizeof(char*),key_list);
+        if (retCode == ERROR_SUCCESS) {
+            if (cSubKeys) {
+            os_calloc(cSubKeys + 1, sizeof(char*), key_list);
             for (i = 0; i < cSubKeys; i++) {
                 cbName = OS_SIZE_256;
                 retCode = RegEnumKeyEx(keyhandle, i,
@@ -1339,11 +1340,11 @@ char** w_list_all_keys(HKEY root_key, char* str_subkey) {
                     &ftLastWriteTime);
                 if (retCode == ERROR_SUCCESS) {
                     os_strdup(achKey, *(key_list + i));
+                    }
                 }
+                *(key_list + i) = NULL;
             }
-            *(key_list + i) = NULL;
         }
-
     }
     RegCloseKey(keyhandle);
     return key_list;
@@ -1391,7 +1392,10 @@ void w_expand_by_wildcard(reg_path_struct **array_struct, char wildcard_chr) {
     }
 
     //Take the remainder part of the path.
-    char* second_part           = strchr(strchr((*array_struct)->path, wildcard_chr), '\\');
+    char* second_part       = NULL;
+    if ((*array_struct)->path != NULL) {
+        second_part         = strchr(strchr((*array_struct)->path, wildcard_chr), '\\');
+    }
 
     //Duplicate key part
     char* temp = NULL;

--- a/src/unit_tests/shared/test_syscheck_op.c
+++ b/src/unit_tests/shared/test_syscheck_op.c
@@ -4437,8 +4437,8 @@ void test_get_subkey(void **state)
 void test_w_is_still_a_wildcard(void **state) {
     int ret;
     reg_path_struct** test_reg;
-    int has_wildcard_vec = {0, 1, 1, 0};
-    int checked_vec = {0, 1, 0, 1};
+    int has_wildcard_vec[4] = {0, 1, 1, 0};
+    int checked_vec[4] = {0, 1, 0, 1};
 
     test_reg    = (reg_path_struct**)calloc(2, sizeof(reg_path_struct*));
     test_reg[0] = (reg_path_struct*)calloc(1, sizeof(reg_path_struct));

--- a/src/unit_tests/shared/test_syscheck_op.c
+++ b/src/unit_tests/shared/test_syscheck_op.c
@@ -4414,78 +4414,45 @@ void test_get_registry_mtime_success(void **state) {
 
 void test_get_subkey(void **state)
 {
-    //Scenario one, single * 
-    char* path_one = "HKEY_SOMETHING\\*\\A";
-    char* subkey_one = get_subkey(path_one, '*');
+    char* test_vector_path[4] = {
+        "HKEY_SOMETHING\\*\\A",
+        "HKEY_SOMETHING\\A\\B\\*",
+        "HKEY_SOMETHING\\A?",
+        "HKEY_SOMETHING\\A\\B\\C?"
+    };
 
-    //Scenario two, something before *
-    char* path_two = "HKEY_SOMETHING\\A\\B\\*";
-    char* subkey_two = get_subkey(path_two, '*');
+    char* expected_subkey[4] = {
+        "",
+        "A\\B",
+        "",
+        "A\\B"
+    };
 
-    //Scenario three, single ? 
-    char* path_three = "HKEY_SOMETHING\\A?";
-    char* subkey_three = get_subkey(path_three, '?');
-
-    //Scenario four, something before ?
-    char* path_four = "HKEY_SOMETHING\\A\\B\\C?";
-    char* subkey_four = get_subkey(path_four, '?');
-
-    assert_string_equal(subkey_one,"");
-    assert_string_equal(subkey_two,"A\\B");
-    assert_string_equal(subkey_three, "");
-    assert_string_equal(subkey_four, "A\\B");
+    for (int scenario = 0; scenario < 4; scenario++) {
+        char* result_function = get_subkey(test_vector_path[scenario]);
+        assert_string_equal(result_function,expected_subkey[scenario]);
+    }
 }
 
 void test_w_is_still_a_wildcard(void **state) {
     int ret;
-    reg_path_struct** test_vector_one = (reg_path_struct**)calloc(2, sizeof(reg_path_struct*));
-    test_vector_one[0] = (reg_path_struct*)calloc(1, sizeof(reg_path_struct));
-    test_vector_one[0]->has_wildcard = 0;
-    test_vector_one[0]->checked = 0;
-    test_vector_one[1] = NULL;
+    reg_path_struct** test_reg;
+    int has_wildcard_vec = {0,1,1,0};
+    int checked_vec = {0,1,0,1};
 
-    ret = w_is_still_a_wildcard(test_vector_one);
+    test_reg    = (reg_path_struct**)calloc(2, sizeof(reg_path_struct*));
+    test_reg[0] = (reg_path_struct*)calloc(1, sizeof(reg_path_struct));
+    test_reg[1] = NULL;
 
-    assert_int_equal(0, ret);
+    for(int scenario = 0; scenario < 4; scenario++) {
+        test_reg[0]->has_wildcard = has_wildcard_vec[scenario];
+        test_reg[0]->checked = checked_vec[scenario];
+        ret = w_is_still_a_wildcard(test_reg);
+        assert_int_equal(0, ret);
+    }
 
-    reg_path_struct** test_vector_two = (reg_path_struct**)calloc(2, sizeof(reg_path_struct*));
-    test_vector_two[0] = (reg_path_struct*)calloc(1, sizeof(reg_path_struct));
-    test_vector_two[0]->has_wildcard = 1;
-    test_vector_two[0]->checked = 1;
-    test_vector_two[1] = NULL;
-
-    ret = w_is_still_a_wildcard(test_vector_two);
-
-    assert_int_equal(0, ret);
-
-    reg_path_struct** test_vector_three = (reg_path_struct**)calloc(2, sizeof(reg_path_struct*));
-    test_vector_three[0] = (reg_path_struct*)calloc(1, sizeof(reg_path_struct));
-    test_vector_three[0]->has_wildcard = 1;
-    test_vector_three[0]->checked = 0;
-    test_vector_three[1] = NULL;
-
-    ret = w_is_still_a_wildcard(test_vector_three);
-
-    reg_path_struct** test_vector_four = (reg_path_struct**)calloc(2, sizeof(reg_path_struct*));
-    test_vector_four[0] = (reg_path_struct*)calloc(1, sizeof(reg_path_struct));
-    test_vector_four[0]->has_wildcard = 0;
-    test_vector_four[0]->checked = 1;
-    test_vector_four[1] = NULL;
-
-    ret = w_is_still_a_wildcard(test_vector_four);
-
-    assert_int_equal(0, ret);
-
-    free(test_vector_one[0]);
-    free(test_vector_two[0]);
-    free(test_vector_three[0]);
-    free(test_vector_four[0]);
-
-    free(test_vector_three);
-    free(test_vector_two);
-    free(test_vector_one);
-    free(test_vector_four);
-
+    os_free(test_reg[0]);
+    os_free(test_reg);
 }
 
 void test_w_list_all_keys_subkey_notnull(void** state) {

--- a/src/unit_tests/shared/test_syscheck_op.c
+++ b/src/unit_tests/shared/test_syscheck_op.c
@@ -4430,15 +4430,15 @@ void test_get_subkey(void **state)
 
     for (int scenario = 0; scenario < 4; scenario++) {
         char* result_function = get_subkey(test_vector_path[scenario]);
-        assert_string_equal(result_function,expected_subkey[scenario]);
+        assert_string_equal(result_function, expected_subkey[scenario]);
     }
 }
 
 void test_w_is_still_a_wildcard(void **state) {
     int ret;
     reg_path_struct** test_reg;
-    int has_wildcard_vec = {0,1,1,0};
-    int checked_vec = {0,1,0,1};
+    int has_wildcard_vec = {0, 1, 1, 0};
+    int checked_vec = {0, 1, 0, 1};
 
     test_reg    = (reg_path_struct**)calloc(2, sizeof(reg_path_struct*));
     test_reg[0] = (reg_path_struct*)calloc(1, sizeof(reg_path_struct));
@@ -4468,18 +4468,18 @@ void test_w_list_all_keys_subkey_notnull(void** state) {
         "RESOURCEMAP"
     };
 
-    expect_RegOpenKeyEx_call(root_key, subkey, 0, KEY_READ, NULL, ERROR_SUCCESS);
+    expect_RegOpenKeyEx_call(root_key, subkey, 0, KEY_READ | KEY_WOW64_64KEY, NULL, ERROR_SUCCESS);
     expect_RegQueryInfoKey_call(4, 0, &last_write_time, ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("ACPI",5,ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("DESCRIPTION",12,ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("DEVICEMAP",10,ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("RESOURCEMAP",12,ERROR_SUCCESS);
+    expect_RegEnumKeyEx_call("ACPI", 5, ERROR_SUCCESS);
+    expect_RegEnumKeyEx_call("DESCRIPTION", 12, ERROR_SUCCESS);
+    expect_RegEnumKeyEx_call("DEVICEMAP", 10, ERROR_SUCCESS);
+    expect_RegEnumKeyEx_call("RESOURCEMAP", 12, ERROR_SUCCESS);
 
     char** query_result = w_list_all_keys(root_key, subkey);
 
     for (int idx = 0; idx < 4; idx++) {
         assert_string_equal(query_result[idx], result[idx]);
-        free(query_result[idx]);
+        os_free(query_result[idx]);
     }
 }
 
@@ -4498,20 +4498,20 @@ void test_w_list_all_keys_subkey_null(void** state) {
         "SYSTEM",
     };
 
-    expect_RegOpenKeyEx_call(root_key, subkey, 0, KEY_READ, NULL, ERROR_SUCCESS);
+    expect_RegOpenKeyEx_call(root_key, subkey, 0, KEY_READ | KEY_WOW64_64KEY, NULL, ERROR_SUCCESS);
     expect_RegQueryInfoKey_call(6, 0, &last_write_time, ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("BCD00000000",12,ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("HARDWARE",9,ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("SAM",4,ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("SECURITY",9,ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("SOFTWARE",9,ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("SYSTEM",7,ERROR_SUCCESS);
+    expect_RegEnumKeyEx_call("BCD00000000", 12, ERROR_SUCCESS);
+    expect_RegEnumKeyEx_call("HARDWARE", 9, ERROR_SUCCESS);
+    expect_RegEnumKeyEx_call("SAM", 4, ERROR_SUCCESS);
+    expect_RegEnumKeyEx_call("SECURITY", 9, ERROR_SUCCESS);
+    expect_RegEnumKeyEx_call("SOFTWARE", 9, ERROR_SUCCESS);
+    expect_RegEnumKeyEx_call("SYSTEM", 7, ERROR_SUCCESS);
 
     char** query_result = w_list_all_keys(root_key, subkey);
 
     for (int idx = 0; idx < 6; idx++) {
         assert_string_equal(query_result[idx], result[idx]);
-        free(query_result[idx]);
+        os_free(query_result[idx]);
     }
 }
 
@@ -4550,7 +4550,7 @@ void test_w_switch_root_key(void** state) {
 void test_expand_wildcard_registers_star_only(void **state){
     char* entry     = "HKEY_LOCAL_MACHINE\\*";
     char** paths    = NULL;
-    os_calloc(OS_SIZE_1024,sizeof(char*),paths);
+    os_calloc(OS_SIZE_1024, sizeof(char*), paths);
     char* subkey    = "";
     HKEY root_key   = HKEY_LOCAL_MACHINE;
 
@@ -4566,21 +4566,21 @@ void test_expand_wildcard_registers_star_only(void **state){
     HKEY keyhandle;
     FILETIME last_write_time = { 0, 1000 };
 
-    expect_RegOpenKeyEx_call(root_key, subkey, 0, KEY_READ, NULL, ERROR_SUCCESS);
+    expect_RegOpenKeyEx_call(root_key, subkey, 0, KEY_READ | KEY_WOW64_64KEY, NULL, ERROR_SUCCESS);
     expect_RegQueryInfoKey_call(6, 0, &last_write_time, ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("BCD00000000",12,ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("HARDWARE",9,ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("SAM",4,ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("SECURITY",9,ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("SOFTWARE",9,ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("SYSTEM",7,ERROR_SUCCESS);
+    expect_RegEnumKeyEx_call("BCD00000000", 12, ERROR_SUCCESS);
+    expect_RegEnumKeyEx_call("HARDWARE", 9, ERROR_SUCCESS);
+    expect_RegEnumKeyEx_call("SAM", 4, ERROR_SUCCESS);
+    expect_RegEnumKeyEx_call("SECURITY", 9, ERROR_SUCCESS);
+    expect_RegEnumKeyEx_call("SOFTWARE", 9, ERROR_SUCCESS);
+    expect_RegEnumKeyEx_call("SYSTEM", 7, ERROR_SUCCESS);
 
-    expand_wildcard_registers(entry,paths);
+    expand_wildcard_registers(entry, paths);
 
     int i = 0;
     while(*paths != NULL){
         assert_string_equal(*paths, result[i]);
-        free(*paths);
+        os_free(*paths);
         paths++;
         i++;
     }
@@ -4589,25 +4589,25 @@ void test_expand_wildcard_registers_star_only(void **state){
 void test_expand_wildcard_registers_invalid_path(void **state){
     char* entry     = "HKEY_LOCAL_MACHINE\\????";
     char** paths    = NULL;
-    os_calloc(OS_SIZE_1024,sizeof(char*),paths);
+    os_calloc(OS_SIZE_1024, sizeof(char*), paths);
     char* subkey    = "";
     HKEY root_key   = HKEY_LOCAL_MACHINE;
 
     FILETIME last_write_time = { 0, 1000 };
 
-    expect_RegOpenKeyEx_call(root_key, subkey, 0, KEY_READ, NULL, ERROR_SUCCESS);
+    expect_RegOpenKeyEx_call(root_key, subkey, 0, KEY_READ | KEY_WOW64_64KEY, NULL, ERROR_SUCCESS);
     expect_RegQueryInfoKey_call(6, 0, &last_write_time, ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("BCD00000000",12,ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("HARDWARE",9,ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("SAM",4,ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("SECURITY",9,ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("SOFTWARE",9,ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("SYSTEM",7,ERROR_SUCCESS);
+    expect_RegEnumKeyEx_call("BCD00000000", 12, ERROR_SUCCESS);
+    expect_RegEnumKeyEx_call("HARDWARE", 9, ERROR_SUCCESS);
+    expect_RegEnumKeyEx_call("SAM", 4, ERROR_SUCCESS);
+    expect_RegEnumKeyEx_call("SECURITY", 9, ERROR_SUCCESS);
+    expect_RegEnumKeyEx_call("SOFTWARE", 9, ERROR_SUCCESS);
+    expect_RegEnumKeyEx_call("SYSTEM", 7, ERROR_SUCCESS);
 
-    expand_wildcard_registers(entry,paths);
+    expand_wildcard_registers(entry, paths);
 
     assert_null(*paths);
-    free(paths);
+    os_free(paths);
 
 }
 

--- a/src/unit_tests/shared/test_syscheck_op.c
+++ b/src/unit_tests/shared/test_syscheck_op.c
@@ -4439,6 +4439,7 @@ void test_w_is_still_a_wildcard(void **state) {
     reg_path_struct** test_reg;
     int has_wildcard_vec[4] = {0, 1, 1, 0};
     int checked_vec[4] = {0, 1, 0, 1};
+    int expected_result[4] = {0, 0, 1, 0};
 
     test_reg    = (reg_path_struct**)calloc(2, sizeof(reg_path_struct*));
     test_reg[0] = (reg_path_struct*)calloc(1, sizeof(reg_path_struct));
@@ -4448,7 +4449,7 @@ void test_w_is_still_a_wildcard(void **state) {
         test_reg[0]->has_wildcard = has_wildcard_vec[scenario];
         test_reg[0]->checked = checked_vec[scenario];
         ret = w_is_still_a_wildcard(test_reg);
-        assert_int_equal(0, ret);
+        assert_int_equal(expected_result[scenario], ret);
     }
 
     os_free(test_reg[0]);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #14321|

This PR aims to add a new feature within the Syscheck module which is the possibility to use wildcard (also called metacharacters) to specify many windows registers at once. The asterisk `*` is replaced by any number of characters in a registry name, and the question mark `?` is replaced by any single character.

## Description of the new feature

When parsing the path composition provided in the `osse.conf` file, the different parts of the path are split using the two wildcard options `*` or `?` as delimiters.
Subsequently, the Windows API is used, where the records of a root key and a (possibly null) subkey are listed and the complete new paths are assembled, which will then be monitored by FIM. It is important to clarify that this solution is **case sensitive.

**Important note**
According with this code section https://github.com/wazuh/wazuh/blob/78bbd9f8e923c1a588b198ce2d0fe530659973dd/src/syscheckd/src/registry/registry.c#L364-L380

Only the root keys: `HKEY_LOCAL_MACHINE`, `HKEY_CLASSES_ROOT`, `HKEY_CURRENT_CONFIG`, `HKEY_USERS` are valid root keys for monitoring and will work well with the current feature.

### Example of configuration and tests

### 🟢 Combine three possibles cases
#### Configuration

```xml
  <syscheck>

    <disabled>no</disabled>

    <!-- Frequency that syscheck is executed default every 12 hours -->
    <frequency>43200</frequency>

    <!-- Testing registers. Win10x64. -->
    <windows_registry arch="both">HKEY_LOCAL_MACHINE\*\D????????</windows_registry>
    <windows_registry arch="both">HKEY_CURRENT_CONFIG\S?????\*</windows_registry>
    <windows_registry arch="both">HKEY_CURRENT_USER\Software\*</windows_registry>
    <windows_registry arch="both">HKEY_CURRENT_CONFIG\S?????</windows_registry>
    <windows_registry arch="both">HKEY_CURRENT_USER\Con??</windows_registry> <!-- Invalid register. No match-->
    <windows_registry arch="both">HKEY_CURRENT_USER\Environment\*</windows_registry> <!-- Invalid register. No match-->
    <windows_registry arch="both">HKEY\*</windows_registry> <!-- Invalid register. Wrong HKEY -->
  </syscheck>
```

<details><summary><h5>🟢 Start agent with new feature</h5></summary>

```
2023/06/16 07:29:18 wazuh-agent[6060] syscheck-config.c:627 at read_reg(): DEBUG: (6372): Starting configuration for Windows registry wildcards.
2023/06/16 07:29:18 wazuh-agent[6060] syscheck-config.c:629 at read_reg(): DEBUG: (6373): Expanding entry 'HKEY_LOCAL_MACHINE\*\D????????' to 'HKEY_LOCAL_MACHINE\HARDWARE\DEVICEMAP' to monitor FIM events.
2023/06/16 07:29:18 wazuh-agent[6060] syscheck-config.c:641 at read_reg(): DEBUG: (6374): Wildcard configuration successfully completed.
2023/06/16 07:29:18 wazuh-agent[6060] syscheck-config.c:627 at read_reg(): DEBUG: (6372): Starting configuration for Windows registry wildcards.
2023/06/16 07:29:18 wazuh-agent[6060] syscheck-config.c:629 at read_reg(): DEBUG: (6373): Expanding entry 'HKEY_CURRENT_CONFIG\S?????\*' to 'HKEY_CURRENT_CONFIG\System\CurrentControlSet' to monitor FIM events.
2023/06/16 07:29:18 wazuh-agent[6060] syscheck-config.c:641 at read_reg(): DEBUG: (6374): Wildcard configuration successfully completed.
2023/06/16 07:29:18 wazuh-agent[6060] syscheck-config.c:627 at read_reg(): DEBUG: (6372): Starting configuration for Windows registry wildcards.
2023/06/16 07:29:18 wazuh-agent[6060] syscheck-config.c:629 at read_reg(): DEBUG: (6373): Expanding entry 'HKEY_CURRENT_USER\Software\*' to 'HKEY_CURRENT_USER\Software\Classes' to monitor FIM events.
2023/06/16 07:29:18 wazuh-agent[6060] syscheck-config.c:629 at read_reg(): DEBUG: (6373): Expanding entry 'HKEY_CURRENT_USER\Software\*' to 'HKEY_CURRENT_USER\Software\Microsoft' to monitor FIM events.
2023/06/16 07:29:18 wazuh-agent[6060] syscheck-config.c:629 at read_reg(): DEBUG: (6373): Expanding entry 'HKEY_CURRENT_USER\Software\*' to 'HKEY_CURRENT_USER\Software\Policies' to monitor FIM events.
2023/06/16 07:29:18 wazuh-agent[6060] syscheck-config.c:641 at read_reg(): DEBUG: (6374): Wildcard configuration successfully completed.
2023/06/16 07:29:18 wazuh-agent[6060] syscheck-config.c:627 at read_reg(): DEBUG: (6372): Starting configuration for Windows registry wildcards.
2023/06/16 07:29:18 wazuh-agent[6060] syscheck-config.c:629 at read_reg(): DEBUG: (6373): Expanding entry 'HKEY_CURRENT_CONFIG\S?????' to 'HKEY_CURRENT_CONFIG\System' to monitor FIM events.
2023/06/16 07:29:18 wazuh-agent[6060] syscheck-config.c:641 at read_reg(): DEBUG: (6374): Wildcard configuration successfully completed.
2023/06/16 07:29:18 wazuh-agent[6060] syscheck_op.c:1197 at w_switch_root_key(): DEBUG: Invalid value of root Handle to Registry Key.
```
</details>
<details><summary><h5>🟢 Add new registry</h5></summary>

```
2023/01/09 14:47:46 wazuh-agent[9580] run_check.c:127 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"event","data":{"path":"HKEY_CURRENT_CONFIG\\Software\\NEW_KEY","version":2,"mode":"scheduled","type":"added","arch":"[x64]","timestamp":1673297266,"attributes":{"type":"registry_key","perm":{"S-1-5-32-545":{"name":"Usuarios","allowed":["read_control","read_data","read_ea","write_ea"]},"S-1-5-32-544":{"name":"Administradores","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-5-18":{"name":"SYSTEM","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-3-0":{"name":"CREATOR OWNER","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-15-2-1":{"name":"ALL APPLICATION PACKAGES","allowed":["read_control","read_data","read_ea","write_ea"]},"S-1-15-3-1024-1065365936-1281604716-3511738428-1654721687-432734479-3232135806-4053264122-3456934681":{"allowed":["read_control","read_data","read_ea","write_ea"]}},"uid":"S-1-5-32-544","user_name":"Administradores","gid":"S-1-5-21-2535345508-762786813-1329944505-513","group_name":"Ninguno","mtime":1673297255,"checksum":"a2bdd12a4d134836bd767f83345275399ce2bc2c"}}}
2023/01/09 14:47:46 wazuh-agent[9580] run_check.c:127 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"event","data":{"path":"HKEY_CURRENT_CONFIG\\Software\\NEW_KEY","version":2,"mode":"scheduled","type":"added","arch":"[x64]","value_name":"NEW_VALUE","timestamp":1673297266,"attributes":{"type":"registry_value","value_type":"REG_BINARY","size":0,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","checksum":"38fdd1d295687fa298dbda6732232ee58c309cb4"}}}
2023/01/09 14:47:48 wazuh-agent[9580] run_check.c:127 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"event","data":{"path":"HKEY_CURRENT_CONFIG\\Software\\NEW_KEY","version":2,"mode":"scheduled","type":"added","arch":"[x32]","timestamp":1673297268,"attributes":{"type":"registry_key","perm":{"S-1-5-32-545":{"name":"Usuarios","allowed":["read_control","read_data","read_ea","write_ea"]},"S-1-5-32-544":{"name":"Administradores","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-5-18":{"name":"SYSTEM","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-3-0":{"name":"CREATOR OWNER","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-15-2-1":{"name":"ALL APPLICATION PACKAGES","allowed":["read_control","read_data","read_ea","write_ea"]},"S-1-15-3-1024-1065365936-1281604716-3511738428-1654721687-432734479-3232135806-4053264122-3456934681":{"allowed":["read_control","read_data","read_ea","write_ea"]}},"uid":"S-1-5-32-544","user_name":"Administradores","gid":"S-1-5-21-2535345508-762786813-1329944505-513","group_name":"Ninguno","mtime":1673297255,"checksum":"a2bdd12a4d134836bd767f83345275399ce2bc2c"}}}
2023/01/09 14:47:48 wazuh-agent[9580] run_check.c:127 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"event","data":{"path":"HKEY_CURRENT_CONFIG\\Software\\NEW_KEY","version":2,"mode":"scheduled","type":"added","arch":"[x32]","value_name":"NEW_VALUE","timestamp":1673297268,"attributes":{"type":"registry_value","value_type":"REG_BINARY","size":0,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","checksum":"38fdd1d295687fa298dbda6732232ee58c309cb4"}}}
```

</details>

<details><summary><h5>🟢 Modify an existenting value</h5></summary>

```
2023/01/09 14:50:07 wazuh-agent[9580] run_check.c:127 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"event","data":{"path":"HKEY_CURRENT_CONFIG\\Software\\NEW_KEY","version":2,"mode":"scheduled","type":"modified","arch":"[x64]","timestamp":1673297407,"attributes":{"type":"registry_key","perm":{"S-1-5-32-545":{"name":"Usuarios","allowed":["read_control","read_data","read_ea","write_ea"]},"S-1-5-32-544":{"name":"Administradores","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-5-18":{"name":"SYSTEM","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-3-0":{"name":"CREATOR OWNER","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-15-2-1":{"name":"ALL APPLICATION PACKAGES","allowed":["read_control","read_data","read_ea","write_ea"]},"S-1-15-3-1024-1065365936-1281604716-3511738428-1654721687-432734479-3232135806-4053264122-3456934681":{"allowed":["read_control","read_data","read_ea","write_ea"]}},"uid":"S-1-5-32-544","user_name":"Administradores","gid":"S-1-5-21-2535345508-762786813-1329944505-513","group_name":"Ninguno","mtime":1673297340,"checksum":"14c2865a3d456c0896fc0bffbacecd18d25ce710"},"changed_attributes":["mtime"],"old_attributes":{"type":"registry_key","perm":{"S-1-5-32-545":{"name":"Usuarios","allowed":["read_control","read_data","read_ea","write_ea"]},"S-1-5-32-544":{"name":"Administradores","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-5-18":{"name":"SYSTEM","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-3-0":{"name":"CREATOR OWNER","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-15-2-1":{"name":"ALL APPLICATION PACKAGES","allowed":["read_control","read_data","read_ea","write_ea"]},"S-1-15-3-1024-1065365936-1281604716-3511738428-1654721687-432734479-3232135806-4053264122-3456934681":{"allowed":["read_control","read_data","read_ea","write_ea"]}},"uid":"S-1-5-32-544","user_name":"Administradores","gid":"S-1-5-21-2535345508-762786813-1329944505-513","group_name":"Ninguno","mtime":1673297255,"checksum":"a2bdd12a4d134836bd767f83345275399ce2bc2c"}}}
2023/01/09 14:50:07 wazuh-agent[9580] run_check.c:127 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"event","data":{"path":"HKEY_CURRENT_CONFIG\\Software\\NEW_KEY","version":2,"mode":"scheduled","type":"modified","arch":"[x64]","value_name":"NEW_VALUE","timestamp":1673297407,"attributes":{"type":"registry_value","value_type":"REG_BINARY","size":1,"hash_md5":"d3d9446802a44259755d38e6d163e820","hash_sha1":"b1d5781111d84f7b3fe45a0852e59758cd7a87e5","hash_sha256":"4a44dc15364204a80fe80e9039455cc1608281820fe2b24f1e5233ade6af1dd5","checksum":"a6905d73e33bd3c3e46fed5750448838df05a2aa"},"changed_attributes":["size","md5","sha1","sha256"],"old_attributes":{"type":"registry_value","value_type":"REG_BINARY","size":0,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","checksum":"38fdd1d295687fa298dbda6732232ee58c309cb4"}}}
2023/01/09 14:50:07 wazuh-agent[9580] run_check.c:127 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"event","data":{"path":"HKEY_CURRENT_CONFIG\\Software\\NEW_KEY","version":2,"mode":"scheduled","type":"modified","arch":"[x32]","timestamp":1673297407,"attributes":{"type":"registry_key","perm":{"S-1-5-32-545":{"name":"Usuarios","allowed":["read_control","read_data","read_ea","write_ea"]},"S-1-5-32-544":{"name":"Administradores","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-5-18":{"name":"SYSTEM","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-3-0":{"name":"CREATOR OWNER","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-15-2-1":{"name":"ALL APPLICATION PACKAGES","allowed":["read_control","read_data","read_ea","write_ea"]},"S-1-15-3-1024-1065365936-1281604716-3511738428-1654721687-432734479-3232135806-4053264122-3456934681":{"allowed":["read_control","read_data","read_ea","write_ea"]}},"uid":"S-1-5-32-544","user_name":"Administradores","gid":"S-1-5-21-2535345508-762786813-1329944505-513","group_name":"Ninguno","mtime":1673297340,"checksum":"14c2865a3d456c0896fc0bffbacecd18d25ce710"},"changed_attributes":["mtime"],"old_attributes":{"type":"registry_key","perm":{"S-1-5-32-545":{"name":"Usuarios","allowed":["read_control","read_data","read_ea","write_ea"]},"S-1-5-32-544":{"name":"Administradores","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-5-18":{"name":"SYSTEM","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-3-0":{"name":"CREATOR OWNER","allowed":["delete","read_control","write_dac","write_owner","read_data","write_data","append_data","read_ea","write_ea","execute"]},"S-1-15-2-1":{"name":"ALL APPLICATION PACKAGES","allowed":["read_control","read_data","read_ea","write_ea"]},"S-1-15-3-1024-1065365936-1281604716-3511738428-1654721687-432734479-3232135806-4053264122-3456934681":{"allowed":["read_control","read_data","read_ea","write_ea"]}},"uid":"S-1-5-32-544","user_name":"Administradores","gid":"S-1-5-21-2535345508-762786813-1329944505-513","group_name":"Ninguno","mtime":1673297255,"checksum":"a2bdd12a4d134836bd767f83345275399ce2bc2c"}}}
2023/01/09 14:50:07 wazuh-agent[9580] run_check.c:127 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"event","data":{"path":"HKEY_CURRENT_CONFIG\\Software\\NEW_KEY","version":2,"mode":"scheduled","type":"modified","arch":"[x32]","value_name":"NEW_VALUE","timestamp":1673297407,"attributes":{"type":"registry_value","value_type":"REG_BINARY","size":1,"hash_md5":"d3d9446802a44259755d38e6d163e820","hash_sha1":"b1d5781111d84f7b3fe45a0852e59758cd7a87e5","hash_sha256":"4a44dc15364204a80fe80e9039455cc1608281820fe2b24f1e5233ade6af1dd5","checksum":"a6905d73e33bd3c3e46fed5750448838df05a2aa"},"changed_attributes":["size","md5","sha1","sha256"],"old_attributes":{"type":"registry_value","value_type":"REG_BINARY","size":0,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","checksum":"38fdd1d295687fa298dbda6732232ee58c309cb4"}}}
```

</details>


### Software Design Document
<details> <summary>SDD Report</summary>

# Introduction
Wildcards provide a shorthand for specifying sets of files with similar names.
An asterisk ``*`` is replaced by any number of characters in a filename. For example, ``ae*`` would match ``aegis``, ``aerie``, ``aeon``, etc. if those files were in the same directory.
And, a question ``?`` mark is replaced by any single character (so ``h?p`` matches ``hop`` and ``hip``, but not ``help``).

This support was already implemented for directories but not for Windows registers. This solution has been
designed, in an effort to create a necessary feature to FIM that is open for extensions; this document describes the implementation of this one.
Not only does this document describe the software already created, it is also intended to enforce compatibility of future modifications or add–ons.

# Algortihm Overview
The algorithm consists in the input of a path provided by the ossec.conf file which is checked to see if it has a wildcard or not.
Subsequently, a copy of this path is created so as not to alter the original and three cases are analyzed: 

- Combination case: Both wildcards are present in the path, expanding first the asterisks and then the question marks.

- Asterisk case: All possible records are analyzed.

- Question mark case: All possible records matching the original path are analyzed.

Once the copy of the original path is created, it is divided into two parts taking the wildcard as the inflection point. The first part extracts the root key and possible sub key. The second part is concatenated with the result of the query that uses the Windows API to obtain all possible values.
For the case of the question mark, the Windows API is also used which has support for finding the matches of two paths.


This can be summarized in the following sequence diagram:
![sequence](https://user-images.githubusercontent.com/27935340/213266526-306b3963-d0b6-41a7-ba42-942028f14b40.png)

Y deterministic finite state machine (FSM) diagram.

> S0 -> Enter expansion function
> S1 -> Check if there is a wildcard
> S2 -> There is a wildcard and it is a *
> S3 -> There is a wildcard and it is a ?
> S4 -> There is no wildcard, return result
> S5 -> Extract the rootkey and the subkey needed to fetch the remaining keys
> S6 -> Reassemble the path and add to the result those that meet the wildcard
> S7 -> Extracts the rootkey and the subkey needed to fetch the remaining keys
> S8 -> Reassemble the path and add to the result those keys that comply with the wildcard
![image](https://user-images.githubusercontent.com/27935340/213266419-79183acc-c57f-4f71-92a7-d92b9a79eebc.png)


# Conclusión 
The proposed solution is based on the use of API functions previously used in the project, testing with 90% code coverage and analyzing with CLANG with positive results.
It is available for future improvements, fixes and/or comments from the management team and the community.

</details>

---------------------------------------------------------------------------------------------------------------------

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
    -   [Results](https://u15810271.ct.sendgrid.net/ls/click?upn=HRESupC-2F2Czv4BOaCWWCy7my0P0qcxCbhZ31OYv50yqgxSCSCoUvZsyOQWelCN1eGu9HosOCYbyK-2BRVlIuFp0Q-3D-3D_3VB_3yVA0AJkLK9RgkvZQZCJdHhspcw09JEPNyGmNvbjVXB6ppCwCfljS-2BTu6eBsDrO8JVLzTTXxCOqb-2BarmX4rBlglnuJDgcg1JRfxwO-2FMMrJmuYeiO6WC6zyS7AFisGWM21bEHatVqKwEhv5kYBdgyKlsVVvYY2eiBMiYHxTQNq6v5ABnb8Ixn7rmeitCUPT1XDjZbjWwolyvZCIR5u9H2VQ-3D-3D) of build ID: **`542569`**
```
  Analysis Summary:
    New defects found: 28
    Defects eliminated: 109
```
> Fixed bugs from previous Coverity run: https://github.com/wazuh/wazuh/pull/15852#pullrequestreview-1510837361 - https://github.com/wazuh/wazuh/pull/15852/commits/fda2d2674707f7dd21d76bd64aa4f19376f4456b
- Memory tests for Windows
  - [x] Scan-build report && coverage
[Coverage and ScanBuild reports](https://github.com/wazuh/wazuh/files/10449571/Reports.zip)
  - [ ] Dr. Memory


<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)
- [ ] Stress test for affected components
