### PR TITLE
Engine - Implementation Redis decoder

### DIFF
--- a/src/engine/ruleset/decoders/redis/redis.yml
+++ b/src/engine/ruleset/decoders/redis/redis.yml
@@ -32,13 +32,6 @@ metadata:
 #       `-._    `-.__.-'    _.-'
 #           `-._        _.-'
 #               `-.__.-'
-# 4961:M 30 May 12:50:13.463 # Server started, Redis version 3.0.2
-
-# Debian
-# 30 May 10:04:45 . 0 clients connected (0 slaves), 618932 bytes in use, 0 shared objects
-
-# Windows
-# [2932] 31 May 04:32:08 - 0 clients connected (0 slaves), 1179968 bytes in use
 
 parse:
   logpar:
@@ -46,12 +39,15 @@ parse:
     - event.original: <process.pid>:<~log.role> <@timestamp/%d %b %Y %T> <log.level> <message>
 
     # Darwin
+    # 4961:M 30 May 12:50:13.457 * Increased maximum number of open files to 10032 (it was originally set to 4864).
     - event.original: <process.pid>:<~log.role> <@timestamp/%d %b %T> <log.level> <message>
 
     # Debian
+    # 30 May 10:04:45 . 0 clients connected (0 slaves), 618932 bytes in use, 0 shared objects
     - event.original: <@timestamp/%d %b %T> <log.level> <message>
 
     # Windows
+    # [2932] 31 May 04:32:08 - 0 clients connected (0 slaves), 1179968 bytes in use
     - event.original: <~/ignore/[><~log.pid>] <@timestamp/%d %b %T> <log.level> <message>
 
 # TODO: Could not map field 'log.offset' due to inability to persist values into yml variables.
@@ -67,42 +63,34 @@ normalize:
       - input.type: log
       - service.type: redis
   - check:
-      - log.level: +ef_exists
       - log.level: +s_eq/.
     map:
       - log.level: debug
   - check:
-      - log.level: +ef_exists
       - log.level: +s_eq/-
     map:
       - log.level: verbose
   - check:
-      - log.level: +ef_exists
       - log.level: +s_eq/*
     map:
       - log.level: notice
   - check:
-      - log.level: +ef_exists
       - log.level: +s_eq/#
     map:
       - log.level: warning
   - check:
-      - ~log.role: +ef_exists
       - ~log.role: +s_eq/M
     map:
       - redis.log.role: master
   - check:
-      - ~log.role: +ef_exists
       - ~log.role: +s_eq/S
     map:
       - redis.log.role: slave
   - check:
-      - ~log.role: +ef_exists
       - ~log.role: +s_eq/C
     map:
       - redis.log.role: child
   - check:
-      - ~log.role: +ef_exists
       - ~log.role: +s_eq/X
     map:
       - redis.log.role: sentinel

--- a/src/engine/ruleset/decoders/redis/redis.yml
+++ b/src/engine/ruleset/decoders/redis/redis.yml
@@ -59,7 +59,7 @@ normalize:
       - event.type: +a_append/info
       - event.category: +a_append/database
       - event.dataset: redis.log
-      - file.name: log
+      - fileset.name: log
       - input.type: log
       - service.type: redis
   - check:

--- a/src/engine/ruleset/decoders/redis/redis.yml
+++ b/src/engine/ruleset/decoders/redis/redis.yml
@@ -35,12 +35,10 @@ metadata:
 
 parse:
   logpar:
-    # 26571:M 27 Dec 2018 11:19:18.874 * Synchronization with replica 10.114.208.18:6023 succeeded
-    - event.original: <process.pid>:<~log.role> <@timestamp/%d %b %Y %T> <log.level> <message>
-
     # Darwin
+    # 26571:M 27 Dec 2018 11:19:18.874 * Synchronization with replica 10.114.208.18:6023 succeeded
     # 4961:M 30 May 12:50:13.457 * Increased maximum number of open files to 10032 (it was originally set to 4864).
-    - event.original: <process.pid>:<~log.role> <@timestamp/%d %b %T> <log.level> <message>
+    - event.original: <process.pid>:<~log.role> <@timestamp/%d %b %Y %T>?<@timestamp/%d %b %T> <log.level> <message>
 
     # Debian
     # 30 May 10:04:45 . 0 clients connected (0 slaves), 618932 bytes in use, 0 shared objects

--- a/src/engine/ruleset/decoders/redis/redis.yml
+++ b/src/engine/ruleset/decoders/redis/redis.yml
@@ -2,10 +2,14 @@
 name: decoder/redis/0
 
 metadata:
-  description: Decoder for Linux redis logs
-  references:
-    - https://docs.elastic.co/en/integrations/redis
   module: redis
+  title: Redis logs decoder
+  description: Decoder for Linux redis logs
+  author:
+    name: Wazuh Inc. info@wazuh.com
+    date: 2023-01-12
+  references:
+    - https://docs.rs/redis-module/latest/redis_module/logging/index.html
 
 # Example redis logs:
 

--- a/src/engine/ruleset/decoders/redis/redis.yml
+++ b/src/engine/ruleset/decoders/redis/redis.yml
@@ -11,28 +11,6 @@ metadata:
   references:
     - https://docs.rs/redis-module/latest/redis_module/logging/index.html
 
-# Example redis logs:
-
-# Darwin
-# 4961:M 30 May 12:50:13.457 * Increased maximum number of open files to 10032 (it was originally set to 4864).
-#                 _._
-#            _.-``__ ''-._
-#       _.-``    `.  `_.  ''-._           Redis 3.0.2 (00000000/0) 64 bit
-#   .-`` .-```.  ```\/    _.,_ ''-._
-#  (    '      ,       .-`  | `,    )     Running in standalone mode
-#  |`-._`-...-` __...-.``-._|'` _.-'|     Port: 6379
-#  |    `-._   `._    /     _.-'    |     PID: 4961
-#   `-._    `-._  `-./  _.-'    _.-'
-#  |`-._`-._    `-.__.-'    _.-'_.-'|
-#  |    `-._`-._        _.-'_.-'    |           http://redis.io
-#   `-._    `-._`-.__.-'_.-'    _.-'
-#  |`-._`-._    `-.__.-'    _.-'_.-'|
-#  |    `-._`-._        _.-'_.-'    |
-#   `-._    `-._`-.__.-'_.-'    _.-'
-#       `-._    `-.__.-'    _.-'
-#           `-._        _.-'
-#               `-.__.-'
-
 parse:
   logpar:
     # Darwin

--- a/src/engine/ruleset/decoders/redis/redis.yml
+++ b/src/engine/ruleset/decoders/redis/redis.yml
@@ -11,6 +11,9 @@ metadata:
   references:
     - https://docs.rs/redis-module/latest/redis_module/logging/index.html
 
+sources:
+  - decoder/queue-localfile/0
+
 parse:
   logpar:
     # Darwin

--- a/src/engine/ruleset/decoders/redis/redis.yml
+++ b/src/engine/ruleset/decoders/redis/redis.yml
@@ -1,0 +1,75 @@
+---
+name: decoder/redis/0
+
+metadata:
+  description: Decoder for Linux redis logs
+  references:
+    - https://docs.elastic.co/en/integrations/redis
+  module: redis
+
+definitions:
+  LOG_PID_ROLE: <~log.process.pid>:<~log.role>
+
+# Example redis logs:
+
+# 4961:M 30 May 12:50:13.457 * Increased maximum number of open files to 10032 (it was originally set to 4864).
+#                 _._                                                  
+#            _.-``__ ''-._                                             
+#       _.-``    `.  `_.  ''-._           Redis 3.0.2 (00000000/0) 64 bit
+#   .-`` .-```.  ```\/    _.,_ ''-._                                   
+#  (    '      ,       .-`  | `,    )     Running in standalone mode
+#  |`-._`-...-` __...-.``-._|'` _.-'|     Port: 6379
+#  |    `-._   `._    /     _.-'    |     PID: 4961
+#   `-._    `-._  `-./  _.-'    _.-'                                   
+#  |`-._`-._    `-.__.-'    _.-'_.-'|                                  
+#  |    `-._`-._        _.-'_.-'    |           http://redis.io        
+#   `-._    `-._`-.__.-'_.-'    _.-'                                   
+#  |`-._`-._    `-.__.-'    _.-'_.-'|                                  
+#  |    `-._`-._        _.-'_.-'    |                                  
+#   `-._    `-._`-.__.-'_.-'    _.-'                                   
+#       `-._    `-.__.-'    _.-'                                       
+#           `-._        _.-'                                           
+#               `-.__.-'                                               
+# 4961:M 30 May 12:50:13.463 # Server started, Redis version 3.0.2
+
+# 30 May 10:04:45 . 0 clients connected (0 slaves), 618932 bytes in use, 0 shared objects
+
+# [2932] 31 May 04:32:08 - 0 clients connected (0 slaves), 1179968 bytes in use
+
+parse:
+  logpar:
+    # 26571:M 27 Dec 2018 11:19:18.874 * Synchronization with replica 10.114.208.18:6023 succeeded
+    - event.original: $LOG_PID_ROLE <~log.timestamp_test/date/%d %b %Y %T> * <~log.msg>
+
+    #  |    `-._   `._    /     _.-'    |     PID: 4961
+
+    - event.original: $LOG_PID_ROLE <~log.timestamp_test/date/%d %b %Y %T> * <~log.msg>
+
+    # Debian
+    # 30 May 10:04:45 . 0 clients connected (0 slaves), 618932 bytes in use, 0 shared objects
+    - event.original: <~log.timestamp_debian/date/%d %b %T> . <~log.msg>
+    - event.original: <~log.timestamp_debian/date/%d %b %T> - <~log.msg>
+    - event.original: <~log.timestamp_debian/date/%d %b %T> * <~log.msg>
+
+    # Windows
+    # [2932] 31 May 04:32:08 # Open data file dump.rdb: No such file or directory
+    - event.original: <~/ignore/[><~log.pid>] <~log.timestamp_window/date/%d %b %T> <~/ignore/#> <~log.msg>
+
+normalize:
+  - map:
+      - event.kind: event
+      - event.module: redis
+      - event.message: $~log.msg
+      - event.process.pid: $~log.process.pid
+  - check:
+      - ~log.role: +ef_exists
+      - ~log.role: +s_eq/M
+    map:
+      - event.role: master
+  - check:
+      - ~log.role: +ef_exists
+      - ~log.role: +s_eq/S
+    map:
+      - event.role: slave
+  - map:
+      - ~log: +ef_delete

--- a/src/engine/ruleset/decoders/redis/redis.yml
+++ b/src/engine/ruleset/decoders/redis/redis.yml
@@ -60,36 +60,28 @@ normalize:
       - fileset.name: log
       - input.type: log
       - service.type: redis
-  - check:
-      - log.level: +s_eq/.
+  - check: log.level==.
     map:
       - log.level: debug
-  - check:
-      - log.level: +s_eq/-
+  - check: log.level==-
     map:
       - log.level: verbose
-  - check:
-      - log.level: +s_eq/*
+  - check: log.level==*
     map:
       - log.level: notice
-  - check:
-      - log.level: +s_eq/#
+  - check: log.level==#
     map:
       - log.level: warning
-  - check:
-      - ~log.role: +s_eq/M
+  - check: ~log.role==M
     map:
       - redis.log.role: master
-  - check:
-      - ~log.role: +s_eq/S
+  - check: ~log.role==S
     map:
       - redis.log.role: slave
-  - check:
-      - ~log.role: +s_eq/C
+  - check: ~log.role==C
     map:
       - redis.log.role: child
-  - check:
-      - ~log.role: +s_eq/X
+  - check:  ~log.role==X
     map:
       - redis.log.role: sentinel
   - map:

--- a/src/engine/ruleset/decoders/redis/redis.yml
+++ b/src/engine/ruleset/decoders/redis/redis.yml
@@ -7,30 +7,27 @@ metadata:
     - https://docs.elastic.co/en/integrations/redis
   module: redis
 
-definitions:
-  LOG_PID_ROLE: <~log.process.pid>:<~log.role>
-
 # Example redis logs:
 
 # Darwin
 # 4961:M 30 May 12:50:13.457 * Increased maximum number of open files to 10032 (it was originally set to 4864).
-#                 _._                                                  
-#            _.-``__ ''-._                                             
+#                 _._
+#            _.-``__ ''-._
 #       _.-``    `.  `_.  ''-._           Redis 3.0.2 (00000000/0) 64 bit
-#   .-`` .-```.  ```\/    _.,_ ''-._                                   
+#   .-`` .-```.  ```\/    _.,_ ''-._
 #  (    '      ,       .-`  | `,    )     Running in standalone mode
 #  |`-._`-...-` __...-.``-._|'` _.-'|     Port: 6379
 #  |    `-._   `._    /     _.-'    |     PID: 4961
-#   `-._    `-._  `-./  _.-'    _.-'                                   
-#  |`-._`-._    `-.__.-'    _.-'_.-'|                                  
-#  |    `-._`-._        _.-'_.-'    |           http://redis.io        
-#   `-._    `-._`-.__.-'_.-'    _.-'                                   
-#  |`-._`-._    `-.__.-'    _.-'_.-'|                                  
-#  |    `-._`-._        _.-'_.-'    |                                  
-#   `-._    `-._`-.__.-'_.-'    _.-'                                   
-#       `-._    `-.__.-'    _.-'                                       
-#           `-._        _.-'                                           
-#               `-.__.-'                                               
+#   `-._    `-._  `-./  _.-'    _.-'
+#  |`-._`-._    `-.__.-'    _.-'_.-'|
+#  |    `-._`-._        _.-'_.-'    |           http://redis.io
+#   `-._    `-._`-.__.-'_.-'    _.-'
+#  |`-._`-._    `-.__.-'    _.-'_.-'|
+#  |    `-._`-._        _.-'_.-'    |
+#   `-._    `-._`-.__.-'_.-'    _.-'
+#       `-._    `-.__.-'    _.-'
+#           `-._        _.-'
+#               `-.__.-'
 # 4961:M 30 May 12:50:13.463 # Server started, Redis version 3.0.2
 
 # Debian
@@ -42,25 +39,23 @@ definitions:
 parse:
   logpar:
     # 26571:M 27 Dec 2018 11:19:18.874 * Synchronization with replica 10.114.208.18:6023 succeeded
-    - event.original: $LOG_PID_ROLE <~log.timestamp_test/date/%d %b %Y %T> <~log.level> <~log.msg>
+    - event.original: <process.pid>:<~log.role> <@timestamp/%d %b %Y %T> <log.level> <message>
 
     # Darwin
-    - event.original: $LOG_PID_ROLE <~log.timestamp_test/date/%d %b %T> <~log.level> <~log.msg>
+    - event.original: <process.pid>:<~log.role> <@timestamp/%d %b %T> <log.level> <message>
 
     # Debian
-    - event.original: <~log.timestamp_debian/date/%d %b %T> <~log.level> <~log.msg>
+    - event.original: <@timestamp/%d %b %T> <~log.level> <message>
 
     # Windows
-    - event.original: <~/ignore/[><~log.pid>] <~log.timestamp_window/date/%d %b %T> <~log.level> <~log.msg>
+    - event.original: <~/ignore/[><~log.pid>] <@timestamp/%d %b %T> <log.level> <message>
 
-# TODO: Could not map field 'log.offset' due to inability to persist values into yml variables. 
+# TODO: Could not map field 'log.offset' due to inability to persist values into yml variables.
 # Also, there is no helper that allows obtaining the size of an event.
 normalize:
   - map:
       - event.kind: event
       - event.module: redis
-      - event.message: $~log.msg
-      - event.process.pid: $~log.process.pid
       - event.type: +a_append/info
       - event.category: +a_append/database
       - event.dataset: redis.log
@@ -68,45 +63,44 @@ normalize:
       - input.type: log
       - service.type: redis
   - check:
-      - ~log.level: +ef_exists
-      - ~log.level: +s_eq/.
+      - log.level: +ef_exists
+      - log.level: +s_eq/.
     map:
       - log.level: debug
   - check:
-      - ~log.level: +ef_exists
-      - ~log.level: +s_eq/-
+      - log.level: +ef_exists
+      - log.level: +s_eq/-
     map:
       - log.level: verbose
   - check:
-      - ~log.level: +ef_exists
-      - ~log.level: +s_eq/*
+      - log.level: +ef_exists
+      - log.level: +s_eq/*
     map:
       - log.level: notice
   - check:
-      - ~log.level: +ef_exists
-      - ~log.level: +s_eq/#
+      - log.level: +ef_exists
+      - log.level: +s_eq/#
     map:
       - log.level: warning
   - check:
       - ~log.role: +ef_exists
       - ~log.role: +s_eq/M
     map:
-      - event.role: master
+      - redis.log.role: master
   - check:
       - ~log.role: +ef_exists
       - ~log.role: +s_eq/S
     map:
-      - event.role: slave
+      - redis.log.role: slave
   - check:
       - ~log.role: +ef_exists
       - ~log.role: +s_eq/C
     map:
-      - event.role: child
+      - redis.log.role: child
   - check:
       - ~log.role: +ef_exists
       - ~log.role: +s_eq/X
     map:
-      - event.role: sentinel
+      - redis.log.role: sentinel
   - map:
       - ~log: +ef_delete
-

--- a/src/engine/ruleset/decoders/redis/redis.yml
+++ b/src/engine/ruleset/decoders/redis/redis.yml
@@ -60,28 +60,36 @@ normalize:
       - fileset.name: log
       - input.type: log
       - service.type: redis
-  - check: log.level==.
+  - check:
+      - log.level: "."
     map:
       - log.level: debug
-  - check: log.level==-
+  - check:
+      - log.level: "-"
     map:
       - log.level: verbose
-  - check: log.level==*
+  - check:
+      - log.level: "*"
     map:
       - log.level: notice
-  - check: log.level==#
+  - check:
+      - log.level: "#"
     map:
       - log.level: warning
-  - check: ~log.role==M
+  - check:
+      - ~log.role: M
     map:
       - redis.log.role: master
-  - check: ~log.role==S
+  - check:
+      - ~log.role: S
     map:
       - redis.log.role: slave
-  - check: ~log.role==C
+  - check:
+      - ~log.role: C
     map:
       - redis.log.role: child
-  - check:  ~log.role==X
+  - check:
+      - ~log.role: X
     map:
       - redis.log.role: sentinel
   - map:

--- a/src/engine/ruleset/decoders/redis/redis.yml
+++ b/src/engine/ruleset/decoders/redis/redis.yml
@@ -53,6 +53,8 @@ parse:
     # Windows
     - event.original: <~/ignore/[><~log.pid>] <~log.timestamp_window/date/%d %b %T> <~log.level> <~log.msg>
 
+# TODO: Could not map field 'log.offset' due to inability to persist values into yml variables. 
+# Also, there is no helper that allows obtaining the size of an event.
 normalize:
   - map:
       - event.kind: event

--- a/src/engine/ruleset/decoders/redis/redis.yml
+++ b/src/engine/ruleset/decoders/redis/redis.yml
@@ -12,6 +12,7 @@ definitions:
 
 # Example redis logs:
 
+# Darwin
 # 4961:M 30 May 12:50:13.457 * Increased maximum number of open files to 10032 (it was originally set to 4864).
 #                 _._                                                  
 #            _.-``__ ''-._                                             
@@ -32,8 +33,10 @@ definitions:
 #               `-.__.-'                                               
 # 4961:M 30 May 12:50:13.463 # Server started, Redis version 3.0.2
 
+# Debian
 # 30 May 10:04:45 . 0 clients connected (0 slaves), 618932 bytes in use, 0 shared objects
 
+# Windows
 # [2932] 31 May 04:32:08 - 0 clients connected (0 slaves), 1179968 bytes in use
 
 parse:
@@ -42,15 +45,12 @@ parse:
     - event.original: $LOG_PID_ROLE <~log.timestamp_test/date/%d %b %Y %T> <~log.level> <~log.msg>
 
     # Darwin
-    # 4961:M 30 May 12:50:13.457 * Increased maximum number of open files to 10032 (it was originally set to 4864).
     - event.original: $LOG_PID_ROLE <~log.timestamp_test/date/%d %b %T> <~log.level> <~log.msg>
 
     # Debian
-    # 30 May 10:04:45 . 0 clients connected (0 slaves), 618932 bytes in use, 0 shared objects
     - event.original: <~log.timestamp_debian/date/%d %b %T> <~log.level> <~log.msg>
 
     # Windows
-    # [2932] 31 May 04:32:08 # Open data file dump.rdb: No such file or directory
     - event.original: <~/ignore/[><~log.pid>] <~log.timestamp_window/date/%d %b %T> <~log.level> <~log.msg>
 
 normalize:
@@ -107,3 +107,4 @@ normalize:
       - event.role: sentinel
   - map:
       - ~log: +ef_delete
+

--- a/src/engine/ruleset/decoders/redis/redis.yml
+++ b/src/engine/ruleset/decoders/redis/redis.yml
@@ -39,21 +39,19 @@ definitions:
 parse:
   logpar:
     # 26571:M 27 Dec 2018 11:19:18.874 * Synchronization with replica 10.114.208.18:6023 succeeded
-    - event.original: $LOG_PID_ROLE <~log.timestamp_test/date/%d %b %Y %T> * <~log.msg>
+    - event.original: $LOG_PID_ROLE <~log.timestamp_test/date/%d %b %Y %T> <~log.level> <~log.msg>
 
-    #  |    `-._   `._    /     _.-'    |     PID: 4961
-
-    - event.original: $LOG_PID_ROLE <~log.timestamp_test/date/%d %b %Y %T> * <~log.msg>
+    # Darwin
+    # 4961:M 30 May 12:50:13.457 * Increased maximum number of open files to 10032 (it was originally set to 4864).
+    - event.original: $LOG_PID_ROLE <~log.timestamp_test/date/%d %b %T> <~log.level> <~log.msg>
 
     # Debian
     # 30 May 10:04:45 . 0 clients connected (0 slaves), 618932 bytes in use, 0 shared objects
-    - event.original: <~log.timestamp_debian/date/%d %b %T> . <~log.msg>
-    - event.original: <~log.timestamp_debian/date/%d %b %T> - <~log.msg>
-    - event.original: <~log.timestamp_debian/date/%d %b %T> * <~log.msg>
+    - event.original: <~log.timestamp_debian/date/%d %b %T> <~log.level> <~log.msg>
 
     # Windows
     # [2932] 31 May 04:32:08 # Open data file dump.rdb: No such file or directory
-    - event.original: <~/ignore/[><~log.pid>] <~log.timestamp_window/date/%d %b %T> <~/ignore/#> <~log.msg>
+    - event.original: <~/ignore/[><~log.pid>] <~log.timestamp_window/date/%d %b %T> <~log.level> <~log.msg>
 
 normalize:
   - map:
@@ -61,6 +59,32 @@ normalize:
       - event.module: redis
       - event.message: $~log.msg
       - event.process.pid: $~log.process.pid
+      - event.type: +a_append/info
+      - event.category: +a_append/database
+      - event.dataset: redis.log
+      - file.name: log
+      - input.type: log
+      - service.type: redis
+  - check:
+      - ~log.level: +ef_exists
+      - ~log.level: +s_eq/.
+    map:
+      - log.level: debug
+  - check:
+      - ~log.level: +ef_exists
+      - ~log.level: +s_eq/-
+    map:
+      - log.level: verbose
+  - check:
+      - ~log.level: +ef_exists
+      - ~log.level: +s_eq/*
+    map:
+      - log.level: notice
+  - check:
+      - ~log.level: +ef_exists
+      - ~log.level: +s_eq/#
+    map:
+      - log.level: warning
   - check:
       - ~log.role: +ef_exists
       - ~log.role: +s_eq/M
@@ -71,5 +95,15 @@ normalize:
       - ~log.role: +s_eq/S
     map:
       - event.role: slave
+  - check:
+      - ~log.role: +ef_exists
+      - ~log.role: +s_eq/C
+    map:
+      - event.role: child
+  - check:
+      - ~log.role: +ef_exists
+      - ~log.role: +s_eq/X
+    map:
+      - event.role: sentinel
   - map:
       - ~log: +ef_delete

--- a/src/engine/ruleset/environments/wazuh-environment.yml
+++ b/src/engine/ruleset/environments/wazuh-environment.yml
@@ -18,6 +18,7 @@ decoders:
   - decoder/fim/0
   - decoder/fim-event/0
   - decoder/fim-scan/0
+  - decoder/redis/0
   - decoder/rootcheck/0
   - decoder/sca/0
   - decoder/syscollector-base/0


### PR DESCRIPTION
|Related issue|
|---|
|closes #15849 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

With the aim of expanding the coverage of the decoders, this PR adds a decoder for Redis.

## Configuration options

Validate the new decoder:
- ./build/main catalog validate decoder/redis/0 < /home/vagrant/engine/wazuh/src/engine/ruleset/decoders/redis/redis.yml 

Create decoder:
- ./build/main  catalog create decoder < /home/vagrant/engine/wazuh/src/engine/ruleset/decoders/redis/redis.yml

Update environment
- ./build/main catalog update environment/wazuh/0 < /home/vagrant/engine/wazuh/src/engine/ruleset/environments/wazuh-environment.yml

Test new decoder
- ./build/main test -q -1

## Logs/Alerts example

Test
- 26571:M 27 Dec 2018 11:19:18.874 * Synchronization with replica 10.114.208.18:6023 succeeded

Darwin
- 4961:M 30 May 12:50:13.457 * Increased maximum number of open files to 10032 (it was originally set to 4864).

Debian
- 30 May 10:04:45 . 0 clients connected (0 slaves), 618932 bytes in use, 0 shared objects

Windows
- [2932] 31 May 04:32:08 - 0 clients connected (0 slaves), 1179968 bytes in use

## Tests

Event:
4961:M 30 May 12:50:13.457 * Increased maximum number of open files to 10032 (it was originally set to 4864).

Output:
```
{
    "wazuh": {
        "queue": -1,
        "origin": "/dev/stdin"
    },
    "event": {
        "original": "26571:M 27 Dec 2018 11:19:18.874 * Synchronization with replica 10.114.208.18:6023 succeeded",
        "kind": "event",
        "module": "redis",
        "type": [
            "info"
        ],
        "category": [
            "database"
        ],
        "dataset": "redis.log"
    },
    "log": {
        "level": "notice"
    },
    "message": "Synchronization with replica 10.114.208.18:6023 succeeded",
    "fileset": {
        "name": "log"
    },
    "input": {
        "type": "log"
    },
    "process": {
        "pid": "26571"
    },
    "service": {
        "type": "redis"
    },
    "redis": {
        "log": {
            "role": "master"
        }
    }
}

```