### PR TITLE
Fixes resource leak reported by coverity

### DIFF
--- a/src/wazuh_db/wdb_sca.c
+++ b/src/wazuh_db/wdb_sca.c
@@ -644,6 +644,7 @@ end:
             OS_SHA256_String(results, hash);
             snprintf(output, OS_MAXSTR - WDB_RESPONSE_BEGIN_SIZE, "%s", hash);
             os_free(str);
+            os_free(results);
         }
         return 1;
     }


### PR DESCRIPTION
|Related issue|Manual Testing|
|---|---|
|#15908|https://github.com/wazuh/wazuh-qa/issues/3753|

## Description

This PR fixes the resource leak reported in #15908 by adding the missing call to `os_free(results)`.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Coverity
