### PR TITLE
Remove unused variable in Authd

### DIFF
--- a/src/os_auth/key_request.c
+++ b/src/os_auth/key_request.c
@@ -211,7 +211,6 @@ char * key_request_exec_output(request_type_t type, char *request) {
 
 void* run_key_request_main(__attribute__((unused)) void *arg) {
     int sock;
-    int recv;
     unsigned int i;
     char buffer[OS_MAXSTR + 1];
     char * copy;
@@ -253,7 +252,7 @@ void* run_key_request_main(__attribute__((unused)) void *arg) {
             }
         }
 
-        if (recv = OS_RecvUnix(sock, OS_MAXSTR, buffer), recv > 0) {
+        if (OS_RecvUnix(sock, OS_MAXSTR, buffer) > 0) {
             if(OSHash_Get_ex(request_hash, buffer)){
                 mdebug2("Request '%s' already being processed. Discarding request.", buffer);
                 continue;

--- a/src/os_auth/key_request.c
+++ b/src/os_auth/key_request.c
@@ -212,7 +212,7 @@ char * key_request_exec_output(request_type_t type, char *request) {
 void* run_key_request_main(__attribute__((unused)) void *arg) {
     int sock;
     unsigned int i;
-    char buffer[OS_MAXSTR + 1];
+    char buffer[OS_MAXSTR + 1] = {0};
     char * copy;
 
     authd_sigblock();


### PR DESCRIPTION
|Related issue|
|---|
|Closes #15956 |

The `OS_RecvUnix()` call in Authd has suffered multiple false positive reports from several analysis tools.

1. Coverity reported that `buffer` is not null-terminated. It seems it's unable to parse the call to `OS_RecvUnix()` before the comma:
```c
if (recv = OS_RecvUnix(sock, OS_MAXSTR, buffer), recv) {
```
2. We proposed this fix (#15573), but now scan-build complains that the variable is not being used:
```c
if ((recv = OS_RecvUnix(sock, OS_MAXSTR, buffer)) > 0) {
```
3. We fixed that again (#15692), but that enabled the Coverity report again:
```c
if (recv = OS_RecvUnix(sock, OS_MAXSTR, buffer), recv > 0) {
```
4. This way, I suggest removing the variable `recv` as it's not used after the condition:
```c
if (OS_RecvUnix(sock, OS_MAXSTR, buffer) > 0) {
```
5. We initialize the variable to zero in order to meet the requirements of the code analyzers:
```c
char buffer[OS_MAXSTR + 1] = {0};
```

## Tests

- [x] scan-build
```
<server>=================== Running Scanbuild   ===================<server>
[CleanAll: PASSED]
[CleanExternals: PASSED]
[MakeDeps: PASSED]
[ScanBuild: PASSED]
<server>[SCANBUILD: PASSED]<server>
```
- [x] Coverity

[Coverity report](https://u15810271.ct.sendgrid.net/ls/click?upn=HRESupC-2F2Czv4BOaCWWCy7my0P0qcxCbhZ31OYv50yqgxSCSCoUvZsyOQWelCN1eGu9HosOCYbyK-2BRVlIuFp0Q-3D-3DRR9r_3yVA0AJkLK9RgkvZQZCJdHhspcw09JEPNyGmNvbjVXDSJ4Tqdc0NUSz4KOtwzDfIkB3DB22e3Rl9U7ROiuuKH-2F5B4dvJFS4flTfwwwvLeoNheWNRNWFqRx0-2FLwi0NdEGBUMKyk413agk6pWap2ei4ExtXwZziNJIZAawUBhklf8m6oepcb5VXEZatGDUL2hbCMGT7wUbwol5rnCAxpaQPg-3D-3D)