### PR TITLE
Fix a read buffer overflow in wazuh-authd when parsing requests

### DIFF
--- a/src/unit_tests/os_auth/test_auth_parse.c
+++ b/src/unit_tests/os_auth/test_auth_parse.c
@@ -85,6 +85,9 @@ parse_evaluator parse_values_default_cfg [] = {
     { "OSSEC PASS: pass124 OSSEC A:'agent0'", "192.0.0.1", NULL,        {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid request for new agent"}, {"Invalid request for new agent from: 192.0.0.1", NULL, NULL, NULL} },
     { "OSSEC A:''", "192.0.0.1", NULL,                                  {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid agent name: "},          {"Invalid agent name:  from 192.0.0.1", NULL, "Received request for a new agent () from: 192.0.0.1", NULL} },
     { "OSSEC A:'inv;agent'", "192.0.0.1", NULL,                         {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid agent name: inv;agent"}, {"Invalid agent name: inv;agent from 192.0.0.1", NULL, "Received request for a new agent (inv;agent) from: 192.0.0.1", NULL} },
+    { "OSSEC A:'agent3' G:'Group1,Group2", "192.0.0.1", NULL,           {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Unterminated group field"}, {"Unterminated group field", NULL, "Received request for a new agent (agent3) from: 192.0.0.1", NULL} },
+    { "OSSEC A:'agent3' G:'Group1,Group2' IP:'192.0.0.3 K:'ABC123'", "192.0.0.1", NULL,           {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Unterminated IP field"}, {"Unterminated IP field", NULL, "Received request for a new agent (agent3) from: 192.0.0.1", "Group(s) is: Group1,Group2"} },
+    { "OSSEC A:'agent3' G:'Group1,Group2' IP:'192.0.0.3' K:'ABC123", "192.0.0.1", NULL,           {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Unterminated key field"}, {"Unterminated key field", NULL, "Received request for a new agent (agent3) from: 192.0.0.1", "Group(s) is: Group1,Group2"} },
 
     {0}
 };
@@ -129,7 +132,7 @@ static void test_w_auth_parse_data(void **state) {
     char *key_hash = NULL;
     w_err_t err;
 
-    unsigned int max = config.flags.use_source_ip == 1 ? 4 : 1;
+    unsigned int max = config.flags.use_source_ip == 1 ? 5 : 1;
     for (unsigned int a = 0; a < max; a++) {
         expect_any(__wrap_OS_IsValidIP, ip_address);
         expect_any(__wrap_OS_IsValidIP, final_ip);

--- a/src/unit_tests/os_auth/test_auth_parse.c
+++ b/src/unit_tests/os_auth/test_auth_parse.c
@@ -125,7 +125,6 @@ extern w_err_t w_auth_parse_data(const char* buf,
 
 static void test_w_auth_parse_data(void **state) {
     char response[2048] = {0};
-    char buffer[OS_SIZE_20480] = {0};
     char ip[IPSIZE + 1];
     char *agentname = NULL;
     char *groups = NULL;
@@ -143,8 +142,7 @@ static void test_w_auth_parse_data(void **state) {
         set_expected_log(&parse_values[i].expected_log);
         response[0] = '\0';
         strncpy(ip, parse_values[i].src_ip, IPSIZE);
-        strncpy(buffer, parse_values[i].buffer, strlen(parse_values[i].buffer) + 1);
-        err = w_auth_parse_data(buffer, response, parse_values[i].pass, ip, &agentname, &groups, &key_hash);
+        err = w_auth_parse_data(parse_values[i].buffer, response, parse_values[i].pass, ip, &agentname, &groups, &key_hash);
 
         assert_int_equal(err, parse_values[i].expected_response.err);
         if (err == OS_SUCCESS) {


### PR DESCRIPTION
|Related issue|QA issue|
|---|---|
|Closes #15861|https://github.com/wazuh/wazuh-qa/issues/3742|

This PR aims to apply the following changes:

1. Fix a read overflow hazard found in wazuh-authd when parsing requests.
2. Let the parser properly validate the group, IP, and key-hash of the request (they must be enclosed between single-quotes).
3. Apply the necessary changes in the unit tests so that they detect the condition that is fixed.

## Rationale

This is an example of request string:

```
OSSEC PASS: pass123 OSSEC A:'agent9' IP:'192.0.0.3' K:'ABC123'
```

Fields are separated by whitespaces, and some values are enclosed by single-quotes. The current (unpatched) version of the parser wrongly assumes that the values are properly enclosed, and there is a trailing whitespace.

This causes that the parser might look up beyond the string boundary.

## Proposed fix

- Check that the fields that shall be enclosed by single-quotes have a trailing single-quote.
- Check if a whitespace separator exists before each next field.

## Tests

### Treating a malformed input string

#### Input string

```
OSSEC PASS: agent1 OSSEC A:'agent4' G:'Group1,Group2,Group1a
```

#### Log

```
wazuh-authd: ERROR: Unterminated group part
```

### AddressSanitizer report

Applying the unit tests from this branch to an unpatched version of wazuh-authd:

```
==19510==ERROR: AddressSanitizer: global-buffer-overflow on address 0x5593a08cf1d1 at pc 0x7feb17bcbc66 bp 0x7ffff804a1f0 sp 0x7ffff8049998
READ of size 1 at 0x5593a08cf1d1 thread T0
    #0 0x7feb17bcbc65 in __interceptor_strncmp ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:497
    #1 0x5593a075d192 in w_auth_parse_data os_auth/auth.c:128
    #2 0x5593a0759db6 in test_w_auth_parse_data /root/wazuh-4.4/src/unit_tests/os_auth/test_auth_parse.c:140
    #3 0x7feb172174e0  (/lib/x86_64-linux-gnu/libcmocka.so.0+0x54e0)
    #4 0x7feb17217ec4 in _cmocka_run_group_tests (/lib/x86_64-linux-gnu/libcmocka.so.0+0x5ec4)
    #5 0x5593a075af29 in main /root/wazuh-4.4/src/unit_tests/os_auth/test_auth_parse.c:173
    #6 0x7feb169dcd8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #7 0x7feb169dce3f in __libc_start_main_impl ../csu/libc-start.c:392
    #8 0x5593a0758834 in _start (/root/wazuh-4.4/src/unit_tests/build/os_auth/test_auth_parse+0x23e834)

0x5593a08cf1d1 is located 47 bytes to the left of global variable '*.LC7' defined in '/root/wazuh-4.4/src/unit_tests/os_auth/test_auth_parse.c' (0x5593a08cf200) of size 10
  '*.LC7' is ascii string '192.0.0.1'
0x5593a08cf1d1 is located 0 bytes to the right of global variable '*.LC6' defined in '/root/wazuh-4.4/src/unit_tests/os_auth/test_auth_parse.c' (0x5593a08cf1c0) of size 17
  '*.LC6' is ascii string 'OSSEC A:'agent1''
SUMMARY: AddressSanitizer: global-buffer-overflow ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:497 in __interceptor_strncmp
Shadow bytes around the buggy address:
  0x0ab2f4111de0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ab2f4111df0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ab2f4111e00: 00 00 00 00 00 00 00 00 00 00 00 01 f9 f9 f9 f9
  0x0ab2f4111e10: 00 06 f9 f9 f9 f9 f9 f9 00 07 f9 f9 f9 f9 f9 f9
  0x0ab2f4111e20: 00 06 f9 f9 f9 f9 f9 f9 00 06 f9 f9 f9 f9 f9 f9
=>0x0ab2f4111e30: 00 00 f9 f9 f9 f9 f9 f9 00 00[01]f9 f9 f9 f9 f9
  0x0ab2f4111e40: 00 02 f9 f9 f9 f9 f9 f9 07 f9 f9 f9 f9 f9 f9 f9
  0x0ab2f4111e50: 01 f9 f9 f9 f9 f9 f9 f9 00 00 00 00 00 00 00 02
  0x0ab2f4111e60: f9 f9 f9 f9 00 00 00 04 f9 f9 f9 f9 07 f9 f9 f9
  0x0ab2f4111e70: f9 f9 f9 f9 07 f9 f9 f9 f9 f9 f9 f9 00 00 00 00
  0x0ab2f4111e80: 00 00 00 02 f9 f9 f9 f9 00 00 04 f9 f9 f9 f9 f9
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==19510==ABORTING
```

