### PR TITLE
Add UTF-8 packages support.

### DIFF
--- a/src/data_provider/src/packages/solarisWrapper.h
+++ b/src/data_provider/src/packages/solarisWrapper.h
@@ -222,6 +222,8 @@ class SolarisWrapper final : public IPackageWrapper
                 while (file.good())
                 {
                     std::getline(file, line);
+                    // Convert 'line' to UTF-8
+                    Utils::ISO8859ToUTF8(line);
                     const auto fields { Utils::split(line, '=') };
 
                     if (fields.size() > 1)

--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -25,6 +25,42 @@
 
 namespace Utils
 {
+    static void ISO8859ToUTF8(std::string& data)
+    {
+        // Convert from ISO-8859-1 to UTF-8
+        std::string strOut;
+        // 0xc0 is 11000000 in binary, used to mask the first 2 bits of the character of a 2-byte sequence
+        constexpr auto UTF8_2BYTE_SEQ{ 0xc0 };
+        // 6 is the number of bits to shift the character to the right
+        constexpr auto UTF8_2BYTE_SEQ_VALUE_LEN{ 6 };
+        // 0x80 is 10000000 in binary, is the first code point of a 2-byte sequence
+        constexpr auto UTF8_2BYTE_FIRST_CODE_VALUE{ 0x80 };
+        // 0x3f is 00111111 in binary, used to mask the last 6 bits of the character of a 2-byte sequence
+        constexpr auto UTF8_2BYTE_MASK{ 0x3f };
+
+        for (auto it = data.begin(); it != data.end(); ++it)
+        {
+            const uint8_t ch = *it;
+
+            // ASCII character
+            if (ch < UTF8_2BYTE_FIRST_CODE_VALUE)
+            {
+                strOut.push_back(ch);
+            }
+            // Extended ASCII
+            else
+            {
+                // 2-byte sequence
+                // 110xxxxx
+                strOut.push_back(UTF8_2BYTE_SEQ | ch >> UTF8_2BYTE_SEQ_VALUE_LEN);
+                // 10xxxxxx
+                strOut.push_back(UTF8_2BYTE_FIRST_CODE_VALUE | (ch & UTF8_2BYTE_MASK));
+            }
+        }
+
+        data = strOut;
+    }
+
     static bool replaceAll(std::string& data,
                            const std::string& toSearch,
                            const std::string& toReplace)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #15838 |

## Description
This PR intends to fix an issue while parsing raw data and translating it to the JSON format.

Basically, all files on the path /var/sadm/pkg/*/pkginfo have the ISO8859-1 encoding, this PR encode to UTF-8


```
2023/01/06 07:21:21 wazuh-modulesd:syscollector: ERROR: [json.exception.type_error.316] invalid UTF-8 byte at index 51: 0xF6
```

This is the package that generated this message, it contains an invalid character in the `VENDOR` field

```
root@vagrant-solaris10:/export/home/vagrant/wazuh/src# cat /var/sadm/pkg/CSWschilybase/pkginfo 
CLASSES=none
BASEDIR=/opt/csw
INSTDATE=Jan 05 2023 22:27
PKGSAV=/var/sadm/pkg/CSWschilybase/save
PKGINST=CSWschilybase
ARCH=i386
VERSION=1.01,REV=2020.09.15
PKG=CSWschilybase
NAME=schilybase - A collection of common files from J. Schilling
CATEGORY=application
VENDOR=http://cdrecord.org/private/  packaged for CSW by J�rg Schilling
HOTLINE=http://www.opencsw.org/bugtrack/
EMAIL=joerg@opencsw.org
PSTAMP=joerg@unstable10x-20200915144927
OPENCSW_MODE64=32
OAMBASE=/usr/sadm/sysadm
PATH=/sbin:/usr/sbin:/usr/bin:/usr/sadm/install/bin
TZ=Asia/Hong_Kong
LANG=C
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report
  - [ ] Coverity
  - [X] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [X] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors