### PR TITLE
Allow reading `ossec.json` using the Wazuh API

### DIFF
--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -216,7 +216,9 @@ SHARED_PATH = os.path.join(WAZUH_PATH, 'etc', 'shared')
 
 
 # ================================================= Wazuh path - Misc ==================================================
-OSSEC_LOG = os.path.join(WAZUH_PATH, 'logs', 'ossec.log')
+WAZUH_LOGS = os.path.join(WAZUH_PATH, 'logs')
+WAZUH_LOG = os.path.join(WAZUH_LOGS, 'ossec.log')
+WAZUH_LOG_JSON = os.path.join(WAZUH_LOGS, 'ossec.json')
 DATABASE_PATH = os.path.join(WAZUH_PATH, 'var', 'db')
 DATABASE_PATH_GLOBAL = os.path.join(DATABASE_PATH, 'global.db')
 DATABASE_PATH_AGENTS = os.path.join(DATABASE_PATH, 'agents')

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -50,6 +50,9 @@ class WazuhException(Exception):
         1017: 'Some Wazuh daemons are not ready yet in node "{node_name}" ({not_ready_daemons})',
         1018: 'Body request is not a valid JSON',
         1019: 'Error trying to create backup file',
+        1020: {'message': 'Could not find any Wazuh log file',
+               'remediation': 'Please check `WAZUH_HOME/logs`'},
+
         # Configuration: 1100 - 1199
         1101: {'message': 'Requested component does not exist',
                'remediation': 'Run `WAZUH_PATH/bin/wazuh-logtest -t` to check your configuration'},

--- a/framework/wazuh/core/tests/data/manager/ossec_log.json
+++ b/framework/wazuh/core/tests/data/manager/ossec_log.json
@@ -1,0 +1,15 @@
+{"timestamp":"2023/01/18 12:52:56","tag":"wazuh-remoted","pid":27006,"file":"secure.c","line":374,"routine":"rem_keyupdate_main","level":"debug","description":"Checking for keys file changes."}
+{"timestamp":"2023/01/18 12:52:57","tag":"wazuh-remoted","pid":27006,"file":"state.c","line":161,"routine":"rem_write_state","level":"debug","description":"Updating state file."}
+{"timestamp":"2023/01/18 12:52:59","tag":"wazuh-db","pid":26854,"file":"wdb_parser.c","line":821,"routine":"wdb_parse","level":"debug","description":"Global query: sync-agent-groups-get {\"condition\": \"sync_status\", \"set_synced\": true, \"get_global_hash\": true}"}
+{"timestamp":"2023/01/18 12:52:59","tag":"wazuh-db","pid":26854,"file":"wdb_integrity.c","line":699,"routine":"wdb_get_global_group_hash","level":"debug","description":"Using global group hash from cache"}
+{"timestamp":"2023/01/18 12:53:02","tag":"wazuh-remoted","pid":27006,"file":"state.c","line":161,"routine":"rem_write_state","level":"debug","description":"Updating state file."}
+{"timestamp":"2023/01/18 12:53:06","tag":"wazuh-remoted","pid":27006,"file":"manager.c","line":693,"routine":"c_files","level":"debug","description":"Updating shared files sums."}
+{"timestamp":"2023/01/18 12:53:06","tag":"wazuh-db","pid":26854,"file":"main.c","line":324,"routine":"run_dealer","level":"debug","description":"New client connected (39)."}
+{"timestamp":"2023/01/18 12:53:06","tag":"wazuh-db","pid":26854,"file":"wdb_parser.c","line":821,"routine":"wdb_parse","level":"debug","description":"Global query: get-all-agents last_id 0"}
+{"timestamp":"2023/01/18 12:53:06","tag":"wazuh-db","pid":26854,"file":"main.c","line":324,"routine":"run_dealer","level":"debug","description":"New client connected (41)."}
+{"timestamp":"2023/01/18 12:53:06","tag":"wazuh-db","pid":26854,"file":"main.c","line":386,"routine":"run_worker","level":"debug","description":"Client 39 disconnected."}
+{"timestamp":"2023/01/18 12:53:06","tag":"wazuh-db","pid":26854,"file":"wdb_parser.c","line":821,"routine":"wdb_parse","level":"debug","description":"Global query: get-agent-info 1"}
+{"timestamp":"2023/01/18 12:53:06","tag":"wazuh-remoted","pid":27006,"file":"manager.c","line":715,"routine":"c_files","level":"debug","description":"End updating shared files sums."}
+{"timestamp":"2023/01/18 12:53:06","tag":"wazuh-db","pid":26854,"file":"main.c","line":386,"routine":"run_worker","level":"debug","description":"Client 41 disconnected."}
+{"timestamp":"2023/01/18 12:53:06","tag":"wazuh-remoted","pid":27006,"file":"secure.c","line":374,"routine":"rem_keyupdate_main","level":"debug","description":"Checking for keys file changes."}
+{"timestamp":"2023/01/18 12:53:07","tag":"wazuh-remoted","pid":27006,"file":"state.c","line":161,"routine":"rem_write_state","level":"debug","description":"Updating state file."}

--- a/framework/wazuh/core/tests/test_manager.py
+++ b/framework/wazuh/core/tests/test_manager.py
@@ -4,8 +4,8 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
-from unittest.mock import patch
 from datetime import timezone, datetime
+from unittest.mock import patch
 
 import pytest
 
@@ -16,6 +16,7 @@ with patch('wazuh.core.common.wazuh_uid'):
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data', 'manager')
 ossec_log_path = '{0}/ossec_log.log'.format(test_data_path)
+ossec_log_json_path = '{0}/ossec_log.log'.format(test_data_path)
 
 
 class InitManager:
@@ -41,8 +42,8 @@ def test_manager():
     return test_manager
 
 
-def get_logs():
-    with open(ossec_log_path) as f:
+def get_logs(json_log: bool = False):
+    with open(ossec_log_json_path if json_log else ossec_log_path) as f:
         return f.read()
 
 
@@ -107,16 +108,24 @@ def test_get_ossec_log_fields_ko():
     assert not result
 
 
-def test_get_ossec_logs():
+@pytest.mark.parametrize("json_log", [
+    True, False
+])
+def test_get_ossec_logs(json_log):
     """Test get_ossec_logs() method returns result with expected information"""
-    logs = get_logs().splitlines()
+    logs = get_logs(json_log=json_log).splitlines()
 
-    with patch('wazuh.core.manager.tail', return_value=logs):
-        result = get_ossec_logs()
-        assert all(key in log for key in ('timestamp', 'tag', 'level', 'description') for log in result)
+    with pytest.raises(WazuhInternalError, match=".*1020.*"):
+        get_ossec_logs()
+
+    with patch('wazuh.core.manager.exists', return_value=True):
+        with patch('wazuh.core.manager.tail', return_value=logs):
+            result = get_ossec_logs()
+            assert all(key in log for key in ('timestamp', 'tag', 'level', 'description') for log in result)
 
 
-def test_get_logs_summary():
+@patch('wazuh.core.manager.exists', return_value=True)
+def test_get_logs_summary(mock_exists):
     """Test get_logs_summary() method returns result with expected information"""
     logs = get_logs().splitlines()
     with patch('wazuh.core.manager.tail', return_value=logs):

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -21,6 +21,7 @@ with patch('wazuh.core.common.wazuh_uid'):
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser
 
         from wazuh.manager import *
+        from wazuh.core.manager import LoggingFormat
         from wazuh.core.tests.test_manager import get_logs
         from wazuh import WazuhInternalError
 
@@ -90,8 +91,9 @@ def test_get_status(mock_status):
     (None, 'random', 0, None, True),
     (None, 'warning', 2, None, False)
 ])
+@patch("wazuh.core.manager.get_wazuh_active_logging_format", return_value=LoggingFormat.plain)
 @patch("wazuh.core.manager.exists", return_value=True)
-def test_ossec_log(mock_exists, tag, level, total_items, sort_by, sort_ascending):
+def test_ossec_log(mock_exists, mock_active_logging_format, tag, level, total_items, sort_by, sort_ascending):
     """Test reading ossec.log file contents.
 
     Parameters
@@ -132,8 +134,9 @@ def test_ossec_log(mock_exists, tag, level, total_items, sort_by, sort_ascending
     ('timestamp=2019/03/26 19:49:15', 'timestamp', '=', '2019/03/26T19:49:15Z'),
     ('timestamp<2019/03/26 19:49:14', 'timestamp', '<', '2019/03/26T19:49:15Z'),
 ])
+@patch("wazuh.core.manager.get_wazuh_active_logging_format", return_value=LoggingFormat.plain)
 @patch("wazuh.core.manager.exists", return_value=True)
-def test_ossec_log_q(mock_exists, q, field, operation, values):
+def test_ossec_log_q(mock_exists, mock_active_logging_format, q, field, operation, values):
     """Check that the 'q' parameter is working correctly.
 
     Parameters
@@ -160,8 +163,9 @@ def test_ossec_log_q(mock_exists, q, field, operation, values):
             assert all(log[field] in values for log in result.render()['data']['affected_items'])
 
 
+@patch("wazuh.core.manager.get_wazuh_active_logging_format", return_value=LoggingFormat.plain)
 @patch("wazuh.core.manager.exists", return_value=True)
-def test_ossec_log_summary(mock_exists):
+def test_ossec_log_summary(mock_exists, mock_active_logging_format):
     """Tests ossec_log_summary function works and returned data match with expected"""
     expected_result = {
         'wazuh-csyslogd': {'all': 2, 'info': 2, 'error': 0, 'critical': 0, 'warning': 0, 'debug': 0},
@@ -181,6 +185,7 @@ def test_ossec_log_summary(mock_exists):
         assert result.render()['data']['total_affected_items'] == 6
         assert all(all(value == expected_result[key] for key, value in item.items())
                    for item in result.render()['data']['affected_items'])
+
 
 def test_get_api_config():
     """Checks that get_api_config method is returning current api_conf dict."""

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -90,7 +90,8 @@ def test_get_status(mock_status):
     (None, 'random', 0, None, True),
     (None, 'warning', 2, None, False)
 ])
-def test_ossec_log(tag, level, total_items, sort_by, sort_ascending):
+@patch("wazuh.core.manager.exists", return_value=True)
+def test_ossec_log(mock_exists, tag, level, total_items, sort_by, sort_ascending):
     """Test reading ossec.log file contents.
 
     Parameters
@@ -131,7 +132,8 @@ def test_ossec_log(tag, level, total_items, sort_by, sort_ascending):
     ('timestamp=2019/03/26 19:49:15', 'timestamp', '=', '2019/03/26T19:49:15Z'),
     ('timestamp<2019/03/26 19:49:14', 'timestamp', '<', '2019/03/26T19:49:15Z'),
 ])
-def test_ossec_log_q(q, field, operation, values):
+@patch("wazuh.core.manager.exists", return_value=True)
+def test_ossec_log_q(mock_exists, q, field, operation, values):
     """Check that the 'q' parameter is working correctly.
 
     Parameters
@@ -158,7 +160,8 @@ def test_ossec_log_q(q, field, operation, values):
             assert all(log[field] in values for log in result.render()['data']['affected_items'])
 
 
-def test_ossec_log_summary():
+@patch("wazuh.core.manager.exists", return_value=True)
+def test_ossec_log_summary(mock_exists):
     """Tests ossec_log_summary function works and returned data match with expected"""
     expected_result = {
         'wazuh-csyslogd': {'all': 2, 'info': 2, 'error': 0, 'critical': 0, 'warning': 0, 'debug': 0},


### PR DESCRIPTION
|Related issue|
|---|
| closes #15656 |

## Description

After configuring the Wazuh log format as JSON, the `ossec.log` file will disappear after the next log rotation. This, as reported, will cause an error in the Wazuh API since it will look for that specific file.

From now on, the active logging format will be consulted before deciding which file to read and parse. In case both formats are active, `plain` will be preferred.

## Logs/Alerts example

### Configuring the logging format as JSON

```xml
  <logging>
    <log_format>json</log_format>
  </logging>

```

### Log files

```shellsession
root@wazuh-master:/# ll /var/ossec/logs/

total 59912
drwxrwx---. 1 wazuh wazuh      202 Jan 18 15:41 ./
drwxr-x---. 1 root  wazuh      200 Jan 18 09:53 ../
-rw-rw----. 1 wazuh wazuh        0 Jan 18 09:53 active-responses.log
drwxr-x---. 1 wazuh wazuh       50 Jan 18 15:40 alerts/
drwxr-x---. 1 wazuh wazuh        0 Jan 18 09:53 api/
-rw-rw----. 1 wazuh wazuh    35508 Jan 18 15:40 api.log
drwxr-x---. 1 wazuh wazuh       32 Jan 18 15:40 archives/
drwxr-x---. 1 wazuh wazuh        8 Jan 19  2023 cluster/
-rw-rw----. 1 wazuh wazuh  1941796 Jan 18 15:41 cluster.log
drwxr-x---. 1 wazuh wazuh       32 Jan 18 15:40 firewall/
-rw-r-----. 1 wazuh wazuh        0 Jan 18 09:53 integrations.log
-rw-rw----. 1 wazuh wazuh 59364863 Jan 18 15:41 ossec.json
drwxr-x---. 1 wazuh wazuh        8 Jan 19  2023 wazuh/

root@wazuh-master:/# 

```

### GET /manager/logs (limit=3)

```json
{
  "data": {
    "affected_items": [
      {
        "timestamp": "2023-01-18T15:40:47Z",
        "tag": "wazuh-db",
        "level": "debug",
        "description": "Agent 000 query: sca query 19188"
      },
      {
        "timestamp": "2023-01-18T15:40:47Z",
        "tag": "wazuh-db",
        "level": "debug",
        "description": "Agent 000 query: sca insert {\"type\":\"check\",\"id\":878117217,\"policy\":\"CIS benchmark for Ubuntu Linux 20.04 LTS\",\"policy_id\":\"cis_ubuntu20-04\",\"check\":{\"id\":19188,\"title\":\"Ensure permissions on /etc/shadow- are configured.\",\"description\":\"The /etc/shadow- file is used to store backup information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information.\",\"rationale\":\"It is critical to ensure that the /etc/shadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions.\",\"remediation\":\"Run one of the following commands to set ownership of /etc/shadow- to root and group to either root or shadow: # chown root:root /etc/shadow- # chown root:shadow /etc/shadow- Run the following command to remove excess permissions form /etc/shadow-: # chmod u-x,g-wx,o-rwx /etc/shadow-\",\"compliance\":{\"cis\":\"6.1.7\",\"cis_csc_v7\":\"16.4\",\"cmmc_v2.0\":\"IA.2.081\",\"iso_27001-2013\":\"A.10.1.1\",\"nist_sp_800-53\":\"IA-5,IA-5 (1)\",\"pci_dss_v3.2.1\":\"3.2,8.2.1\"},\"rules\":[\"c:stat /etc/shadow- -> r:^Access:\\\\s*\\\\(0640/-rw-r-----\\\\)|Access:\\\\s*\\\\(0600/-rw-------\\\\) && r:\\\\s*Uid:\\\\s*\\\\(\\\\s*\\\\t*0/\\\\s*\\\\t*root\\\\)\\\\s*\\\\t*Gid:\\\\s*\\\\(\\\\s*\\\\t*0/\\\\s*\\\\t*root\\\\)\",\"c:stat /etc/shadow- -> r:^Access:\\\\s*\\\\(0640/-rw-r-----\\\\)|Access:\\\\s*\\\\(0600/-rw-------\\\\) && r:\\\\s*Uid:\\\\s*\\\\(\\\\s*\\\\t*0/\\\\s*\\\\t*root\\\\)\\\\s*\\\\t*Gid:\\\\s*\\\\(\\\\s*\\\\t*\\\\d+/\\\\s*\\\\t*shadow\\\\)\"],\"condition\":\"any\",\"command\":\"stat /etc/shadow-\",\"result\":\"passed\"}}"
      },
      {
        "timestamp": "2023-01-18T15:40:47Z",
        "tag": "wazuh-db",
        "level": "debug",
        "description": "Agent 000 query: sca insert_compliance 19188|cis|6.1.7"
      }
    ],
    "total_affected_items": 2000,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Logs were successfully read in specified node",
  "error": 0
}
```

## Tests

### Unit tests

```
======================================== test session starts ========================================
platform linux -- Python 3.9.9, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: testinfra-5.0.0, metadata-1.11.0, cov-2.12.0, asyncio-0.18.3, aiohttp-0.3.0, html-3.1.1, trio-0.7.0
asyncio: mode=legacy
collected 2083 items                                                                                

framework/scripts/tests/test_agent_groups.py ..............                                   [  0%]
framework/scripts/tests/test_agent_upgrade.py ..............                                  [  1%]
framework/scripts/tests/test_cluster_control.py ......                                        [  1%]
framework/scripts/tests/test_wazuh_clusterd.py .......                                        [  1%]
framework/scripts/tests/test_wazuh_logtest.py ......................                          [  3%]
framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................................         [  4%]
framework/wazuh/core/cluster/tests/test_client.py ................                            [  5%]
framework/wazuh/core/cluster/tests/test_cluster.py ...................................        [  7%]
framework/wazuh/core/cluster/tests/test_common.py ........................................... [  9%]
.........................................                                                     [ 11%]
framework/wazuh/core/cluster/tests/test_control.py ......                                     [ 11%]
framework/wazuh/core/cluster/tests/test_local_client.py ..............                        [ 12%]
framework/wazuh/core/cluster/tests/test_local_server.py ........................              [ 13%]
framework/wazuh/core/cluster/tests/test_master.py ........................................... [ 15%]
.........                                                                                     [ 15%]
framework/wazuh/core/cluster/tests/test_server.py .............................               [ 17%]
framework/wazuh/core/cluster/tests/test_utils.py ...........                                  [ 17%]
framework/wazuh/core/cluster/tests/test_worker.py ...................................         [ 19%]
framework/wazuh/core/tests/test_active_response.py ..............                             [ 19%]
framework/wazuh/core/tests/test_agent.py .................................................... [ 22%]
............................................................................................. [ 26%]
..                                                                                            [ 26%]
framework/wazuh/core/tests/test_cdb_list.py ......................................            [ 28%]
framework/wazuh/core/tests/test_common.py .........                                           [ 29%]
framework/wazuh/core/tests/test_configuration.py ............................................ [ 31%]
...........................                                                                   [ 32%]
framework/wazuh/core/tests/test_database.py .............                                     [ 33%]
framework/wazuh/core/tests/test_decoder.py ................                                   [ 34%]
framework/wazuh/core/tests/test_exception.py ...                                              [ 34%]
framework/wazuh/core/tests/test_input_validator.py ...                                        [ 34%]
framework/wazuh/core/tests/test_logtest.py ..                                                 [ 34%]
framework/wazuh/core/tests/test_manager.py ................                                   [ 35%]
framework/wazuh/core/tests/test_mitre.py .............                                        [ 35%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                                       [ 36%]
framework/wazuh/core/tests/test_results.py ........................................           [ 37%]
framework/wazuh/core/tests/test_rootcheck.py .............                                    [ 38%]
framework/wazuh/core/tests/test_rule.py ......................                                [ 39%]
framework/wazuh/core/tests/test_sca.py ........................                               [ 40%]
framework/wazuh/core/tests/test_security.py ............                                      [ 41%]
framework/wazuh/core/tests/test_stats.py .................                                    [ 42%]
framework/wazuh/core/tests/test_syscheck.py .......                                           [ 42%]
framework/wazuh/core/tests/test_syscollector.py ...                                           [ 42%]
framework/wazuh/core/tests/test_task.py ........                                              [ 43%]
framework/wazuh/core/tests/test_utils.py .................................................... [ 45%]
............................................................................................. [ 50%]
............................................................................................. [ 54%]
.......                                                                                       [ 54%]
framework/wazuh/core/tests/test_vulnerability.py ..                                           [ 54%]
framework/wazuh/core/tests/test_wazuh_queue.py ....................                           [ 55%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                          [ 56%]
framework/wazuh/core/tests/test_wdb.py ...............................                        [ 58%]
framework/wazuh/core/tests/test_wlogging.py ............                                      [ 58%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                            [ 59%]
framework/wazuh/rbac/tests/test_decorators.py ............................................... [ 61%]
..........................................................                                    [ 64%]
framework/wazuh/rbac/tests/test_default_configuration.py .................................... [ 65%]
....................                                                                          [ 66%]
framework/wazuh/rbac/tests/test_orm.py ...................................................... [ 69%]
                                                                                              [ 69%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                                   [ 69%]
framework/wazuh/tests/test_active_response.py ............                                    [ 70%]
framework/wazuh/tests/test_agent.py ......................................................... [ 73%]
.............................................................                                 [ 76%]
framework/wazuh/tests/test_cdb_list.py .....................................................  [ 78%]
framework/wazuh/tests/test_ciscat.py .................................                        [ 80%]
framework/wazuh/tests/test_cluster.py ..........                                              [ 80%]
framework/wazuh/tests/test_decoder.py ...................................                     [ 82%]
framework/wazuh/tests/test_group.py .......                                                   [ 82%]
framework/wazuh/tests/test_logtest.py ......                                                  [ 83%]
framework/wazuh/tests/test_manager.py ....................................                    [ 84%]
framework/wazuh/tests/test_mitre.py .......                                                   [ 85%]
framework/wazuh/tests/test_rootcheck.py ..................................................    [ 87%]
framework/wazuh/tests/test_rule.py ........................................................   [ 90%]
framework/wazuh/tests/test_sca.py ...........                                                 [ 90%]
framework/wazuh/tests/test_security.py ...................................................... [ 93%]
...................                                                                           [ 94%]
framework/wazuh/tests/test_stats.py ...............                                           [ 94%]
framework/wazuh/tests/test_syscheck.py ..........................                             [ 96%]
framework/wazuh/tests/test_syscollector.py ............                                       [ 96%]
framework/wazuh/tests/test_task.py ............................                               [ 98%]
framework/wazuh/tests/test_vulnerability.py ........................................          [100%]

=========================== 2083 passed, 50 warnings in 315.72s (0:05:15) ===========================

```

Regards,
Víctor 