### PR TITLE
Update agents DB version to 10

### DIFF
--- a/src/unit_tests/os_crypto/md5_sha1_sha256/test_md5_sha1_sha256_op.c
+++ b/src/unit_tests/os_crypto/md5_sha1_sha256/test_md5_sha1_sha256_op.c
@@ -42,7 +42,7 @@ void test_md5_sha1_sha256_file(void **state)
     /* create tmp file */
     char file_name[256] = "/tmp/tmp_file-XXXXXX";
 
-    FILE * fp;
+    FILE * fp = 0x1;
     expect_wfopen(file_name, "r", fp);
     expect_fread(string, strlen(string));
     expect_fread(string, 0);

--- a/src/wazuh_db/schema_agents.sql
+++ b/src/wazuh_db/schema_agents.sql
@@ -397,7 +397,7 @@ CREATE INDEX IF NOT EXISTS cve_status ON vuln_cves (status);
 
 BEGIN;
 
-INSERT INTO metadata (key, value) VALUES ('db_version', '9');
+INSERT INTO metadata (key, value) VALUES ('db_version', '10');
 INSERT INTO scan_info (module) VALUES ('fim');
 INSERT INTO scan_info (module) VALUES ('syscollector');
 INSERT INTO sync_info (component) VALUES ('fim');


### PR DESCRIPTION
|Related issue|QA|
|---|---|
|Closes #15897|https://github.com/wazuh/wazuh-qa/issues/3751|

This PR aims to fix the following warning that Wazuh DB appears as of the second execution of the manager:

```
2023/01/13 16:38:19 wazuh-db: WARNING: DB(000) wdb_sql_exec returned error: 'no such column: status'
```

This happens because new databases have version 9 (same as Wazuh 4.3), causing Wazuh DB to upgrade them to version 10 (when the right starting version should be 10).

## Proposed fix

New databases should start with version 10.

## Tests

- [X] Start the manager three times, no warnings appear from Wazuh DB.

#### First run

```
2023/01/16 10:33:52 wazuh-db[17306] main.c:196 at main(): INFO: Started (pid: 17306).
2023/01/16 10:33:52 wazuh-db[17306] main.c:324 at run_dealer(): DEBUG: New client connected (6).
2023/01/16 10:33:52 wazuh-db[17306] wdb.c:344 at wdb_open_global(): DEBUG: Global database not found, creating.
2023/01/16 10:33:52 wazuh-db[17306] wdb.c:808 at wdb_create_file(): DEBUG: Ignoring chown when creating file from SQL.
```

#### Second run

```
2023/01/16 10:34:12 wazuh-db[17334] main.c:196 at main(): INFO: Started (pid: 17334).
2023/01/16 10:34:12 wazuh-db[17334] main.c:324 at run_dealer(): DEBUG: New client connected (8).
2023/01/16 10:34:12 wazuh-db[17334] main.c:386 at run_worker(): DEBUG: Client 8 disconnected.
```

### Memory tests

We skip memory tests because this PR won't change any executable code.