### PR TITLE
Fix windows UTs compilation in FIM DB branch

### DIFF
--- a/src/unit_tests/config/CMakeLists.txt
+++ b/src/unit_tests/config/CMakeLists.txt
@@ -24,7 +24,9 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 
 # Generate config tests
 list(APPEND config_names "test_client-config_validate_ipv6_link_local_interface")
-list(APPEND config_flags "-Wl,--wrap,OS_GetHost ${DEBUG_OP_WRAPPERS}")
+list(APPEND config_flags "-Wl,--wrap,OS_GetHost -Wl,--wrap=Start_win32_Syscheck -Wl,--wrap,syscom_dispatch \
+                          -Wl,--wrap=is_fim_shutdown -Wl,--wrap=_imp__dbsync_initialize \
+                          -Wl,--wrap=_imp__rsync_initialize -Wl,--wrap=fim_db_teardown ${DEBUG_OP_WRAPPERS}")
 
 # Compiling tests
 list(LENGTH config_names count)


### PR DESCRIPTION
|Related issue|
|---|
|#9103|



## Description
Hello team,
after the last merge from master we have done to our development branch, some new unit test files have been created:
`src/unit_tests/config`

And since some of the wrappers that we have included in our development, must exists in all CMakeFile files, it is necessary to include them in this one so all the tests can compile correctly.